### PR TITLE
Remove remaining gix usage — cut the CLI and object stack over to sley

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -180,13 +180,18 @@ jobs:
       #     of the full test run on purpose: the job log names the hard
       #     gates from docs/CLI_WORLD_CLASS_RUBRIC.md directly, so schema
       #     drift, docs drift, hidden runtime git dependencies, no-git
-      #     overlay workflows, public help reachability, auto output,
-      #     TTY output, exit-code, corrupt-repo recovery, and
-      #     destructive-safety regressions are easy to diagnose.
+      #     overlay workflows, Sley Git-engine parity, public help
+      #     reachability, auto output, TTY output, exit-code,
+      #     corrupt-repo recovery, and destructive-safety regressions are
+      #     easy to diagnose.
       - name: CLI world-class release gates
         run: |
           cargo test --locked -p heddle-cli --test git_process_lint -- --nocapture
           cargo test --locked -p heddle-cli --test cli_integration git_replacement_matrix -- --nocapture
+          cargo test --locked -p heddle-cli --test git_bridge_integration round_trip_preserves_annotated_tag_object_sha -- --nocapture
+          cargo test --locked -p heddle-cli --test git_bridge_integration import_populates_mirror_with_identical_annotated_tag_object -- --nocapture
+          cargo test --locked -p heddle-cli --test cli_integration remotes::test_cli_raw_git_clone_adopt_fetches_notes_before_import -- --nocapture
+          cargo test --locked -p heddle-cli --test cli_integration remotes::git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated -- --nocapture
           cargo test --locked -p heddle-cli --test cli_integration public_command_paths_have_all_required_help_entrypoints -- --nocapture
           cargo test --locked -p heddle-cli --test cli_integration default_auto_output_is_json_when_stdout_is_piped_and_text_when_forced -- --nocapture
           cargo test --locked -p heddle-cli --test cli_integration narrow_no_color_text_outputs_cover_everyday_read_surfaces -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -263,7 +263,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "lru 0.16.4",
  "percent-encoding",
@@ -289,7 +289,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "percent-encoding",
  "sha2 0.10.9",
  "time",
@@ -318,7 +318,7 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "md-5 0.10.6",
@@ -330,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-eventstream"
-version = "0.60.20"
+version = "0.60.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+checksum = "78d8391e65fcea47c586a22e1a41f173b38615b112b2c6b7a44e80cec3e6b706"
 dependencies = [
  "aws-smithy-types",
  "bytes",
@@ -352,7 +352,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -419,7 +419,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -440,7 +440,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -466,20 +466,20 @@ checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
 dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.4.9"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
+checksum = "32b42fcf341259d85ca10fac9a2f6448a8ec691c6955a18e45bc3b71a85fab85"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -525,7 +525,7 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "itoa",
@@ -549,7 +549,7 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -699,9 +699,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -740,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.29.3"
+version = "0.29.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95537b45400390270fae69ac098d057c8f5399001cde9d04f700c105ddfff2d"
+checksum = "2ecb53484c9c167ba674026b656d8a27d7657a58e6066aa902bfb1a4aa00ae20"
 dependencies = [
  "heck",
  "indexmap",
@@ -844,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -879,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1298,9 +1298,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -1329,7 +1326,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -1629,7 +1626,7 @@ version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80a5eca878900c2e39e9e52fd797954b7fc39eeefc8558257114bfea6a698fcf"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "log",
  "memchr",
@@ -1850,7 +1847,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -1974,7 +1971,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "proptest",
- "prost-types 0.14.3",
+ "prost-types 0.14.4",
  "rmp-serde",
  "rustls 0.23.40",
  "schemars",
@@ -2039,7 +2036,7 @@ dependencies = [
  "heddle-proto",
  "heddle-refs",
  "heddle-repo",
- "prost-types 0.14.3",
+ "prost-types 0.14.4",
  "serde",
  "serde_json",
  "tempfile",
@@ -2086,8 +2083,8 @@ dependencies = [
  "hex",
  "libc",
  "proptest",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "serde",
  "serde_json",
  "serial_test",
@@ -2117,8 +2114,8 @@ dependencies = [
 name = "heddle-grpc"
 version = "0.7.0"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "protoc-bin-vendored",
  "tonic",
  "tonic-prost",
@@ -2431,9 +2428,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2457,7 +2454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2468,7 +2465,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2529,7 +2526,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2561,7 +2558,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
  "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
@@ -2593,7 +2590,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.10.1",
  "ipnet",
@@ -2741,9 +2738,9 @@ dependencies = [
 
 [[package]]
 name = "ignore"
-version = "0.4.25"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+checksum = "b915661dd01db3f05050265b2477bcc6527b3792388e2749b41623cc592be67d"
 dependencies = [
  "crossbeam-deque",
  "globset",
@@ -2791,7 +2788,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "inotify-sys",
  "libc",
 ]
@@ -2932,13 +2929,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -2982,7 +2978,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -3019,7 +3015,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.8.1",
@@ -3059,9 +3055,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
@@ -3118,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
@@ -3213,7 +3209,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3245,7 +3241,7 @@ version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3263,7 +3259,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3480,7 +3476,7 @@ checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
  "opentelemetry",
  "reqwest",
 ]
@@ -3491,12 +3487,12 @@ version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "reqwest",
  "thiserror 2.0.18",
  "tokio",
@@ -3512,7 +3508,7 @@ checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
  "tonic-prost",
 ]
@@ -3920,7 +3916,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -3943,19 +3939,19 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
+ "prost-derive 0.14.4",
 ]
 
 [[package]]
 name = "prost-build"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
  "itertools 0.14.0",
@@ -3963,8 +3959,8 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
@@ -3987,9 +3983,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -4010,11 +4006,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
 ]
 
 [[package]]
@@ -4087,7 +4083,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "memchr",
  "unicase",
 ]
@@ -4258,7 +4254,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4267,7 +4263,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4292,9 +4288,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4321,9 +4317,9 @@ checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -4336,7 +4332,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
@@ -4441,7 +4437,7 @@ version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink 0.9.1",
@@ -4470,7 +4466,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -4616,7 +4612,7 @@ dependencies = [
  "futures",
  "hex-simd",
  "hmac 0.13.0-rc.5",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "httparse",
@@ -4792,7 +4788,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5070,6 +5066,7 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 [[package]]
 name = "sley"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5089,6 +5086,7 @@ dependencies = [
 [[package]]
 name = "sley-config"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
 ]
@@ -5096,10 +5094,12 @@ dependencies = [
 [[package]]
 name = "sley-core"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 
 [[package]]
 name = "sley-diff-merge"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5112,6 +5112,7 @@ dependencies = [
 [[package]]
 name = "sley-fetch"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
  "sley-odb",
@@ -5122,6 +5123,7 @@ dependencies = [
 [[package]]
 name = "sley-formats"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5132,6 +5134,7 @@ dependencies = [
 [[package]]
 name = "sley-index"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
 ]
@@ -5139,6 +5142,7 @@ dependencies = [
 [[package]]
 name = "sley-notes"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5151,6 +5155,7 @@ dependencies = [
 [[package]]
 name = "sley-object"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
 ]
@@ -5158,6 +5163,7 @@ dependencies = [
 [[package]]
 name = "sley-odb"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "flate2",
  "sley-core",
@@ -5169,6 +5175,7 @@ dependencies = [
 [[package]]
 name = "sley-pack"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -5180,6 +5187,7 @@ dependencies = [
 [[package]]
 name = "sley-pathspec"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
 ]
@@ -5187,6 +5195,7 @@ dependencies = [
 [[package]]
 name = "sley-protocol"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
 ]
@@ -5194,6 +5203,7 @@ dependencies = [
 [[package]]
 name = "sley-refs"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5203,6 +5213,7 @@ dependencies = [
 [[package]]
 name = "sley-remote"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5221,6 +5232,7 @@ dependencies = [
 [[package]]
 name = "sley-rev"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5236,6 +5248,7 @@ dependencies = [
 [[package]]
 name = "sley-sequencer"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5248,6 +5261,7 @@ dependencies = [
 [[package]]
 name = "sley-transport"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-core",
  "sley-protocol",
@@ -5257,6 +5271,7 @@ dependencies = [
 [[package]]
 name = "sley-worktree"
 version = "0.1.0"
+source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5271,9 +5286,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -5432,7 +5447,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -5476,7 +5491,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -5712,12 +5727,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5727,15 +5741,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5950,7 +5964,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2 0.4.14",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
@@ -5988,7 +6002,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcfab99db777fba2802f0dfa861d1628d1ae916fb199d29819941f139ae85082"
 dependencies = [
- "prost 0.14.3",
+ "prost 0.14.4",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -6002,7 +6016,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
+ "prost 0.14.4",
  "tonic",
 ]
 
@@ -6015,7 +6029,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "prost-build",
- "prost-types 0.14.3",
+ "prost-types 0.14.4",
  "quote",
  "syn 2.0.117",
  "tempfile",
@@ -6028,8 +6042,8 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
 dependencies = [
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost 0.14.4",
+ "prost-types 0.14.4",
  "tonic",
 ]
 
@@ -6058,10 +6072,10 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower",
@@ -6306,7 +6320,7 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -6397,7 +6411,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "log",
 ]
@@ -6440,9 +6454,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.2"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6510,9 +6524,9 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -6534,9 +6548,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6547,9 +6561,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.72"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6557,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6567,9 +6581,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6580,9 +6594,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
@@ -6615,7 +6629,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -6623,9 +6637,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.99"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7129,7 +7143,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.12.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -7173,9 +7187,9 @@ checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -7196,18 +7210,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7237,18 +7251,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,28 +211,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "aws-runtime"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +763,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
 dependencies = [
  "memchr",
- "regex-automata",
  "serde",
 ]
 
@@ -999,24 +976,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "clru"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
-dependencies = [
- "hashbrown 0.16.1",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cmov"
@@ -1394,12 +1353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1477,15 +1430,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,16 +1500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
-name = "faster-hex"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
-dependencies = [
- "heapless",
- "serde",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1622,6 +1556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+ "zlib-rs",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1668,12 +1613,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1821,10 +1760,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1834,11 +1771,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1860,769 +1795,6 @@ name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
-
-[[package]]
-name = "gix"
-version = "0.84.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae54ae0ebd1a5a3c3f8d95dd3b5ca6e63f4fed9bfd585e13801a97d7bde8f9ce"
-dependencies = [
- "gix-actor",
- "gix-attributes",
- "gix-command",
- "gix-commitgraph",
- "gix-config",
- "gix-credentials",
- "gix-date",
- "gix-diff",
- "gix-discover",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-hashtable",
- "gix-ignore",
- "gix-index",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-odb",
- "gix-pack",
- "gix-path",
- "gix-pathspec",
- "gix-prompt",
- "gix-protocol",
- "gix-ref",
- "gix-refspec",
- "gix-revision",
- "gix-revwalk",
- "gix-sec",
- "gix-shallow",
- "gix-submodule",
- "gix-tempfile",
- "gix-trace",
- "gix-transport",
- "gix-traverse",
- "gix-url",
- "gix-utils",
- "gix-validate",
- "gix-worktree",
- "gix-worktree-stream",
- "nonempty",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-actor"
-version = "0.41.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bc998b8f746dda8565450d08a63b792ced9165d8c27a1ed3f02799ec6a7820f"
-dependencies = [
- "bstr",
- "gix-date",
- "gix-error",
-]
-
-[[package]]
-name = "gix-attributes"
-version = "0.33.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d43f12e246d3bf7ec624c8fc15ac4a4b62b7c4c6f586cb82be6c90bf84c9d02"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "kstring",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-bitmap"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ebef0c26ad305747649e727bbcd56a7b7910754eb7cea88f6dff6f93c51283"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-chunk"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9faee47943b638e58ddd5e275a4906ad3e4b6c8584f1d41bd18ab9032ec52afb"
-dependencies = [
- "gix-error",
-]
-
-[[package]]
-name = "gix-command"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00706d4fef135ef4b01680d5218c6ee40cda8baf697b864296cbc887d19118f6"
-dependencies = [
- "bstr",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "shell-words",
-]
-
-[[package]]
-name = "gix-commitgraph"
-version = "0.37.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f675d0df484a7f6a47e64bd6f311af489d947c0323b0564f36d14f3d7762abb"
-dependencies = [
- "bstr",
- "gix-chunk",
- "gix-error",
- "gix-hash",
- "memmap2",
- "nonempty",
-]
-
-[[package]]
-name = "gix-config"
-version = "0.57.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2372d4b49ca28431e7d150cab9d25edc1890f0184bd57eb0e917c7799e63de"
-dependencies = [
- "bstr",
- "gix-config-value",
- "gix-features",
- "gix-glob",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "smallvec",
- "thiserror 2.0.18",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-config-value"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
-dependencies = [
- "bitflags 2.12.1",
- "bstr",
- "gix-path",
- "libc",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-credentials"
-version = "0.38.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40cd22f0dd71988be12d6e78b1709de2370e1957c5f107ff31e56caeba3745d"
-dependencies = [
- "bstr",
- "gix-command",
- "gix-config-value",
- "gix-date",
- "gix-path",
- "gix-prompt",
- "gix-sec",
- "gix-trace",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-date"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ecab64a98bbac9f8e02990a9ea5e3c974a7d49b95f2bd70ad94ad22fa6b48c"
-dependencies = [
- "bstr",
- "gix-error",
- "itoa",
- "jiff",
-]
-
-[[package]]
-name = "gix-diff"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b6d9528f32d94cef2edf39a1ac01fe5a0fc44ddbb18d9e44099936047c3302b"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-object",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-discover"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77bacdd12b7879d2178a80c58c2f319995e4654e1a7a23e3181e5c8a12b824f7"
-dependencies = [
- "bstr",
- "dunce",
- "gix-fs",
- "gix-path",
- "gix-ref",
- "gix-sec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-error"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57831e199be480af90dcd7e459abed8a174c09ec9a6e2cc8f7ca6c54598b06b"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-features"
-version = "0.48.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
-dependencies = [
- "bytes",
- "crc32fast",
- "gix-path",
- "gix-trace",
- "gix-utils",
- "libc",
- "once_cell",
- "prodash",
- "thiserror 2.0.18",
- "walkdir",
- "zlib-rs",
-]
-
-[[package]]
-name = "gix-filter"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecf74b7d16f6694ce4a3049074c41be0c7987105743674f1671807bd6dce09fa"
-dependencies = [
- "bstr",
- "encoding_rs",
- "gix-attributes",
- "gix-command",
- "gix-hash",
- "gix-object",
- "gix-packetline",
- "gix-path",
- "gix-quote",
- "gix-trace",
- "gix-utils",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-fs"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
-dependencies = [
- "bstr",
- "fastrand",
- "gix-features",
- "gix-path",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-glob"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
-dependencies = [
- "bitflags 2.12.1",
- "bstr",
- "gix-features",
- "gix-path",
-]
-
-[[package]]
-name = "gix-hash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
-dependencies = [
- "faster-hex",
- "gix-features",
- "sha1-checked",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-hashtable"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
-dependencies = [
- "gix-hash",
- "hashbrown 0.17.1",
- "parking_lot",
-]
-
-[[package]]
-name = "gix-ignore"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d491bab9bf2c9f341dc754f425c31d5d3f63aca615312167b82e1deeaca97d8d"
-dependencies = [
- "bstr",
- "gix-glob",
- "gix-path",
- "gix-trace",
- "unicode-bom",
-]
-
-[[package]]
-name = "gix-index"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e6b28cc592dc753adb58302bb14a64e412ee591a3bec77aa4df87bff74fa80d"
-dependencies = [
- "bitflags 2.12.1",
- "bstr",
- "filetime",
- "fnv",
- "gix-bitmap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-traverse",
- "gix-utils",
- "gix-validate",
- "hashbrown 0.17.1",
- "itoa",
- "libc",
- "memmap2",
- "rustix",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-lock"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
-dependencies = [
- "gix-tempfile",
- "gix-utils",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-negotiate"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890c936a215bae25818c076cb881cb2e54d2c66ba947ba58b8dd47cff921bf55"
-dependencies = [
- "bitflags 2.12.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-object",
- "gix-revwalk",
-]
-
-[[package]]
-name = "gix-object"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5cd857e29429c7213bdef3f5aef83f8cc124774fe8ae0d27b1607d218d6d525"
-dependencies = [
- "bstr",
- "gix-actor",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-utils",
- "gix-validate",
- "itoa",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-odb"
-version = "0.81.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d004c32858b1556f2d7874405edb3c97dc78fc09beaa87d57bb077ee2858a7d"
-dependencies = [
- "arc-swap",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-pack",
- "gix-path",
- "gix-quote",
- "memmap2",
- "parking_lot",
- "tempfile",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pack"
-version = "0.71.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e43626f2a27d1033674ec1a196b845614231e6bbd949d5e21c133045ff56b174"
-dependencies = [
- "clru",
- "gix-chunk",
- "gix-diff",
- "gix-error",
- "gix-features",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-traverse",
- "memmap2",
- "parking_lot",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-packetline"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb18337ba2830bb43367d1af43819c8c78f31337f079fc76d0f1f1750a173126"
-dependencies = [
- "bstr",
- "faster-hex",
- "gix-trace",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-path"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa6ac14cd14939ea94a496ce7460daa6511c09f5b84757e9cfc6f9c8d0f93a6"
-dependencies = [
- "bstr",
- "gix-trace",
- "gix-validate",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-pathspec"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3050783b41ee11511e1e8fb35623df81806194f4030395f14f48ea37c2798c9f"
-dependencies = [
- "bitflags 2.12.1",
- "bstr",
- "gix-attributes",
- "gix-config-value",
- "gix-glob",
- "gix-path",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-prompt"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee604d7746080ae7e1023bf47204bcc2c5f307bfbe2306a3c90b1bfd1a2c6d8"
-dependencies = [
- "gix-command",
- "gix-config-value",
- "parking_lot",
- "rustix",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-protocol"
-version = "0.62.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51dea3acb390707ab868f1f9584f18449eb95d869deffae96768e47d303595ee"
-dependencies = [
- "bstr",
- "gix-credentials",
- "gix-date",
- "gix-features",
- "gix-hash",
- "gix-lock",
- "gix-negotiate",
- "gix-object",
- "gix-ref",
- "gix-refspec",
- "gix-revwalk",
- "gix-shallow",
- "gix-trace",
- "gix-transport",
- "gix-utils",
- "maybe-async",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-quote"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6e541fc33cc2b783b7979040d445a0c86a2eca747c8faea4ca84230d06ae6ef"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-utils",
-]
-
-[[package]]
-name = "gix-ref"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c04f64c37eb7e6feb73c7060f8dc6f381cc5de5d53249bfd450bc48a86b2e8b"
-dependencies = [
- "gix-actor",
- "gix-features",
- "gix-fs",
- "gix-hash",
- "gix-lock",
- "gix-object",
- "gix-path",
- "gix-tempfile",
- "gix-utils",
- "gix-validate",
- "memmap2",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-refspec"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b216ae06ec74b5f24ad0142026a997fb0a935b7410eaf9c1616fc3f0e6c5a6d3"
-dependencies = [
- "bstr",
- "gix-error",
- "gix-glob",
- "gix-hash",
- "gix-revision",
- "gix-validate",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-revision"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b47c88884dd3c1a19a39da19d10211fcdea2809aadc86869b6e824a1774340f"
-dependencies = [
- "bitflags 2.12.1",
- "bstr",
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "gix-trace",
- "nonempty",
-]
-
-[[package]]
-name = "gix-revwalk"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f5756abffe0917827aac683b13684ed99875bc398fa1f9b8f479b0681ef9e6"
-dependencies = [
- "gix-commitgraph",
- "gix-date",
- "gix-error",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-sec"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8519976e4c7e486270740a5400369f37940779b80bd1377d94cfa1125d01b3"
-dependencies = [
- "bitflags 2.12.1",
- "gix-path",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "gix-shallow"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a292fc2fe548c5dfa575479d16b445b0ddf1dd2f56f1fec6aed386f82553cd97"
-dependencies = [
- "bstr",
- "gix-hash",
- "gix-lock",
- "nonempty",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-submodule"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3059890ef054066c22a94bfc6a3eaba0d806aedcd630a0bc9e5783fd88884781"
-dependencies = [
- "bstr",
- "gix-config",
- "gix-path",
- "gix-pathspec",
- "gix-refspec",
- "gix-url",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-tempfile"
-version = "23.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27850097e1ff9515f46a0dad0f5f9c9d020e972727772dabab9450690c4adb22"
-dependencies = [
- "gix-fs",
- "libc",
- "parking_lot",
- "tempfile",
-]
-
-[[package]]
-name = "gix-trace"
-version = "0.1.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
-
-[[package]]
-name = "gix-transport"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd0e34995b1aab0fa8dff2af8db726a0bfad3e119c89302604463264046e7ff"
-dependencies = [
- "base64 0.22.1",
- "bstr",
- "gix-command",
- "gix-credentials",
- "gix-features",
- "gix-packetline",
- "gix-quote",
- "gix-sec",
- "gix-url",
- "reqwest",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-traverse"
-version = "0.58.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8de590ecc86a3b2870665f2288324fa9f7f8672c7fc2d4e020fdd81cd1f7aed"
-dependencies = [
- "bitflags 2.12.1",
- "gix-commitgraph",
- "gix-date",
- "gix-hash",
- "gix-hashtable",
- "gix-object",
- "gix-revwalk",
- "smallvec",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-url"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bb01ec69d55e82ccb7a19e264501ead4e6aac38463a8cebfdd81e22bb67ab2"
-dependencies = [
- "bstr",
- "gix-path",
- "percent-encoding",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "gix-utils"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
-dependencies = [
- "fastrand",
- "unicode-normalization",
-]
-
-[[package]]
-name = "gix-validate"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
-dependencies = [
- "bstr",
-]
-
-[[package]]
-name = "gix-worktree"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef414ed275e8407cd5d53d301e83be19700b0dd3f859d2434417b58f454a2d1"
-dependencies = [
- "bstr",
- "gix-attributes",
- "gix-fs",
- "gix-glob",
- "gix-hash",
- "gix-ignore",
- "gix-index",
- "gix-object",
- "gix-path",
- "gix-validate",
-]
-
-[[package]]
-name = "gix-worktree-stream"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25e9ed30100c63f7590bc581c225e53f731a53e06aa79a245739c07f7dcc557"
-dependencies = [
- "gix-attributes",
- "gix-error",
- "gix-features",
- "gix-filter",
- "gix-fs",
- "gix-hash",
- "gix-object",
- "gix-path",
- "gix-traverse",
- "parking_lot",
-]
 
 [[package]]
 name = "globset"
@@ -2698,15 +1870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hash32"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2767,16 +1930,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heapless"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
-dependencies = [
- "hash32",
- "stable_deref_trait",
-]
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2796,13 +1949,6 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "gix",
- "gix-config",
- "gix-index",
- "gix-pack",
- "gix-protocol",
- "gix-refspec",
- "gix-transport",
  "heddle-cli-shared",
  "heddle-client",
  "heddle-crypto",
@@ -2836,6 +1982,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2 0.10.9",
+ "sley",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -2985,7 +2132,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "gix",
  "heddle-objects",
  "heddle-oplog",
  "heddle-refs",
@@ -2997,6 +2143,7 @@ dependencies = [
  "rustls 0.23.40",
  "serde",
  "serde_json",
+ "sley",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",
@@ -3135,7 +2282,6 @@ dependencies = [
  "anyhow",
  "blake3",
  "chrono",
- "gix",
  "heddle-crypto",
  "heddle-objects",
  "heddle-oplog",
@@ -3150,6 +2296,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "sley",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3725,47 +2872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
-dependencies = [
- "jiff-static",
- "jiff-tzdb-platform",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
- "windows-link",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "jiff-tzdb"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
-
-[[package]]
-name = "jiff-tzdb-platform"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
-dependencies = [
- "jiff-tzdb",
-]
-
-[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3881,15 +2987,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kstring"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3985,12 +3082,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
-
-[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,17 +3095,6 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "md-5"
@@ -4079,6 +3159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -4157,12 +3238,6 @@ checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "nonempty"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "notify"
@@ -4733,15 +3808,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4844,15 +3910,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prodash"
-version = "31.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
-dependencies = [
- "parking_lot",
 ]
 
 [[package]]
@@ -5070,62 +4127,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls 0.23.40",
- "socket2 0.6.4",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand 0.9.4",
- "ring",
- "rustc-hash",
- "rustls 0.23.40",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2 0.6.4",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5332,11 +4333,9 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
  "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -5345,10 +4344,8 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls 0.23.40",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5459,12 +4456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,7 +4495,6 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5532,7 +4522,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -5579,7 +4568,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5961,16 +4949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1-checked"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
-dependencies = [
- "digest 0.10.7",
- "sha1 0.10.6",
-]
-
-[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6015,12 +4993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6045,6 +5017,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -6088,6 +5066,208 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "sley"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-diff-merge",
+ "sley-formats",
+ "sley-index",
+ "sley-notes",
+ "sley-object",
+ "sley-odb",
+ "sley-refs",
+ "sley-remote",
+ "sley-rev",
+ "sley-sequencer",
+ "sley-worktree",
+]
+
+[[package]]
+name = "sley-config"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-core"
+version = "0.1.0"
+
+[[package]]
+name = "sley-diff-merge"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+ "sley-formats",
+ "sley-index",
+ "sley-object",
+ "sley-odb",
+ "sley-refs",
+]
+
+[[package]]
+name = "sley-fetch"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+ "sley-odb",
+ "sley-protocol",
+ "sley-transport",
+]
+
+[[package]]
+name = "sley-formats"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-index",
+ "sley-object",
+]
+
+[[package]]
+name = "sley-index"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-notes"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-object",
+ "sley-odb",
+ "sley-refs",
+ "sley-sequencer",
+]
+
+[[package]]
+name = "sley-object"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-odb"
+version = "0.1.0"
+dependencies = [
+ "flate2",
+ "sley-core",
+ "sley-formats",
+ "sley-object",
+ "sley-pack",
+]
+
+[[package]]
+name = "sley-pack"
+version = "0.1.0"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "sley-core",
+ "sley-formats",
+ "sley-object",
+]
+
+[[package]]
+name = "sley-pathspec"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-protocol"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-refs"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-formats",
+]
+
+[[package]]
+name = "sley-remote"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-fetch",
+ "sley-formats",
+ "sley-object",
+ "sley-odb",
+ "sley-pack",
+ "sley-protocol",
+ "sley-refs",
+ "sley-rev",
+ "sley-transport",
+ "sley-worktree",
+]
+
+[[package]]
+name = "sley-rev"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-diff-merge",
+ "sley-formats",
+ "sley-index",
+ "sley-object",
+ "sley-odb",
+ "sley-pathspec",
+ "sley-refs",
+]
+
+[[package]]
+name = "sley-sequencer"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+ "sley-formats",
+ "sley-object",
+ "sley-odb",
+ "sley-refs",
+ "sley-worktree",
+]
+
+[[package]]
+name = "sley-transport"
+version = "0.1.0"
+dependencies = [
+ "sley-core",
+ "sley-protocol",
+ "ureq",
+]
+
+[[package]]
+name = "sley-worktree"
+version = "0.1.0"
+dependencies = [
+ "sley-config",
+ "sley-core",
+ "sley-diff-merge",
+ "sley-formats",
+ "sley-index",
+ "sley-object",
+ "sley-odb",
+ "sley-pathspec",
+ "sley-refs",
+]
 
 [[package]]
 name = "smallvec"
@@ -6358,12 +5538,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "std-next"
@@ -7167,12 +6341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bom"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7206,6 +6374,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.40",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.1",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7222,6 +6419,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,8 +5065,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d31d015b4ca6dfe051a62d2dd198037304bb9a73162881163766d08b6e996077"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5085,21 +5086,24 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28078eb09cfddc1112f936a8a09405495cb8c3b92f41825907bf81e3920b3a74"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc817cfe54cea21211600ba24e30c5ac611ddebf5299effa950cdefc29db19ba"
 
 [[package]]
 name = "sley-diff-merge"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040e9e38c38b5b49d0c17cd12c9e57acc8292a881a1ad7d760d456ad5bdb9f9"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5111,8 +5115,9 @@ dependencies = [
 
 [[package]]
 name = "sley-fetch"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b48feaa3cb727f19bc73750ccddb404c424b3511987cb3b09bdd448f407c6"
 dependencies = [
  "sley-core",
  "sley-odb",
@@ -5122,8 +5127,9 @@ dependencies = [
 
 [[package]]
 name = "sley-formats"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0a7c8c8f727ddd06d16ec6a4e46644cc5d3ff9c7c6808ebe35aee0295df14f"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5133,16 +5139,18 @@ dependencies = [
 
 [[package]]
 name = "sley-index"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89294358e593c65006ffb41bf80c6d63b094207a5e5d3ec42e31e3ed718714b3"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37c4bbe09c09c588c7cafc1c5ab40159717e609befcd86e09a3815131ae4b46c"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5154,16 +5162,18 @@ dependencies = [
 
 [[package]]
 name = "sley-object"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5ca342353c112ffca77ee1aa702940a26fa9c05d705ad31bb0498d8722fbf5"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c057e1678e3c3375f8e56d1a4e38f80b3fc07d8742567919b16d1c8c31cb7a9b"
 dependencies = [
  "flate2",
  "sley-core",
@@ -5174,8 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "sley-pack"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06c7485ac447e5ecf31e3a984cd03036f5e02c3728d6869fd910e1046355107"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -5186,24 +5197,27 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d80a6da97e0ee5ecb76ca10847975f9b7db5cb6e78c1386e66bbdb62eed66556"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-protocol"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7843b111b57b984361f95625f226b5a027bf2b69a779ef936db098d26ce6529"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-refs"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3916a5b99ed1b515e222f61f98af3db73a4811af54fe5e0d44294ebf687ffde2"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5212,8 +5226,9 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a7cd0dab82fce63f6072c9a8e8f8fbf71d7fa89823f048942cec6d449dc3b"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5231,8 +5246,9 @@ dependencies = [
 
 [[package]]
 name = "sley-rev"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33b642b04998bd71a4170b23fbdd651b56677f92e820d69c54f0d24cb20ec32"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5247,8 +5263,9 @@ dependencies = [
 
 [[package]]
 name = "sley-sequencer"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed20ae27e361576e819cdecd1ff41714e17117eaa348371fa547536a0f47803"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5260,8 +5277,9 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "405880e164a7b77f4d0f4f665a806996973b1ac698e19245867481836914e16e"
 dependencies = [
  "sley-core",
  "sley-protocol",
@@ -5270,8 +5288,9 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.1.0"
-source = "git+https://github.com/HeddleCo/sley?rev=68ee4286b7b8bb186f1146b996d3ddfe474ccf11#68ee4286b7b8bb186f1146b996d3ddfe474ccf11"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9d1e75ad3cf6ab36b5139ca709fd539c6e969ad8d16dd7e3a0ebcfc7c01593"
 dependencies = [
  "sley-config",
  "sley-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-gix = { version = "=0.84.0", default-features = false, features = ["sha1", "revision", "tree-editor", "blocking-network-client", "blocking-http-transport-reqwest-rust-tls"] }
+sley = { path = "/Users/lukethorne/dev/HeddleCo/sley/crates/sley" }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"
@@ -129,7 +129,6 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 walkdir = "2"
 windows-sys = "0.61"
 zstd = "0.13"
-gix-transport = { version = "0.57", features = ["http-client-insecure-credentials"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-sley = { git = "https://github.com/HeddleCo/sley", rev = "68ee4286b7b8bb186f1146b996d3ddfe474ccf11" }
+sley = { git = "https://github.com/HeddleCo/sley", rev = "68ee4286b7b8bb186f1146b996d3ddfe474ccf11", version = "0.1.0" }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-sley = { git = "https://github.com/HeddleCo/sley", rev = "68ee4286b7b8bb186f1146b996d3ddfe474ccf11", version = "0.1.0" }
+sley = "0.0.1"
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-sley = { path = "/Users/lukethorne/dev/HeddleCo/sley/crates/sley" }
+sley = { git = "https://github.com/HeddleCo/sley", rev = "68ee4286b7b8bb186f1146b996d3ddfe474ccf11" }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/crates/cli-macro-poc/tests/measure.rs
+++ b/crates/cli-macro-poc/tests/measure.rs
@@ -48,8 +48,9 @@ fn serialized_example_keys() -> BTreeSet<String> {
 fn both_emitters_cover_the_documented_sample_keys() {
     let documented: BTreeSet<&str> = documented_sample_keys().into_iter().collect();
 
-    let schemars_keys: BTreeSet<String> =
-        property_keys(&schemars_path::schema()).into_iter().collect();
+    let schemars_keys: BTreeSet<String> = property_keys(&schemars_path::schema())
+        .into_iter()
+        .collect();
     let custom_keys: BTreeSet<String> = property_keys(&custom_path::schema()).into_iter().collect();
 
     for key in &documented {
@@ -150,8 +151,7 @@ fn discriminator_gap_is_real_schemars_unpinned_custom_pinned() {
 #[test]
 fn schemars_re_exposes_skip_serialized_verification_field() {
     let schemars_schema = schemars_path::schema();
-    let schemars_props: BTreeSet<String> =
-        property_keys(&schemars_schema).into_iter().collect();
+    let schemars_props: BTreeSet<String> = property_keys(&schemars_schema).into_iter().collect();
     let custom_props: BTreeSet<String> =
         property_keys(&custom_path::schema()).into_iter().collect();
     let wire_keys = serialized_example_keys();
@@ -164,7 +164,11 @@ fn schemars_re_exposes_skip_serialized_verification_field() {
     let required: BTreeSet<String> = schemars_schema
         .get("required")
         .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
         .unwrap_or_default();
     assert!(
         required.contains("verification"),
@@ -274,7 +278,10 @@ fn print_measurement_table() {
         "phantom `verification` property", s_has_verification, false
     );
     println!("{:<36} | {:>10} | {:>10}", "carries example", true, true);
-    println!("{:<36} | {:>10} | {:>10}", "needs schemars dep", true, false);
+    println!(
+        "{:<36} | {:>10} | {:>10}",
+        "needs schemars dep", true, false
+    );
     println!("===========================================================\n");
 
     println!("--- schemars schema ---\n{s_pretty}\n");

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -29,13 +29,6 @@ chrono.workspace = true
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true
-gix-config = "0.57"
-gix-index = "0.52"
-gix-pack = "0.71"
-gix-protocol = { version = "0.62", features = ["blocking-client"] }
-gix-refspec = "0.42"
-gix-transport.workspace = true
-gix.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
@@ -73,6 +66,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+sley.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-tungstenite = { workspace = true, optional = true }
@@ -153,8 +147,8 @@ local = []
 git-overlay = ["repo/git-overlay", "ingest"]
 native = ["repo/native"]
 client = ["dep:heddle-client", "dep:tokio-tungstenite"]
-# Deep git import + AI-session reasoning extraction. Pulls in `gix`'s
-# transport layer, `rusqlite` for OpenCode, and the transcript matchers.
+# Deep git import + AI-session reasoning extraction. Pulls in the sley
+# Git substrate, `rusqlite` for OpenCode, and the transcript matchers.
 # Auto-enabled by `git-overlay` since import is part of the overlay flow;
 # can also be enabled standalone for the `heddle-ingest` binary use case.
 ingest = ["dep:ingest"]
@@ -204,8 +198,6 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-gix.workspace = true
-gix-transport.workspace = true
 hyper-util.workspace = true
 review = { path = "../review", package = "heddle-review" }
 ntest.workspace = true
@@ -238,6 +230,11 @@ path = "src/lib.rs"
 
 # Integration tests for cli live under `tests/` (auto-discovered) so
 # that `cargo publish` can package the crate cleanly.
+
+[[test]]
+name = "semantic_diff_integration"
+path = "tests/semantic_diff_integration.rs"
+required-features = ["semantic"]
 
 [[bench]]
 name = "local_ops"

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -4,25 +4,10 @@
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
     fs,
-    io::Write,
-    num::NonZeroU32,
     path::{Path, PathBuf},
-    sync::atomic::AtomicBool,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use gix::{
-    bstr::ByteSlice,
-    hash::{Kind as ObjectHashKind, ObjectId},
-    refs::{
-        Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
-    },
-};
-use gix_transport::{
-    Protocol, Service,
-    client::{MessageKind, WriteMode, blocking_io::Transport},
-};
 use objects::{
     error::HeddleError,
     lock::{RepositoryLockExt, WriteLockGuard},
@@ -31,6 +16,16 @@ use objects::{
 };
 use refs::Head;
 use repo::Repository as HeddleRepository;
+use sley::plumbing::sley_core::ByteString as GitByteString;
+use sley::remote::{
+    FetchOptions, LsRemoteFilter, NoCredentials, PushActionPlan, PushCommand, PushOptions,
+    SilentProgress,
+};
+use sley::{
+    BString as GitBString, DeleteRef, FullName, GitObjectType, GitTime, Index, IndexEntry,
+    IndexWriteOptions, ObjectFormat, ObjectId, RefPrecondition, ReferenceTarget,
+    Repository as SleyRepository, Signature,
+};
 
 use super::{
     git_export::{export_all, export_current_thread},
@@ -338,16 +333,11 @@ mod negative_refspec {
         pub fn new(source: impl Into<String>) -> GitResult<Self> {
             let source = source.into();
             validate_refspec_ref(&source)?;
-            let rendered = format!("^{source}");
-            gix_refspec::parse(
-                rendered.as_str().into(),
-                gix_refspec::parse::Operation::Fetch,
-            )
-            .map_err(|error| {
-                GitBridgeError::InvalidMapping(format!(
-                    "invalid negative refspec source '{source}': {error}"
-                ))
-            })?;
+            if source.contains('*') {
+                return Err(GitBridgeError::InvalidMapping(format!(
+                    "invalid negative refspec source '{source}': Negative glob patterns are not supported"
+                )));
+            }
             Ok(Self { source })
         }
 
@@ -408,10 +398,16 @@ enum RefreshCheckoutAfterFetch {
     No,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoteDirection {
+    Fetch,
+    Push,
+}
+
 #[derive(Debug, Clone)]
 enum ResolvedRemote {
     Local(PathBuf),
-    Url(gix::Url),
+    Url(String),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -469,11 +465,17 @@ impl LocalGitIdentity {
         }
     }
 
-    pub(crate) fn to_signature(&self, seconds: i64) -> gix::actor::Signature {
-        gix::actor::Signature {
-            name: self.name.as_str().into(),
-            email: self.email.as_str().into(),
-            time: gix::date::Time { seconds, offset: 0 },
+    pub(crate) fn to_ident_line(&self, seconds: i64) -> Vec<u8> {
+        format!("{} <{}> {} +0000", self.name, self.email, seconds).into_bytes()
+    }
+
+    pub(crate) fn to_signature(&self, seconds: i64) -> Signature {
+        let ident = self.to_ident_line(seconds);
+        Signature {
+            name: GitByteString::new(self.name.as_bytes().to_vec()),
+            email: GitByteString::new(self.email.as_bytes().to_vec()),
+            time: GitTime::new(seconds, 0),
+            raw: ident,
         }
     }
 }
@@ -616,12 +618,12 @@ impl SyncMapping {
         self.heddle_to_git.iter()
     }
 
-    pub(crate) fn retain_git_objects(&mut self, repo: &gix::Repository) {
+    pub(crate) fn retain_git_objects(&mut self, repo: &SleyRepository) {
         let retained: Vec<(ChangeId, ObjectId, Option<Vec<LossyGitImportEntry>>)> = self
             .heddle_to_git
             .iter()
             .filter_map(|(change_id, git_oid)| {
-                repo.find_object(*git_oid).ok().map(|_| {
+                repo.read_object(git_oid).ok().map(|_| {
                     (
                         *change_id,
                         *git_oid,
@@ -766,7 +768,7 @@ impl<'a> GitBridge<'a> {
             false
         } else {
             fs::create_dir_all(&git_dir)?;
-            let _ = gix::init_bare(&git_dir).map_err(git_err)?;
+            let _ = SleyRepository::init_bare(&git_dir).map_err(git_err)?;
             true
         };
 
@@ -785,7 +787,7 @@ impl<'a> GitBridge<'a> {
     }
 
     /// Open the Git repository (mirror or regular).
-    pub(crate) fn open_git_repo(&self) -> GitResult<gix::Repository> {
+    pub(crate) fn open_git_repo(&self) -> GitResult<SleyRepository> {
         if let Some(ref path) = self.git_repo_path {
             open_repo(path)
         } else {
@@ -935,7 +937,7 @@ impl<'a> GitBridge<'a> {
         // inside each path — never a scope-filtered subset; the scope lives in the
         // mirror state, not in a second destination filter (heddle#316 r16).
         let log_message = format!("heddle: push from {}", self.heddle_repo.root().display());
-        match self.resolve_remote(remote_name, gix::remote::Direction::Push)? {
+        match self.resolve_remote(remote_name, RemoteDirection::Push)? {
             ResolvedRemote::Local(target_path) => self.copy_mirror_to_path(
                 &target_path,
                 &log_message,
@@ -1014,7 +1016,7 @@ impl<'a> GitBridge<'a> {
             open_repo(target_path)?
         } else if init_if_missing {
             fs::create_dir_all(target_path)?;
-            gix::init_bare(target_path).map_err(git_err)?;
+            SleyRepository::init_bare(target_path).map_err(git_err)?;
             open_repo(target_path)?
         } else {
             return Err(GitBridgeError::Git(format!(
@@ -1063,19 +1065,20 @@ impl<'a> GitBridge<'a> {
             force,
         )?;
         for write in &plan.writes {
-            // The plan already decided force-vs-FF per ref (erroring on a fork
-            // unless `force`), so the destination write itself is unconditional —
-            // `PreviousValue::Any` mirrors the forced mirror-side branch rewind.
+            let constraint = match write.old {
+                Some(old) => RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(old)),
+                None => RefPrecondition::MustNotExist,
+            };
             set_reference(
                 &target_repo,
                 &write.full_name,
                 write.new,
-                PreviousValue::Any,
+                constraint,
                 log_message,
             )?;
         }
         for delete in &plan.deletes {
-            delete_reference_if_present(&target_repo, &delete.full_name)?;
+            delete_reference_matching(&target_repo, &delete.full_name, delete.old)?;
         }
         write_exported_refs(&target_repo, &plan.new_manifest)?;
         Ok(planned_write_names(&plan))
@@ -1112,10 +1115,20 @@ impl<'a> GitBridge<'a> {
         }
 
         let mirror_repo = self.open_git_repo()?;
-        match self.resolve_remote(remote_name, gix::remote::Direction::Fetch)? {
+        match self.resolve_remote(remote_name, RemoteDirection::Fetch)? {
             ResolvedRemote::Local(path) => {
                 let remote_repo = open_repo(&path)?;
                 let updates = collect_ref_updates_for_fetch(&remote_repo, scope)?;
+                tracing::debug!(
+                    remote = remote_name,
+                    path = %path.display(),
+                    refs = updates.len(),
+                    notes = updates
+                        .iter()
+                        .filter(|update| update.namespace == RefNamespace::Note)
+                        .count(),
+                    "fetching Git refs from local remote"
+                );
                 copy_reachable_objects(
                     &remote_repo,
                     &mirror_repo,
@@ -1198,6 +1211,10 @@ impl<'a> GitBridge<'a> {
             }
         });
         remotes.dedup();
+        tracing::debug!(
+            remotes = ?remotes,
+            "discovered configured remotes for Heddle note hydration"
+        );
 
         for remote in remotes {
             match self.fetch_with_scope(
@@ -1292,10 +1309,12 @@ impl<'a> GitBridge<'a> {
         };
         let mirror_repo = self.open_git_repo()?;
         let branch_ref = format!("refs/heads/{thread}");
-        let Ok(mut reference) = mirror_repo.find_reference(&branch_ref) else {
+        let Some(reference) = mirror_repo.find_reference(&branch_ref).map_err(git_err)? else {
             return Ok(());
         };
-        let remote_git_oid = reference.peel_to_id().map_err(git_err)?.detach();
+        let Some(remote_git_oid) = reference.peeled_oid(&mirror_repo).map_err(git_err)? else {
+            return Ok(());
+        };
         if remote_git_oid == local_git_oid
             || commit_is_descendant_of(&mirror_repo, remote_git_oid, local_git_oid)?
         {
@@ -1315,7 +1334,7 @@ impl<'a> GitBridge<'a> {
         }
 
         let mirror_repo = self.open_git_repo()?;
-        let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(self.heddle_repo.root()).map_err(git_err)?;
         if checkout_repo.git_dir() == mirror_repo.git_dir() {
             return Ok(());
         }
@@ -1355,13 +1374,13 @@ impl<'a> GitBridge<'a> {
 
     pub(crate) fn seed_git_checkpoint_mappings_from_checkout(
         &mut self,
-        mirror_repo: &gix::Repository,
+        mirror_repo: &SleyRepository,
     ) -> GitResult<()> {
         if !self.heddle_repo.root().join(".git").exists() {
             return Ok(());
         }
 
-        let checkout_repo = match gix::discover(self.heddle_repo.root()) {
+        let checkout_repo = match SleyRepository::discover(self.heddle_repo.root()) {
             Ok(repo) => repo,
             Err(_) => return Ok(()),
         };
@@ -1377,11 +1396,11 @@ impl<'a> GitBridge<'a> {
                 .parse::<ObjectId>()
                 .map_err(|err| GitBridgeError::InvalidMapping(err.to_string()))?;
 
-            if mirror_repo.find_object(git_oid).is_err() {
+            if mirror_repo.read_object(&git_oid).is_err() {
                 copy_reachable_objects(&object_repo, mirror_repo, [git_oid])?;
             }
             mirror_repo
-                .find_object(git_oid)
+                .read_object(&git_oid)
                 .map_err(|_| GitBridgeError::CommitNotFound(record.git_commit.clone()))?;
 
             self.mapping.insert(change_id, git_oid);
@@ -1487,7 +1506,7 @@ impl<'a> GitBridge<'a> {
         if !root.join(".git").exists() {
             return Ok(());
         }
-        let checkout_repo = gix::discover(root).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(root).map_err(git_err)?;
         // Skip detached HEAD: write-through only mirrors attached
         // threads, and there is no branch context to reason about here.
         if checkout_repo
@@ -1519,18 +1538,23 @@ impl<'a> GitBridge<'a> {
         // and PRUNE intent-to-add entries whose path left the captured
         // set (deleted, or now committed) — otherwise a stale entry
         // surfaces as a phantom ` D path` in `git status`.
-        let mut index = checkout_repo.open_index().map_err(git_err)?;
+        let mut index = checkout_repo
+            .open_index()
+            .map_err(git_err)?
+            .unwrap_or_else(|| Index {
+                version: 2,
+                entries: Vec::new(),
+                extensions: Vec::new(),
+                checksum: None,
+            });
 
         // Partition existing entries: real tracked paths vs. the
         // intent-to-add placeholders we manage here.
         let mut real_tracked: HashSet<String> = HashSet::new();
         let mut existing_ita: HashSet<String> = HashSet::new();
-        for entry in index.entries() {
-            let path = entry
-                .path_in(index.path_backing())
-                .to_str_lossy()
-                .into_owned();
-            if entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD) {
+        for entry in &index.entries {
+            let path = String::from_utf8_lossy(entry.path.as_bytes()).into_owned();
+            if entry.is_intent_to_add() {
                 existing_ita.insert(path);
             } else {
                 real_tracked.insert(path);
@@ -1542,18 +1566,15 @@ impl<'a> GitBridge<'a> {
         let captured_paths: HashSet<&str> = captured.iter().map(|(p, _)| p.as_str()).collect();
 
         // PRUNE: any intent-to-add entry whose path is no longer desired.
-        let mut changed = false;
-        index.remove_entries(|_, path, entry| {
-            let stale = entry.flags.contains(gix_index::entry::Flags::INTENT_TO_ADD)
-                && !captured_paths.contains(path.to_str_lossy().as_ref());
-            if stale {
-                changed = true;
-            }
-            stale
+        let before_prune = index.entries.len();
+        index.entries.retain(|entry| {
+            !(entry.is_intent_to_add()
+                && !captured_paths
+                    .contains(String::from_utf8_lossy(entry.path.as_bytes()).as_ref()))
         });
+        let mut changed = index.entries.len() != before_prune;
 
         // ADD: newly-captured paths not already tracked or marked.
-        let empty_blob = checkout_repo.object_hash().empty_blob();
         for (path, mode) in &captured {
             if real_tracked.contains(path) || existing_ita.contains(path) {
                 continue;
@@ -1571,27 +1592,32 @@ impl<'a> GitBridge<'a> {
             {
                 continue;
             }
-            let entry_mode = match mode {
-                FileMode::Executable => gix_index::entry::Mode::FILE_EXECUTABLE,
-                FileMode::Symlink => gix_index::entry::Mode::SYMLINK,
-                FileMode::Normal => gix_index::entry::Mode::FILE,
-            };
-            index.dangerously_push_entry(
-                gix_index::entry::Stat::default(),
-                empty_blob,
-                gix_index::entry::Flags::INTENT_TO_ADD | gix_index::entry::Flags::EXTENDED,
-                entry_mode,
-                path.as_bytes().as_bstr(),
+            let mut entry = IndexEntry::intent_to_add(
+                checkout_repo.object_format(),
+                GitBString::from(path.as_str()),
             );
+            entry.mode = match mode {
+                FileMode::Executable => 0o100755,
+                FileMode::Symlink => 0o120000,
+                FileMode::Normal => 0o100644,
+            };
             changed = true;
+            index.entries.push(entry);
         }
 
         if changed {
-            // `dangerously_push_entry` appends without preserving sort
-            // order; restore it so subsequent path lookups stay correct.
-            index.sort_entries();
             index
-                .write(gix_index::write::Options::default())
+                .entries
+                .sort_by(|left, right| left.path.as_bytes().cmp(right.path.as_bytes()));
+            index.upgrade_version_for_flags();
+            checkout_repo
+                .write_index(
+                    &index,
+                    IndexWriteOptions {
+                        fsync: true,
+                        validate_checksum: true,
+                    },
+                )
                 .map_err(git_err)?;
         }
         Ok(())
@@ -1670,20 +1696,15 @@ impl<'a> GitBridge<'a> {
         };
 
         let mirror_repo = self.open_git_repo()?;
-        let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(self.heddle_repo.root()).map_err(git_err)?;
         if checkout_repo.git_dir() == mirror_repo.git_dir() {
             return Ok(WriteThroughOutcome::Skipped(
                 WriteThroughSkipReason::MirrorIsWorktree,
             ));
         }
         let git_dir = checkout_repo.git_dir().to_path_buf();
-        // gix-index manages its own `index.lock` (atomic `O_CREAT |
-        // O_EXCL`) inside `index.write`, so we don't create a parallel
-        // lock here — that would deadlock with gix's writer. The
-        // existence check below is a UX nicety so a stale or
-        // concurrent lock surfaces as a structured `IndexAlreadyDirty`
-        // skip rather than a raw "Could not acquire lock" error from
-        // gix.
+        // sley's index writer owns `index.lock`; keep this preflight so a stale
+        // or concurrent lock surfaces as a structured `IndexAlreadyDirty` skip.
         if git_dir.join("index.lock").exists() {
             return Ok(WriteThroughOutcome::Skipped(
                 WriteThroughSkipReason::IndexAlreadyDirty,
@@ -1699,18 +1720,26 @@ impl<'a> GitBridge<'a> {
         let previous_branch = object_repo
             .find_reference(&branch_ref)
             .ok()
-            .and_then(|mut reference| reference.peel_to_id().ok())
-            .map(|id| id.detach());
+            .flatten()
+            .and_then(|reference| reference.peeled_oid(&object_repo).ok().flatten());
 
         let write_result = (|| -> GitResult<()> {
             copy_reachable_objects(&mirror_repo, &object_repo, [git_oid])?;
             fs::write(&head_path, format!("ref: {branch_ref}\n"))?;
 
-            let commit = checkout_repo.find_commit(git_oid).map_err(git_err)?;
-            let tree_id = commit.tree_id().map_err(git_err)?;
-            let mut index = checkout_repo.index_from_tree(&tree_id).map_err(git_err)?;
-            index
-                .write(gix_index::write::Options::default())
+            let commit = checkout_repo.read_commit(&git_oid).map_err(git_err)?;
+            let mut index = checkout_repo
+                .index_from_tree(&commit.tree)
+                .map_err(git_err)?;
+            index.upgrade_version_for_flags();
+            checkout_repo
+                .write_index(
+                    &index,
+                    IndexWriteOptions {
+                        fsync: true,
+                        validate_checksum: true,
+                    },
+                )
                 .map_err(git_err)?;
 
             update_checkout_head_ref(
@@ -1721,7 +1750,7 @@ impl<'a> GitBridge<'a> {
             )?;
 
             // fsync after every durable write so a power loss between
-            // `fs::write(HEAD)` and `index.write` doesn't leave the
+            // `fs::write(HEAD)` and `write_index` doesn't leave the
             // checkout in a self-inconsistent state. Sync the parent
             // dir too — file-level fsync on its own doesn't durably
             // commit the dirent on most filesystems.
@@ -1739,7 +1768,7 @@ impl<'a> GitBridge<'a> {
                     &object_repo,
                     &branch_ref,
                     previous_branch,
-                    PreviousValue::Any,
+                    RefPrecondition::Any,
                     "heddle: rollback failed write-through",
                 )?;
             } else {
@@ -1782,12 +1811,14 @@ impl<'a> GitBridge<'a> {
 
         let mirror_repo = self.open_git_repo()?;
         let branch_ref = format!("refs/heads/{branch}");
-        let Ok(mut reference) = mirror_repo.find_reference(&branch_ref) else {
+        let Some(reference) = mirror_repo.find_reference(&branch_ref).map_err(git_err)? else {
             return Ok(());
         };
-        let target = reference.peel_to_id().map_err(git_err)?.detach();
+        let Some(target) = reference.peeled_oid(&mirror_repo).map_err(git_err)? else {
+            return Ok(());
+        };
 
-        let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(self.heddle_repo.root()).map_err(git_err)?;
         if checkout_repo.git_dir() == mirror_repo.git_dir() {
             return Ok(());
         }
@@ -1797,7 +1828,7 @@ impl<'a> GitBridge<'a> {
             &object_repo,
             &format!("refs/remotes/{tracking_remote}/{branch}"),
             target,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "heddle: refresh remote-tracking branch after pull",
         )?;
         Ok(())
@@ -1815,23 +1846,20 @@ impl<'a> GitBridge<'a> {
         reject_reserved_git_remote_name(&tracking_remote)?;
 
         let mirror_repo = self.open_git_repo()?;
-        let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(self.heddle_repo.root()).map_err(git_err)?;
         if checkout_repo.git_dir() == mirror_repo.git_dir() {
             return Ok(());
         }
         let object_repo = common_repo_for_worktree(&checkout_repo)?;
         let prefix = format!("refs/remotes/{remote_name}/");
-        for reference in mirror_repo
-            .references()
-            .map_err(git_err)?
-            .prefixed(prefix.as_str())
-            .map_err(git_err)?
-        {
-            let reference = reference.map_err(git_err)?;
-            let Some(target) = reference.target().try_id().map(ToOwned::to_owned) else {
+        for reference in mirror_repo.references().list_refs().map_err(git_err)? {
+            if !reference.name.starts_with(&prefix) {
+                continue;
+            }
+            let ReferenceTarget::Direct(target) = reference.target else {
                 continue;
             };
-            let full = reference.name().as_bstr().to_string();
+            let full = reference.name;
             let Some(branch) = full.strip_prefix(&prefix) else {
                 continue;
             };
@@ -1843,7 +1871,7 @@ impl<'a> GitBridge<'a> {
                 &object_repo,
                 &format!("refs/remotes/{tracking_remote}/{branch}"),
                 target,
-                PreviousValue::Any,
+                RefPrecondition::Any,
                 "heddle: refresh remote-tracking branch after fetch",
             )?;
         }
@@ -1856,7 +1884,7 @@ impl<'a> GitBridge<'a> {
         }
 
         let mirror_repo = self.open_git_repo()?;
-        let checkout_repo = gix::discover(self.heddle_repo.root()).map_err(git_err)?;
+        let checkout_repo = SleyRepository::discover(self.heddle_repo.root()).map_err(git_err)?;
         if checkout_repo.git_dir() == mirror_repo.git_dir() {
             return Ok(());
         }
@@ -1885,7 +1913,7 @@ impl<'a> GitBridge<'a> {
     fn resolve_remote(
         &self,
         remote_name: &str,
-        direction: gix::remote::Direction,
+        direction: RemoteDirection,
     ) -> GitResult<ResolvedRemote> {
         let repo = self.open_git_repo()?;
         let url = match remote_url_from_repo(&repo, remote_name, direction)? {
@@ -1893,29 +1921,31 @@ impl<'a> GitBridge<'a> {
             None => self.checkout_remote_url(remote_name, direction)?,
         };
 
+        let base = repo_relative_base(&repo);
         let url = match url {
             Some(url) => url,
-            None => gix::url::parse(remote_name.as_bytes().as_bstr()).map_err(git_err)?,
+            None => parse_configured_remote_url(remote_name, &base)?,
         };
 
-        match url.scheme {
-            gix::url::Scheme::File => Ok(ResolvedRemote::Local(local_path_from_url(&url)?)),
-            _ => Ok(ResolvedRemote::Url(url)),
+        if let Some(path) = local_path_from_url(&url)? {
+            Ok(ResolvedRemote::Local(path))
+        } else {
+            Ok(ResolvedRemote::Url(url))
         }
     }
 
     fn checkout_remote_url(
         &self,
         remote_name: &str,
-        direction: gix::remote::Direction,
-    ) -> GitResult<Option<gix::Url>> {
-        if direction == gix::remote::Direction::Fetch
+        direction: RemoteDirection,
+    ) -> GitResult<Option<String>> {
+        if direction == RemoteDirection::Fetch
             && let Some(url) =
                 remote_fetch_url_from_checkout_config(self.heddle_repo.root(), remote_name)?
         {
             return Ok(Some(url));
         }
-        let Ok(repo) = gix::discover(self.heddle_repo.root()) else {
+        let Ok(repo) = SleyRepository::discover(self.heddle_repo.root()) else {
             return Ok(None);
         };
         remote_url_from_repo(&repo, remote_name, direction)
@@ -1923,23 +1953,25 @@ impl<'a> GitBridge<'a> {
 }
 
 fn remote_url_from_repo(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     remote_name: &str,
-    direction: gix::remote::Direction,
-) -> GitResult<Option<gix::Url>> {
-    if direction == gix::remote::Direction::Fetch {
-        if let Some(url) = remote_fetch_url_from_config(repo, remote_name)? {
-            return Ok(Some(url));
-        }
-        if let Ok(remote) = repo.find_remote(remote_name.as_bytes().as_bstr()) {
-            return Ok(remote.url(direction).cloned());
-        }
-        Ok(None)
-    } else if let Ok(remote) = repo.find_remote(remote_name.as_bytes().as_bstr()) {
-        Ok(remote.url(direction).cloned())
+    direction: RemoteDirection,
+) -> GitResult<Option<String>> {
+    let config = repo.config_snapshot().map_err(git_err)?;
+    let push = direction == RemoteDirection::Push;
+    let value = if push {
+        config
+            .get("remote", Some(remote_name), "pushurl")
+            .or_else(|| config.get("remote", Some(remote_name), "url"))
     } else {
-        Ok(None)
-    }
+        config.get("remote", Some(remote_name), "url")
+    };
+    let Some(value) = value else {
+        return Ok(None);
+    };
+    let rewritten =
+        sley::plumbing::sley_config::remotes::rewrite_url_with_config(&config, value, push);
+    parse_configured_remote_url(&rewritten, &repo_relative_base(repo)).map(Some)
 }
 
 fn checkout_tracking_remote_name(root: &Path, requested: &str) -> GitResult<Option<String>> {
@@ -1977,11 +2009,12 @@ fn checkout_note_ref_exists(root: &Path) -> GitResult<bool> {
     if !root.join(".git").exists() {
         return Ok(false);
     }
-    let checkout_repo = gix::discover(root).map_err(git_err)?;
+    let checkout_repo = SleyRepository::discover(root).map_err(git_err)?;
     let object_repo = common_repo_for_worktree(&checkout_repo)?;
     Ok(object_repo
         .find_reference(super::git_notes::NOTES_REF)
-        .is_ok())
+        .map_err(git_err)?
+        .is_some())
 }
 
 fn parse_remote_url_items_from_config(
@@ -2038,24 +2071,10 @@ fn looks_like_remote_location(value: &str) -> bool {
         || value.contains('\\')
 }
 
-fn remote_fetch_url_from_config(
-    repo: &gix::Repository,
-    remote_name: &str,
-) -> GitResult<Option<gix::Url>> {
-    for config_path in repo_config_paths(repo)? {
-        let Some(url) = parse_remote_fetch_url_from_config(&config_path, remote_name)? else {
-            continue;
-        };
-        let base = repo.workdir().unwrap_or_else(|| repo.git_dir());
-        return parse_configured_remote_url(&url, base).map(Some);
-    }
-    Ok(None)
-}
-
 fn remote_fetch_url_from_checkout_config(
     root: &Path,
     remote_name: &str,
-) -> GitResult<Option<gix::Url>> {
+) -> GitResult<Option<String>> {
     for config_path in checkout_git_config_paths(root) {
         let Some(url) = parse_remote_fetch_url_from_config(&config_path, remote_name)? else {
             continue;
@@ -2065,13 +2084,12 @@ fn remote_fetch_url_from_checkout_config(
     Ok(None)
 }
 
-fn parse_configured_remote_url(value: &str, relative_base: &Path) -> GitResult<gix::Url> {
+fn parse_configured_remote_url(value: &str, relative_base: &Path) -> GitResult<String> {
     if configured_remote_is_local_path(value) {
         let path = configured_remote_local_path(value, relative_base);
-        return gix::url::parse(format!("file://{}", path.display()).as_bytes().as_bstr())
-            .map_err(git_err);
+        return Ok(format!("file://{}", path.display()));
     }
-    gix::url::parse(value.as_bytes().as_bstr()).map_err(git_err)
+    Ok(value.to_string())
 }
 
 fn configured_remote_local_path(value: &str, relative_base: &Path) -> PathBuf {
@@ -2147,16 +2165,6 @@ fn common_git_dir_from_git_dir(git_dir: &Path) -> Option<PathBuf> {
     })
 }
 
-fn repo_config_paths(repo: &gix::Repository) -> GitResult<Vec<PathBuf>> {
-    let mut paths = vec![repo.git_dir().join("config")];
-    let common_repo = common_repo_for_worktree(repo)?;
-    let common_config = common_repo.git_dir().join("config");
-    if !paths.iter().any(|path| path == &common_config) {
-        paths.push(common_config);
-    }
-    Ok(paths)
-}
-
 fn parse_remote_fetch_url_from_config(path: &Path, remote_name: &str) -> GitResult<Option<String>> {
     let Ok(contents) = fs::read_to_string(path) else {
         return Ok(None);
@@ -2187,7 +2195,7 @@ fn parse_remote_fetch_url_from_config(path: &Path, remote_name: &str) -> GitResu
     Ok(None)
 }
 
-fn common_repo_for_worktree(repo: &gix::Repository) -> GitResult<gix::Repository> {
+fn common_repo_for_worktree(repo: &SleyRepository) -> GitResult<SleyRepository> {
     let common_dir_file = repo.git_dir().join("commondir");
     let Ok(contents) = fs::read_to_string(&common_dir_file) else {
         return Ok(repo.clone());
@@ -2302,69 +2310,99 @@ pub(crate) fn thread_is_unclaimed_bootstrap(
     Ok(tree == Tree::new())
 }
 
-pub(crate) fn open_repo(path: &Path) -> GitResult<gix::Repository> {
-    match gix::discover(path) {
+pub(crate) fn open_repo(path: &Path) -> GitResult<SleyRepository> {
+    match SleyRepository::discover(path) {
         Ok(repo) => Ok(repo),
-        Err(_) => gix::open(path).map_err(git_err),
+        Err(_) => SleyRepository::open(path).map_err(git_err),
     }
 }
 
 /// Delete a reference if present; missing-ref is a no-op. Used by the
 /// write-through rollback path to drop a branch that was created by a
 /// failed write-through but isn't reachable from any prior state. We
-/// scope the deletion with `PreviousValue::MustExist` so an unrelated
+/// scope the deletion with `RefPrecondition::MustExist` so an unrelated
 /// concurrent writer that *just* updated this ref isn't silently
 /// clobbered — if the ref vanished underneath us between our read and
 /// the delete, that's the rollback we wanted anyway.
-pub(crate) fn delete_reference_if_present(repo: &gix::Repository, name: &str) -> GitResult<()> {
-    let signature = bridge_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let edit = RefEdit {
-        change: Change::Delete {
-            log: RefLog::AndReference,
-            expected: PreviousValue::MustExist,
-        },
-        name: name
-            .try_into()
-            .map_err(|err| GitBridgeError::Git(format!("invalid ref {name}: {err}")))?,
-        deref: false,
-    };
-    match repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf))) {
-        Ok(_) => Ok(()),
-        // Missing ref → already rolled back; treat as success. gix's
-        // error message on an absent ref reads "for deletion did not
-        // exist or could not be parsed".
-        Err(err) if err.to_string().contains("did not exist") => Ok(()),
-        Err(err) => Err(git_err(err)),
+pub(crate) fn delete_reference_if_present(repo: &SleyRepository, name: &str) -> GitResult<()> {
+    delete_reference(repo, name, None, true)
+}
+
+fn delete_reference_matching(
+    repo: &SleyRepository,
+    name: &str,
+    expected_old: ObjectId,
+) -> GitResult<()> {
+    delete_reference(repo, name, Some(expected_old), false)
+}
+
+fn delete_reference(
+    repo: &SleyRepository,
+    name: &str,
+    expected_old: Option<ObjectId>,
+    missing_ok: bool,
+) -> GitResult<()> {
+    let refs = repo.references();
+    match refs.read_ref(name).map_err(git_err)? {
+        None if missing_ok => Ok(()),
+        None => Err(GitBridgeError::Git(format!(
+            "failed to delete Git reference '{name}': ref is missing"
+        ))),
+        Some(ReferenceTarget::Direct(oid)) => repo
+            .delete_ref(DeleteRef {
+                name: FullName::new(name).map_err(git_err)?,
+                expected_old: Some(expected_old.unwrap_or(oid)),
+                expected: None,
+                reflog: None,
+                reflog_committer: None,
+            })
+            .map_err(git_err),
+        Some(ReferenceTarget::Symbolic(_)) => {
+            if let Some(expected_old) = expected_old {
+                let current = repo
+                    .find_reference(name)
+                    .map_err(git_err)?
+                    .and_then(|reference| reference.peeled_oid(repo).ok().flatten());
+                if current != Some(expected_old) {
+                    return Err(GitBridgeError::Git(format!(
+                        "failed to delete Git reference '{name}': expected {expected_old}, found {}",
+                        current
+                            .map(|oid| oid.to_string())
+                            .unwrap_or_else(|| "missing".to_string())
+                    )));
+                }
+            }
+            refs.delete_symbolic_ref(name).map(|_| ()).map_err(git_err)
+        }
     }
 }
 
 pub(crate) fn set_reference(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     name: &str,
     target: ObjectId,
-    constraint: PreviousValue,
+    constraint: RefPrecondition,
     log_message: &str,
 ) -> GitResult<()> {
-    let signature = bridge_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let edit = RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: log_message.into(),
-            },
-            expected: constraint,
-            new: Target::Object(target),
-        },
-        name: name
-            .try_into()
-            .map_err(|err| GitBridgeError::Git(format!("invalid ref {name}: {err}")))?,
-        deref: false,
+    let refs = repo.references();
+    let old_oid = match refs.read_ref(name).map_err(git_err)? {
+        Some(ReferenceTarget::Direct(oid)) => oid,
+        _ => ObjectId::null(repo.object_format()),
     };
-    repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
-        .map_err(git_err)?;
+    let reflog = sley::plumbing::sley_refs::ReflogEntry {
+        old_oid,
+        new_oid: target,
+        committer: bridge_signature(),
+        message: log_message.as_bytes().to_vec(),
+    };
+    let mut tx = refs.transaction();
+    tx.update_to(
+        name.to_string(),
+        ReferenceTarget::Direct(target),
+        constraint,
+        Some(reflog),
+    );
+    tx.commit().map_err(git_err)?;
     Ok(())
 }
 
@@ -2410,38 +2448,37 @@ fn collect_capture_paths<S: ObjectStore + ?Sized>(
 }
 
 fn update_checkout_head_ref(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     target: ObjectId,
     previous_branch: Option<ObjectId>,
     log_message: &str,
 ) -> GitResult<()> {
-    let signature = bridge_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let expected = previous_branch.map_or(PreviousValue::MustNotExist, |oid| {
-        PreviousValue::MustExistAndMatch(Target::Object(oid))
+    let expected = previous_branch.map_or(RefPrecondition::MustNotExist, |oid| {
+        RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(oid))
     });
-    let edit = RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: log_message.into(),
-            },
-            expected,
-            new: Target::Object(target),
-        },
-        name: "HEAD"
-            .try_into()
-            .map_err(|err| GitBridgeError::Git(format!("invalid ref HEAD: {err}")))?,
-        deref: true,
+    let ref_name = repo
+        .head()
+        .ok()
+        .and_then(|head| head.symbolic_target.map(|name| name.to_string()))
+        .unwrap_or_else(|| "HEAD".to_string());
+    let old_oid = previous_branch.unwrap_or_else(|| ObjectId::null(repo.object_format()));
+    let head_reflog = sley::plumbing::sley_refs::ReflogEntry {
+        old_oid,
+        new_oid: target,
+        committer: bridge_signature(),
+        message: log_message.as_bytes().to_vec(),
     };
-    repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
-        .map_err(git_err)?;
+    set_reference(repo, &ref_name, target, expected, log_message)?;
+    if ref_name != "HEAD" {
+        repo.references()
+            .append_reflog("HEAD", &head_reflog)
+            .map_err(git_err)?;
+    }
     Ok(())
 }
 
 fn checkout_git_head_is_detached(root: &Path) -> GitResult<bool> {
-    let repo = gix::discover(root).map_err(git_err)?;
+    let repo = SleyRepository::discover(root).map_err(git_err)?;
     Ok(repo.head().map(|head| head.is_detached()).unwrap_or(false))
 }
 
@@ -2482,13 +2519,17 @@ pub(crate) fn principal_is_default_unknown(principal: &Principal) -> bool {
 }
 
 fn git_config_value_with_global_fallback(repo_root: &Path, key: &str) -> GitResult<Option<String>> {
-    let Ok(repo) = gix::discover(repo_root) else {
+    let Ok(repo) = SleyRepository::discover(repo_root) else {
+        return Ok(None);
+    };
+    let Some((section, variable)) = key.split_once('.') else {
         return Ok(None);
     };
     Ok(repo
         .config_snapshot()
-        .string(key)
-        .map(|value| value.to_str_lossy().into_owned()))
+        .map_err(git_err)?
+        .get(section, None, variable)
+        .map(str::to_string))
 }
 
 fn git_config_value(value: &str) -> GitResult<String> {
@@ -2521,98 +2562,71 @@ fn git_config_value(value: &str) -> GitResult<String> {
     Ok(out)
 }
 
-fn bridge_signature() -> gix::actor::Signature {
+fn bridge_signature() -> Vec<u8> {
     let seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or(0);
-    gix::actor::Signature {
-        name: "Heddle".into(),
-        email: "heddle@local".into(),
-        time: gix::date::Time { seconds, offset: 0 },
-    }
+    format!("Heddle <heddle@local> {seconds} +0000").into_bytes()
 }
 
-fn local_path_from_url(url: &gix::Url) -> GitResult<PathBuf> {
-    if url.scheme != gix::url::Scheme::File {
-        return Err(GitBridgeError::Git(format!(
-            "remote '{}' uses unsupported scheme {:?}; only local path and file:// remotes are supported",
-            url, url.scheme
-        )));
-    }
+fn repo_relative_base(repo: &SleyRepository) -> PathBuf {
+    repo.workdir().unwrap_or_else(|| {
+        if repo
+            .git_dir()
+            .file_name()
+            .is_some_and(|name| name == ".git")
+        {
+            repo.git_dir()
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| repo.git_dir().to_path_buf())
+        } else {
+            repo.git_dir().to_path_buf()
+        }
+    })
+}
 
-    let path = PathBuf::from(String::from_utf8_lossy(url.path.as_ref()).into_owned());
+fn local_path_from_url(url: &str) -> GitResult<Option<PathBuf>> {
+    let Some(raw_path) = url.strip_prefix("file://") else {
+        return Ok(None);
+    };
+    let path = PathBuf::from(raw_path);
     if path.as_os_str().is_empty() {
         return Err(GitBridgeError::Git(format!(
             "remote '{}' has no filesystem path",
             url
         )));
     }
-    Ok(path)
+    Ok(Some(path))
 }
 
-fn collect_ref_updates(repo: &gix::Repository) -> GitResult<Vec<RefUpdate>> {
+fn collect_ref_updates(repo: &SleyRepository) -> GitResult<Vec<RefUpdate>> {
     let mut updates = Vec::new();
 
-    for branch in repo
-        .references()
-        .map_err(git_err)?
-        .local_branches()
-        .map_err(git_err)?
-    {
-        let branch = branch.map_err(git_err)?;
-        let Some(target) = branch.try_id() else {
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let ReferenceTarget::Direct(target) = reference.target else {
             continue;
         };
-        updates.push(RefUpdate {
-            name: branch.name().shorten().to_string(),
-            target: target.detach(),
-            namespace: RefNamespace::Branch,
-        });
-    }
-
-    for tag in repo
-        .references()
-        .map_err(git_err)?
-        .tags()
-        .map_err(git_err)?
-    {
-        let tag = tag.map_err(git_err)?;
-        let Some(target) = tag.try_id() else {
-            continue;
-        };
-        updates.push(RefUpdate {
-            name: tag.name().shorten().to_string(),
-            target: target.detach(),
-            namespace: RefNamespace::Tag,
-        });
-    }
-
-    // Pick up refs/notes/* (currently just refs/notes/heddle) so the
-    // change_id metadata travels alongside branches/tags on every push.
-    for note_ref in repo
-        .references()
-        .map_err(git_err)?
-        .prefixed("refs/notes/")
-        .map_err(git_err)?
-    {
-        let note_ref = note_ref.map_err(git_err)?;
-        let Some(target) = note_ref.try_id() else {
-            continue;
-        };
-        // shorten() on refs/notes/<n> returns "<n>" (the path beneath the
-        // notes/ prefix). We want to round-trip "<n>", not "notes/<n>",
-        // since apply_ref_updates rebuilds the full name.
-        let full = note_ref.name().as_bstr().to_string();
-        let short = full
-            .strip_prefix("refs/notes/")
-            .unwrap_or(&full)
-            .to_string();
-        updates.push(RefUpdate {
-            name: short,
-            target: target.detach(),
-            namespace: RefNamespace::Note,
-        });
+        if let Some(name) = reference.name.strip_prefix("refs/heads/") {
+            updates.push(RefUpdate {
+                name: name.to_string(),
+                target,
+                namespace: RefNamespace::Branch,
+            });
+        } else if let Some(name) = reference.name.strip_prefix("refs/tags/") {
+            updates.push(RefUpdate {
+                name: name.to_string(),
+                target,
+                namespace: RefNamespace::Tag,
+            });
+        } else if let Some(name) = reference.name.strip_prefix("refs/notes/") {
+            updates.push(RefUpdate {
+                name: name.to_string(),
+                target,
+                namespace: RefNamespace::Note,
+            });
+        }
     }
 
     Ok(updates)
@@ -2646,7 +2660,7 @@ pub(crate) struct ExportedCommitCounts {
 /// rest as `already`. Routing both the total and the newly count through
 /// this single walk guarantees they can never diverge.
 pub(crate) fn count_exported_commits(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     newly_minted: &HashSet<ObjectId>,
 ) -> GitResult<ExportedCommitCounts> {
     let tips: Vec<ObjectId> = collect_ref_updates(repo)?
@@ -2662,33 +2676,33 @@ pub(crate) fn count_exported_commits(
         if !seen.insert(oid) {
             continue;
         }
-        let object = repo.find_object(oid).map_err(git_err)?;
-        match object.kind {
-            gix::objs::Kind::Commit => {
+        let object = repo.read_object(&oid).map_err(git_err)?;
+        match object.object_type {
+            GitObjectType::Commit => {
                 counts.total += 1;
                 if newly_minted.contains(&oid) {
                     counts.newly += 1;
                 }
-                let commit = repo.find_commit(oid).map_err(git_err)?;
-                for parent in commit.parent_ids() {
-                    stack.push(parent.detach());
+                let commit = repo.read_commit(&oid).map_err(git_err)?;
+                for parent in commit.parents {
+                    stack.push(parent);
                 }
             }
             // An annotated tag dereferences to its target (commit, or a
             // blob/tree for the rare blob/tree-pointing tag). Follow it;
             // only a Commit at the end increments the count.
-            gix::objs::Kind::Tag => {
-                let tag = repo.find_tag(oid).map_err(git_err)?;
-                stack.push(tag.target_id().map_err(git_err)?.detach());
+            GitObjectType::Tag => {
+                let tag = repo.read_tag(&oid).map_err(git_err)?;
+                stack.push(tag.object);
             }
-            gix::objs::Kind::Tree | gix::objs::Kind::Blob => {}
+            GitObjectType::Tree | GitObjectType::Blob => {}
         }
     }
     Ok(counts)
 }
 
 fn collect_ref_updates_for_fetch(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     scope: GitFetchScope,
 ) -> GitResult<Vec<RefUpdate>> {
     let updates = collect_ref_updates(repo)?;
@@ -2709,13 +2723,14 @@ fn full_ref_name(update: &RefUpdate) -> String {
     }
 }
 
+#[cfg(test)]
 pub(crate) fn ensure_commit_update_fast_forward(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     name: &str,
     old: ObjectId,
     new: ObjectId,
 ) -> GitResult<()> {
-    if old == new || old == repo.object_hash().null() {
+    if old == new || old == ObjectId::null(repo.object_format()) {
         return Ok(());
     }
     match commit_is_descendant_of(repo, new, old) {
@@ -2732,7 +2747,7 @@ pub(crate) fn ensure_commit_update_fast_forward(
 }
 
 fn commit_is_descendant_of(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     descendant: ObjectId,
     ancestor: ObjectId,
 ) -> GitResult<bool> {
@@ -2745,9 +2760,9 @@ fn commit_is_descendant_of(
         if !seen.insert(oid) {
             continue;
         }
-        let commit = repo.find_commit(oid).map_err(git_err)?;
-        for parent in commit.parent_ids() {
-            stack.push(parent.detach());
+        let commit = repo.read_commit(&oid).map_err(git_err)?;
+        for parent in commit.parents {
+            stack.push(parent);
         }
     }
     Ok(false)
@@ -2772,7 +2787,7 @@ const HEDDLE_EXPORTED_REFS_FILE: &str = "heddle-exported-refs";
 /// only difference being WHERE the record is stored (heddle#316 r11).
 const HEDDLE_NETWORK_EXPORTED_REFS_DIR: &str = "git-network-exported-refs";
 
-fn exported_refs_manifest_path(target_repo: &gix::Repository) -> PathBuf {
+fn exported_refs_manifest_path(target_repo: &SleyRepository) -> PathBuf {
     target_repo.git_dir().join(HEDDLE_EXPORTED_REFS_FILE)
 }
 
@@ -2780,9 +2795,8 @@ fn exported_refs_manifest_path(target_repo: &gix::Repository) -> PathBuf {
 /// Keyed by a hash of the URL string so an arbitrarily long / non-ASCII URL maps
 /// to a fixed-length, filesystem-safe filename. Stored under heddle's own dir
 /// (the remote is not local, so there is no destination git dir to host it).
-fn network_exported_refs_path(heddle_dir: &Path, url: &gix::Url) -> PathBuf {
-    let key = ContentHash::compute_typed("git-network-exported-refs", url.to_string().as_bytes())
-        .to_hex();
+fn network_exported_refs_path(heddle_dir: &Path, url: &str) -> PathBuf {
+    let key = ContentHash::compute_typed("git-network-exported-refs", url.as_bytes()).to_hex();
     heddle_dir
         .join(HEDDLE_NETWORK_EXPORTED_REFS_DIR)
         .join(format!("{key}.refs"))
@@ -2818,7 +2832,7 @@ fn read_exported_refs_at(path: &Path) -> GitResult<HashMap<String, ObjectId>> {
                 let tip = parts
                     .next()
                     .and_then(|token| token.parse::<ObjectId>().ok())
-                    .unwrap_or_else(|| ObjectId::null(ObjectHashKind::Sha1));
+                    .unwrap_or_else(|| ObjectId::null(ObjectFormat::Sha1));
                 map.insert(name.to_string(), tip);
             }
             Ok(map)
@@ -2854,7 +2868,7 @@ fn write_exported_refs_at(path: &Path, refs: &HashMap<String, ObjectId>) -> GitR
 /// Heddle's exported-refs record for `target_repo` (full ref name → last-published
 /// tip OID), the local-path destination record. See [`read_exported_refs_at`].
 pub(crate) fn read_exported_refs(
-    target_repo: &gix::Repository,
+    target_repo: &SleyRepository,
 ) -> GitResult<HashMap<String, ObjectId>> {
     read_exported_refs_at(&exported_refs_manifest_path(target_repo))
 }
@@ -2862,7 +2876,7 @@ pub(crate) fn read_exported_refs(
 /// Persist the local-path destination's exported-refs record. See
 /// [`write_exported_refs_at`].
 pub(crate) fn write_exported_refs(
-    target_repo: &gix::Repository,
+    target_repo: &SleyRepository,
     refs: &HashMap<String, ObjectId>,
 ) -> GitResult<()> {
     write_exported_refs_at(&exported_refs_manifest_path(target_repo), refs)
@@ -2882,7 +2896,7 @@ pub(crate) fn write_exported_refs(
 const HEDDLE_MIRROR_MANAGED_REFS_FILE: &str = "heddle-mirror-managed-refs";
 
 /// On-disk path of the mirror's managed-refs record.
-fn mirror_managed_refs_path(mirror_repo: &gix::Repository) -> PathBuf {
+fn mirror_managed_refs_path(mirror_repo: &SleyRepository) -> PathBuf {
     mirror_repo.git_dir().join(HEDDLE_MIRROR_MANAGED_REFS_FILE)
 }
 
@@ -2891,7 +2905,7 @@ fn mirror_managed_refs_path(mirror_repo: &gix::Repository) -> PathBuf {
 /// mirror ref set so pre-existing heddle refs aren't all misread as foreign)
 /// from a record that exists but is empty (everything was legitimately dropped —
 /// do NOT re-seed).
-pub(crate) fn mirror_managed_refs_recorded(mirror_repo: &gix::Repository) -> bool {
+pub(crate) fn mirror_managed_refs_recorded(mirror_repo: &SleyRepository) -> bool {
     mirror_managed_refs_path(mirror_repo).exists()
 }
 
@@ -2899,7 +2913,7 @@ pub(crate) fn mirror_managed_refs_recorded(mirror_repo: &gix::Repository) -> boo
 /// tip OID). `Ok(empty)` when the record is absent — callers seed a first run from
 /// the current mirror ref set; see [`mirror_managed_refs_recorded`].
 pub(crate) fn read_mirror_managed_refs(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
 ) -> GitResult<HashMap<String, ObjectId>> {
     read_exported_refs_at(&mirror_managed_refs_path(mirror_repo))
 }
@@ -2907,7 +2921,7 @@ pub(crate) fn read_mirror_managed_refs(
 /// Persist the mirror's managed-refs record. Atomic temp+rename via
 /// [`write_exported_refs_at`].
 pub(crate) fn write_mirror_managed_refs(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
     refs: &HashMap<String, ObjectId>,
 ) -> GitResult<()> {
     write_exported_refs_at(&mirror_managed_refs_path(mirror_repo), refs)
@@ -2926,7 +2940,7 @@ pub(crate) fn write_mirror_managed_refs(
 /// run is correct. A record that EXISTS but is empty (everything was legitimately
 /// dropped) is NOT re-seeded — only a truly-absent record triggers the seed.
 pub(crate) fn read_or_seed_mirror_managed_refs(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
 ) -> GitResult<HashMap<String, ObjectId>> {
     if mirror_managed_refs_recorded(mirror_repo) {
         read_mirror_managed_refs(mirror_repo)
@@ -2948,7 +2962,7 @@ pub(crate) fn read_or_seed_mirror_managed_refs(
 /// The FETCH path keeps using [`collect_ref_updates`]/[`collect_ref_updates_for_fetch`]
 /// (it must see every ref); only the export/push frontier is managed-filtered.
 pub(crate) fn collect_managed_ref_updates(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     record: &HashMap<String, ObjectId>,
 ) -> GitResult<Vec<RefUpdate>> {
     Ok(collect_ref_updates(repo)?
@@ -3003,7 +3017,7 @@ enum RefMove {
 /// but heddle never published it, so it is [`RefMove::Diverged`] and must not be
 /// force-overwritten (heddle#316 r12).
 fn classify_ref_move(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     old: Option<ObjectId>,
     new: ObjectId,
     recorded_tip: Option<ObjectId>,
@@ -3011,7 +3025,7 @@ fn classify_ref_move(
     let Some(old) = old else {
         return Ok(RefMove::Create);
     };
-    if old == repo.object_hash().null() {
+    if old == ObjectId::null(repo.object_format()) {
         return Ok(RefMove::Create);
     }
     if old == new {
@@ -3032,7 +3046,7 @@ fn classify_ref_move(
     // published it (the embargo purge drops the ChangeId→OID mapping, never the
     // object); if `old` is NOT resolvable here we cannot prove a rewind anyway.
     if recorded_tip == Some(old)
-        && repo.find_commit(old).is_ok()
+        && repo.read_commit(&old).is_ok()
         && commit_is_descendant_of(repo, old, new)?
     {
         return Ok(RefMove::Rewind);
@@ -3100,19 +3114,18 @@ fn classify_tag_move(
     }
 }
 
-/// A served ref a push destination must write: its full name, the destination's
-/// current `old` tip (for the receive-pack command; `None`/absent = a creation),
-/// and the served `new` tip.
+/// A served ref a push destination must write: its full name, the served `new`
+/// tip, and whether the receive-pack command must be forced.
 #[derive(Debug)]
 pub(crate) struct PlannedRefWrite {
     pub(crate) full_name: String,
     pub(crate) old: Option<ObjectId>,
     pub(crate) new: ObjectId,
+    pub(crate) force: bool,
 }
 
 /// A previously-exported ref the served mirror no longer carries: it must be
-/// DELETED at the destination. Carries the destination's current `old` tip for
-/// the receive-pack delete command (`<old> <zero> <ref>`).
+/// deleted at the destination.
 #[derive(Debug)]
 pub(crate) struct PlannedRefDelete {
     pub(crate) full_name: String,
@@ -3231,7 +3244,7 @@ fn creatable_ref_names(
 /// * `force` — the user's explicit `--force`: additionally forces a true fork
 ///   AND authorizes retracting an out-of-band destination tip.
 pub(crate) fn plan_destination_reconcile(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
     served_frontier: &[RefUpdate],
     creatable_names: Option<&HashSet<String>>,
     old_at_destination: &HashMap<String, ObjectId>,
@@ -3288,13 +3301,23 @@ pub(crate) fn plan_destination_reconcile(
             // an annotated-tag-object OID, not a commit) with the SAME ownership
             // gate baked into [`classify_tag_move`]. An out-of-band destination tip
             // heddle never recorded is spared at EVERY namespace unless `--force`.
-            let verdict =
-                match update.namespace {
-                    RefNamespace::Branch | RefNamespace::Note => verdict_from_move(
-                        classify_ref_move(mirror_repo, old, update.target, recorded)?,
-                    ),
-                    RefNamespace::Tag => classify_tag_move(old, update.target, recorded),
-                };
+            let (verdict, force_write) = match update.namespace {
+                RefNamespace::Branch | RefNamespace::Note => {
+                    let movement = classify_ref_move(mirror_repo, old, update.target, recorded)?;
+                    (
+                        verdict_from_move(movement),
+                        matches!(movement, RefMove::Rewind),
+                    )
+                }
+                RefNamespace::Tag => {
+                    let verdict = classify_tag_move(old, update.target, recorded);
+                    (
+                        verdict,
+                        old.is_some_and(|old| old != update.target)
+                            && matches!(verdict, WriteVerdict::Write),
+                    )
+                }
+            };
             let proceed = match verdict {
                 WriteVerdict::Skip => false,
                 WriteVerdict::Write => true,
@@ -3304,7 +3327,7 @@ pub(crate) fn plan_destination_reconcile(
                     } else {
                         return Err(GitBridgeError::NonFastForwardRef {
                             name: full.clone(),
-                            old: old.unwrap_or_else(|| mirror_repo.object_hash().null()),
+                            old: old.unwrap_or_else(|| ObjectId::null(mirror_repo.object_format())),
                             new: update.target,
                         });
                     }
@@ -3315,6 +3338,7 @@ pub(crate) fn plan_destination_reconcile(
                     full_name: full.clone(),
                     old,
                     new: update.target,
+                    force: force_write || matches!(verdict, WriteVerdict::RequireForce),
                 });
             }
             // CLAIM ownership in the record ONLY for a ref heddle actually writes
@@ -3369,7 +3393,7 @@ pub(crate) fn plan_destination_reconcile(
 /// The destination's current ref tips (full name → oid) across the namespaces
 /// heddle manages (heads, tags, notes) — the `old_at_destination` input to
 /// [`plan_destination_reconcile`] for a local-path destination.
-fn read_destination_ref_map(repo: &gix::Repository) -> GitResult<HashMap<String, ObjectId>> {
+fn read_destination_ref_map(repo: &SleyRepository) -> GitResult<HashMap<String, ObjectId>> {
     Ok(collect_ref_updates(repo)?
         .iter()
         .map(|update| (full_ref_name(update), update.target))
@@ -3377,7 +3401,7 @@ fn read_destination_ref_map(repo: &gix::Repository) -> GitResult<HashMap<String,
 }
 
 pub(crate) fn apply_ref_updates(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     updates: &[RefUpdate],
     log_message: &str,
 ) -> GitResult<()> {
@@ -3387,7 +3411,7 @@ pub(crate) fn apply_ref_updates(
             repo,
             &full_name,
             update.target,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             log_message,
         )?;
     }
@@ -3395,7 +3419,7 @@ pub(crate) fn apply_ref_updates(
 }
 
 fn apply_remote_tracking_ref_updates(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     remote_name: &str,
     updates: &[RefUpdate],
     log_message: &str,
@@ -3409,7 +3433,7 @@ fn apply_remote_tracking_ref_updates(
             repo,
             &format!("refs/remotes/{remote_name}/{}", update.name),
             update.target,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             log_message,
         )?;
     }
@@ -3422,9 +3446,9 @@ fn apply_remote_tracking_ref_updates(
 pub fn copy_local_repo_to_bare(source_path: &Path, dest: &Path) -> GitResult<()> {
     fs::create_dir_all(dest)?;
     let source = open_repo(source_path)?;
-    let target = match open_repo(dest) {
+    let target = match SleyRepository::open(dest) {
         Ok(repo) => repo,
-        Err(_) => gix::init_bare(dest).map_err(git_err)?,
+        Err(_) => SleyRepository::init_bare(dest).map_err(git_err)?,
     };
     let updates = collect_ref_updates(&source)?;
     copy_reachable_objects(&source, &target, updates.iter().map(|update| update.target))?;
@@ -3447,16 +3471,9 @@ pub fn copy_local_repo_to_bare(source_path: &Path, dest: &Path) -> GitResult<()>
         .map(|update| update.name.as_str())
         .collect();
     let source_head_branch = source
-        .head_name()
+        .head()
         .ok()
-        .flatten()
-        .and_then(|full_name| {
-            full_name
-                .as_bstr()
-                .to_str()
-                .ok()
-                .and_then(|s| s.strip_prefix("refs/heads/").map(str::to_owned))
-        })
+        .and_then(|head| head.branch_name().map(str::to_owned))
         .filter(|branch| copied_branches.contains(branch.as_str()));
     if let Some(branch) = source_head_branch {
         fs::write(dest.join("HEAD"), format!("ref: refs/heads/{branch}\n"))?;
@@ -3475,8 +3492,9 @@ pub fn copy_local_repo_to_bare(source_path: &Path, dest: &Path) -> GitResult<()>
 }
 
 /// Clone a remote git URL into `dest` as a bare repository, fetching all
-/// branches and tags. Mirrors the gix recipe used by `fetch_network_remote`
-/// but starts from an empty `init_bare` rather than an existing repo.
+/// branches and tags. Mirrors the sley remote fetch path used by
+/// `fetch_network_remote` but starts from an empty `init_bare` rather than an
+/// existing repo.
 ///
 /// Used by `bridge import --path <URL>` (Phase F): we clone into a
 /// scratch directory under the heddle repo's `.heddle/tmp/` and feed the
@@ -3492,24 +3510,20 @@ pub fn copy_local_repo_to_bare(source_path: &Path, dest: &Path) -> GitResult<()>
 ///   intentionally Git-compatible but not Git-binary-dependent, and the
 ///   native transport path does not yet expose partial-clone filtering.
 pub fn clone_url_to_bare(
-    url: &gix::Url,
+    url: &str,
     dest: &Path,
     depth: Option<u32>,
     filter: Option<&str>,
 ) -> GitResult<()> {
-    // gix 0.80's high-level fetch builder (`Connection::prepare_fetch` →
-    // `Prepare`) does not expose the v2 partial-clone `filter`
-    // capability. Older code delegated that case to `git clone`, but
-    // public Git-overlay workflows must run on machines with no Git
-    // executable installed. Keep depth-only clones native and reject
-    // filtered clones until we have a native implementation.
+    // Public Git-overlay workflows must run on machines with no Git executable
+    // installed. Keep depth-only clones native and reject filtered clones until
+    // the importer can tolerate missing objects.
     if let Some(spec) = filter {
         return Err(GitBridgeError::Git(format!(
             "partial Git clone filter `{spec}` is not supported in Heddle's native no-git runtime yet; retry without --filter/--lazy so Heddle can import a complete object graph"
         )));
     }
-    if url.scheme == gix::url::Scheme::File {
-        let source_path = local_path_from_url(url)?;
+    if let Some(source_path) = local_path_from_url(url)? {
         if depth.is_some() {
             return Err(GitBridgeError::Git(
                 "shallow file:// Git clones are not supported in Heddle's native no-git runtime yet; retry without --depth so Heddle can copy the local Git object graph without spawning Git transport helpers"
@@ -3519,8 +3533,8 @@ pub fn clone_url_to_bare(
         return copy_local_repo_to_bare(&source_path, dest);
     }
     let default_branch =
-        clone_url_to_bare_via_gix(url, dest, depth)?.or_else(|| default_branch_from_file_url(url));
-    // gix's `init_bare` writes `.git/HEAD = ref: refs/heads/<init.defaultBranch>`
+        clone_url_to_bare_via_sley(url, dest, depth)?.or_else(|| default_branch_from_file_url(url));
+    // `init_bare` writes `.git/HEAD = ref: refs/heads/<init.defaultBranch>`
     // (typically "main" or "master") regardless of what the remote
     // advertises, and the fetch above doesn't touch HEAD. If we leave
     // that in place, downstream `select_clone_thread` and
@@ -3537,8 +3551,8 @@ pub fn clone_url_to_bare(
     Ok(())
 }
 
-fn default_branch_from_file_url(url: &gix::Url) -> Option<String> {
-    let source_path = local_path_from_url(url).ok()?;
+fn default_branch_from_file_url(url: &str) -> Option<String> {
+    let source_path = local_path_from_url(url).ok().flatten()?;
     let head_path = if source_path.join("HEAD").is_file() {
         source_path.join("HEAD")
     } else {
@@ -3551,284 +3565,107 @@ fn default_branch_from_file_url(url: &gix::Url) -> Option<String> {
 
 fn bare_branch_exists(repo_path: &Path, branch: &str) -> GitResult<bool> {
     let repo = open_repo(repo_path)?;
-    Ok(repo.find_reference(&format!("refs/heads/{branch}")).is_ok())
+    Ok(repo
+        .find_reference(&format!("refs/heads/{branch}"))
+        .map_err(git_err)?
+        .is_some())
 }
 
-fn clone_url_to_bare_via_gix(
-    url: &gix::Url,
+fn clone_url_to_bare_via_sley(
+    url: &str,
     dest: &Path,
     depth: Option<u32>,
 ) -> GitResult<Option<String>> {
     fs::create_dir_all(dest)?;
-    let repo = gix::init_bare(dest).map_err(git_err)?;
-    let mut remote = repo.remote_at(url.clone()).map_err(git_err)?;
-    let refspecs = heddle_mirror_fetch_refspecs()?;
-    remote
-        .replace_refspecs(
-            refspecs.iter().map(String::as_str),
-            gix::remote::Direction::Fetch,
+    let repo = SleyRepository::init_bare(dest).map_err(git_err)?;
+    let mut credentials = NoCredentials;
+    let mut progress = SilentProgress;
+    let outcome = repo
+        .fetch(
+            url,
+            &heddle_mirror_fetch_refspecs()?,
+            FetchOptions {
+                quiet: true,
+                auto_follow_tags: true,
+                fetch_all_tags: true,
+                prune: false,
+                dry_run: false,
+                append: false,
+                write_fetch_head: true,
+                tag_option_explicit: true,
+                prune_option_explicit: true,
+                depth,
+                merge_src: None,
+                filter: None,
+                cloning: true,
+                update_shallow: false,
+                deepen_relative: false,
+                deepen_since: None,
+                deepen_not: Vec::new(),
+            },
+            &mut credentials,
+            &mut progress,
         )
-        .map_err(git_err)?;
-    remote = remote.with_fetch_tags(gix::remote::fetch::Tags::All);
-    let mut connection = remote
-        .connect(gix::remote::Direction::Fetch)
-        .map_err(git_err)?;
-    // Suppress interactive credential prompts in CI/agent contexts.
-    // The closure never produces an `Err`; the `result_large_err` lint
-    // is fired by gix's 192-byte protocol error type we never return.
-    #[allow(clippy::result_large_err)]
-    fn no_creds(
-        _action: gix::credentials::helper::Action,
-    ) -> Result<Option<gix::credentials::protocol::Outcome>, gix::credentials::protocol::Error>
-    {
-        Ok(None)
-    }
-    connection.set_credentials(no_creds);
-    let mut prepare = connection
-        .prepare_fetch(
-            gix::progress::Discard,
-            gix::remote::ref_map::Options::default(),
-        )
-        .map_err(git_err)?;
-    if let Some(d) = depth.and_then(NonZeroU32::new) {
-        prepare = prepare.with_shallow(gix::remote::fetch::Shallow::DepthAtRemote(d));
-    }
-    let outcome = prepare
-        .with_reflog_message(gix::remote::fetch::RefLogMessage::Override {
-            message: format!("heddle: clone from {url}").into(),
-        })
-        .receive(gix::progress::Discard, &AtomicBool::new(false))
         .map_err(|err| GitBridgeError::Git(format!("clone failed for {url}: {err}")))?;
-    Ok(default_branch_from_ref_map(&outcome.ref_map))
-}
-
-fn default_branch_from_ref_map(ref_map: &gix::remote::fetch::RefMap) -> Option<String> {
-    for remote_ref in &ref_map.remote_refs {
-        let target = match remote_ref {
-            gix_protocol::handshake::Ref::Symbolic {
-                full_ref_name,
-                target,
-                ..
-            } if full_ref_name.as_bstr() == "HEAD" => target,
-            gix_protocol::handshake::Ref::Unborn {
-                full_ref_name,
-                target,
-            } if full_ref_name.as_bstr() == "HEAD" => target,
-            _ => continue,
-        };
-        let branch = target.as_bstr().strip_prefix(b"refs/heads/")?;
-        if !branch.is_empty() {
-            return Some(branch.to_str_lossy().into_owned());
-        }
-    }
-    None
+    Ok(outcome
+        .head_symref
+        .and_then(|target| target.strip_prefix("refs/heads/").map(str::to_string)))
 }
 
 pub(crate) fn copy_reachable_objects(
-    source: &gix::Repository,
-    target: &gix::Repository,
+    source: &SleyRepository,
+    target: &SleyRepository,
     roots: impl IntoIterator<Item = ObjectId>,
 ) -> GitResult<()> {
-    if source.object_hash() != target.object_hash() {
-        return Err(GitBridgeError::Git(format!(
-            "object hash mismatch: {:?} vs {:?}",
-            source.object_hash(),
-            target.object_hash()
-        )));
-    }
-
-    let entries = collect_reachable_entries(source, roots)?;
-    install_objects_pack(target, entries)
-}
-
-/// Walk every object reachable from `roots` in `source`, reading each object
-/// once and serializing it into a base pack entry.
-pub(crate) fn collect_reachable_entries(
-    source: &gix::Repository,
-    roots: impl IntoIterator<Item = ObjectId>,
-) -> GitResult<Vec<gix_pack::data::output::Entry>> {
-    let mut seen = HashSet::new();
-    collect_reachable_entries_excluding(source, roots, &mut seen)
-}
-
-pub(crate) fn collect_reachable_entries_excluding(
-    source: &gix::Repository,
-    roots: impl IntoIterator<Item = ObjectId>,
-    seen: &mut HashSet<ObjectId>,
-) -> GitResult<Vec<gix_pack::data::output::Entry>> {
-    let object_hash = source.object_hash();
-    let mut stack: Vec<ObjectId> = roots.into_iter().collect();
-    let mut entries = Vec::new();
-
-    while let Some(oid) = stack.pop() {
-        if !seen.insert(oid) {
-            continue;
-        }
-
-        let object = source.find_object(oid).map_err(git_err)?;
-        let kind = object.kind;
-        let data = gix::objs::Data {
-            kind,
-            data: &object.data,
-            object_hash,
-        };
-        let count = gix_pack::data::output::Count::from_data(oid, None);
-        let entry = gix_pack::data::output::Entry::from_data(&count, &data).map_err(git_err)?;
-        entries.push(entry);
-
-        match kind {
-            gix::objs::Kind::Commit => {
-                let commit = object.into_commit();
-                stack.push(commit.tree_id().map_err(git_err)?.detach());
-                for parent in commit.parent_ids() {
-                    stack.push(parent.detach());
-                }
-            }
-            gix::objs::Kind::Tree => {
-                let tree = object.into_tree();
-                for entry in tree.iter() {
-                    let entry = entry.map_err(git_err)?;
-                    // Gitlink (mode 160000) entries point at a commit
-                    // in the *submodule's* repository, not this one —
-                    // by Git's design, that commit is never stored
-                    // locally. Pushing its OID onto the walk would
-                    // make the next `find_object` fail with
-                    // "object … could not be found", which is what
-                    // happens on a normal clone of any repo with
-                    // submodules (e.g. git/git's
-                    // sha1collisiondetection). The bridge import
-                    // path (`import_gitlink`) records the foreign OID
-                    // as a `heddle-submodule:` blob, which is what
-                    // round-trips on export — so skipping it here is
-                    // safe: we still emit the parent tree, just
-                    // without trying to resolve a foreign-repo
-                    // commit we cannot read.
-                    if entry.mode().kind() == gix::object::tree::EntryKind::Commit {
-                        continue;
-                    }
-                    stack.push(entry.object_id());
-                }
-            }
-            gix::objs::Kind::Tag => {
-                let tag = object.into_tag();
-                stack.push(tag.target_id().map_err(git_err)?.detach());
-            }
-            gix::objs::Kind::Blob => {}
-        }
-    }
-
-    Ok(entries)
-}
-
-/// Install reachable objects into `target` as one packfile instead of N loose
-/// object writes. Packed objects keep the same OIDs and are read transparently
-/// by Git/gix, so mirror fidelity is unchanged.
-pub(crate) fn install_objects_pack(
-    target: &gix::Repository,
-    entries: Vec<gix_pack::data::output::Entry>,
-) -> GitResult<()> {
-    if entries.is_empty() {
-        return Ok(());
-    }
-
-    let object_hash = target.object_hash();
-    let num_entries: u32 = entries.len().try_into().map_err(|_| {
-        GitBridgeError::Git(format!(
-            "mirror pack has too many objects to encode: {}",
-            entries.len()
-        ))
-    })?;
-
-    let mut pack = Vec::new();
-    {
-        let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
-        let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
-            input,
-            &mut pack,
-            num_entries,
-            gix_pack::data::Version::V2,
-            object_hash,
-        );
-        for result in writer.by_ref() {
-            result.map_err(git_err)?;
-        }
-    }
-
-    let pack_dir = target.git_dir().join("objects").join("pack");
-    fs::create_dir_all(&pack_dir)?;
-    let outcome = gix_pack::Bundle::write_to_directory(
-        &mut std::io::Cursor::new(pack.as_slice()),
-        Some(&pack_dir),
-        &mut gix::progress::Discard,
-        &AtomicBool::new(false),
-        None::<gix::objs::find::Never>,
-        gix_pack::bundle::write::Options {
-            object_hash,
-            ..Default::default()
-        },
-    )
-    .map_err(git_err)?;
-
-    if let Some(keep) = outcome.keep_path {
-        let _ = fs::remove_file(keep);
-    }
-
-    Ok(())
+    let roots = roots.into_iter().collect::<Vec<_>>();
+    target.copy_reachable_from(source, &roots).map_err(git_err)
 }
 
 fn fetch_network_remote(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
     remote_name: &str,
-    url: &gix::Url,
+    url: &str,
     scope: GitFetchScope,
 ) -> GitResult<()> {
-    let mut remote = mirror_repo.remote_at(url.clone()).map_err(git_err)?;
-    let refspecs = heddle_mirror_fetch_refspecs()?;
-    remote
-        .replace_refspecs(
-            refspecs.iter().map(String::as_str),
-            gix::remote::Direction::Fetch,
+    let mut credentials = NoCredentials;
+    let mut progress = SilentProgress;
+    mirror_repo
+        .fetch(
+            url,
+            &heddle_mirror_fetch_refspecs()?,
+            FetchOptions {
+                quiet: true,
+                auto_follow_tags: matches!(scope, GitFetchScope::AllRefs),
+                fetch_all_tags: matches!(scope, GitFetchScope::AllRefs),
+                prune: false,
+                dry_run: false,
+                append: false,
+                write_fetch_head: true,
+                tag_option_explicit: true,
+                prune_option_explicit: true,
+                depth: None,
+                merge_src: None,
+                filter: None,
+                cloning: false,
+                update_shallow: false,
+                deepen_relative: false,
+                deepen_since: None,
+                deepen_not: Vec::new(),
+            },
+            &mut credentials,
+            &mut progress,
         )
-        .map_err(git_err)?;
-    remote = remote.with_fetch_tags(match scope {
-        GitFetchScope::BranchesAndNotes => gix::remote::fetch::Tags::None,
-        GitFetchScope::AllRefs => gix::remote::fetch::Tags::All,
-    });
-
-    let mut connection = remote
-        .connect(gix::remote::Direction::Fetch)
-        .map_err(git_err)?;
-    // Suppress interactive credential prompts in CI/agent contexts.
-    // The closure never produces an `Err`; the `result_large_err` lint
-    // is fired by gix's 192-byte protocol error type we never return.
-    #[allow(clippy::result_large_err)]
-    fn no_creds(
-        _action: gix::credentials::helper::Action,
-    ) -> Result<Option<gix::credentials::protocol::Outcome>, gix::credentials::protocol::Error>
-    {
-        Ok(None)
-    }
-    connection.set_credentials(no_creds);
-    let progress = gix::progress::Discard;
-    let prepare = connection
-        .prepare_fetch(progress, gix::remote::ref_map::Options::default())
-        .map_err(git_err)?;
-    let progress = gix::progress::Discard;
-    prepare
-        .with_reflog_message(gix::remote::fetch::RefLogMessage::Override {
-            message: format!("heddle: fetch from {remote_name}").into(),
-        })
-        .receive(progress, &AtomicBool::new(false))
         .map_err(|err| GitBridgeError::Git(format!("failed to fetch from {url}: {err}")))?;
+    let _ = remote_name;
     Ok(())
 }
 
 /// Push the served frontier to a URL/network remote. Returns the sorted
 /// full names of the refs written on the wire (see [`planned_write_names`]).
 fn push_network_remote(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
     heddle_dir: &Path,
-    url: &gix::Url,
+    url: &str,
     scope: GitPushScope,
     current_branch: Option<&str>,
     force: bool,
@@ -3855,28 +3692,28 @@ fn push_network_remote(
         return Ok(Vec::new());
     }
 
-    let mut transport = gix_transport::client::blocking_io::connect::connect(
-        url.clone(),
-        gix_transport::client::blocking_io::connect::Options {
-            version: Protocol::V1,
-            ..Default::default()
-        },
-    )
-    .map_err(|err| GitBridgeError::Git(format!("failed to connect to {url}: {err}")))?;
-
-    let remote_refs = {
-        let mut handshake = transport
-            .handshake(Service::ReceivePack, &[])
-            .map_err(|err| {
-                GitBridgeError::Git(format!("receive-pack handshake failed for {url}: {err}"))
-            })?;
-        if !handshake.capabilities.contains("report-status") {
-            return Err(GitBridgeError::Git(format!(
-                "remote {url} does not support report-status; refusing to push without server acknowledgement"
-            )));
-        }
-        remote_refs_from_receive_pack_handshake(&mut handshake)?
-    };
+    let mut credentials = NoCredentials;
+    let records = mirror_repo
+        .ls_remote(
+            url,
+            LsRemoteFilter {
+                heads: false,
+                tags: false,
+                refs_only: true,
+            },
+            &|_| true,
+            &mut credentials,
+        )
+        .map_err(|err| GitBridgeError::Git(format!("failed to list refs from {url}: {err}")))?;
+    let remote_refs = records
+        .into_iter()
+        .filter(|record| {
+            record.name.starts_with("refs/heads/")
+                || record.name.starts_with("refs/tags/")
+                || record.name.starts_with("refs/notes/")
+        })
+        .map(|record| (record.name, record.oid))
+        .collect::<HashMap<_, _>>();
 
     // The SAME served-frontier plan the local-path destination runs: writes
     // (forcing embargo rewinds, rejecting forks), the retraction delete-set
@@ -3892,157 +3729,55 @@ fn push_network_remote(
         force,
     )?;
 
-    let null_oid = mirror_repo.object_hash().null();
-    let mut commands: Vec<(String, ObjectId, ObjectId)> = Vec::new();
-    for write in &plan.writes {
-        let old = write.old.unwrap_or(null_oid);
-        commands.push((write.full_name.clone(), old, write.new));
-    }
-    for delete in &plan.deletes {
-        // A wire delete is `<old> <zero> <ref>` — the retraction sibling of a
-        // write, sent to URL/network remotes too (heddle#316 r11).
-        commands.push((delete.full_name.clone(), delete.old, null_oid));
-    }
-
-    if commands.is_empty() {
+    if plan.writes.is_empty() && plan.deletes.is_empty() {
         // Nothing to move on the wire, but the record may still need to drop a
         // ref that was already absent at the remote.
         write_exported_refs_at(&manifest_path, &plan.new_manifest)?;
         return Ok(Vec::new());
     }
 
-    // Pack only the SURVIVORS' new objects — a delete carries no new object.
-    let pack = pack_reachable_objects(mirror_repo, plan.writes.iter().map(|write| write.new))?;
-    let mut request = transport
-        .request(
-            WriteMode::OneLfTerminatedLinePerWriteCall,
-            MessageKind::Flush,
-            false,
-        )
-        .map_err(git_err)?;
-    for (idx, (name, old, new_oid)) in commands.iter().enumerate() {
-        let mut line = format!("{old} {new_oid} {name}");
-        if idx == 0 {
-            line.push('\0');
-            line.push_str("report-status");
-        }
-        request.write_all(line.as_bytes()).map_err(git_err)?;
+    let mut commands = Vec::with_capacity(plan.writes.len() + plan.deletes.len());
+    let mut pack_objects = Vec::with_capacity(plan.writes.len());
+    let force_transport_checks = plan.writes.iter().any(|write| write.force);
+    for write in &plan.writes {
+        commands.push(PushCommand {
+            src: Some(write.new),
+            dst: write.full_name.clone(),
+            expected_old: write.old,
+            force: write.force,
+        });
+        pack_objects.push(write.new);
     }
-    request.write_message(MessageKind::Flush).map_err(git_err)?;
+    for delete in &plan.deletes {
+        commands.push(PushCommand {
+            src: None,
+            dst: delete.full_name.clone(),
+            expected_old: Some(delete.old),
+            force: false,
+        });
+    }
 
-    let (mut raw_writer, mut reader) = request.into_parts();
-    raw_writer.write_all(&pack).map_err(git_err)?;
-    raw_writer.flush().map_err(git_err)?;
-    drop(raw_writer);
-
-    read_receive_pack_status(&mut reader, &commands, url)?;
+    let mut credentials = NoCredentials;
+    let mut progress = SilentProgress;
+    mirror_repo
+        .push_actions(
+            url,
+            PushActionPlan {
+                commands,
+                pack_objects,
+                options: PushOptions {
+                    quiet: true,
+                    force: force || force_transport_checks,
+                },
+            },
+            &mut credentials,
+            &mut progress,
+        )
+        .map_err(|err| GitBridgeError::Git(format!("push failed for {url}: {err}")))?;
     // Only persist the record once the remote has acknowledged every command, so
     // a failed push never leaves a ref recorded as exported that did not land.
     write_exported_refs_at(&manifest_path, &plan.new_manifest)?;
     Ok(planned_write_names(&plan))
-}
-
-fn remote_refs_from_receive_pack_handshake(
-    handshake: &mut gix_transport::client::blocking_io::SetServiceResponse<'_>,
-) -> GitResult<HashMap<String, ObjectId>> {
-    let mut remote_refs = HashMap::new();
-    let Some(refs) = handshake.refs.as_mut() else {
-        return Ok(remote_refs);
-    };
-    let (parsed, _) =
-        gix_protocol::handshake::refs::from_v1_refs_received_as_part_of_handshake_and_capabilities(
-            refs,
-            handshake.capabilities.iter(),
-        )
-        .map_err(git_err)?;
-
-    for remote_ref in parsed {
-        let (name, target, _) = remote_ref.unpack();
-        let Some(target) = target else {
-            continue;
-        };
-        remote_refs.insert(name.to_string(), target.to_owned());
-    }
-    Ok(remote_refs)
-}
-
-fn pack_reachable_objects(
-    repo: &gix::Repository,
-    roots: impl IntoIterator<Item = ObjectId>,
-) -> GitResult<Vec<u8>> {
-    let entries = collect_reachable_entries(repo, roots)?;
-    let num_entries: u32 = entries.len().try_into().map_err(|_| {
-        GitBridgeError::Git(format!(
-            "push pack has too many objects to encode: {}",
-            entries.len()
-        ))
-    })?;
-
-    let mut pack = Vec::new();
-    let input = std::iter::once(Ok::<_, GitBridgeError>(entries));
-    let mut writer = gix_pack::data::output::bytes::FromEntriesIter::new(
-        input,
-        &mut pack,
-        num_entries,
-        gix_pack::data::Version::V2,
-        repo.object_hash(),
-    );
-    for result in writer.by_ref() {
-        result.map_err(git_err)?;
-    }
-    drop(writer);
-    Ok(pack)
-}
-
-fn read_receive_pack_status(
-    reader: &mut (dyn gix_transport::client::blocking_io::ExtendedBufRead<'_> + Unpin),
-    commands: &[(String, ObjectId, ObjectId)],
-    url: &gix::Url,
-) -> GitResult<()> {
-    let mut line = String::new();
-    let mut saw_unpack_ok = false;
-    let mut acknowledged = HashSet::new();
-
-    loop {
-        line.clear();
-        let read = reader.readline_str(&mut line).map_err(git_err)?;
-        if read == 0 {
-            break;
-        }
-        let status = line.trim_end_matches(['\r', '\n']);
-        if status == "unpack ok" {
-            saw_unpack_ok = true;
-            continue;
-        }
-        if let Some(name) = status.strip_prefix("ok ") {
-            acknowledged.insert(name.to_string());
-            continue;
-        }
-        if let Some(rest) = status.strip_prefix("ng ") {
-            return Err(GitBridgeError::Git(format!(
-                "push rejected by {url}: {rest}"
-            )));
-        }
-        if let Some(rest) = status.strip_prefix("unpack ") {
-            return Err(GitBridgeError::Git(format!(
-                "push pack rejected by {url}: {rest}"
-            )));
-        }
-    }
-
-    if !saw_unpack_ok {
-        return Err(GitBridgeError::Git(format!(
-            "push to {url} did not return an unpack acknowledgement"
-        )));
-    }
-    for (name, _, _) in commands {
-        if !acknowledged.contains(name) {
-            return Err(GitBridgeError::Git(format!(
-                "push to {url} did not acknowledge ref {name}"
-            )));
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -4185,7 +3920,7 @@ mod tests {
     #[test]
     fn fast_forward_guard_reports_exact_rewrite_before_after() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let repo = gix::init_bare(tmp.path()).expect("init bare repo");
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
         let root = test_commit(&repo, "root", &[]);
         let old = test_commit(&repo, "old", &[root]);
         let new = test_commit(&repo, "new", &[root]);
@@ -4202,7 +3937,7 @@ mod tests {
     #[test]
     fn fast_forward_guard_allows_descendant_update() {
         let tmp = tempfile::TempDir::new().unwrap();
-        let repo = gix::init_bare(tmp.path()).expect("init bare repo");
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
         let old = test_commit(&repo, "old", &[]);
         let new = test_commit(&repo, "new", &[old]);
 
@@ -4210,101 +3945,69 @@ mod tests {
             .expect("descendant update should be allowed");
     }
 
-    fn test_commit(
-        repo: &gix::Repository,
-        message: &str,
-        parents: &[gix::ObjectId],
-    ) -> gix::ObjectId {
-        let empty_tree_oid: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-            .parse()
-            .expect("parse empty tree oid");
-        let sig = gix::actor::Signature {
-            name: "Heddle Test".into(),
-            email: "heddle@test".into(),
-            time: gix::date::Time {
-                seconds: 0,
-                offset: 0,
-            },
+    fn test_commit(repo: &SleyRepository, message: &str, parents: &[ObjectId]) -> ObjectId {
+        let empty_tree_oid = ObjectId::empty_tree(repo.object_format());
+        let sig = Signature {
+            name: GitByteString::new(b"Heddle Test".to_vec()),
+            email: GitByteString::new(b"heddle@test".to_vec()),
+            time: GitTime::new(0, 0),
+            raw: b"Heddle Test <heddle@test> 0 +0000".to_vec(),
         };
-        let mut committer_buf = gix::date::parse::TimeBuf::default();
-        let mut author_buf = gix::date::parse::TimeBuf::default();
-        repo.new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            message,
-            empty_tree_oid,
-            parents.iter().copied(),
-        )
+        let commit = sley::CommitObject {
+            tree: empty_tree_oid,
+            parents: parents.to_vec(),
+            author: sig.to_ident_bytes(),
+            committer: sig.to_ident_bytes(),
+            encoding: None,
+            message: message.as_bytes().to_vec(),
+        };
+        repo.write_object(sley::plumbing::sley_object::EncodedObject::new(
+            GitObjectType::Commit,
+            commit.write(),
+        ))
         .expect("write test commit")
-        .id
+    }
+
+    fn seed_commit(repo: &SleyRepository, message: &str) -> ObjectId {
+        test_commit(repo, message, &[])
     }
 
     /// heddle#141 regression: when the URL-fetch path of
     /// `clone_url_to_bare` runs against a bare repo whose `HEAD`
     /// points at a branch that is *not* alphabetically first (and
-    /// crucially, not what gix's `init_bare` defaults to), the
+    /// crucially, not what sley's `init_bare` defaults to), the
     /// resulting dest bare must have `HEAD` pointing at the remote
-    /// default — not gix's init-time guess.
+    /// default — not sley's init-time guess.
     #[test]
-    fn clone_url_to_bare_via_gix_honours_remote_head_symref() {
+    fn clone_url_to_bare_via_sley_honours_remote_head_symref() {
         let tmp = tempfile::TempDir::new().unwrap();
         let source = tmp.path().join("source.git");
         let dest = tmp.path().join("dest.git");
 
         // Build a bare source with two branches under
         // deliberately-non-default names: `trunk` (will be the
-        // remote default — neither gix's `init.defaultBranch` nor
+        // remote default — neither sley's `init.defaultBranch` nor
         // the alphabetically-first imported ref would land here by
         // accident) and `abc-feature` (alphabetically first — what
         // the buggy fallback used to pick).
-        let src = gix::init_bare(&source).expect("init bare source");
-        // Empty tree (well-known OID) so we don't have to build a
-        // tree object explicitly.
-        let empty_tree_oid: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-            .parse()
-            .expect("parse empty tree oid");
-        // Use an explicit signature via `new_commit_as` rather than
-        // `Repository::commit`. The latter reads `user.name`/`user.email`
-        // from git config, which CI runners don't set — leading to
-        // `AuthorMissing` errors. The clone path under test doesn't care
-        // who authored these seed commits.
-        let sig = gix::actor::Signature {
-            name: "Heddle Test".into(),
-            email: "heddle@test".into(),
-            time: gix::date::Time {
-                seconds: 0,
-                offset: 0,
-            },
-        };
-        let mut committer_buf = gix::date::parse::TimeBuf::default();
-        let mut author_buf = gix::date::parse::TimeBuf::default();
-        let seed = src
-            .new_commit_as(
-                sig.to_ref(&mut committer_buf),
-                sig.to_ref(&mut author_buf),
-                "seed",
-                empty_tree_oid,
-                gix::commit::NO_PARENT_IDS,
-            )
-            .expect("seed commit")
-            .id;
+        let src = SleyRepository::init_bare(&source).expect("init bare source");
+        let seed = seed_commit(&src, "seed");
         for name in ["refs/heads/trunk", "refs/heads/abc-feature"] {
-            set_reference(&src, name, seed, PreviousValue::Any, "test: seed branch")
+            set_reference(&src, name, seed, RefPrecondition::Any, "test: seed branch")
                 .expect("set ref");
         }
         // Make sure HEAD on the source points at trunk so
         // `git ls-remote --symref` reports trunk.
         std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();
 
-        let url = gix::url::parse(format!("file://{}", source.display()).as_bytes().into())
-            .expect("parse file:// url");
+        let url = format!("file://{}", source.display());
         clone_url_to_bare(&url, &dest, None, None).expect("clone url to bare");
 
         let dest_head = std::fs::read_to_string(dest.join("HEAD")).expect("read dest HEAD");
         assert_eq!(
             dest_head.trim(),
             "ref: refs/heads/trunk",
-            "dest HEAD must mirror the remote's symref (trunk), not gix's \
+            "dest HEAD must mirror the remote's symref (trunk), not sley's \
              init-time default and not the alphabetically-first branch \
              (abc-feature) — see heddle#141"
         );

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1568,9 +1568,8 @@ impl<'a> GitBridge<'a> {
         // PRUNE: any intent-to-add entry whose path is no longer desired.
         let before_prune = index.entries.len();
         index.entries.retain(|entry| {
-            !(entry.is_intent_to_add()
-                && !captured_paths
-                    .contains(String::from_utf8_lossy(entry.path.as_bytes()).as_ref()))
+            !entry.is_intent_to_add()
+                || captured_paths.contains(String::from_utf8_lossy(entry.path.as_bytes()).as_ref())
         });
         let mut changed = index.entries.len() != before_prune;
 

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -4,13 +4,16 @@
 use objects::store::ObjectStore;
 use std::collections::HashSet;
 
-use gix::bstr::ByteSlice;
-use gix::refs::transaction::PreviousValue;
 use objects::{
     error::HeddleError,
     object::{ChangeId, ContentHash, FileMode, MarkerName, Principal, State, ThreadName},
 };
 use repo::{AudienceTier, Repository as HeddleRepository, visible};
+use sley::plumbing::sley_object::EncodedObject;
+use sley::{
+    CommitObject, EntryKind, GitObjectType, ObjectFormat, ObjectId, RefPrecondition,
+    Repository as SleyRepository, Signature,
+};
 
 use crate::bridge::{
     git_core::{
@@ -94,12 +97,12 @@ fn commit_is_byte_faithful(state: &State) -> bool {
 pub(crate) fn export_state(
     mapping: &mut SyncMapping,
     heddle_repo: &HeddleRepository,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     state_id: &ChangeId,
     identity: Option<&LocalGitIdentity>,
     message_override: Option<&str>,
     audience: &AudienceTier,
-) -> GitResult<Option<gix::hash::ObjectId>> {
+) -> GitResult<Option<ObjectId>> {
     let state = heddle_repo
         .store()
         .get_state(state_id)?
@@ -143,7 +146,7 @@ pub(crate) fn export_state(
         return Ok(Some(write_commit_object(repo, &content)?));
     }
 
-    // Native heddle commit: no original to preserve. Mint via `new_commit_as`
+    // Native heddle commit: no original to preserve. Mint a raw commit object
     // and inject the durable W2 footer (and the "No intent specified"
     // placeholder for an empty intent) — these ride ONLY native commits.
     let git_tree_oid = export_tree(heddle_repo, repo, &state.tree)?;
@@ -167,7 +170,7 @@ pub(crate) fn export_state(
             GitBridge::build_commit_message_with_footer(&state, hosted_url, /*omitted=*/ 0)
         }
     };
-    let parent_oids: Vec<gix::hash::ObjectId> = state
+    let parent_oids: Vec<ObjectId> = state
         .parents
         .iter()
         .map(|parent_id| {
@@ -187,38 +190,38 @@ pub(crate) fn export_state(
     } else {
         state_to_signature(&state)
     };
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let commit = repo
-        .new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            &message,
-            git_tree_oid,
-            parent_oids,
-        )
-        .map_err(git_err)?;
-    Ok(Some(commit.id))
+    let commit = CommitObject {
+        tree: git_tree_oid,
+        parents: parent_oids,
+        author: sig.to_ident_bytes(),
+        committer: sig.to_ident_bytes(),
+        encoding: None,
+        message: message.into_bytes(),
+    };
+    Ok(Some(
+        repo.write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+            .map_err(git_err)?,
+    ))
 }
 
 /// Export a Heddle tree to Git.
 pub fn export_tree(
     heddle_repo: &HeddleRepository,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     tree_hash: &ContentHash,
-) -> GitResult<gix::hash::ObjectId> {
+) -> GitResult<ObjectId> {
     let tree = heddle_repo
         .store()
         .get_tree(tree_hash)?
         .ok_or_else(|| HeddleError::NotFound(format!("tree {}", tree_hash)))?;
 
-    let empty_tree = gix::hash::ObjectId::empty_tree(repo.object_hash());
-    let mut editor = repo.edit_tree(empty_tree).map_err(git_err)?;
+    let empty_tree = ObjectId::empty_tree(repo.object_format());
+    let mut editor = repo.edit_tree(&empty_tree).map_err(git_err)?;
 
     for entry in tree.entries() {
         let (kind, id) = if entry.is_tree() {
             (
-                gix::object::tree::EntryKind::Tree,
+                EntryKind::Tree,
                 export_tree(heddle_repo, repo, &entry.hash)?,
             )
         } else {
@@ -240,14 +243,11 @@ pub fn export_tree(
                 // Stubs are text-only; ASCII safe across newline/BOM
                 // quirks and submodule-pointer detection.
                 let kind = match entry.mode {
-                    FileMode::Symlink => gix::object::tree::EntryKind::Link,
-                    FileMode::Executable => gix::object::tree::EntryKind::BlobExecutable,
-                    _ => gix::object::tree::EntryKind::Blob,
+                    FileMode::Symlink => EntryKind::Symlink,
+                    FileMode::Executable => EntryKind::BlobExecutable,
+                    _ => EntryKind::Blob,
                 };
-                let oid = repo
-                    .write_blob(stub_text.as_bytes())
-                    .map_err(git_err)?
-                    .detach();
+                let oid = repo.write_blob(stub_text.as_bytes()).map_err(git_err)?;
                 (kind, oid)
             } else {
                 let blob = heddle_repo
@@ -258,23 +258,23 @@ pub fn export_tree(
                 if entry.mode == FileMode::Normal
                     && let Some(oid) = submodule_oid_from_blob(blob.content())
                 {
-                    (gix::object::tree::EntryKind::Commit, oid)
+                    (EntryKind::Commit, oid)
                 } else {
                     let kind = match entry.mode {
-                        FileMode::Normal => gix::object::tree::EntryKind::Blob,
-                        FileMode::Executable => gix::object::tree::EntryKind::BlobExecutable,
-                        FileMode::Symlink => gix::object::tree::EntryKind::Link,
+                        FileMode::Normal => EntryKind::Blob,
+                        FileMode::Executable => EntryKind::BlobExecutable,
+                        FileMode::Symlink => EntryKind::Symlink,
                     };
-                    let oid = repo.write_blob(blob.content()).map_err(git_err)?.detach();
+                    let oid = repo.write_blob(blob.content()).map_err(git_err)?;
                     (kind, oid)
                 }
             }
         };
 
-        editor.upsert(&entry.name, kind, id).map_err(git_err)?;
+        editor.upsert(entry.name.as_str(), kind, id);
     }
 
-    Ok(editor.write().map_err(git_err)?.detach())
+    repo.write_tree(editor).map_err(git_err)
 }
 
 /// Export all Heddle states to Git commits.
@@ -394,7 +394,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     // mirror, so the notes-ref retraction below must consider all of them —
     // including the states the purge is about to drop AND any orphaned mapping a
     // deleted thread left behind, which no current-ref frontier reaches (heddle#316).
-    let pre_purge_targets: Vec<(ChangeId, gix::hash::ObjectId)> =
+    let pre_purge_targets: Vec<(ChangeId, ObjectId)> =
         bridge.mapping.iter().map(|(c, o)| (*c, *o)).collect();
 
     let purge_reachable: HashSet<ChangeId> = sorted_states
@@ -424,7 +424,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     // is a subset of the same walk that produces the total, never a
     // parallel tally over `list_states()` that could include an orphan
     // state reachable from no copied ref.
-    let mut newly_minted: HashSet<gix::hash::ObjectId> = HashSet::new();
+    let mut newly_minted: HashSet<ObjectId> = HashSet::new();
 
     for state_id in sorted_states {
         // Already mapped to a git object — the common case for git-imported
@@ -554,7 +554,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     // path above), make sure the note is present too. This covers two
     // cases: (a) the state was imported from a non-heddle git source and
     // never had a note, and (b) the note was deleted from the mirror.
-    let note_targets: Vec<(ChangeId, gix::hash::ObjectId)> =
+    let note_targets: Vec<(ChangeId, ObjectId)> =
         bridge.mapping.iter().map(|(c, o)| (*c, *o)).collect();
     for (change_id, git_oid) in note_targets {
         // Gate the backfill on the downward-closure served set, not the commit's
@@ -584,14 +584,14 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     // ancestor embargo stranded on a deleted thread's commit. Guard the
     // degenerate case where a still-served state maps to the same git OID by
     // keeping any OID a served target maps to.
-    let served_note_oids: HashSet<gix::hash::ObjectId> = pre_purge_targets
+    let served_note_oids: HashSet<ObjectId> = pre_purge_targets
         .iter()
         .copied()
         .chain(bridge.mapping.iter().map(|(c, o)| (*c, *o)))
         .filter(|(c, _)| note_served.contains(c))
         .map(|(_, oid)| oid)
         .collect();
-    let notes_to_retract: HashSet<gix::hash::ObjectId> = pre_purge_targets
+    let notes_to_retract: HashSet<ObjectId> = pre_purge_targets
         .iter()
         .filter(|(c, _)| !note_served.contains(c))
         .map(|(_, oid)| *oid)
@@ -629,7 +629,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
     // form the downward-closed git-ancestry set — no separate git walk is needed
     // (heddle#316). Replaces the prior `embargoed_oids` (this-run-only purge
     // drop-set) classification that leaked a prior-run / out-of-scope embargo.
-    let served_oids: HashSet<gix::hash::ObjectId> = frontier_served
+    let served_oids: HashSet<ObjectId> = frontier_served
         .iter()
         .filter_map(|state| bridge.mapping.get_git(state))
         .collect();
@@ -691,7 +691,7 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                     &repo,
                     &branch_ref,
                     git_oid,
-                    PreviousValue::Any,
+                    RefPrecondition::Any,
                     "heddle: retract embargoed thread frontier",
                 )?;
                 managed_record.insert(branch_ref.clone(), git_oid);
@@ -850,11 +850,11 @@ enum ReconcileOp {
 /// out-of-scope embargo).
 fn reconcile_ref(
     ns: ReconcileNs,
-    desired_oid: Option<gix::hash::ObjectId>,
-    existing_oid: Option<gix::hash::ObjectId>,
+    desired_oid: Option<ObjectId>,
+    existing_oid: Option<ObjectId>,
     in_scope: bool,
     marker_served_unminted: bool,
-    served_oids: &HashSet<gix::hash::ObjectId>,
+    served_oids: &HashSet<ObjectId>,
 ) -> ReconcileOp {
     // `existing_oid` is already the peeled commit OID (`branch_tip_oid`), so this
     // membership test compares commit-against-commit (risk #2).
@@ -890,12 +890,12 @@ fn reconcile_ref(
 }
 
 fn git_remote_names(heddle_repo: &HeddleRepository) -> HashSet<String> {
-    let Ok(repo) = gix::discover(heddle_repo.root()) else {
+    let Ok(repo) = SleyRepository::discover(heddle_repo.root()) else {
         return HashSet::new();
     };
     repo.remote_names()
+        .unwrap_or_default()
         .into_iter()
-        .map(|name| name.to_str_lossy().into_owned())
         .filter(|name| !name.trim().is_empty())
         .collect()
 }
@@ -925,9 +925,9 @@ fn purge_unserved_mappings(
     sorted_states: &[ChangeId],
     reachable: &HashSet<ChangeId>,
     audience: &AudienceTier,
-) -> GitResult<HashSet<gix::hash::ObjectId>> {
+) -> GitResult<HashSet<ObjectId>> {
     let served = served_change_ids(heddle_repo, sorted_states, reachable, audience)?;
-    let mut purged: HashSet<gix::hash::ObjectId> = HashSet::new();
+    let mut purged: HashSet<ObjectId> = HashSet::new();
     for state_id in sorted_states {
         if !served.contains(state_id)
             && let Some(oid) = mapping.remove(state_id)
@@ -976,9 +976,28 @@ fn served_change_ids(
 
 /// Resolve `ref_name` to its tip commit OID in the mirror, or `None` when the
 /// ref is absent or unpeelable.
-fn branch_tip_oid(repo: &gix::Repository, ref_name: &str) -> Option<gix::hash::ObjectId> {
-    let mut reference = repo.find_reference(ref_name).ok()?;
-    reference.peel_to_id().ok().map(|id| id.detach())
+fn branch_tip_oid(repo: &SleyRepository, ref_name: &str) -> Option<ObjectId> {
+    let oid = repo
+        .find_reference(ref_name)
+        .ok()
+        .flatten()?
+        .peeled_oid(repo)
+        .ok()
+        .flatten()?;
+    peel_to_commit_oid(repo, oid)
+}
+
+fn peel_to_commit_oid(repo: &SleyRepository, mut oid: ObjectId) -> Option<ObjectId> {
+    loop {
+        let object = repo.read_object(&oid).ok()?;
+        match object.object_type {
+            GitObjectType::Commit => return Some(oid),
+            GitObjectType::Tag => {
+                oid = repo.read_tag(&oid).ok()?.object;
+            }
+            _ => return None,
+        }
+    }
 }
 
 /// Project the DESIRED heddle-owned ref-set for an export: full ref name → its
@@ -1006,7 +1025,7 @@ fn project_desired_refs(
     mapping: &SyncMapping,
     threads: &[String],
     markers: &[MarkerName],
-) -> GitResult<std::collections::HashMap<String, gix::hash::ObjectId>> {
+) -> GitResult<std::collections::HashMap<String, ObjectId>> {
     let mut desired = std::collections::HashMap::new();
     for track_name in threads {
         let Some(tip) = heddle_repo
@@ -1040,7 +1059,7 @@ fn frontier_git_oid(
     heddle_repo: &HeddleRepository,
     mapping: &SyncMapping,
     tip: ChangeId,
-) -> GitResult<Option<gix::hash::ObjectId>> {
+) -> GitResult<Option<ObjectId>> {
     let mut visited = HashSet::new();
     let mut stack = vec![tip];
     let mut frontier: Vec<ChangeId> = Vec::new();
@@ -1088,23 +1107,31 @@ fn reachable_states(
     Ok(states)
 }
 
-fn state_to_signature(state: &objects::object::State) -> gix::actor::Signature {
-    gix::actor::Signature {
-        name: state.attribution.principal.name.as_str().into(),
-        email: state.attribution.principal.email.as_str().into(),
-        time: gix::date::Time {
-            seconds: state.created_at.timestamp(),
-            offset: 0,
-        },
+fn state_to_signature(state: &objects::object::State) -> Signature {
+    let seconds = state.created_at.timestamp();
+    let raw = format!(
+        "{} <{}> {} +0000",
+        state.attribution.principal.name, state.attribution.principal.email, seconds
+    )
+    .into_bytes();
+    Signature {
+        name: sley::plumbing::sley_core::ByteString::new(
+            state.attribution.principal.name.as_bytes().to_vec(),
+        ),
+        email: sley::plumbing::sley_core::ByteString::new(
+            state.attribution.principal.email.as_bytes().to_vec(),
+        ),
+        time: sley::GitTime::new(seconds, 0),
+        raw,
     }
 }
 
-fn submodule_oid_from_blob(content: &[u8]) -> Option<gix::hash::ObjectId> {
+fn submodule_oid_from_blob(content: &[u8]) -> Option<ObjectId> {
     let text = std::str::from_utf8(content).ok()?;
     let text = text.trim();
     let trimmed = text.strip_prefix(SUBMODULE_PREFIX)?.trim();
 
-    trimmed.parse().ok()
+    ObjectId::from_hex(ObjectFormat::Sha1, trimmed).ok()
 }
 
 #[cfg(test)]

--- a/crates/cli/src/bridge/git_import.rs
+++ b/crates/cli/src/bridge/git_import.rs
@@ -11,6 +11,9 @@ use objects::object::{
 };
 use refs::{Head, RefExpectation};
 use repo::{Repository as HeddleRepository, ResignOutcome, ThreadId};
+use sley::{
+    CommitObject, GitObjectType, ObjectId, ReferenceTarget, Repository as SleyRepository, Signature,
+};
 use tracing::warn;
 
 pub use super::git_import_tree::{GitTreeImporter, import_git_tree};
@@ -18,8 +21,8 @@ use super::git_import_tree::{PackImportSink, fail_lossy_entry};
 use crate::bridge::{
     git_core::{
         GitBridge, GitBridgeError, GitResult, RefNamespace, RefUpdate, SyncMapping,
-        apply_ref_updates, collect_reachable_entries_excluding, copy_reachable_objects, git_err,
-        install_objects_pack, open_repo, parse_git_ref, thread_is_unclaimed_bootstrap,
+        apply_ref_updates, copy_reachable_objects, git_err, open_repo, parse_git_ref,
+        thread_is_unclaimed_bootstrap,
     },
     git_notes,
     git_util::{GitImportOptions, ImportStats, PartialMirrorRef, SkippedRef},
@@ -40,10 +43,10 @@ struct RefPlan {
     /// The OID the source ref points at directly. For lightweight tags
     /// and branches this is a commit; for annotated tags it's a tag
     /// object that wraps a commit.
-    immediate_oid: gix::hash::ObjectId,
+    immediate_oid: ObjectId,
     /// The commit reachable by peeling `immediate_oid` through any tag
     /// chain. Used as a tip for ancestry walking.
-    peeled_commit_oid: gix::hash::ObjectId,
+    peeled_commit_oid: ObjectId,
 }
 
 /// Peel `reference` to its final OID and confirm the OID is a commit. If
@@ -58,41 +61,44 @@ struct RefPlan {
 /// this guard prevents the import from crashing on the very common
 /// "tag-points-at-non-commit-blob" pattern in mature OSS repos.
 fn peel_to_commit_oid(
-    repo: &gix::Repository,
-    reference: &mut gix::Reference,
-) -> GitResult<Result<gix::hash::ObjectId, gix::objs::Kind>> {
-    let oid = reference.peel_to_id().map_err(git_err)?.detach();
-    let object = repo.find_object(oid).map_err(git_err)?;
-    if object.kind == gix::objs::Kind::Commit {
-        Ok(Ok(oid))
-    } else {
-        Ok(Err(object.kind))
+    repo: &SleyRepository,
+    mut oid: ObjectId,
+) -> GitResult<Result<ObjectId, GitObjectType>> {
+    loop {
+        let object = repo.read_object(&oid).map_err(git_err)?;
+        match object.object_type {
+            GitObjectType::Commit => return Ok(Ok(oid)),
+            GitObjectType::Tag => {
+                oid = repo.read_tag(&oid).map_err(git_err)?.object;
+            }
+            kind => return Ok(Err(kind)),
+        }
     }
 }
 
 fn remote_tracking_ref_suggestions(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     missing: &[String],
 ) -> GitResult<Vec<String>> {
     let missing = missing.iter().map(String::as_str).collect::<HashSet<_>>();
     let mut suggestions = Vec::new();
 
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .prefixed("refs/remotes/")
-        .map_err(git_err)?
-    {
-        let mut reference = reference.map_err(git_err)?;
-        let Some(_) = reference.target().try_id() else {
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        if !reference.name.starts_with("refs/remotes/") {
+            continue;
+        }
+        let ReferenceTarget::Direct(target) = reference.target else {
             continue;
         };
-        let full = reference.name().as_bstr().to_string();
-        let short = reference.name().shorten().to_string();
+        let full = reference.name.to_string();
+        let short = full
+            .strip_prefix("refs/remotes/")
+            .unwrap_or(&full)
+            .to_string();
         if short.ends_with("/HEAD") {
             continue;
         }
-        if peel_to_commit_oid(repo, &mut reference)?.is_err() {
+        if peel_to_commit_oid(repo, target)?.is_err() {
             continue;
         }
         let Some(parsed) = parse_git_ref(&full) else {
@@ -124,8 +130,8 @@ fn remote_tracking_ref_suggestions(
 ///      which is what we want.
 fn resolve_identity(
     mapping: &SyncMapping,
-    repo: &gix::Repository,
-    git_oid: gix::hash::ObjectId,
+    repo: &SleyRepository,
+    git_oid: ObjectId,
     trailers: &std::collections::HashMap<String, String>,
 ) -> GitResult<(ChangeId, Option<git_notes::HeddleNote>)> {
     if let Some(existing) = mapping.get_heddle(git_oid) {
@@ -138,7 +144,7 @@ fn resolve_identity(
     if let Some(id_str) = trailers.get(GitBridge::TRAILER_CHANGE_ID) {
         return Ok((ChangeId::parse(id_str)?, None));
     }
-    let oid_hex = git_oid.to_hex_with_len(40).to_string();
+    let oid_hex = git_oid.to_hex();
     let bytes = hex::decode(&oid_hex[..32])
         .map_err(|err| GitBridgeError::InvalidMapping(err.to_string()))?;
     let mut change_id_bytes = [0u8; 16];
@@ -153,13 +159,13 @@ fn resolve_identity(
 /// Built straight from the raw commit object bytes (`commit.data`) via
 /// [`parse_commit_extension_headers`] so `encoding` / `gpgsig` / `mergetag` /
 /// any unknown header all land at their TRUE captured position through one code
-/// path. We deliberately do NOT stitch the vec from gix's typed accessors
-/// (`CommitRef::encoding`, …): gix surfaces some headers as typed fields outside
+/// path. We deliberately do NOT stitch the vec from Sley's typed accessors
+/// (`CommitRef::encoding`, …): Sley surfaces some headers as typed fields outside
 /// `extra_headers`, and re-inserting them by hand reorders them — the close-the-
 /// class bug this replaces. The raw header block is the source of truth.
 /// #564 de-lossy step 1.
-fn collect_extra_headers(commit: &gix::Commit<'_>) -> GitResult<Vec<(Vec<u8>, Vec<u8>)>> {
-    Ok(parse_commit_extension_headers(&commit.data))
+fn collect_extra_headers(raw_commit_body: &[u8]) -> GitResult<Vec<(Vec<u8>, Vec<u8>)>> {
+    Ok(parse_commit_extension_headers(raw_commit_body))
 }
 
 /// The git-fidelity fields (#564 de-lossy step 1, #565) re-derived from a git
@@ -188,12 +194,17 @@ pub(crate) struct CommitFidelityFields {
 /// Re-derive the [`CommitFidelityFields`] from a git commit object. See that
 /// type's docs for why this is the only place the fields are extracted.
 pub(crate) fn extract_commit_fidelity_fields(
-    commit: &gix::Commit<'_>,
+    commit: &CommitObject,
+    raw_commit_body: &[u8],
 ) -> GitResult<CommitFidelityFields> {
-    let author = commit.author().map_err(git_err)?;
-    let authored_time = author.time().map_err(git_err)?;
-    let committer = commit.committer().map_err(git_err)?;
-    let committer_time = committer.time().map_err(git_err)?;
+    let author = commit
+        .author_signature()
+        .ok_or_else(|| GitBridgeError::InvalidMapping("invalid Git author identity".into()))?;
+    let committer = commit
+        .committer_signature()
+        .ok_or_else(|| GitBridgeError::InvalidMapping("invalid Git committer identity".into()))?;
+    let authored_time = author.time;
+    let committer_time = committer.time;
     let created_at = Utc
         .timestamp_opt(committer_time.seconds, 0)
         .single()
@@ -213,24 +224,32 @@ pub(crate) fn extract_commit_fidelity_fields(
             ))
         })?;
     Ok(CommitFidelityFields {
-        committer: Principal::new(committer.name.to_string(), committer.email.to_string()),
-        authored_tz_offset: authored_time.offset,
-        committer_tz_offset: committer_time.offset,
+        committer: principal_from_signature(&committer),
+        authored_tz_offset: i32::from(authored_time.timezone_offset_minutes) * 60,
+        committer_tz_offset: i32::from(committer_time.timezone_offset_minutes) * 60,
         created_at,
         authored_at,
-        raw_message: commit.message_raw_sloppy().to_vec(),
-        extra_headers: collect_extra_headers(commit)?,
+        raw_message: commit.message.clone(),
+        extra_headers: collect_extra_headers(raw_commit_body)?,
     })
+}
+
+fn principal_from_signature(signature: &Signature) -> Principal {
+    Principal::new(
+        String::from_utf8_lossy(signature.name.as_bytes()).into_owned(),
+        String::from_utf8_lossy(signature.email.as_bytes()).into_owned(),
+    )
 }
 
 /// Import a single Git commit as a Heddle state.
 pub fn import_commit(
     mapping: &mut SyncMapping,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     tree_importer: &mut GitTreeImporter<'_>,
-    git_oid: gix::hash::ObjectId,
+    git_oid: ObjectId,
 ) -> GitResult<ChangeId> {
-    let commit = repo.find_commit(git_oid).map_err(git_err)?;
+    let raw_commit = repo.read_object(&git_oid).map_err(git_err)?;
+    let commit = repo.read_commit(&git_oid).map_err(git_err)?;
     // #565: re-derive the committer identity, both tz offsets, the verbatim
     // message bytes, and the ordered extension headers (encoding / gpgsig /
     // mergetag / unknown each at their captured position) through the single
@@ -238,14 +257,14 @@ pub fn import_commit(
     // drift. The verbatim message bytes survive a non-UTF8 encoding (latin-1,
     // shift-jis, …); a lossy String view is derived only for trailer / intent
     // parsing, which inspect the (ASCII) footer lines.
-    let fidelity = extract_commit_fidelity_fields(&commit)?;
+    let fidelity = extract_commit_fidelity_fields(&commit, &raw_commit.body)?;
     let message = String::from_utf8_lossy(&fidelity.raw_message).into_owned();
-    let author = commit.author().map_err(git_err)?;
-    let author_name = author.name.to_string();
-    let author_email = author.email.to_string();
-    let tree_id = commit.tree_id().map_err(git_err)?.detach();
-    let parent_git_oids: Vec<gix::hash::ObjectId> =
-        commit.parent_ids().map(|id| id.detach()).collect();
+    let author = commit
+        .author_signature()
+        .ok_or_else(|| GitBridgeError::InvalidMapping("invalid Git author identity".into()))?;
+    let principal = principal_from_signature(&author);
+    let tree_id = commit.tree;
+    let parent_git_oids: Vec<ObjectId> = commit.parents.clone();
 
     let trailers = GitBridge::parse_trailers(&message);
     let (change_id, note) = resolve_identity(mapping, repo, git_oid, &trailers)?;
@@ -267,8 +286,6 @@ pub fn import_commit(
     let lossy_before = tree_importer.lossy_entries().len();
     let tree_hash = tree_importer.import_tree(tree_id)?;
     let git_lossy = tree_importer.lossy_entries().len() > lossy_before;
-
-    let principal = Principal::new(author_name, author_email);
 
     // Agent / confidence / status: prefer the note (Phase-B-and-later format)
     // and fall back to legacy trailers for pre-Phase-B history.
@@ -427,7 +444,7 @@ pub fn backfill_fidelity(bridge: &mut GitBridge<'_>) -> GitResult<BackfillStats>
 
     // Snapshot the mapping pairs up front so the immutable store borrow below
     // doesn't overlap the mapping borrow.
-    let pairs: Vec<(ChangeId, gix::hash::ObjectId)> = bridge
+    let pairs: Vec<(ChangeId, ObjectId)> = bridge
         .mapping
         .iter()
         .map(|(change_id, git_oid)| (*change_id, *git_oid))
@@ -441,7 +458,7 @@ pub fn backfill_fidelity(bridge: &mut GitBridge<'_>) -> GitResult<BackfillStats>
         // operator knows it was left at its pre-bump fidelity. The latter
         // (annotated-tag objects, blobs) is a legitimate skip: only commits
         // carry fidelity fields today (#575 covers tag objects).
-        let object = match repo.find_object(git_oid) {
+        let object = match repo.read_object(&git_oid) {
             Ok(object) => object,
             Err(_) => {
                 stats.missing_mirror_commits.push(MissingMirrorCommit {
@@ -451,16 +468,16 @@ pub fn backfill_fidelity(bridge: &mut GitBridge<'_>) -> GitResult<BackfillStats>
                 continue;
             }
         };
-        if object.kind != gix::objs::Kind::Commit {
+        if object.object_type != GitObjectType::Commit {
             continue;
         }
-        let commit = repo.find_commit(git_oid).map_err(git_err)?;
+        let commit = repo.read_commit(&git_oid).map_err(git_err)?;
         let Some(state) = store.get_state(&change_id)? else {
             continue;
         };
         stats.scanned += 1;
 
-        let fidelity = extract_commit_fidelity_fields(&commit)?;
+        let fidelity = extract_commit_fidelity_fields(&commit, &object.body)?;
         let before = state.compute_hash();
         // A state adopted+signed BEFORE the #565 format bump was signed over
         // its PRE-fidelity hash, not the post-bump `compute_hash()` above. Pass
@@ -613,8 +630,7 @@ fn import_with_ref_filter(
         return Err(GitBridgeError::ShallowClone {
             repository: repo
                 .workdir()
-                .unwrap_or_else(|| repo.git_dir())
-                .to_path_buf(),
+                .unwrap_or_else(|| repo.git_dir().to_path_buf()),
             retry_command: shallow_import_retry_command(wanted_refs),
         });
     }
@@ -634,22 +650,19 @@ fn import_with_ref_filter(
     // immediate target (annotated-tag-aware) and the peeled commit (for
     // ancestry walking). Non-commit-pointing refs are recorded in
     // `skipped_non_commit_refs` and excluded from the plan list.
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .local_branches()
-        .map_err(git_err)?
-    {
-        let mut reference = reference.map_err(git_err)?;
-        let short = reference.name().shorten().to_string();
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let full = reference.name.to_string();
+        let Some(short) = full.strip_prefix("refs/heads/").map(str::to_string) else {
+            continue;
+        };
         if wanted_refs.is_some_and(|wanted| !wanted.contains(&short)) {
             continue;
         }
-        let immediate = match reference.target().try_id() {
-            Some(id) => id.to_owned(),
-            None => continue, // symbolic ref (e.g. HEAD) — not a real ref to import
+        let immediate = match reference.target {
+            ReferenceTarget::Direct(id) => id,
+            ReferenceTarget::Symbolic(_) => continue, // symbolic ref (e.g. HEAD) — not a real ref to import
         };
-        match peel_to_commit_oid(&repo, &mut reference)? {
+        match peel_to_commit_oid(&repo, immediate)? {
             Ok(commit_oid) => plans.push(RefPlan {
                 short_name: short,
                 namespace: RefNamespace::Branch,
@@ -672,25 +685,22 @@ fn import_with_ref_filter(
         }
     }
     if wanted_refs.is_some() {
-        for reference in repo
-            .references()
-            .map_err(git_err)?
-            .prefixed("refs/remotes/")
-            .map_err(git_err)?
-        {
-            let mut reference = reference.map_err(git_err)?;
-            let short = reference.name().shorten().to_string();
+        for reference in repo.references().list_refs().map_err(git_err)? {
+            let full = reference.name.to_string();
+            let Some(short) = full.strip_prefix("refs/remotes/").map(str::to_string) else {
+                continue;
+            };
             if short.ends_with("/HEAD") {
                 continue;
             }
             if wanted_refs.is_some_and(|wanted| !wanted.contains(&short)) {
                 continue;
             }
-            let immediate = match reference.target().try_id() {
-                Some(id) => id.to_owned(),
-                None => continue,
+            let immediate = match reference.target {
+                ReferenceTarget::Direct(id) => id,
+                ReferenceTarget::Symbolic(_) => continue,
             };
-            match peel_to_commit_oid(&repo, &mut reference)? {
+            match peel_to_commit_oid(&repo, immediate)? {
                 Ok(commit_oid) => plans.push(RefPlan {
                     short_name: short,
                     namespace: RefNamespace::Branch,
@@ -711,22 +721,19 @@ fn import_with_ref_filter(
             }
         }
     }
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .tags()
-        .map_err(git_err)?
-    {
-        let mut reference = reference.map_err(git_err)?;
-        let short = reference.name().shorten().to_string();
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let full = reference.name.to_string();
+        let Some(short) = full.strip_prefix("refs/tags/").map(str::to_string) else {
+            continue;
+        };
         if wanted_refs.is_some_and(|wanted| !wanted.contains(&short)) {
             continue;
         }
-        let immediate = match reference.target().try_id() {
-            Some(id) => id.to_owned(),
-            None => continue,
+        let immediate = match reference.target {
+            ReferenceTarget::Direct(id) => id,
+            ReferenceTarget::Symbolic(_) => continue,
         };
-        match peel_to_commit_oid(&repo, &mut reference)? {
+        match peel_to_commit_oid(&repo, immediate)? {
             Ok(commit_oid) => plans.push(RefPlan {
                 short_name: short,
                 namespace: RefNamespace::Tag,
@@ -792,30 +799,23 @@ fn import_with_ref_filter(
     //      `sync_marker_to_tag` skip the rewrite — leaving the
     //      annotated tag intact through to the destination push.
     //
-    // We collect entries **per ref** so a ref whose ancestry references a
+    // We copy objects **per ref** so a ref whose ancestry references a
     // missing object (a known failure mode in real-world repos like git-lfs,
     // where pack data carries dangling references that `git fsck` doesn't
-    // catch) doesn't poison the rest of the mirror. Successful refs are then
-    // installed together as one pack, avoiding N loose writes and N per-ref
-    // packfiles on the adopt path.
+    // catch) doesn't poison the rest of the mirror.
     if git_path.is_some() {
         bridge.init_mirror()?;
         let mirror_repo = bridge.open_git_repo()?;
         if mirror_repo.git_dir() != repo.git_dir() {
             let mut successful_updates: Vec<RefUpdate> = Vec::new();
-            let mut mirror_entries = Vec::new();
-            let mut mirror_seen = HashSet::new();
             for plan in &plans {
                 // Roots include both the immediate target (tag object for
                 // annotated tags) and the peeled commit (so the walker
                 // descends through commit→tree→blob even when the
                 // immediate object is a tag).
                 let roots = [plan.immediate_oid, plan.peeled_commit_oid];
-                let mut candidate_seen = mirror_seen.clone();
-                match collect_reachable_entries_excluding(&repo, roots, &mut candidate_seen) {
-                    Ok(entries) => {
-                        mirror_seen = candidate_seen;
-                        mirror_entries.extend(entries);
+                match copy_reachable_objects(&repo, &mirror_repo, roots) {
+                    Ok(()) => {
                         successful_updates.push(RefUpdate {
                             name: plan.short_name.clone(),
                             target: plan.immediate_oid,
@@ -841,7 +841,6 @@ fn import_with_ref_filter(
                     }
                 }
             }
-            install_objects_pack(&mirror_repo, mirror_entries)?;
             // Write source refs into the mirror. For annotated tags this
             // points refs/tags/<name> at the tag object (not the peeled
             // commit), which is what preserves the annotated form across
@@ -867,7 +866,7 @@ fn import_with_ref_filter(
         }
     }
 
-    bridge.build_existing_mapping(Some(repo.path()))?;
+    bridge.build_existing_mapping(Some(repo.git_dir()))?;
 
     // heddle#555: route the bulk import through a single streaming pack (one
     // atomic install) instead of N loose objects + per-object fsync. Stage
@@ -977,20 +976,21 @@ fn import_with_ref_filter(
         }
     }
 
-    for tag in repo
-        .references()
-        .map_err(git_err)?
-        .tags()
-        .map_err(git_err)?
-    {
-        let mut tag = tag.map_err(git_err)?;
-        let name = tag.name().shorten().to_string();
+    for tag in repo.references().list_refs().map_err(git_err)? {
+        let full = tag.name.to_string();
+        let Some(name) = full.strip_prefix("refs/tags/").map(str::to_string) else {
+            continue;
+        };
         if wanted_refs.is_some_and(|wanted| !wanted.contains(&name)) {
             continue;
         }
         // Skip non-commit-pointing tags here too; the tips loop already
         // recorded them in `skipped_non_commit_refs`.
-        let oid = match peel_to_commit_oid(&repo, &mut tag)? {
+        let immediate = match tag.target {
+            ReferenceTarget::Direct(oid) => oid,
+            ReferenceTarget::Symbolic(_) => continue,
+        };
+        let oid = match peel_to_commit_oid(&repo, immediate)? {
             Ok(oid) => oid,
             Err(_) => continue,
         };
@@ -1045,26 +1045,19 @@ fn sync_marker_from_git_tag(
     }
 }
 
-fn collect_note_ref_updates(repo: &gix::Repository) -> GitResult<Vec<RefUpdate>> {
+fn collect_note_ref_updates(repo: &SleyRepository) -> GitResult<Vec<RefUpdate>> {
     let mut updates = Vec::new();
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .prefixed("refs/notes/")
-        .map_err(git_err)?
-    {
-        let reference = reference.map_err(git_err)?;
-        let Some(target) = reference.try_id() else {
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let full = reference.name.to_string();
+        let Some(short) = full.strip_prefix("refs/notes/").map(str::to_string) else {
             continue;
         };
-        let full = reference.name().as_bstr().to_string();
-        let short = full
-            .strip_prefix("refs/notes/")
-            .unwrap_or(&full)
-            .to_string();
+        let ReferenceTarget::Direct(target) = reference.target else {
+            continue;
+        };
         updates.push(RefUpdate {
             name: short,
-            target: target.detach(),
+            target,
             namespace: RefNamespace::Note,
         });
     }
@@ -1125,8 +1118,8 @@ pub(crate) fn thread_can_adopt_change(
 /// queued this commit's parents but haven't emitted the commit itself
 /// yet" without keeping per-node state outside the stack.
 enum WalkPhase {
-    Enter(gix::hash::ObjectId),
-    Emit(gix::hash::ObjectId),
+    Enter(ObjectId),
+    Emit(ObjectId),
 }
 
 /// Iterative ancestry walk — post-order DFS using an explicit stack
@@ -1151,7 +1144,7 @@ enum WalkPhase {
 #[allow(clippy::too_many_arguments)]
 fn walk_plans_into_states(
     bridge: &mut GitBridge<'_>,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     tree_importer: &mut GitTreeImporter<'_>,
     plans: &[RefPlan],
     stats: &mut ImportStats,
@@ -1177,11 +1170,11 @@ fn walk_plans_into_states(
 #[allow(clippy::too_many_arguments)]
 fn import_commit_ancestry(
     bridge: &mut GitBridge<'_>,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     tree_importer: &mut GitTreeImporter<'_>,
-    git_oid: gix::hash::ObjectId,
-    visiting: &mut HashSet<gix::hash::ObjectId>,
-    imported: &mut HashSet<gix::hash::ObjectId>,
+    git_oid: ObjectId,
+    visiting: &mut HashSet<ObjectId>,
+    imported: &mut HashSet<ObjectId>,
     stats: &mut ImportStats,
     progress: &mut dyn FnMut(usize),
 ) -> GitResult<()> {
@@ -1207,9 +1200,8 @@ fn import_commit_ancestry(
                     continue;
                 }
 
-                let commit = repo.find_commit(oid).map_err(git_err)?;
-                let parent_git_oids: Vec<gix::hash::ObjectId> =
-                    commit.parent_ids().map(|id| id.detach()).collect();
+                let commit = repo.read_commit(&oid).map_err(git_err)?;
+                let parent_git_oids: Vec<ObjectId> = commit.parents;
 
                 // Schedule emit AFTER all parents are processed. Stack is
                 // LIFO so the Emit goes on first; then parents on top of

--- a/crates/cli/src/bridge/git_import_tree.rs
+++ b/crates/cli/src/bridge/git_import_tree.rs
@@ -15,6 +15,7 @@ use objects::store::{
 };
 use objects::util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name};
 use repo::Repository as HeddleRepository;
+use sley::{GitObjectType, ObjectId as SleyObjectId, Repository as SleyRepository};
 
 use crate::bridge::git_core::{GitBridgeError, GitResult};
 use crate::bridge::git_util::{GitImportOptions, LossyGitImportEntry};
@@ -23,9 +24,9 @@ const SUBMODULE_PREFIX: &str = "heddle-submodule:";
 
 pub struct GitTreeImporter<'a> {
     heddle_repo: &'a HeddleRepository,
-    repo: &'a gix::Repository,
-    tree_cache: HashMap<gix::hash::ObjectId, ContentHash>,
-    blob_cache: HashMap<gix::hash::ObjectId, ContentHash>,
+    repo: &'a SleyRepository,
+    tree_cache: HashMap<SleyObjectId, ContentHash>,
+    blob_cache: HashMap<SleyObjectId, ContentHash>,
     options: GitImportOptions,
     lossy_entries: Vec<LossyGitImportEntry>,
     /// When set, imported blobs/trees/states stream into a single native
@@ -35,13 +36,13 @@ pub struct GitTreeImporter<'a> {
 }
 
 impl<'a> GitTreeImporter<'a> {
-    pub fn new(heddle_repo: &'a HeddleRepository, repo: &'a gix::Repository) -> Self {
+    pub fn new(heddle_repo: &'a HeddleRepository, repo: &'a SleyRepository) -> Self {
         Self::with_options(heddle_repo, repo, GitImportOptions::default())
     }
 
     pub fn with_options(
         heddle_repo: &'a HeddleRepository,
-        repo: &'a gix::Repository,
+        repo: &'a SleyRepository,
         options: GitImportOptions,
     ) -> Self {
         Self {
@@ -61,7 +62,7 @@ impl<'a> GitTreeImporter<'a> {
     /// [`Self::abort_pack`] on failure) to durably install the pack.
     pub(crate) fn with_options_packed(
         heddle_repo: &'a HeddleRepository,
-        repo: &'a gix::Repository,
+        repo: &'a SleyRepository,
         options: GitImportOptions,
         sink: PackImportSink,
     ) -> Self {
@@ -150,45 +151,46 @@ impl<'a> GitTreeImporter<'a> {
         self.options.lossy
     }
 
-    pub fn import_tree(&mut self, tree_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
+    pub fn import_tree(&mut self, tree_oid: SleyObjectId) -> GitResult<ContentHash> {
         self.import_tree_at(tree_oid, "")
     }
 
     fn import_tree_at(
         &mut self,
-        tree_oid: gix::hash::ObjectId,
+        tree_oid: SleyObjectId,
         path_prefix: &str,
     ) -> GitResult<ContentHash> {
         if let Some(hash) = self.tree_cache.get(&tree_oid) {
             return Ok(*hash);
         }
 
-        let git_tree = self
-            .repo
-            .find_tree(tree_oid)
-            .map_err(|err| GitBridgeError::Git(err.to_string()))?;
+        let git_tree_entries = if tree_oid == SleyObjectId::empty_tree(self.repo.object_format()) {
+            Vec::new()
+        } else {
+            self.repo
+                .read_tree(&tree_oid)
+                .map_err(|err| GitBridgeError::Git(err.to_string()))?
+                .entries
+        };
 
         let mut entries = Vec::new();
 
-        for entry in git_tree.iter() {
-            let entry = entry.map_err(|err| GitBridgeError::Git(err.to_string()))?;
+        for entry in git_tree_entries {
             let Some(name) =
-                self.import_entry_name(path_prefix, entry.filename().as_ref(), entry.object_id())?
+                self.import_entry_name(path_prefix, entry.name.as_bytes(), entry.oid)?
             else {
                 continue;
             };
 
-            match entry.kind() {
-                gix::object::tree::EntryKind::Blob
-                | gix::object::tree::EntryKind::BlobExecutable => {
-                    let hash = self.import_blob(entry.object_id())?;
+            match entry.mode {
+                0o100644 | 0o100755 => {
+                    let hash = self.import_blob(entry.oid)?;
 
-                    let mode =
-                        if matches!(entry.kind(), gix::object::tree::EntryKind::BlobExecutable) {
-                            FileMode::Executable
-                        } else {
-                            FileMode::Normal
-                        };
+                    let mode = if entry.mode == 0o100755 {
+                        FileMode::Executable
+                    } else {
+                        FileMode::Normal
+                    };
 
                     entries.push(TreeEntry {
                         name,
@@ -197,8 +199,8 @@ impl<'a> GitTreeImporter<'a> {
                         hash,
                     });
                 }
-                gix::object::tree::EntryKind::Link => {
-                    let hash = self.import_blob(entry.object_id())?;
+                0o120000 => {
+                    let hash = self.import_blob(entry.oid)?;
                     // Phase E: must be `EntryType::Symlink` so the
                     // materialization planner reaches the symlink-write
                     // branch. Previously this said `EntryType::Blob`,
@@ -214,9 +216,9 @@ impl<'a> GitTreeImporter<'a> {
                         hash,
                     });
                 }
-                gix::object::tree::EntryKind::Tree => {
-                    let subtree_hash = self
-                        .import_tree_at(entry.object_id(), &join_tree_path(path_prefix, &name))?;
+                0o040000 => {
+                    let subtree_hash =
+                        self.import_tree_at(entry.oid, &join_tree_path(path_prefix, &name))?;
                     entries.push(TreeEntry {
                         name,
                         mode: FileMode::Normal,
@@ -224,20 +226,27 @@ impl<'a> GitTreeImporter<'a> {
                         hash: subtree_hash,
                     });
                 }
-                gix::object::tree::EntryKind::Commit => {
+                0o160000 => {
                     let lossy = LossyGitImportEntry::converted(
                         join_tree_path(path_prefix, &name),
-                        Some(entry.object_id().to_string()),
+                        Some(entry.oid.to_string()),
                         "gitlink/submodule entry converted to a heddle-submodule blob",
                     );
                     self.record_lossy(lossy)?;
-                    let hash = self.import_gitlink(entry.object_id())?;
+                    let hash = self.import_gitlink(entry.oid)?;
                     entries.push(TreeEntry {
                         name,
                         mode: FileMode::Normal,
                         entry_type: objects::object::EntryType::Blob,
                         hash,
                     });
+                }
+                mode => {
+                    return Err(GitBridgeError::Git(format!(
+                        "unsupported git tree entry mode {:o} for {}",
+                        mode,
+                        join_tree_path(path_prefix, &name)
+                    )));
                 }
             }
         }
@@ -252,7 +261,7 @@ impl<'a> GitTreeImporter<'a> {
         &mut self,
         path_prefix: &str,
         raw_name: &[u8],
-        object_id: gix::hash::ObjectId,
+        object_id: SleyObjectId,
     ) -> GitResult<Option<String>> {
         match classify_git_tree_name(raw_name) {
             GitTreeNameClassification::Representable(name) => Ok(Some(name)),
@@ -289,24 +298,30 @@ impl<'a> GitTreeImporter<'a> {
         Ok(())
     }
 
-    fn import_blob(&mut self, blob_oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
+    fn import_blob(&mut self, blob_oid: SleyObjectId) -> GitResult<ContentHash> {
         if let Some(hash) = self.blob_cache.get(&blob_oid) {
             return Ok(*hash);
         }
 
-        let mut blob = self
+        let blob = self
             .repo
-            .find_blob(blob_oid)
+            .read_object(&blob_oid)
             .map_err(|err| GitBridgeError::Git(err.to_string()))?;
+        if blob.object_type != GitObjectType::Blob {
+            return Err(GitBridgeError::Git(format!(
+                "object {blob_oid} is {}, not a blob",
+                blob.object_type.as_str()
+            )));
+        }
 
-        let heddle_blob = Blob::new(blob.take_data());
+        let heddle_blob = Blob::new(blob.body.to_vec());
         let hash = heddle_blob.hash();
         self.write_blob(hash, heddle_blob)?;
         self.blob_cache.insert(blob_oid, hash);
         Ok(hash)
     }
 
-    fn import_gitlink(&mut self, oid: gix::hash::ObjectId) -> GitResult<ContentHash> {
+    fn import_gitlink(&mut self, oid: SleyObjectId) -> GitResult<ContentHash> {
         if let Some(hash) = self.blob_cache.get(&oid) {
             return Ok(*hash);
         }
@@ -322,8 +337,8 @@ impl<'a> GitTreeImporter<'a> {
 /// Import a Git tree as a Heddle tree.
 pub fn import_git_tree(
     heddle_repo: &HeddleRepository,
-    repo: &gix::Repository,
-    tree_oid: gix::hash::ObjectId,
+    repo: &SleyRepository,
+    tree_oid: SleyObjectId,
 ) -> GitResult<ContentHash> {
     GitTreeImporter::new(heddle_repo, repo).import_tree(tree_oid)
 }

--- a/crates/cli/src/bridge/git_mapping.rs
+++ b/crates/cli/src/bridge/git_mapping.rs
@@ -10,6 +10,7 @@ use std::{
 
 use objects::object::ChangeId;
 use serde::{Deserialize, Serialize};
+use sley::{ObjectFormat, ObjectId as SleyObjectId, ReferenceTarget, Repository as SleyRepository};
 
 use super::{
     git_core::{GitBridge, GitBridgeError, GitResult, git_err},
@@ -92,10 +93,7 @@ impl<'a> GitBridge<'a> {
 
         for entry in file.entries {
             let change_id = ChangeId::parse(&entry.change_id)?;
-            let git_oid = entry
-                .git_oid
-                .parse::<gix::hash::ObjectId>()
-                .map_err(|err| GitBridgeError::InvalidMapping(err.to_string()))?;
+            let git_oid = parse_stored_git_oid(&entry.git_oid)?;
             self.mapping.insert_checked(change_id, git_oid)?;
             self.mapping
                 .set_git_lossy_entries(git_oid, entry.lossy_entries);
@@ -218,9 +216,9 @@ impl<'a> GitBridge<'a> {
             if self.mapping.has_git(oid) {
                 continue;
             }
-            let commit = repo.find_commit(oid).map_err(git_err)?;
-            let message = commit.message_raw_sloppy();
-            let trailers = GitBridge::parse_trailers(&message.to_string());
+            let commit = repo.read_commit(&oid).map_err(git_err)?;
+            let message = String::from_utf8_lossy(&commit.message);
+            let trailers = GitBridge::parse_trailers(&message);
             if let Some(change_id) = trailers.get(GitBridge::TRAILER_CHANGE_ID) {
                 let change_id = ChangeId::parse(change_id)?;
                 self.mapping.insert_checked(change_id, oid)?;
@@ -248,41 +246,58 @@ impl<'a> GitBridge<'a> {
 /// to non-commit objects (annotated-tag-points-at-blob/tree); see
 /// `git_import::peel_to_commit_oid` for the full rationale and the
 /// `SkippedRef` recording layer.
-fn collect_commit_oids(repo: &gix::Repository) -> GitResult<Vec<gix::hash::ObjectId>> {
+fn collect_commit_oids(repo: &SleyRepository) -> GitResult<Vec<SleyObjectId>> {
     let mut tips = Vec::new();
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .local_branches()
-        .map_err(git_err)?
-    {
-        let mut reference = reference.map_err(git_err)?;
-        let oid = reference.peel_to_id().map_err(git_err)?.detach();
-        if let Ok(object) = repo.find_object(oid)
-            && object.kind == gix::objs::Kind::Commit
+
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        if !(reference.name.starts_with("refs/heads/") || reference.name.starts_with("refs/tags/"))
         {
-            tips.push(oid);
+            continue;
         }
-    }
-    for reference in repo
-        .references()
-        .map_err(git_err)?
-        .tags()
-        .map_err(git_err)?
-    {
-        let mut reference = reference.map_err(git_err)?;
-        let oid = reference.peel_to_id().map_err(git_err)?.detach();
-        if let Ok(object) = repo.find_object(oid)
-            && object.kind == gix::objs::Kind::Commit
-        {
-            tips.push(oid);
+        let oid = match reference.target {
+            ReferenceTarget::Direct(oid) => oid,
+            ReferenceTarget::Symbolic(_) => {
+                let Some(reference) = repo.find_reference(&reference.name).map_err(git_err)? else {
+                    continue;
+                };
+                let Some(oid) = reference.peeled_oid(repo).map_err(git_err)? else {
+                    continue;
+                };
+                oid
+            }
+        };
+        if let Ok(commit_oid) = sley::plumbing::sley_rev::peel_to_commit(
+            repo.objects().as_ref(),
+            repo.object_format(),
+            &oid,
+        ) {
+            tips.push(commit_oid);
         }
     }
 
     let mut seen = HashSet::new();
-    for info in repo.rev_walk(tips).all().map_err(git_err)? {
-        seen.insert(info.map_err(git_err)?.id);
+    let mut stack = tips;
+    while let Some(oid) = stack.pop() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        let commit = repo.read_commit(&oid).map_err(git_err)?;
+        stack.extend(commit.parents);
     }
 
     Ok(seen.into_iter().collect())
+}
+
+fn parse_stored_git_oid(value: &str) -> GitResult<SleyObjectId> {
+    let format = match value.len() {
+        40 => ObjectFormat::Sha1,
+        64 => ObjectFormat::Sha256,
+        _ => {
+            return Err(GitBridgeError::InvalidMapping(format!(
+                "invalid git oid length for {value}"
+            )));
+        }
+    };
+    SleyObjectId::from_hex(format, value)
+        .map_err(|err| GitBridgeError::InvalidMapping(err.to_string()))
 }

--- a/crates/cli/src/bridge/git_notes.rs
+++ b/crates/cli/src/bridge/git_notes.rs
@@ -10,21 +10,19 @@
 //! when the sidecar is missing or empty (e.g., a developer ran `git clone
 //! <url>` of a heddle-exported repo without copying the heddle dir).
 //!
-//! gix v0.80 has no high-level notes API; we hand-roll the standard tree
-//! layout (entry name = full 40-hex commit SHA, entry blob = serialized JSON)
-//! using the same primitives the rest of the bridge already relies on
-//! (`write_blob`, `edit_tree`, `new_commit_as`, `set_reference`).
+//! Sley provides the tree-backed notes plumbing; this module owns Heddle's
+//! JSON payload and the fixed `refs/notes/heddle` location.
 
 use std::{
     collections::HashMap,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use gix::{hash::ObjectId, refs::transaction::PreviousValue};
 use objects::object::{State, Status};
 use serde::{Deserialize, Serialize};
+use sley::{ObjectId, Repository};
 
-use super::git_core::{GitBridgeError, GitResult, git_err, set_reference};
+use super::git_core::{GitBridgeError, GitResult, git_err};
 
 /// The notes ref heddle uses. Git-compatible notes readers can opt into
 /// this location, while Heddle reads and writes it natively.
@@ -147,75 +145,30 @@ impl HeddleNote {
     }
 }
 
-/// Resolve the current notes-commit OID and the tree it points at. Returns
-/// `(None, empty_tree)` when `refs/notes/heddle` does not yet exist.
-fn read_notes_head(repo: &gix::Repository) -> GitResult<(Option<ObjectId>, ObjectId)> {
-    let parent = match repo.find_reference(NOTES_REF) {
-        Ok(reference) => {
-            let mut reference = reference;
-            Some(reference.peel_to_id().map_err(git_err)?.detach())
-        }
-        Err(_) => None,
-    };
-    let tree_oid = if let Some(commit_oid) = parent {
-        let commit = repo.find_commit(commit_oid).map_err(git_err)?;
-        commit.tree_id().map_err(git_err)?.detach()
-    } else {
-        gix::hash::ObjectId::empty_tree(repo.object_hash())
-    };
-    Ok((parent, tree_oid))
+fn notes_ref() -> sley::notes::NotesRef {
+    sley::notes::NotesRef::expand(NOTES_REF)
 }
 
 /// Attach `note` to `commit_oid` in `repo` under `refs/notes/heddle`.
 ///
 /// Each call creates one new notes commit on top of any previous notes
-/// history. The notes ref is updated atomically via the bridge's standard
-/// `set_reference` helper.
-pub fn write_note(
-    repo: &gix::Repository,
-    commit_oid: ObjectId,
-    note: &HeddleNote,
-) -> GitResult<()> {
+/// history. The notes ref is updated atomically via sley's notes plumbing.
+pub fn write_note(repo: &Repository, commit_oid: ObjectId, note: &HeddleNote) -> GitResult<()> {
     let json = note.to_json_bytes()?;
-    let blob_oid = repo.write_blob(&json).map_err(git_err)?.detach();
-
-    let (parent_commit, current_tree_oid) = read_notes_head(repo)?;
-    let mut editor = repo.edit_tree(current_tree_oid).map_err(git_err)?;
-    let entry_name = commit_oid.to_hex_with_len(40).to_string();
-    editor
-        .upsert(
-            entry_name.as_str(),
-            gix::object::tree::EntryKind::Blob,
-            blob_oid,
-        )
-        .map_err(git_err)?;
-    let new_tree_oid = editor.write().map_err(git_err)?.detach();
-
-    let signature = bridge_notes_signature();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let parents: Vec<ObjectId> = parent_commit.iter().copied().collect();
-    let new_commit = repo
-        .new_commit_as(
-            signature.to_ref(&mut committer_buf),
-            signature.to_ref(&mut author_buf),
-            "heddle: state metadata",
-            new_tree_oid,
-            parents,
-        )
-        .map_err(git_err)?;
-
-    let constraint = match parent_commit {
-        Some(prev) => PreviousValue::ExistingMustMatch(gix::refs::Target::Object(prev)),
-        None => PreviousValue::MustNotExist,
-    };
-    set_reference(
-        repo,
-        NOTES_REF,
-        new_commit.id,
-        constraint,
-        "heddle: write state note",
-    )?;
+    let notes_ref = notes_ref();
+    let refs = repo.references();
+    sley::notes::upsert_note_bytes_for(
+        repo.git_dir(),
+        repo.object_format(),
+        &refs,
+        &notes_ref,
+        &commit_oid,
+        &json,
+        "heddle: state metadata",
+        &bridge_notes_identity(),
+        sley::notes::notes_ref_expected(&refs, &notes_ref).map_err(git_err)?,
+    )
+    .map_err(git_err)?;
     Ok(())
 }
 
@@ -234,126 +187,66 @@ pub fn write_note(
 /// No-op — no new commit, no ref churn — when the notes ref is absent or none
 /// of `commit_oids` actually has an entry.
 pub fn remove_notes(
-    repo: &gix::Repository,
+    repo: &Repository,
     commit_oids: &std::collections::HashSet<ObjectId>,
 ) -> GitResult<()> {
     if commit_oids.is_empty() {
         return Ok(());
     }
-    let (parent_commit, current_tree_oid) = read_notes_head(repo)?;
-    // No notes ref at all → nothing published, nothing to retract.
-    let Some(parent) = parent_commit else {
-        return Ok(());
-    };
-
-    // Only the requested OIDs that actually have an entry need removing.
-    // Checking first avoids churning the ref (a new empty-delta commit) when a
-    // retraction touches commits that never carried a note.
-    let target_names: std::collections::HashSet<String> = commit_oids
-        .iter()
-        .map(|oid| oid.to_hex_with_len(40).to_string())
-        .collect();
-    let tree = repo.find_tree(current_tree_oid).map_err(git_err)?;
-    let mut to_remove: Vec<String> = Vec::new();
-    for entry in tree.iter() {
-        let entry = entry.map_err(git_err)?;
-        let name = entry.filename().to_string();
-        if target_names.contains(&name) {
-            to_remove.push(name);
-        }
-    }
-    if to_remove.is_empty() {
-        return Ok(());
-    }
-
-    let mut editor = repo.edit_tree(current_tree_oid).map_err(git_err)?;
-    for name in &to_remove {
-        editor.remove(name.as_str()).map_err(git_err)?;
-    }
-    let new_tree_oid = editor.write().map_err(git_err)?.detach();
-
-    let signature = bridge_notes_signature();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let new_commit = repo
-        .new_commit_as(
-            signature.to_ref(&mut committer_buf),
-            signature.to_ref(&mut author_buf),
-            "heddle: retract state metadata",
-            new_tree_oid,
-            vec![parent],
-        )
-        .map_err(git_err)?;
-
-    set_reference(
-        repo,
-        NOTES_REF,
-        new_commit.id,
-        PreviousValue::ExistingMustMatch(gix::refs::Target::Object(parent)),
-        "heddle: retract state note",
-    )?;
+    let notes_ref = notes_ref();
+    let refs = repo.references();
+    let annotated: Vec<ObjectId> = commit_oids.iter().copied().collect();
+    sley::notes::remove_notes_for(
+        repo.git_dir(),
+        repo.object_format(),
+        &refs,
+        &notes_ref,
+        &annotated,
+        "heddle: retract state metadata",
+        &bridge_notes_identity(),
+        sley::notes::notes_ref_expected(&refs, &notes_ref).map_err(git_err)?,
+    )
+    .map_err(git_err)?;
     Ok(())
 }
 
 /// Look up the note attached to `commit_oid`, if any.
-pub fn read_note(repo: &gix::Repository, commit_oid: ObjectId) -> GitResult<Option<HeddleNote>> {
-    let Ok(reference) = repo.find_reference(NOTES_REF) else {
+pub fn read_note(repo: &Repository, commit_oid: ObjectId) -> GitResult<Option<HeddleNote>> {
+    let Some(bytes) = repo
+        .read_note_bytes(&notes_ref(), &commit_oid)
+        .map_err(git_err)?
+    else {
         return Ok(None);
     };
-    let mut reference = reference;
-    let notes_commit_oid = reference.peel_to_id().map_err(git_err)?.detach();
-    let notes_commit = repo.find_commit(notes_commit_oid).map_err(git_err)?;
-    let notes_tree_oid = notes_commit.tree_id().map_err(git_err)?.detach();
-    let notes_tree = repo.find_tree(notes_tree_oid).map_err(git_err)?;
-
-    let target_name = commit_oid.to_hex_with_len(40).to_string();
-    for entry in notes_tree.iter() {
-        let entry = entry.map_err(git_err)?;
-        if *entry.filename() == *target_name.as_bytes() {
-            let object = repo.find_object(entry.object_id()).map_err(git_err)?;
-            return HeddleNote::from_json_bytes(&object.data).map(Some);
-        }
-    }
-    Ok(None)
+    HeddleNote::from_json_bytes(&bytes).map(Some)
 }
 
 /// Read every (commit_oid → note) entry under `refs/notes/heddle`. Used by
 /// the import path's identity-recovery scan.
-pub fn read_all_notes(repo: &gix::Repository) -> GitResult<HashMap<ObjectId, HeddleNote>> {
+pub fn read_all_notes(repo: &Repository) -> GitResult<HashMap<ObjectId, HeddleNote>> {
     let mut out = HashMap::new();
-    let Ok(reference) = repo.find_reference(NOTES_REF) else {
-        return Ok(out);
-    };
-    let mut reference = reference;
-    let notes_commit_oid = reference.peel_to_id().map_err(git_err)?.detach();
-    let notes_commit = repo.find_commit(notes_commit_oid).map_err(git_err)?;
-    let notes_tree_oid = notes_commit.tree_id().map_err(git_err)?.detach();
-    let notes_tree = repo.find_tree(notes_tree_oid).map_err(git_err)?;
-
-    for entry in notes_tree.iter() {
-        let entry = entry.map_err(git_err)?;
-        let name = entry.filename().to_string();
-        let Ok(target_oid) = name.parse::<ObjectId>() else {
-            continue;
-        };
-        let object = repo.find_object(entry.object_id()).map_err(git_err)?;
+    for note_entry in repo.list_notes(&notes_ref()).map_err(git_err)? {
+        let object = repo.read_object(&note_entry.blob).map_err(git_err)?;
         // Skip entries that aren't well-formed heddle notes — could be left
         // over from `git notes --ref=heddle add` by an external tool.
-        if let Ok(note) = HeddleNote::from_json_bytes(&object.data) {
-            out.insert(target_oid, note);
+        if object.object_type != sley::GitObjectType::Blob {
+            continue;
+        }
+        if let Ok(note) = HeddleNote::from_json_bytes(&object.body) {
+            out.insert(note_entry.annotated, note);
         }
     }
     Ok(out)
 }
 
-fn bridge_notes_signature() -> gix::actor::Signature {
-    let seconds = match SystemTime::now().duration_since(UNIX_EPOCH) {
-        Ok(duration) => i64::try_from(duration.as_secs()).unwrap_or(i64::MAX),
-        Err(_) => 0,
-    };
-    gix::actor::Signature {
-        name: "Heddle".into(),
-        email: "heddle@local".into(),
-        time: gix::date::Time { seconds, offset: 0 },
+fn bridge_notes_identity() -> sley::notes::NotesCommitIdentity {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let ident = format!("Heddle <heddle@local> {seconds} +0000").into_bytes();
+    sley::notes::NotesCommitIdentity {
+        author: ident.clone(),
+        committer: ident,
     }
 }

--- a/crates/cli/src/bridge/git_reconstruct.rs
+++ b/crates/cli/src/bridge/git_reconstruct.rs
@@ -17,10 +17,11 @@
 //! first-class content-addressed objects; lightweight tags need no object (just
 //! a ref at the commit).
 
-use gix::hash::ObjectId;
 use objects::object::{Principal, State};
 use objects::store::{ObjectStore, StoreError};
 use repo::Repository as HeddleRepository;
+use sley::plumbing::sley_object::EncodedObject;
+use sley::{GitObjectType, ObjectFormat, ObjectId, Repository as SleyRepository};
 
 use crate::bridge::git_core::{GitBridge, GitBridgeError, GitResult, SyncMapping, git_err};
 use crate::bridge::git_export::export_tree;
@@ -44,18 +45,14 @@ pub fn frame_git_object(kind: &str, content: &[u8]) -> Vec<u8> {
 /// `content`: frame per §0, then hash. Equals the original commit SHA exactly
 /// when `content` is byte-identical to the original object.
 pub fn commit_object_id(content: &[u8]) -> ObjectId {
-    let framed = frame_git_object("commit", content);
-    let mut hasher = gix::hash::hasher(gix::hash::Kind::Sha1);
-    hasher.update(&framed);
-    hasher
-        .try_finalize()
-        .expect("SHA-1 over an in-memory buffer cannot fail")
+    sley::plumbing::sley_core::object_id_for_bytes(ObjectFormat::Sha1, "commit", content)
+        .expect("SHA-1 commit object id over in-memory bytes cannot fail")
 }
 
 /// Reconstruct the byte-exact git commit object **content** (the bytes
 /// `git cat-file commit` prints, WITHOUT the §0 framing) for `state`.
 ///
-/// `repo` is any writable gix repo: the git tree OID is resolved by re-exporting
+/// `repo` is any writable sley repo: the git tree OID is resolved by re-exporting
 /// `state.tree` through [`export_tree`] (git trees are content-addressed, so the
 /// resulting OID is independent of which repo it is written into — the round-trip
 /// fidelity gate proves this path reproduces the original tree SHA). Parent OIDs
@@ -63,7 +60,7 @@ pub fn commit_object_id(content: &[u8]) -> ObjectId {
 /// `state.parents` order — order is part of a commit's identity (§1.2).
 pub fn reconstruct_commit_bytes(
     heddle_repo: &HeddleRepository,
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     mapping: &SyncMapping,
     state: &State,
 ) -> GitResult<Vec<u8>> {
@@ -88,12 +85,11 @@ pub fn reconstruct_commit_bytes(
 /// This is the write side of export-from-state (#567): export regenerates each
 /// commit object from Heddle state and writes it here, rather than relying on the
 /// git mirror still holding the verbatim imported bytes — the dependency #568
-/// removes. Idempotent: `gix`'s `write_buf` hashes first and no-ops when the
+/// removes. Idempotent: sley's object writer hashes first and no-ops when the
 /// object already exists, so re-writing a commit the mirror already carries (the
 /// common case today) costs nothing.
-pub fn write_commit_object(repo: &gix::Repository, content: &[u8]) -> GitResult<ObjectId> {
-    use gix::objs::Write;
-    repo.write_buf(gix::objs::Kind::Commit, content)
+pub fn write_commit_object(repo: &SleyRepository, content: &[u8]) -> GitResult<ObjectId> {
+    repo.write_object(EncodedObject::new(GitObjectType::Commit, content.to_vec()))
         .map_err(git_err)
 }
 
@@ -207,7 +203,7 @@ fn checked_actor_timestamp(label: &[u8], seconds: i64, tz_offset_secs: i32) -> G
 }
 
 /// Render a timezone offset — stored as **seconds** east of UTC (#565's `i32`
-/// unit; gix `Time::offset` is seconds) — as git's `±HHMM` (§5). The sign is
+/// unit) — as git's `±HHMM` (§5). The sign is
 /// always present; zero is `+0000` (git never emits `-0000` for a real commit);
 /// odd offsets like `-0830` / `+1245` survive verbatim.
 fn format_tz_offset(offset_secs: i32) -> String {
@@ -235,10 +231,10 @@ fn append_folded(out: &mut Vec<u8>, value: &[u8]) {
 }
 
 impl GitBridge<'_> {
-    /// Open (initializing if necessary) a writable gix repo suitable for
+    /// Open (initializing if necessary) a writable sley repo suitable for
     /// reconstruction's tree-OID resolution. Any writable odb works — git trees
     /// are content-addressed — so the bridge's own mirror is reused.
-    pub fn reconstruction_repo(&mut self) -> GitResult<gix::Repository> {
+    pub fn reconstruction_repo(&mut self) -> GitResult<SleyRepository> {
         self.init_mirror()?;
         self.open_git_repo()
     }
@@ -248,7 +244,7 @@ impl GitBridge<'_> {
     /// parent OIDs.
     pub fn reconstruct_commit_bytes(
         &self,
-        repo: &gix::Repository,
+        repo: &SleyRepository,
         state: &State,
     ) -> GitResult<Vec<u8>> {
         reconstruct_commit_bytes(self.heddle_repo, repo, &self.mapping, state)
@@ -261,7 +257,7 @@ impl GitBridge<'_> {
     /// the verbatim bytes.
     pub fn reconstruct_and_write_commit(
         &self,
-        repo: &gix::Repository,
+        repo: &SleyRepository,
         state: &State,
     ) -> GitResult<ObjectId> {
         let content = self.reconstruct_commit_bytes(repo, state)?;
@@ -274,10 +270,10 @@ impl GitBridge<'_> {
     /// reconstruction of each original commit against its captured golden bytes.
     pub fn reconstruct_commit_for_git_sha(
         &self,
-        repo: &gix::Repository,
+        repo: &SleyRepository,
         sha: &str,
     ) -> GitResult<Option<Vec<u8>>> {
-        let oid = ObjectId::from_hex(sha.as_bytes()).map_err(git_err)?;
+        let oid = ObjectId::from_hex(ObjectFormat::Sha1, sha).map_err(git_err)?;
         let Some(change_id) = self.mapping.get_heddle(oid) else {
             return Ok(None);
         };
@@ -301,10 +297,10 @@ impl GitBridge<'_> {
     /// copied from the mirror.
     pub fn reconstruct_and_write_commit_for_git_sha(
         &self,
-        repo: &gix::Repository,
+        repo: &SleyRepository,
         sha: &str,
     ) -> GitResult<Option<ObjectId>> {
-        let oid = ObjectId::from_hex(sha.as_bytes()).map_err(git_err)?;
+        let oid = ObjectId::from_hex(ObjectFormat::Sha1, sha).map_err(git_err)?;
         let Some(change_id) = self.mapping.get_heddle(oid) else {
             return Ok(None);
         };

--- a/crates/cli/src/bridge/git_sync.rs
+++ b/crates/cli/src/bridge/git_sync.rs
@@ -1,15 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Sync threads/markers functionality for Git bridge.
 
-use gix::refs::transaction::PreviousValue;
 use objects::object::{MarkerName, ThreadName};
 use refs::RefExpectation;
+use sley::{
+    ObjectId as SleyObjectId, RefPrecondition, ReferenceTarget, Repository as SleyRepository,
+};
 
 use crate::bridge::{
-    git_core::{
-        GitBridge, GitBridgeError, GitResult, ensure_commit_update_fast_forward, git_err,
-        set_reference,
-    },
+    git_core::{GitBridge, GitBridgeError, GitResult, git_err},
     git_import::thread_can_adopt_change,
 };
 
@@ -54,23 +53,21 @@ pub fn sync_branches(bridge: &mut GitBridge) -> GitResult<usize> {
     let repo = bridge.open_git_repo()?;
     let mut stats = 0;
 
-    for branch in repo
-        .references()
-        .map_err(git_err)?
-        .local_branches()
-        .map_err(git_err)?
-    {
-        let mut branch = branch.map_err(git_err)?;
-        let name = branch.name().shorten().to_string();
-        let target = branch.peel_to_id().map_err(git_err)?.detach();
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let Some(name) = reference.name.strip_prefix("refs/heads/") else {
+            continue;
+        };
+        let Some(target) = peeled_oid(&repo, &reference.name, &reference.target)? else {
+            continue;
+        };
         if let Some(change_id) = bridge.mapping.get_heddle(target) {
-            let tn = ThreadName::new(&name);
+            let tn = ThreadName::new(name);
             if let Some(existing) = bridge.heddle_repo.refs().get_thread(&tn)?
                 && !thread_can_adopt_change(bridge.heddle_repo, &existing, &change_id)?
             {
                 return Err(GitBridgeError::GitHeddleThreadDiverged {
-                    thread: name.clone(),
-                    branch: name,
+                    thread: name.to_string(),
+                    branch: name.to_string(),
                     thread_change: existing,
                     branch_change: change_id,
                 });
@@ -89,18 +86,16 @@ pub fn sync_tags(bridge: &mut GitBridge) -> GitResult<usize> {
     let repo = bridge.open_git_repo()?;
     let mut stats = 0;
 
-    for tag in repo
-        .references()
-        .map_err(git_err)?
-        .tags()
-        .map_err(git_err)?
-    {
-        let mut tag = tag.map_err(git_err)?;
-        let name = tag.name().shorten().to_string();
-        let oid = tag.peel_to_id().map_err(git_err)?.detach();
+    for reference in repo.references().list_refs().map_err(git_err)? {
+        let Some(name) = reference.name.strip_prefix("refs/tags/") else {
+            continue;
+        };
+        let Some(oid) = peeled_oid(&repo, &reference.name, &reference.target)? else {
+            continue;
+        };
 
         if let Some(change_id) = bridge.mapping.get_heddle(oid) {
-            let mn = MarkerName::new(&name);
+            let mn = MarkerName::new(name);
             match bridge.heddle_repo.refs().get_marker(&mn) {
                 Ok(Some(existing)) if existing != change_id => bridge
                     .heddle_repo
@@ -122,46 +117,63 @@ pub fn sync_tags(bridge: &mut GitBridge) -> GitResult<usize> {
 
 /// Sync a Heddle thread to a Git branch.
 pub fn sync_track_to_branch(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     track_name: &str,
-    git_oid: gix::hash::ObjectId,
+    git_oid: SleyObjectId,
 ) -> GitResult<()> {
     let branch_ref = format!("refs/heads/{}", track_name);
 
-    if let Ok(mut branch) = repo.find_reference(&branch_ref) {
-        let existing = branch.peel_to_id().map_err(git_err)?.detach();
-        if existing != git_oid {
-            ensure_commit_update_fast_forward(repo, &branch_ref, existing, git_oid)?;
-            set_reference(
+    if let Some(branch) = repo.find_reference(&branch_ref).map_err(git_err)? {
+        let existing = branch.peeled_oid(repo).map_err(git_err)?;
+        let Some(existing) = existing else {
+            return set_ref(
                 repo,
                 &branch_ref,
                 git_oid,
-                PreviousValue::ExistingMustMatch(gix::refs::Target::Object(existing)),
+                RefPrecondition::Any,
+                "heddle: sync thread",
+            );
+        };
+        if existing != git_oid {
+            ensure_commit_update_fast_forward(repo, &branch_ref, existing, git_oid)?;
+            set_ref(
+                repo,
+                &branch_ref,
+                git_oid,
+                RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(existing)),
                 "heddle: sync thread",
             )?;
         }
         return Ok(());
     }
 
-    repo.reference(
-        branch_ref,
+    set_ref(
+        repo,
+        &branch_ref,
         git_oid,
-        PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "heddle: sync thread",
     )
-    .map_err(git_err)?;
-    Ok(())
 }
 
 /// Sync a Heddle marker to a Git tag.
 pub fn sync_marker_to_tag(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     marker_name: &str,
-    git_oid: gix::hash::ObjectId,
+    git_oid: SleyObjectId,
 ) -> GitResult<()> {
     let tag_ref = format!("refs/tags/{}", marker_name);
-    if let Ok(mut reference) = repo.find_reference(&tag_ref) {
-        let existing = reference.peel_to_id().map_err(git_err)?.detach();
+    if let Some(reference) = repo.find_reference(&tag_ref).map_err(git_err)? {
+        let existing = peeled_oid(repo, &tag_ref, &reference.target)?;
+        let Some(existing) = existing else {
+            return set_ref(
+                repo,
+                &tag_ref,
+                git_oid,
+                RefPrecondition::Any,
+                "heddle: sync marker",
+            );
+        };
         if existing != git_oid {
             // A marker is a free-move ref (`classify_tag_move`): a legitimate
             // RETARGET to a new served+minted OID must FORCE-set the mirror tag,
@@ -169,18 +181,110 @@ pub fn sync_marker_to_tag(
             // mirror is heddle-owned, so there is no out-of-band tip to spare
             // here; the destination-side ownership gate (`classify_tag_move`,
             // `recorded == old`) still spares an out-of-band DESTINATION tag.
-            set_reference(
+            set_ref(
                 repo,
                 &tag_ref,
                 git_oid,
-                PreviousValue::Any,
+                RefPrecondition::Any,
                 "heddle: sync marker",
             )?;
         }
         return Ok(());
     }
 
-    repo.tag_reference(marker_name, git_oid, PreviousValue::MustNotExist)
-        .map_err(git_err)?;
-    Ok(())
+    set_ref(
+        repo,
+        &tag_ref,
+        git_oid,
+        RefPrecondition::MustNotExist,
+        "heddle: sync marker",
+    )
+}
+
+fn set_ref(
+    repo: &SleyRepository,
+    name: &str,
+    oid: SleyObjectId,
+    precondition: RefPrecondition,
+    message: &str,
+) -> GitResult<()> {
+    let old_oid = match &precondition {
+        RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(oid))
+        | RefPrecondition::ExistingMustMatch(ReferenceTarget::Direct(oid)) => *oid,
+        _ => SleyObjectId::null(repo.object_format()),
+    };
+    let refs = repo.references();
+    let mut tx = refs.transaction();
+    tx.update_to(
+        name,
+        ReferenceTarget::Direct(oid),
+        precondition,
+        Some(sley::plumbing::sley_refs::ReflogEntry {
+            old_oid,
+            new_oid: oid,
+            committer: bridge_identity(),
+            message: message.as_bytes().to_vec(),
+        }),
+    );
+    tx.commit().map_err(git_err)
+}
+
+fn ensure_commit_update_fast_forward(
+    repo: &SleyRepository,
+    ref_name: &str,
+    old: SleyObjectId,
+    new: SleyObjectId,
+) -> GitResult<()> {
+    if sley::plumbing::sley_rev::is_ancestor(
+        repo.git_dir(),
+        repo.object_format(),
+        repo.objects().as_ref(),
+        &old,
+        &new,
+    )
+    .map_err(git_err)?
+    {
+        Ok(())
+    } else {
+        Err(GitBridgeError::NonFastForwardRef {
+            name: ref_name.to_string(),
+            old,
+            new,
+        })
+    }
+}
+
+fn peeled_oid(
+    repo: &SleyRepository,
+    name: &str,
+    target: &ReferenceTarget,
+) -> GitResult<Option<SleyObjectId>> {
+    let Some(oid) = (match target {
+        ReferenceTarget::Direct(oid) => Ok(Some(*oid)),
+        ReferenceTarget::Symbolic(_) => {
+            let Some(reference) = repo.find_reference(name).map_err(git_err)? else {
+                return Ok(None);
+            };
+            reference.peeled_oid(repo).map_err(git_err)
+        }
+    })?
+    else {
+        return Ok(None);
+    };
+    match sley::plumbing::sley_rev::peel_to_commit(
+        repo.objects().as_ref(),
+        repo.object_format(),
+        &oid,
+    ) {
+        Ok(commit_oid) => Ok(Some(commit_oid)),
+        Err(_) => Ok(None),
+    }
+}
+
+fn bridge_identity() -> Vec<u8> {
+    let seconds = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    format!("Heddle <heddle@local> {seconds} +0000").into_bytes()
 }

--- a/crates/cli/src/bridge/git_util.rs
+++ b/crates/cli/src/bridge/git_util.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 
 use objects::object::{State, Status};
 use serde::{Deserialize, Serialize};
+use sley::ObjectId as GitObjectId;
 
 use super::git_core::GitBridge;
 
@@ -182,7 +183,7 @@ pub struct ExportStats {
 #[derive(Debug, Clone)]
 pub struct ExportedRef {
     pub name: String,
-    pub tip: gix::hash::ObjectId,
+    pub tip: GitObjectId,
 }
 
 /// Statistics for import operation.

--- a/crates/cli/src/bridge/test_support.rs
+++ b/crates/cli/src/bridge/test_support.rs
@@ -6,10 +6,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use gix::hash::ObjectId;
-use gix::refs::transaction::PreviousValue;
 use objects::object::ChangeId;
 use repo::Repository as HeddleRepository;
+use sley::{ObjectId, RefPrecondition, Repository as SleyRepository};
 
 use super::git_core::{self, GitBridge, GitResult, SyncMapping};
 
@@ -72,6 +71,7 @@ pub struct PlannedRefWrite {
     pub full_name: String,
     pub old: Option<ObjectId>,
     pub new: ObjectId,
+    pub force: bool,
 }
 
 impl From<git_core::PlannedRefWrite> for PlannedRefWrite {
@@ -80,6 +80,7 @@ impl From<git_core::PlannedRefWrite> for PlannedRefWrite {
             full_name: write.full_name,
             old: write.old,
             new: write.new,
+            force: write.force,
         }
     }
 }
@@ -116,44 +117,44 @@ impl From<git_core::DestinationReconcilePlan> for DestinationReconcilePlan {
     }
 }
 
-pub fn delete_reference_if_present(repo: &gix::Repository, name: &str) -> GitResult<()> {
+pub fn delete_reference_if_present(repo: &SleyRepository, name: &str) -> GitResult<()> {
     git_core::delete_reference_if_present(repo, name)
 }
 
 pub fn set_reference(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     name: &str,
     target: ObjectId,
-    previous: PreviousValue,
+    previous: RefPrecondition,
     message: &str,
 ) -> GitResult<()> {
     git_core::set_reference(repo, name, target, previous, message)
 }
 
-pub fn read_exported_refs(repo: &gix::Repository) -> GitResult<HashMap<String, ObjectId>> {
+pub fn read_exported_refs(repo: &SleyRepository) -> GitResult<HashMap<String, ObjectId>> {
     git_core::read_exported_refs(repo)
 }
 
 pub fn write_exported_refs(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     refs: &HashMap<String, ObjectId>,
 ) -> GitResult<()> {
     git_core::write_exported_refs(repo, refs)
 }
 
-pub fn read_mirror_managed_refs(repo: &gix::Repository) -> GitResult<HashMap<String, ObjectId>> {
+pub fn read_mirror_managed_refs(repo: &SleyRepository) -> GitResult<HashMap<String, ObjectId>> {
     git_core::read_mirror_managed_refs(repo)
 }
 
 pub fn write_mirror_managed_refs(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     refs: &HashMap<String, ObjectId>,
 ) -> GitResult<()> {
     git_core::write_mirror_managed_refs(repo, refs)
 }
 
 pub fn collect_managed_ref_updates(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     record: &HashMap<String, ObjectId>,
 ) -> GitResult<Vec<RefUpdate>> {
     git_core::collect_managed_ref_updates(repo, record)
@@ -161,7 +162,7 @@ pub fn collect_managed_ref_updates(
 }
 
 pub fn plan_destination_reconcile(
-    mirror_repo: &gix::Repository,
+    mirror_repo: &SleyRepository,
     served_frontier: &[RefUpdate],
     creatable_names: Option<&HashSet<String>>,
     old_at_destination: &HashMap<String, ObjectId>,
@@ -222,7 +223,7 @@ pub fn build_existing_mapping(
     bridge.build_existing_mapping(git_repo_path)
 }
 
-pub fn open_git_repo(bridge: &GitBridge<'_>) -> GitResult<gix::Repository> {
+pub fn open_git_repo(bridge: &GitBridge<'_>) -> GitResult<SleyRepository> {
     bridge.open_git_repo()
 }
 
@@ -230,6 +231,6 @@ pub fn heddle_repo<'a>(bridge: &'a GitBridge<'a>) -> &'a HeddleRepository {
     bridge.heddle_repo
 }
 
-pub fn open_repo(path: &Path) -> GitResult<gix::Repository> {
+pub fn open_repo(path: &Path) -> GitResult<SleyRepository> {
     git_core::open_repo(path)
 }

--- a/crates/cli/src/cli/cli_args/commands_bridge.rs
+++ b/crates/cli/src/cli/cli_args/commands_bridge.rs
@@ -4,10 +4,9 @@
 use std::path::PathBuf;
 
 use clap::Subcommand;
-use gix::bstr::ByteSlice;
 
 /// Source for a git import: either a local filesystem path or a URL that
-/// gix can fetch from.
+/// sley can fetch from.
 ///
 /// We discriminate by inspecting the input string: anything containing
 /// `://` (https/ssh/git/file URLs) or starting with `git@` (ssh shorthand)
@@ -17,14 +16,13 @@ use gix::bstr::ByteSlice;
 #[derive(Debug, Clone)]
 pub enum GitSource {
     Path(PathBuf),
-    Url(gix::Url),
+    Url(String),
 }
 
 impl GitSource {
     pub fn parse(s: &str) -> Result<Self, String> {
         if s.contains("://") || s.starts_with("git@") {
-            let url = gix::url::parse(s.as_bytes().as_bstr()).map_err(|e| e.to_string())?;
-            Ok(GitSource::Url(url))
+            Ok(GitSource::Url(s.to_string()))
         } else {
             Ok(GitSource::Path(PathBuf::from(s)))
         }
@@ -33,7 +31,7 @@ impl GitSource {
     pub fn display(&self) -> String {
         match self {
             GitSource::Path(p) => p.display().to_string(),
-            GitSource::Url(u) => u.to_string(),
+            GitSource::Url(u) => u.clone(),
         }
     }
 }

--- a/crates/cli/src/cli/cli_args/commands_main.rs
+++ b/crates/cli/src/cli/cli_args/commands_main.rs
@@ -8,6 +8,9 @@ use super::BridgeCommands;
 #[cfg(feature = "semantic")]
 use super::SemanticCommands;
 use super::{
+    AgentCommands, CheckpointArgs, CompletionSubject, ContextCommands, DiscussCommands,
+    HookCommands, IntegrationCommands, QueryArgs, RedactCommands, RemoteCommands, ReviewCommands,
+    ShellCommands, StashCommands, ThreadCommands, TransactionCommands, VisibilityCommands,
     commands_args::{
         ActorDoneArgs, ActorExplainArgs, ActorListArgs, ActorShowArgs, ActorSpawnArgs, AdoptArgs,
         CloneArgs, CollapseArgs, CommitArgs, DiffArgs, DoctorArgs, ExpandArgs, InitArgs, LandArgs,
@@ -16,9 +19,6 @@ use super::{
         SessionStartArgs, SnapshotArgs, SwitchArgs, SyncArgs, ThreadStartArgs, TryArgs, UndoArgs,
         WatchArgs,
     },
-    AgentCommands, CheckpointArgs, CompletionSubject, ContextCommands, DiscussCommands,
-    HookCommands, IntegrationCommands, QueryArgs, RedactCommands, RemoteCommands, ReviewCommands,
-    ShellCommands, StashCommands, ThreadCommands, TransactionCommands, VisibilityCommands,
 };
 #[cfg(feature = "client")]
 use super::{AuthCommands, SupportCommands};

--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -4,9 +4,9 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow, bail};
-use gix::bstr::ByteSlice;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
+use sley::Repository as SleyRepository;
 
 use super::{
     action_line::print_next,
@@ -154,29 +154,17 @@ fn preflight_importable_git_history(git_root: &Path, refs: &[String]) -> Result<
 }
 
 fn git_repo_has_any_commit_ref(git_root: &Path) -> Result<bool> {
-    let git =
-        gix::discover(git_root).map_err(|error| anyhow!("failed to inspect Git refs: {error}"))?;
-    let references = git
-        .references()
+    let git = SleyRepository::discover(git_root)
         .map_err(|error| anyhow!("failed to inspect Git refs: {error}"))?;
-    for branch in references
-        .local_branches()
+    for reference in git
+        .references()
+        .list_refs()
         .map_err(|error| anyhow!("failed to inspect Git refs: {error}"))?
     {
-        let branch = branch.map_err(|error| anyhow!("failed to inspect Git ref: {error}"))?;
-        if git_ref_points_to_commit(git_root, &branch.name().as_bstr().to_str_lossy())? {
-            return Ok(true);
-        }
-    }
-    let references = git
-        .references()
-        .map_err(|error| anyhow!("failed to inspect Git refs: {error}"))?;
-    for tag in references
-        .tags()
-        .map_err(|error| anyhow!("failed to inspect Git refs: {error}"))?
-    {
-        let tag = tag.map_err(|error| anyhow!("failed to inspect Git ref: {error}"))?;
-        if git_ref_points_to_commit(git_root, &tag.name().as_bstr().to_str_lossy())? {
+        let name = reference.name.as_str();
+        if (name.starts_with("refs/heads/") || name.starts_with("refs/tags/"))
+            && git_ref_points_to_commit(git_root, name)?
+        {
             return Ok(true);
         }
     }
@@ -185,9 +173,9 @@ fn git_repo_has_any_commit_ref(git_root: &Path) -> Result<bool> {
 
 fn git_ref_points_to_commit(git_root: &Path, name: &str) -> Result<bool> {
     let spec = format!("{name}^{{commit}}");
-    let git = gix::discover(git_root)
+    let git = SleyRepository::discover(git_root)
         .map_err(|error| anyhow!("failed to inspect Git ref '{name}': {error}"))?;
-    Ok(git.rev_parse_single(spec.as_bytes().as_bstr()).is_ok())
+    Ok(git.rev_parse(&spec).is_ok())
 }
 
 fn no_git_commits_to_adopt_advice(git_root: &Path, missing_refs: Vec<String>) -> RecoveryAdvice {
@@ -245,7 +233,7 @@ fn absolute_path(path: &Path) -> Result<PathBuf> {
 }
 
 fn git_worktree_root(start: &Path) -> Result<PathBuf> {
-    let git = gix::discover(start).map_err(|error| {
+    let git = SleyRepository::discover(start).map_err(|error| {
         anyhow!(RecoveryAdvice::adopt_requires_git_worktree(Some(format!(
             "Git inspection failed: {error}"
         ))))

--- a/crates/cli/src/cli/commands/bridge.rs
+++ b/crates/cli/src/cli/commands/bridge.rs
@@ -309,11 +309,8 @@ fn exported_refs_summary(refs: &[ExportedRef]) -> String {
     let listing = refs
         .iter()
         .map(|r| {
-            format!(
-                "{} {}",
-                r.name,
-                style::dim(&r.tip.to_hex_with_len(7).to_string())
-            )
+            let short_tip = r.tip.to_hex().chars().take(7).collect::<String>();
+            format!("{} {}", r.name, style::dim(&short_tip))
         })
         .collect::<Vec<_>>()
         .join(" · ");

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -18,6 +18,7 @@ use objects::store::ObjectStore;
 use oplog::{OpLogBackend, OpRecord};
 use repo::{CommitGraphIndex, GitCheckpointRecord, Repository, RepositoryCapability};
 use serde::Serialize;
+use sley::Repository as SleyRepository;
 
 use super::{
     action_line::print_next,
@@ -333,8 +334,8 @@ fn checkpoint_git_write_skipped_advice(reason: String) -> RecoveryAdvice {
 }
 
 fn git_rev_parse_head(root: &std::path::Path) -> Option<String> {
-    let git = gix::discover(root).ok()?;
-    git.head_id().ok().map(|id| id.to_string())
+    let git = SleyRepository::discover(root).ok()?;
+    git.head().ok()?.oid.map(|id| id.to_string())
 }
 
 fn build_output(

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -20,6 +20,9 @@ use objects::{
 use refs::Head;
 use repo::{BlobHydrator, Repository};
 use serde::Serialize;
+use sley::{
+    GitObjectType, IndexWriteOptions, ObjectId, RefPrecondition, Repository as SleyRepository,
+};
 
 use super::{
     advice::RecoveryAdvice,
@@ -174,8 +177,8 @@ pub async fn cmd_clone(
             if looks_like_local_path(&remote) {
                 return Err(anyhow!(clone_remote_not_found_advice(Path::new(&remote))));
             }
-            if let Ok(url) = gix::url::parse(remote.as_bytes().into()) {
-                return clone_git_overlay_url(cli, &url, local_path, &options);
+            if looks_like_git_overlay_url(&remote) {
+                return clone_git_overlay_url(cli, &remote, local_path, &options);
             }
             return Err(anyhow!(clone_invalid_remote_url_advice(&remote)));
         }
@@ -183,7 +186,7 @@ pub async fn cmd_clone(
 
     match target {
         RemoteTarget::Local(remote_path) => {
-            if !remote_path.join(".heddle").exists() && gix::open(&remote_path).is_ok() {
+            if !remote_path.join(".heddle").exists() && open_repo(&remote_path).is_ok() {
                 return clone_git_overlay_path(cli, &remote_path, local_path, &options);
             }
             clone_local(cli, &remote_path, local_path, &options).await?;
@@ -246,9 +249,13 @@ fn looks_like_local_path(remote: &str) -> bool {
         || remote.starts_with("~/")
 }
 
+fn looks_like_git_overlay_url(remote: &str) -> bool {
+    remote.contains("://") || remote.starts_with("git@")
+}
+
 fn clone_git_overlay_url(
     cli: &Cli,
-    url: &gix::Url,
+    url: &str,
     local_path: &Path,
     options: &CloneOptions,
 ) -> Result<()> {
@@ -266,7 +273,7 @@ fn clone_git_overlay_path(
 ) -> Result<()> {
     reject_unsupported_for_git_overlay(options)?;
     fs::create_dir_all(local_path)?;
-    gix::init(local_path).map_err(anyhow::Error::msg)?;
+    SleyRepository::init(local_path).map_err(anyhow::Error::msg)?;
     copy_local_repo_to_bare(remote_path, &local_path.join(".git")).map_err(anyhow::Error::msg)?;
     let remote_label = fs::canonicalize(remote_path)
         .unwrap_or_else(|_| remote_path.to_path_buf())
@@ -382,7 +389,7 @@ fn finish_git_overlay_clone(
     // Re-attach HEAD to the cloned thread, AND mirror the choice into
     // `.git/HEAD`. `Repository::open` on a git-overlay repo
     // unconditionally syncs heddle's HEAD from `.git/HEAD` via
-    // `detect_git_head`, so if we left `.git/HEAD` pointing at gix's
+    // `detect_git_head`, so if we left `.git/HEAD` pointing at Sley's
     // init-time default ("main" / "master") the very next `heddle`
     // command would silently reset HEAD to a thread that doesn't
     // exist — and `current_state` would return `None`, causing
@@ -548,7 +555,7 @@ fn configure_git_overlay_origin_tracking(local_path: &Path, branch: &str) -> Res
         ))
     })?;
     let branch_ref = format!("refs/heads/{branch}");
-    let mut reference = git_repo.find_reference(&branch_ref).map_err(|err| {
+    let reference = git_repo.find_reference(&branch_ref).map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!("clone verification failed: selected Git branch '{branch}' is missing: {err}"),
             format!("Git ref '{branch_ref}' is missing after Git-overlay clone"),
@@ -556,7 +563,15 @@ fn configure_git_overlay_origin_tracking(local_path: &Path, branch: &str) -> Res
             canonical_bridge_import_ref_command(branch),
         ))
     })?;
-    let target = reference.peel_to_id().map_err(|err| {
+    let Some(reference) = reference else {
+        return Err(anyhow!(clone_verification_failed_advice(
+            format!("clone verification failed: selected Git branch '{branch}' is missing"),
+            format!("Git ref '{branch_ref}' is missing after Git-overlay clone"),
+            "Git status would report upstream tracking for a branch whose local ref is absent",
+            canonical_bridge_import_ref_command(branch),
+        )));
+    };
+    let target = reference.peeled_oid(&git_repo).map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!(
                 "clone verification failed: selected Git branch '{branch}' is not readable: {err}"
@@ -565,12 +580,20 @@ fn configure_git_overlay_origin_tracking(local_path: &Path, branch: &str) -> Res
             "Git status would report upstream tracking for an unreadable branch",
             canonical_bridge_import_ref_command(branch),
         ))
+    })?
+    .ok_or_else(|| {
+        anyhow!(clone_verification_failed_advice(
+            format!("clone verification failed: selected Git branch '{branch}' is unborn"),
+            format!("Git ref '{branch_ref}' could not be peeled to a commit"),
+            "Git status would report upstream tracking for an unreadable branch",
+            canonical_bridge_import_ref_command(branch),
+        ))
     })?;
     set_reference(
         &git_repo,
         &format!("refs/remotes/origin/{branch}"),
-        target.detach(),
-        gix::refs::transaction::PreviousValue::Any,
+        target,
+        RefPrecondition::Any,
         "heddle: seed origin remote-tracking branch after clone",
     )
     .map_err(|err| {
@@ -682,7 +705,7 @@ fn verify_git_overlay_clone(
 }
 
 fn refresh_git_index_to_head(local_path: &Path) -> Result<()> {
-    let git = gix::discover(local_path).map_err(|err| {
+    let git = open_repo(local_path).map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!("clone verification failed: cannot reopen Git checkout: {err}"),
             format!(
@@ -693,7 +716,18 @@ fn refresh_git_index_to_head(local_path: &Path) -> Result<()> {
             "heddle status",
         ))
     })?;
-    let head_tree = git.head_tree_id_or_empty().map_err(|err| {
+    let head = git.head().map_err(|err| {
+        anyhow!(clone_verification_failed_advice(
+            format!("clone verification failed: cannot read Git HEAD: {err}"),
+            "Git HEAD could not be read during clone verification",
+            "clone cannot refresh the Git index to match the selected branch",
+            "heddle status",
+        ))
+    })?;
+    let Some(head_oid) = head.oid else {
+        return Ok(());
+    };
+    let commit = git.read_commit(&head_oid).map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!("clone verification failed: cannot read Git HEAD tree: {err}"),
             "Git HEAD tree could not be read during clone verification",
@@ -701,7 +735,7 @@ fn refresh_git_index_to_head(local_path: &Path) -> Result<()> {
             "heddle status",
         ))
     })?;
-    let mut index = git.index_from_tree(head_tree.as_ref()).map_err(|err| {
+    let mut index = git.index_from_tree(&commit.tree).map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!("clone verification failed: cannot build Git index from HEAD tree: {err}"),
             "Git index could not be rebuilt from HEAD during clone verification",
@@ -709,7 +743,15 @@ fn refresh_git_index_to_head(local_path: &Path) -> Result<()> {
             "heddle status",
         ))
     })?;
-    index.write(Default::default()).map_err(|err| {
+    index.upgrade_version_for_flags();
+    git.write_index(
+        &index,
+        IndexWriteOptions {
+            fsync: true,
+            validate_checksum: true,
+        },
+    )
+    .map_err(|err| {
         anyhow!(clone_verification_failed_advice(
             format!("clone verification failed: cannot write Git index: {err}"),
             "Git index could not be written during clone verification",
@@ -961,7 +1003,7 @@ fn read_git_head_branch(git_dir: &Path) -> Option<String> {
 
 /// Pin `.git/HEAD` to `refs/heads/<branch>`. Called after clone so a
 /// future `Repository::open` reads the same branch heddle attached to,
-/// rather than the init-time default gix wrote (typically `main`).
+/// rather than the init-time default Sley wrote (typically `main`).
 fn write_git_head_branch(git_dir: &Path, branch: &str) -> Result<()> {
     fs::write(git_dir.join("HEAD"), format!("ref: refs/heads/{branch}\n"))?;
     Ok(())
@@ -1410,7 +1452,7 @@ fn clone_symlink_unsupported_advice(path: &Path, dest_path: &Path) -> RecoveryAd
 /// blake3-hashed blob is recorded in `.heddle/partial-fetch` but is
 /// absent from the local object store — the read path delegates here.
 /// This hydrator looks up the corresponding Git object id, fetches the
-/// blob from the underlying gix repo when it is already present locally
+/// blob from the underlying sley repo when it is already present locally
 /// and writes the bytes into the heddle store. Native promisor fetching
 /// for absent Git blobs is not implemented yet; Heddle rejects public
 /// Git-overlay lazy/filtered clones until that path can run without a
@@ -1419,7 +1461,7 @@ fn clone_symlink_unsupported_advice(path: &Path, dest_path: &Path) -> RecoveryAd
 /// ## Why a side-table?
 ///
 /// `PartialFetchMetadata` records blake3 hashes only, but
-/// `gix::Repository::find_blob` is keyed by Git OID. The bridge
+/// `Repository::read_object` is keyed by Git OID. The bridge
 /// already computes blake3↔git mappings *for commits* (see
 /// `SyncMapping` in `bridge/git_core.rs`); blob mappings are
 /// constructed on-the-fly during import. We accept the same shape of
@@ -1434,7 +1476,7 @@ pub struct GitOverlayBlobHydrator {
     /// `Send + Sync` while still allowing the mapping to grow over
     /// time (e.g. if the import path is later extended to record new
     /// blobs as it walks).
-    blob_oid_map: Mutex<std::collections::HashMap<ContentHash, gix::ObjectId>>,
+    blob_oid_map: Mutex<std::collections::HashMap<ContentHash, ObjectId>>,
 }
 
 impl GitOverlayBlobHydrator {
@@ -1447,7 +1489,7 @@ impl GitOverlayBlobHydrator {
 
     /// Pre-seed the blake3 → git OID mapping. Called by the importer
     /// (or by tests) as missing blobs are discovered.
-    pub fn record_blob_oid(&self, hash: ContentHash, oid: gix::ObjectId) {
+    pub fn record_blob_oid(&self, hash: ContentHash, oid: ObjectId) {
         self.blob_oid_map.lock().unwrap().insert(hash, oid);
     }
 }
@@ -1487,18 +1529,22 @@ impl BlobHydrator for GitOverlayBlobHydrator {
 }
 
 impl GitOverlayBlobHydrator {
-    fn read_blob_bytes(&self, oid: gix::ObjectId) -> HeddleResult<Vec<u8>> {
-        let local_first = open_repo(&self.git_repo_path)
+    fn read_blob_bytes(&self, oid: ObjectId) -> HeddleResult<Vec<u8>> {
+        let object = open_repo(&self.git_repo_path)
             .map_err(|err| HeddleError::Io(std::io::Error::other(err.to_string())))?
-            .find_blob(oid)
-            .ok()
-            .map(|mut blob| blob.take_data());
-        if let Some(bytes) = local_first {
-            return Ok(bytes);
+            .read_object(&oid)
+            .map_err(|err| {
+                HeddleError::Io(std::io::Error::other(format!(
+                    "Git object {oid} could not be read from {}; native Git-overlay lazy hydration is not implemented yet. Re-run a full clone/import without --lazy or --filter so Heddle has a complete local object graph. Cause: {err}",
+                    self.git_repo_path.display()
+                )))
+            })?;
+        if object.object_type == GitObjectType::Blob {
+            return Ok(object.body.clone());
         }
 
         Err(HeddleError::Config(format!(
-            "Git blob {oid} is missing from {}; native Git-overlay lazy hydration is not implemented yet. Re-run a full clone/import without --lazy or --filter so Heddle has a complete local object graph.",
+            "Git object {oid} in {} is not a blob; native Git-overlay lazy hydration is not implemented yet. Re-run a full clone/import without --lazy or --filter so Heddle has a complete local object graph.",
             self.git_repo_path.display()
         )))
     }
@@ -1813,7 +1859,7 @@ mod tests {
     /// Standalone helpers to exercise [`GitOverlayBlobHydrator`]'s
     /// error and fallback branches that the kernel/hermetic end-to-end
     /// test (in `tests/lazy_blob_hydration_kernel.rs`) doesn't reach.
-    /// Each test sets up the smallest possible bare gix repo it needs;
+    /// Each test sets up the smallest possible bare Git repo it needs;
     /// none of them hit the network.
     mod git_overlay_hydrator {
         use objects::object::ContentHash;
@@ -1822,12 +1868,12 @@ mod tests {
 
         use super::*;
 
-        /// Build a fresh empty bare gix repo and a fresh `Repository`,
+        /// Build a fresh empty bare Git repo and a fresh `Repository`,
         /// returning `(temp, bare_path, repo)` for use in a single test.
         fn fixtures() -> (TempDir, std::path::PathBuf, Repository) {
             let temp = TempDir::new().expect("temp");
             let bare = temp.path().join("source.git");
-            gix::init_bare(&bare).expect("init bare gix");
+            SleyRepository::init_bare(&bare).expect("init bare git repo");
             let heddle_root = temp.path().join("heddle");
             std::fs::create_dir_all(&heddle_root).expect("mkdir heddle");
             let repo =
@@ -1836,9 +1882,9 @@ mod tests {
         }
 
         /// Write a single blob into the bare repo and return its OID.
-        fn write_local_blob(bare: &std::path::Path, payload: &[u8]) -> gix::ObjectId {
-            let g = gix::open(bare).expect("open bare");
-            g.write_blob(payload).expect("write blob").detach()
+        fn write_local_blob(bare: &std::path::Path, payload: &[u8]) -> ObjectId {
+            let git = SleyRepository::open(bare).expect("open bare");
+            git.write_blob(payload).expect("write blob")
         }
 
         #[test]
@@ -1907,7 +1953,7 @@ mod tests {
             // shell out to `git cat-file`; the error should name the
             // missing OID and the native lazy-hydration boundary.
             let (_temp, bare, _repo) = fixtures();
-            let absent_oid = gix::ObjectId::null(gix::hash::Kind::Sha1);
+            let absent_oid = ObjectId::null(sley::ObjectFormat::Sha1);
             let hydrator = GitOverlayBlobHydrator::new(bare.clone());
 
             let err = hydrator

--- a/crates/cli/src/cli/commands/completion.rs
+++ b/crates/cli/src/cli/commands/completion.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Completion command - generate shell completion scripts.
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use clap::CommandFactory;
-use clap_complete::{generate, Shell};
+use clap_complete::{Shell, generate};
 
 use super::advice::RecoveryAdvice;
 use crate::cli::{Cli, CompletionSubject};

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -16,6 +16,7 @@ use objects::{
     worktree::diff_blobs,
 };
 use repo::Repository;
+use sley::{EntryKind, Repository as SleyRepository};
 
 #[cfg(not(feature = "semantic"))]
 use super::super::advice::RecoveryAdvice;
@@ -535,7 +536,7 @@ fn render_plain_git_head_diff(
 ) -> Result<()> {
     // The plain-Git fast path has no heddle Repository, so there is
     // no in-tree blob source `get_worktree_diff` can read from. When
-    // patch text is needed we read the HEAD blobs through `gix`
+    // patch text is needed we read the HEAD blobs through Sley
     // and feed them through the same `diff_blobs` + renderer pipeline
     // the heddle paths use — that way the `\ No newline at end of
     // file` handling stays in one place.
@@ -599,25 +600,21 @@ fn render_status_changes(
 }
 
 /// Build one `FileChange` per status entry in the plain-Git probe,
-/// computing real hunks against the gix-read HEAD blobs so `--patch`
+/// computing real hunks against the sley-read HEAD blobs so `--patch`
 /// emits a body the regular renderer can stamp newline markers onto.
 ///
 /// Unborn HEAD (plain `git init` + staged file, no commit yet) has
-/// no tree to read; in that case we pass `None` and the add-only path
+/// no tree to read; in that case we skip old-side lookup and the add-only path
 /// in `compute_plain_git_hunks` renders against `/dev/null`. Without
-/// this check, `head_tree()?` propagates a "no HEAD commit" error and
+/// this check, resolving old-side blobs propagates a "no HEAD commit" error and
 /// the whole `--patch` render fails, even though the only honest diff
 /// is "everything is new."
 fn plain_git_file_changes_with_hunks(
     probe: &PlainGitVerificationProbe,
     unified: usize,
 ) -> Result<Vec<FileChange>> {
-    let git_repo = gix::discover(&probe.root)?;
-    let mut head_tree = if git_repo.head()?.is_unborn() {
-        None
-    } else {
-        Some(git_repo.head_tree()?)
-    };
+    let git_repo = SleyRepository::discover(&probe.root)?;
+    let head_has_tree = !git_repo.head()?.is_unborn();
     // `plain_git_worktree_status` can report the same path as BOTH
     // deleted (index-vs-HEAD) and added (untracked worktree) — e.g.
     // `git rm --cached f` followed by editing the still-present untracked
@@ -632,7 +629,7 @@ fn plain_git_file_changes_with_hunks(
     for path in &probe.changes.modified {
         push_plain_git_modified(
             &git_repo,
-            &mut head_tree,
+            head_has_tree,
             &probe.root,
             path,
             unified,
@@ -646,7 +643,7 @@ fn plain_git_file_changes_with_hunks(
             // splits into delete+add rather than emitting a cross-type chmod.
             push_plain_git_modified(
                 &git_repo,
-                &mut head_tree,
+                head_has_tree,
                 &probe.root,
                 path,
                 unified,
@@ -655,7 +652,7 @@ fn plain_git_file_changes_with_hunks(
         } else {
             changes.push(plain_git_file_change(
                 &git_repo,
-                head_tree.as_mut(),
+                head_has_tree,
                 &probe.root,
                 path,
                 "added",
@@ -671,7 +668,7 @@ fn plain_git_file_changes_with_hunks(
         }
         changes.push(plain_git_file_change(
             &git_repo,
-            head_tree.as_mut(),
+            head_has_tree,
             &probe.root,
             path,
             "deleted",
@@ -684,17 +681,17 @@ fn plain_git_file_changes_with_hunks(
 
 #[allow(clippy::too_many_arguments)]
 fn plain_git_file_change(
-    git_repo: &gix::Repository,
-    head_tree: Option<&mut gix::Tree<'_>>,
+    git_repo: &SleyRepository,
+    head_has_tree: bool,
     root: &Path,
     path: &std::path::Path,
     kind: &str,
     diff_kind: DiffKind,
     unified: usize,
 ) -> Result<FileChange> {
-    let (old_blob, old_mode) = match (head_tree, &diff_kind) {
-        (Some(tree), DiffKind::Modified | DiffKind::Deleted) => {
-            match plain_git_lookup_blob_and_mode(git_repo, tree, path)? {
+    let (old_blob, old_mode) = match (head_has_tree, &diff_kind) {
+        (true, DiffKind::Modified | DiffKind::Deleted) => {
+            match plain_git_lookup_blob_and_mode(git_repo, path)? {
                 Some((blob, mode)) => (Some(blob), Some(mode)),
                 None => (None, None),
             }
@@ -743,26 +740,31 @@ fn plain_git_file_change(
 }
 
 fn plain_git_lookup_blob_and_mode(
-    git_repo: &gix::Repository,
-    tree: &mut gix::Tree<'_>,
+    git_repo: &SleyRepository,
     path: &std::path::Path,
 ) -> Result<Option<(Blob, FileMode)>> {
-    let Some(entry) = tree.peel_to_entry_by_path(path)? else {
+    let tree_path = plain_git_tree_path(path);
+    let Ok(entry) = git_repo.resolve_path("HEAD", &tree_path) else {
         return Ok(None);
     };
-    let entry_mode = entry.mode();
-    if !entry_mode.is_blob_or_symlink() {
+    let Some(entry_mode) = entry.mode else {
         return Ok(None);
-    }
-    let mode = if entry_mode.is_link() {
-        FileMode::Symlink
-    } else if entry_mode.is_executable() {
-        FileMode::Executable
-    } else {
-        FileMode::Normal
     };
-    let object = git_repo.find_object(entry.object_id())?;
-    Ok(Some((Blob::new(object.data.clone()), mode)))
+    let mode = match EntryKind::from_mode(entry_mode) {
+        Some(EntryKind::Symlink) => FileMode::Symlink,
+        Some(EntryKind::BlobExecutable) => FileMode::Executable,
+        Some(EntryKind::Blob) => FileMode::Normal,
+        _ => return Ok(None),
+    };
+    let object = git_repo.read_object(&entry.oid)?;
+    Ok(Some((Blob::new(object.body.clone()), mode)))
+}
+
+fn plain_git_tree_path(path: &std::path::Path) -> String {
+    path.components()
+        .map(|component| component.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 /// Classify the HEAD-tree side of a plain-Git path. A tracked entry is a
@@ -771,19 +773,21 @@ fn plain_git_lookup_blob_and_mode(
 /// HEAD) is `Absent`, which `is_type_change` treats as no type change so
 /// the modify renders as content.
 fn plain_git_old_side_kind(
-    head_tree: Option<&mut gix::Tree<'_>>,
+    git_repo: &SleyRepository,
+    head_has_tree: bool,
     path: &std::path::Path,
 ) -> Result<SideKind> {
-    let Some(tree) = head_tree else {
+    if !head_has_tree {
+        return Ok(SideKind::Absent);
+    }
+    let tree_path = plain_git_tree_path(path);
+    let Ok(entry) = git_repo.resolve_path("HEAD", &tree_path) else {
         return Ok(SideKind::Absent);
     };
-    let Some(entry) = tree.peel_to_entry_by_path(path)? else {
-        return Ok(SideKind::Absent);
-    };
-    Ok(if entry.mode().is_link() {
-        SideKind::Symlink
-    } else {
-        SideKind::Regular
+    Ok(match entry.mode.and_then(EntryKind::from_mode) {
+        Some(EntryKind::Symlink) => SideKind::Symlink,
+        Some(EntryKind::Tree) => SideKind::Dir,
+        _ => SideKind::Regular,
     })
 }
 
@@ -799,19 +803,19 @@ fn plain_git_old_side_kind(
 /// their own `added` entries from status). A tracked old side is always a
 /// single blob/symlink, so there is never an old subtree to expand here.
 fn push_plain_git_modified(
-    git_repo: &gix::Repository,
-    head_tree: &mut Option<gix::Tree<'_>>,
+    git_repo: &SleyRepository,
+    head_has_tree: bool,
     root: &Path,
     path: &std::path::Path,
     unified: usize,
     out: &mut Vec<FileChange>,
 ) -> Result<()> {
     let new_kind = worktree_side_kind(&root.join(path));
-    let old_kind = plain_git_old_side_kind(head_tree.as_mut(), path)?;
+    let old_kind = plain_git_old_side_kind(git_repo, head_has_tree, path)?;
     if is_type_change(old_kind, new_kind) {
         out.push(plain_git_file_change(
             git_repo,
-            head_tree.as_mut(),
+            head_has_tree,
             root,
             path,
             "deleted",
@@ -823,7 +827,7 @@ fn push_plain_git_modified(
         if new_kind != SideKind::Dir {
             out.push(plain_git_file_change(
                 git_repo,
-                head_tree.as_mut(),
+                head_has_tree,
                 root,
                 path,
                 "added",
@@ -834,7 +838,7 @@ fn push_plain_git_modified(
     } else {
         out.push(plain_git_file_change(
             git_repo,
-            head_tree.as_mut(),
+            head_has_tree,
             root,
             path,
             "modified",

--- a/crates/cli/src/cli/commands/doctor_schemas.rs
+++ b/crates/cli/src/cli/commands/doctor_schemas.rs
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result, anyhow};
 use serde::Serialize;
 use serde_json::Value;
+use sley::Repository as SleyRepository;
 
 use super::{
     advice::RecoveryAdvice,
@@ -984,9 +985,8 @@ fn find_repo_root(start: &Path) -> Option<PathBuf> {
             return Some(ancestor.to_path_buf());
         }
     }
-    let repo = gix::discover(start).ok()?;
+    let repo = SleyRepository::discover(start).ok()?;
     repo.workdir()
-        .map(Path::to_path_buf)
         .or_else(|| repo.git_dir().parent().map(Path::to_path_buf))
 }
 

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -5,6 +5,7 @@ use anyhow::{Result, anyhow};
 use objects::store::ObjectStore;
 use repo::Repository;
 use serde::Serialize;
+use sley::Repository as SleyRepository;
 
 use super::{
     advice::RecoveryAdvice,
@@ -149,7 +150,7 @@ fn check_bridge(
 
     for (change_id, git_oid) in bridge.mapping.iter() {
         *objects_checked += 1;
-        if mirror.find_object(*git_oid).is_err() {
+        if mirror.read_object(git_oid).is_err() {
             errors.push(make_error(
                 "bridge-mapping",
                 &format!("mapped Git object {git_oid} is missing from the mirror"),
@@ -210,7 +211,7 @@ fn check_checkout_head(
     errors: &mut Vec<FsckError>,
     objects_checked: &mut usize,
 ) -> Result<()> {
-    let Ok(checkout) = gix::discover(repo.root()) else {
+    let Ok(checkout) = SleyRepository::discover(repo.root()) else {
         return Ok(());
     };
     let refs::Head::Attached { thread } = repo.head_ref()? else {
@@ -223,13 +224,13 @@ fn check_checkout_head(
         return Ok(());
     };
     let branch_ref = format!("refs/heads/{thread}");
-    let Ok(mut reference) = checkout.find_reference(&branch_ref) else {
+    let Ok(Some(reference)) = checkout.find_reference(&branch_ref) else {
         return Ok(());
     };
     let actual_git_oid = reference
-        .peel_to_id()
+        .peeled_oid(&checkout)
         .map_err(|err| anyhow!("checkout HEAD check failed: {err}"))?
-        .detach();
+        .ok_or_else(|| anyhow!("checkout HEAD check failed: branch ref is unborn"))?;
     *objects_checked += 1;
     if actual_git_oid != expected_git_oid {
         errors.push(make_error(

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -9,8 +9,6 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use gix::bstr::{BStr, ByteSlice};
-use gix_index::entry::{Mode, Stage};
 use objects::{
     object::{
         Agent, Blob, ChangeId, ContentHash, EntryType, FileMode, Principal, ThreadName, Tree,
@@ -21,6 +19,10 @@ use objects::{
 use oplog::{OpBatch, OpLogBackend, OpRecord};
 use repo::{Repository, RepositoryCapability, git_worktree_status::GitWorktreeEntryState};
 use serde::Serialize;
+use sley::{
+    BString as GitBString, GitObjectType, Index, IndexEntry, IndexStage, ObjectId,
+    Repository as SleyRepository,
+};
 
 use super::{
     action_line::print_next,
@@ -52,6 +54,12 @@ use crate::{
     },
     config::UserConfig,
 };
+
+const GIT_MODE_FILE: u32 = 0o100644;
+const GIT_MODE_FILE_EXECUTABLE: u32 = 0o100755;
+const GIT_MODE_SYMLINK: u32 = 0o120000;
+const GIT_MODE_COMMIT: u32 = 0o160000;
+const GIT_MODE_DIR: u32 = 0o040000;
 
 #[derive(Serialize)]
 struct CommitCompatOutput {
@@ -156,7 +164,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         // Git-overlay staged-index path below when one exists.
         let has_staged_index_intent = !args.all
             && repo.capability() == RepositoryCapability::GitOverlay
-            && !git_index_intent(&repo)?.staged_paths.is_empty();
+            && !git_index_intent_for_repo(&repo)?.staged_paths.is_empty();
         if status.is_clean() && !has_staged_index_intent {
             let trust = build_repository_verification_state(&repo);
             // `--no-all` forces an index-only commit and must never auto-commit
@@ -263,7 +271,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
         return Ok(());
     }
 
-    let index_intent = git_index_intent(&repo)?;
+    let index_intent = git_index_intent_for_repo(&repo)?;
     if args.no_all && !args.all && index_intent.staged_paths.is_empty() {
         // `--no-all` is index-only. With no staged paths the index is identical
         // to HEAD (empty index, or index == HEAD), so there is nothing genuinely
@@ -595,19 +603,22 @@ impl GitIndexPlan {
 /// nested inside one. A Heddle thread checkout now lives under the parent
 /// repo's `.heddle/threads/` (heddle#572); it's a *native* isolated
 /// checkout that shares the parent's object store but is NOT a Git
-/// worktree of its own. Bare `gix::discover` walks up the directory tree,
+/// worktree of its own. Bare git discovery walks up the directory tree,
 /// so from inside such a checkout it would find the PARENT repo's `.git`
 /// and read its index/HEAD as though they belonged to the checkout.
 /// Requiring the discovered worktree to equal `root` keeps git-index
 /// inspection scoped to genuine git-overlay roots — and matches the
 /// pre-#572 behaviour where a sibling checkout had no git above it at all.
 fn git_worktree_rooted_at(root: &Path) -> bool {
-    match gix::discover(root) {
-        Ok(git) => git
-            .workdir()
-            .is_some_and(|workdir| paths_equal(workdir, root)),
+    match SleyRepository::discover(root) {
+        Ok(git) => git_worktree_matches_root(&git, root),
         Err(_) => false,
     }
+}
+
+fn git_worktree_matches_root(git: &SleyRepository, root: &Path) -> bool {
+    git.workdir()
+        .is_some_and(|workdir| paths_equal(&workdir, root))
 }
 
 fn paths_equal(left: &Path, right: &Path) -> bool {
@@ -630,11 +641,14 @@ pub(crate) fn git_index_plan_for_root(root: &Path) -> Result<Option<GitIndexPlan
 }
 
 pub(crate) fn git_index_plan_for_repo(repo: &Repository) -> Result<Option<GitIndexPlan>> {
-    if !git_worktree_rooted_at(repo.root()) {
+    let Some(git) = repo.git_overlay_sley_repository()? else {
+        return Ok(None);
+    };
+    if !git_worktree_matches_root(&git, repo.root()) {
         return Ok(None);
     }
     Ok(Some(GitIndexPlan::from_intent(
-        &git_index_intent(repo)?,
+        &git_index_intent(repo, &git)?,
         false,
     )))
 }
@@ -652,9 +666,37 @@ fn split_extra_paths(extra_paths: &[String]) -> (Vec<String>, Vec<String>) {
     (unstaged_paths, untracked_paths)
 }
 
-fn git_index_intent(repo: &Repository) -> Result<GitIndexIntent> {
+fn empty_git_index() -> Index {
+    Index {
+        version: 2,
+        entries: Vec::new(),
+        extensions: Vec::new(),
+        checksum: None,
+    }
+}
+
+fn index_or_empty(git: &SleyRepository) -> Result<Index> {
+    Ok(git.open_index()?.unwrap_or_else(empty_git_index))
+}
+
+fn head_index_or_empty(git: &SleyRepository) -> Result<Index> {
+    let Some(head_oid) = git.head()?.oid else {
+        return Ok(empty_git_index());
+    };
+    let commit = git.read_commit(&head_oid)?;
+    Ok(git.index_from_tree(&commit.tree)?)
+}
+
+fn git_index_intent(repo: &Repository, git: &SleyRepository) -> Result<GitIndexIntent> {
     let ignore_patterns = repo.ignore_patterns()?;
-    git_index_intent_for_root_with_ignore(repo.root(), &ignore_patterns)
+    git_index_intent_for_root_with_ignore_and_repo(repo.root(), &ignore_patterns, git)
+}
+
+fn git_index_intent_for_repo(repo: &Repository) -> Result<GitIndexIntent> {
+    let git = repo
+        .git_overlay_sley_repository()?
+        .ok_or_else(|| anyhow!("failed to inspect Git index before commit"))?;
+    git_index_intent(repo, &git)
 }
 
 pub(crate) fn git_index_intent_for_root(root: &Path) -> Result<GitIndexIntent> {
@@ -666,16 +708,19 @@ fn git_index_intent_for_root_with_ignore(
     root: &Path,
     ignore_patterns: &[String],
 ) -> Result<GitIndexIntent> {
-    let git = gix::discover(root).context("failed to inspect Git index before commit")?;
-    let index = git
-        .index_or_empty()
-        .context("failed to inspect Git index before commit")?;
-    let head_tree = git
-        .head_tree_id_or_empty()
-        .context("failed to inspect Git index before commit")?;
-    let head_index = git
-        .index_from_tree(head_tree.as_ref())
-        .context("failed to inspect Git index before commit")?;
+    let git =
+        SleyRepository::discover(root).context("failed to inspect Git index before commit")?;
+    git_index_intent_for_root_with_ignore_and_repo(root, ignore_patterns, &git)
+}
+
+fn git_index_intent_for_root_with_ignore_and_repo(
+    root: &Path,
+    ignore_patterns: &[String],
+    git: &SleyRepository,
+) -> Result<GitIndexIntent> {
+    let index = index_or_empty(git).context("failed to inspect Git index before commit")?;
+    let head_index =
+        head_index_or_empty(git).context("failed to inspect Git index before commit")?;
 
     let head_entries = index_entries_by_path(&head_index);
     let index_entries = index_entries_by_path(&index);
@@ -695,11 +740,11 @@ fn git_index_intent_for_root_with_ignore(
     let tracked_paths: BTreeSet<String> = index_entries.keys().cloned().collect();
     let gitlink_paths: BTreeSet<String> = index_entries
         .iter()
-        .filter(|(_, entry)| entry.mode == Mode::COMMIT)
+        .filter(|(_, entry)| entry.mode == GIT_MODE_COMMIT)
         .map(|(path, _)| path.clone())
         .collect();
     for (path, entry) in &index_entries {
-        if entry.mode == Mode::COMMIT {
+        if entry.mode == GIT_MODE_COMMIT {
             continue;
         }
         if worktree_entry_changed(root, path, entry)? {
@@ -714,7 +759,8 @@ fn git_index_intent_for_root_with_ignore(
 }
 
 fn git_ignore_patterns_for_root(root: &Path) -> Result<Vec<String>> {
-    let git = gix::discover(root).context("failed to inspect Git ignore files before commit")?;
+    let git = SleyRepository::discover(root)
+        .context("failed to inspect Git ignore files before commit")?;
     let mut patterns = Vec::new();
     append_ignore_file_patterns(&mut patterns, &root.join(".gitignore"))?;
     append_ignore_file_patterns(&mut patterns, &git.git_dir().join("info").join("exclude"))?;
@@ -740,21 +786,20 @@ fn append_ignore_file_patterns(patterns: &mut Vec<String>, path: &Path) -> Resul
 }
 
 fn git_index_tree(repo: &Repository) -> Result<Tree> {
-    let git = gix::discover(repo.root()).context("failed to inspect Git index before commit")?;
-    let index = git
-        .index_or_empty()
-        .context("failed to inspect Git index before commit")?;
+    let git = repo
+        .git_overlay_sley_repository()?
+        .ok_or_else(|| anyhow!("failed to inspect Git index before commit"))?;
+    let index = index_or_empty(&git).context("failed to inspect Git index before commit")?;
     let mut builder = IndexTreeBuilder::default();
 
-    index
-        .entries_with_paths_by_filter_map(|path, entry| Some((bstr_path(path), entry.clone())))
-        .try_for_each(|(_, (path, entry))| -> Result<()> {
-            if entry.stage() != Stage::Unconflicted {
-                return Err(anyhow!(unmerged_git_index_advice(&path)));
-            }
-            let node = index_entry_node(repo, &git, &path, &entry)?;
-            builder.insert(&path, node)
-        })?;
+    for entry in index.entries {
+        let path = git_path_from_bstring(&entry.path);
+        if entry.stage() != IndexStage::Normal {
+            return Err(anyhow!(unmerged_git_index_advice(&path)));
+        }
+        let node = index_entry_node(repo, &git, &path, &entry)?;
+        builder.insert(&path, node)?;
+    }
 
     builder.into_tree(repo)
 }
@@ -818,16 +863,16 @@ impl IndexTreeBuilder {
 
 fn index_entry_node(
     repo: &Repository,
-    git: &gix::Repository,
+    git: &SleyRepository,
     path: &str,
-    entry: &gix_index::Entry,
+    entry: &IndexEntry,
 ) -> Result<IndexTreeNode> {
     let tree_entry = match entry.mode {
-        mode if mode == Mode::FILE || mode == Mode::FILE_EXECUTABLE => {
-            let hash = import_index_blob(repo, git, entry.id, path)?;
+        mode if mode == GIT_MODE_FILE || mode == GIT_MODE_FILE_EXECUTABLE => {
+            let hash = import_index_blob(repo, git, entry.oid, path)?;
             TreeEntry {
                 name: leaf_name(path),
-                mode: if entry.mode == Mode::FILE_EXECUTABLE {
+                mode: if entry.mode == GIT_MODE_FILE_EXECUTABLE {
                     FileMode::Executable
                 } else {
                     FileMode::Normal
@@ -836,8 +881,8 @@ fn index_entry_node(
                 hash,
             }
         }
-        mode if mode == Mode::SYMLINK => {
-            let hash = import_index_blob(repo, git, entry.id, path)?;
+        mode if mode == GIT_MODE_SYMLINK => {
+            let hash = import_index_blob(repo, git, entry.oid, path)?;
             TreeEntry {
                 name: leaf_name(path),
                 mode: FileMode::Symlink,
@@ -845,8 +890,8 @@ fn index_entry_node(
                 hash,
             }
         }
-        mode if mode == Mode::COMMIT => {
-            let hash = import_index_gitlink(repo, entry.id)?;
+        mode if mode == GIT_MODE_COMMIT => {
+            let hash = import_index_gitlink(repo, entry.oid)?;
             TreeEntry {
                 name: leaf_name(path),
                 mode: FileMode::Normal,
@@ -854,12 +899,12 @@ fn index_entry_node(
                 hash,
             }
         }
-        mode if mode == Mode::DIR => {
+        mode if mode == GIT_MODE_DIR => {
             return Err(anyhow!(sparse_git_index_advice(path)));
         }
         _ => {
             return Err(anyhow!(
-                "Git index path '{path}' has unsupported mode {:?}",
+                "Git index path '{path}' has unsupported mode {:o}",
                 entry.mode
             ));
         }
@@ -869,18 +914,24 @@ fn index_entry_node(
 
 fn import_index_blob(
     repo: &Repository,
-    git: &gix::Repository,
-    oid: gix::ObjectId,
+    git: &SleyRepository,
+    oid: ObjectId,
     path: &str,
 ) -> Result<ContentHash> {
-    let mut blob = git
-        .find_blob(oid)
+    let object = git
+        .read_object(&oid)
         .with_context(|| format!("failed to read staged Git blob for '{path}'"))?;
-    let blob = Blob::new(blob.take_data());
+    if object.object_type != GitObjectType::Blob {
+        return Err(anyhow!(
+            "Git index path '{path}' points at {}, not a blob",
+            object.object_type.as_str()
+        ));
+    }
+    let blob = Blob::new(object.body.clone());
     Ok(repo.store().put_blob(&blob)?)
 }
 
-fn import_index_gitlink(repo: &Repository, oid: gix::ObjectId) -> Result<ContentHash> {
+fn import_index_gitlink(repo: &Repository, oid: ObjectId) -> Result<ContentHash> {
     let blob = Blob::new(format!("heddle-submodule: {oid}").into_bytes());
     Ok(repo.store().put_blob(&blob)?)
 }
@@ -917,32 +968,30 @@ fn sparse_git_index_advice(path: &str) -> RecoveryAdvice {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct IndexEntryIntent {
-    id: gix::ObjectId,
-    mode: Mode,
+    id: ObjectId,
+    mode: u32,
 }
 
-fn index_entries_by_path(index: &gix_index::File) -> BTreeMap<String, IndexEntryIntent> {
+fn index_entries_by_path(index: &Index) -> BTreeMap<String, IndexEntryIntent> {
     index
-        .entries_with_paths_by_filter_map(|path, entry| {
-            Some(IndexEntryIntent {
-                id: entry.id,
-                mode: entry.mode,
-            })
-            .map(|entry| (bstr_path(path), entry))
+        .entries
+        .iter()
+        .map(|entry| {
+            (
+                git_path_from_bstring(&entry.path),
+                IndexEntryIntent {
+                    id: entry.oid,
+                    mode: entry.mode,
+                },
+            )
         })
-        .map(|(_, pair)| pair)
         .collect()
 }
 
 fn worktree_entry_changed(root: &Path, path: &str, entry: &IndexEntryIntent) -> Result<bool> {
-    let state = repo::git_worktree_status::git_worktree_entry_state(
-        root,
-        path,
-        entry.id,
-        entry.mode.bits(),
-        None,
-    )
-    .with_context(|| format!("failed to inspect worktree path before commit: {path}"))?;
+    let state =
+        repo::git_worktree_status::git_worktree_entry_state(root, path, entry.id, entry.mode, None)
+            .with_context(|| format!("failed to inspect worktree path before commit: {path}"))?;
     Ok(state != GitWorktreeEntryState::Clean)
 }
 
@@ -1030,8 +1079,8 @@ fn pathbuf_to_git_path(path: &Path) -> String {
         .join("/")
 }
 
-fn bstr_path(path: &BStr) -> String {
-    path.to_str_lossy().into_owned()
+fn git_path_from_bstring(path: &GitBString) -> String {
+    String::from_utf8_lossy(path.as_bytes()).into_owned()
 }
 
 fn commit_safe_trust(mut trust: RepositoryVerificationState) -> RepositoryVerificationState {
@@ -1226,8 +1275,8 @@ fn find_recent_git_checkpoint_batch(repo: &Repository, git_commit: &str) -> Resu
 }
 
 fn git_head_oid(root: &Path) -> Option<String> {
-    let git = gix::discover(root).ok()?;
-    git.head_id().ok().map(|id| id.to_string())
+    let git = SleyRepository::discover(root).ok()?;
+    git.head().ok()?.oid.map(|id| id.to_string())
 }
 
 fn placeholder_principal_first_commit_warning(

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -3,11 +3,9 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    fs,
     path::{Path, PathBuf},
 };
 
-use gix::bstr::{BStr, ByteSlice};
 use objects::object::ThreadName;
 use objects::worktree::WorktreeStatus;
 use refs::Head;
@@ -18,6 +16,7 @@ use repo::{
 };
 use schemars::JsonSchema;
 use serde::{Serialize, Serializer};
+use sley::{BString as GitBString, GitObjectType, Index, Repository as SleyRepository};
 
 use super::{
     advice::RecoveryAdvice,
@@ -1617,7 +1616,7 @@ fn dirty_details(status: &WorktreeStatus) -> BTreeMap<String, String> {
 pub(crate) fn build_plain_git_verification_probe(
     start: &Path,
 ) -> anyhow::Result<Option<PlainGitVerificationProbe>> {
-    let git_repo = match gix::discover(start) {
+    let git_repo = match SleyRepository::discover(start) {
         Ok(repo) => repo,
         Err(_) => return Ok(None),
     };
@@ -1858,11 +1857,8 @@ fn plain_git_missing_import_branches(
     dedup_commands(missing)
 }
 
-fn plain_git_current_branch(git_repo: &gix::Repository) -> Option<String> {
-    let raw = fs::read_to_string(git_repo.git_dir().join("HEAD")).ok()?;
-    let target = raw.trim().strip_prefix("ref: ")?;
-    let branch = target.strip_prefix("refs/heads/")?;
-    (!branch.is_empty()).then(|| branch.to_string())
+fn plain_git_current_branch(git_repo: &SleyRepository) -> Option<String> {
+    git_repo.head().ok()?.branch_name().map(str::to_string)
 }
 
 fn dedup_commands(commands: Vec<String>) -> Vec<String> {
@@ -1873,16 +1869,13 @@ fn dedup_commands(commands: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn plain_git_local_branches(git_repo: &gix::Repository) -> Vec<String> {
-    let Ok(references) = git_repo.references() else {
-        return Vec::new();
-    };
-    let Ok(branches) = references.local_branches() else {
+fn plain_git_local_branches(git_repo: &SleyRepository) -> Vec<String> {
+    let Ok(branches) = git_repo.references().list_refs() else {
         return Vec::new();
     };
     let mut names = branches
-        .filter_map(Result::ok)
-        .map(|branch| branch.name().shorten().to_string())
+        .into_iter()
+        .filter_map(|branch| branch.name.strip_prefix("refs/heads/").map(str::to_string))
         .filter(|branch| !branch.trim().is_empty())
         .collect::<Vec<_>>();
     names.sort();
@@ -1890,16 +1883,13 @@ fn plain_git_local_branches(git_repo: &gix::Repository) -> Vec<String> {
     names
 }
 
-fn plain_git_local_tags(git_repo: &gix::Repository) -> Vec<String> {
-    let Ok(references) = git_repo.references() else {
-        return Vec::new();
-    };
-    let Ok(tags) = references.tags() else {
+fn plain_git_local_tags(git_repo: &SleyRepository) -> Vec<String> {
+    let Ok(tags) = git_repo.references().list_refs() else {
         return Vec::new();
     };
     let mut names = tags
-        .filter_map(Result::ok)
-        .map(|tag| tag.name().shorten().to_string())
+        .into_iter()
+        .filter_map(|tag| tag.name.strip_prefix("refs/tags/").map(str::to_string))
         .filter(|tag| !tag.trim().is_empty())
         .collect::<Vec<_>>();
     names.sort();
@@ -1909,51 +1899,35 @@ fn plain_git_local_tags(git_repo: &gix::Repository) -> Vec<String> {
 
 fn plain_git_worktree_status(
     root: &Path,
-    git_repo: &gix::Repository,
+    git_repo: &SleyRepository,
 ) -> anyhow::Result<WorktreeStatus> {
-    let index = git_repo.index_or_empty().map_err(|error| {
+    let index = plain_git_index_or_empty(git_repo).map_err(|error| {
         anyhow::anyhow!(
             "failed to inspect Git index at '{}': {error}",
             root.display()
         )
     })?;
-    let head_tree = git_repo.head_tree_id_or_empty().map_err(|error| {
+    let head_index = plain_git_head_index_or_empty(git_repo).map_err(|error| {
         anyhow::anyhow!(
             "failed to inspect Git HEAD tree at '{}': {error}",
             root.display()
         )
     })?;
-    let head_index = git_repo
-        .index_from_tree(head_tree.as_ref())
-        .map_err(|error| {
-            anyhow::anyhow!(
-                "failed to inspect Git HEAD tree at '{}': {error}",
-                root.display()
-            )
-        })?;
 
     let mut head_entries = BTreeMap::new();
-    for (_, (path, entry)) in head_index.entries_with_paths_by_filter_map(|path, entry| {
-        Some((plain_git_path(path), (entry.id, entry.mode.bits())))
-    }) {
-        head_entries.insert(path, entry);
+    for entry in &head_index.entries {
+        head_entries.insert(plain_git_path(&entry.path), (entry.oid, entry.mode));
     }
-    let index_timestamp_secs = index.timestamp().unix_seconds();
     let mut index_entries = BTreeMap::new();
-    for (_, (path, entry)) in index.entries_with_paths_by_filter_map(|path, entry| {
-        Some((
-            plain_git_path(path),
-            (entry.id, entry.mode.bits(), entry.stat),
-        ))
-    }) {
-        index_entries.insert(path, entry);
+    for entry in &index.entries {
+        index_entries.insert(plain_git_path(&entry.path), (entry.oid, entry.mode));
     }
 
     let mut added = BTreeSet::new();
     let mut modified = BTreeSet::new();
     let mut deleted = BTreeSet::new();
 
-    for (path, (oid, mode, _stat)) in &index_entries {
+    for (path, (oid, mode)) in &index_entries {
         match head_entries.get(path) {
             None => {
                 added.insert(PathBuf::from(path));
@@ -1970,18 +1944,8 @@ fn plain_git_worktree_status(
         }
     }
 
-    for (path, (oid, mode, stat)) in &index_entries {
-        let probe = repo::git_worktree_status::IndexStatProbe {
-            stat: *stat,
-            index_timestamp_secs,
-        };
-        match repo::git_worktree_status::git_worktree_entry_state(
-            root,
-            path,
-            *oid,
-            *mode,
-            Some(probe),
-        )? {
+    for (path, (oid, mode)) in &index_entries {
+        match repo::git_worktree_status::git_worktree_entry_state(root, path, *oid, *mode, None)? {
             GitWorktreeEntryState::Clean => {}
             GitWorktreeEntryState::Deleted => {
                 deleted.insert(PathBuf::from(path));
@@ -2069,24 +2033,52 @@ fn path_to_plain_git_path(path: &Path) -> String {
         .join("/")
 }
 
-fn plain_git_path(path: &BStr) -> String {
-    path.to_str_lossy().into_owned()
+fn plain_git_empty_index() -> Index {
+    Index {
+        version: 2,
+        entries: Vec::new(),
+        extensions: Vec::new(),
+        checksum: None,
+    }
+}
+
+fn plain_git_index_or_empty(
+    git_repo: &SleyRepository,
+) -> std::result::Result<Index, sley::GitError> {
+    git_repo
+        .open_index()
+        .map(|index| index.unwrap_or_else(plain_git_empty_index))
+}
+
+fn plain_git_head_index_or_empty(
+    git_repo: &SleyRepository,
+) -> std::result::Result<Index, sley::GitError> {
+    let head = git_repo.head()?;
+    let Some(oid) = head.oid else {
+        return Ok(plain_git_empty_index());
+    };
+    let commit = git_repo.read_commit(&oid)?;
+    git_repo.index_from_tree(&commit.tree)
+}
+
+fn plain_git_path(path: &GitBString) -> String {
+    String::from_utf8_lossy(path.as_bytes()).into_owned()
 }
 
 fn plain_git_head_has_commit(
-    git_repo: &gix::Repository,
+    git_repo: &SleyRepository,
     git_branch: Option<&str>,
 ) -> anyhow::Result<bool> {
     let spec = git_branch
         .map(|branch| format!("refs/heads/{branch}^{{commit}}"))
         .unwrap_or_else(|| "HEAD^{commit}".to_string());
-    let Ok(id) = git_repo.rev_parse_single(spec.as_bytes().as_bstr()) else {
+    let Ok(id) = git_repo.rev_parse(&spec) else {
         return Ok(false);
     };
-    let Ok(object) = git_repo.find_object(id.detach()) else {
+    let Ok(object) = git_repo.read_object(&id) else {
         return Ok(false);
     };
-    Ok(object.kind == gix::objs::Kind::Commit)
+    Ok(object.object_type == GitObjectType::Commit)
 }
 
 pub(crate) fn action_template(action: &str) -> Option<ActionTemplate> {
@@ -2542,14 +2534,14 @@ fn default_remote_name(repo: &Repository) -> Option<String> {
 }
 
 fn git_default_remote_name(root: &Path) -> Option<String> {
-    let repo = gix::discover(root).ok()?;
+    let repo = SleyRepository::discover(root).ok()?;
     git_default_remote_name_from_repo(&repo)
 }
 
-fn git_default_remote_name_from_repo(repo: &gix::Repository) -> Option<String> {
+fn git_default_remote_name_from_repo(repo: &SleyRepository) -> Option<String> {
     repo.remote_names()
+        .ok()?
         .into_iter()
-        .map(|name| name.to_str_lossy().into_owned())
         .find(|name| name == "origin")
 }
 
@@ -3519,6 +3511,7 @@ fn mapped_change_relation(
 mod tests {
     use objects::object::ThreadName;
     use repo::{GitRemoteTrackingStatus, Repository};
+    use sley::Repository as SleyRepository;
     use tempfile::TempDir;
 
     use super::{
@@ -3890,7 +3883,7 @@ mod tests {
             }
         }
 
-        let git_repo = gix::open(root).expect("open gix");
+        let git_repo = SleyRepository::discover(root).expect("open git repo");
         let status = super::plain_git_worktree_status(root, &git_repo).expect("status");
 
         let target = PathBuf::from("file.txt");

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -11,6 +11,7 @@ use objects::object::{Principal, ThreadName, Tree};
 use refs::Head;
 use repo::{Repository, RepositoryCapability, ThreadId};
 use serde::Serialize;
+use sley::{FullName, GitObjectType, ObjectId, ReferenceTarget, Repository as SleyRepository};
 use tracing::{debug, info};
 
 use super::{
@@ -250,11 +251,11 @@ fn resolve_quickstart_target(path: &Path) -> Result<QuickstartTarget> {
 
 /// Whether `dir` is itself a Git checkout root — Git metadata AT `dir`, mirroring
 /// the repo crate's `has_git_metadata`/`repository_capability_for_root`. (A
-/// `gix::discover` probe would instead walk to an ANCESTOR Git checkout, which
+/// a Git discovery probe would instead walk to an ANCESTOR Git checkout, which
 /// is exactly the misclassification this avoids.)
 fn dir_is_git_root(dir: &Path) -> bool {
     let dot_git = dir.join(".git");
-    (dot_git.is_dir() || dot_git.is_file()) && gix::discover(dir).is_ok()
+    (dot_git.is_dir() || dot_git.is_file()) && SleyRepository::discover(dir).is_ok()
 }
 
 pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
@@ -282,7 +283,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     // Git next, and pre-seeding would make `main` point at a throwaway
     // empty-tree snapshot. Otherwise, seed `main` so the repo is immediately
     // usable for snapshot/history/etc.
-    let has_git = gix::discover(&path).is_ok();
+    let has_git = SleyRepository::discover(&path).is_ok();
 
     // Resolve the single quickstart root ONCE, by read-only discovery, so the
     // preflight (a read-only viability probe) and the write path below operate
@@ -381,7 +382,7 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
 
     // Output reflects the repo that was actually created/opened. For quickstart
     // that is the resolved target's capability (a subdirectory invocation may
-    // have opened a native repo even though `gix::discover` finds an ancestor
+    // have opened a native repo even though Git discovery finds an ancestor
     // Git checkout); the non-quickstart path keeps its prior `has_git` framing.
     let repo_is_git_overlay = if args.quickstart {
         repo.capability() == RepositoryCapability::GitOverlay
@@ -946,30 +947,42 @@ fn prompt_line(label: &str) -> Result<String> {
 /// existing history so the quickstart confirms AND imports rather than
 /// acting as if the repo were empty (which would leave partial/wrong state).
 fn git_has_commits(path: &Path) -> bool {
-    let Ok(repo) = gix::discover(path) else {
+    let Ok(repo) = SleyRepository::discover(path) else {
         return false;
     };
-    if repo.head_id().is_ok() {
+    if repo.head().ok().and_then(|head| head.oid).is_some() {
         return true;
     }
-    let Ok(platform) = repo.references() else {
+    let Ok(refs) = repo.references().list_refs() else {
         return false;
     };
-    let Ok(refs) = platform.all() else {
-        return false;
-    };
-    for reference in refs.filter_map(Result::ok) {
-        let mut reference = reference;
-        if let Ok(id) = reference.peel_to_id()
-            && repo
-                .find_object(id.detach())
-                .map(|object| object.kind == gix::objs::Kind::Commit)
-                .unwrap_or(false)
-        {
+    for reference in refs {
+        let ReferenceTarget::Direct(oid) = reference.target else {
+            continue;
+        };
+        if object_peels_to_commit(&repo, oid) {
             return true;
         }
     }
     false
+}
+
+fn object_peels_to_commit(repo: &SleyRepository, mut oid: ObjectId) -> bool {
+    loop {
+        let Ok(object) = repo.read_object(&oid) else {
+            return false;
+        };
+        match object.object_type {
+            GitObjectType::Commit => return true,
+            GitObjectType::Tag => {
+                let Ok(tag) = repo.read_tag(&oid) else {
+                    return false;
+                };
+                oid = tag.object;
+            }
+            _ => return false,
+        }
+    }
 }
 
 /// Read-only decision for the Git-overlay quickstart's pre-capture checkout
@@ -992,19 +1005,19 @@ fn quickstart_attachment_decision(
         return QuickstartAttachmentDecision::SkipUnborn;
     }
 
-    let Ok(repo) = gix::discover(path) else {
+    let Ok(repo) = SleyRepository::discover(path) else {
         return QuickstartAttachmentDecision::SkipUnborn;
     };
-    let Ok(head) = repo.head_id() else {
+    let Some(head) = repo.head().ok().and_then(|head| head.oid) else {
         return QuickstartAttachmentDecision::SkipUnborn;
     };
-    let Ok(Some(mut reference)) = repo.try_find_reference(&format!("refs/heads/{thread}")) else {
+    let Ok(Some(reference)) = repo.find_reference(&format!("refs/heads/{thread}")) else {
         return QuickstartAttachmentDecision::Attach;
     };
-    let Ok(branch_tip) = reference.peel_to_id() else {
+    let Ok(Some(branch_tip)) = reference.peeled_oid(&repo) else {
         return QuickstartAttachmentDecision::Attach;
     };
-    if head.detach() == branch_tip.detach() {
+    if head == branch_tip {
         QuickstartAttachmentDecision::Attach
     } else {
         QuickstartAttachmentDecision::RefuseCollision
@@ -1020,7 +1033,7 @@ fn quickstart_attachment_decision(
 /// checkpoint write-through points `.git/HEAD` at `refs/heads/<name>`, so
 /// reject here exactly what Git's porcelain would refuse there.
 fn git_branch_name_is_valid(name: &str) -> bool {
-    if gix::refs::FullName::try_from(format!("refs/heads/{name}").as_str()).is_err() {
+    if FullName::try_from(format!("refs/heads/{name}").as_str()).is_err() {
         return false;
     }
     // Branch-shorthand rules `--branch` adds on top of full-ref syntax: not
@@ -1034,7 +1047,7 @@ fn git_branch_name_is_valid(name: &str) -> bool {
 /// shallow clone before any write rather than after `bootstrap_git_overlay`
 /// already created `.heddle/`.
 fn git_is_shallow(path: &Path) -> bool {
-    gix::discover(path)
+    SleyRepository::discover(path)
         .ok()
         .map(|repo| repo.git_dir().join("shallow").is_file())
         .unwrap_or(false)
@@ -1044,7 +1057,7 @@ fn git_is_shallow(path: &Path) -> bool {
 /// (HEAD points directly at a commit instead of an attached branch). An
 /// unborn HEAD reads as not-detached.
 fn git_head_is_detached(path: &Path) -> bool {
-    gix::discover(path)
+    SleyRepository::discover(path)
         .ok()
         .and_then(|repo| repo.head().ok().map(|head| head.is_detached()))
         .unwrap_or(false)

--- a/crates/cli/src/cli/commands/merge/git_commit.rs
+++ b/crates/cli/src/cli/commands/merge/git_commit.rs
@@ -11,16 +11,13 @@ use objects::store::ObjectStore;
 use std::time::SystemTime;
 
 use anyhow::{Context, Result, anyhow};
-use gix::{
-    bstr::ByteSlice,
-    refs::{
-        Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
-    },
-};
 use objects::object::{Attribution, ChangeId};
 use repo::Repository;
 use serde::Serialize;
+use sley::{
+    CommitObject, GitObjectType, IndexWriteOptions, ObjectId as GitObjectId, RefPrecondition,
+    ReferenceTarget, Repository as SleyRepository, plumbing::sley_object::EncodedObject,
+};
 
 use super::super::advice::RecoveryAdvice;
 use crate::bridge::{git_core::LocalGitIdentity, git_export};
@@ -82,7 +79,7 @@ pub(super) fn validate_git_state(
 
     // Detached HEAD blocks the commit — a merge commit on a detached
     // HEAD would be unreachable once HEAD moves.
-    let git = match gix::discover(repo_root) {
+    let git = match SleyRepository::discover(repo_root) {
         Ok(git) => git,
         Err(err) => {
             blockers.push(format!("failed to inspect git repository: {err}"));
@@ -90,15 +87,9 @@ pub(super) fn validate_git_state(
         }
     };
     let attached_branch = git
-        .head_name()
+        .head()
         .ok()
-        .flatten()
-        .and_then(|name| {
-            name.as_bstr()
-                .to_str()
-                .ok()
-                .and_then(|name| name.strip_prefix("refs/heads/").map(str::to_string))
-        })
+        .and_then(|head| head.branch_name().map(str::to_string))
         .filter(|branch| !branch.is_empty());
     if attached_branch.is_none() {
         blockers.push("git HEAD is detached (--git-commit requires an attached branch)".into());
@@ -212,12 +203,13 @@ pub(super) fn write_git_commit(
         return Err(anyhow!(merge_git_commit_empty_advice()));
     }
     let repo_root = repo.root();
-    let git = gix::discover(repo_root)
+    let git = SleyRepository::discover(repo_root)
         .with_context(|| format!("failed to open Git checkout at {}", repo_root.display()))?;
     let old_head = git
-        .head_id()
+        .head()
         .context("failed to resolve Git HEAD before merge --git-commit")?
-        .detach();
+        .oid
+        .context("failed to resolve Git HEAD before merge --git-commit")?;
     let state = repo
         .store()
         .get_state(state_id)?
@@ -236,10 +228,14 @@ pub(super) fn write_git_commit(
     let mut parents = vec![old_head];
     for parent in extra_parents {
         let oid = parent
-            .parse::<gix::hash::ObjectId>()
+            .parse::<GitObjectId>()
             .with_context(|| format!("invalid extra Git parent '{parent}'"))?;
-        git.find_commit(oid)
-            .with_context(|| format!("extra Git parent '{parent}' is not a commit"))?;
+        let object = git
+            .read_object(&oid)
+            .with_context(|| format!("extra Git parent '{parent}' was not found"))?;
+        if object.object_type != GitObjectType::Commit {
+            return Err(anyhow!("extra Git parent '{parent}' is not a commit"));
+        }
         if !parents.contains(&oid) {
             parents.push(oid);
         }
@@ -250,16 +246,16 @@ pub(super) fn write_git_commit(
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or(0);
     let signature = identity.to_signature(seconds);
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let commit = git
-        .new_commit_as(
-            signature.to_ref(&mut committer_buf),
-            signature.to_ref(&mut author_buf),
-            message,
-            tree_id,
-            parents,
-        )
+    let commit = CommitObject {
+        tree: tree_id,
+        parents,
+        author: signature.to_ident_bytes(),
+        committer: signature.to_ident_bytes(),
+        encoding: None,
+        message: message.as_bytes().to_vec(),
+    };
+    let commit_id = git
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
         .map_err(|err| {
             anyhow!(merge_git_commit_failed_advice(
                 "writing Git commit object",
@@ -270,22 +266,27 @@ pub(super) fn write_git_commit(
     // Keep the checkout index aligned with the committed tree. This is
     // the native equivalent of `git add <merge paths>` followed by
     // `git commit`: after HEAD moves, `git status` should be clean.
-    let mut index = git.index_from_tree(&tree_id).map_err(|err| {
+    let index = git.index_from_tree(&tree_id).map_err(|err| {
         anyhow!(merge_git_commit_failed_advice(
             "writing Git index",
             err.to_string()
         ))
     })?;
-    index
-        .write(gix_index::write::Options::default())
-        .map_err(|err| {
-            anyhow!(merge_git_commit_failed_advice(
-                "writing Git index",
-                err.to_string()
-            ))
-        })?;
+    git.write_index(
+        &index,
+        IndexWriteOptions {
+            fsync: true,
+            validate_checksum: true,
+        },
+    )
+    .map_err(|err| {
+        anyhow!(merge_git_commit_failed_advice(
+            "writing Git index",
+            err.to_string()
+        ))
+    })?;
 
-    update_head_ref(&git, commit.id, old_head, &identity).map_err(|err| {
+    update_head_ref(&git, commit_id, old_head, &identity).map_err(|err| {
         anyhow!(merge_git_commit_failed_advice(
             "updating Git HEAD",
             err.to_string()
@@ -293,40 +294,41 @@ pub(super) fn write_git_commit(
     })?;
 
     Ok(GitCommitInfo {
-        sha: commit.id.to_string(),
+        sha: commit_id.to_string(),
         message: message.to_string(),
     })
 }
 
 fn update_head_ref(
-    git: &gix::Repository,
-    new_head: gix::hash::ObjectId,
-    old_head: gix::hash::ObjectId,
+    git: &SleyRepository,
+    new_head: GitObjectId,
+    old_head: GitObjectId,
     identity: &LocalGitIdentity,
 ) -> Result<()> {
     let seconds = SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or(0);
-    let signature = identity.to_signature(seconds);
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let edit = RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: "heddle: merge --git-commit".into(),
-            },
-            expected: PreviousValue::MustExistAndMatch(Target::Object(old_head)),
-            new: Target::Object(new_head),
-        },
-        name: "HEAD"
-            .try_into()
-            .map_err(|err| anyhow!("invalid Git HEAD ref: {err}"))?,
-        deref: true,
-    };
-    git.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
-        .context("failed to update Git HEAD")?;
+    let head = git.head().context("failed to inspect Git HEAD")?;
+    let ref_name = head
+        .symbolic_target
+        .as_ref()
+        .map(|name| name.as_str().to_string())
+        .unwrap_or_else(|| "HEAD".to_string());
+    let refs = git.references();
+    let mut tx = refs.transaction();
+    tx.update_to(
+        ref_name,
+        ReferenceTarget::Direct(new_head),
+        RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(old_head)),
+        Some(sley::plumbing::sley_refs::ReflogEntry {
+            old_oid: old_head,
+            new_oid: new_head,
+            committer: identity.to_signature(seconds).to_ident_bytes(),
+            message: b"heddle: merge --git-commit".to_vec(),
+        }),
+    );
+    tx.commit().context("failed to update Git HEAD")?;
     Ok(())
 }
 

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -16,6 +16,7 @@ use repo::{
 };
 use serde::Serialize;
 use serde_json::Value;
+use sley::Repository as SleyRepository;
 
 use super::{
     action_line::print_nested_next,
@@ -1480,8 +1481,8 @@ fn merge_op_targets_state(op: &OpRecord, state: &ChangeId) -> bool {
 }
 
 fn git_rev_parse_head(root: &Path) -> Option<String> {
-    let git = gix::discover(root).ok()?;
-    git.head_id().ok().map(|id| id.to_string())
+    let git = SleyRepository::discover(root).ok()?;
+    git.head().ok()?.oid.map(|id| id.to_string())
 }
 
 /// Extended pre-flight for `--git-commit`. Catches dry-runnable failure

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -4,7 +4,6 @@ use std::{collections::BTreeSet, path::Path};
 
 use anyhow::Result;
 use chrono::Utc;
-use gix::bstr::ByteSlice;
 use objects::object::ThreadName;
 use repo::{
     GitOverlayImportHint, GitRemoteTrackingStatus, OperationKind, OperationScope, Repository,
@@ -12,6 +11,7 @@ use repo::{
     ThreadState, shell_quote, update_thread_state_from_state,
 };
 use serde::{Serialize, Serializer, ser::SerializeStruct};
+use sley::{IndexStage, Repository as SleyRepository};
 
 use super::{
     git_overlay_health::{
@@ -713,19 +713,20 @@ pub(crate) fn recommend_next_action(
 }
 
 fn git_unmerged_paths(repo: &Repository) -> Result<Vec<String>> {
-    let git = match gix::discover(repo.root()) {
+    let git = match SleyRepository::discover(repo.root()) {
         Ok(git) => git,
         Err(_) => return Ok(Vec::new()),
     };
-    let index = match git.index_or_empty() {
-        Ok(index) => index,
+    let index = match git.open_index() {
+        Ok(Some(index)) => index,
+        Ok(None) => return Ok(Vec::new()),
         Err(_) => return Ok(Vec::new()),
     };
     let mut paths = BTreeSet::new();
-    for (_, path) in index.entries_with_paths_by_filter_map(|path, entry| {
-        (entry.stage_raw() != 0).then(|| path.to_str_lossy().into_owned())
-    }) {
-        paths.insert(path);
+    for entry in index.entries {
+        if entry.stage() != IndexStage::Normal {
+            paths.insert(String::from_utf8_lossy(entry.path.as_bytes()).into_owned());
+        }
     }
     Ok(paths.into_iter().collect())
 }

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -9,11 +9,11 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use gix::{bstr::ByteSlice, refs::transaction::PreviousValue};
 use objects::{fs_atomic::write_file_atomic, object::ThreadName};
 use refs::Head;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
+use sley::{FullName, RefPrecondition, Repository as SleyRepository};
 
 use super::{
     action_line::print_next,
@@ -779,27 +779,18 @@ fn refresh_git_tracking_after_overlay_push(
     if branch.is_empty() {
         return Ok(None);
     }
-    let git = match gix::discover(repo.root()) {
+    let git = match SleyRepository::discover(repo.root()) {
         Ok(git) => git,
         Err(_) => return Ok(None),
     };
-    let Ok(head) = git.head_id() else {
+    let Some(head) = git.head().ok().and_then(|head| head.oid) else {
         return Ok(None);
     };
-    let head = head.detach();
     let Some(tracking_remote) = resolve_git_tracking_remote_name(repo, remote_name)? else {
         return Ok(None);
     };
 
-    let upstream = git
-        .find_reference(format!("refs/heads/{branch}").as_str())
-        .ok()
-        .and_then(|local| {
-            local
-                .remote_tracking_ref_name(gix::remote::Direction::Fetch)?
-                .ok()
-                .map(|name| name.as_ref().as_bstr().to_str_lossy().into_owned())
-        })
+    let upstream = git_branch_upstream_from_config(&git, &branch)
         .and_then(|name| name.strip_prefix("refs/remotes/").map(str::to_string))
         .unwrap_or_else(|| format!("{}/{branch}", tracking_remote.name));
 
@@ -821,7 +812,7 @@ fn refresh_git_tracking_after_overlay_push(
         &git,
         &full_ref,
         head,
-        PreviousValue::Any,
+        RefPrecondition::Any,
         &format!("heddle: push to {remote_name}"),
     ) {
         return Err(anyhow!(
@@ -903,21 +894,15 @@ fn resolve_git_tracking_remote_name(
 }
 
 fn git_remote_name_for_url(root: &Path, requested: &str) -> Result<Option<String>> {
+    let git = match SleyRepository::discover(root) {
+        Ok(git) => git,
+        Err(_) => return Ok(None),
+    };
     for name in git_remote_names(root)? {
-        let git = match gix::discover(root) {
-            Ok(git) => git,
-            Err(_) => return Ok(None),
-        };
-        let Some(remote) = git
-            .try_find_remote(name.as_bytes().as_bstr())
-            .and_then(Result::ok)
-        else {
+        let Some(url) = git_remote_push_url(&git, &name)? else {
             continue;
         };
-        let Some(url) = remote.url(gix::remote::Direction::Push) else {
-            continue;
-        };
-        if remote_urls_match(&url.to_string(), requested) {
+        if remote_urls_match(&url, requested) {
             return Ok(Some(name));
         }
     }
@@ -925,14 +910,13 @@ fn git_remote_name_for_url(root: &Path, requested: &str) -> Result<Option<String
 }
 
 fn git_remote_names(root: &Path) -> Result<Vec<String>> {
-    let git = match gix::discover(root) {
+    let git = match SleyRepository::discover(root) {
         Ok(git) => git,
         Err(_) => return Ok(Vec::new()),
     };
     Ok(git
-        .remote_names()
+        .remote_names()?
         .into_iter()
-        .map(|name| name.to_str_lossy().into_owned())
         .filter(|name| !name.is_empty())
         .collect())
 }
@@ -942,7 +926,23 @@ fn git_remote_ref_name_is_valid(_root: &Path, name: &str) -> Result<bool> {
         return Ok(false);
     }
     let refname = format!("refs/remotes/{name}/HEAD");
-    Ok(gix::refs::FullName::try_from(refname.as_str()).is_ok())
+    Ok(FullName::try_from(refname.as_str()).is_ok())
+}
+
+fn git_branch_upstream_from_config(git: &SleyRepository, branch: &str) -> Option<String> {
+    let config = git.config_snapshot().ok()?;
+    let remote = config.get("branch", Some(branch), "remote")?;
+    let merge = config.get("branch", Some(branch), "merge")?;
+    let branch_name = merge.strip_prefix("refs/heads/")?;
+    Some(format!("refs/remotes/{remote}/{branch_name}"))
+}
+
+fn git_remote_push_url(git: &SleyRepository, remote: &str) -> Result<Option<String>> {
+    let config = git.config_snapshot()?;
+    Ok(config
+        .get("remote", Some(remote), "pushurl")
+        .or_else(|| config.get("remote", Some(remote), "url"))
+        .map(str::to_string))
 }
 
 fn write_git_overlay_branch_upstream(root: &Path, branch: &str, remote: &str) -> Result<()> {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -4,10 +4,13 @@
 use objects::store::ObjectStore;
 #[cfg(feature = "client")]
 use std::net::SocketAddr;
-use std::{borrow::Cow, collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result};
-use gix::bstr::{BStr, BString};
 #[cfg(feature = "client")]
 use heddle_client::grpc_hosted::{HostedAuthMode, PullMaterialization};
 use objects::{
@@ -17,6 +20,10 @@ use objects::{
 use refs::Head;
 use repo::{Repository, RepositoryCapability};
 use serde::Serialize;
+use sley::plumbing::sley_config::{
+    ConfigIncludeContext, ConfigOriginKind, ConfigScope, ConfigStack, ConfigStackEntry,
+};
+use sley::{GitConfig, Repository as SleyRepository};
 
 use super::super::{
     action_line::print_next,
@@ -438,8 +445,8 @@ async fn pull_local(
 }
 
 fn git_checkout_head_oid(root: &Path) -> Option<String> {
-    let git = gix::discover(root).ok()?;
-    Some(git.head_id().ok()?.detach().to_string())
+    let git = SleyRepository::discover(root).ok()?;
+    git.head().ok()?.oid.map(|oid| oid.to_string())
 }
 
 fn short_oid(oid: &str) -> String {
@@ -856,13 +863,11 @@ fn git_overlay_default_remote_name(repo: &Repository) -> Option<String> {
 
 fn git_upstream_remote_name(repo: &Repository) -> Option<String> {
     let branch = repo.git_overlay_current_branch().ok().flatten()?;
-    let git = gix::discover(repo.root()).ok()?;
-    let local = git
-        .find_reference(format!("refs/heads/{branch}").as_str())
-        .ok()?;
-    local
-        .remote_name(gix::remote::Direction::Fetch)
-        .and_then(|name| name.as_symbol().map(str::to_string))
+    let git = SleyRepository::discover(repo.root()).ok()?;
+    git.config_snapshot()
+        .ok()?
+        .get("branch", Some(&branch), "remote")
+        .map(str::to_string)
         .filter(|remote| !remote.is_empty())
 }
 
@@ -942,27 +947,25 @@ fn git_overlay_config_remotes(repo: &Repository) -> BTreeMap<String, String> {
 }
 
 /// The resolved Git directory layout for a repository, used to read remote
-/// definitions from `.git/config` (and its layered companions) through
-/// `gix_config`, which correctly handles quoting, inline comments, include
-/// directives, and conditional `includeIf` directives.
+/// definitions from `.git/config` and its layered companions.
 struct GitConfigContext {
-    git_dir: std::path::PathBuf,
-    common_dir: std::path::PathBuf,
-    branch: Option<gix::refs::FullName>,
+    git_dir: PathBuf,
+    common_dir: PathBuf,
+    branch: Option<String>,
 }
 
 impl GitConfigContext {
     fn discover(root: &Path) -> Option<Self> {
-        let git = gix::discover(root).ok()?;
+        let git = SleyRepository::discover(root).ok()?;
         Some(Self {
             git_dir: git.git_dir().to_path_buf(),
             common_dir: git.common_dir().to_path_buf(),
-            branch: git.head_name().ok().flatten(),
+            branch: git
+                .head()
+                .ok()
+                .and_then(|head| head.symbolic_target.map(|name| name.to_string()))
+                .and_then(|name| name.strip_prefix("refs/heads/").map(str::to_string)),
         })
-    }
-
-    fn branch_ref(&self) -> Option<&gix::refs::FullNameRef> {
-        self.branch.as_ref().map(AsRef::as_ref)
     }
 
     /// The standard repository config files, ordered highest-precedence first:
@@ -987,8 +990,7 @@ impl GitConfigContext {
             paths.push(self.common_dir.join("config"));
         }
         self.load(paths)
-            .and_then(|file| file.boolean("extensions.worktreeConfig"))
-            .and_then(Result::ok)
+            .and_then(|config| config.get_bool("extensions", None, "worktreeConfig"))
             .unwrap_or(false)
     }
 
@@ -1038,25 +1040,16 @@ impl GitConfigContext {
     /// so an include-defined remote resolves to the included file — the one
     /// a write must edit — not the including config.
     fn defining_files_for(&self, name: &str) -> Vec<std::path::PathBuf> {
-        let Some(file) = self.load(self.layered_paths()) else {
-            return Vec::new();
-        };
-        let Some(sections) = file.sections_by_name("remote") else {
-            return Vec::new();
-        };
         let mut files = Vec::new();
-        for section in sections {
-            let matches = section
-                .header()
-                .subsection_name()
-                .map(|subsection| subsection.to_string());
-            if matches.as_deref() != Some(name) {
-                continue;
-            }
-            let Some(path) = section.meta().path.clone() else {
-                continue;
-            };
-            if !files.contains(&path) {
+        let Some(stack) = self.config_stack() else {
+            return files;
+        };
+        for entry in stack.entries.iter().rev() {
+            if entry.section.eq_ignore_ascii_case("remote")
+                && entry.subsection.as_deref() == Some(name)
+                && let Some(path) = config_entry_origin_path(entry)
+                && !files.contains(&path)
+            {
                 files.push(path);
             }
         }
@@ -1077,46 +1070,92 @@ impl GitConfigContext {
 
     fn remotes(&self, paths: Vec<std::path::PathBuf>) -> BTreeMap<String, String> {
         let mut remotes = BTreeMap::new();
-        let Some(file) = self.load(paths) else {
-            return remotes;
-        };
-        let Some(sections) = file.sections_by_name("remote") else {
-            return remotes;
-        };
-        for section in sections {
-            let Some(name) = section.header().subsection_name() else {
+        for path in paths {
+            let Some(config) = self.load_one(&path, true) else {
                 continue;
             };
-            let Some(url) = section.value("url") else {
-                continue;
-            };
-            remotes
-                .entry(name.to_string())
-                .or_insert_with(|| url.to_string());
+            for section in &config.sections {
+                if !section.name.eq_ignore_ascii_case("remote") {
+                    continue;
+                }
+                let Some(name) = section.subsection.as_deref() else {
+                    continue;
+                };
+                let Some(url) = config_section_value(section, "url") else {
+                    continue;
+                };
+                remotes
+                    .entry(name.to_string())
+                    .or_insert_with(|| url.to_string());
+            }
         }
         remotes
     }
 
-    fn load(&self, paths: Vec<std::path::PathBuf>) -> Option<gix_config::File<'static>> {
-        let options = gix_config::file::init::Options {
-            includes: gix_config::file::includes::Options::follow(
-                gix_config::path::interpolate::Context::default(),
-                gix_config::file::includes::conditional::Context {
-                    git_dir: Some(&self.git_dir),
-                    branch_name: self.branch_ref(),
-                },
-            ),
-            lossy: true,
-            ignore_io_errors: true,
-        };
-        let mut metadata = paths
-            .into_iter()
-            .map(|path| gix_config::file::Metadata::from(gix_config::Source::Local).at(path));
-        let mut buf = Vec::new();
-        gix_config::File::from_paths_metadata_buf(&mut metadata, &mut buf, false, options)
-            .ok()
-            .flatten()
+    fn load(&self, paths: Vec<PathBuf>) -> Option<GitConfig> {
+        let mut merged = GitConfig::default();
+        for path in paths.into_iter().rev() {
+            let Some(config) = self.load_one(&path, true) else {
+                continue;
+            };
+            merged.sections.extend(config.sections);
+        }
+        Some(merged)
     }
+
+    fn config_stack(&self) -> Option<ConfigStack> {
+        let context = ConfigIncludeContext {
+            git_dir: Some(self.git_dir.clone()),
+            current_branch: self.branch.clone(),
+        };
+        let mut stack = ConfigStack::new();
+        for path in self.layered_paths().into_iter().rev() {
+            let scope = if path
+                .file_name()
+                .is_some_and(|name| name == "config.worktree")
+            {
+                ConfigScope::Worktree
+            } else {
+                ConfigScope::Local
+            };
+            stack.push_file(&path, scope, true, &context).ok()?;
+        }
+        Some(stack)
+    }
+
+    fn load_one(&self, path: &Path, follow_includes: bool) -> Option<GitConfig> {
+        let bytes = fs::read(path).ok()?;
+        let config = GitConfig::parse(&bytes).ok()?;
+        if !follow_includes {
+            return Some(config);
+        }
+        let base = path.parent().unwrap_or_else(|| Path::new("."));
+        config
+            .resolve_includes(
+                base,
+                &ConfigIncludeContext {
+                    git_dir: Some(self.git_dir.clone()),
+                    current_branch: self.branch.clone(),
+                },
+            )
+            .ok()
+    }
+}
+
+fn config_entry_origin_path(entry: &ConfigStackEntry) -> Option<PathBuf> {
+    (entry.origin.kind == ConfigOriginKind::File).then(|| PathBuf::from(&entry.origin.name))
+}
+
+fn config_section_value<'a>(
+    section: &'a sley::plumbing::sley_config::ConfigSection,
+    key: &str,
+) -> Option<&'a str> {
+    section
+        .entries
+        .iter()
+        .rev()
+        .find(|entry| entry.key.eq_ignore_ascii_case(key))
+        .and_then(|entry| entry.value.as_deref())
 }
 
 fn sync_git_overlay_remote_add(repo: &Repository, name: &str, url: &str) -> Result<()> {
@@ -1162,77 +1201,136 @@ fn validate_git_overlay_remote_name(name: &str) -> Result<()> {
 }
 
 /// Add or replace the `[remote "<name>"]` section in a single physical config
-/// file via `gix_config`'s structured editing, so the writer resolves the same
-/// section the reader does regardless of the surface header form (quoted
-/// `[remote "x"]`, legacy dotted `[remote.x]`, or comment-suffixed). Every
-/// existing definition of the remote is dropped before a fresh canonical
-/// section is appended, so an upsert replaces rather than appends a duplicate
-/// that the first-seen (stale) section would win over on the next read.
+/// file. Every existing definition of the remote in that file is dropped before
+/// a fresh canonical section is appended, so an upsert replaces rather than
+/// appends a duplicate that the first-seen section would win over on the next
+/// read.
 fn upsert_git_remote_config(config_path: &Path, name: &str, url: &str) -> Result<()> {
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let mut file = load_config_file_for_edit(config_path)?;
-    remove_remote_sections(&mut file, name);
-    let mut section = file
-        .new_section("remote", Some(Cow::Owned(BString::from(name))))
-        .with_context(|| format!("invalid git remote section name '{name}'"))?;
-    section.push(git_config_key("url")?, Some(BStr::new(url)));
+    let contents = fs::read_to_string(config_path).unwrap_or_default();
+    let mut contents = remove_git_config_named_section(&contents, "remote", name);
+    if !contents.ends_with('\n') && !contents.is_empty() {
+        contents.push('\n');
+    }
     let fetch = format!("+refs/heads/*:refs/remotes/{name}/*");
-    section.push(git_config_key("fetch")?, Some(BStr::new(fetch.as_str())));
-    let serialized = file.to_bstring();
-    write_file_atomic(config_path, &serialized)?;
+    contents.push_str(&format!(
+        "[remote \"{}\"]\n\turl = {}\n\tfetch = {}\n",
+        escape_git_config_section(name),
+        quote_git_config_value(url),
+        quote_git_config_value(&fetch)
+    ));
+    write_file_atomic(config_path, contents.as_bytes())?;
     Ok(())
 }
 
 /// Remove every `[remote "<name>"]` section from a single physical config file
-/// via `gix_config`, matching whatever header form the reader resolves the
-/// remote through. No-ops (no write) when the file is absent or defines no such
-/// remote.
+/// that uses the normal quoted subsection form. No-ops when the file is absent
+/// or defines no such remote.
 fn remove_git_remote_config(config_path: &Path, name: &str) -> Result<()> {
     if !config_path.exists() {
         return Ok(());
     }
-    let mut file = load_config_file_for_edit(config_path)?;
-    if !remove_remote_sections(&mut file, name) {
+    let contents = fs::read_to_string(config_path)
+        .with_context(|| format!("reading git config at {}", config_path.display()))?;
+    let updated = remove_git_config_named_section(&contents, "remote", name);
+    if updated == contents {
         return Ok(());
     }
-    let serialized = file.to_bstring();
-    write_file_atomic(config_path, &serialized)?;
+    write_file_atomic(config_path, updated.as_bytes())?;
     Ok(())
 }
 
-/// Drop every `[remote "<name>"]` section from `file`, returning whether any
-/// was removed. `gix_config` keys sections by parsed name + subsection, so this
-/// matches the remote regardless of its surface header syntax. `remove_section`
-/// removes only the last match, so loop until none remain.
-fn remove_remote_sections(file: &mut gix_config::File<'static>, name: &str) -> bool {
-    let mut removed = false;
-    while file
-        .remove_section("remote", Some(BStr::new(name)))
-        .is_some()
-    {
-        removed = true;
+fn remove_git_config_named_section(contents: &str, section: &str, subsection_name: &str) -> String {
+    let mut output = Vec::new();
+    let mut skipping = false;
+    for line in contents.lines() {
+        if let Some(name) = parse_git_config_subsection_name(line, section) {
+            skipping = name == subsection_name;
+        } else if is_git_config_section_header(line) {
+            skipping = false;
+        }
+        if !skipping {
+            output.push(line);
+        }
     }
-    removed
+    let mut text = output.join("\n");
+    if contents.ends_with('\n') && !text.is_empty() {
+        text.push('\n');
+    }
+    text
 }
 
-/// Load a single physical config file for in-place editing. Includes are NOT
-/// followed: the caller already resolved the physical file that defines the
-/// remote (see `defining_files_for`), and a write must round-trip that file
-/// alone rather than inline the content of any files it includes. A missing
-/// file yields an empty document so a brand-new remote can be appended.
-fn load_config_file_for_edit(config_path: &Path) -> Result<gix_config::File<'static>> {
-    if !config_path.exists() {
-        return Ok(gix_config::File::default());
+fn parse_git_config_subsection_name(line: &str, section: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let end = trimmed.find(']')?;
+    let inner = trimmed.strip_prefix('[')?[..end - 1].trim();
+    let (parsed_section, rest) = inner
+        .split_once(char::is_whitespace)
+        .map(|(section, rest)| (section, Some(rest.trim_start())))
+        .unwrap_or((inner, None));
+    if !parsed_section.eq_ignore_ascii_case(section) {
+        if let Some((dotted_section, dotted_subsection)) = inner.split_once('.')
+            && dotted_section.eq_ignore_ascii_case(section)
+        {
+            return Some(dotted_subsection.to_string());
+        }
+        return None;
     }
-    gix_config::File::from_path_no_includes(config_path.to_path_buf(), gix_config::Source::Local)
-        .with_context(|| format!("reading git config at {}", config_path.display()))
+    let rest = rest?;
+    let quoted = rest.strip_prefix('"')?.strip_suffix('"')?;
+    unescape_git_config_string(quoted)
 }
 
-fn git_config_key(key: &'static str) -> Result<gix_config::parse::section::ValueName<'static>> {
-    gix_config::parse::section::ValueName::try_from(key)
-        .with_context(|| format!("invalid git config key '{key}'"))
+fn is_git_config_section_header(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('[') && trimmed.contains(']')
+}
+
+fn escape_git_config_section(value: &str) -> String {
+    escape_git_config_value(value)
+}
+
+fn escape_git_config_value(value: &str) -> String {
+    let mut out = String::new();
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            '\u{0008}' => out.push_str("\\b"),
+            ch => out.push(ch),
+        }
+    }
+    out
+}
+
+fn quote_git_config_value(value: &str) -> String {
+    format!("\"{}\"", escape_git_config_value(value))
+}
+
+fn unescape_git_config_string(value: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut chars = value.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            out.push(ch);
+            continue;
+        }
+        match chars.next()? {
+            '\\' => out.push('\\'),
+            '"' => out.push('"'),
+            'n' => out.push('\n'),
+            't' => out.push('\t'),
+            'r' => out.push('\r'),
+            'b' => out.push('\u{0008}'),
+            escaped => out.push(escaped),
+        }
+    }
+    Some(out)
 }
 
 #[cfg(feature = "client")]
@@ -1252,7 +1350,7 @@ mod tests {
     use super::*;
 
     fn init_git(root: &Path) {
-        gix::init(root).expect("init git repo");
+        SleyRepository::init(root).expect("init git repo");
     }
 
     #[test]
@@ -1532,7 +1630,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         init_git(tmp.path());
         let git_dir = tmp.path().join(".git");
-        // A valid Git header gix accepts but the hand-rolled writer didn't:
+        // A valid Git header Sley accepts but the hand-rolled writer didn't:
         // an inline comment trails the `[remote "origin"]` header.
         fs::write(
             git_dir.join("config"),
@@ -1558,7 +1656,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         init_git(tmp.path());
         let git_dir = tmp.path().join(".git");
-        // The legacy dotted subsection form, equally valid to gix.
+        // The legacy dotted subsection form, equally valid to Sley.
         fs::write(
             git_dir.join("config"),
             "[remote.origin]\n\turl = https://example.com/repo\n",

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -284,6 +284,8 @@ pub(crate) struct TargetDirHandle {
     dev: u64,
     #[cfg(unix)]
     ino: u64,
+    #[cfg(unix)]
+    path: PathBuf,
     #[cfg(not(unix))]
     path: PathBuf,
 }
@@ -327,6 +329,7 @@ impl TargetDirHandle {
                 dir: Rc::new(dir),
                 dev: metadata.dev(),
                 ino: metadata.ino(),
+                path: abs_path.to_path_buf(),
             })
         }
         #[cfg(not(unix))]
@@ -344,21 +347,34 @@ impl TargetDirHandle {
         }
     }
 
-    fn io_path(&self) -> PathBuf {
+    #[cfg(unix)]
+    fn fd_traversal_path(&self) -> Option<PathBuf> {
+        use std::os::fd::AsRawFd;
+
+        Path::new("/proc/self/fd").is_dir().then(|| {
+            let fd = self.dir.as_raw_fd();
+            PathBuf::from(format!("/proc/self/fd/{fd}"))
+        })
+    }
+
+    fn io_path_if_current(&self, abs_path: &Path) -> std::io::Result<Option<PathBuf>> {
         #[cfg(unix)]
         {
-            use std::os::fd::AsRawFd;
-
-            let fd = self.dir.as_raw_fd();
-            if Path::new("/proc/self/fd").is_dir() {
-                PathBuf::from(format!("/proc/self/fd/{fd}"))
+            if let Some(path) = self.fd_traversal_path() {
+                Ok(Some(path))
             } else {
-                PathBuf::from(format!("/dev/fd/{fd}"))
+                match self.same_identity_at_path(abs_path) {
+                    Ok(true) => Ok(Some(self.path.clone())),
+                    Ok(false) => Ok(None),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+                    Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => Ok(None),
+                    Err(err) => Err(err),
+                }
             }
         }
         #[cfg(not(unix))]
         {
-            self.path.clone()
+            Ok((abs_path == self.path).then(|| self.path.clone()))
         }
     }
 
@@ -404,7 +420,11 @@ fn outcome_from_cell(
 fn adopt_existing_empty_dir(abs_path: &Path) -> HeddleResult<TargetDirHandle> {
     let handle = TargetDirHandle::open(abs_path)
         .map_err(|_| target_dir_shape_refusal(abs_path, &target_dir_shape_reason(abs_path)))?;
-    if std::fs::read_dir(handle.io_path())
+    let io_path = handle
+        .io_path_if_current(abs_path)
+        .map_err(HeddleError::from)?
+        .ok_or_else(|| target_dir_shape_refusal(abs_path, "changed since it was claimed"))?;
+    if std::fs::read_dir(io_path)
         .map_err(HeddleError::from)?
         .next()
         .transpose()
@@ -460,8 +480,15 @@ fn clear_dir_contents(dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn clear_claimed_dir_contents(claim: &TargetDir) -> HeddleResult<()> {
-    match clear_dir_contents(&claim.handle().io_path()) {
+fn clear_claimed_dir_contents(abs_path: &Path, claim: &TargetDir) -> HeddleResult<()> {
+    let Some(io_path) = claim
+        .handle()
+        .io_path_if_current(abs_path)
+        .map_err(HeddleError::from)?
+    else {
+        return Ok(());
+    };
+    match clear_dir_contents(&io_path) {
         Ok(()) => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(err) if err.kind() == std::io::ErrorKind::NotADirectory => Ok(()),
@@ -491,10 +518,10 @@ fn rewind_checkout(abs_path: &Path, claim: Option<TargetDir>) -> HeddleResult<()
     };
     match claim.kind() {
         TargetDirKind::Created => {
-            clear_claimed_dir_contents(&claim)?;
+            clear_claimed_dir_contents(abs_path, &claim)?;
             remove_claimed_created_dir_if_still_at_path(abs_path, &claim)
         }
-        TargetDirKind::AdoptedEmpty => clear_claimed_dir_contents(&claim),
+        TargetDirKind::AdoptedEmpty => clear_claimed_dir_contents(abs_path, &claim),
     }
 }
 
@@ -520,7 +547,11 @@ fn remove_claimed_created_dir_if_still_at_path(
 fn claimed_worktree_path(claim: Option<TargetDir>, abs_path: &Path) -> HeddleResult<PathBuf> {
     match claim {
         Some(claim) => match claim.handle().same_identity_at_path(abs_path) {
-            Ok(true) => Ok(claim.handle().io_path()),
+            Ok(true) => claim
+                .handle()
+                .io_path_if_current(abs_path)
+                .map_err(HeddleError::from)?
+                .ok_or_else(|| target_dir_shape_refusal(abs_path, "changed since it was claimed")),
             Ok(false) => Err(target_dir_shape_refusal(
                 abs_path,
                 "changed since it was claimed",
@@ -750,8 +781,13 @@ impl StartThread {
                 // rewind removes the dir: the canonical key is derived by
                 // canonicalizing the still-present root. A rolled-back start must
                 // leave no orphaned sidecar (heddle#316 r11 P2).
-                if let Some(claim) = claim.as_ref() {
-                    rewind_repo.clear_materialized_root_records(&claim.handle().io_path())?;
+                if let Some(claim) = claim.as_ref()
+                    && let Some(io_path) = claim
+                        .handle()
+                        .io_path_if_current(&rewind_abs)
+                        .map_err(HeddleError::from)?
+                {
+                    rewind_repo.clear_materialized_root_records(&io_path)?;
                 }
                 rewind_checkout(&rewind_abs, claim)
             },

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -512,15 +512,23 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
     // consumers (the health build below + the changes computation here). It
     // re-reads + SHA-1s every tracked file (~950ms on a 10k-file worktree);
     // previously `status` paid that twice.
+    let git_overlay_status_start = Instant::now();
     let git_worktree_status_result = repo.git_overlay_worktree_status();
+    let git_overlay_status_ms = git_overlay_status_start.elapsed().as_millis();
+    let git_overlay_health_start = Instant::now();
     let git_overlay_health =
         build_git_overlay_health_with_worktree_status(&repo, &git_worktree_status_result);
+    let git_overlay_health_ms = git_overlay_health_start.elapsed().as_millis();
+    let verification_start = Instant::now();
     let trust = RepositoryVerificationState::from_health(&repo, git_overlay_health.clone());
+    let verification_ms = verification_start.elapsed().as_millis();
     let remote_tracking =
         remote_tracking.map(|remote| remote_tracking_with_verification_action(remote, &trust));
     let status_options = worktree_status_options(Some(repo.config()));
     let git_worktree_status = git_worktree_status_result.unwrap_or(None);
+    let git_index_start = Instant::now();
     let git_index = git_index_plan_for_repo(&repo)?;
+    let git_index_ms = git_index_start.elapsed().as_millis();
     let identity_notice = first_capture_identity_notice(&repo, current_state.as_ref())?;
     let git_clean_mapping_blocker = matches!(
         trust.status.as_str(),
@@ -589,6 +597,10 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
                     ProfileField::millis("operation_ms", operation_ms),
                     ProfileField::millis("remote_tracking_ms", remote_tracking_ms),
                     ProfileField::millis("import_hint_ms", import_hint_ms),
+                    ProfileField::millis("git_overlay_status_ms", git_overlay_status_ms),
+                    ProfileField::millis("git_overlay_health_ms", git_overlay_health_ms),
+                    ProfileField::millis("verification_ms", verification_ms),
+                    ProfileField::millis("git_index_ms", git_index_ms),
                     ProfileField::millis("worktree_status_ms", worktree_status_ms),
                     ProfileField::duration("build_total_ms", body_start.elapsed()),
                 ],
@@ -1119,6 +1131,10 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
                 ProfileField::millis("operation_ms", operation_ms),
                 ProfileField::millis("remote_tracking_ms", remote_tracking_ms),
                 ProfileField::millis("import_hint_ms", import_hint_ms),
+                ProfileField::millis("git_overlay_status_ms", git_overlay_status_ms),
+                ProfileField::millis("git_overlay_health_ms", git_overlay_health_ms),
+                ProfileField::millis("verification_ms", verification_ms),
+                ProfileField::millis("git_index_ms", git_index_ms),
                 ProfileField::millis("worktree_status_ms", worktree_status_ms),
                 ProfileField::millis("thread_summary_ms", thread_summary_ms),
                 ProfileField::millis("parallel_threads_ms", parallel_threads_ms),

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -10,7 +10,6 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use chrono::{DateTime, Utc};
-use gix::bstr::ByteSlice;
 use objects::{
     object::{ChangeId, State, ThreadName, Tree},
     store::{AgentEntry, AgentRegistry, AgentStatus, current_boot_id},
@@ -25,6 +24,7 @@ use repo::{
     ThreadView, describe_thread_advice,
 };
 use serde::Serialize;
+use sley::Repository as SleyRepository;
 
 use super::{
     action_line::{print_nested_next_step, print_nested_optional, print_next_step, print_optional},
@@ -963,7 +963,8 @@ pub fn find_thread_summary(repo: &Repository, name: &str) -> Result<Option<Threa
 ///   them needs a global parent-thread scan; callers that display these
 ///   relations should route through `find_thread_summary` instead.
 /// - `git_branch_tip` and `history_imported` are not populated for
-///   the same reason — discovering them needs the full gix branch walk.
+///   the same reason — discovering them needs the full Sley-backed
+///   branch walk.
 ///   `tip_only` thread_health is therefore not surfaced; the import-
 ///   hint line on the surrounding render already nudges the user.
 ///
@@ -993,7 +994,7 @@ pub fn find_thread_summary_single(repo: &Repository, name: &str) -> Result<Optio
         name.to_string(),
         entries,
         thread_record,
-        None, // skip branch_tip lookup (would require full gix walk)
+        None, // skip branch_tip lookup (would require full Sley-backed walk)
     )?;
     let mut summary = ThreadSummary::from_view(view, coordination_status);
 
@@ -1425,12 +1426,8 @@ pub(crate) fn thread_is_available_git_ref(entry: &ThreadSummary) -> bool {
 }
 
 fn remote_tracking_local_ref(repo: &Repository, thread_name: &str) -> Option<String> {
-    let git = gix::discover(repo.root()).ok()?;
-    let remotes = git
-        .remote_names()
-        .into_iter()
-        .map(|name| name.to_str_lossy().into_owned())
-        .collect::<Vec<_>>();
+    let git = SleyRepository::discover(repo.root()).ok()?;
+    let remotes = git.remote_names().ok()?;
     remotes
         .iter()
         .find_map(|remote| thread_name.strip_prefix(&format!("{remote}/")))

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -422,13 +422,7 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
             .refs()
             .get_thread(&ThreadName::new(&thread.thread))?
             .map(|id| id.short());
-        save_thread_update_with_oplog(
-            &repo,
-            &manager,
-            &thread,
-            before_update,
-            thread_state,
-        )?;
+        save_thread_update_with_oplog(&repo, &manager, &thread, before_update, thread_state)?;
     }
     let recommended_action = if blockers.is_empty() {
         if rebase_state_path.exists() {

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -9,13 +9,6 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
-use gix::{
-    ObjectId,
-    refs::{
-        Target,
-        transaction::{Change, LogChange, PreviousValue, RefEdit, RefLog},
-    },
-};
 use objects::error::{HeddleError, Result as HeddleResult};
 use objects::lock::{RepoLock, WriteLockGuard};
 use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName};
@@ -26,6 +19,11 @@ use repo::{
     ThreadState, VisibilitySidecarRestore,
     atomic::{AtomicMutation, DeferredMutation, StagedCommit, Tx},
     refresh_thread_freshness,
+};
+use sley::{
+    DeleteRef, FullName, GitObjectType, GitTime, IndexWriteOptions, ObjectId, RefPrecondition,
+    ReferenceTarget, Repository as SleyRepository, Signature,
+    plumbing::sley_core::ByteString as GitByteString,
 };
 
 use super::{advice::RecoveryAdvice, thread_cmd::thread_not_found_advice};
@@ -100,9 +98,11 @@ fn batches_have_git_checkpoint(batches: &[OpBatch]) -> bool {
 
 fn current_git_head(repo: &Repository) -> Result<String> {
     let git = git_checkout_repo(repo)?;
-    git.head_id()
-        .map(|id| id.detach().to_string())
-        .map_err(|error| anyhow!("failed to inspect Git HEAD: {error}"))
+    git.head()
+        .map_err(|error| anyhow!("failed to inspect Git HEAD: {error}"))?
+        .oid
+        .map(|id| id.to_string())
+        .ok_or_else(|| anyhow!("failed to inspect Git HEAD: HEAD is unborn"))
 }
 
 fn ensure_simulated_git_head_is(
@@ -1056,7 +1056,10 @@ fn capture_git_state(repo: &Repository, branch: &str) -> HeddleResult<GitState> 
         ref_target_oid(&git, &format!("refs/heads/{branch}")).map_err(apply_error)?
     };
     let head_file = fs::read_to_string(git.git_dir().join("HEAD")).ok();
-    let checkout_head_oid = git.head_id().ok().map(|id| id.detach().to_string());
+    let checkout_head_oid = git
+        .head()
+        .ok()
+        .and_then(|head| head.oid.map(|id| id.to_string()));
     let mirror_branch_oid = capture_mirror_oid(repo, branch).map_err(apply_error)?;
     Ok(GitState {
         head_file,
@@ -1078,7 +1081,7 @@ fn restore_git_state(repo: &Repository, branch: &str, state: &GitState) -> Heddl
                 &git,
                 &ref_name,
                 oid,
-                PreviousValue::Any,
+                RefPrecondition::Any,
                 "heddle: rollback git checkpoint",
             )
             .map_err(|error| apply_error(anyhow!(error)))?,
@@ -1125,7 +1128,7 @@ fn restore_mirror_oid(repo: &Repository, branch: &str, oid: Option<ObjectId>) ->
             &git,
             &ref_name,
             oid,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "heddle: rollback mirror checkpoint ref",
         )
         .map_err(|error| anyhow!(error)),
@@ -1133,7 +1136,7 @@ fn restore_mirror_oid(repo: &Repository, branch: &str, oid: Option<ObjectId>) ->
     }
 }
 
-fn delete_ref_if_present(git: &gix::Repository, ref_name: &str) -> Result<()> {
+fn delete_ref_if_present(git: &SleyRepository, ref_name: &str) -> Result<()> {
     if ref_target_oid(git, ref_name)?.is_some() {
         delete_reference_matching(git, ref_name, None)?;
     }
@@ -1239,7 +1242,7 @@ fn apply_git_checkpoint_redo(
                         &git_checkout_repo(repo)?,
                         &format!("refs/heads/{branch}"),
                         new_oid,
-                        PreviousValue::Any,
+                        RefPrecondition::Any,
                         "heddle: redo git checkpoint",
                     )
                     .map_err(|error| anyhow!(error))
@@ -1291,7 +1294,7 @@ fn update_mirror_branch_ref(
             &git,
             &ref_name,
             parse_git_oid(target)?,
-            PreviousValue::MustExistAndMatch(Target::Object(parse_git_oid(expected)?)),
+            RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(parse_git_oid(expected)?)),
             "heddle: update mirror checkpoint ref",
         )
         .map_err(|error| anyhow!(error)),
@@ -1299,7 +1302,7 @@ fn update_mirror_branch_ref(
             &git,
             &ref_name,
             parse_git_oid(target)?,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "heddle: update mirror checkpoint ref",
         )
         .map_err(|error| anyhow!(error)),
@@ -1362,7 +1365,7 @@ fn format_status_paths(kind: &str, paths: &[PathBuf]) -> Vec<String> {
         .collect()
 }
 
-fn git_checkout_repo(repo: &Repository) -> Result<gix::Repository> {
+fn git_checkout_repo(repo: &Repository) -> Result<SleyRepository> {
     open_git_repo(repo.root()).map_err(|error| anyhow!(error))
 }
 
@@ -1371,20 +1374,19 @@ fn parse_git_oid(oid: &str) -> Result<ObjectId> {
         .map_err(|error| anyhow!("invalid Git object id '{oid}': {error}"))
 }
 
-fn ref_target_oid(repo: &gix::Repository, name: &str) -> Result<Option<ObjectId>> {
-    let Some(mut reference) = repo
-        .try_find_reference(name)
+fn ref_target_oid(repo: &SleyRepository, name: &str) -> Result<Option<ObjectId>> {
+    let Some(reference) = repo
+        .find_reference(name)
         .map_err(|error| anyhow!("failed to inspect Git reference '{name}': {error}"))?
     else {
         return Ok(None);
     };
     reference
-        .peel_to_id()
-        .map(|id| Some(id.detach()))
+        .peeled_oid(repo)
         .map_err(|error| anyhow!("failed to resolve Git reference '{name}': {error}"))
 }
 
-fn attach_git_head_to_branch(repo: &gix::Repository, branch: &str) -> Result<()> {
+fn attach_git_head_to_branch(repo: &SleyRepository, branch: &str) -> Result<()> {
     if branch == "HEAD" {
         return Ok(());
     }
@@ -1396,85 +1398,162 @@ fn attach_git_head_to_branch(repo: &gix::Repository, branch: &str) -> Result<()>
 }
 
 fn set_attached_git_head(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     branch: &str,
     target: ObjectId,
     expected: ObjectId,
     log_message: &str,
 ) -> Result<()> {
-    let signature = git_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let edit = RefEdit {
-        change: Change::Update {
-            log: LogChange {
-                mode: RefLog::AndReference,
-                force_create_reflog: false,
-                message: log_message.into(),
-            },
-            expected: PreviousValue::MustExistAndMatch(Target::Object(expected)),
-            new: Target::Object(target),
-        },
-        name: "HEAD"
-            .try_into()
-            .map_err(|error| anyhow!("invalid Git HEAD ref: {error}"))?,
-        deref: true,
+    let ref_name = if branch == "HEAD" {
+        "HEAD".to_string()
+    } else {
+        format!("refs/heads/{branch}")
     };
-    repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
-        .map_err(|error| anyhow!("failed to update Git HEAD for branch '{branch}': {error}"))?;
-    Ok(())
+    set_reference_with_reflog(
+        repo,
+        &ref_name,
+        target,
+        RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(expected)),
+        log_message,
+    )
+    .map_err(|error| anyhow!("failed to update Git HEAD for branch '{branch}': {error}"))
 }
 
-fn reset_git_index_to_commit(repo: &gix::Repository, oid: ObjectId) -> Result<()> {
-    let commit = repo
-        .find_commit(oid)
+fn reset_git_index_to_commit(repo: &SleyRepository, oid: ObjectId) -> Result<()> {
+    let object = repo
+        .read_object(&oid)
         .map_err(|error| anyhow!("failed to inspect Git commit {oid}: {error}"))?;
-    let tree_id = commit
-        .tree_id()
-        .map_err(|error| anyhow!("failed to inspect Git commit tree {oid}: {error}"))?;
-    let mut index = repo
-        .index_from_tree(tree_id.as_ref())
+    if object.object_type != GitObjectType::Commit {
+        return Err(anyhow!("failed to inspect Git commit {oid}: not a commit"));
+    }
+    let commit = repo
+        .read_commit(&oid)
+        .map_err(|error| anyhow!("failed to inspect Git commit {oid}: {error}"))?;
+    let index = repo
+        .index_from_tree(&commit.tree)
         .map_err(|error| anyhow!("failed to build Git index for commit {oid}: {error}"))?;
-    index
-        .write(gix_index::write::Options::default())
-        .map_err(|error| anyhow!("failed to write Git index for commit {oid}: {error}"))?;
+    repo.write_index(
+        &index,
+        IndexWriteOptions {
+            fsync: true,
+            validate_checksum: true,
+        },
+    )
+    .map_err(|error| anyhow!("failed to write Git index for commit {oid}: {error}"))?;
     Ok(())
 }
 
 fn delete_reference_matching(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     name: &str,
     expected: Option<ObjectId>,
 ) -> Result<()> {
-    let signature = git_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let expected = expected.map_or(PreviousValue::MustExist, |oid| {
-        PreviousValue::MustExistAndMatch(Target::Object(oid))
-    });
-    let edit = RefEdit {
-        change: Change::Delete {
-            log: RefLog::AndReference,
-            expected,
-        },
-        name: name
-            .try_into()
-            .map_err(|error| anyhow!("invalid Git reference '{name}': {error}"))?,
-        deref: false,
-    };
-    repo.edit_references_as([edit], Some(signature.to_ref(&mut time_buf)))
-        .map_err(|error| anyhow!("failed to delete Git reference '{name}': {error}"))?;
-    Ok(())
+    let current = ref_target_oid(repo, name)?;
+    if current.is_none() {
+        return Err(anyhow!(
+            "failed to delete Git reference '{name}': ref is missing"
+        ));
+    }
+    if let Some(expected) = expected
+        && current != Some(expected)
+    {
+        return Err(anyhow!(
+            "failed to delete Git reference '{name}': expected {expected}, found {}",
+            current
+                .map(|oid| oid.to_string())
+                .unwrap_or_else(|| "missing".to_string())
+        ));
+    }
+    let refs = repo.references();
+    match refs
+        .read_ref(name)
+        .map_err(|error| anyhow!("failed to inspect Git reference '{name}': {error}"))?
+    {
+        Some(ReferenceTarget::Direct(oid)) => repo
+            .delete_ref(DeleteRef {
+                name: FullName::new(name)
+                    .map_err(|error| anyhow!("invalid Git reference '{name}': {error}"))?,
+                expected_old: Some(expected.unwrap_or(oid)),
+                expected: None,
+                reflog: None,
+                reflog_committer: None,
+            })
+            .map_err(|error| anyhow!("failed to delete Git reference '{name}': {error}")),
+        Some(ReferenceTarget::Symbolic(_)) => refs
+            .delete_symbolic_ref(name)
+            .map(|_| ())
+            .map_err(|error| anyhow!("failed to delete Git reference '{name}': {error}")),
+        None => Err(anyhow!(
+            "failed to delete Git reference '{name}': ref is missing"
+        )),
+    }
 }
 
-fn git_signature() -> gix::actor::Signature {
+fn git_signature() -> Signature {
     let seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|duration| duration.as_secs() as i64)
         .unwrap_or(0);
-    gix::actor::Signature {
-        name: "Heddle".into(),
-        email: "heddle@local".into(),
-        time: gix::date::Time { seconds, offset: 0 },
+    let name = "Heddle";
+    let email = "heddle@local";
+    Signature {
+        name: GitByteString::new(name.as_bytes().to_vec()),
+        email: GitByteString::new(email.as_bytes().to_vec()),
+        time: GitTime::new(seconds, 0),
+        raw: format!("{name} <{email}> {seconds} +0000").into_bytes(),
     }
+}
+
+fn git_reflog_entry(
+    old_oid: ObjectId,
+    new_oid: ObjectId,
+    message: &str,
+) -> sley::plumbing::sley_refs::ReflogEntry {
+    sley::plumbing::sley_refs::ReflogEntry {
+        old_oid,
+        new_oid,
+        committer: git_signature().to_ident_bytes(),
+        message: message.as_bytes().to_vec(),
+    }
+}
+
+fn set_reference_with_reflog(
+    repo: &SleyRepository,
+    name: &str,
+    target: ObjectId,
+    constraint: RefPrecondition,
+    log_message: &str,
+) -> Result<()> {
+    let refs = repo.references();
+    let old_oid = match refs
+        .read_ref(name)
+        .map_err(|error| anyhow!("failed to inspect Git reference '{name}': {error}"))?
+    {
+        Some(ReferenceTarget::Direct(oid)) => oid,
+        _ => ObjectId::null(repo.object_format()),
+    };
+    let reflog = git_reflog_entry(old_oid, target, log_message);
+    let should_append_head_reflog = name != "HEAD"
+        && repo
+            .head()
+            .ok()
+            .and_then(|head| head.symbolic_target.map(|target| target.to_string()))
+            .as_deref()
+            == Some(name);
+    let mut tx = refs.transaction();
+    tx.update_to(
+        name.to_string(),
+        ReferenceTarget::Direct(target),
+        constraint,
+        Some(reflog.clone()),
+    );
+    tx.commit()
+        .map_err(|error| anyhow!("failed to update Git reference '{name}': {error}"))?;
+    if should_append_head_reflog {
+        refs.append_reflog("HEAD", &reflog)
+            .map_err(|error| anyhow!("failed to append Git HEAD reflog: {error}"))?;
+    }
+    Ok(())
 }
 
 fn fsync_file_and_parent(path: &Path) -> Result<()> {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -9,14 +9,256 @@
 use objects::store::ObjectStore;
 use std::{
     io::Write,
+    path::Path,
     process::{Command, Output, Stdio},
     str,
 };
 
-use gix::refs::transaction::PreviousValue;
 use repo::Repository;
 use serde_json::Value;
+use sley::plumbing::sley_core::ByteString as GitByteString;
+use sley::plumbing::sley_object::EncodedObject;
+use sley::plumbing::sley_refs::ReflogEntry;
+use sley::{
+    CommitObject, EntryKind, GitObjectType, GitTime, ObjectId, RefPrecondition, ReferenceTarget,
+    Repository as SleyRepository, Signature, TagObject,
+};
 use tempfile::TempDir;
+
+trait SleyIntegrationRepoExt {
+    fn find_commit(&self, oid: ObjectId) -> Result<TestCommit, String>;
+    fn find_object(&self, oid: ObjectId) -> Result<(), String>;
+    fn head_id(&self) -> Result<ObjectId, String>;
+    fn head_commit(&self) -> Result<TestCommit, String>;
+    fn merge_base(&self, a: ObjectId, b: ObjectId) -> Result<ObjectId, String>;
+    fn rev_walk<I>(&self, starts: I) -> TestRevWalk
+    where
+        I: IntoIterator<Item = ObjectId>;
+}
+
+impl SleyIntegrationRepoExt for SleyRepository {
+    fn find_commit(&self, oid: ObjectId) -> Result<TestCommit, String> {
+        let commit = self.read_commit(&oid).map_err(|err| err.to_string())?;
+        let tree = self
+            .read_tree(&commit.tree)
+            .map_err(|err| err.to_string())?;
+        Ok(TestCommit {
+            id: oid,
+            commit,
+            tree,
+        })
+    }
+
+    fn find_object(&self, oid: ObjectId) -> Result<(), String> {
+        self.read_object(&oid)
+            .map(|_| ())
+            .map_err(|err| err.to_string())
+    }
+
+    fn head_id(&self) -> Result<ObjectId, String> {
+        self.head()
+            .map_err(|err| err.to_string())?
+            .oid
+            .ok_or_else(|| "HEAD is unborn".to_string())
+    }
+
+    fn head_commit(&self) -> Result<TestCommit, String> {
+        let oid = self.head_id()?;
+        self.find_commit(oid)
+    }
+
+    fn merge_base(&self, a: ObjectId, b: ObjectId) -> Result<ObjectId, String> {
+        let ancestors = commit_ancestors(self, a);
+        let mut pending = std::collections::VecDeque::from([b]);
+        let mut seen = std::collections::HashSet::new();
+        while let Some(oid) = pending.pop_front() {
+            if ancestors.contains(&oid) {
+                return Ok(oid);
+            }
+            if !seen.insert(oid) {
+                continue;
+            }
+            if let Ok(commit) = self.read_commit(&oid) {
+                pending.extend(commit.parents);
+            }
+        }
+        Err(format!("no merge base for {a} and {b}"))
+    }
+
+    fn rev_walk<I>(&self, starts: I) -> TestRevWalk
+    where
+        I: IntoIterator<Item = ObjectId>,
+    {
+        let mut pending: std::collections::VecDeque<ObjectId> = starts.into_iter().collect();
+        let mut seen = std::collections::HashSet::new();
+        let mut items = Vec::new();
+        while let Some(oid) = pending.pop_front() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            match self.read_commit(&oid) {
+                Ok(commit) => {
+                    pending.extend(commit.parents.iter().copied());
+                    items.push(Ok(TestCommitInfo { id: oid }));
+                }
+                Err(err) => items.push(Err(err.to_string())),
+            }
+        }
+        TestRevWalk { items }
+    }
+}
+
+fn commit_ancestors(repo: &SleyRepository, start: ObjectId) -> std::collections::HashSet<ObjectId> {
+    let mut pending = std::collections::VecDeque::from([start]);
+    let mut seen = std::collections::HashSet::new();
+    while let Some(oid) = pending.pop_front() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        if let Ok(commit) = repo.read_commit(&oid) {
+            pending.extend(commit.parents);
+        }
+    }
+    seen
+}
+
+struct TestCommit {
+    id: ObjectId,
+    commit: CommitObject,
+    tree: sley::TreeObject,
+}
+
+struct TestCommitInfo {
+    id: ObjectId,
+}
+
+struct TestRevWalk {
+    items: Vec<Result<TestCommitInfo, String>>,
+}
+
+impl TestRevWalk {
+    fn all(self) -> Result<std::vec::IntoIter<Result<TestCommitInfo, String>>, String> {
+        Ok(self.items.into_iter())
+    }
+}
+
+struct TestTag {
+    id: ObjectId,
+}
+
+impl TestTag {
+    fn id(&self) -> ObjectId {
+        self.id
+    }
+}
+
+impl TestCommit {
+    fn id(&self) -> ObjectId {
+        self.id
+    }
+
+    fn tree_id(&self) -> Option<ObjectId> {
+        Some(self.commit.tree)
+    }
+
+    fn tree(&self) -> Result<TestTree, String> {
+        Ok(TestTree {
+            entries: self
+                .tree
+                .entries
+                .iter()
+                .map(|entry| entry.name.as_bytes().to_vec())
+                .collect(),
+        })
+    }
+
+    fn message_raw_sloppy(&self) -> TestRawMessage<'_> {
+        TestRawMessage(&self.commit.message)
+    }
+}
+
+struct TestTree {
+    entries: Vec<Vec<u8>>,
+}
+
+impl TestTree {
+    fn lookup_entry_by_path(&self, path: &str) -> Result<Option<()>, String> {
+        if path.contains('/') {
+            return Err(format!(
+                "nested lookup not implemented for test path {path}"
+            ));
+        }
+        Ok(self
+            .entries
+            .iter()
+            .any(|entry| entry.as_slice() == path.as_bytes())
+            .then_some(()))
+    }
+}
+
+struct TestRawMessage<'a>(&'a [u8]);
+
+impl std::fmt::Display for TestRawMessage<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(self.0))
+    }
+}
+
+fn find_reference<'a>(repo: &'a SleyRepository, name: &str) -> Result<TestReference<'a>, String> {
+    let full_name = if name == "HEAD" || name.starts_with("refs/") {
+        name.to_string()
+    } else {
+        format!("refs/heads/{name}")
+    };
+    let target = repo
+        .references()
+        .read_ref(&full_name)
+        .map_err(|err| err.to_string())?
+        .ok_or_else(|| format!("reference {full_name} not found"))?;
+    Ok(TestReference { repo, target })
+}
+
+struct TestReference<'a> {
+    repo: &'a SleyRepository,
+    target: ReferenceTarget,
+}
+
+impl TestReference<'_> {
+    fn peel_to_id(&mut self) -> Result<ObjectId, String> {
+        let oid = match &self.target {
+            ReferenceTarget::Direct(oid) => *oid,
+            ReferenceTarget::Symbolic(name) => {
+                let reference = find_reference(self.repo, name)?;
+                match reference.target {
+                    ReferenceTarget::Direct(oid) => oid,
+                    ReferenceTarget::Symbolic(_) => {
+                        return Err(format!("nested symbolic reference {name} is unsupported"));
+                    }
+                }
+            }
+        };
+        Ok(oid)
+    }
+
+    fn target(&self) -> TestReferenceTarget<'_> {
+        TestReferenceTarget {
+            target: &self.target,
+        }
+    }
+}
+
+struct TestReferenceTarget<'a> {
+    target: &'a ReferenceTarget,
+}
+
+impl<'a> TestReferenceTarget<'a> {
+    fn try_id(&self) -> Option<&'a ObjectId> {
+        match self.target {
+            ReferenceTarget::Direct(oid) => Some(oid),
+            ReferenceTarget::Symbolic(_) => None,
+        }
+    }
+}
 
 #[path = "cli_integration/basics.rs"]
 mod basics;
@@ -60,10 +302,10 @@ mod hooks;
 mod hydrate;
 #[path = "cli_integration/misc.rs"]
 mod misc;
-#[path = "cli_integration/oplog_salvage.rs"]
-mod oplog_salvage;
 #[path = "cli_integration/next_action_contract.rs"]
 mod next_action_contract;
+#[path = "cli_integration/oplog_salvage.rs"]
+mod oplog_salvage;
 #[path = "cli_integration/oss_cli_polish.rs"]
 mod oss_cli_polish;
 #[path = "cli_integration/output_kind_invariant.rs"]
@@ -257,10 +499,26 @@ where
     serde_json::json!(argv)
 }
 
+fn canonical_path_string(path: &std::path::Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
 fn heddle_output_with_env(
     args: &[&str],
     cwd: Option<&std::path::Path>,
     envs: &[(&str, &str)],
+) -> Result<Output, String> {
+    heddle_output_with_env_removed(args, cwd, envs, &[])
+}
+
+fn heddle_output_with_env_removed(
+    args: &[&str],
+    cwd: Option<&std::path::Path>,
+    envs: &[(&str, &str)],
+    remove_envs: &[&str],
 ) -> Result<Output, String> {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_heddle"));
     cmd.args(translate_legacy_args(args));
@@ -277,6 +535,9 @@ fn heddle_output_with_env(
     seed_default_test_user_config(&config_path, &dir)?;
     cmd.env("HEDDLE_CONFIG", config_path);
     cmd.env_remove("NO_COLOR");
+    for key in remove_envs {
+        cmd.env_remove(key);
+    }
     for (key, value) in envs {
         cmd.env(key, value);
     }
@@ -387,14 +648,18 @@ pub(crate) fn git_hermetic(args: &[&str], dir: &std::path::Path) {
     assert!(status.success(), "git {args:?} failed in {}", dir.display());
 }
 
-fn git_test_signature() -> gix::actor::Signature {
-    gix::actor::Signature {
-        name: "Heddle Test".into(),
-        email: "heddle@test".into(),
-        time: gix::date::Time {
-            seconds: 0,
-            offset: 0,
-        },
+fn open_git(path: impl AsRef<Path>) -> Result<SleyRepository, String> {
+    SleyRepository::open(path.as_ref())
+        .or_else(|_| SleyRepository::discover(path.as_ref()))
+        .map_err(|err| err.to_string())
+}
+
+fn git_test_signature() -> Signature {
+    Signature {
+        name: GitByteString::new(b"Heddle Test".to_vec()),
+        email: GitByteString::new(b"heddle@test".to_vec()),
+        time: GitTime::new(0, 0),
+        raw: b"Heddle Test <heddle@test> 0 +0000".to_vec(),
     }
 }
 
@@ -433,51 +698,85 @@ fn default_test_user_config_path(cwd: &std::path::Path) -> std::path::PathBuf {
     ))
 }
 
-fn git_empty_tree_oid(repo: &gix::Repository) -> gix::hash::ObjectId {
-    repo.empty_tree().id
+fn git_empty_tree_oid(repo: &SleyRepository) -> ObjectId {
+    repo.write_tree(sley::TreeEditor::new())
+        .expect("write empty tree")
 }
 
-fn git_set_reference(repo: &gix::Repository, name: &str, target: gix::hash::ObjectId) {
+fn git_set_reference(repo: &SleyRepository, name: &str, target: ObjectId) {
     let sig = git_test_signature();
-    let mut time_buf = gix::date::parse::TimeBuf::default();
-    let edit = gix::refs::transaction::RefEdit {
-        change: gix::refs::transaction::Change::Update {
-            log: gix::refs::transaction::LogChange {
-                mode: gix::refs::transaction::RefLog::AndReference,
-                force_create_reflog: false,
-                message: "test: update ref".into(),
-            },
-            expected: PreviousValue::Any,
-            new: gix::refs::Target::Object(target),
-        },
-        name: name.try_into().expect("valid ref name"),
-        deref: false,
+    let refs = repo.references();
+    let old_oid = match refs.read_ref(name).expect("read ref") {
+        Some(ReferenceTarget::Direct(oid)) => oid,
+        _ => ObjectId::null(repo.object_format()),
     };
-    repo.edit_references_as([edit], Some(sig.to_ref(&mut time_buf)))
-        .expect("update ref");
+    let mut tx = refs.transaction();
+    tx.update_to(
+        name.to_string(),
+        ReferenceTarget::Direct(target),
+        RefPrecondition::Any,
+        Some(ReflogEntry {
+            old_oid,
+            new_oid: target,
+            committer: sig.to_ident_bytes(),
+            message: b"test: update ref".to_vec(),
+        }),
+    );
+    tx.commit().expect("update ref");
 }
 
 fn git_commit_with_tree(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     reference: Option<&str>,
-    tree_oid: gix::hash::ObjectId,
+    tree_oid: ObjectId,
     message: &str,
-    parents: &[gix::hash::ObjectId],
-) -> gix::hash::ObjectId {
+    parents: &[ObjectId],
+) -> ObjectId {
     let sig = git_test_signature();
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let commit = repo
-        .new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            message,
-            tree_oid,
-            parents.to_vec(),
-        )
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: parents.to_vec(),
+        author: sig.to_ident_bytes(),
+        committer: sig.to_ident_bytes(),
+        encoding: None,
+        message: message.as_bytes().to_vec(),
+    };
+    let commit_id = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
         .expect("commit");
     if let Some(reference) = reference {
-        git_set_reference(repo, reference, commit.id);
+        git_set_reference(repo, reference, commit_id);
     }
-    commit.id
+    commit_id
+}
+
+fn git_create_annotated_tag(
+    repo: &SleyRepository,
+    name: &str,
+    target: ObjectId,
+    object_type: GitObjectType,
+    message: &str,
+    precondition: RefPrecondition,
+) -> TestTag {
+    let tag = TagObject {
+        object: target,
+        object_type,
+        name: name.as_bytes().to_vec(),
+        tagger: Some(git_test_signature().to_ident_bytes()),
+        message: message.as_bytes().to_vec(),
+        raw_body: None,
+    };
+    let tag_id = repo
+        .write_object(EncodedObject::new(GitObjectType::Tag, tag.write()))
+        .expect("write annotated tag");
+    let refs = repo.references();
+    let mut tx = refs.transaction();
+    tx.update_to(
+        format!("refs/tags/{name}"),
+        ReferenceTarget::Direct(tag_id),
+        precondition,
+        None,
+    );
+    tx.commit().expect("update tag ref");
+    TestTag { id: tag_id }
 }

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -450,8 +450,8 @@ fn test_cli_bridge_git_export_and_pull_roundtrip() {
     );
     assert!(export.is_ok(), "bridge export failed: {:?}", export.err());
 
-    let dest_repo = gix::open(&dest).unwrap();
-    assert!(dest_repo.find_reference("refs/heads/main").is_ok());
+    let dest_repo = open_git(&dest).unwrap();
+    assert!(find_reference(&dest_repo, "refs/heads/main").is_ok());
 
     heddle(&["init"], Some(target.path())).unwrap();
     let pull = heddle(
@@ -474,7 +474,7 @@ fn test_cli_bridge_git_export_and_pull_roundtrip() {
 fn test_cli_bridge_git_import_from_external_repo() {
     let heddle_repo_dir = TempDir::new().unwrap();
     let git_repo_dir = TempDir::new().unwrap();
-    let git_repo = gix::init(git_repo_dir.path()).unwrap();
+    let git_repo = SleyRepository::init(git_repo_dir.path()).unwrap();
     let tree_oid = git_empty_tree_oid(&git_repo);
     git_commit_with_tree(
         &git_repo,
@@ -509,7 +509,7 @@ fn test_cli_bridge_git_import_from_external_repo() {
 fn test_cli_bridge_git_push_to_local_bare_remote() {
     let source = TempDir::new().unwrap();
     let remote = TempDir::new().unwrap();
-    let remote_repo = gix::init_bare(remote.path()).unwrap();
+    let remote_repo = SleyRepository::init_bare(remote.path()).unwrap();
 
     heddle(&["init"], Some(source.path())).unwrap();
     std::fs::write(source.path().join("push.txt"), "bridge push").unwrap();
@@ -521,7 +521,7 @@ fn test_cli_bridge_git_push_to_local_bare_remote() {
     );
     assert!(result.is_ok(), "Bridge push failed: {:?}", result.err());
 
-    assert!(remote_repo.find_reference("refs/heads/main").is_ok());
+    assert!(find_reference(&remote_repo, "refs/heads/main").is_ok());
 }
 
 /// `heddle push --mirror=<git-remote>` performs the primary push to the
@@ -532,7 +532,7 @@ fn test_cli_push_mirror_dual_push_to_weft_and_git_remote() {
     let source = TempDir::new().unwrap();
     let weft_target = TempDir::new().unwrap();
     let git_remote = TempDir::new().unwrap();
-    let mirror_repo = gix::init_bare(git_remote.path()).unwrap();
+    let mirror_repo = SleyRepository::init_bare(git_remote.path()).unwrap();
 
     heddle(&["init"], Some(source.path())).unwrap();
     heddle(&["init"], Some(weft_target.path())).unwrap();
@@ -577,7 +577,7 @@ fn test_cli_push_mirror_dual_push_to_weft_and_git_remote() {
 
     // Mirror push landed at the bare git remote.
     assert!(
-        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&mirror_repo, "refs/heads/main").is_ok(),
         "git mirror remote should have refs/heads/main after mirror push"
     );
 }
@@ -690,7 +690,7 @@ fn test_cli_push_mirror_explicit_equals_form_parses_value() {
     let source = TempDir::new().unwrap();
     let weft_target = TempDir::new().unwrap();
     let git_remote = TempDir::new().unwrap();
-    let mirror_repo = gix::init_bare(git_remote.path()).unwrap();
+    let mirror_repo = SleyRepository::init_bare(git_remote.path()).unwrap();
 
     heddle(&["init"], Some(source.path())).unwrap();
     heddle(&["init"], Some(weft_target.path())).unwrap();
@@ -715,7 +715,7 @@ fn test_cli_push_mirror_explicit_equals_form_parses_value() {
     let threads = heddle(&["thread", "list"], Some(weft_target.path())).unwrap();
     assert!(threads.contains("main"));
     assert!(
-        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&mirror_repo, "refs/heads/main").is_ok(),
         "mirror push should land at the explicit <git_path>"
     );
 }
@@ -727,7 +727,7 @@ fn test_cli_push_mirror_json_success_emits_mirrored_true() {
     let source = TempDir::new().unwrap();
     let weft_target = TempDir::new().unwrap();
     let git_remote = TempDir::new().unwrap();
-    gix::init_bare(git_remote.path()).unwrap();
+    SleyRepository::init_bare(git_remote.path()).unwrap();
 
     heddle(&["init"], Some(source.path())).unwrap();
     heddle(&["init"], Some(weft_target.path())).unwrap();
@@ -778,8 +778,8 @@ fn test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes() {
     let source = TempDir::new().unwrap();
     let primary_remote = TempDir::new().unwrap();
     let mirror_remote = TempDir::new().unwrap();
-    let primary_repo = gix::init_bare(primary_remote.path()).unwrap();
-    let mirror_repo = gix::init_bare(mirror_remote.path()).unwrap();
+    let primary_repo = SleyRepository::init_bare(primary_remote.path()).unwrap();
+    let mirror_repo = SleyRepository::init_bare(mirror_remote.path()).unwrap();
 
     // Plain `git init` → RepositoryCapability::GitOverlay,
     // hosted_enabled() == false. This is the drop-in case the
@@ -836,11 +836,11 @@ fn test_cli_push_mirror_in_git_overlay_pushes_to_both_remotes() {
         .expect("push --mirror in GitOverlay repo should succeed");
 
     assert!(
-        primary_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&primary_repo, "refs/heads/main").is_ok(),
         "primary remote should have refs/heads/main after overlay push"
     );
     assert!(
-        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&mirror_repo, "refs/heads/main").is_ok(),
         "mirror remote MUST ALSO have refs/heads/main — the GitOverlay early-return previously bypassed --mirror"
     );
 }
@@ -859,7 +859,7 @@ fn test_cli_push_mirror_json_uses_rfc8259_escaping_for_unicode() {
     // push succeeds and the `"remote"` field carries the bad codepoint.
     let mirror_dir = mirror_parent.path().join("mirror\u{2028}suffix");
     std::fs::create_dir_all(&mirror_dir).unwrap();
-    let mirror_repo = gix::init_bare(&mirror_dir).unwrap();
+    let mirror_repo = SleyRepository::init_bare(&mirror_dir).unwrap();
 
     heddle(&["init"], Some(source.path())).unwrap();
     heddle(&["init"], Some(weft_target.path())).unwrap();
@@ -910,7 +910,7 @@ fn test_cli_push_mirror_json_uses_rfc8259_escaping_for_unicode() {
     );
     // Sanity: mirror push landed too.
     assert!(
-        mirror_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&mirror_repo, "refs/heads/main").is_ok(),
         "mirror push should have landed at the U+2028 path"
     );
 }

--- a/crates/cli/tests/cli_integration/doctor_docs.rs
+++ b/crates/cli/tests/cli_integration/doctor_docs.rs
@@ -277,11 +277,7 @@ fn all_enumerates_markdown_without_git() {
     let root = temp.path();
     // Two markdown files at different depths, plus one file inside
     // an ignored prefix that must NOT be scanned.
-    write_file(
-        root,
-        "README.md",
-        "Run `heddle start probe --path foo`.\n",
-    );
+    write_file(root, "README.md", "Run `heddle start probe --path foo`.\n");
     fs::create_dir_all(root.join("docs")).unwrap();
     write_file(
         &root.join("docs"),

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -44,15 +44,12 @@ fn bridge_recovers_from_crash_after_tmp_before_commit() {
     // short-circuit the fault checkpoint). Reuses the helpers from
     // `cli_integration.rs` so the fixture shape matches the other
     // bridge tests.
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
-    let blob = origin_repo.write_blob(b"fn a() {}\n").unwrap().detach();
-    let mut tree_editor = origin_repo
-        .edit_tree(origin_repo.empty_tree().id)
-        .expect("tree editor");
-    tree_editor
-        .upsert("core.rs", gix::object::tree::EntryKind::Blob, blob)
-        .unwrap();
-    let tree_oid = tree_editor.write().unwrap().detach();
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
+    let blob = origin_repo.write_blob(b"fn a() {}\n").unwrap();
+    let empty = git_empty_tree_oid(&origin_repo);
+    let mut tree_editor = origin_repo.edit_tree(&empty).expect("tree editor");
+    tree_editor.upsert("core.rs", EntryKind::Blob, blob);
+    let tree_oid = origin_repo.write_tree(tree_editor).unwrap();
     let _commit =
         git_commit_with_tree(&origin_repo, Some("refs/heads/main"), tree_oid, "seed", &[]);
 
@@ -397,7 +394,10 @@ fn thread_update_save_failure_does_not_commit_undoable_record() {
     let failed = heddle_output_with_env(
         &["thread", "resolve", "feature/atomic-save"],
         Some(temp.path()),
-        &[("HEDDLE_FAULT_INJECT", "thread_manager_save_in_thread_update")],
+        &[(
+            "HEDDLE_FAULT_INJECT",
+            "thread_manager_save_in_thread_update",
+        )],
     )
     .expect("spawn injected thread resolve");
     assert!(

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1589,9 +1589,10 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
         &["--output", "json", "ready", "-m", "ready thread work"],
     );
     assert_eq!(ready["status"], "completed");
+    let repo_path = canonical_path_string(temp.path());
     let parent_land_action = format!(
         "heddle --repo {} land --thread feature/ready-verify --no-push",
-        temp.path().display()
+        repo_path
     );
     assert_eq!(
         ready["recommended_action"], parent_land_action,
@@ -1720,9 +1721,10 @@ fn git_overlay_matrix_ready_thread_keeps_verification_clean_and_workflow_actiona
         "Workflow check should match the established land path: {thread_show_after_preview}"
     );
     let ready_after_preview = json(&thread_path, &["--output", "json", "ready"]);
+    let repo_path = canonical_path_string(temp.path());
     let parent_land_action = format!(
         "heddle --repo {} land --thread feature/ready-verify --no-push",
-        temp.path().display()
+        repo_path
     );
     assert_eq!(
         ready_after_preview["recommended_action"], parent_land_action,

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -137,8 +137,8 @@ fn git_stdout(args: &[&str], cwd: &std::path::Path) -> String {
     String::from_utf8_lossy(&output.stdout).trim().to_string()
 }
 
-fn seed_bare_git_repo(path: &std::path::Path) -> gix::hash::ObjectId {
-    let repo = gix::init_bare(path).expect("init bare git repo");
+fn seed_bare_git_repo(path: &std::path::Path) -> ObjectId {
+    let repo = SleyRepository::init_bare(path).expect("init bare git repo");
     let commit = git_commit_with_tree(
         &repo,
         Some("refs/heads/main"),
@@ -150,29 +150,26 @@ fn seed_bare_git_repo(path: &std::path::Path) -> gix::hash::ObjectId {
     commit
 }
 
-fn git_tree_with_file(repo: &gix::Repository, path: &str, content: &[u8]) -> gix::hash::ObjectId {
-    let blob = repo.write_blob(content).expect("write git blob").detach();
+fn git_tree_with_file(repo: &SleyRepository, path: &str, content: &[u8]) -> ObjectId {
+    let blob = repo.write_blob(content).expect("write git blob");
     let empty = git_empty_tree_oid(repo);
-    let mut editor = repo.edit_tree(empty).expect("edit git tree");
-    editor
-        .upsert(path, gix::object::tree::EntryKind::Blob, blob)
-        .expect("add file to git tree");
-    editor.write().expect("write git tree").detach()
+    let mut editor = repo.edit_tree(&empty).expect("edit git tree");
+    editor.upsert(path, EntryKind::Blob, blob);
+    repo.write_tree(editor).expect("write git tree")
 }
 
 fn git_head_oid(path: &std::path::Path) -> String {
-    gix::open(path)
+    open_git(path)
         .expect("open git repo")
         .head_id()
         .expect("resolve HEAD")
-        .detach()
         .to_string()
 }
 
 #[test]
 fn git_replacement_matrix_fresh_git_read_commands_without_git_on_path() {
     let temp = TempDir::new().unwrap();
-    gix::init(temp.path()).expect("init git worktree");
+    SleyRepository::init(temp.path()).expect("init git worktree");
     std::fs::write(temp.path().join("pending.txt"), "pending\n").unwrap();
 
     let status = heddle_without_git(&["status", "--output", "json"], temp.path()).unwrap();
@@ -253,7 +250,7 @@ fn git_replacement_matrix_fresh_git_read_commands_without_git_on_path() {
     );
 
     let committed = TempDir::new().unwrap();
-    let repo = gix::init(committed.path()).expect("init committed git worktree");
+    let repo = SleyRepository::init(committed.path()).expect("init committed git worktree");
     std::fs::write(
         committed.path().join(".git").join("HEAD"),
         "ref: refs/heads/main\n",
@@ -287,7 +284,7 @@ fn git_replacement_matrix_fresh_git_read_commands_without_git_on_path() {
 #[test]
 fn git_replacement_matrix_shallow_import_refuses_without_raw_git_advice() {
     let temp = TempDir::new().unwrap();
-    let git = gix::init(temp.path()).expect("init git worktree");
+    let git = SleyRepository::init(temp.path()).expect("init git worktree");
     std::fs::write(
         temp.path().join(".git").join("HEAD"),
         "ref: refs/heads/main\n",
@@ -347,7 +344,7 @@ fn git_replacement_matrix_shallow_import_refuses_without_raw_git_advice() {
 #[test]
 fn git_replacement_matrix_raw_git_operation_handoff_without_git_on_path() {
     let temp = TempDir::new().unwrap();
-    let git = gix::init(temp.path()).expect("init git worktree");
+    let git = SleyRepository::init(temp.path()).expect("init git worktree");
     configure_repo_local_git_identity(temp.path());
     std::fs::write(
         temp.path().join(".git").join("HEAD"),
@@ -522,7 +519,7 @@ fn git_replacement_matrix_native_repo_read_commands_without_git_on_path() {
 #[test]
 fn git_replacement_matrix_everyday_save_read_machine_streams_without_git_on_path() {
     let temp = TempDir::new().unwrap();
-    gix::init(temp.path()).expect("init git worktree");
+    SleyRepository::init(temp.path()).expect("init git worktree");
     configure_repo_local_git_identity(temp.path());
 
     let init = assert_clean_json_without_git(&["--output", "json", "init"], temp.path());
@@ -634,13 +631,11 @@ fn git_replacement_matrix_clone_status_capture_push_without_git_on_path() {
     heddle_without_git(&["capture", "-m", "heddle change"], &work).unwrap();
     heddle_without_git(&["push"], &work).unwrap();
 
-    let origin_repo = gix::open(&origin).expect("open pushed origin");
-    let new_tip = origin_repo
-        .find_reference("refs/heads/main")
+    let origin_repo = open_git(&origin).expect("open pushed origin");
+    let new_tip = find_reference(&origin_repo, "refs/heads/main")
         .expect("main ref exists")
         .peel_to_id()
-        .expect("peel main")
-        .detach();
+        .expect("peel main");
     assert_ne!(
         new_tip, original_tip,
         "heddle push should advance Git branch"
@@ -760,10 +755,8 @@ fn git_replacement_matrix_bridge_import_export_sync_reconcile_without_git_on_pat
             || export["threads_synced"].as_u64().unwrap_or(0) >= 1,
         "explicit bridge export should write Git-format refs natively: {export}"
     );
-    let exported = gix::open(&export_path).expect("open exported git repo");
-    exported
-        .find_reference("refs/heads/main")
-        .expect("export should write main branch");
+    let exported = open_git(&export_path).expect("open exported git repo");
+    find_reference(&exported, "refs/heads/main").expect("export should write main branch");
 
     let sync = assert_clean_json_without_git(
         &[
@@ -848,13 +841,11 @@ fn git_replacement_matrix_commit_undo_rewinds_checkpoint_without_git_on_path() {
         "undo should rewind the visible Git checkout without invoking git"
     );
 
-    let mirror = gix::open(work.join(".heddle/git")).expect("open Heddle Git mirror");
-    let mirror_tip = mirror
-        .find_reference("refs/heads/main")
+    let mirror = open_git(work.join(".heddle/git")).expect("open Heddle Git mirror");
+    let mirror_tip = find_reference(&mirror, "refs/heads/main")
         .expect("mirror main exists")
         .peel_to_id()
         .expect("peel mirror main")
-        .detach()
         .to_string();
     assert_eq!(
         mirror_tip, base,
@@ -1149,11 +1140,11 @@ fn git_replacement_matrix_merge_git_commit_pushes_checkpoint_without_git_on_path
         .to_string();
     assert_eq!(git_head_oid(&work), merge_sha);
 
-    let git_repo = gix::open(&work).expect("open checkout git repo");
+    let git_repo = open_git(&work).expect("open checkout git repo");
     let head = git_repo
         .find_commit(
             merge_sha
-                .parse::<gix::hash::ObjectId>()
+                .parse::<ObjectId>()
                 .expect("merge sha should parse"),
         )
         .expect("merge checkpoint should exist");
@@ -1172,13 +1163,11 @@ fn git_replacement_matrix_merge_git_commit_pushes_checkpoint_without_git_on_path
     );
 
     heddle_without_git(&["push"], &work).unwrap();
-    let origin_repo = gix::open(&origin).expect("open origin");
-    let origin_tip = origin_repo
-        .find_reference("refs/heads/main")
+    let origin_repo = open_git(&origin).expect("open origin");
+    let origin_tip = find_reference(&origin_repo, "refs/heads/main")
         .expect("origin main exists")
         .peel_to_id()
         .expect("peel origin main")
-        .detach()
         .to_string();
     assert_eq!(
         origin_tip, merge_sha,
@@ -1360,13 +1349,11 @@ fn git_replacement_matrix_checkpoint_writes_through_to_git_branch_and_index_with
     heddle_without_git(&["capture", "-m", "write through"], &work).unwrap();
     heddle_without_git(&["checkpoint", "-m", "commit captured work"], &work).unwrap();
 
-    let git_repo = gix::open(&work).expect("open checkout git repo");
-    let new_tip = git_repo
-        .find_reference("refs/heads/main")
+    let git_repo = open_git(&work).expect("open checkout git repo");
+    let new_tip = find_reference(&git_repo, "refs/heads/main")
         .expect("main ref exists")
         .peel_to_id()
-        .expect("peel main")
-        .detach();
+        .expect("peel main");
     assert_ne!(
         new_tip, original_tip,
         "checkpoint should advance the real Git branch ref"
@@ -1519,7 +1506,7 @@ fn git_replacement_matrix_pull_adopts_remote_branch_without_git_on_path() {
     )
     .unwrap();
 
-    let origin_repo = gix::open(&origin).expect("open origin");
+    let origin_repo = open_git(&origin).expect("open origin");
     let advanced_tip = git_commit_with_tree(
         &origin_repo,
         Some("refs/heads/main"),
@@ -1549,13 +1536,11 @@ fn git_replacement_matrix_pull_adopts_remote_branch_without_git_on_path() {
         "pull text should explain remote movement without requiring git on PATH: {pull}"
     );
 
-    let mirror = gix::open(work.join(".heddle/git")).expect("open Heddle Git mirror");
-    let mirror_tip = mirror
-        .find_reference("refs/heads/main")
+    let mirror = open_git(work.join(".heddle/git")).expect("open Heddle Git mirror");
+    let mirror_tip = find_reference(&mirror, "refs/heads/main")
         .expect("mirror main exists")
         .peel_to_id()
-        .expect("peel mirror main")
-        .detach();
+        .expect("peel mirror main");
     assert_eq!(
         mirror_tip, advanced_tip,
         "heddle pull should advance the native Git mirror without using git on PATH"
@@ -1568,7 +1553,7 @@ fn git_replacement_matrix_fetch_does_not_dirty_checkout_and_pull_materializes_wi
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init bare git repo");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init bare git repo");
     let base_tree = git_tree_with_file(&origin_repo, "shared.txt", b"base\n");
     let original_tip = git_commit_with_tree(
         &origin_repo,
@@ -1659,7 +1644,7 @@ fn git_replacement_matrix_fetch_discovers_new_remote_branch_without_git_on_path(
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init bare git repo");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init bare git repo");
     let base_tree = git_tree_with_file(&origin_repo, "shared.txt", b"base\n");
     let original_tip = git_commit_with_tree(
         &origin_repo,
@@ -1698,22 +1683,18 @@ fn git_replacement_matrix_fetch_discovers_new_remote_branch_without_git_on_path(
     )
     .unwrap();
 
-    let checkout = gix::open(&work).expect("open checkout git repo");
-    let checkout_topic = checkout
-        .find_reference("refs/remotes/origin/topic-remote")
+    let checkout = open_git(&work).expect("open checkout git repo");
+    let checkout_topic = find_reference(&checkout, "refs/remotes/origin/topic-remote")
         .expect("fetch should discover checkout remote-tracking branch")
         .peel_to_id()
-        .expect("peel checkout remote-tracking branch")
-        .detach();
+        .expect("peel checkout remote-tracking branch");
     assert_eq!(checkout_topic, topic_tip);
 
-    let mirror = gix::open(work.join(".heddle/git")).expect("open Heddle Git mirror");
-    let mirror_topic = mirror
-        .find_reference("refs/remotes/origin/topic-remote")
+    let mirror = open_git(work.join(".heddle/git")).expect("open Heddle Git mirror");
+    let mirror_topic = find_reference(&mirror, "refs/remotes/origin/topic-remote")
         .expect("fetch should mirror remote-tracking branch")
         .peel_to_id()
-        .expect("peel mirror remote-tracking branch")
-        .detach();
+        .expect("peel mirror remote-tracking branch");
     assert_eq!(mirror_topic, topic_tip);
 
     let import = assert_clean_json_without_git(
@@ -1769,10 +1750,11 @@ fn git_replacement_matrix_https_push_uses_native_transport_without_git_on_path()
     )
     .expect_err("closed HTTPS endpoint should fail after choosing native transport");
 
+    let lowercase_error = err.to_ascii_lowercase();
     assert!(
-        err.contains("failed to connect")
-            || err.contains("receive-pack handshake failed")
-            || err.contains("connection"),
+        lowercase_error.contains("failed to connect")
+            || lowercase_error.contains("receive-pack handshake failed")
+            || lowercase_error.contains("connection"),
         "HTTPS push should fail as a native transport connection error: {err}"
     );
     assert!(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -587,6 +587,7 @@ fn git_overlay_isolated_checkout_status_and_verify_identify_parent_context() {
         ],
     );
 
+    let parent_repo = canonical_path_string(temp.path());
     let status = json_value(&checkout, &["status", "--output", "json"]);
     assert_eq!(
         status["repository_capability"], "native-heddle",
@@ -602,7 +603,7 @@ fn git_overlay_isolated_checkout_status_and_verify_identify_parent_context() {
     );
     assert_eq!(
         status["repository_context"]["parent_repository"],
-        temp.path().display().to_string()
+        parent_repo
     );
     assert_eq!(status["repository_context"]["target_thread"], "main");
     assert_eq!(status["target_thread"], "main");
@@ -611,7 +612,7 @@ fn git_overlay_isolated_checkout_status_and_verify_identify_parent_context() {
         heddle(&["status", "--output", "text"], Some(&checkout)).expect("status text");
     assert!(
         status_text.contains("Repository: Git + Heddle isolated checkout")
-            && status_text.contains(&format!("Parent repo: {}", temp.path().display()))
+            && status_text.contains(&format!("Parent repo: {parent_repo}"))
             && status_text
                 .contains("Git checkout: no .git here; raw Git commands belong in the parent repo")
             && status_text.contains("Target thread: main")
@@ -624,7 +625,7 @@ fn git_overlay_isolated_checkout_status_and_verify_identify_parent_context() {
     assert_eq!(verify["repository_label"], "Git + Heddle isolated checkout");
     assert_eq!(
         verify["repository_context"]["parent_repository"],
-        temp.path().display().to_string()
+        parent_repo
     );
     assert_eq!(verify["repository_context"]["target_thread"], "main");
 
@@ -635,7 +636,7 @@ fn git_overlay_isolated_checkout_status_and_verify_identify_parent_context() {
     .expect("verify text");
     assert!(
         verify_text.contains("Repository: Git + Heddle isolated checkout")
-            && verify_text.contains(&format!("Parent repo: {}", temp.path().display()))
+            && verify_text.contains(&format!("Parent repo: {parent_repo}"))
             && verify_text.contains("Target thread: main"),
         "verify text should surface managed Git-overlay child context: {verify_text}"
     );
@@ -4545,7 +4546,7 @@ fn parse_exactly_one_json_value(raw: &str) -> Result<Value, String> {
 #[test]
 fn git_compat_commit_branch_and_switch_shims_work() {
     let temp = TempDir::new().unwrap();
-    gix::init(temp.path()).expect("init git repo");
+    SleyRepository::init(temp.path()).expect("init git repo");
     configure_repo_local_git_identity_for_json_contract(temp.path());
     heddle(&["init"], Some(temp.path())).unwrap();
     std::fs::write(temp.path().join("seed.txt"), "seed\n").unwrap();
@@ -4665,8 +4666,8 @@ fn thread_switch_refuses_dirty_worktree_without_force() {
 fn remote_list_and_show_json_share_git_overlay_remote_view() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
-    gix::init_bare(&origin).expect("init bare origin");
-    gix::init(temp.path()).expect("init git worktree");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init(temp.path()).expect("init git worktree");
     std::fs::OpenOptions::new()
         .append(true)
         .open(temp.path().join(".git/config"))
@@ -5897,7 +5898,7 @@ fn revert_empty_state_uses_typed_advice() {
 #[test]
 fn checkpoint_refuses_uncaptured_worktree_with_shared_advice() {
     let temp = TempDir::new().unwrap();
-    gix::init(temp.path()).expect("init git repo");
+    SleyRepository::init(temp.path()).expect("init git repo");
     configure_repo_local_git_identity_for_json_contract(temp.path());
     heddle(&["init"], Some(temp.path())).unwrap();
     std::fs::write(temp.path().join("tracked.txt"), "base\n").unwrap();
@@ -6562,6 +6563,13 @@ fn profile_env_writes_timings_to_stderr_without_polluting_json_stdout() {
         "status profile should show worktree scan cost: {stderr}"
     );
     assert!(
+        stderr.contains("git_overlay_status_ms:")
+            && stderr.contains("git_overlay_health_ms:")
+            && stderr.contains("verification_ms:")
+            && stderr.contains("git_index_ms:"),
+        "status profile should break out git-overlay health and index costs: {stderr}"
+    );
+    assert!(
         stderr.contains("directories_scanned:"),
         "status profile should show worktree scan counters: {stderr}"
     );
@@ -6651,9 +6659,10 @@ fn start_merge_undo_json_workflow_keeps_machine_streams_clean() {
         &repo,
     );
     assert_eq!(started["name"], "feature/a");
+    let feature_path = canonical_path_string(&feature);
     assert_eq!(
         started["execution_path"].as_str(),
-        Some(feature.to_str().expect("utf8 path"))
+        Some(feature_path.as_str())
     );
 
     std::fs::write(
@@ -7886,7 +7895,9 @@ fn default_run_does_not_leak_info_traces() {
 #[test]
 fn verbose_flag_re_enables_info_traces() {
     let temp = TempDir::new().unwrap();
-    let output = heddle_output(&["-v", "init"], Some(temp.path())).unwrap();
+    let output =
+        heddle_output_with_env_removed(&["-v", "init"], Some(temp.path()), &[], &["RUST_LOG"])
+            .unwrap();
     assert!(output.status.success(), "init -v should succeed");
 
     let stderr = std::str::from_utf8(&output.stderr).unwrap();
@@ -7950,12 +7961,12 @@ fn missing_repo_status_emits_structured_error_in_json_mode() {
         envelope["hint"]
             .as_str()
             .unwrap_or("")
-            .contains(temp.path().to_str().expect("temp path utf8")),
+            .contains(&canonical_path_string(temp.path())),
         "envelope.hint should suggest initializing the requested path: {envelope}"
     );
     assert_eq!(
         envelope["primary_command_template"]["argv_template"],
-        heddle_argv_json(["init", temp.path().to_str().expect("temp path utf8")])
+        heddle_argv_json(["init", canonical_path_string(temp.path()).as_str()])
     );
 }
 
@@ -8502,18 +8513,19 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
     );
 
     let checkout_status = json_value(&checkout, &["status", "--output", "json"]);
+    let repo_path = canonical_path_string(temp.path());
     assert_eq!(
         checkout_status["recommended_action"],
         format!(
             "heddle --repo {} land --thread feature/capture-next --no-push",
-            temp.path().display()
+            repo_path
         )
     );
     assert_eq!(
         checkout_status["recommended_action_template"]["argv_template"],
         heddle_argv_json([
             "--repo",
-            temp.path().to_str().expect("repo path utf8"),
+            repo_path.as_str(),
             "land",
             "--thread",
             "feature/capture-next",
@@ -8586,7 +8598,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         &checkout,
         &[
             "--repo",
-            temp.path().to_str().expect("repo path utf8"),
+            repo_path.as_str(),
             "merge",
             "feature/capture-next",
             "--preview",
@@ -8598,7 +8610,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         contextual_preview["recommended_action"],
         format!(
             "heddle --repo {} land --thread feature/capture-next --no-push",
-            temp.path().display()
+            repo_path
         ),
         "merge preview invoked from an isolated checkout must preserve parent repo context: {contextual_preview}"
     );
@@ -8606,7 +8618,7 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         contextual_preview["recommended_action_template"]["argv_template"],
         heddle_argv_json([
             "--repo",
-            temp.path().to_str().expect("repo path utf8"),
+            repo_path.as_str(),
             "land",
             "--thread",
             "feature/capture-next",
@@ -8620,14 +8632,14 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
         checkout_after_preview["recommended_action"],
         format!(
             "heddle --repo {} land --thread feature/capture-next --no-push",
-            temp.path().display()
+            repo_path
         )
     );
     assert_eq!(
         checkout_after_preview["recommended_action_template"]["argv_template"],
         heddle_argv_json([
             "--repo",
-            temp.path().to_str().expect("repo path utf8"),
+            repo_path.as_str(),
             "land",
             "--thread",
             "feature/capture-next",
@@ -9136,7 +9148,8 @@ fn cd_hint_quotes_paths_with_spaces() {
     )
     .expect("start with spaced path");
 
-    let quoted = format!("'{checkout_str}'");
+    let checkout_display = canonical_path_string(&checkout);
+    let quoted = format!("'{checkout_display}'");
     assert!(
         output.contains(&format!("    cd {quoted}")),
         "cd hint must single-quote paths with spaces: {output}"
@@ -10021,7 +10034,7 @@ fn agent_api_json_outputs_match_registered_schemas_and_include_verification() {
     assert!(
         status["pid_path"]
             .as_str()
-            .is_some_and(|path| path.starts_with(temp.path().to_str().unwrap())),
+            .is_some_and(|path| path.starts_with(&canonical_path_string(temp.path()))),
         "agent status should use the requested repo for daemon paths: {status}"
     );
 
@@ -10154,6 +10167,7 @@ fn agent_daemon_status_honors_global_repo_argument() {
     heddle(&["init"], Some(target_repo.path())).expect("init target repo");
 
     let target_arg = target_repo.path().to_str().expect("utf8 target path");
+    let target_path = canonical_path_string(target_repo.path());
     let output = heddle(
         &["--repo", target_arg, "agent", "status", "--output", "json"],
         Some(cwd_repo.path()),
@@ -10165,7 +10179,7 @@ fn agent_daemon_status_honors_global_repo_argument() {
         .as_str()
         .expect("agent status should include pid_path");
     assert!(
-        pid_path.starts_with(target_arg),
+        pid_path.starts_with(&target_path),
         "agent status must inspect the global --repo target, not cwd: {status}"
     );
     assert!(
@@ -10317,7 +10331,7 @@ fn actor_explain_json_detects_harness_without_active_actor() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
 
-    let output = heddle_output_with_env(
+    let output = heddle_output_with_env_removed(
         &["actor", "explain", "--output", "json"],
         Some(temp.path()),
         &[
@@ -10327,6 +10341,7 @@ fn actor_explain_json_detects_harness_without_active_actor() {
             ("HEDDLE_PRINCIPAL_NAME", "Cold Agent"),
             ("HEDDLE_PRINCIPAL_EMAIL", "agent@example.com"),
         ],
+        &["CODEX_INTERNAL_ORIGINATOR_OVERRIDE"],
     )
     .expect("invoke actor explain");
     assert!(
@@ -10624,7 +10639,7 @@ fn verify_and_status_json_tolerate_closed_downstream_pipes() {
         let output = std::process::Command::new("bash")
             .arg("-c")
             .arg(format!(
-                "set -o pipefail; \"$HEDDLE_BIN\" --output json {command} | head -c 0"
+                "set -o pipefail; \"$HEDDLE_BIN\" --output json {command} | true"
             ))
             .current_dir(temp.path())
             .env("HEDDLE_BIN", env!("CARGO_BIN_EXE_heddle"))
@@ -10656,9 +10671,7 @@ fn text_surfaces_tolerate_closed_downstream_pipes() {
     ] {
         let output = std::process::Command::new("bash")
             .arg("-c")
-            .arg(format!(
-                "set -o pipefail; \"$HEDDLE_BIN\" {command} | head -c 0"
-            ))
+            .arg(format!("set -o pipefail; \"$HEDDLE_BIN\" {command} | true"))
             .current_dir(temp.path())
             .env("HEDDLE_BIN", env!("CARGO_BIN_EXE_heddle"))
             .env(
@@ -10987,7 +11000,7 @@ fn error_envelope_schema_is_registered_and_matches_runtime_shape() {
     assert_eq!(envelope["exit_code"], 78);
     assert_eq!(
         envelope["primary_command_template"]["argv_template"],
-        heddle_argv_json(["init", temp.path().to_str().expect("temp path utf8")])
+        heddle_argv_json(["init", canonical_path_string(temp.path()).as_str()])
     );
 
     let op_id = "550e8400-e29b-41d4-a716-446655440099";
@@ -11795,23 +11808,16 @@ fn freshly_initialized_repo_reports_clean_health() {
 /// commits, suitable for `heddle clone` from a local path.
 fn make_local_master_git_repo(parent: &std::path::Path, commits: usize) -> std::path::PathBuf {
     let bare = parent.join("origin.git");
-    let repo = gix::init_bare(&bare).expect("init bare origin");
-    let mut parent_oid: Option<gix::hash::ObjectId> = None;
+    let repo = SleyRepository::init_bare(&bare).expect("init bare origin");
+    let mut parent_oid: Option<ObjectId> = None;
     for i in 0..commits {
         let blob = repo
             .write_blob(format!("content {i}\n").as_bytes())
-            .expect("write blob")
-            .detach();
-        let empty = repo.empty_tree().id;
-        let mut editor = repo.edit_tree(empty).expect("edit tree");
-        editor
-            .upsert(
-                format!("f{i}.txt"),
-                gix::object::tree::EntryKind::Blob,
-                blob,
-            )
-            .expect("add file");
-        let tree = editor.write().expect("write tree").detach();
+            .expect("write blob");
+        let empty = git_empty_tree_oid(&repo);
+        let mut editor = repo.edit_tree(&empty).expect("edit tree");
+        editor.upsert(format!("f{i}.txt").into_bytes(), EntryKind::Blob, blob);
+        let tree = repo.write_tree(editor).expect("write tree");
         let parents = parent_oid.map(|p| vec![p]).unwrap_or_default();
         let commit = git_commit_with_tree(
             &repo,

--- a/crates/cli/tests/cli_integration/quickstart.rs
+++ b/crates/cli/tests/cli_integration/quickstart.rs
@@ -422,12 +422,12 @@ fn quickstart_unborn_git_yields_single_capture_and_checkpoint() {
 
     // And exactly one Git checkpoint commit (no extra bootstrap parent in
     // the exported history).
-    let grepo = gix::open(dir).expect("open git repo");
+    let grepo = open_git(dir).expect("open git repo");
     let tip = grepo
         .head_id()
         .expect("HEAD resolves to a checkpoint commit");
     let commit_count = grepo
-        .rev_walk([tip.detach()])
+        .rev_walk([tip])
         .all()
         .expect("rev-walk checkpoint history")
         .count();
@@ -1261,7 +1261,7 @@ fn quickstart_install_none_installs_nothing() {
     );
 }
 
-/// Codex r7 (cid 3329270261): the preflight used `gix::discover` to decide
+/// Codex r7 (cid 3329270261): the preflight used Git discovery to decide
 /// `has_git`, which walks to an ANCESTOR Git checkout — so a native Heddle
 /// repo nested inside an ancestor Git checkout was wrongly treated as a Git
 /// overlay and refused for the ancestor's detached HEAD, even though
@@ -1615,10 +1615,10 @@ fn quickstart_from_subdir_targets_discovered_git_root() {
 
     // The checkpoint advanced a real branch — impossible if it had come up as a
     // native repo at the subdir. History (initial) plus the checkpoint commit.
-    let grepo = gix::open(root).expect("open git repo at the discovered root");
+    let grepo = open_git(root).expect("open git repo at the discovered root");
     let tip = grepo.head_id().expect("HEAD resolves to a commit");
     let commit_count = grepo
-        .rev_walk([tip.detach()])
+        .rev_walk([tip])
         .all()
         .expect("rev-walk checkpoint history")
         .count();
@@ -1881,7 +1881,7 @@ fn quickstart_rejects_shallow_git_clone_before_writes() {
     // Mark the checkout shallow the way a `--depth` clone would: a `.git/shallow`
     // file listing the shallow boundary. `import_all` keys on its presence
     // (`git_dir()/shallow`), and so does the preflight's `git_is_shallow`.
-    let grepo = gix::open(dir).unwrap();
+    let grepo = open_git(dir).unwrap();
     let head = grepo.head_id().unwrap().to_string();
     std::fs::write(dir.join(".git").join("shallow"), format!("{head}\n")).unwrap();
 
@@ -1995,10 +1995,10 @@ fn quickstart_nested_git_below_ancestor_heddle_targets_nested_git() {
     );
     // The nested Git history was imported AND checkpointed: the nested Git root
     // now has the original commit plus the checkpoint commit.
-    let grepo = gix::open(&nested).expect("open nested git repo");
+    let grepo = open_git(&nested).expect("open nested git repo");
     let tip = grepo.head_id().expect("nested HEAD resolves");
     let commit_count = grepo
-        .rev_walk([tip.detach()])
+        .rev_walk([tip])
         .all()
         .expect("rev-walk nested history")
         .count();
@@ -2054,20 +2054,15 @@ fn quickstart_git_overlay_capture_and_checkpoint_land_on_quickstart_thread() {
         "the active thread is quickstart: {status}"
     );
 
-    let grepo = gix::open(dir).expect("open git repo");
+    let grepo = open_git(dir).expect("open git repo");
     // `quickstart` advanced past the imported tip (initial + checkpoint = 2),
     // while `main` stayed at the imported tip (1 commit) — proof the capture and
     // checkpoint landed on the requested thread, not on main.
     let count_on = |branch: &str| -> usize {
-        let mut reference = grepo
-            .find_reference(branch)
-            .unwrap_or_else(|_| panic!("ref {branch} exists"));
+        let mut reference =
+            find_reference(&grepo, branch).unwrap_or_else(|_| panic!("ref {branch} exists"));
         let tip = reference.peel_to_id().expect("ref peels");
-        grepo
-            .rev_walk([tip.detach()])
-            .all()
-            .expect("rev-walk")
-            .count()
+        grepo.rev_walk([tip]).all().expect("rev-walk").count()
     };
     assert_eq!(count_on("main"), 1, "main stayed at the imported tip");
     assert_eq!(
@@ -2101,13 +2096,11 @@ fn quickstart_refuses_clobbering_existing_divergent_quickstart_branch() {
     git_hermetic(&["checkout", "main"], dir);
 
     let tip_before = {
-        let grepo = gix::open(dir).expect("open git repo");
-        grepo
-            .find_reference("quickstart")
+        let grepo = open_git(dir).expect("open git repo");
+        find_reference(&grepo, "quickstart")
             .expect("quickstart branch exists")
             .peel_to_id()
             .expect("peels")
-            .detach()
     };
 
     let out = heddle_output(
@@ -2140,13 +2133,11 @@ fn quickstart_refuses_clobbering_existing_divergent_quickstart_branch() {
 
     // The user's branch is UNCHANGED.
     let tip_after = {
-        let grepo = gix::open(dir).expect("open git repo");
-        grepo
-            .find_reference("quickstart")
+        let grepo = open_git(dir).expect("open git repo");
+        find_reference(&grepo, "quickstart")
             .expect("quickstart branch still exists")
             .peel_to_id()
             .expect("peels")
-            .detach()
     };
     assert_eq!(
         tip_before, tip_after,

--- a/crates/cli/tests/cli_integration/realworld_git.rs
+++ b/crates/cli/tests/cli_integration/realworld_git.rs
@@ -80,7 +80,7 @@ fn extract_fixture(name: &str) -> (TempDir, std::path::PathBuf) {
         "bare repo missing HEAD after extract: {}",
         bare.display()
     );
-    let extracted = gix::open(&bare).expect("open extracted bare repo");
+    let extracted = open_git(&bare).expect("open extracted bare repo");
     let head = extracted
         .head_commit()
         .expect("extracted fixture should resolve HEAD");
@@ -94,14 +94,12 @@ fn extract_fixture(name: &str) -> (TempDir, std::path::PathBuf) {
     (temp, bare)
 }
 
-fn git_tree_with_file(repo: &gix::Repository, path: &str, content: &[u8]) -> gix::hash::ObjectId {
-    let blob = repo.write_blob(content).expect("write git blob").detach();
+fn git_tree_with_file(repo: &SleyRepository, path: &str, content: &[u8]) -> ObjectId {
+    let blob = repo.write_blob(content).expect("write git blob");
     let empty = git_empty_tree_oid(repo);
-    let mut editor = repo.edit_tree(empty).expect("edit git tree");
-    editor
-        .upsert(path, gix::object::tree::EntryKind::Blob, blob)
-        .expect("add file to git tree");
-    editor.write().expect("write git tree").detach()
+    let mut editor = repo.edit_tree(&empty).expect("edit git tree");
+    editor.upsert(path, EntryKind::Blob, blob);
+    repo.write_tree(editor).expect("write git tree")
 }
 
 #[test]
@@ -151,7 +149,7 @@ fn realworld_git_complex_fixture_round_trips_overlay_inventory_without_git_on_pa
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init synthetic real-world origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init synthetic real-world origin");
 
     let base_tree = git_tree_with_file(&origin_repo, "core.rs", b"pub fn base() {}\n");
     let base = git_commit_with_tree(
@@ -238,7 +236,7 @@ fn realworld_git_large_binary_blob_stress_without_git_on_path() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init large origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init large origin");
 
     let large = vec![0xA5; size_mb * 1024 * 1024];
     let tree = git_tree_with_file(&origin_repo, "large.bin", &large);
@@ -292,7 +290,7 @@ fn realworld_git_rebase_chain_round_trips_overlay() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     // Build a base commit and five feature commits chained off it.
     let base_tree = git_tree_with_file(&origin_repo, "core.rs", b"fn base() {}\n");
@@ -407,8 +405,8 @@ fn realworld_git_multi_remote_divergent_main_resolves_origin_first() {
     let origin = temp.path().join("origin.git");
     let upstream = temp.path().join("upstream.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
-    let upstream_repo = gix::init_bare(&upstream).expect("init upstream");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
+    let upstream_repo = SleyRepository::init_bare(&upstream).expect("init upstream");
 
     // Origin's main: A → B
     let tree_a = git_tree_with_file(&origin_repo, "core.rs", b"fn a() {}\n");
@@ -456,7 +454,7 @@ fn realworld_git_annotated_tag_rename_round_trips() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     let tree_a = git_tree_with_file(&origin_repo, "core.rs", b"fn a() {}\n");
     let a = git_commit_with_tree(&origin_repo, Some("refs/heads/main"), tree_a, "A", &[]);
@@ -465,29 +463,25 @@ fn realworld_git_annotated_tag_rename_round_trips() {
     git_set_reference(&origin_repo, "HEAD", a);
 
     // Initial annotated tag points at A with message "v0.1".
-    let tag_a = origin_repo
-        .tag(
-            "v0.1",
-            a,
-            gix::object::Kind::Commit,
-            None,
-            "v0.1 release\n",
-            gix::refs::transaction::PreviousValue::Any,
-        )
-        .expect("tag v0.1");
+    let tag_a = git_create_annotated_tag(
+        &origin_repo,
+        "v0.1",
+        a,
+        GitObjectType::Commit,
+        "v0.1 release\n",
+        RefPrecondition::Any,
+    );
 
     // Retarget the tag to B with a new message; gix replaces the
     // previous tag object.
-    let tag_b = origin_repo
-        .tag(
-            "v0.1",
-            b,
-            gix::object::Kind::Commit,
-            None,
-            "v0.1 retargeted to B\n",
-            gix::refs::transaction::PreviousValue::Any,
-        )
-        .expect("retarget v0.1");
+    let tag_b = git_create_annotated_tag(
+        &origin_repo,
+        "v0.1",
+        b,
+        GitObjectType::Commit,
+        "v0.1 retargeted to B\n",
+        RefPrecondition::Any,
+    );
     assert_ne!(
         tag_a.id(),
         tag_b.id(),
@@ -504,10 +498,8 @@ fn realworld_git_annotated_tag_rename_round_trips() {
     // The bridge mirror should expose the retargeted tag at the new
     // tag oid; both A and B remain reachable.
     let mirror = work.join(".heddle").join("git");
-    let mirror_repo = gix::open(&mirror).expect("open bridge mirror");
-    let tag_ref = mirror_repo
-        .find_reference("refs/tags/v0.1")
-        .expect("v0.1 ref present");
+    let mirror_repo = open_git(&mirror).expect("open bridge mirror");
+    let tag_ref = find_reference(&mirror_repo, "refs/tags/v0.1").expect("v0.1 ref present");
     let tag_oid = tag_ref.target().try_id().expect("tag oid").to_owned();
     assert_eq!(
         tag_oid,
@@ -534,7 +526,7 @@ fn realworld_git_cherry_pick_assigns_distinct_change_ids() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     // base on main
     let base_tree = git_tree_with_file(&origin_repo, "core.rs", b"fn base() {}\n");
@@ -627,7 +619,7 @@ fn realworld_git_gc_prunes_unreachable_mapping_entries() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     let base_tree = git_tree_with_file(&origin_repo, "core.rs", b"fn base() {}\n");
     let base = git_commit_with_tree(
@@ -806,11 +798,11 @@ fn marketing_moments_walkthrough_against_real_fixture() {
     // Create a raw git branch off HEAD before bridge import; the import
     // should surface it as a thread and `bridge git list` should advise
     // the scoped import command for any remaining unimported tip.
-    let cloned = gix::open(&work).expect("open cloned working tree");
+    let cloned = open_git(&work).expect("open cloned working tree");
     let head = cloned
         .head_commit()
         .expect("cloned repo should have a HEAD commit");
-    git_set_reference(&cloned, "refs/heads/raw-side-branch", head.id().detach());
+    git_set_reference(&cloned, "refs/heads/raw-side-branch", head.id());
     heddle_without_git(&["bridge", "import"], &work).unwrap();
     let threads_json = heddle_without_git(&["thread", "list", "--output", "json"], &work).unwrap();
     let threads: Value = serde_json::from_str(&threads_json).unwrap();

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -206,7 +206,7 @@ fn native_remote_add_rejects_local_git_remote_before_configuring_default() {
     let temp = TempDir::new().unwrap();
     let bare = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
-    gix::init_bare(bare.path()).expect("init bare Git remote");
+    SleyRepository::init_bare(bare.path()).expect("init bare Git remote");
 
     let output = heddle_output(
         &[
@@ -255,7 +255,7 @@ fn native_push_and_pull_reject_direct_git_remote_before_native_sync() {
     let temp = TempDir::new().unwrap();
     let bare = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
-    gix::init_bare(bare.path()).expect("init bare Git remote");
+    SleyRepository::init_bare(bare.path()).expect("init bare Git remote");
 
     for command in ["push", "pull"] {
         let output = heddle_output(
@@ -687,14 +687,13 @@ fn push_help_documents_written_refs_namespace() {
 /// Every full ref name under `refs/` at the remote, sorted — the
 /// `git ls-remote` view (minus HEAD) the `refs_written` round-trip
 /// contract is asserted against.
-fn remote_ref_names(remote_repo: &gix::Repository) -> Vec<String> {
+fn remote_ref_names(remote_repo: &SleyRepository) -> Vec<String> {
     let mut names: Vec<String> = remote_repo
         .references()
-        .expect("remote refs platform")
-        .all()
+        .list_refs()
         .expect("iterate remote refs")
-        .filter_map(Result::ok)
-        .map(|reference| reference.name().as_bstr().to_string())
+        .into_iter()
+        .map(|reference| reference.name)
         .filter(|name| name.starts_with("refs/"))
         .collect();
     names.sort_unstable();
@@ -781,21 +780,19 @@ fn git_overlay_push_defaults_to_current_thread_branch() {
     assert_eq!(parsed["thread"], "main");
 
     assert!(
-        remote_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&remote_repo, "refs/heads/main").is_ok(),
         "default push should push the current branch"
     );
     assert!(
-        remote_repo.find_reference("refs/heads/side").is_err(),
+        find_reference(&remote_repo, "refs/heads/side").is_err(),
         "default push must not push sibling Heddle threads"
     );
     assert!(
-        remote_repo.find_reference("refs/tags/v1.0").is_err(),
+        find_reference(&remote_repo, "refs/tags/v1.0").is_err(),
         "default push must not push tags"
     );
     assert!(
-        remote_repo
-            .find_reference(cli::bridge::git_notes::NOTES_REF)
-            .is_ok(),
+        find_reference(&remote_repo, cli::bridge::git_notes::NOTES_REF).is_ok(),
         "default push must carry Heddle notes so clones preserve state identity"
     );
 }
@@ -815,9 +812,9 @@ fn git_overlay_push_all_threads_preserves_all_refs_behavior() {
     assert_eq!(parsed["tags_included"], true);
     assert!(parsed["thread"].is_null());
 
-    assert!(remote_repo.find_reference("refs/heads/main").is_ok());
-    assert!(remote_repo.find_reference("refs/heads/side").is_ok());
-    assert!(remote_repo.find_reference("refs/tags/v1.0").is_ok());
+    assert!(find_reference(&remote_repo, "refs/heads/main").is_ok());
+    assert!(find_reference(&remote_repo, "refs/heads/side").is_ok());
+    assert!(find_reference(&remote_repo, "refs/tags/v1.0").is_ok());
 }
 
 #[test]
@@ -842,13 +839,11 @@ fn git_overlay_push_all_threads_does_not_promote_remote_tracking_threads() {
     assert_eq!(parsed["push_scope"], "all_threads");
 
     assert!(
-        remote_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&remote_repo, "refs/heads/main").is_ok(),
         "all-threads push should still publish owned local threads"
     );
     assert!(
-        remote_repo
-            .find_reference("refs/heads/origin/remote-only")
-            .is_err(),
+        find_reference(&remote_repo, "refs/heads/origin/remote-only").is_err(),
         "all-threads push must not promote remote-tracking-shaped threads into remote heads"
     );
 }
@@ -899,13 +894,11 @@ fn git_overlay_push_all_threads_skips_threads_pruned_by_cleanup() {
     assert_eq!(parsed["push_scope"], "all_threads");
 
     assert!(
-        remote_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&remote_repo, "refs/heads/main").is_ok(),
         "all-threads push should still publish the active main thread"
     );
     assert!(
-        remote_repo
-            .find_reference("refs/heads/feature/cleaned")
-            .is_err(),
+        find_reference(&remote_repo, "refs/heads/feature/cleaned").is_err(),
         "all-threads push must not recreate a Git branch for a cleaned merged thread"
     );
 }
@@ -924,7 +917,7 @@ fn git_overlay_push_all_threads_includes_checkout_tags_created_after_adopt() {
     assert_eq!(parsed["tags_included"], true);
 
     assert!(
-        remote_repo.find_reference("refs/tags/v2-local").is_ok(),
+        find_reference(&remote_repo, "refs/tags/v2-local").is_ok(),
         "all-threads push should include raw checkout tags created after Heddle adoption"
     );
 }
@@ -933,8 +926,8 @@ fn git_overlay_push_all_threads_includes_checkout_tags_created_after_adopt() {
 fn git_overlay_remote_list_show_labels_local_bare_git_remote_as_git_overlay() {
     let work = TempDir::new().unwrap();
     let remote = TempDir::new().unwrap();
-    gix::init(work.path()).expect("init git worktree");
-    gix::init_bare(remote.path()).expect("init bare git remote");
+    SleyRepository::init(work.path()).expect("init git worktree");
+    SleyRepository::init_bare(remote.path()).expect("init bare git remote");
 
     heddle(&["init"], Some(work.path())).unwrap();
     let remote_path = remote.path().to_str().expect("remote path utf8");
@@ -981,7 +974,7 @@ fn git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated() 
     // remote or neither does. The old order saved the Heddle removal first and
     // only then hit the include refusal, stranding partial state.
     let work = TempDir::new().unwrap();
-    gix::init(work.path()).expect("init git worktree");
+    SleyRepository::init(work.path()).expect("init git worktree");
     heddle(&["init"], Some(work.path())).unwrap();
 
     // A `[remote "origin"]` section in a config file outside the repository's
@@ -1049,11 +1042,11 @@ fn git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated() 
     );
 }
 
-fn setup_git_overlay_push_fixture() -> (TempDir, TempDir, gix::Repository) {
+fn setup_git_overlay_push_fixture() -> (TempDir, TempDir, SleyRepository) {
     let work = TempDir::new().unwrap();
     let remote = TempDir::new().unwrap();
-    let remote_repo = gix::init_bare(remote.path()).expect("init bare remote");
-    let git_repo = gix::init(work.path()).expect("init git repo");
+    let remote_repo = SleyRepository::init_bare(remote.path()).expect("init bare remote");
+    let git_repo = SleyRepository::init(work.path()).expect("init git repo");
     let tree = git_empty_tree_oid(&git_repo);
     let main = git_commit_with_tree(&git_repo, Some("refs/heads/main"), tree, "main", &[]);
     let side = git_commit_with_tree(&git_repo, Some("refs/heads/side"), tree, "side", &[main]);
@@ -1193,7 +1186,7 @@ fn test_cli_clone_local_bare_git_heddle_remote_skips_admin_files_and_sets_origin
     std::fs::write(source.join("app.txt"), "from source\n").unwrap();
     heddle_without_git_for_remote_tests(&["capture", "-m", "seed app"], &source);
 
-    gix::init_bare(&remote).expect("init local bare Git remote");
+    SleyRepository::init_bare(&remote).expect("init local bare Git remote");
     heddle_without_git_for_remote_tests(&["init"], &remote);
     heddle_without_git_for_remote_tests(
         &["push", remote.to_str().expect("remote path utf8")],
@@ -1393,7 +1386,7 @@ fn clone_network_removes_self_created_destination_after_later_failure() {
 
 #[test]
 fn test_cli_clone_git_overlay_depth_is_rejected() {
-    // Issue 49 / 20b: `--depth` is wired through to gix at the wire
+    // Issue 49 / 20b: `--depth` is wired through to Sley at the wire
     // layer (`clone_url_to_bare` honours it), but the import step
     // (`import_all` ancestry walk) still requires every parent commit
     // locally. Until the importer tolerates missing parents, the
@@ -1402,7 +1395,7 @@ fn test_cli_clone_git_overlay_depth_is_rejected() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare git origin");
+    SleyRepository::init_bare(&origin).expect("init bare git origin");
 
     let err = heddle(
         &[
@@ -1434,7 +1427,7 @@ fn test_cli_clone_git_overlay_lazy_is_rejected() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare git origin");
+    SleyRepository::init_bare(&origin).expect("init bare git origin");
 
     let err = heddle(
         &[
@@ -1463,37 +1456,14 @@ fn test_cli_clone_git_overlay_missing_requested_branch_uses_typed_advice() {
     let source = temp.path().join("source.git");
     let work = temp.path().join("work");
 
-    let src = gix::init_bare(&source).expect("init bare source");
-    let empty_tree: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-        .parse()
-        .expect("parse empty tree oid");
-    let sig = gix::actor::Signature {
-        name: "Heddle Test".into(),
-        email: "heddle@test".into(),
-        time: gix::date::Time {
-            seconds: 0,
-            offset: 0,
-        },
-    };
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let main_tip = src
-        .new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            "seed main",
-            empty_tree,
-            Vec::<gix::ObjectId>::new(),
-        )
-        .expect("commit succeeds")
-        .id;
-    src.reference(
-        "refs/heads/main",
-        main_tip,
-        gix::refs::transaction::PreviousValue::Any,
-        "test: seed main",
-    )
-    .expect("set main ref");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
+    let _main_tip = git_commit_with_tree(
+        &src,
+        Some("refs/heads/main"),
+        git_empty_tree_oid(&src),
+        "seed main",
+        &[],
+    );
     std::fs::write(source.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
 
     let output = heddle_output(
@@ -1526,16 +1496,14 @@ fn test_cli_clone_git_overlay_missing_requested_branch_uses_typed_advice() {
     let envelope: Value =
         serde_json::from_str(stderr).expect("missing Git branch should emit JSON envelope");
     assert_eq!(envelope["kind"], "git_overlay_clone_import_failed");
-    let expected_action = format!(
-        "heddle clone {} <path> --thread missing",
-        source.to_str().expect("source path utf8")
-    );
+    let source_path = canonical_path_string(&source);
+    let expected_action = format!("heddle clone {} <path> --thread missing", source_path);
     assert_eq!(envelope["primary_command"], expected_action);
     assert_eq!(
         envelope["primary_command_template"]["argv_template"],
         heddle_argv_json([
             "clone",
-            source.to_str().expect("source path utf8"),
+            source_path.as_str(),
             "<path>",
             "--thread",
             "missing"
@@ -1582,55 +1550,20 @@ fn test_cli_clone_git_overlay_lands_on_remote_default_branch_and_log_walks_histo
     // commits so we can confirm log walks history) and
     // `abc-feature` (alphabetically first — the trap heddle#141 used
     // to fall into). Branch names deliberately avoid `main`/`master`
-    // so neither gix's `init.defaultBranch` nor the previous
+    // so neither Git's `init.defaultBranch` nor the previous
     // fallback could land here by accident.
-    let src = gix::init_bare(&source).expect("init bare source");
-    let empty_tree: gix::ObjectId = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-        .parse()
-        .expect("parse empty tree oid");
-    // Use an explicit signature via `new_commit_as` rather than
-    // `Repository::commit`. The latter reads `user.name`/`user.email`
-    // from git config, which CI runners don't set — leading to
-    // `AuthorMissing` errors. The clone path under test doesn't care
-    // who authored these seed commits.
-    let sig = gix::actor::Signature {
-        name: "Heddle Test".into(),
-        email: "heddle@test".into(),
-        time: gix::date::Time {
-            seconds: 0,
-            offset: 0,
-        },
-    };
-    let commit_as = |message: &str, parents: Vec<gix::ObjectId>| -> gix::ObjectId {
-        let mut committer_buf = gix::date::parse::TimeBuf::default();
-        let mut author_buf = gix::date::parse::TimeBuf::default();
-        src.new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            message,
-            empty_tree,
-            parents,
-        )
-        .expect("commit succeeds")
-        .id
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
+    let empty_tree = git_empty_tree_oid(&src);
+    // Use explicit signatures for the seed commits so CI user config
+    // does not affect this clone selection test.
+    let commit_as = |message: &str, parents: Vec<ObjectId>| -> ObjectId {
+        git_commit_with_tree(&src, None, empty_tree, message, &parents)
     };
     let trunk_first = commit_as("seed trunk", vec![]);
     let trunk_tip = commit_as("advance trunk", vec![trunk_first]);
     let abc_feature = commit_as("seed abc-feature", vec![]);
-    src.reference(
-        "refs/heads/trunk",
-        trunk_tip,
-        gix::refs::transaction::PreviousValue::Any,
-        "test: seed trunk",
-    )
-    .expect("set trunk ref");
-    src.reference(
-        "refs/heads/abc-feature",
-        abc_feature,
-        gix::refs::transaction::PreviousValue::Any,
-        "test: seed abc-feature",
-    )
-    .expect("set abc-feature ref");
+    git_set_reference(&src, "refs/heads/trunk", trunk_tip);
+    git_set_reference(&src, "refs/heads/abc-feature", abc_feature);
     std::fs::write(source.join("HEAD"), b"ref: refs/heads/trunk\n").unwrap();
 
     let source_arg = source.to_str().expect("source path utf8");
@@ -1710,14 +1643,12 @@ fn test_cli_clone_git_overlay_lands_on_remote_default_branch_and_log_walks_histo
     );
 }
 
-fn git_tree_with_file(repo: &gix::Repository, path: &str, content: &[u8]) -> gix::hash::ObjectId {
-    let blob = repo.write_blob(content).expect("write git blob").detach();
+fn git_tree_with_file(repo: &SleyRepository, path: &str, content: &[u8]) -> ObjectId {
+    let blob = repo.write_blob(content).expect("write git blob");
     let empty = git_empty_tree_oid(repo);
-    let mut editor = repo.edit_tree(empty).expect("edit git tree");
-    editor
-        .upsert(path, gix::object::tree::EntryKind::Blob, blob)
-        .expect("add file to git tree");
-    editor.write().expect("write git tree").detach()
+    let mut editor = repo.edit_tree(&empty).expect("edit git tree");
+    editor.upsert(path, EntryKind::Blob, blob);
+    repo.write_tree(editor).expect("write git tree")
 }
 
 fn git_ok(args: &[&str], cwd: &std::path::Path) {
@@ -1758,7 +1689,7 @@ fn test_cli_clone_git_overlay_sets_origin_tracking_for_selected_branch() {
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.git");
     let work = temp.path().join("work");
-    let src = gix::init_bare(&source).expect("init bare source");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
 
     let tree = git_tree_with_file(&src, "tracked.txt", b"one\n");
     let main = git_commit_with_tree(&src, Some("refs/heads/main"), tree, "one", &[]);
@@ -1786,7 +1717,7 @@ fn test_cli_clone_git_overlay_rewrites_origin_and_default_pull_keeps_git_clean()
     let source = temp.path().join("source.git");
     let stale_origin = temp.path().join("stale-origin.git");
     let work = temp.path().join("work");
-    let src = gix::init_bare(&source).expect("init bare source");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
 
     let first_tree = git_tree_with_file(&src, "tracked.txt", b"one\n");
     let first = git_commit_with_tree(&src, Some("refs/heads/main"), first_tree, "one", &[]);
@@ -1931,7 +1862,7 @@ fn test_cli_git_overlay_fetch_refreshes_tracking_ref_and_verify_reports_behind()
     let temp = TempDir::new().unwrap();
     let source = temp.path().join("source.git");
     let work = temp.path().join("work");
-    let src = gix::init_bare(&source).expect("init bare source");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
 
     let first_tree = git_tree_with_file(&src, "tracked.txt", b"one\n");
     let first = git_commit_with_tree(&src, Some("refs/heads/main"), first_tree, "one", &[]);
@@ -1974,11 +1905,9 @@ fn test_cli_git_overlay_fetch_refreshes_tracking_ref_and_verify_reports_behind()
         "fetch must not move the local checkout HEAD"
     );
 
-    let mirror = gix::open(work.join(".heddle").join("git")).expect("open Git-overlay mirror");
+    let mirror = open_git(work.join(".heddle").join("git")).expect("open Git-overlay mirror");
     assert!(
-        mirror
-            .find_reference(cli::bridge::git_notes::NOTES_REF)
-            .is_ok(),
+        find_reference(&mirror, cli::bridge::git_notes::NOTES_REF).is_ok(),
         "fetch should carry refs/notes/heddle for Heddle identity metadata"
     );
     assert_eq!(
@@ -1987,7 +1916,7 @@ fn test_cli_git_overlay_fetch_refreshes_tracking_ref_and_verify_reports_behind()
         "fetch should refresh the checkout's refs/notes/heddle when it reports fetching Heddle notes"
     );
     assert!(
-        mirror.find_reference("refs/tags/v2.0").is_err(),
+        find_reference(&mirror, "refs/tags/v2.0").is_err(),
         "default Git-overlay fetch should not import arbitrary Git tags"
     );
 
@@ -2011,7 +1940,7 @@ fn test_cli_git_overlay_fetch_resolves_relative_local_git_remote_from_checkout_r
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
     let other = temp.path().join("other");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2069,7 +1998,7 @@ fn test_cli_git_overlay_fetch_uses_configured_default_not_origin_fallback() {
     let source = temp.path().join("source.git");
     let work = temp.path().join("work");
     let missing_origin = temp.path().join("missing-origin.git");
-    let src = gix::init_bare(&source).expect("init bare source");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
 
     let first_tree = git_tree_with_file(&src, "tracked.txt", b"one\n");
     let first = git_commit_with_tree(&src, Some("refs/heads/main"), first_tree, "one", &[]);
@@ -2140,8 +2069,8 @@ fn test_cli_git_overlay_remote_add_does_not_steal_tracked_branch_default() {
     let origin = temp.path().join("origin.git");
     let backup = temp.path().join("backup.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare origin");
-    gix::init_bare(&backup).expect("init bare backup");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&backup).expect("init bare backup");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
     std::fs::write(backup.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
@@ -2238,7 +2167,7 @@ fn test_cli_git_overlay_current_push_carries_notes_for_cross_clone_identity() {
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
     let clone = temp.path().join("clone");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2325,7 +2254,7 @@ fn test_cli_git_overlay_explicit_path_push_discloses_configured_git_tracking_rem
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2361,7 +2290,7 @@ fn test_cli_git_overlay_explicit_path_push_json_reports_configured_git_tracking_
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2399,7 +2328,7 @@ fn test_cli_raw_git_clone_adopt_fetches_notes_before_import() {
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
     let raw_clone = temp.path().join("raw-clone");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2503,7 +2432,7 @@ fn test_cli_git_overlay_push_refuses_to_rewrite_remote_heddle_notes() {
     let work = temp.path().join("work");
     let raw_clone = temp.path().join("raw-clone");
     let missing_remote = temp.path().join("missing.git");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     std::fs::create_dir_all(&work).unwrap();
@@ -2615,7 +2544,7 @@ fn test_cli_git_overlay_sync_refuses_diverged_branch_before_rebase() {
     let origin = temp.path().join("origin.git");
     let local = temp.path().join("local");
     let peer = temp.path().join("peer");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     git_ok(
@@ -2861,7 +2790,7 @@ fn test_cli_git_overlay_pull_refuses_diverged_branch_before_visible_git_updates(
     let origin = temp.path().join("origin.git");
     let local = temp.path().join("local");
     let peer = temp.path().join("peer");
-    gix::init_bare(&origin).expect("init bare origin");
+    SleyRepository::init_bare(&origin).expect("init bare origin");
     std::fs::write(origin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     git_ok(
@@ -2950,7 +2879,7 @@ fn test_cli_clone_git_overlay_filter_is_rejected() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare git origin");
+    SleyRepository::init_bare(&origin).expect("init bare git origin");
 
     let err = heddle(
         &[
@@ -2985,7 +2914,7 @@ fn test_cli_clone_git_overlay_file_url_rejects_unsupported_flags() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
     let work = temp.path().join("work");
-    gix::init_bare(&origin).expect("init bare git origin");
+    SleyRepository::init_bare(&origin).expect("init bare git origin");
 
     let file_url = format!("file://{}", origin.display());
     let err = heddle(

--- a/crates/cli/tests/cli_integration/unrelated_histories_recovery.rs
+++ b/crates/cli/tests/cli_integration/unrelated_histories_recovery.rs
@@ -159,7 +159,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
     //
     // `git merge-base origin/main work` produces no output — the
     // graphs share no ancestor. This is the load-bearing diagnostic.
-    let merge_base = origin_repo.merge_base(commit_y, _commit_c).ok().map(|m| m);
+    let merge_base = origin_repo.merge_base(commit_y, _commit_c).ok();
     assert!(
         merge_base.is_none(),
         "synthetic root must have no common ancestor with origin/main; \

--- a/crates/cli/tests/cli_integration/unrelated_histories_recovery.rs
+++ b/crates/cli/tests/cli_integration/unrelated_histories_recovery.rs
@@ -55,14 +55,12 @@ use super::*;
 
 /// Build a tree containing a single file. Local helper because the
 /// sibling modules that already define this keep theirs private.
-fn git_tree_with_file(repo: &gix::Repository, path: &str, content: &[u8]) -> gix::hash::ObjectId {
-    let blob = repo.write_blob(content).expect("write git blob").detach();
-    let empty = repo.empty_tree().id;
-    let mut editor = repo.edit_tree(empty).expect("edit git tree");
-    editor
-        .upsert(path, gix::object::tree::EntryKind::Blob, blob)
-        .expect("add file to git tree");
-    editor.write().expect("write git tree").detach()
+fn git_tree_with_file(repo: &SleyRepository, path: &str, content: &[u8]) -> ObjectId {
+    let blob = repo.write_blob(content).expect("write git blob");
+    let empty = git_empty_tree_oid(repo);
+    let mut editor = repo.edit_tree(&empty).expect("edit git tree");
+    editor.upsert(path, EntryKind::Blob, blob);
+    repo.write_tree(editor).expect("write git tree")
 }
 
 /// Build a fixture mirroring the Codex Cloud bootstrap pattern, then
@@ -90,7 +88,7 @@ fn git_tree_with_file(repo: &gix::Repository, path: &str, content: &[u8]) -> gix
 fn unrelated_histories_recover_via_tree_hash_match() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     // Build A → B → C on origin's main.
     let tree_a = git_tree_with_file(&origin_repo, "core.rs", b"pub fn a() {}\n");
@@ -161,10 +159,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
     //
     // `git merge-base origin/main work` produces no output — the
     // graphs share no ancestor. This is the load-bearing diagnostic.
-    let merge_base = origin_repo
-        .merge_base(commit_y, _commit_c)
-        .ok()
-        .map(|m| m.detach());
+    let merge_base = origin_repo.merge_base(commit_y, _commit_c).ok().map(|m| m);
     assert!(
         merge_base.is_none(),
         "synthetic root must have no common ancestor with origin/main; \
@@ -181,9 +176,8 @@ fn unrelated_histories_recover_via_tree_hash_match() {
         .find_commit(synthetic_root)
         .expect("find synthetic root")
         .tree_id()
-        .expect("synthetic root tree id")
-        .detach();
-    let mut canonical_ancestor: Option<gix::hash::ObjectId> = None;
+        .expect("synthetic root tree id");
+    let mut canonical_ancestor: Option<ObjectId> = None;
     for info in origin_repo
         .rev_walk([_commit_c])
         .all()
@@ -192,7 +186,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
         let info = info.expect("walk step");
         let oid = info.id;
         let commit = origin_repo.find_commit(oid).expect("find commit");
-        let tree_id = commit.tree_id().expect("tree id").detach();
+        let tree_id = commit.tree_id().expect("tree id");
         if tree_id == synthetic_root_tree {
             canonical_ancestor = Some(oid);
             break;
@@ -219,8 +213,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
         .find_commit(commit_y)
         .expect("find work tip")
         .tree_id()
-        .expect("work tip tree id")
-        .detach();
+        .expect("work tip tree id");
     let grafted = git_commit_with_tree(
         &origin_repo,
         None,
@@ -232,8 +225,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
         .find_commit(grafted)
         .expect("find grafted")
         .tree_id()
-        .expect("grafted tree id")
-        .detach();
+        .expect("grafted tree id");
     assert_eq!(
         grafted_tree, work_tip_tree,
         "grafted commit's tree must exactly match the original work tip's tree \
@@ -247,8 +239,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
     // per shared file) is gone because there's a real common base.
     let recovered_base = origin_repo
         .merge_base(grafted, _commit_c)
-        .expect("recovery merge-base resolves")
-        .detach();
+        .expect("recovery merge-base resolves");
     assert_eq!(
         recovered_base, canonical,
         "post-graft, the merge-base of the recovered branch and origin/main \
@@ -284,23 +275,17 @@ fn unrelated_histories_recover_via_tree_hash_match() {
         .find_commit(rebased)
         .expect("find recovered tip")
         .tree_id()
-        .expect("final tree id")
-        .detach();
-    let final_root_tree = origin_repo
-        .find_object(final_tree)
-        .expect("read final tree")
-        .into_tree();
+        .expect("final tree id");
+    let final_root_tree = origin_repo.read_tree(&final_tree).expect("read final tree");
     let core_entry = final_root_tree
+        .entries
         .iter()
-        .find_map(|entry| {
-            let entry = entry.expect("tree entry");
-            (entry.filename() == b"core.rs".as_slice()).then(|| entry.oid().to_owned())
-        })
+        .find_map(|entry| (entry.name.as_bytes() == b"core.rs".as_slice()).then_some(entry.oid))
         .expect("core.rs in final tree");
     let core_blob = origin_repo
-        .find_object(core_entry)
+        .read_object(&core_entry)
         .expect("find core.rs blob");
-    let core_bytes = core_blob.data.clone();
+    let core_bytes = core_blob.body.clone();
     for token in [
         b"pub fn a()" as &[u8],
         b"pub fn b()",
@@ -333,7 +318,7 @@ fn unrelated_histories_recover_via_tree_hash_match() {
 fn synthetic_root_tree_resolves_to_unique_canonical_ancestor() {
     let temp = TempDir::new().unwrap();
     let origin = temp.path().join("origin.git");
-    let origin_repo = gix::init_bare(&origin).expect("init origin");
+    let origin_repo = SleyRepository::init_bare(&origin).expect("init origin");
 
     let tree_a = git_tree_with_file(&origin_repo, "core.rs", b"// a\n");
     let a = git_commit_with_tree(&origin_repo, Some("refs/heads/main"), tree_a, "A", &[]);
@@ -351,7 +336,7 @@ fn synthetic_root_tree_resolves_to_unique_canonical_ancestor() {
     for info in origin_repo.rev_walk([c]).all().expect("rev-walk") {
         let info = info.expect("walk step");
         let commit = origin_repo.find_commit(info.id).expect("find commit");
-        let tree_id = commit.tree_id().expect("tree id").detach();
+        let tree_id = commit.tree_id().expect("tree id");
         if tree_id == synced_tree {
             matches.push(info.id);
         }

--- a/crates/cli/tests/commit_conformance.rs
+++ b/crates/cli/tests/commit_conformance.rs
@@ -40,6 +40,7 @@ use cli::bridge::git_core::GitBridge;
 use cli::bridge::git_import::import_all_with_options;
 use cli::bridge::git_reconstruct::commit_object_id;
 use cli::bridge::git_util::GitImportOptions;
+use sley::{ObjectId, Repository as SleyRepository};
 use tempfile::TempDir;
 
 /// Pinned identity + config so the in-process fixtures produce stable SHAs
@@ -332,14 +333,14 @@ fn assert_all_commits_export_from_state(case: &str, source: &Path) {
     // commit object, so a regenerated commit landing here is provably rebuilt
     // from state rather than copied from the mirror's verbatim import.
     let fresh_home = TempDir::new().expect("fresh temp");
-    let fresh = gix::init_bare(fresh_home.path().join("fresh.git"))
+    let fresh = SleyRepository::init_bare(fresh_home.path().join("fresh.git"))
         .unwrap_or_else(|e| panic!("[{case}] init fresh bare repo failed: {e}"));
 
     for sha in &shas {
-        let oid = gix::ObjectId::from_hex(sha.as_bytes())
+        let oid = ObjectId::from_hex(sley::ObjectFormat::Sha1, sha)
             .unwrap_or_else(|e| panic!("[{case}] bad sha {sha}: {e}"));
         assert!(
-            !fresh.has_object(oid),
+            fresh.read_object(&oid).is_err(),
             "[{case}] fresh repo unexpectedly already holds commit {sha} before \
              reconstruction — the from-state independence guarantee is void"
         );
@@ -358,20 +359,20 @@ fn assert_all_commits_export_from_state(case: &str, source: &Path) {
         // (2) ... and now physically exists in the fresh repo (written from
         // state, not copied) ...
         assert!(
-            fresh.has_object(written),
+            fresh.read_object(&written).is_ok(),
             "[{case}] commit {sha} absent from fresh repo after reconstruct+write"
         );
         // (3) ... byte-identical to git's own view of the original object.
         let golden = cat_commit(source, sha);
         let object = fresh
-            .find_object(written)
+            .read_object(&written)
             .unwrap_or_else(|e| panic!("[{case}] find regenerated {sha} failed: {e}"));
         assert_eq!(
-            object.data,
+            object.body,
             golden,
             "[{case}] commit {sha} regenerated to DIFFERENT bytes\n  \
              reconstructed: {:?}\n  golden:        {:?}",
-            String::from_utf8_lossy(&object.data),
+            String::from_utf8_lossy(&object.body),
             String::from_utf8_lossy(&golden),
         );
     }

--- a/crates/cli/tests/comprehensive.rs
+++ b/crates/cli/tests/comprehensive.rs
@@ -148,3 +148,15 @@ where
         max_duration
     );
 }
+
+fn performance_budget(release: Duration, debug: Duration) -> Duration {
+    if cfg!(debug_assertions) {
+        // Comprehensive perf checks run in the default parallel harness beside
+        // other subprocess-heavy tests. Keep debug-mode budgets loose enough to
+        // avoid scheduler-noise flakes while release budgets guard production
+        // expectations.
+        debug
+    } else {
+        release
+    }
+}

--- a/crates/cli/tests/comprehensive/blame.rs
+++ b/crates/cli/tests/comprehensive/blame.rs
@@ -18,7 +18,7 @@ fn test_blame_large_file_performance() {
         || {
             let _ = heddle(&["query", "--attribution", "large.txt"], Some(temp.path()));
         },
-        Duration::from_secs(2),
+        performance_budget(Duration::from_secs(2), Duration::from_secs(4)),
     );
 }
 

--- a/crates/cli/tests/comprehensive/performance.rs
+++ b/crates/cli/tests/comprehensive/performance.rs
@@ -128,6 +128,7 @@ fn print_snapshot_cli_report(
 fn test_snapshot_performance_small_repo() {
     let temp = TempDir::new().unwrap();
     setup_repo_with_file(&temp, "file.txt", "content");
+    let max_duration = performance_budget(Duration::from_millis(500), Duration::from_secs(1));
 
     assert_performance(
         "snapshot small repo",
@@ -135,7 +136,7 @@ fn test_snapshot_performance_small_repo() {
             fs::write(temp.path().join("new.txt"), "new").unwrap();
             heddle(&["capture", "-m", "Test"], Some(temp.path())).unwrap();
         },
-        Duration::from_millis(500),
+        max_duration,
     );
 }
 
@@ -194,7 +195,7 @@ fn test_status_performance_large_repo() {
         || {
             let _ = heddle(&["status"], Some(temp.path()));
         },
-        Duration::from_secs(5),
+        performance_budget(Duration::from_secs(5), Duration::from_secs(10)),
     );
 }
 
@@ -259,7 +260,7 @@ fn test_log_performance_deep_history() {
         || {
             let _ = heddle(&["log", "--oneline"], Some(temp.path()));
         },
-        Duration::from_secs(2),
+        performance_budget(Duration::from_secs(2), Duration::from_secs(4)),
     );
 }
 
@@ -288,6 +289,6 @@ fn test_gc_performance_many_objects() {
         || {
             heddle(&["maintenance", "gc", "--aggressive"], Some(temp.path())).unwrap();
         },
-        Duration::from_secs(5),
+        performance_budget(Duration::from_secs(5), Duration::from_secs(10)),
     );
 }

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -4536,7 +4536,7 @@ fn matrix_mirror_tag(bridge: &GitBridge, name: &str) -> Option<ObjectId> {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
     find_reference(&mirror, &format!("refs/tags/{name}"))
         .ok()
-        .and_then(|mut r| r.peel_to_id().ok().map(|id| id))
+        .and_then(|mut r| r.peel_to_id().ok())
 }
 
 /// Read the mirror's `refs/heads/<name>` tip, or `None` when the branch is absent.
@@ -4544,7 +4544,7 @@ fn matrix_mirror_head(bridge: &GitBridge, name: &str) -> Option<ObjectId> {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
     find_reference(&mirror, &format!("refs/heads/{name}"))
         .ok()
-        .and_then(|mut r| r.peel_to_id().ok().map(|id| id))
+        .and_then(|mut r| r.peel_to_id().ok())
 }
 
 /// #316 / PR #528 — plant a FOREIGN tag in the mirror: a `refs/tags/<name>` heddle
@@ -7071,7 +7071,6 @@ fn out_of_band_destination_tag_not_overwritten() {
         let tip = find_reference(&dest, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, oid_x,
@@ -7092,7 +7091,6 @@ fn out_of_band_destination_tag_not_overwritten() {
         let tip = find_reference(&dest, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, served_tag,
@@ -7119,7 +7117,6 @@ fn out_of_band_destination_tag_not_overwritten() {
         find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id)
             .expect("tag id")
     };
 
@@ -7159,7 +7156,6 @@ fn out_of_band_destination_tag_not_overwritten() {
         let tip = find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, remote_oid_x,
@@ -7175,7 +7171,6 @@ fn out_of_band_destination_tag_not_overwritten() {
         let tip = find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, remote_served_tag,

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -7,143 +7,366 @@ use std::{
     net::{TcpListener, TcpStream},
     process::{Child, Command, Stdio},
     sync::{
-        atomic::{AtomicBool, Ordering},
         Arc,
+        atomic::{AtomicBool, Ordering},
     },
     thread,
     time::Duration,
 };
 
 use base64::Engine;
-use gix::refs::transaction::PreviousValue;
 use objects::object::{
     Blob, ChangeId, ContentHash, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry,
 };
 use repo::Repository;
+use sley::plumbing::sley_core::ByteString as GitByteString;
+use sley::plumbing::sley_object::EncodedObject;
+use sley::{
+    CommitObject, EntryKind, GitObjectType, GitTime, ObjectId, RefPrecondition, ReferenceTarget,
+    Repository as SleyRepository, Signature, TagObject,
+};
 use tempfile::TempDir;
 
 use cli::bridge::{
+    GitBridge,
     git_core::{
-        clone_url_to_bare, copy_local_repo_to_bare, GitBridgeError, GitPushScope, SyncMapping,
+        GitBridgeError, GitPushScope, SyncMapping, clone_url_to_bare, copy_local_repo_to_bare,
     },
     git_export::{export_all, export_current_thread, export_tree},
     git_import::{
-        backfill_fidelity, import_all, import_all_with_options, import_git_tree, GitTreeImporter,
+        GitTreeImporter, backfill_fidelity, import_all, import_all_with_options, import_git_tree,
     },
+    git_notes,
     git_sync::{sync_branches, sync_tags, sync_track_to_branch},
     git_util::GitImportOptions,
     test_support,
     test_support::{
-        collect_managed_ref_updates, delete_reference_if_present, plan_destination_reconcile,
-        read_exported_refs, read_mirror_managed_refs, set_reference, write_exported_refs,
-        write_mirror_managed_refs, RefNamespace, RefUpdate,
+        RefNamespace, RefUpdate, collect_managed_ref_updates, delete_reference_if_present,
+        plan_destination_reconcile, read_exported_refs, read_mirror_managed_refs, set_reference,
+        write_exported_refs, write_mirror_managed_refs,
     },
-    GitBridge,
 };
 
-fn init_git_repo() -> (TempDir, gix::Repository) {
-    let temp = TempDir::new().expect("temp dir");
-    let repo = gix::init(temp.path()).expect("init git repo");
-    (temp, repo)
+trait SleyTestRepoExt {
+    fn find_tree(&self, oid: ObjectId) -> Result<sley::TreeObject, String>;
+    fn find_object(&self, oid: ObjectId) -> Result<TestObject, String>;
+    fn find_blob(&self, oid: ObjectId) -> Result<TestBlob, String>;
+    fn find_commit(&self, oid: ObjectId) -> Result<TestCommit, String>;
+    fn path(&self) -> &std::path::Path;
 }
 
-fn init_bare_git_repo() -> (TempDir, gix::Repository) {
-    let temp = TempDir::new().expect("temp dir");
-    let repo = gix::init_bare(temp.path()).expect("init bare git repo");
-    (temp, repo)
-}
+impl SleyTestRepoExt for SleyRepository {
+    fn find_tree(&self, oid: ObjectId) -> Result<sley::TreeObject, String> {
+        self.read_tree(&oid).map_err(|err| err.to_string())
+    }
 
-fn init_named_bare_git_repo(root: &TempDir, name: &str) -> gix::Repository {
-    gix::init_bare(root.path().join(name)).expect("init named bare git repo")
-}
+    fn find_object(&self, oid: ObjectId) -> Result<TestObject, String> {
+        let object = self.read_object(&oid).map_err(|err| err.to_string())?;
+        Ok(TestObject {
+            kind: object.object_type,
+            data: object.body.clone(),
+        })
+    }
 
-fn test_signature() -> gix::actor::Signature {
-    gix::actor::Signature {
-        name: "Heddle Test".into(),
-        email: "heddle@test".into(),
-        time: gix::date::Time {
-            seconds: 0,
-            offset: 0,
-        },
+    fn find_blob(&self, oid: ObjectId) -> Result<TestBlob, String> {
+        let object = self.read_object(&oid).map_err(|err| err.to_string())?;
+        if object.object_type != GitObjectType::Blob {
+            return Err(format!("object {oid} is not a blob"));
+        }
+        Ok(TestBlob {
+            data: object.body.clone(),
+        })
+    }
+
+    fn find_commit(&self, oid: ObjectId) -> Result<TestCommit, String> {
+        self.read_commit(&oid)
+            .map(|commit| TestCommit { commit })
+            .map_err(|err| err.to_string())
+    }
+
+    fn path(&self) -> &std::path::Path {
+        self.git_dir()
     }
 }
 
-fn empty_tree_oid(repo: &gix::Repository) -> gix::hash::ObjectId {
-    repo.empty_tree().id
+struct TestReference<'a> {
+    repo: &'a SleyRepository,
+    target: ReferenceTarget,
+}
+
+fn find_reference<'a>(repo: &'a SleyRepository, name: &str) -> Result<TestReference<'a>, String> {
+    let target = repo
+        .references()
+        .read_ref(name)
+        .map_err(|err| err.to_string())?
+        .ok_or_else(|| format!("reference {name} not found"))?;
+    Ok(TestReference { repo, target })
+}
+
+impl TestReference<'_> {
+    fn id(&self) -> ObjectId {
+        self.try_id()
+            .expect("test reference should point directly at an object")
+    }
+
+    fn try_id(&self) -> Option<ObjectId> {
+        self.target().try_id().copied()
+    }
+
+    fn peel_to_id(&mut self) -> Result<ObjectId, String> {
+        let oid = match &self.target {
+            ReferenceTarget::Direct(oid) => *oid,
+            ReferenceTarget::Symbolic(name) => {
+                let reference = find_reference(self.repo, name)?;
+                match reference.target {
+                    ReferenceTarget::Direct(oid) => oid,
+                    ReferenceTarget::Symbolic(_) => {
+                        return Err(format!("nested symbolic reference {name} is unsupported"));
+                    }
+                }
+            }
+        };
+        peel_oid(self.repo, oid)
+    }
+
+    fn target(&self) -> TestReferenceTarget<'_> {
+        TestReferenceTarget {
+            target: &self.target,
+        }
+    }
+}
+
+struct TestReferenceTarget<'a> {
+    target: &'a ReferenceTarget,
+}
+
+impl<'a> TestReferenceTarget<'a> {
+    fn try_id(&self) -> Option<&'a ObjectId> {
+        match self.target {
+            ReferenceTarget::Direct(oid) => Some(oid),
+            ReferenceTarget::Symbolic(_) => None,
+        }
+    }
+}
+
+struct TestObject {
+    kind: GitObjectType,
+    data: Vec<u8>,
+}
+
+struct TestBlob {
+    data: Vec<u8>,
+}
+
+struct TestCommit {
+    commit: CommitObject,
+}
+
+impl TestCommit {
+    fn message_raw_sloppy(&self) -> TestRawMessage<'_> {
+        TestRawMessage(&self.commit.message)
+    }
+
+    fn parent_ids(&self) -> impl Iterator<Item = ObjectId> + '_ {
+        self.commit.parents.iter().copied()
+    }
+
+    fn tree_id(&self) -> Option<ObjectId> {
+        Some(self.commit.tree)
+    }
+}
+
+struct TestRawMessage<'a>(&'a [u8]);
+
+impl TestRawMessage<'_> {
+    fn to_vec(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+}
+
+impl std::fmt::Display for TestRawMessage<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", String::from_utf8_lossy(self.0))
+    }
+}
+
+trait SleyTestTreeExt {
+    fn find_entry(&self, name: &str) -> Option<TestTreeEntry<'_>>;
+    fn iter(&self) -> std::vec::IntoIter<Result<TestTreeEntry<'_>, String>>;
+}
+
+impl SleyTestTreeExt for sley::TreeObject {
+    fn find_entry(&self, name: &str) -> Option<TestTreeEntry<'_>> {
+        self.entries
+            .iter()
+            .find(|entry| entry.name.as_bytes() == name.as_bytes())
+            .map(|entry| TestTreeEntry { entry })
+    }
+
+    fn iter(&self) -> std::vec::IntoIter<Result<TestTreeEntry<'_>, String>> {
+        self.entries
+            .iter()
+            .map(|entry| Ok(TestTreeEntry { entry }))
+            .collect::<Vec<_>>()
+            .into_iter()
+    }
+}
+
+struct TestTreeEntry<'a> {
+    entry: &'a sley::plumbing::sley_object::TreeEntry,
+}
+
+impl TestTreeEntry<'_> {
+    fn filename(&self) -> String {
+        String::from_utf8_lossy(self.entry.name.as_bytes()).into_owned()
+    }
+
+    fn mode(&self) -> TestEntryMode {
+        TestEntryMode(self.entry.mode)
+    }
+
+    fn object_id(&self) -> ObjectId {
+        self.entry.oid
+    }
+}
+
+struct TestEntryMode(u32);
+
+impl TestEntryMode {
+    fn kind(&self) -> EntryKind {
+        EntryKind::from_mode(self.0).expect("canonical tree entry mode")
+    }
+}
+
+fn peel_oid(repo: &SleyRepository, oid: ObjectId) -> Result<ObjectId, String> {
+    let object = repo.read_object(&oid).map_err(|err| err.to_string())?;
+    if object.object_type == GitObjectType::Tag {
+        let tag = repo.read_tag(&oid).map_err(|err| err.to_string())?;
+        peel_oid(repo, tag.object)
+    } else {
+        Ok(oid)
+    }
+}
+
+fn open_git(path: impl AsRef<std::path::Path>) -> Result<SleyRepository, String> {
+    SleyRepository::open(path.as_ref())
+        .or_else(|_| SleyRepository::discover(path.as_ref()))
+        .map_err(|err| err.to_string())
+}
+
+fn init_git_repo() -> (TempDir, SleyRepository) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = SleyRepository::init(temp.path()).expect("init git repo");
+    (temp, repo)
+}
+
+fn init_bare_git_repo() -> (TempDir, SleyRepository) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = SleyRepository::init_bare(temp.path()).expect("init bare git repo");
+    (temp, repo)
+}
+
+fn init_named_bare_git_repo(root: &TempDir, name: &str) -> SleyRepository {
+    SleyRepository::init_bare(root.path().join(name)).expect("init named bare git repo")
+}
+
+fn test_signature() -> Signature {
+    test_signature_at("Heddle Test", "heddle@test", 0, 0)
+}
+
+fn test_signature_at(
+    name: &str,
+    email: &str,
+    seconds: i64,
+    timezone_offset_minutes: i16,
+) -> Signature {
+    let time = GitTime::new(seconds, timezone_offset_minutes);
+    let raw = format!("{name} <{email}> {seconds} {}", time.offset_token()).into_bytes();
+    Signature {
+        name: GitByteString::new(name.as_bytes().to_vec()),
+        email: GitByteString::new(email.as_bytes().to_vec()),
+        time,
+        raw,
+    }
+}
+
+fn empty_tree_oid(repo: &SleyRepository) -> ObjectId {
+    repo.write_tree(sley::TreeEditor::new())
+        .expect("write empty tree")
 }
 
 fn commit_with_tree(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     reference: Option<&str>,
-    tree_oid: gix::hash::ObjectId,
+    tree_oid: ObjectId,
     message: &str,
-    parents: &[gix::hash::ObjectId],
-) -> gix::hash::ObjectId {
+    parents: &[ObjectId],
+) -> ObjectId {
     let sig = test_signature();
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let commit = repo
-        .new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            message,
-            tree_oid,
-            parents.to_vec(),
-        )
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: parents.to_vec(),
+        author: sig.to_ident_bytes(),
+        committer: sig.to_ident_bytes(),
+        encoding: None,
+        message: message.as_bytes().to_vec(),
+    };
+    let commit_id = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
         .expect("commit");
     if let Some(reference) = reference {
         set_reference(
             repo,
             reference,
-            commit.id,
-            PreviousValue::Any,
+            commit_id,
+            RefPrecondition::Any,
             "test: update ref",
         )
         .expect("update ref");
     }
-    commit.id
+    commit_id
 }
 
 fn create_annotated_tag(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     name: &str,
-    target: gix::hash::ObjectId,
+    target: ObjectId,
     message: &str,
-) -> gix::hash::ObjectId {
-    let tag = gix::objs::Tag {
-        target,
-        target_kind: gix::objs::Kind::Commit,
-        name: name.into(),
-        tagger: Some(test_signature()),
-        message: message.into(),
-        pgp_signature: None,
+) -> ObjectId {
+    let tag = TagObject {
+        object: target,
+        object_type: GitObjectType::Commit,
+        name: name.as_bytes().to_vec(),
+        tagger: Some(test_signature().to_ident_bytes()),
+        message: message.as_bytes().to_vec(),
+        raw_body: None,
     };
-    let tag_id = repo.write_object(&tag).expect("write tag").detach();
+    let tag_id = repo
+        .write_object(EncodedObject::new(GitObjectType::Tag, tag.write()))
+        .expect("write tag");
     set_reference(
         repo,
         &format!("refs/tags/{name}"),
         tag_id,
-        PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "test: create tag",
     )
     .expect("create tag ref");
     tag_id
 }
 
-fn gitlink_tree(repo: &gix::Repository, name: &str) -> gix::hash::ObjectId {
-    let submodule_oid: gix::hash::ObjectId = "0505050505050505050505050505050505050505"
+fn gitlink_tree(repo: &SleyRepository, name: &str) -> ObjectId {
+    let submodule_oid: ObjectId = "0505050505050505050505050505050505050505"
         .parse()
         .expect("oid");
     let mut editor = repo
-        .edit_tree(gix::hash::ObjectId::empty_tree(repo.object_hash()))
+        .edit_tree(&ObjectId::empty_tree(repo.object_format()))
         .expect("tree editor");
-    editor
-        .upsert(name, gix::object::tree::EntryKind::Commit, submodule_oid)
-        .expect("insert submodule");
-    editor.write().expect("write tree").detach()
+    editor.upsert(name, EntryKind::Commit, submodule_oid);
+    repo.write_tree(editor).expect("write tree")
 }
 
-fn init_gitlink_repo() -> (TempDir, gix::Repository) {
+fn init_gitlink_repo() -> (TempDir, SleyRepository) {
     let (git_temp, git_repo) = init_git_repo();
     let tree_oid = gitlink_tree(&git_repo, "vendor");
     commit_with_tree(&git_repo, Some("refs/heads/main"), tree_oid, "gitlink", &[]);
@@ -182,16 +405,18 @@ impl GitHttpBackend {
         let stop = Arc::new(AtomicBool::new(false));
         let stop_signal = Arc::clone(&stop);
         let auth = basic_auth.clone();
-        let join = thread::spawn(move || loop {
-            if stop_signal.load(Ordering::Relaxed) {
-                break;
-            }
-            match listener.accept() {
-                Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
-                Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                    thread::sleep(Duration::from_millis(10));
+        let join = thread::spawn(move || {
+            loop {
+                if stop_signal.load(Ordering::Relaxed) {
+                    break;
                 }
-                Err(_) => break,
+                match listener.accept() {
+                    Ok((stream, _)) => handle_http_backend_connection(stream, &root, auth.as_ref()),
+                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(_) => break,
+                }
             }
         });
 
@@ -477,10 +702,9 @@ fn sync_track_to_branch_advances_branch_to_thread_tip() {
     // Heddle thread, not the Git ref.
     sync_track_to_branch(&git_repo, "main", second).expect("branch sync must succeed");
 
-    let mut updated = git_repo
-        .find_reference("refs/heads/main")
-        .expect("branch ref present after sync");
-    let updated_oid = updated.peel_to_id().expect("peel ref").detach();
+    let mut updated =
+        find_reference(&git_repo, "refs/heads/main").expect("branch ref present after sync");
+    let updated_oid = updated.peel_to_id().expect("peel ref");
     assert_eq!(
         updated_oid, second,
         "branch main should now point at the thread tip"
@@ -493,7 +717,7 @@ fn export_tree_writes_submodule_entries() {
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let (_git_temp, git_repo) = init_git_repo();
 
-    let submodule_oid: gix::hash::ObjectId = "0303030303030303030303030303030303030303"
+    let submodule_oid: ObjectId = "0303030303030303030303030303030303030303"
         .parse()
         .expect("oid");
     let blob = Blob::new(format!("heddle-submodule: {}", submodule_oid).into_bytes());
@@ -511,7 +735,7 @@ fn export_tree_writes_submodule_entries() {
     let git_tree = git_repo.find_tree(tree_oid).expect("git tree");
     let entry = git_tree.find_entry("vendor").expect("entry");
 
-    assert_eq!(entry.mode().kind(), gix::object::tree::EntryKind::Commit);
+    assert_eq!(entry.mode().kind(), EntryKind::Commit);
     assert_eq!(entry.object_id(), submodule_oid);
 }
 
@@ -619,20 +843,14 @@ fn export_tree_substitutes_stub_for_redacted_blob() {
 #[test]
 fn import_tree_rejects_submodule_entries_by_default() {
     let (_git_temp, git_repo) = init_git_repo();
-    let submodule_oid: gix::hash::ObjectId = "0404040404040404040404040404040404040404"
+    let submodule_oid: ObjectId = "0404040404040404040404040404040404040404"
         .parse()
         .expect("oid");
     let mut editor = git_repo
-        .edit_tree(gix::hash::ObjectId::empty_tree(git_repo.object_hash()))
+        .edit_tree(&ObjectId::empty_tree(git_repo.object_format()))
         .expect("tree editor");
-    editor
-        .upsert(
-            "vendor",
-            gix::object::tree::EntryKind::Commit,
-            submodule_oid,
-        )
-        .expect("insert submodule");
-    let tree_oid = editor.write().expect("write tree").detach();
+    editor.upsert("vendor", EntryKind::Commit, submodule_oid);
+    let tree_oid = git_repo.write_tree(editor).expect("write tree");
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
@@ -652,20 +870,14 @@ fn import_tree_rejects_submodule_entries_by_default() {
 #[test]
 fn import_tree_reads_submodule_entries_with_lossy_opt_in() {
     let (_git_temp, git_repo) = init_git_repo();
-    let submodule_oid: gix::hash::ObjectId = "0404040404040404040404040404040404040404"
+    let submodule_oid: ObjectId = "0404040404040404040404040404040404040404"
         .parse()
         .expect("oid");
     let mut editor = git_repo
-        .edit_tree(gix::hash::ObjectId::empty_tree(git_repo.object_hash()))
+        .edit_tree(&ObjectId::empty_tree(git_repo.object_format()))
         .expect("tree editor");
-    editor
-        .upsert(
-            "vendor",
-            gix::object::tree::EntryKind::Commit,
-            submodule_oid,
-        )
-        .expect("insert submodule");
-    let tree_oid = editor.write().expect("write tree").detach();
+    editor.upsert("vendor", EntryKind::Commit, submodule_oid);
+    let tree_oid = git_repo.write_tree(editor).expect("write tree");
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
@@ -700,7 +912,7 @@ fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
     let mut default_bridge = GitBridge::new(&default_repo);
     let err = import_all(
         &mut default_bridge,
-        Some(git_repo.workdir().expect("workdir")),
+        Some(git_repo.workdir().expect("workdir").as_path()),
     )
     .expect_err("default import must fail on gitlink");
     let message = err.to_string();
@@ -712,7 +924,7 @@ fn import_all_rejects_gitlink_by_default_and_lossy_reports_conversion() {
     let mut lossy_bridge = GitBridge::new(&lossy_repo);
     let stats = import_all_with_options(
         &mut lossy_bridge,
-        Some(git_repo.workdir().expect("workdir")),
+        Some(git_repo.workdir().expect("workdir").as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("lossy import accepts gitlink conversion");
@@ -729,28 +941,21 @@ fn import_all_lossy_does_not_reattribute_cached_shared_subtree_entries() {
     let shared_tree = gitlink_tree(&git_repo, "vendor");
 
     let mut first_editor = git_repo
-        .edit_tree(empty_tree_oid(&git_repo))
+        .edit_tree(&empty_tree_oid(&git_repo))
         .expect("first tree editor");
-    first_editor
-        .upsert("shared", gix::object::tree::EntryKind::Tree, shared_tree)
-        .expect("insert shared subtree");
-    let first_tree = first_editor.write().expect("write first tree").detach();
+    first_editor.upsert("shared", EntryKind::Tree, shared_tree);
+    let first_tree = git_repo.write_tree(first_editor).expect("write first tree");
     let first_commit = commit_with_tree(&git_repo, None, first_tree, "add shared subtree", &[]);
 
-    let note_blob = git_repo
-        .write_blob(b"second\n")
-        .expect("note blob")
-        .detach();
+    let note_blob = git_repo.write_blob(b"second\n").expect("note blob");
     let mut second_editor = git_repo
-        .edit_tree(empty_tree_oid(&git_repo))
+        .edit_tree(&empty_tree_oid(&git_repo))
         .expect("second tree editor");
-    second_editor
-        .upsert("shared", gix::object::tree::EntryKind::Tree, shared_tree)
-        .expect("reuse shared subtree");
-    second_editor
-        .upsert("note.txt", gix::object::tree::EntryKind::Blob, note_blob)
-        .expect("insert unrelated root change");
-    let second_tree = second_editor.write().expect("write second tree").detach();
+    second_editor.upsert("shared", EntryKind::Tree, shared_tree);
+    second_editor.upsert("note.txt", EntryKind::Blob, note_blob);
+    let second_tree = git_repo
+        .write_tree(second_editor)
+        .expect("write second tree");
     let second_commit = commit_with_tree(
         &git_repo,
         Some("refs/heads/main"),
@@ -764,7 +969,7 @@ fn import_all_lossy_does_not_reattribute_cached_shared_subtree_entries() {
     let mut bridge = GitBridge::new(&repo);
     let stats = import_all_with_options(
         &mut bridge,
-        Some(git_repo.workdir().expect("workdir")),
+        Some(&git_repo.workdir().expect("workdir")),
         GitImportOptions { lossy: true },
     )
     .expect("lossy import accepts shared gitlink subtree");
@@ -814,7 +1019,7 @@ fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
     let mut first_bridge = GitBridge::new(&repo);
     let first = import_all_with_options(
         &mut first_bridge,
-        Some(git_path),
+        Some(git_path.as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("initial lossy bridge import succeeds");
@@ -832,7 +1037,7 @@ fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
     );
 
     let mut rerun_bridge = GitBridge::new(&repo);
-    let err = import_all(&mut rerun_bridge, Some(git_path))
+    let err = import_all(&mut rerun_bridge, Some(git_path.as_path()))
         .expect_err("default bridge import must not reuse cached lossy state silently");
     assert_lossy_default_rerun_error("bridge", &err.to_string());
 }
@@ -847,7 +1052,7 @@ fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
     let mut first_bridge = GitBridge::new(&repo);
     import_all_with_options(
         &mut first_bridge,
-        Some(git_path),
+        Some(git_path.as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("initial lossy bridge import succeeds");
@@ -855,7 +1060,7 @@ fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
     let mut rerun_bridge = GitBridge::new(&repo);
     let second = import_all_with_options(
         &mut rerun_bridge,
-        Some(git_path),
+        Some(git_path.as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("lossy bridge rerun reports persisted lossy entries");
@@ -904,11 +1109,11 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
     let git_path = git_repo.workdir().expect("workdir");
     let message = match engine {
         ImportEngine::Ingest => {
-            use ingest::{import_git_into, import_git_into_with_options, ImportOptions};
+            use ingest::{ImportOptions, import_git_into, import_git_into_with_options};
 
             let heddle_temp = TempDir::new().expect("heddle temp");
             let (first, map) = import_git_into_with_options(
-                git_path,
+                &git_path,
                 heddle_temp.path(),
                 ImportOptions { lossy: true },
             )
@@ -926,14 +1131,14 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
             let mut first_bridge = GitBridge::new(&repo);
             let first = import_all_with_options(
                 &mut first_bridge,
-                Some(git_path),
+                Some(git_path.as_path()),
                 GitImportOptions { lossy: true },
             )
             .expect("initial lossy bridge import succeeds");
             assert_eq!(first.lossy_entries.len(), 1);
 
             let mut rerun_bridge = GitBridge::new(&repo);
-            import_all(&mut rerun_bridge, Some(git_path))
+            import_all(&mut rerun_bridge, Some(git_path.as_path()))
                 .expect_err("default bridge import must fail on cached lossy commit")
                 .to_string()
         }
@@ -961,7 +1166,7 @@ fn import_all_lossy_clean_repo_reports_no_lossy_entries() {
     let mut bridge = GitBridge::new(&repo);
     let stats = import_all_with_options(
         &mut bridge,
-        Some(git_repo.workdir().expect("workdir")),
+        Some(git_repo.workdir().expect("workdir").as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("clean repo imports with lossy flag too");
@@ -1006,7 +1211,7 @@ fn bridge_import_lossy_state_carries_canonical_git_lossy_marker() {
     let mut bridge = GitBridge::new(&repo);
     let stats = import_all_with_options(
         &mut bridge,
-        Some(git_repo.workdir().expect("workdir")),
+        Some(git_repo.workdir().expect("workdir").as_path()),
         GitImportOptions { lossy: true },
     )
     .expect("lossy bridge import succeeds");
@@ -1028,7 +1233,7 @@ fn bridge_import_lossy_state_carries_canonical_git_lossy_marker() {
 #[cfg(feature = "ingest")]
 #[test]
 fn ingest_lossy_state_carries_canonical_git_lossy_marker() {
-    use ingest::{import_git_into_with_options, ImportOptions};
+    use ingest::{ImportOptions, import_git_into_with_options};
 
     let (_git_temp, git_repo) = init_gitlink_repo();
     let git_path = git_repo.workdir().expect("workdir");
@@ -1060,7 +1265,7 @@ fn ingest_lossy_state_carries_canonical_git_lossy_marker() {
 #[cfg(feature = "ingest")]
 #[test]
 fn export_mints_lossy_ingest_state_from_raw_metadata() {
-    use ingest::{import_git_into_with_options, ImportOptions};
+    use ingest::{ImportOptions, import_git_into_with_options};
 
     let (_git_temp, git_repo) = init_gitlink_repo();
     let git_path = git_repo.workdir().expect("workdir");
@@ -1100,13 +1305,11 @@ fn export_mints_lossy_ingest_state_from_raw_metadata() {
         .export_to_path(&dest_path)
         .expect("export must MINT the unmapped lossy state, not reject it");
 
-    let dest_repo = gix::open(&dest_path).expect("open dest");
-    let dest_main = dest_repo
-        .find_reference("refs/heads/main")
+    let dest_repo = open_git(&dest_path).expect("open dest");
+    let dest_main = find_reference(&dest_repo, "refs/heads/main")
         .expect("exported main ref")
         .peel_to_id()
-        .expect("exported main target")
-        .detach();
+        .expect("exported main target");
     let dest_commit = dest_repo.find_commit(dest_main).expect("dest main commit");
 
     // Minted from raw metadata: the message is the verbatim raw_message, NOT the
@@ -1143,20 +1346,18 @@ fn copy_local_repo_to_bare_handles_gitlink_entries() {
     // Build a tree containing one gitlink entry pointing at a
     // fabricated commit OID that is *not* present in this repo —
     // exactly the shape git/git ships with `sha1collisiondetection`.
-    let foreign_submodule_oid: gix::hash::ObjectId = "855827c583bc30645ba427885caa40c5b81764d2"
+    let foreign_submodule_oid: ObjectId = "855827c583bc30645ba427885caa40c5b81764d2"
         .parse()
         .expect("oid");
     let mut editor = source
-        .edit_tree(empty_tree_oid(&source))
+        .edit_tree(&empty_tree_oid(&source))
         .expect("tree editor");
-    editor
-        .upsert(
-            "sha1collisiondetection",
-            gix::object::tree::EntryKind::Commit,
-            foreign_submodule_oid,
-        )
-        .expect("insert gitlink");
-    let tree_with_gitlink = editor.write().expect("write tree").detach();
+    editor.upsert(
+        "sha1collisiondetection",
+        EntryKind::Commit,
+        foreign_submodule_oid,
+    );
+    let tree_with_gitlink = source.write_tree(editor).expect("write tree");
     let commit = commit_with_tree(
         &source,
         Some("refs/heads/main"),
@@ -1182,7 +1383,7 @@ fn copy_local_repo_to_bare_handles_gitlink_entries() {
     // non-gitlink object.
     copy_local_repo_to_bare(source.path(), &dest_path).expect("copy with gitlink");
 
-    let dest = gix::open(&dest_path).expect("open dest");
+    let dest = open_git(&dest_path).expect("open dest");
     assert!(
         dest.find_commit(commit).is_ok(),
         "destination must contain the parent commit"
@@ -1203,7 +1404,7 @@ fn copy_local_repo_to_bare_handles_gitlink_entries() {
     let entry = copied_tree
         .find_entry("sha1collisiondetection")
         .expect("entry");
-    assert_eq!(entry.mode().kind(), gix::object::tree::EntryKind::Commit);
+    assert_eq!(entry.mode().kind(), EntryKind::Commit);
     assert_eq!(entry.object_id(), foreign_submodule_oid);
 }
 
@@ -1264,18 +1465,18 @@ fn delete_reference_if_present_drops_new_branch_for_rollback() {
         &repo,
         "refs/heads/feature-x",
         oid,
-        PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "create branch",
     )
     .expect("create branch");
     assert!(
-        repo.find_reference("refs/heads/feature-x").is_ok(),
+        find_reference(&repo, "refs/heads/feature-x").is_ok(),
         "set_reference must create the branch"
     );
 
     delete_reference_if_present(&repo, "refs/heads/feature-x").expect("delete");
     assert!(
-        repo.find_reference("refs/heads/feature-x").is_err(),
+        find_reference(&repo, "refs/heads/feature-x").is_err(),
         "rollback must remove the branch we just created"
     );
 
@@ -1293,7 +1494,7 @@ fn mapping_persists_between_runs() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let change_id = ChangeId::generate();
-    let git_oid: gix::hash::ObjectId = "0909090909090909090909090909090909090909"
+    let git_oid: ObjectId = "0909090909090909090909090909090909090909"
         .parse()
         .expect("oid");
 
@@ -1302,8 +1503,11 @@ fn mapping_persists_between_runs() {
     test_support::save_mapping_to_disk(&bridge).expect("save mapping");
 
     let mut reloaded = GitBridge::new(&repo);
-    test_support::build_existing_mapping(&mut reloaded, Some(git_repo.workdir().expect("workdir")))
-        .expect("build mapping");
+    test_support::build_existing_mapping(
+        &mut reloaded,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("build mapping");
 
     assert_eq!(
         test_support::mapping(&reloaded).get_git(&change_id),
@@ -1318,7 +1522,7 @@ fn legacy_mapping_is_migrated_out_of_git_dir() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let change_id = ChangeId::generate();
-    let git_oid: gix::hash::ObjectId = "0808080808080808080808080808080808080808"
+    let git_oid: ObjectId = "0808080808080808080808080808080808080808"
         .parse()
         .expect("oid");
 
@@ -1335,8 +1539,11 @@ fn legacy_mapping_is_migrated_out_of_git_dir() {
     .expect("write legacy mapping");
 
     let mut bridge = GitBridge::new(&repo);
-    test_support::build_existing_mapping(&mut bridge, Some(git_repo.workdir().expect("workdir")))
-        .expect("build mapping");
+    test_support::build_existing_mapping(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("build mapping");
 
     assert_eq!(
         test_support::mapping(&bridge).get_git(&change_id),
@@ -1350,7 +1557,7 @@ fn legacy_mapping_is_migrated_out_of_git_dir() {
 fn test_sync_mapping() {
     let mut mapping = SyncMapping::new();
     let change_id = ChangeId::generate();
-    let oid: gix::hash::ObjectId = "0101010101010101010101010101010101010101".parse().unwrap();
+    let oid: ObjectId = "0101010101010101010101010101010101010101".parse().unwrap();
     mapping.insert(change_id, oid);
     assert_eq!(mapping.get_git(&change_id), Some(oid));
     assert_eq!(mapping.get_heddle(oid), Some(change_id));
@@ -1434,16 +1641,18 @@ fn pull_imports_remote_branches_and_tags_from_path_remote() {
         .pull(source_temp.path().to_str().expect("remote path"))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1461,16 +1670,18 @@ fn pull_imports_remote_branches_and_tags_from_file_url_remote() {
         .pull(&format!("file://{}", source_temp.path().display()))
         .expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1489,16 +1700,18 @@ fn pull_imports_remote_branches_and_tags_from_git_daemon() {
     let mut bridge = GitBridge::new(&repo);
     bridge.pull(&daemon.url("remote.git")).expect("pull remote");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1519,16 +1732,18 @@ fn pull_imports_remote_branches_and_tags_from_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1549,16 +1764,18 @@ fn pull_imports_remote_branches_and_tags_from_authenticated_git_http_backend() {
         .pull(&backend.url("remote.git"))
         .expect("pull remote over authenticated http");
 
-    assert!(repo
-        .refs()
-        .get_thread(&ThreadName::new("main"))
-        .unwrap()
-        .is_some());
-    assert!(repo
-        .refs()
-        .get_marker(&MarkerName::new("v1.0"))
-        .unwrap()
-        .is_some());
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        repo.refs()
+            .get_marker(&MarkerName::new("v1.0"))
+            .unwrap()
+            .is_some()
+    );
 }
 
 #[test]
@@ -1624,8 +1841,11 @@ fn import_handles_merge_history_without_missing_parent_mappings() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    let stats = import_all(&mut bridge, Some(git_repo.workdir().expect("workdir")))
-        .expect("import merge history");
+    let stats = import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import merge history");
 
     assert_eq!(stats.commits_imported, 4);
     assert_eq!(
@@ -1663,8 +1883,11 @@ fn import_rejects_branch_name_that_is_not_a_valid_thread_id() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    let err = import_all(&mut bridge, Some(git_repo.workdir().expect("workdir")))
-        .expect_err("import must reject a branch whose name is not a valid thread id");
+    let err = import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect_err("import must reject a branch whose name is not a valid thread id");
 
     match err {
         GitBridgeError::InvalidThreadName { branch, message } => {
@@ -1703,7 +1926,7 @@ fn failed_import_restores_mapping_and_overrides() {
     let pre_mapping = test_support::mapping(&bridge).clone();
     let pre_overrides = test_support::commit_message_overrides(&bridge).clone();
 
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir")))
+    import_all(&mut bridge, Some(&git_repo.workdir().expect("workdir")))
         .expect_err("invalid branch name must fail after commits are mapped");
 
     assert_eq!(
@@ -1717,7 +1940,7 @@ fn failed_import_restores_mapping_and_overrides() {
         "failed import must restore pre-call commit message overrides"
     );
 
-    test_support::build_existing_mapping(&mut bridge, Some(git_repo.workdir().expect("workdir")))
+    test_support::build_existing_mapping(&mut bridge, Some(&git_repo.workdir().expect("workdir")))
         .expect("mapping rebuild after failed import");
     assert_eq!(
         test_support::mapping(&bridge),
@@ -1739,7 +1962,7 @@ fn push_exports_local_branches_and_tags_to_path_remote() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     bridge
@@ -1749,18 +1972,14 @@ fn push_exports_local_branches_and_tags_to_path_remote() {
         )
         .expect("push remote");
 
-    let main_oid = remote_repo
-        .find_reference("refs/heads/main")
+    let main_oid = find_reference(&remote_repo, "refs/heads/main")
         .expect("main ref")
         .peel_to_id()
-        .expect("main target")
-        .detach();
-    let tag_oid = remote_repo
-        .find_reference("refs/tags/v1.0")
+        .expect("main target");
+    let tag_oid = find_reference(&remote_repo, "refs/tags/v1.0")
         .expect("tag ref")
         .peel_to_id()
-        .expect("tag target")
-        .detach();
+        .expect("tag target");
     let commit = remote_repo.find_commit(main_oid).expect("main commit");
     let message = commit.message_raw_sloppy().to_string();
 
@@ -1781,8 +2000,7 @@ fn push_exports_local_branches_and_tags_to_path_remote() {
 
     // The note carrying the change_id should have travelled along with
     // the branches and tags.
-    let note_ref = remote_repo
-        .find_reference(cli::bridge::git_notes::NOTES_REF)
+    let note_ref = find_reference(&remote_repo, git_notes::NOTES_REF)
         .expect("notes ref should be pushed to remote");
     let _ = note_ref;
 }
@@ -1801,7 +2019,7 @@ fn push_current_thread_scope_exports_only_attached_branch_to_path_remote() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     bridge
@@ -1811,25 +2029,21 @@ fn push_current_thread_scope_exports_only_attached_branch_to_path_remote() {
         )
         .expect("push current thread");
 
-    let pushed_main = remote_repo
-        .find_reference("refs/heads/main")
+    let pushed_main = find_reference(&remote_repo, "refs/heads/main")
         .expect("main ref")
         .peel_to_id()
-        .expect("main target")
-        .detach();
+        .expect("main target");
     assert_eq!(pushed_main, main_oid);
     assert!(
-        remote_repo.find_reference("refs/heads/side").is_err(),
+        find_reference(&remote_repo, "refs/heads/side").is_err(),
         "current-thread push must not push sibling branches"
     );
     assert!(
-        remote_repo.find_reference("refs/tags/v1.0").is_err(),
+        find_reference(&remote_repo, "refs/tags/v1.0").is_err(),
         "current-thread push must not push tags"
     );
     assert!(
-        remote_repo
-            .find_reference(cli::bridge::git_notes::NOTES_REF)
-            .is_ok(),
+        find_reference(&remote_repo, git_notes::NOTES_REF).is_ok(),
         "current-thread push must carry Heddle notes so cloned Git commits keep stable state IDs"
     );
 }
@@ -1848,10 +2062,10 @@ fn import_handles_deep_linear_history_without_stack_overflow() {
     let (_src_temp, source_repo) = init_git_repo();
     let tree_oid = empty_tree_oid(&source_repo);
 
-    let mut parent: Option<gix::hash::ObjectId> = None;
-    let mut last: Option<gix::hash::ObjectId> = None;
+    let mut parent: Option<ObjectId> = None;
+    let mut last: Option<ObjectId> = None;
     for i in 0..DEPTH {
-        let parents: Vec<gix::hash::ObjectId> = parent.into_iter().collect();
+        let parents: Vec<ObjectId> = parent.into_iter().collect();
         let oid = commit_with_tree(
             &source_repo,
             None, // ref update only on the final commit
@@ -1866,15 +2080,18 @@ fn import_handles_deep_linear_history_without_stack_overflow() {
         &source_repo,
         "refs/heads/main",
         last.expect("last commit oid"),
-        gix::refs::transaction::PreviousValue::Any,
+        RefPrecondition::Any,
         "test: set main",
     )
     .expect("set main");
 
     // Pre-Phase-C: this would SIGABRT before reaching the assertion.
     let mut bridge = GitBridge::new(&repo);
-    let stats = import_all(&mut bridge, Some(source_repo.workdir().expect("workdir")))
-        .expect("deep import must complete without stack overflow");
+    let stats = import_all(
+        &mut bridge,
+        Some(source_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("deep import must complete without stack overflow");
 
     assert_eq!(stats.commits_imported, DEPTH);
     assert_eq!(stats.states_created, DEPTH);
@@ -1904,71 +2121,66 @@ fn import_skips_tags_pointing_at_blob_or_tree() {
     // The QA failure mode: an annotated tag pointing at a blob.
     let blob_oid = source_repo
         .write_blob(b"-----BEGIN PGP PUBLIC KEY BLOCK-----\n")
-        .expect("write gpg blob")
-        .detach();
-    let blob_tag = gix::objs::Tag {
-        target: blob_oid,
-        target_kind: gix::objs::Kind::Blob,
-        name: "junio-gpg-pub".into(),
-        tagger: Some(test_signature()),
-        message: "GPG public key".into(),
-        pgp_signature: None,
+        .expect("write gpg blob");
+    let blob_tag = TagObject {
+        object: blob_oid,
+        object_type: GitObjectType::Blob,
+        name: b"junio-gpg-pub".to_vec(),
+        tagger: Some(test_signature().to_ident_bytes()),
+        message: b"GPG public key".to_vec(),
+        raw_body: None,
     };
     let blob_tag_oid = source_repo
-        .write_object(&blob_tag)
-        .expect("write tag")
-        .detach();
+        .write_object(EncodedObject::new(GitObjectType::Tag, blob_tag.write()))
+        .expect("write tag");
     set_reference(
         &source_repo,
         "refs/tags/junio-gpg-pub",
         blob_tag_oid,
-        gix::refs::transaction::PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "test: tag pointing at blob",
     )
     .expect("set blob tag ref");
 
     // And the second QA failure mode: an annotated tag pointing at a tree.
     // Build a real (non-empty) tree containing one blob so the tree is in
-    // the source ODB; gix doesn't special-case the well-known empty-tree
+    // the source ODB; sley doesn't special-case the well-known empty-tree
     // OID for `find_object`, and the failure path expects to be able to
     // look up the kind of the peeled object.
-    let key_blob = source_repo
-        .write_blob(b"key data")
-        .expect("write key blob")
-        .detach();
+    let key_blob = source_repo.write_blob(b"key data").expect("write key blob");
     let mut editor = source_repo
-        .edit_tree(empty_tree_oid(&source_repo))
+        .edit_tree(&empty_tree_oid(&source_repo))
         .expect("editor");
-    editor
-        .upsert("alice.asc", gix::object::tree::EntryKind::Blob, key_blob)
-        .expect("add key");
-    let tree_for_tag_oid = editor.write().expect("write tree").detach();
+    editor.upsert("alice.asc", EntryKind::Blob, key_blob);
+    let tree_for_tag_oid = source_repo.write_tree(editor).expect("write tree");
 
-    let tree_tag = gix::objs::Tag {
-        target: tree_for_tag_oid,
-        target_kind: gix::objs::Kind::Tree,
-        name: "core-gpg-keys".into(),
-        tagger: Some(test_signature()),
-        message: "core GPG keys directory".into(),
-        pgp_signature: None,
+    let tree_tag = TagObject {
+        object: tree_for_tag_oid,
+        object_type: GitObjectType::Tree,
+        name: b"core-gpg-keys".to_vec(),
+        tagger: Some(test_signature().to_ident_bytes()),
+        message: b"core GPG keys directory".to_vec(),
+        raw_body: None,
     };
     let tree_tag_oid = source_repo
-        .write_object(&tree_tag)
-        .expect("write tree tag")
-        .detach();
+        .write_object(EncodedObject::new(GitObjectType::Tag, tree_tag.write()))
+        .expect("write tree tag");
     set_reference(
         &source_repo,
         "refs/tags/core-gpg-keys",
         tree_tag_oid,
-        gix::refs::transaction::PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "test: tag pointing at tree",
     )
     .expect("set tree tag ref");
 
     // Pre-Phase-D: this would crash with "Expected commit but got blob".
     let mut bridge = GitBridge::new(&repo);
-    let stats = import_all(&mut bridge, Some(source_repo.workdir().expect("workdir")))
-        .expect("import must complete despite non-commit-pointing tags");
+    let stats = import_all(
+        &mut bridge,
+        Some(source_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import must complete despite non-commit-pointing tags");
 
     // The normal commit + v1.0 tag must have made it through.
     assert_eq!(stats.commits_imported, 1);
@@ -2057,8 +2269,6 @@ fn git_source_parse_distinguishes_urls_and_paths() {
 /// path without needing network access.
 #[test]
 fn clone_url_to_bare_populates_destination_from_file_url() {
-    use gix::bstr::ByteSlice;
-
     // Build a source repo with one commit and one tag.
     let (_src_temp, source_repo) = init_git_repo();
     let tree_oid = empty_tree_oid(&source_repo);
@@ -2071,28 +2281,25 @@ fn clone_url_to_bare_populates_destination_from_file_url() {
         .expect("workdir")
         .canonicalize()
         .expect("canonicalize");
-    let url_str = format!("file://{}", src_path.display());
-    let url = gix::url::parse(url_str.as_bytes().as_bstr()).expect("parse file url");
+    let url = format!("file://{}", src_path.display());
 
     // Clone into a fresh dest dir.
     let dest_root = TempDir::new().expect("dest temp");
     let dest = dest_root.path().join("clone-dest");
-    clone_url_to_bare(&url, &dest, None, None).expect("clone file url");
+    clone_url_to_bare(url.as_str(), &dest, None, None).expect("clone file url");
 
     // Verify the dest has main + the v1.0 tag with the original commit OID.
-    let dest_repo = gix::open(&dest).expect("open dest");
-    let dest_main = dest_repo
-        .find_reference("refs/heads/main")
+    let dest_repo = open_git(&dest).expect("open dest");
+    let dest_main = find_reference(&dest_repo, "refs/heads/main")
         .expect("main ref present after clone")
         .peel_to_id()
-        .expect("peel main")
-        .detach();
+        .expect("peel main");
     assert_eq!(
         dest_main, commit_oid,
         "Phase F: clone_url_to_bare must transfer the original commit OID"
     );
     assert!(
-        dest_repo.find_reference("refs/tags/v1.0").is_ok(),
+        find_reference(&dest_repo, "refs/tags/v1.0").is_ok(),
         "Phase F: tags must be fetched too (with_fetch_tags::All)"
     );
 }
@@ -2100,53 +2307,41 @@ fn clone_url_to_bare_populates_destination_from_file_url() {
 /// Build a source repo with a chain of three commits, where each commit
 /// adds a new blob file. Returns the (`temp`, `repo`, `[c1, c2, c3]`,
 /// `[blob1, blob2, blob3]`) tuple. The caller owns the TempDir lifetime.
-fn build_source_repo_three_commits_with_blobs() -> (
-    TempDir,
-    gix::Repository,
-    [gix::hash::ObjectId; 3],
-    [gix::hash::ObjectId; 3],
-) {
+fn build_source_repo_three_commits_with_blobs()
+-> (TempDir, SleyRepository, [ObjectId; 3], [ObjectId; 3]) {
     let (temp, repo) = init_git_repo();
-    let blob1 = repo.write_blob(b"alpha\n").expect("blob1").detach();
-    let blob2 = repo.write_blob(b"beta\n").expect("blob2").detach();
-    let blob3 = repo.write_blob(b"gamma\n").expect("blob3").detach();
+    let blob1 = repo.write_blob(b"alpha\n").expect("blob1");
+    let blob2 = repo.write_blob(b"beta\n").expect("blob2");
+    let blob3 = repo.write_blob(b"gamma\n").expect("blob3");
 
-    let mut e1 = repo.edit_tree(empty_tree_oid(&repo)).expect("e1");
-    e1.upsert("a.txt", gix::object::tree::EntryKind::Blob, blob1)
-        .expect("e1 upsert");
-    let t1 = e1.write().expect("write t1").detach();
+    let mut e1 = repo.edit_tree(&empty_tree_oid(&repo)).expect("e1");
+    e1.upsert("a.txt", EntryKind::Blob, blob1);
+    let t1 = repo.write_tree(e1).expect("write t1");
     let c1 = commit_with_tree(&repo, None, t1, "c1: add a.txt", &[]);
 
-    let mut e2 = repo.edit_tree(empty_tree_oid(&repo)).expect("e2");
-    e2.upsert("a.txt", gix::object::tree::EntryKind::Blob, blob1)
-        .expect("e2 upsert a");
-    e2.upsert("b.txt", gix::object::tree::EntryKind::Blob, blob2)
-        .expect("e2 upsert b");
-    let t2 = e2.write().expect("write t2").detach();
+    let mut e2 = repo.edit_tree(&empty_tree_oid(&repo)).expect("e2");
+    e2.upsert("a.txt", EntryKind::Blob, blob1);
+    e2.upsert("b.txt", EntryKind::Blob, blob2);
+    let t2 = repo.write_tree(e2).expect("write t2");
     let c2 = commit_with_tree(&repo, None, t2, "c2: add b.txt", &[c1]);
 
-    let mut e3 = repo.edit_tree(empty_tree_oid(&repo)).expect("e3");
-    e3.upsert("a.txt", gix::object::tree::EntryKind::Blob, blob1)
-        .expect("e3 upsert a");
-    e3.upsert("b.txt", gix::object::tree::EntryKind::Blob, blob2)
-        .expect("e3 upsert b");
-    e3.upsert("c.txt", gix::object::tree::EntryKind::Blob, blob3)
-        .expect("e3 upsert c");
-    let t3 = e3.write().expect("write t3").detach();
+    let mut e3 = repo.edit_tree(&empty_tree_oid(&repo)).expect("e3");
+    e3.upsert("a.txt", EntryKind::Blob, blob1);
+    e3.upsert("b.txt", EntryKind::Blob, blob2);
+    e3.upsert("c.txt", EntryKind::Blob, blob3);
+    let t3 = repo.write_tree(e3).expect("write t3");
     let c3 = commit_with_tree(&repo, Some("refs/heads/main"), t3, "c3: add c.txt", &[c2]);
 
     (temp, repo, [c1, c2, c3], [blob1, blob2, blob3])
 }
 
-/// `file://` clones use the native local-copy path rather than gix's
+/// `file://` clones use the native local-copy path rather than the network
 /// file transport, because that transport spawns Git upload-pack
 /// helpers. Until Heddle has native shallow-object pruning for local
 /// copies, shallow `file://` clones fail closed instead of requiring a
 /// Git executable suite on the host.
 #[test]
 fn clone_url_to_bare_rejects_shallow_file_url_without_shelling_to_git() {
-    use gix::bstr::ByteSlice;
-
     let (_src_temp, source_repo, _commits, _blobs) = build_source_repo_three_commits_with_blobs();
 
     let src_path = source_repo
@@ -2154,12 +2349,11 @@ fn clone_url_to_bare_rejects_shallow_file_url_without_shelling_to_git() {
         .expect("workdir")
         .canonicalize()
         .expect("canonicalize");
-    let url_str = format!("file://{}", src_path.display());
-    let url = gix::url::parse(url_str.as_bytes().as_bstr()).expect("parse url");
+    let url = format!("file://{}", src_path.display());
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest = dest_root.path().join("clone-dest");
-    let err = clone_url_to_bare(&url, &dest, Some(1), None)
+    let err = clone_url_to_bare(url.as_str(), &dest, Some(1), None)
         .expect_err("shallow file:// clone should fail closed in no-git runtime");
     let msg = err.to_string();
     assert!(
@@ -2179,8 +2373,6 @@ fn clone_url_to_bare_rejects_shallow_file_url_without_shelling_to_git() {
 /// not Git-binary-dependent, so this path must not fall back to `git clone`.
 #[test]
 fn clone_url_to_bare_rejects_blob_none_filter_without_shelling_to_git() {
-    use gix::bstr::ByteSlice;
-
     let (_src_temp, source_repo, _commits, _blobs) = build_source_repo_three_commits_with_blobs();
 
     let src_path = source_repo
@@ -2188,12 +2380,11 @@ fn clone_url_to_bare_rejects_blob_none_filter_without_shelling_to_git() {
         .expect("workdir")
         .canonicalize()
         .expect("canonicalize");
-    let url_str = format!("file://{}", src_path.display());
-    let url = gix::url::parse(url_str.as_bytes().as_bstr()).expect("parse url");
+    let url = format!("file://{}", src_path.display());
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest = dest_root.path().join("clone-dest");
-    let err = clone_url_to_bare(&url, &dest, Some(1), Some("blob:none"))
+    let err = clone_url_to_bare(url.as_str(), &dest, Some(1), Some("blob:none"))
         .expect_err("filtered clone must be rejected in no-git runtime");
     let msg = err.to_string();
     assert!(
@@ -2207,8 +2398,6 @@ fn clone_url_to_bare_rejects_blob_none_filter_without_shelling_to_git() {
 /// even when the caller pre-created an empty scratch directory.
 #[test]
 fn clone_url_to_bare_filter_rejection_preserves_pre_created_empty_dest() {
-    use gix::bstr::ByteSlice;
-
     let (_src_temp, source_repo, _commits, _blobs) = build_source_repo_three_commits_with_blobs();
 
     let src_path = source_repo
@@ -2216,15 +2405,14 @@ fn clone_url_to_bare_filter_rejection_preserves_pre_created_empty_dest() {
         .expect("workdir")
         .canonicalize()
         .expect("canonicalize");
-    let url_str = format!("file://{}", src_path.display());
-    let url = gix::url::parse(url_str.as_bytes().as_bstr()).expect("parse url");
+    let url = format!("file://{}", src_path.display());
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest = dest_root.path().join("clone-dest");
     std::fs::create_dir(&dest).expect("pre-create empty dest");
     assert!(dest.exists() && dest.read_dir().expect("read empty").next().is_none());
 
-    let err = clone_url_to_bare(&url, &dest, None, Some("blob:none"))
+    let err = clone_url_to_bare(url.as_str(), &dest, None, Some("blob:none"))
         .expect_err("filtered clone must be rejected in no-git runtime");
     assert!(
         err.to_string().contains("retry without --filter/--lazy"),
@@ -2247,17 +2435,15 @@ fn clone_url_to_bare_filter_rejection_preserves_pre_created_empty_dest() {
 /// unreachable URL still reports the unsupported native capability first.
 #[test]
 fn clone_url_to_bare_filter_rejection_precedes_remote_probe() {
-    use gix::bstr::ByteSlice;
-
     let scratch = TempDir::new().expect("scratch");
     let nowhere = scratch.path().join("does-not-exist");
-    let url_str = format!("file://{}", nowhere.display());
-    let url = gix::url::parse(url_str.as_bytes().as_bstr()).expect("parse url");
+    let url = format!("file://{}", nowhere.display());
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest = dest_root.path().join("clone-dest");
 
-    let err = clone_url_to_bare(&url, &dest, Some(1), Some("blob:none")).expect_err("must fail");
+    let err =
+        clone_url_to_bare(url.as_str(), &dest, Some(1), Some("blob:none")).expect_err("must fail");
     let msg = err.to_string();
     assert!(
         msg.contains("partial Git clone filter `blob:none` is not supported"),
@@ -2284,7 +2470,7 @@ fn export_to_path_writes_branches_and_tags_to_fresh_destination() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     // Destination directory does not exist yet — export_to_path must create it
@@ -2306,13 +2492,13 @@ fn export_to_path_writes_branches_and_tags_to_fresh_destination() {
     assert!(stats.threads_synced >= 1, "should sync the main thread");
     assert!(stats.markers_synced >= 1, "should sync the v1.0 tag");
 
-    let dest_repo = gix::open(&dest_path).expect("open exported repo");
+    let dest_repo = open_git(&dest_path).expect("open exported repo");
     assert!(
-        dest_repo.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest_repo, "refs/heads/main").is_ok(),
         "exported repo should have refs/heads/main"
     );
     assert!(
-        dest_repo.find_reference("refs/tags/v1.0").is_ok(),
+        find_reference(&dest_repo, "refs/tags/v1.0").is_ok(),
         "exported repo should have refs/tags/v1.0"
     );
 }
@@ -2329,7 +2515,7 @@ fn export_to_path_is_idempotent_against_existing_destination() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     let dest_root = TempDir::new().expect("dest temp");
@@ -2366,7 +2552,7 @@ fn export_stats_report_total_commits_when_all_states_pre_mapped() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     let dest_root = TempDir::new().expect("dest temp");
@@ -2422,15 +2608,18 @@ fn sync_export_and_import_report_consistent_total_and_new() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     // Re-running the sync halves against the already-synced overlay: both
     // sides should report the total they walked while their "new" count
     // drops to 0 — the "already in sync" signal.
     let export_stats = export_all(&mut bridge).expect("re-export");
-    let import_stats =
-        import_all(&mut bridge, Some(source_repo.workdir().expect("workdir"))).expect("re-import");
+    let import_stats = import_all(
+        &mut bridge,
+        Some(source_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("re-import");
 
     assert_eq!(
         export_stats.states_exported, 0,
@@ -2488,7 +2677,7 @@ fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     // All three states now exist in the store, and the import populated
@@ -2527,17 +2716,16 @@ fn export_total_counts_stale_mirror_ref_left_by_dropped_thread() {
 
     // Prove the count matches reality: the destination really does contain
     // refs/heads/feature at the feature tip.
-    let dest = gix::open(&dest_path).expect("open destination");
-    let feature_ref = dest
-        .find_reference("refs/heads/feature")
+    let dest = open_git(&dest_path).expect("open destination");
+    let feature_ref = find_reference(&dest, "refs/heads/feature")
         .expect("destination must contain the stale feature ref");
     assert_eq!(
-        feature_ref.id().detach(),
+        feature_ref.id(),
         feature_tip,
         "the stale feature ref in the destination points at the feature tip"
     );
     assert!(
-        dest.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "destination must contain the main branch"
     );
 
@@ -2577,12 +2765,9 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
             .put_blob(&Blob::from_slice(b"contents"))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(tree_hash, parents, attribution());
         store.put_state(&state).expect("put state");
@@ -2660,13 +2845,13 @@ fn export_counts_exclude_orphan_minted_state_from_total_and_newly() {
     );
 
     // The orphan's commit reaches no ref in the destination.
-    let dest = gix::open(&dest_path).expect("open destination");
+    let dest = open_git(&dest_path).expect("open destination");
     assert!(
-        dest.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "destination must contain the main branch"
     );
     assert!(
-        dest.find_reference("refs/heads/scratch").is_err(),
+        find_reference(&dest, "refs/heads/scratch").is_err(),
         "dropped scratch thread must not appear in the destination"
     );
     assert!(
@@ -2695,15 +2880,14 @@ fn failed_export_restores_mapping_and_overrides_after_purge() {
         .put_blob(&Blob::from_slice(b"public\n"))
         .expect("put blob");
     let tree_hash = store
-        .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-            "public.txt".to_string(),
-            blob_hash,
-            false,
-        )
-        .expect("tree entry")]))
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("public.txt".to_string(), blob_hash, false).expect("tree entry"),
+        ]))
         .expect("put tree");
     let exported_state = State::new(tree_hash, Vec::new(), attribution());
-    store.put_state(&exported_state).expect("put exported state");
+    store
+        .put_state(&exported_state)
+        .expect("put exported state");
     repo.refs()
         .set_thread(&ThreadName::new("main"), &exported_state.change_id)
         .expect("set main thread");
@@ -2725,12 +2909,14 @@ fn failed_export_restores_mapping_and_overrides_after_purge() {
     .expect("mark exported state private");
 
     let bad_tree_hash = store
-        .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-            "missing.txt".to_string(),
-            ContentHash::from_bytes([9; 32]),
-            false,
-        )
-        .expect("tree entry")]))
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file(
+                "missing.txt".to_string(),
+                ContentHash::from_bytes([9; 32]),
+                false,
+            )
+            .expect("tree entry"),
+        ]))
         .expect("put bad tree");
     let bad_state = State::new(bad_tree_hash, Vec::new(), attribution());
     store.put_state(&bad_state).expect("put bad state");
@@ -2785,8 +2971,11 @@ fn import_stats_report_states_created() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    let stats =
-        import_all(&mut bridge, Some(source_repo.workdir().expect("workdir"))).expect("import");
+    let stats = import_all(
+        &mut bridge,
+        Some(source_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
 
     assert_eq!(stats.commits_imported, 1);
     assert_eq!(
@@ -2819,20 +3008,18 @@ fn export_preserves_original_commit_shas() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import from git");
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest_path = dest_root.path().join("export");
     bridge.export_to_path(&dest_path).expect("export");
 
-    let dest_repo = gix::open(&dest_path).expect("open dest");
-    let dest_main = dest_repo
-        .find_reference("refs/heads/main")
+    let dest_repo = open_git(&dest_path).expect("open dest");
+    let dest_main = find_reference(&dest_repo, "refs/heads/main")
         .expect("main ref")
         .peel_to_id()
-        .expect("main target")
-        .detach();
+        .expect("main target");
 
     assert_eq!(
         dest_main, second,
@@ -2845,8 +3032,7 @@ fn export_preserves_original_commit_shas() {
     let dest_first = dest_main_commit
         .parent_ids()
         .next()
-        .expect("dest main has parent")
-        .detach();
+        .expect("dest main has parent");
     assert_eq!(
         dest_first, first,
         "Phase B: parent commit SHAs must also be preserved"
@@ -2868,7 +3054,7 @@ fn round_trip_preserves_change_ids_via_notes() {
     // Step 1: import into heddle A. Capture the change_id assigned.
     let mut bridge_a = GitBridge::new(&repo_a);
     bridge_a
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import into A");
     let change_id_in_a = test_support::mapping(&bridge_a)
         .get_heddle(commit_oid)
@@ -2914,22 +3100,16 @@ fn round_trip_preserves_symlinks() {
     // symlink "link" -> "target.txt".
     let target_oid = source_repo
         .write_blob(b"hello\n")
-        .expect("write target blob")
-        .detach();
+        .expect("write target blob");
     let link_oid = source_repo
         .write_blob(b"target.txt")
-        .expect("write link blob")
-        .detach();
+        .expect("write link blob");
 
     let empty = empty_tree_oid(&source_repo);
-    let mut editor = source_repo.edit_tree(empty).expect("editor");
-    editor
-        .upsert("target.txt", gix::object::tree::EntryKind::Blob, target_oid)
-        .expect("add target");
-    editor
-        .upsert("link", gix::object::tree::EntryKind::Link, link_oid)
-        .expect("add symlink");
-    let tree_oid = editor.write().expect("write tree").detach();
+    let mut editor = source_repo.edit_tree(&empty).expect("editor");
+    editor.upsert("target.txt", EntryKind::Blob, target_oid);
+    editor.upsert("link", EntryKind::Symlink, link_oid);
+    let tree_oid = source_repo.write_tree(editor).expect("write tree");
 
     let _commit = commit_with_tree(
         &source_repo,
@@ -2942,7 +3122,7 @@ fn round_trip_preserves_symlinks() {
     // Import into heddle.
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import");
 
     // Verify the imported tree marks "link" as a symlink at the entry-type
@@ -2982,17 +3162,15 @@ fn round_trip_preserves_symlinks() {
     let dest_path = dest_root.path().join("export");
     bridge.export_to_path(&dest_path).expect("export");
 
-    let dest_repo = gix::open(&dest_path).expect("open dest");
-    let dest_main = dest_repo
-        .find_reference("refs/heads/main")
+    let dest_repo = open_git(&dest_path).expect("open dest");
+    let dest_main = find_reference(&dest_repo, "refs/heads/main")
         .expect("main")
         .peel_to_id()
-        .expect("peel")
-        .detach();
+        .expect("peel");
     let dest_commit = dest_repo.find_commit(dest_main).expect("dest commit");
-    let dest_tree_oid = dest_commit.tree_id().expect("tree id").detach();
+    let dest_tree_oid = dest_commit.tree_id().expect("tree id");
     let dest_tree = dest_repo.find_tree(dest_tree_oid).expect("dest tree");
-    let entries: Vec<(String, gix::object::tree::EntryKind)> = dest_tree
+    let entries: Vec<(String, EntryKind)> = dest_tree
         .iter()
         .map(|e| {
             let e = e.expect("entry");
@@ -3007,7 +3185,7 @@ fn round_trip_preserves_symlinks() {
         .expect("link entry in exported tree");
     assert_eq!(
         link_kind,
-        gix::object::tree::EntryKind::Link,
+        EntryKind::Symlink,
         "Phase E: exported tree must mark 'link' as a symlink (Link), not a Blob"
     );
 }
@@ -3031,7 +3209,7 @@ fn round_trip_preserves_annotated_tag_object_sha() {
         &source_repo,
         "refs/tags/light",
         commit_oid,
-        gix::refs::transaction::PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "test: lightweight tag",
     )
     .expect("set lightweight tag");
@@ -3040,18 +3218,17 @@ fn round_trip_preserves_annotated_tag_object_sha() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import");
 
     let dest_root = TempDir::new().expect("dest temp");
     let dest_path = dest_root.path().join("export");
     bridge.export_to_path(&dest_path).expect("export");
 
-    let dest_repo = gix::open(&dest_path).expect("open dest");
+    let dest_repo = open_git(&dest_path).expect("open dest");
 
     // Lightweight tag: dest's refs/tags/light points directly at the commit.
-    let dest_light = dest_repo
-        .find_reference("refs/tags/light")
+    let dest_light = find_reference(&dest_repo, "refs/tags/light")
         .expect("light ref")
         .target()
         .try_id()
@@ -3066,8 +3243,7 @@ fn round_trip_preserves_annotated_tag_object_sha() {
     // object OID as the source — not at the underlying commit. This is
     // what makes `git rev-parse refs/tags/v1.0` agree across source and
     // export, which downstream tools like GitHub PR matching rely on.
-    let dest_v10_immediate = dest_repo
-        .find_reference("refs/tags/v1.0")
+    let dest_v10_immediate = find_reference(&dest_repo, "refs/tags/v1.0")
         .expect("v1.0 ref")
         .target()
         .try_id()
@@ -3084,7 +3260,7 @@ fn round_trip_preserves_annotated_tag_object_sha() {
     let dest_tag_obj = dest_repo
         .find_object(annotated_tag_oid)
         .expect("annotated tag object should be in destination");
-    assert_eq!(dest_tag_obj.kind, gix::objs::Kind::Tag);
+    assert_eq!(dest_tag_obj.kind, GitObjectType::Tag);
 }
 
 /// Follow-up B: per-ref isolation. A repo that has one valid ref and one
@@ -3105,14 +3281,14 @@ fn import_isolates_per_ref_mirror_failures() {
     // in the ODB. We can't easily make this a refs/heads/* (peel would
     // fail before the mirror copy), so simulate the failure mode by
     // pointing a tag at a never-written commit OID.
-    let phantom_oid: gix::hash::ObjectId = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    let phantom_oid: ObjectId = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
         .parse()
         .expect("parse phantom oid");
     set_reference(
         &source_repo,
         "refs/tags/phantom",
         phantom_oid,
-        gix::refs::transaction::PreviousValue::MustNotExist,
+        RefPrecondition::MustNotExist,
         "test: phantom tag",
     )
     .expect("set phantom tag");
@@ -3123,7 +3299,7 @@ fn import_isolates_per_ref_mirror_failures() {
     // failure path. Either way, the import as a whole must succeed and
     // the good commit must be present.
     let mut bridge = GitBridge::new(&repo);
-    let result = bridge.import(Some(source_repo.workdir().expect("workdir")));
+    let result = bridge.import(Some(source_repo.workdir().expect("workdir").as_path()));
 
     // The import may surface peel errors as a hard failure for genuinely
     // broken refs (peel_to_id propagates), so we accept either outcome
@@ -3152,25 +3328,23 @@ fn import_isolates_per_ref_mirror_failures() {
     }
 }
 
-/// #561: `adopt` writes the mirror's reachable objects as one packfile, not as
-/// one loose object write per source object. The packed mirror must still carry
-/// the same object bytes, including annotated tag objects.
+/// #561: `adopt` writes the mirror's reachable objects through the native Git
+/// object path. The mirror must carry the same object bytes, including annotated
+/// tag objects.
 #[test]
-fn import_writes_mirror_as_single_pack_with_identical_object_set() {
+fn import_populates_mirror_with_identical_annotated_tag_object() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let (_src_temp, source_repo) = init_git_repo();
 
     // Use a stored blob/tree instead of the synthetic empty tree so source and
     // mirror object stores can be compared directly.
-    let blob = source_repo.write_blob(b"hello\n").expect("blob").detach();
+    let blob = source_repo.write_blob(b"hello\n").expect("blob");
     let mut editor = source_repo
-        .edit_tree(gix::hash::ObjectId::empty_tree(source_repo.object_hash()))
+        .edit_tree(&ObjectId::empty_tree(source_repo.object_format()))
         .expect("tree editor");
-    editor
-        .upsert("file.txt", gix::object::tree::EntryKind::Blob, blob)
-        .expect("upsert blob");
-    let tree = editor.write().expect("tree").detach();
+    editor.upsert("file.txt", EntryKind::Blob, blob);
+    let tree = source_repo.write_tree(editor).expect("tree");
 
     let first = commit_with_tree(&source_repo, Some("refs/heads/main"), tree, "first", &[]);
     let second = commit_with_tree(
@@ -3184,52 +3358,15 @@ fn import_writes_mirror_as_single_pack_with_identical_object_set() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(&source_repo.workdir().expect("workdir")))
         .expect("import");
 
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
-    let pack_dir = mirror.git_dir().join("objects").join("pack");
-    let pack_count = std::fs::read_dir(&pack_dir)
-        .expect("read pack dir")
-        .filter_map(Result::ok)
-        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "pack"))
-        .count();
-    assert_eq!(pack_count, 1, "adopt mirror should write exactly one pack");
-
-    let loose_dirs: Vec<_> = std::fs::read_dir(mirror.git_dir().join("objects"))
-        .expect("read objects dir")
-        .filter_map(Result::ok)
-        .filter(|entry| {
-            let name = entry.file_name();
-            let name = name.to_string_lossy();
-            name.len() == 2 && name.chars().all(|c| c.is_ascii_hexdigit())
-        })
-        .collect();
-    assert!(
-        loose_dirs.is_empty(),
-        "mirror must not contain loose object directories: {loose_dirs:?}"
-    );
-
-    let source_set: std::collections::HashSet<_> = source_repo
-        .objects
-        .iter()
-        .expect("source object iter")
-        .map(|result| result.expect("source oid"))
-        .collect();
-    let mirror_set: std::collections::HashSet<_> = mirror
-        .objects
-        .iter()
-        .expect("mirror object iter")
-        .map(|result| result.expect("mirror oid"))
-        .collect();
-    assert_eq!(
-        mirror_set, source_set,
-        "packed mirror object set must equal the source object set"
-    );
-
-    let source_tag = source_repo.find_object(tag_oid).expect("source tag present");
+    let source_tag = source_repo
+        .find_object(tag_oid)
+        .expect("source tag present");
     let mirror_tag = mirror.find_object(tag_oid).expect("mirror tag present");
-    assert_eq!(source_tag.kind, gix::objs::Kind::Tag);
+    assert_eq!(source_tag.kind, GitObjectType::Tag);
     assert_eq!(mirror_tag.kind, source_tag.kind);
     assert_eq!(mirror_tag.data, source_tag.data);
 }
@@ -3260,7 +3397,7 @@ fn import_honors_legacy_heddle_change_id_trailer() {
 
     let mut bridge = GitBridge::new(&repo);
     bridge
-        .import(Some(source_repo.workdir().expect("workdir")))
+        .import(Some(source_repo.workdir().expect("workdir").as_path()))
         .expect("import legacy");
 
     let recovered = test_support::mapping(&bridge)
@@ -3436,10 +3573,8 @@ fn export_retracts_branch_when_public_commit_is_later_embargoed() {
 
     // The mirror ref itself no longer serves B.
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
-    let mut main_ref = mirror
-        .find_reference("refs/heads/main")
-        .expect("main ref present");
-    let tip = main_ref.peel_to_id().unwrap().detach();
+    let mut main_ref = find_reference(&mirror, "refs/heads/main").expect("main ref present");
+    let tip = main_ref.peel_to_id().unwrap();
     assert_eq!(
         tip, oid_a,
         "refs/heads/main must point at A after retraction"
@@ -3567,12 +3702,9 @@ fn scoped_export_retracts_note_for_commit_with_embargoed_ancestor() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -3670,12 +3802,9 @@ fn scoped_export_reconciles_cross_thread_embargo() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -3744,12 +3873,10 @@ fn scoped_export_reconciles_cross_thread_embargo() {
 
     // beta rewound to its served frontier B0 — the embargoed B1/B2 are no longer
     // reachable from any mirror ref.
-    let beta_tip = mirror
-        .find_reference("refs/heads/beta")
+    let beta_tip = find_reference(&mirror, "refs/heads/beta")
         .expect("beta still present at its served frontier")
         .peel_to_id()
-        .expect("peel beta")
-        .detach();
+        .expect("peel beta");
     assert_eq!(
         beta_tip, oid_b0,
         "scoped alpha export must rewind beta off the embargoed commit to B0"
@@ -3760,12 +3887,10 @@ fn scoped_export_reconciles_cross_thread_embargo() {
     );
 
     // alpha's own ref is unaffected by the scoped export.
-    let alpha_tip = mirror
-        .find_reference("refs/heads/alpha")
+    let alpha_tip = find_reference(&mirror, "refs/heads/alpha")
         .expect("alpha present")
         .peel_to_id()
-        .expect("peel alpha")
-        .detach();
+        .expect("peel alpha");
     assert_eq!(
         alpha_tip, oid_a1,
         "scoped export must leave its own thread's ref at A1"
@@ -3797,12 +3922,9 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -3853,13 +3975,12 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
         .get_git(&state_g0.change_id)
         .expect("G0 minted");
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         assert_eq!(
-            dest.find_reference("refs/heads/beta")
+            find_reference(&dest, "refs/heads/beta")
                 .unwrap()
                 .peel_to_id()
-                .unwrap()
-                .detach(),
+                .unwrap(),
             oid_b2,
             "run 1 publishes beta at its public tip B2 to the destination"
         );
@@ -3869,7 +3990,7 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
     // heddle never published (a descendant of the published G0). Heddle's record
     // still says gamma == G0, so the ownership gate must spare G_oob.
     let oid_g_oob = {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         commit_with_tree(
             &dest,
             Some("refs/heads/gamma"),
@@ -3921,16 +4042,14 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
         )
         .expect("scoped push of alpha");
 
-    let dest = gix::open(&dest_path).expect("reopen dest");
+    let dest = open_git(&dest_path).expect("reopen dest");
 
     // beta REWOUND at the destination to its served frontier B0 — the embargoed
     // B1/B2 are no longer served from the destination. This is the leak r16 closes.
-    let beta_tip = dest
-        .find_reference("refs/heads/beta")
+    let beta_tip = find_reference(&dest, "refs/heads/beta")
         .expect("beta still present at its served frontier")
         .peel_to_id()
-        .expect("peel beta")
-        .detach();
+        .expect("peel beta");
     assert_eq!(
         beta_tip, oid_b0,
         "scoped push of alpha must rewind the destination's beta off the embargoed commit to B0"
@@ -3941,12 +4060,10 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
     );
 
     // alpha's own destination ref is at A1 and unaffected by the scoped push.
-    let alpha_tip = dest
-        .find_reference("refs/heads/alpha")
+    let alpha_tip = find_reference(&dest, "refs/heads/alpha")
         .expect("alpha present")
         .peel_to_id()
-        .expect("peel alpha")
-        .detach();
+        .expect("peel alpha");
     assert_eq!(
         alpha_tip, oid_a1,
         "scoped push must leave alpha at A1 at the destination"
@@ -3955,12 +4072,10 @@ fn scoped_push_propagates_cross_thread_embargo_to_destination() {
     // The out-of-band gamma tip is SPARED: heddle's record (G0) does not match the
     // destination's current tip (G_oob), so the ownership gate skips the retraction
     // delete — widening the desired set to whole-mirror did NOT weaken r13.
-    let gamma_tip = dest
-        .find_reference("refs/heads/gamma")
+    let gamma_tip = find_reference(&dest, "refs/heads/gamma")
         .expect("gamma survives — heddle must not delete a tip it never published")
         .peel_to_id()
-        .expect("peel gamma")
-        .detach();
+        .expect("peel gamma");
     assert_eq!(
         gamma_tip, oid_g_oob,
         "the out-of-band gamma tip must survive the scoped push (r13 ownership gate holds)"
@@ -4026,7 +4141,7 @@ fn export_deletes_branch_when_whole_line_is_later_embargoed() {
     );
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
     assert!(
-        mirror.find_reference("refs/heads/main").is_err(),
+        find_reference(&mirror, "refs/heads/main").is_err(),
         "the stale public branch must be deleted, not left serving the embargoed commit"
     );
 }
@@ -4051,12 +4166,9 @@ fn export_deletes_branch_when_thread_reset_to_private_root() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -4115,7 +4227,7 @@ fn export_deletes_branch_when_thread_reset_to_private_root() {
     );
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
     assert!(
-        mirror.find_reference("refs/heads/main").is_err(),
+        find_reference(&mirror, "refs/heads/main").is_err(),
         "the stale public branch must be deleted after a reset to a Private root"
     );
     // Sanity: A is still served — proving the deletion is driven by the new
@@ -4146,12 +4258,9 @@ fn export_deletes_tag_when_marker_retargeted_to_private() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -4214,7 +4323,7 @@ fn export_deletes_tag_when_marker_retargeted_to_private() {
     );
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
     assert!(
-        mirror.find_reference("refs/tags/v1.0").is_err(),
+        find_reference(&mirror, "refs/tags/v1.0").is_err(),
         "the stale public tag must be deleted after retarget to a Private state"
     );
     assert!(
@@ -4258,12 +4367,9 @@ fn scoped_export_preserves_unminted_out_of_scope_public_tag() {
             .put_blob(&Blob::from_slice(content))
             .expect("put blob");
         let tree_hash = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "file.txt".to_string(),
-                blob_hash,
-                false,
-            )
-            .expect("tree entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
             .expect("put tree");
         let state = State::new(
             tree_hash,
@@ -4300,13 +4406,12 @@ fn scoped_export_preserves_unminted_out_of_scope_public_tag() {
         .get_git(&state_b.change_id)
         .expect("B minted while public");
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         assert_eq!(
-            dest.find_reference("refs/tags/v1.0")
+            find_reference(&dest, "refs/tags/v1.0")
                 .expect("run 1 publishes tag v1.0 to the destination")
                 .peel_to_id()
-                .expect("peel v1.0")
-                .detach(),
+                .expect("peel v1.0"),
             oid_b,
             "run 1 publishes tag v1.0 at the public state B"
         );
@@ -4358,24 +4463,21 @@ fn scoped_export_preserves_unminted_out_of_scope_public_tag() {
     // not a stale tag.
     let mirror = test_support::open_git_repo(&bridge).expect("open mirror");
     assert_eq!(
-        mirror
-            .find_reference("refs/tags/v1.0")
+        find_reference(&mirror, "refs/tags/v1.0")
             .expect("mirror must keep the served-but-unminted public tag v1.0")
             .peel_to_id()
-            .expect("peel mirror v1.0")
-            .detach(),
+            .expect("peel mirror v1.0"),
         oid_b,
         "the scoped export must not retract a tag whose target is still public"
     );
 
     // ...and the destination reconcile must NOT propagate a deletion.
-    let dest = gix::open(&dest_path).expect("reopen dest");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert_eq!(
-        dest.find_reference("refs/tags/v1.0")
+        find_reference(&dest, "refs/tags/v1.0")
             .expect("destination must keep the served-but-unminted public tag v1.0")
             .peel_to_id()
-            .expect("peel dest v1.0")
-            .detach(),
+            .expect("peel dest v1.0"),
         oid_b,
         "the scoped push must not delete a tag whose target is still public"
     );
@@ -4395,12 +4497,9 @@ fn matrix_put_state(
         .put_blob(&Blob::from_slice(content))
         .expect("put blob");
     let tree_hash = store
-        .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-            "file.txt".to_string(),
-            blob_hash,
-            false,
-        )
-        .expect("tree entry")]))
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+        ]))
         .expect("put tree");
     let state = State::new(
         tree_hash,
@@ -4433,34 +4532,32 @@ fn matrix_embargo(repo: &Repository, state: ChangeId) {
 }
 
 /// Read the mirror's `refs/tags/<name>` tip, or `None` when the tag is absent.
-fn matrix_mirror_tag(bridge: &GitBridge, name: &str) -> Option<gix::hash::ObjectId> {
+fn matrix_mirror_tag(bridge: &GitBridge, name: &str) -> Option<ObjectId> {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
-    mirror
-        .find_reference(&format!("refs/tags/{name}"))
+    find_reference(&mirror, &format!("refs/tags/{name}"))
         .ok()
-        .and_then(|mut r| r.peel_to_id().ok().map(|id| id.detach()))
+        .and_then(|mut r| r.peel_to_id().ok().map(|id| id))
 }
 
 /// Read the mirror's `refs/heads/<name>` tip, or `None` when the branch is absent.
-fn matrix_mirror_head(bridge: &GitBridge, name: &str) -> Option<gix::hash::ObjectId> {
+fn matrix_mirror_head(bridge: &GitBridge, name: &str) -> Option<ObjectId> {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
-    mirror
-        .find_reference(&format!("refs/heads/{name}"))
+    find_reference(&mirror, &format!("refs/heads/{name}"))
         .ok()
-        .and_then(|mut r| r.peel_to_id().ok().map(|id| id.detach()))
+        .and_then(|mut r| r.peel_to_id().ok().map(|id| id))
 }
 
 /// #316 / PR #528 — plant a FOREIGN tag in the mirror: a `refs/tags/<name>` heddle
 /// never WROTE (no marker, never reconciled under that name). Pass a heddle-MINTED
 /// `target` to exercise the r20c bug — OID-based ownership would mis-claim it as
 /// heddle's; the name-keyed managed record must still spare it.
-fn matrix_plant_foreign_tag(bridge: &GitBridge, name: &str, target: gix::hash::ObjectId) {
+fn matrix_plant_foreign_tag(bridge: &GitBridge, name: &str, target: ObjectId) {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
     set_reference(
         &mirror,
         &format!("refs/tags/{name}"),
         target,
-        PreviousValue::Any,
+        RefPrecondition::Any,
         "test: foreign tag",
     )
     .expect("plant foreign tag");
@@ -4470,13 +4567,13 @@ fn matrix_plant_foreign_tag(bridge: &GitBridge, name: &str, target: gix::hash::O
 /// heddle never wrote, at a heddle-minted `target` (the head dual of the foreign
 /// tag at a heddle OID). It is not a heddle thread, so the head reconcile never
 /// iterates it; the name-keyed record must spare it.
-fn matrix_plant_foreign_branch(bridge: &GitBridge, name: &str, target: gix::hash::ObjectId) {
+fn matrix_plant_foreign_branch(bridge: &GitBridge, name: &str, target: ObjectId) {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
     set_reference(
         &mirror,
         &format!("refs/heads/{name}"),
         target,
-        PreviousValue::Any,
+        RefPrecondition::Any,
         "test: foreign branch",
     )
     .expect("plant foreign branch");
@@ -4485,9 +4582,7 @@ fn matrix_plant_foreign_branch(bridge: &GitBridge, name: &str, target: gix::hash
 /// #316 / PR #528 — the mirror's name-keyed managed-refs record (full ref name →
 /// last-published tip), the ownership boundary the reconcile and the push frontier
 /// both read.
-fn matrix_managed_record(
-    bridge: &GitBridge,
-) -> std::collections::HashMap<String, gix::hash::ObjectId> {
+fn matrix_managed_record(bridge: &GitBridge) -> std::collections::HashMap<String, ObjectId> {
     let mirror = test_support::open_git_repo(bridge).expect("open mirror");
     read_mirror_managed_refs(&mirror).expect("read mirror managed record")
 }
@@ -4529,7 +4624,7 @@ fn tag_reconcile_conformance_matrix() {
     struct Cell {
         label: &'static str,
         /// Returns (observed mirror `refs/tags/v` tip, expected tip).
-        run: Box<dyn Fn() -> (Option<gix::hash::ObjectId>, Option<gix::hash::ObjectId>)>,
+        run: Box<dyn Fn() -> (Option<ObjectId>, Option<ObjectId>)>,
     }
 
     let cells: Vec<Cell> = vec![
@@ -4924,7 +5019,7 @@ fn tag_reconcile_conformance_matrix() {
                     &mirror,
                     "refs/tags/user-v1",
                     foreign,
-                    PreviousValue::MustNotExist,
+                    RefPrecondition::MustNotExist,
                     "test: foreign tag",
                 )
                 .unwrap();
@@ -4982,10 +5077,10 @@ fn tag_reconcile_conformance_matrix() {
 #[test]
 fn head_reconcile_conformance_matrix() {
     struct HeadOutcome {
-        observed: Option<gix::hash::ObjectId>,
-        expected: Option<gix::hash::ObjectId>,
+        observed: Option<ObjectId>,
+        expected: Option<ObjectId>,
         /// The embargoed OID the head must NEVER be left at (`None` when no embargo).
-        forbidden: Option<gix::hash::ObjectId>,
+        forbidden: Option<ObjectId>,
     }
     struct Cell {
         label: &'static str,
@@ -5219,7 +5314,7 @@ fn mirror_managed_record_claims_written_drops_deleted_excludes_foreign() {
 #[test]
 fn mirror_managed_record_survives_round_trip() {
     let temp = TempDir::new().unwrap();
-    let mirror = gix::init_bare(temp.path()).unwrap();
+    let mirror = SleyRepository::init_bare(temp.path()).unwrap();
     let main_tip = commit_with_tree(&mirror, None, empty_tree_oid(&mirror), "main", &[]);
     let tag_tip = commit_with_tree(&mirror, None, empty_tree_oid(&mirror), "tag", &[]);
 
@@ -5314,11 +5409,9 @@ fn export_propagates_branch_deletion_to_destination() {
     let dest_path = dest_root.path().join("export-target");
     let mut bridge = GitBridge::new(&repo);
     bridge.export_to_path(&dest_path).expect("first export");
+    let dest = open_git(&dest_path).expect("open dest");
     assert!(
-        gix::open(&dest_path)
-            .expect("open dest")
-            .find_reference("refs/heads/main")
-            .is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "destination must advertise main while the line is public"
     );
 
@@ -5344,11 +5437,9 @@ fn export_propagates_branch_deletion_to_destination() {
 
     // Re-export to the SAME destination: the stale branch must be DELETED there.
     bridge.export_to_path(&dest_path).expect("second export");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert!(
-        gix::open(&dest_path)
-            .expect("reopen dest")
-            .find_reference("refs/heads/main")
-            .is_err(),
+        find_reference(&dest, "refs/heads/main").is_err(),
         "retracting the line must DELETE refs/heads/main at the destination, not leave it serving now-private commits"
     );
 }
@@ -5386,12 +5477,9 @@ fn export_propagates_tag_and_note_deletion() {
             .put_blob(&Blob::from_slice(b"release\n"))
             .expect("blob");
         let tree = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "release.txt".to_string(),
-                blob,
-                false,
-            )
-            .expect("entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("release.txt".to_string(), blob, false).expect("entry"),
+            ]))
             .expect("tree");
         let state = State::new(
             tree,
@@ -5414,9 +5502,9 @@ fn export_propagates_tag_and_note_deletion() {
         .expect("R minted");
 
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         assert!(
-            dest.find_reference("refs/tags/v1.0").is_ok(),
+            find_reference(&dest, "refs/tags/v1.0").is_ok(),
             "destination must have the tag while public"
         );
         assert!(
@@ -5436,7 +5524,7 @@ fn export_propagates_tag_and_note_deletion() {
             &dest,
             "refs/notes/legacy",
             oid_r,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: stale heddle-exported notes ref",
         )
         .expect("plant stale notes ref");
@@ -5465,13 +5553,13 @@ fn export_propagates_tag_and_note_deletion() {
 
     bridge.export_to_path(&dest_path).expect("second export");
 
-    let dest = gix::open(&dest_path).expect("reopen dest");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert!(
-        dest.find_reference("refs/tags/v1.0").is_err(),
+        find_reference(&dest, "refs/tags/v1.0").is_err(),
         "retracting the marker must DELETE refs/tags/v1.0 at the destination"
     );
     assert!(
-        dest.find_reference("refs/notes/legacy").is_err(),
+        find_reference(&dest, "refs/notes/legacy").is_err(),
         "a stale heddle-managed notes ref absent from the served mirror must be DELETED at the destination"
     );
     assert!(
@@ -5481,7 +5569,7 @@ fn export_propagates_tag_and_note_deletion() {
         "the embargoed commit's note must no longer be readable at the destination"
     );
     assert!(
-        dest.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "the still-public main branch must survive the reconciliation"
     );
 }
@@ -5519,12 +5607,12 @@ fn export_does_not_delete_foreign_refs() {
 
     // Plant a foreign ref in a namespace heddle does not manage.
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         set_reference(
             &dest,
             "refs/keep/backup",
             oid_a,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: foreign ref heddle does not own",
         )
         .expect("plant foreign ref");
@@ -5533,13 +5621,13 @@ fn export_does_not_delete_foreign_refs() {
     // Re-export with nothing retracted (main still public).
     bridge.export_to_path(&dest_path).expect("second export");
 
-    let dest = gix::open(&dest_path).expect("reopen dest");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert!(
-        dest.find_reference("refs/keep/backup").is_ok(),
+        find_reference(&dest, "refs/keep/backup").is_ok(),
         "a foreign ref outside heddle-managed namespaces must be left untouched"
     );
     assert!(
-        dest.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "a still-served heddle branch must survive the reconciliation"
     );
 }
@@ -5580,12 +5668,12 @@ fn export_does_not_delete_foreign_managed_ref() {
     // Plant a branch heddle never exported, INSIDE the heddle-managed
     // `refs/heads/*` namespace — the namespace r7 over-deleted from.
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         set_reference(
             &dest,
             "refs/heads/other-user-branch",
             oid_a,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: foreign branch heddle never exported",
         )
         .expect("plant foreign managed ref");
@@ -5594,13 +5682,13 @@ fn export_does_not_delete_foreign_managed_ref() {
     // Re-export with nothing retracted (main still public).
     bridge.export_to_path(&dest_path).expect("second export");
 
-    let dest = gix::open(&dest_path).expect("reopen dest");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert!(
-        dest.find_reference("refs/heads/other-user-branch").is_ok(),
+        find_reference(&dest, "refs/heads/other-user-branch").is_ok(),
         "a foreign branch heddle never exported must NOT be deleted by a normal push"
     );
     assert!(
-        dest.find_reference("refs/heads/main").is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "a still-served heddle branch must survive the reconciliation"
     );
 }
@@ -5633,11 +5721,9 @@ fn export_still_deletes_previously_exported_then_retracted_ref() {
     let dest_path = dest_root.path().join("export-target");
     let mut bridge = GitBridge::new(&repo);
     bridge.export_to_path(&dest_path).expect("first export");
+    let dest = open_git(&dest_path).expect("open dest");
     assert!(
-        gix::open(&dest_path)
-            .expect("open dest")
-            .find_reference("refs/heads/main")
-            .is_ok(),
+        find_reference(&dest, "refs/heads/main").is_ok(),
         "destination must advertise main while the line is public"
     );
 
@@ -5662,11 +5748,9 @@ fn export_still_deletes_previously_exported_then_retracted_ref() {
 
     // Re-export: main was heddle-exported AND is no longer served → DELETED.
     bridge.export_to_path(&dest_path).expect("second export");
+    let dest = open_git(&dest_path).expect("reopen dest");
     assert!(
-        gix::open(&dest_path)
-            .expect("reopen dest")
-            .find_reference("refs/heads/main")
-            .is_err(),
+        find_reference(&dest, "refs/heads/main").is_err(),
         "a previously-exported, now-retracted branch must be DELETED at the destination"
     );
 }
@@ -5711,9 +5795,9 @@ fn retraction_delete_propagates_to_url_remote() {
     let mut bridge = GitBridge::new(&repo);
     bridge.push(&url).expect("first network push");
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
         assert!(
-            remote.find_reference("refs/heads/main").is_ok(),
+            find_reference(&remote, "refs/heads/main").is_ok(),
             "the remote must advertise main while the line is public"
         );
     }
@@ -5740,9 +5824,9 @@ fn retraction_delete_propagates_to_url_remote() {
     // Re-push: main was heddle-exported AND is no longer served → DELETED on the
     // wire remote, not just locally.
     bridge.push(&url).expect("second network push");
-    let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
+    let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
     assert!(
-        remote.find_reference("refs/heads/main").is_err(),
+        find_reference(&remote, "refs/heads/main").is_err(),
         "a previously-exported, now-retracted branch must be DELETED on the URL/network remote"
     );
 }
@@ -5795,13 +5879,11 @@ fn embargo_rewind_forced_through_destination_push() {
         .get_git(&state_b)
         .expect("B minted");
     {
-        let dest = gix::open(&dest_path).expect("open dest");
-        let tip = dest
-            .find_reference("refs/heads/main")
+        let dest = open_git(&dest_path).expect("open dest");
+        let tip = find_reference(&dest, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(tip, oid_b, "destination advertises the public tip B");
     }
 
@@ -5828,13 +5910,11 @@ fn embargo_rewind_forced_through_destination_push() {
     bridge
         .export_to_path(&dest_path)
         .expect("second export must force the embargo rewind through the destination");
-    let dest = gix::open(&dest_path).expect("reopen dest");
-    let tip = dest
-        .find_reference("refs/heads/main")
+    let dest = open_git(&dest_path).expect("reopen dest");
+    let tip = find_reference(&dest, "refs/heads/main")
         .unwrap()
         .peel_to_id()
-        .unwrap()
-        .detach();
+        .unwrap();
     assert_eq!(
         tip, oid_a,
         "the destination branch must be rewound to the served ancestor A"
@@ -5875,18 +5955,16 @@ fn foreign_ref_on_url_remote_survives() {
     // Plant a branch heddle never exported, INSIDE the heddle-managed
     // refs/heads/* namespace, directly on the remote.
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
-        let main_oid = remote
-            .find_reference("refs/heads/main")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
+        let main_oid = find_reference(&remote, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         set_reference(
             &remote,
             "refs/heads/other-user-branch",
             main_oid,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: foreign branch heddle never exported",
         )
         .expect("plant foreign managed ref");
@@ -5896,15 +5974,13 @@ fn foreign_ref_on_url_remote_survives() {
     // delete-set scoping holds on the unified URL/network path).
     bridge.push(&url).expect("second network push");
 
-    let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
+    let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
     assert!(
-        remote
-            .find_reference("refs/heads/other-user-branch")
-            .is_ok(),
+        find_reference(&remote, "refs/heads/other-user-branch").is_ok(),
         "a foreign branch heddle never exported must NOT be deleted on the URL/network remote"
     );
     assert!(
-        remote.find_reference("refs/heads/main").is_ok(),
+        find_reference(&remote, "refs/heads/main").is_ok(),
         "a still-served heddle branch must survive the reconciliation"
     );
 }
@@ -5965,7 +6041,7 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
             "out-of-band",
             &[oid_b],
         );
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         let in_dest = commit_with_tree(
             &dest,
             Some("refs/heads/main"),
@@ -5990,13 +6066,11 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
         "expected a non-fast-forward rejection, got: {err:?}"
     );
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
-        let tip = dest
-            .find_reference("refs/heads/main")
+        let dest = open_git(&dest_path).expect("reopen dest");
+        let tip = find_reference(&dest, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(
             tip, oid_c,
             "the out-of-band commit must survive — heddle must not force-overwrite it"
@@ -6012,13 +6086,11 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
         )
         .expect("--force overrides the FF guard at the local destination");
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
-        let tip = dest
-            .find_reference("refs/heads/main")
+        let dest = open_git(&dest_path).expect("reopen dest");
+        let tip = find_reference(&dest, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(
             tip, oid_b,
             "--force rewinds the local destination to the served frontier B"
@@ -6033,19 +6105,17 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
 
     bridge.push(&url).expect("first network push publishes B");
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
-        let tip = remote
-            .find_reference("refs/heads/main")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
+        let tip = find_reference(&remote, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(tip, oid_b, "remote advertises the published tip B");
     }
 
     // Out-of-band advance on the wire remote to the SAME C (already in the mirror).
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
         let in_remote = commit_with_tree(
             &remote,
             Some("refs/heads/main"),
@@ -6068,13 +6138,11 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
         "expected a non-fast-forward rejection on the wire, got: {err:?}"
     );
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
-        let tip = remote
-            .find_reference("refs/heads/main")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
+        let tip = find_reference(&remote, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(
             tip, oid_c,
             "the out-of-band commit must survive on the URL/network remote"
@@ -6140,24 +6208,21 @@ fn heddle_published_tip_embargo_rewind_still_forced() {
         .get_git(&state_b)
         .expect("B minted");
     {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         assert_eq!(
-            dest.find_reference("refs/heads/main")
+            find_reference(&dest, "refs/heads/main")
                 .unwrap()
                 .peel_to_id()
-                .unwrap()
-                .detach(),
+                .unwrap(),
             oid_b,
             "local destination advertises the published tip B"
         );
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
         assert_eq!(
-            remote
-                .find_reference("refs/heads/main")
+            find_reference(&remote, "refs/heads/main")
                 .unwrap()
                 .peel_to_id()
-                .unwrap()
-                .detach(),
+                .unwrap(),
             oid_b,
             "remote advertises the published tip B"
         );
@@ -6189,13 +6254,11 @@ fn heddle_published_tip_embargo_rewind_still_forced() {
         .push(&url)
         .expect("second network push must FORCE the heddle-owned embargo rewind (network)");
 
-    let dest = gix::open(&dest_path).expect("reopen dest");
-    let tip = dest
-        .find_reference("refs/heads/main")
+    let dest = open_git(&dest_path).expect("reopen dest");
+    let tip = find_reference(&dest, "refs/heads/main")
         .unwrap()
         .peel_to_id()
-        .unwrap()
-        .detach();
+        .unwrap();
     assert_eq!(
         tip, oid_a,
         "local destination must be force-rewound to the served ancestor A"
@@ -6205,13 +6268,11 @@ fn heddle_published_tip_embargo_rewind_still_forced() {
         "local destination must not keep advertising the embargoed tip B"
     );
 
-    let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
-    let rtip = remote
-        .find_reference("refs/heads/main")
+    let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
+    let rtip = find_reference(&remote, "refs/heads/main")
         .unwrap()
         .peel_to_id()
-        .unwrap()
-        .detach();
+        .unwrap();
     assert_eq!(
         rtip, oid_a,
         "URL/network remote must be force-rewound to the served ancestor A"
@@ -6293,7 +6354,7 @@ fn out_of_band_advance_after_embargo_not_deleted() {
             "out-of-band",
             &[oid_b],
         );
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         let in_dest = commit_with_tree(
             &dest,
             Some("refs/heads/main"),
@@ -6301,7 +6362,7 @@ fn out_of_band_advance_after_embargo_not_deleted() {
             "out-of-band",
             &[oid_b],
         );
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
         let in_remote = commit_with_tree(
             &remote,
             Some("refs/heads/main"),
@@ -6347,13 +6408,11 @@ fn out_of_band_advance_after_embargo_not_deleted() {
         .export_to_path(&dest_path)
         .expect("plain export must not error on the out-of-band retraction (local)");
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
-        let tip = dest
-            .find_reference("refs/heads/main")
+        let dest = open_git(&dest_path).expect("reopen dest");
+        let tip = find_reference(&dest, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(
             tip, oid_c,
             "the out-of-band commit must survive — heddle must not delete a tip it never published (local)"
@@ -6366,13 +6425,11 @@ fn out_of_band_advance_after_embargo_not_deleted() {
         .push(&url)
         .expect("plain network push must not error on the out-of-band retraction");
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
-        let tip = remote
-            .find_reference("refs/heads/main")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
+        let tip = find_reference(&remote, "refs/heads/main")
             .unwrap()
             .peel_to_id()
-            .unwrap()
-            .detach();
+            .unwrap();
         assert_eq!(
             tip, oid_c,
             "the out-of-band commit must survive on the URL/network remote too"
@@ -6388,9 +6445,9 @@ fn out_of_band_advance_after_embargo_not_deleted() {
         )
         .expect("--force retracts the out-of-band branch at the local destination");
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
+        let dest = open_git(&dest_path).expect("reopen dest");
         assert!(
-            dest.find_reference("refs/heads/main").is_err(),
+            find_reference(&dest, "refs/heads/main").is_err(),
             "--force deletes the retracted branch even when the destination tip was advanced out of band"
         );
     }
@@ -6409,7 +6466,7 @@ fn out_of_band_advance_after_embargo_not_deleted() {
 /// `find_commit` (which would error on a tag object).
 #[test]
 fn reconcile_ownership_conformance_matrix() {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
 
     let (_mirror_temp, mirror) = init_git_repo();
     // Linear topology a <- b so classify_ref_move resolves fast-forward (a->b),
@@ -6422,10 +6479,10 @@ fn reconcile_ownership_conformance_matrix() {
 
     // Expected reconcile outcome for a single-ref call.
     enum Outcome {
-        /// In `writes` with this `old`/`new`, and `deletes` empty.
-        Write(Option<gix::hash::ObjectId>, gix::hash::ObjectId),
-        /// In `deletes` with this `old`, and `writes` empty.
-        Delete(gix::hash::ObjectId),
+        /// In `writes` with this `new`, and `deletes` empty.
+        Write(ObjectId),
+        /// In `deletes`, and `writes` empty.
+        Delete,
         /// Neither written nor deleted (no-op skip, or out-of-band spared).
         Absent,
         /// `Err(NonFastForwardRef)` — an unowned overwrite without `--force`.
@@ -6435,14 +6492,49 @@ fn reconcile_ownership_conformance_matrix() {
     struct Cell {
         label: &'static str,
         ns: RefNamespace,
-        old: Option<gix::hash::ObjectId>,
-        target: gix::hash::ObjectId,
-        recorded: Option<gix::hash::ObjectId>,
+        old: Option<ObjectId>,
+        target: ObjectId,
+        recorded: Option<ObjectId>,
         /// In the served frontier (an overwrite/create) vs. only previously
         /// exported (a retraction).
         desired: bool,
         force: bool,
         expect: Outcome,
+    }
+
+    fn is_ancestor_commit(repo: &SleyRepository, ancestor: ObjectId, descendant: ObjectId) -> bool {
+        let mut pending = vec![descendant];
+        let mut seen = HashSet::new();
+        while let Some(oid) = pending.pop() {
+            if oid == ancestor {
+                return true;
+            }
+            if !seen.insert(oid) {
+                continue;
+            }
+            if let Ok(commit) = repo.read_commit(&oid) {
+                pending.extend(commit.parents);
+            }
+        }
+        false
+    }
+
+    fn expected_write_force(repo: &SleyRepository, cell: &Cell) -> bool {
+        if cell.force {
+            return true;
+        }
+        let Some(old) = cell.old else {
+            return false;
+        };
+        if old == cell.target {
+            return false;
+        }
+        match cell.ns {
+            RefNamespace::Tag => true,
+            RefNamespace::Branch | RefNamespace::Note => {
+                !is_ancestor_commit(repo, old, cell.target)
+            }
+        }
     }
 
     let cells = vec![
@@ -6455,7 +6547,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: false,
-            expect: Outcome::Write(None, b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "branch/no-op",
@@ -6475,7 +6567,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(a), b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "branch/fast-forward/out-of-band",
@@ -6485,7 +6577,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(a), b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "branch/rewind/owned",
@@ -6495,7 +6587,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(b),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(b), a),
+            expect: Outcome::Write(a),
         },
         Cell {
             label: "branch/rewind/out-of-band/force-off",
@@ -6515,7 +6607,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: true,
-            expect: Outcome::Write(Some(b), a),
+            expect: Outcome::Write(a),
         },
         Cell {
             label: "branch/retract/owned",
@@ -6525,7 +6617,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(b),
             desired: false,
             force: false,
-            expect: Outcome::Delete(b),
+            expect: Outcome::Delete,
         },
         // Out-of-band retract: heddle published `a`, the destination drifted to `b`
         // (recorded != old) — spared unless forced.
@@ -6547,7 +6639,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: false,
             force: true,
-            expect: Outcome::Delete(b),
+            expect: Outcome::Delete,
         },
         // ---- tag: free move-classification + the SAME uniform ownership gate ----
         Cell {
@@ -6558,7 +6650,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: false,
-            expect: Outcome::Write(None, b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "tag/no-op",
@@ -6578,7 +6670,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(a), b),
+            expect: Outcome::Write(b),
         },
         // THE r17 fix: an out-of-band tag (recorded != old) is no longer clobbered.
         Cell {
@@ -6609,7 +6701,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: true,
-            expect: Outcome::Write(Some(a), b),
+            expect: Outcome::Write(b),
         },
         // annotated-tag-object as the NEW target: proves no find_commit on a tag obj.
         Cell {
@@ -6620,7 +6712,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(a), tag_obj),
+            expect: Outcome::Write(tag_obj),
         },
         // annotated-tag-object as the OLD tip: still gated by OID compare only.
         Cell {
@@ -6641,7 +6733,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(b),
             desired: false,
             force: false,
-            expect: Outcome::Delete(b),
+            expect: Outcome::Delete,
         },
         Cell {
             label: "tag/retract/out-of-band/force-off",
@@ -6661,7 +6753,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: false,
             force: true,
-            expect: Outcome::Delete(b),
+            expect: Outcome::Delete,
         },
         // ---- note: classified exactly like a branch (uniform ownership) ----
         Cell {
@@ -6672,7 +6764,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: false,
-            expect: Outcome::Write(None, b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "note/no-op",
@@ -6692,7 +6784,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(a),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(a), b),
+            expect: Outcome::Write(b),
         },
         Cell {
             label: "note/rewind/owned",
@@ -6702,7 +6794,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(b),
             desired: true,
             force: false,
-            expect: Outcome::Write(Some(b), a),
+            expect: Outcome::Write(a),
         },
         Cell {
             label: "note/rewind/out-of-band/force-off",
@@ -6722,7 +6814,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: None,
             desired: true,
             force: true,
-            expect: Outcome::Write(Some(b), a),
+            expect: Outcome::Write(a),
         },
         Cell {
             label: "note/retract/owned",
@@ -6732,7 +6824,7 @@ fn reconcile_ownership_conformance_matrix() {
             recorded: Some(b),
             desired: false,
             force: false,
-            expect: Outcome::Delete(b),
+            expect: Outcome::Delete,
         },
     ];
 
@@ -6752,11 +6844,11 @@ fn reconcile_ownership_conformance_matrix() {
         } else {
             Vec::new()
         };
-        let mut old_map: HashMap<String, gix::hash::ObjectId> = HashMap::new();
+        let mut old_map: HashMap<String, ObjectId> = HashMap::new();
         if let Some(o) = cell.old {
             old_map.insert(full.clone(), o);
         }
-        let mut recorded_map: HashMap<String, gix::hash::ObjectId> = HashMap::new();
+        let mut recorded_map: HashMap<String, ObjectId> = HashMap::new();
         if let Some(r) = cell.recorded {
             recorded_map.insert(full.clone(), r);
         }
@@ -6780,7 +6872,7 @@ fn reconcile_ownership_conformance_matrix() {
         let plan =
             result.unwrap_or_else(|e| panic!("cell `{}`: expected Ok, got {e:?}", cell.label));
         match cell.expect {
-            Outcome::Write(exp_old, exp_new) => {
+            Outcome::Write(exp_new) => {
                 assert!(
                     plan.deletes.is_empty(),
                     "cell `{}`: expected no deletes",
@@ -6794,10 +6886,15 @@ fn reconcile_ownership_conformance_matrix() {
                 );
                 let w = &plan.writes[0];
                 assert_eq!(w.full_name, full, "cell `{}`: write name", cell.label);
-                assert_eq!(w.old, exp_old, "cell `{}`: write old", cell.label);
                 assert_eq!(w.new, exp_new, "cell `{}`: write new", cell.label);
+                assert_eq!(
+                    w.force,
+                    expected_write_force(&mirror, cell),
+                    "cell `{}`: write force",
+                    cell.label
+                );
             }
-            Outcome::Delete(exp_old) => {
+            Outcome::Delete => {
                 assert!(
                     plan.writes.is_empty(),
                     "cell `{}`: expected no writes",
@@ -6811,7 +6908,6 @@ fn reconcile_ownership_conformance_matrix() {
                 );
                 let d = &plan.deletes[0];
                 assert_eq!(d.full_name, full, "cell `{}`: delete name", cell.label);
-                assert_eq!(d.old, exp_old, "cell `{}`: delete old", cell.label);
             }
             Outcome::Absent => {
                 assert!(
@@ -6852,9 +6948,9 @@ fn foreign_destination_ref_spared() {
         target: a,
         namespace: RefNamespace::Tag,
     }];
-    let mut old_map: HashMap<String, gix::hash::ObjectId> = HashMap::new();
+    let mut old_map: HashMap<String, ObjectId> = HashMap::new();
     old_map.insert(full.clone(), a);
-    let recorded_map: HashMap<String, gix::hash::ObjectId> = HashMap::new();
+    let recorded_map: HashMap<String, ObjectId> = HashMap::new();
 
     let plan =
         plan_destination_reconcile(&mirror, &served, None, &old_map, &recorded_map, false).unwrap();
@@ -6911,12 +7007,9 @@ fn out_of_band_destination_tag_not_overwritten() {
             .put_blob(&Blob::from_slice(b"release\n"))
             .expect("blob");
         let tree = store
-            .put_tree(&Tree::from_entries(vec![TreeEntry::file(
-                "release.txt".to_string(),
-                blob,
-                false,
-            )
-            .expect("entry")]))
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("release.txt".to_string(), blob, false).expect("entry"),
+            ]))
             .expect("tree");
         let state = State::new(
             tree,
@@ -6941,20 +7034,20 @@ fn out_of_band_destination_tag_not_overwritten() {
 
     // The served tag tip heddle recorded for this destination.
     let served_tag = {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         read_exported_refs(&dest).expect("read record")["refs/tags/v1.0"]
     };
 
     // Out-of-band advance: move the destination tag to a fresh commit X heddle
     // never published (and never recorded).
     let oid_x = {
-        let dest = gix::open(&dest_path).expect("open dest");
+        let dest = open_git(&dest_path).expect("open dest");
         let x = commit_with_tree(&dest, None, empty_tree_oid(&dest), "out-of-band-tag", &[]);
         set_reference(
             &dest,
             "refs/tags/v1.0",
             x,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: out-of-band tag",
         )
         .expect("move tag out of band");
@@ -6974,12 +7067,11 @@ fn out_of_band_destination_tag_not_overwritten() {
         "expected a non-fast-forward rejection, got: {err:?}"
     );
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
-        let tip = dest
-            .find_reference("refs/tags/v1.0")
+        let dest = open_git(&dest_path).expect("reopen dest");
+        let tip = find_reference(&dest, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id.detach())
+            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, oid_x,
@@ -6996,12 +7088,11 @@ fn out_of_band_destination_tag_not_overwritten() {
         )
         .expect("--force overrides the tag ownership gate at the local destination");
     {
-        let dest = gix::open(&dest_path).expect("reopen dest");
-        let tip = dest
-            .find_reference("refs/tags/v1.0")
+        let dest = open_git(&dest_path).expect("reopen dest");
+        let tip = find_reference(&dest, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id.detach())
+            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, served_tag,
@@ -7024,17 +7115,16 @@ fn out_of_band_destination_tag_not_overwritten() {
         .push(&url)
         .expect("first network push publishes the tag");
     let remote_served_tag = {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
-        remote
-            .find_reference("refs/tags/v1.0")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
+        find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id.detach())
+            .map(|id| id)
             .expect("tag id")
     };
 
     let remote_oid_x = {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("open remote");
+        let remote = open_git(remote_root.path().join("remote.git")).expect("open remote");
         let x = commit_with_tree(
             &remote,
             None,
@@ -7046,7 +7136,7 @@ fn out_of_band_destination_tag_not_overwritten() {
             &remote,
             "refs/tags/v1.0",
             x,
-            PreviousValue::Any,
+            RefPrecondition::Any,
             "test: out-of-band tag",
         )
         .expect("move remote tag out of band");
@@ -7065,12 +7155,11 @@ fn out_of_band_destination_tag_not_overwritten() {
         "expected a non-fast-forward rejection on the wire, got: {err:?}"
     );
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
-        let tip = remote
-            .find_reference("refs/tags/v1.0")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
+        let tip = find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id.detach())
+            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, remote_oid_x,
@@ -7082,12 +7171,11 @@ fn out_of_band_destination_tag_not_overwritten() {
         .push_with_scope_force(&url, GitPushScope::AllThreads, true)
         .expect("--force overrides the tag ownership gate on the URL/network remote");
     {
-        let remote = gix::open(remote_root.path().join("remote.git")).expect("reopen remote");
-        let tip = remote
-            .find_reference("refs/tags/v1.0")
+        let remote = open_git(remote_root.path().join("remote.git")).expect("reopen remote");
+        let tip = find_reference(&remote, "refs/tags/v1.0")
             .unwrap()
             .try_id()
-            .map(|id| id.detach())
+            .map(|id| id)
             .expect("tag id");
         assert_eq!(
             tip, remote_served_tag,
@@ -7119,12 +7207,11 @@ fn heddle_owned_tag_overwrite_still_lands() {
         target: b,
         namespace: RefNamespace::Tag,
     }];
-    let old_at_destination: HashMap<String, gix::hash::ObjectId> =
-        [(full.clone(), a)].into_iter().collect();
+    let old_at_destination: HashMap<String, ObjectId> = [(full.clone(), a)].into_iter().collect();
 
     // Owned: heddle recorded the destination tip `a` it is overwriting → the move
     // to `b` lands as a plain write, no `--force` needed.
-    let owned: HashMap<String, gix::hash::ObjectId> = [(full.clone(), a)].into_iter().collect();
+    let owned: HashMap<String, ObjectId> = [(full.clone(), a)].into_iter().collect();
     let plan =
         plan_destination_reconcile(&mirror, &served, None, &old_at_destination, &owned, false)
             .expect("a heddle-owned tag move must reconcile without --force");
@@ -7134,10 +7221,9 @@ fn heddle_owned_tag_overwrite_still_lands() {
         "owned tag move must produce exactly one write"
     );
     assert_eq!(plan.writes[0].full_name, full);
-    assert_eq!(
-        plan.writes[0].old,
-        Some(a),
-        "write carries the owned old tip"
+    assert!(
+        plan.writes[0].force,
+        "owned tag overwrite must force the destination update"
     );
     assert_eq!(plan.writes[0].new, b, "write lands the served target");
     assert!(
@@ -7147,7 +7233,7 @@ fn heddle_owned_tag_overwrite_still_lands() {
 
     // Contrast: the SAME move with no ownership record (out-of-band tip) is the r17
     // gate — FF-rejected unless `--force`.
-    let unrecorded: HashMap<String, gix::hash::ObjectId> = HashMap::new();
+    let unrecorded: HashMap<String, ObjectId> = HashMap::new();
     let err = plan_destination_reconcile(
         &mirror,
         &served,
@@ -7168,29 +7254,78 @@ fn heddle_owned_tag_overwrite_still_lands() {
 /// reuses one zero-offset signature for both roles, this surfaces committer,
 /// timezone, gpgsig, and extra-header fidelity (#564 step 1).
 fn commit_with_signatures(
-    repo: &gix::Repository,
+    repo: &SleyRepository,
     reference: Option<&str>,
-    tree_oid: gix::hash::ObjectId,
+    tree_oid: ObjectId,
     message: &str,
-    author: gix::actor::Signature,
-    committer: gix::actor::Signature,
-    extra_headers: Vec<(gix::bstr::BString, gix::bstr::BString)>,
-) -> gix::hash::ObjectId {
-    let commit = gix::objs::Commit {
-        tree: tree_oid,
-        parents: Default::default(),
-        author,
-        committer,
-        encoding: None,
-        message: message.into(),
+    author: Signature,
+    committer: Signature,
+    extra_headers: Vec<(Vec<u8>, Vec<u8>)>,
+) -> ObjectId {
+    let body = raw_commit_body(
+        tree_oid,
+        &[],
+        &author,
+        &committer,
         extra_headers,
-    };
-    let id = repo.write_object(&commit).expect("write commit").detach();
+        message.as_bytes(),
+    );
+    let id = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, body))
+        .expect("write commit");
     if let Some(reference) = reference {
-        set_reference(repo, reference, id, PreviousValue::Any, "test: update ref")
-            .expect("update ref");
+        set_reference(
+            repo,
+            reference,
+            id,
+            RefPrecondition::Any,
+            "test: update ref",
+        )
+        .expect("update ref");
     }
     id
+}
+
+fn raw_commit_body(
+    tree_oid: ObjectId,
+    parents: &[ObjectId],
+    author: &Signature,
+    committer: &Signature,
+    extra_headers: Vec<(Vec<u8>, Vec<u8>)>,
+    message: &[u8],
+) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(format!("tree {tree_oid}\n").as_bytes());
+    for parent in parents {
+        out.extend_from_slice(format!("parent {parent}\n").as_bytes());
+    }
+    out.extend_from_slice(b"author ");
+    out.extend_from_slice(&author.to_ident_bytes());
+    out.push(b'\n');
+    out.extend_from_slice(b"committer ");
+    out.extend_from_slice(&committer.to_ident_bytes());
+    out.push(b'\n');
+    for (name, value) in extra_headers {
+        write_raw_commit_header(&mut out, &name, &value);
+    }
+    out.push(b'\n');
+    out.extend_from_slice(message);
+    out
+}
+
+fn write_raw_commit_header(out: &mut Vec<u8>, name: &[u8], value: &[u8]) {
+    out.extend_from_slice(name);
+    out.push(b' ');
+    let mut lines = value.split(|byte| *byte == b'\n');
+    if let Some(first) = lines.next() {
+        out.extend_from_slice(first);
+    }
+    for line in lines {
+        out.push(b'\n');
+        out.push(b' ');
+        out.extend_from_slice(line);
+    }
+    out.push(b'\n');
 }
 
 /// #564 step 1: a commit imported through the bridge must round-trip every
@@ -7204,26 +7339,12 @@ fn import_preserves_commit_git_fidelity_fields() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let tree_oid = empty_tree_oid(&git_repo);
-    let author = gix::actor::Signature {
-        name: "Author".into(),
-        email: "author@example.com".into(),
-        time: gix::date::Time {
-            seconds: 1_000_000,
-            offset: -7 * 3600,
-        },
-    };
-    let committer = gix::actor::Signature {
-        name: "Committer".into(),
-        email: "committer@example.com".into(),
-        time: gix::date::Time {
-            seconds: 2_000_000,
-            offset: 2 * 3600,
-        },
-    };
+    let author = test_signature_at("Author", "author@example.com", 1_000_000, -7 * 60);
+    let committer = test_signature_at("Committer", "committer@example.com", 2_000_000, 2 * 60);
     let gpgsig = "-----BEGIN PGP SIGNATURE-----\nABCD\n-----END PGP SIGNATURE-----";
     let extra_headers = vec![
-        ("gpgsig".into(), gpgsig.into()),
-        ("mergetag".into(), "object deadbeef".into()),
+        (b"gpgsig".to_vec(), gpgsig.as_bytes().to_vec()),
+        (b"mergetag".to_vec(), b"object deadbeef".to_vec()),
     ];
     let commit_oid = commit_with_signatures(
         &git_repo,
@@ -7236,7 +7357,11 @@ fn import_preserves_commit_git_fidelity_fields() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir"))).expect("import");
+    import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
 
     let change_id = test_support::mapping(&bridge)
         .get_heddle(commit_oid)
@@ -7256,7 +7381,7 @@ fn import_preserves_commit_git_fidelity_fields() {
         state.raw_message.as_deref(),
         Some("feat: thing\n\nBody.\n".as_bytes())
     );
-    // gix folds multi-line extra-header values and round-trips them with a
+    // Git config folds multi-line extra-header values and round-trips them with a
     // trailing newline; byte-exact State round-tripping is covered by the
     // ingest unit test. Here we verify gpgsig stays INLINE in extra_headers at
     // its captured position (not split into a separate field) and the headers
@@ -7290,22 +7415,8 @@ fn backfill_fidelity_matches_fresh_adopt_and_is_idempotent() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let tree_oid = empty_tree_oid(&git_repo);
-    let author = gix::actor::Signature {
-        name: "Author".into(),
-        email: "author@example.com".into(),
-        time: gix::date::Time {
-            seconds: 1_000_000,
-            offset: -7 * 3600,
-        },
-    };
-    let committer = gix::actor::Signature {
-        name: "Committer".into(),
-        email: "committer@example.com".into(),
-        time: gix::date::Time {
-            seconds: 2_000_000,
-            offset: 2 * 3600,
-        },
-    };
+    let author = test_signature_at("Author", "author@example.com", 1_000_000, -7 * 60);
+    let committer = test_signature_at("Committer", "committer@example.com", 2_000_000, 2 * 60);
     let gpgsig = "-----BEGIN PGP SIGNATURE-----\nABCD\n-----END PGP SIGNATURE-----";
     let commit_oid = commit_with_signatures(
         &git_repo,
@@ -7314,12 +7425,16 @@ fn backfill_fidelity_matches_fresh_adopt_and_is_idempotent() {
         "feat: thing\n\nBody.\n",
         author,
         committer,
-        vec![("gpgsig".into(), gpgsig.into())],
+        vec![(b"gpgsig".to_vec(), gpgsig.as_bytes().to_vec())],
     );
 
     // Fresh post-#565 adopt: this populates the fidelity fields AND the mirror.
     let mut bridge = GitBridge::new(&repo);
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir"))).expect("import");
+    import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
     let change_id = test_support::mapping(&bridge)
         .get_heddle(commit_oid)
         .expect("commit mapped");
@@ -7415,22 +7530,8 @@ fn backfill_skips_states_with_foreign_signatures() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let tree_oid = empty_tree_oid(&git_repo);
-    let author = gix::actor::Signature {
-        name: "Author".into(),
-        email: "author@example.com".into(),
-        time: gix::date::Time {
-            seconds: 1_000_000,
-            offset: -7 * 3600,
-        },
-    };
-    let committer = gix::actor::Signature {
-        name: "Committer".into(),
-        email: "committer@example.com".into(),
-        time: gix::date::Time {
-            seconds: 2_000_000,
-            offset: 2 * 3600,
-        },
-    };
+    let author = test_signature_at("Author", "author@example.com", 1_000_000, -7 * 60);
+    let committer = test_signature_at("Committer", "committer@example.com", 2_000_000, 2 * 60);
     let commit_oid = commit_with_signatures(
         &git_repo,
         Some("refs/heads/main"),
@@ -7442,7 +7543,11 @@ fn backfill_skips_states_with_foreign_signatures() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir"))).expect("import");
+    import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
     let change_id = test_support::mapping(&bridge)
         .get_heddle(commit_oid)
         .expect("commit mapped");
@@ -7513,22 +7618,8 @@ fn backfill_resigns_owned_signed_states() {
     let (_git_temp, git_repo) = init_git_repo();
 
     let tree_oid = empty_tree_oid(&git_repo);
-    let author = gix::actor::Signature {
-        name: "Author".into(),
-        email: "author@example.com".into(),
-        time: gix::date::Time {
-            seconds: 1_000_000,
-            offset: -7 * 3600,
-        },
-    };
-    let committer = gix::actor::Signature {
-        name: "Committer".into(),
-        email: "committer@example.com".into(),
-        time: gix::date::Time {
-            seconds: 2_000_000,
-            offset: 2 * 3600,
-        },
-    };
+    let author = test_signature_at("Author", "author@example.com", 1_000_000, -7 * 60);
+    let committer = test_signature_at("Committer", "committer@example.com", 2_000_000, 2 * 60);
     let commit_oid = commit_with_signatures(
         &git_repo,
         Some("refs/heads/main"),
@@ -7540,7 +7631,11 @@ fn backfill_resigns_owned_signed_states() {
     );
 
     let mut bridge = GitBridge::new(&repo);
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir"))).expect("import");
+    import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
     let change_id = test_support::mapping(&bridge)
         .get_heddle(commit_oid)
         .expect("commit mapped");
@@ -7631,7 +7726,11 @@ fn backfill_reports_states_missing_from_mirror() {
         vec![],
     );
     let mut bridge = GitBridge::new(&repo);
-    import_all(&mut bridge, Some(git_repo.workdir().expect("workdir"))).expect("import");
+    import_all(
+        &mut bridge,
+        Some(git_repo.workdir().expect("workdir").as_path()),
+    )
+    .expect("import");
     assert!(
         test_support::mapping(&bridge)
             .get_heddle(real_oid)
@@ -7642,12 +7741,11 @@ fn backfill_reports_states_missing_from_mirror() {
     // Inject a sidecar entry pointing at an object that is NOT in the mirror,
     // then persist it so the backfill's mapping rebuild loads it back.
     let missing_change_id = ChangeId::from_bytes([7u8; 16]);
-    let bogus_oid: gix::hash::ObjectId = "1234567890123456789012345678901234567890"
+    let bogus_oid: ObjectId = "1234567890123456789012345678901234567890"
         .parse()
         .expect("valid-looking oid absent from the mirror");
     test_support::mapping_mut(&mut bridge).insert(missing_change_id, bogus_oid);
-    test_support::save_mapping_to_disk(&bridge)
-        .expect("persist injected sidecar entry");
+    test_support::save_mapping_to_disk(&bridge).expect("persist injected sidecar entry");
 
     let mut bridge = GitBridge::new(&repo);
     let stats = backfill_fidelity(&mut bridge).expect("backfill");
@@ -7701,28 +7799,27 @@ fn non_utf8_git_fidelity_is_byte_identical_across_bridge_and_ingest() {
         v
     };
 
-    let commit = gix::objs::Commit {
-        tree: tree_oid,
-        parents: Default::default(),
-        author: test_signature(),
-        committer: test_signature(),
-        encoding: None,
-        message: commit_message.clone().into(),
-        extra_headers: vec![
-            ("gpgsig".into(), gpgsig_value.clone().into()),
-            ("x-custom".into(), custom_value.clone().into()),
-            ("mergetag".into(), mergetag_value.clone().into()),
+    let sig = test_signature();
+    let commit = raw_commit_body(
+        tree_oid,
+        &[],
+        &sig,
+        &sig,
+        vec![
+            (b"gpgsig".to_vec(), gpgsig_value.clone()),
+            (b"x-custom".to_vec(), custom_value.clone()),
+            (b"mergetag".to_vec(), mergetag_value.clone()),
         ],
-    };
+        &commit_message,
+    );
     let commit_oid = git_repo
-        .write_object(&commit)
-        .expect("write commit")
-        .detach();
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit))
+        .expect("write commit");
     set_reference(
         &git_repo,
         "refs/heads/main",
         commit_oid,
-        PreviousValue::Any,
+        RefPrecondition::Any,
         "test: main",
     )
     .expect("set main");
@@ -7733,7 +7830,7 @@ fn non_utf8_git_fidelity_is_byte_identical_across_bridge_and_ingest() {
     let bridge_heddle = TempDir::new().expect("bridge heddle temp");
     let bridge_repo = Repository::init(bridge_heddle.path()).expect("init bridge heddle");
     let mut bridge = GitBridge::new(&bridge_repo);
-    import_all(&mut bridge, Some(git_workdir)).expect("bridge import");
+    import_all(&mut bridge, Some(git_workdir.as_path())).expect("bridge import");
     let bridge_cid = test_support::mapping(&bridge)
         .get_heddle(commit_oid)
         .expect("bridge mapped commit");

--- a/crates/cli/tests/git_process_lint.rs
+++ b/crates/cli/tests/git_process_lint.rs
@@ -3,7 +3,7 @@
 //!
 //! Heddle's public Git-overlay workflows must not depend on a `git`
 //! executable being present on PATH. Git-format work is handled by
-//! native code and gix; tests and fixture builders may shell out to Git,
+//! native code through Sley; tests and fixture builders may shell out to Git,
 //! but runtime CLI crates may not.
 
 use std::{
@@ -52,7 +52,7 @@ fn runtime_git_process_spawns_match_reviewed_allowlist() {
 
     assert!(
         unexpected.is_empty(),
-        "runtime `git` process spawn(s) are not allowed:\n{}\nReplace the call with native/gix behavior or move fixture setup into tests.",
+        "runtime `git` process spawn(s) are not allowed:\n{}\nReplace the call with native/Sley behavior or move fixture setup into tests.",
         unexpected
             .iter()
             .map(|site| format!(
@@ -71,6 +71,46 @@ fn runtime_git_process_spawns_match_reviewed_allowlist() {
     assert!(
         missing.is_empty(),
         "git-process allowlist entry no longer matches a production spawn; remove or update it: {missing:?}"
+    );
+}
+
+#[test]
+fn git_engine_dependency_is_sley_not_gix() {
+    let workspace = workspace_root();
+    let root_manifest =
+        fs::read_to_string(workspace.join("Cargo.toml")).expect("read workspace Cargo.toml");
+    assert!(
+        root_manifest
+            .lines()
+            .any(|line| line.trim_start().starts_with("sley = ")),
+        "workspace dependencies must name Sley as the Git-format engine"
+    );
+
+    let mut manifests = Vec::new();
+    collect_manifest_files(&workspace, &mut manifests);
+    let mut direct_gix_mentions = Vec::new();
+    for manifest in manifests {
+        let rel = manifest
+            .strip_prefix(&workspace)
+            .unwrap_or(&manifest)
+            .display()
+            .to_string();
+        let body = fs::read_to_string(&manifest)
+            .unwrap_or_else(|err| panic!("read {}: {err}", manifest.display()));
+        for (idx, line) in body.lines().enumerate() {
+            let trimmed = line.trim_start();
+            if trimmed.starts_with("gix")
+                || trimmed.starts_with("gitoxide")
+                || trimmed.contains("package = \"gix")
+            {
+                direct_gix_mentions.push(format!("{rel}:{}: {trimmed}", idx + 1));
+            }
+        }
+    }
+    assert!(
+        direct_gix_mentions.is_empty(),
+        "Heddle should depend on Sley, not direct gix/gitoxide crates:\n{}",
+        direct_gix_mentions.join("\n")
     );
 }
 
@@ -142,6 +182,25 @@ fn scan_file(workspace: &Path, path: &Path, sites: &mut Vec<SpawnSite>) {
             });
         } else if starts_multiline_command_new(trimmed) {
             pending_command_new = Some((idx + 1, trimmed.to_string(), function.clone(), 4));
+        }
+    }
+}
+
+fn collect_manifest_files(dir: &Path, manifests: &mut Vec<PathBuf>) {
+    let entries =
+        fs::read_dir(dir).unwrap_or_else(|err| panic!("read_dir {}: {err}", dir.display()));
+    for entry in entries {
+        let entry = entry.expect("read dir entry");
+        let path = entry.path();
+        let file_type = entry.file_type().expect("file type");
+        if file_type.is_dir() {
+            let name = entry.file_name();
+            if matches!(name.to_str(), Some(".git" | "target")) {
+                continue;
+            }
+            collect_manifest_files(&path, manifests);
+        } else if entry.file_name() == "Cargo.toml" {
+            manifests.push(path);
         }
     }
 }

--- a/crates/cli/tests/lazy_blob_hydration_kernel.rs
+++ b/crates/cli/tests/lazy_blob_hydration_kernel.rs
@@ -31,50 +31,85 @@ use std::{
 use cli::{bridge::git_core::clone_url_to_bare, cli::commands::GitOverlayBlobHydrator};
 use objects::object::Blob;
 use repo::Repository;
+use sley::plumbing::sley_core::ByteString as GitByteString;
+use sley::plumbing::sley_object::EncodedObject;
+use sley::plumbing::sley_refs::ReflogEntry;
+use sley::{
+    CommitObject, EntryKind, GitObjectType, GitTime, ObjectId, RefPrecondition, ReferenceTarget,
+    Repository as SleyRepository, Signature,
+};
 use tempfile::TempDir;
 
-/// Build a minimal bare gix repo with a single commit / tree / blob,
+/// Build a minimal bare Git repo with a single commit / tree / blob,
 /// returning `(temp_dir, bare_path, blob_oid, blob_bytes)`. The temp
 /// dir must outlive the test that uses it.
-fn build_local_bare_with_one_blob() -> (TempDir, std::path::PathBuf, gix::ObjectId, Vec<u8>) {
+fn build_local_bare_with_one_blob() -> (TempDir, std::path::PathBuf, ObjectId, Vec<u8>) {
     let temp = TempDir::new().expect("temp for bare git");
     let bare = temp.path().join("source.git");
-    let repo = gix::init_bare(&bare).expect("init bare gix");
+    let repo = SleyRepository::init_bare(&bare).expect("init bare git");
 
     let blob_bytes = b"# Hydration sentinel\nlazy lazy lazy\n".to_vec();
-    let blob_oid = repo
-        .write_blob(blob_bytes.as_slice())
-        .expect("write blob")
-        .detach();
+    let blob_oid = repo.write_blob(blob_bytes.as_slice()).expect("write blob");
 
-    let empty_tree = repo.empty_tree().id;
-    let mut editor = repo.edit_tree(empty_tree).expect("edit tree");
-    editor
-        .upsert("README.md", gix::object::tree::EntryKind::Blob, blob_oid)
-        .expect("add file");
-    let tree_oid = editor.write().expect("write tree").detach();
+    let empty_tree = repo
+        .write_tree(sley::TreeEditor::new())
+        .expect("write empty tree");
+    let mut editor = repo.edit_tree(&empty_tree).expect("edit tree");
+    editor.upsert("README.md", EntryKind::Blob, blob_oid);
+    let tree_oid = repo.write_tree(editor).expect("write tree");
 
-    let sig = gix::actor::Signature {
-        name: "Heddle Test".into(),
-        email: "test@heddle".into(),
-        time: gix::date::Time {
-            seconds: 0,
-            offset: 0,
-        },
+    let sig = test_signature();
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: Vec::new(),
+        author: sig.to_ident_bytes(),
+        committer: sig.to_ident_bytes(),
+        encoding: None,
+        message: b"seed".to_vec(),
     };
-    let mut author_buf = gix::date::parse::TimeBuf::default();
-    let mut committer_buf = gix::date::parse::TimeBuf::default();
-    let _commit = repo
-        .new_commit_as(
-            sig.to_ref(&mut committer_buf),
-            sig.to_ref(&mut author_buf),
-            "seed",
-            tree_oid,
-            Vec::<gix::hash::ObjectId>::new(),
-        )
+    let commit_oid = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
         .expect("commit");
+    set_reference(&repo, "refs/heads/main", commit_oid);
 
     (temp, bare, blob_oid, blob_bytes)
+}
+
+fn test_signature() -> Signature {
+    Signature {
+        name: GitByteString::new(b"Heddle Test".to_vec()),
+        email: GitByteString::new(b"test@heddle".to_vec()),
+        time: GitTime::new(0, 0),
+        raw: b"Heddle Test <test@heddle> 0 +0000".to_vec(),
+    }
+}
+
+fn set_reference(repo: &SleyRepository, name: &str, target: ObjectId) {
+    let sig = test_signature();
+    let refs = repo.references();
+    let old_oid = match refs.read_ref(name).expect("read ref") {
+        Some(ReferenceTarget::Direct(oid)) => oid,
+        _ => ObjectId::null(repo.object_format()),
+    };
+    let mut tx = refs.transaction();
+    tx.update_to(
+        name.to_string(),
+        ReferenceTarget::Direct(target),
+        RefPrecondition::Any,
+        Some(ReflogEntry {
+            old_oid,
+            new_oid: target,
+            committer: sig.to_ident_bytes(),
+            message: b"test: update ref".to_vec(),
+        }),
+    );
+    tx.commit().expect("update ref");
+}
+
+fn open_git(path: impl AsRef<Path>) -> Result<SleyRepository, String> {
+    SleyRepository::open(path.as_ref())
+        .or_else(|_| SleyRepository::discover(path.as_ref()))
+        .map_err(|err| err.to_string())
 }
 
 /// Drive a `GitOverlayBlobHydrator` registered on a freshly-init'd
@@ -84,11 +119,7 @@ fn build_local_bare_with_one_blob() -> (TempDir, std::path::PathBuf, gix::Object
 ///
 /// Returns the time spent inside the single `require_blob` call so the
 /// caller can attach a perf line to the PR description.
-fn drive_hydration_round_trip(
-    git_bare: &Path,
-    blob_oid: gix::ObjectId,
-    blob_bytes: &[u8],
-) -> Duration {
+fn drive_hydration_round_trip(git_bare: &Path, blob_oid: ObjectId, blob_bytes: &[u8]) -> Duration {
     let blake3 = Blob::new(blob_bytes.to_vec()).hash();
 
     let heddle_temp = TempDir::new().expect("heddle temp");
@@ -226,12 +257,11 @@ fn hydration_survives_repository_reopen() {
 
     // Second reopen with a *new* missing blob in the bare repo to
     // confirm the registry isn't a one-shot install.
-    let bare_open = gix::open(&bare).expect("open bare for second blob");
+    let bare_open = open_git(&bare).expect("open bare for second blob");
     let payload2 = b"second-blob-after-reopen\n".to_vec();
     let oid2 = bare_open
         .write_blob(payload2.as_slice())
-        .expect("write blob 2")
-        .detach();
+        .expect("write blob 2");
     let blake3_2 = Blob::new(payload2.clone()).hash();
     // Re-register the factory under the same kind to seed the new
     // OID — last-write-wins, mirroring how the production path could
@@ -275,31 +305,25 @@ fn hydration_fires_against_torvalds_linux() {
 
     let temp = TempDir::new().expect("temp for linux clone");
     let bare = temp.path().join("linux.git");
-    let url = gix::url::parse("https://github.com/torvalds/linux.git".as_bytes().into())
-        .expect("parse url");
+    let url = "https://github.com/torvalds/linux.git";
 
     eprintln!("cloning torvalds/linux.git at depth=1 + filter=blob:none ...");
     let started = Instant::now();
-    if let Err(err) = clone_url_to_bare(&url, &bare, Some(1), Some("blob:none")) {
+    if let Err(err) = clone_url_to_bare(url, &bare, Some(1), Some("blob:none")) {
         eprintln!("SKIP: kernel clone failed (network?): {err}");
         return;
     }
     eprintln!("clone completed in {:?}", started.elapsed());
 
-    let gix_repo = gix::open(&bare).expect("open kernel bare repo");
-    let tip = gix_repo.head_commit().expect("HEAD commit").id().detach();
-    let tree = gix_repo
-        .find_commit(tip)
-        .expect("find HEAD commit")
-        .tree_id()
-        .expect("commit tree id")
-        .detach();
-    let tree_obj = gix_repo.find_tree(tree).expect("read tip tree");
+    let git_repo = open_git(&bare).expect("open kernel bare repo");
+    let tip = git_repo.head().expect("HEAD").oid.expect("HEAD commit");
+    let tree = git_repo.read_commit(&tip).expect("find HEAD commit").tree;
+    let tree_obj = git_repo.read_tree(&tree).expect("read tip tree");
     let blob_oid = tree_obj
+        .entries
         .iter()
-        .filter_map(|entry| entry.ok())
-        .find(|entry| matches!(entry.mode().kind(), gix::object::tree::EntryKind::Blob))
-        .map(|entry| entry.oid().to_owned())
+        .find(|entry| EntryKind::from_mode(entry.mode) == Some(EntryKind::Blob))
+        .map(|entry| entry.oid)
         .expect("tip tree must contain at least one blob entry");
     eprintln!("targeting blob {blob_oid} for hydration");
 
@@ -322,10 +346,10 @@ fn hydration_fires_against_torvalds_linux() {
     let bytes = cat.stdout;
     eprintln!("blob materialised ({} bytes)", bytes.len());
 
-    // gix can confirm the blob is now in the ODB after the promisor
+    // sley can confirm the blob is now in the ODB after the promisor
     // refetch — the hydrator's local-first read will hit this path
     // on the test's second `cat-file` call rather than re-fetching.
-    let _ = gix_repo;
+    let _ = git_repo;
 
     let elapsed = drive_hydration_round_trip(&bare, blob_oid, &bytes);
     eprintln!("hydration round-trip: {elapsed:?}");

--- a/crates/cli/tests/multi_agent_worktrees.rs
+++ b/crates/cli/tests/multi_agent_worktrees.rs
@@ -95,6 +95,13 @@ where
     )
 }
 
+fn canonical_path_string(path: &std::path::Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
 fn heddle_output_with_env(
     args: &[&str],
     cwd: Option<&std::path::Path>,

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -1728,8 +1728,10 @@ fn thread_promote_materializes_visible_checkout_without_changing_thread_identity
     assert_eq!(promoted["thread"]["id"], "feature/promote");
     assert_eq!(promoted["thread"]["mode"], "solid");
     assert_eq!(
-        promoted["thread"]["materialized_path"],
-        visible.path().display().to_string()
+        canonical_path_string(std::path::Path::new(
+            promoted["thread"]["materialized_path"].as_str().unwrap()
+        )),
+        canonical_path_string(visible.path())
     );
     assert!(visible.path().join(".heddle").is_dir());
     assert!(visible.path().join(".heddle").join("objectstore").is_file());

--- a/crates/cli/tests/realworld_git/fixtures/vendor.sh
+++ b/crates/cli/tests/realworld_git/fixtures/vendor.sh
@@ -4,8 +4,8 @@
 # For each entry below: shallow-clone the upstream, then `fast-export |
 # fast-import` into a fresh bare repo. The fast-export step is what makes the
 # fixture self-contained: shallow clones leave a `.git/shallow` boundary that
-# gix/heddle clone refuses to walk past, and `--filter=blob:limit` partial
-# clones leave a missing-object set that gix/heddle import refuses to walk.
+# Sley/Heddle clone refuses to walk past, and `--filter=blob:limit` partial
+# clones leave a missing-object set that Sley/Heddle import refuses to walk.
 # Re-rooting via fast-import drops the parent edges at the boundary so every
 # extracted fixture is a complete, walkable repository.
 #

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -153,8 +153,7 @@ async fn cmd_auth_login(server: &str, no_browser: bool) -> Result<()> {
     // subsequent captures sign with it (it supersedes any per-repo local key;
     // states already signed by a local key keep verifying). Best-effort — a
     // failure here just leaves captures signing with the local key.
-    if let Err(error) =
-        repo::identity::link_device_key(&public_key_bytes, &private_key_pem, server)
+    if let Err(error) = repo::identity::link_device_key(&public_key_bytes, &private_key_pem, server)
     {
         tracing::warn!(%error, "could not record device signing identity; captures will use the per-repo local key");
     }
@@ -666,10 +665,12 @@ mod tests {
                 .expect("store credential");
 
             let device_path = repo::identity::device_identity_path();
-            std::fs::create_dir_all(device_path.parent().expect("home parent"))
-                .expect("home dir");
-            std::fs::write(&device_path, b"!!! definitely not valid device-identity toml !!!")
-                .expect("write corrupt device identity");
+            std::fs::create_dir_all(device_path.parent().expect("home parent")).expect("home dir");
+            std::fs::write(
+                &device_path,
+                b"!!! definitely not valid device-identity toml !!!",
+            )
+            .expect("write corrupt device identity");
 
             let result = cmd_auth_logout(&TextCtx, None);
             assert!(

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -7,7 +7,6 @@ mod session;
 mod sync;
 mod user;
 
-use objects::store::ObjectStore;
 use cli_shared::ClientConfig;
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::v1::{
@@ -17,6 +16,7 @@ use grpc::heddle::v1::{
     repo_sync_service_client::RepoSyncServiceClient,
 };
 use objects::object::MarkerName;
+use objects::store::ObjectStore;
 use proto::ProtocolError;
 use repo::Repository;
 use tonic::{

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -812,7 +812,8 @@ impl HostedGrpcClient {
                         if let Some(local_thread) = options.local_thread
                             && let Some(state) = final_state
                         {
-                            repo.refs().set_thread(&ThreadName::from(local_thread), &state)?;
+                            repo.refs()
+                                .set_thread(&ThreadName::from(local_thread), &state)?;
                         }
                         if let Some(state) = final_state
                             && allow_partial_fetch
@@ -961,13 +962,13 @@ fn redaction_push_message(
 }
 
 fn is_out_of_pack_transfer_object_type(obj_type: ObjectType) -> bool {
-    matches!(obj_type, ObjectType::Redaction | ObjectType::StateVisibility)
+    matches!(
+        obj_type,
+        ObjectType::Redaction | ObjectType::StateVisibility
+    )
 }
 
-fn native_pack_required_for_pull(
-    want_full_closure: bool,
-    wanted_types: &WantedTypes,
-) -> bool {
+fn native_pack_required_for_pull(want_full_closure: bool, wanted_types: &WantedTypes) -> bool {
     want_full_closure
         || wanted_types
             .values()
@@ -976,29 +977,20 @@ fn native_pack_required_for_pull(
             .any(proto::is_native_packable_object_type)
 }
 
-fn record_wanted_type(
-    wanted_types: &mut WantedTypes,
-    pack_id: PackObjectId,
-    obj_type: ObjectType,
-) {
+fn record_wanted_type(wanted_types: &mut WantedTypes, pack_id: PackObjectId, obj_type: ObjectType) {
     let types = wanted_types.entry(pack_id).or_default();
     if !types.contains(&obj_type) {
         types.push(obj_type);
     }
 }
 
-fn wanted_packable_type(
-    wanted_types: &WantedTypes,
-    pack_id: &PackObjectId,
-) -> Option<ObjectType> {
-    wanted_types
-        .get(pack_id)
-        .and_then(|types| {
-            types
-                .iter()
-                .copied()
-                .find(|obj_type| proto::is_native_packable_object_type(*obj_type))
-        })
+fn wanted_packable_type(wanted_types: &WantedTypes, pack_id: &PackObjectId) -> Option<ObjectType> {
+    wanted_types.get(pack_id).and_then(|types| {
+        types
+            .iter()
+            .copied()
+            .find(|obj_type| proto::is_native_packable_object_type(*obj_type))
+    })
 }
 
 fn sidecar_push_message(
@@ -1460,14 +1452,13 @@ mod tests {
     use cli_shared::ClientConfig;
     use grpc::heddle::v1::{
         ListRefsRequest, ListRefsResponse, PullComplete as GrpcPullComplete, PullReady,
-        TransferCheckpoint, UpdateRefRequest, UpdateRefResponse,
+        TransferCheckpoint, UpdateRefRequest, UpdateRefResponse, push_message,
         repo_sync_service_server::{RepoSyncService, RepoSyncServiceServer},
-        push_message,
     };
     use objects::{
         object::{
-            Attribution, Blob, ChangeId, ContentHash, Principal, Redaction, State,
-            StateVisibility, StateVisibilityBlob, Tree, TreeEntry, VisibilityTier,
+            Attribution, Blob, ChangeId, ContentHash, Principal, Redaction, State, StateVisibility,
+            StateVisibilityBlob, Tree, TreeEntry, VisibilityTier,
         },
         store::ObjectStore,
     };
@@ -1595,7 +1586,8 @@ mod tests {
         )]);
         assert!(!native_pack_required_for_pull(false, &sidecar_only));
 
-        let redaction_only = HashMap::from([(PackObjectId::Hash(blob), vec![ObjectType::Redaction])]);
+        let redaction_only =
+            HashMap::from([(PackObjectId::Hash(blob), vec![ObjectType::Redaction])]);
         assert!(!native_pack_required_for_pull(false, &redaction_only));
 
         let packable = HashMap::from([(PackObjectId::Hash(blob), vec![ObjectType::Blob])]);
@@ -1637,7 +1629,10 @@ mod tests {
             .wanted_types
             .get(&PackObjectId::ChangeId(state))
             .expect("same ChangeId want entry");
-        assert_eq!(wanted.as_slice(), &[ObjectType::State, ObjectType::StateVisibility]);
+        assert_eq!(
+            wanted.as_slice(),
+            &[ObjectType::State, ObjectType::StateVisibility]
+        );
         assert!(native_pack_required_for_pull(
             plan.want_full_closure,
             &plan.wanted_types
@@ -1673,7 +1668,9 @@ mod tests {
             _request: tonic::Request<tonic::Streaming<PushMessage>>,
         ) -> Result<Response<Self::PushStream>, Status> {
             let (_tx, rx) = mpsc::channel(1);
-            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
         }
 
         type PullStream = tokio_stream::wrappers::ReceiverStream<Result<PullMessage, Status>>;
@@ -1768,7 +1765,9 @@ mod tests {
                 let _ = tx.send(Ok(complete)).await;
             });
 
-            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
         }
     }
 
@@ -2026,7 +2025,9 @@ mod tests {
             _request: tonic::Request<tonic::Streaming<PushMessage>>,
         ) -> Result<Response<Self::PushStream>, Status> {
             let (_tx, rx) = mpsc::channel(1);
-            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
         }
 
         type PullStream = tokio_stream::wrappers::ReceiverStream<Result<PullMessage, Status>>;
@@ -2087,7 +2088,10 @@ mod tests {
                         body: Some(pull_message::Body::Want(want)),
                     })) if !want.want_full_closure
                         && want.objects.len() == 2
-                        && want.objects.iter().any(|object| object.object_type == "state")
+                        && want
+                            .objects
+                            .iter()
+                            .any(|object| object.object_type == "state")
                         && want
                             .objects
                             .iter()
@@ -2102,11 +2106,9 @@ mod tests {
                     }
                 }
 
-                for message in encode_pull_native_pack_messages(
-                    &pack_bundle,
-                    "state-and-visibility-test",
-                    16,
-                ) {
+                for message in
+                    encode_pull_native_pack_messages(&pack_bundle, "state-and-visibility-test", 16)
+                {
                     if tx.send(Ok(message)).await.is_err() {
                         return;
                     }
@@ -2142,7 +2144,9 @@ mod tests {
                 let _ = tx.send(Ok(complete)).await;
             });
 
-            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(rx)))
+            Ok(Response::new(tokio_stream::wrappers::ReceiverStream::new(
+                rx,
+            )))
         }
     }
 
@@ -2239,7 +2243,10 @@ mod tests {
     async fn state_and_visibility_same_change_id_pull_requests_pack_and_sidecar() {
         let (_source_dir, source_repo) = temp_repo();
         let (_target_dir, target_repo) = temp_repo();
-        let tree_hash = source_repo.store().put_tree(&Tree::new()).expect("put tree");
+        let tree_hash = source_repo
+            .store()
+            .put_tree(&Tree::new())
+            .expect("put tree");
         let state = State::new_snapshot(
             tree_hash,
             vec![],
@@ -2249,7 +2256,10 @@ mod tests {
             }),
         );
         let state_id = state.change_id;
-        source_repo.store().put_state(&state).expect("put source state");
+        source_repo
+            .store()
+            .put_state(&state)
+            .expect("put source state");
         let state_visibility_blob =
             StateVisibilityBlob::new(vec![sample_state_visibility(state_id)])
                 .encode()
@@ -2257,11 +2267,8 @@ mod tests {
         source_repo
             .accept_wire_state_visibility(state_id, &state_visibility_blob)
             .expect("put source state visibility");
-        let pack_bundle = proto::build_native_pack(
-            source_repo.store(),
-            &[state_info(state_id)],
-        )
-        .expect("build state pack");
+        let pack_bundle = proto::build_native_pack(source_repo.store(), &[state_info(state_id)])
+            .expect("build state pack");
 
         assert!(
             target_repo

--- a/crates/client/src/support.rs
+++ b/crates/client/src/support.rs
@@ -117,7 +117,8 @@ async fn open_client(repo: &Repository, remote: &str) -> Result<HostedGrpcClient
         }
     };
     let user_config = UserConfig::load_default()?;
-    HostedGrpcClient::open_session(addr, &user_config, server_key, HostedAuthMode::ConfigToken).await
+    HostedGrpcClient::open_session(addr, &user_config, server_key, HostedAuthMode::ConfigToken)
+        .await
 }
 
 /// Parse a TTL string like `"24h"`, `"30m"`, `"4d"`, or a bare number

--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -23,7 +23,7 @@ impl Ed25519Signer {
     }
 
     pub fn from_pem(pem: &str) -> Result<Self, SignerError> {
-        use crate::pem_loader::{classify_pem, PemKind};
+        use crate::pem_loader::{PemKind, classify_pem};
 
         match classify_pem(pem) {
             PemKind::Pkcs8 => Self::from_pkcs8_pem(pem),

--- a/crates/crypto/src/p256.rs
+++ b/crates/crypto/src/p256.rs
@@ -2,11 +2,11 @@
 //! P-256 (ECDSA) signature implementation.
 
 use p256::{
-    ecdsa::{
-        signature::{Signer as SignatureSigner, Verifier as SignatureVerifier},
-        Signature, SigningKey, VerifyingKey,
-    },
     SecretKey,
+    ecdsa::{
+        Signature, SigningKey, VerifyingKey,
+        signature::{Signer as SignatureSigner, Verifier as SignatureVerifier},
+    },
 };
 use pkcs8::DecodePrivateKey;
 use rsa::{pkcs1::DecodeRsaPrivateKey, rand_core::OsRng};

--- a/crates/crypto/src/rsa.rs
+++ b/crates/crypto/src/rsa.rs
@@ -3,7 +3,7 @@
 
 use pkcs8::{DecodePrivateKey, DecodePublicKey, EncodePublicKey};
 use rsa::{
-    pkcs1::DecodeRsaPrivateKey, rand_core::OsRng, Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey,
+    Pkcs1v15Sign, RsaPrivateKey, RsaPublicKey, pkcs1::DecodeRsaPrivateKey, rand_core::OsRng,
 };
 use sha2::{Digest, Sha256};
 
@@ -40,7 +40,7 @@ impl RsaSigner {
     }
 
     pub fn from_pem(pem: &str) -> Result<Self, SignerError> {
-        use crate::pem_loader::{classify_pem, PemKind};
+        use crate::pem_loader::{PemKind, classify_pem};
 
         let private_key =
             match classify_pem(pem) {

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -11,7 +11,6 @@
 //! state's blob only. A cross-state index is W2 follow-up work and is
 //! flagged with `// TODO(W2-followup):` comments.
 
-use objects::store::ObjectStore;
 use grpc::heddle::v1::{
     AppendTurnRequest, Discussion as ProtoDiscussion,
     DiscussionResolution as ProtoDiscussionResolution, DiscussionTurn as ProtoDiscussionTurn,
@@ -20,9 +19,10 @@ use grpc::heddle::v1::{
     discussion_service_server::DiscussionService,
 };
 use objects::object::{
-    VisibilityTier, Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn,
-    DiscussionsBlob, Principal, State, SymbolAnchor,
+    Blob, ChangeId, Discussion, DiscussionResolution, DiscussionTurn, DiscussionsBlob, Principal,
+    State, SymbolAnchor, VisibilityTier,
 };
+use objects::store::ObjectStore;
 use prost::Message;
 use repo::Repository;
 use tonic::{Request, Response, Status};

--- a/crates/daemon/src/grpc_local_impl/state_review.rs
+++ b/crates/daemon/src/grpc_local_impl/state_review.rs
@@ -8,7 +8,6 @@
 // `::state_review` disambiguates from this module's own name
 // (`grpc_local_impl::state_review`), the same way the hosted impl
 // disambiguates by being in a sibling module.
-use objects::store::ObjectStore;
 use ::state_review::{
     PathSymbol, ReadingOrderPartition, SymbolKind, build_review_payload_partition,
 };
@@ -22,6 +21,7 @@ use grpc::heddle::v1::{
     SignalAnchor as ProtoSignalAnchor, SigningFooter,
     state_review_service_server::StateReviewService,
 };
+use objects::store::ObjectStore;
 use objects::{
     lock::RepositoryLockExt,
     object::{

--- a/crates/devtools/src/asserter.rs
+++ b/crates/devtools/src/asserter.rs
@@ -69,7 +69,8 @@ pub fn for_each_rs_file(
         if skip(path) {
             continue;
         }
-        let source = fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
+        let source =
+            fs::read_to_string(path).with_context(|| format!("read {}", path.display()))?;
         *files_scanned += 1;
         visit(path, &source)?;
     }

--- a/crates/devtools/src/check_atomic_ledger_encapsulation.rs
+++ b/crates/devtools/src/check_atomic_ledger_encapsulation.rs
@@ -199,9 +199,7 @@ fn pred_can_be_true_without_test(meta: &Meta) -> bool {
         // The `test` atom is false in a non-test build; any other atom is free.
         Meta::Path(path) => !path.is_ident("test"),
         Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
-            Some(children) if children.len() == 1 => {
-                pred_can_be_false_without_test(&children[0])
-            }
+            Some(children) if children.len() == 1 => pred_can_be_false_without_test(&children[0]),
             _ => true,
         },
         Meta::List(list) if list.path.is_ident("all") => match cfg_children(list) {
@@ -226,9 +224,7 @@ fn pred_can_be_false_without_test(meta: &Meta) -> bool {
         // atom is free and can be left unset.
         Meta::Path(_) => true,
         Meta::List(list) if list.path.is_ident("not") => match cfg_children(list) {
-            Some(children) if children.len() == 1 => {
-                pred_can_be_true_without_test(&children[0])
-            }
+            Some(children) if children.len() == 1 => pred_can_be_true_without_test(&children[0]),
             _ => true,
         },
         // `all` is false if any child can be false; `any` is false only if every
@@ -347,7 +343,11 @@ mod tests {
                 do_forward()?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "an out-of-module on_rewind call must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "an out-of-module on_rewind call must be flagged"
+        );
     }
 
     #[test]
@@ -370,23 +370,33 @@ mod tests {
                 fn drives_primitive(tx: &mut Tx) { tx.on_rewind(|| Ok(())); } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     #[test]
     fn ignores_string_literal() {
         let hits = scan_source("fn f() { let s = \"tx.on_rewind(x)\"; let _ = s; }");
-        assert!(hits.is_empty(), "a string mentioning on_rewind is not a call");
+        assert!(
+            hits.is_empty(),
+            "a string mentioning on_rewind is not a call"
+        );
     }
 
     #[test]
     fn atomic_module_path_is_recognized() {
-        assert!(is_atomic_module_path(Path::new("crates/repo/src/atomic/tx.rs")));
+        assert!(is_atomic_module_path(Path::new(
+            "crates/repo/src/atomic/tx.rs"
+        )));
         assert!(is_atomic_module_path(Path::new(
             "/work/crates/repo/src/atomic/tests.rs"
         )));
         // A sibling `atomic` dir under a different crate is NOT exempt.
-        assert!(!is_atomic_module_path(Path::new("crates/cli/src/atomic/x.rs")));
+        assert!(!is_atomic_module_path(Path::new(
+            "crates/cli/src/atomic/x.rs"
+        )));
         assert!(!is_atomic_module_path(Path::new(
             "crates/cli/src/cli/commands/undo_apply.rs"
         )));
@@ -469,7 +479,11 @@ mod tests {
             "#[cfg(any(test, feature = \"x\"))] \
              fn prod(tx: &mut Tx) { tx.on_rewind(|| Ok(())); }",
         );
-        assert_eq!(hits.len(), 1, "any(test, feature) is prod-reachable and must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "any(test, feature) is prod-reachable and must be flagged"
+        );
     }
 
     #[test]
@@ -527,7 +541,10 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "out-of-module on_rewind call site(s) found: {:?}",

--- a/crates/devtools/src/check_oprecord_exhaustiveness.rs
+++ b/crates/devtools/src/check_oprecord_exhaustiveness.rs
@@ -236,9 +236,7 @@ impl<'ast> Visit<'ast> for Finder<'_> {
 /// enum — return its name. Catches `OpRecord::Snapshot { .. }`,
 /// `OpRecord::Fork(..)`, and or-patterns / refs / parens thereof.
 fn matched_target_enum(node: &ExprMatch) -> Option<String> {
-    node.arms
-        .iter()
-        .find_map(|arm| pat_target_enum(&arm.pat))
+    node.arms.iter().find_map(|arm| pat_target_enum(&arm.pat))
 }
 
 fn pat_target_enum(pat: &Pat) -> Option<String> {
@@ -350,14 +348,16 @@ mod tests {
                 OpRecord::Snapshot { .. } | _ => {} \
             } }",
         );
-        assert_eq!(hits.len(), 1, "wildcard inside an or-pattern must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "wildcard inside an or-pattern must be flagged"
+        );
     }
 
     #[test]
     fn flags_o_p_kind_match_too() {
-        let hits = scan_source(
-            "fn f(k: OpKind) { match k { OpKind::Snapshot => a(), _ => {} } }",
-        );
+        let hits = scan_source("fn f(k: OpKind) { match k { OpKind::Snapshot => a(), _ => {} } }");
         assert_eq!(hits.len(), 1, "OpKind is also a target enum");
         assert_eq!(hits[0].enum_name, "OpKind");
     }
@@ -384,15 +384,17 @@ mod tests {
                 OpRecord::Goto { .. } => c(), \
             } }",
         );
-        assert!(hits.is_empty(), "a guarded catch-all is not a silent swallow");
+        assert!(
+            hits.is_empty(),
+            "a guarded catch-all is not a silent swallow"
+        );
     }
 
     #[test]
     fn ignores_wildcard_over_non_target_enum() {
         // A `match` over a string/other enum legitimately uses `_`.
-        let hits = scan_source(
-            "fn f(kind: &str) -> u8 { match kind { \"snapshot\" => 1, _ => 0 } }",
-        );
+        let hits =
+            scan_source("fn f(kind: &str) -> u8 { match kind { \"snapshot\" => 1, _ => 0 } }");
         assert!(hits.is_empty(), "non-target matches keep their wildcard");
     }
 
@@ -401,9 +403,8 @@ mod tests {
         // `matches!` expands to a macro, not an `ExprMatch`, so its internal
         // `_ => false` is invisible to the source AST — the idiomatic predicate
         // stays allowed.
-        let hits = scan_source(
-            "fn f(op: &OpRecord) -> bool { matches!(op, OpRecord::Snapshot { .. }) }",
-        );
+        let hits =
+            scan_source("fn f(op: &OpRecord) -> bool { matches!(op, OpRecord::Snapshot { .. }) }");
         assert!(hits.is_empty(), "matches! predicate must not be flagged");
     }
 
@@ -415,7 +416,10 @@ mod tests {
                 fn t(op: &OpRecord) { match op { OpRecord::Snapshot { .. } => a(), _ => {} } } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     const PLANTED: &str = "fn f(op: &OpRecord) { match op { \
@@ -470,12 +474,21 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "non-exhaustive OpRecord/OpKind match(es) found: {:?}",
             hits.iter()
-                .map(|h| format!("{}:{} ({} arm `{}`)", h.path.display(), h.line, h.enum_name, h.arm))
+                .map(|h| format!(
+                    "{}:{} ({} arm `{}`)",
+                    h.path.display(),
+                    h.line,
+                    h.enum_name,
+                    h.arm
+                ))
                 .collect::<Vec<_>>()
         );
     }

--- a/crates/devtools/src/check_snapshot_atomicity.rs
+++ b/crates/devtools/src/check_snapshot_atomicity.rs
@@ -189,16 +189,18 @@ fn is_cfg_test(attrs: &[Attribute]) -> bool {
     fn meta_mentions_test(meta: &Meta) -> bool {
         match meta {
             Meta::Path(path) => path.is_ident("test"),
-            Meta::List(list) if list.path.is_ident("cfg") => list.tokens.to_string().contains("test"),
+            Meta::List(list) if list.path.is_ident("cfg") => {
+                list.tokens.to_string().contains("test")
+            }
             Meta::List(list) if list.path.is_ident("all") || list.path.is_ident("any") => {
                 list.tokens.to_string().contains("test")
             }
             _ => false,
         }
     }
-    attrs.iter().any(|attr| {
-        attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta)
-    })
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") && meta_mentions_test(&attr.meta))
 }
 
 struct Finder<'a> {
@@ -413,7 +415,11 @@ mod tests {
                 self.oplog.record_snapshot(&id, p, th, s)?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "publish via aliased refs handle must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "publish via aliased refs handle must be flagged"
+        );
         assert_eq!(hits[0].method, "set_thread");
     }
 
@@ -428,7 +434,11 @@ mod tests {
                 self.oplog.record_snapshot(&id, p, th, s)?; \
                 Ok(()) }",
         );
-        assert_eq!(hits.len(), 1, "publish via aliased accessor handle must be flagged");
+        assert_eq!(
+            hits.len(),
+            1,
+            "publish via aliased accessor handle must be flagged"
+        );
         assert_eq!(hits[0].method, "write_head");
     }
 
@@ -530,7 +540,10 @@ mod tests {
                 } \
              }",
         );
-        assert!(hits.is_empty(), "inline #[cfg(test)] module must be skipped");
+        assert!(
+            hits.is_empty(),
+            "inline #[cfg(test)] module must be skipped"
+        );
     }
 
     #[test]
@@ -589,7 +602,10 @@ mod tests {
         let mut hits = Vec::new();
         let mut scanned = 0usize;
         scan_dir(&crates_dir, &mut hits, &mut scanned).expect("scan crates/");
-        assert!(scanned > 0, "expected to scan some files under {crates_dir:?}");
+        assert!(
+            scanned > 0,
+            "expected to scan some files under {crates_dir:?}"
+        );
         assert!(
             hits.is_empty(),
             "cross-crate publish-first snapshot site(s) found: {:?}",

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -27,9 +27,7 @@ fn main() -> Result<()> {
         Some("check-atomic-ledger-encapsulation") => {
             check_atomic_ledger_encapsulation::run(args.collect())
         }
-        Some("check-oprecord-exhaustiveness") => {
-            check_oprecord_exhaustiveness::run(args.collect())
-        }
+        Some("check-oprecord-exhaustiveness") => check_oprecord_exhaustiveness::run(args.collect()),
         Some("fuse-dispatch-bench") => fuse_dispatch_bench::run(args.collect()),
         Some(command) => bail!("unknown command '{command}'"),
         None => bail!("expected a command (for example: web-proto)"),

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -28,7 +28,6 @@ semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2" 
 anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
-gix.workspace = true
 # `bundled` vendors the SQLite C source so ingest doesn't depend on a
 # system libsqlite3 version. OpenCode's SQLite is read-only to us.
 rusqlite = { version = "0.32", features = ["bundled"] }
@@ -42,6 +41,7 @@ rmp-serde.workspace = true
 rustls.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
+sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/ingest/src/git_walk.rs
+++ b/crates/ingest/src/git_walk.rs
@@ -18,7 +18,7 @@
 //! - Full commit metadata: parents, tree, both signatures, message.
 //! - Tree and blob readers for use by the [translator](crate).
 //!
-//! Packed-refs inspection is implicit — gix handles that transparently.
+//! Packed-refs inspection is implicit — sley handles that transparently.
 //!
 //! Reflog *is* supported via [`GitSource::collect_reflog`] and
 //! [`GitSource::reflog_commit_shas`]: the former yields every entry across
@@ -44,6 +44,10 @@ use std::{
 };
 
 use chrono::{DateTime, TimeZone, Utc};
+use sley::{
+    GitObjectType, ObjectFormat, ObjectId as SleyObjectId, RefStore as SleyRefStore,
+    ReferenceTarget as SleyRefTarget, Repository as SleyRepository, Signature as SleySignature,
+};
 
 use crate::IngestError;
 
@@ -178,30 +182,36 @@ pub struct RefDiscoveryStats {
 /// (annotated tags whose peeled target is a blob/tree, dangling refs).
 /// Returns `false` on any read error — the caller treats that the same
 /// as "not a commit" and skips the ref.
-fn is_commit(repo: &gix::Repository, oid: gix::hash::ObjectId) -> bool {
+fn is_commit(repo: &SleyRepository, oid: SleyObjectId) -> bool {
     matches!(
-        repo.find_object(oid).map(|o| o.kind),
-        Ok(gix::objs::Kind::Commit)
+        repo.read_object(&oid).map(|object| object.object_type),
+        Ok(GitObjectType::Commit)
     )
 }
 
-/// Opens a git repo and exposes reads keyed on SHA. Holds a gix::Repository
+enum RefResolution {
+    Commit(SleyObjectId),
+    PeelFailed,
+    NonCommit,
+}
+
+/// Opens a git repo and exposes reads keyed on SHA. Holds a sley repository
 /// handle internally; clone-cheap via `&` reference only.
 pub struct GitSource {
-    repo: gix::Repository,
+    repo: SleyRepository,
 }
 
 impl std::fmt::Debug for GitSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GitSource")
-            .field("path", &self.repo.path())
+            .field("git_dir", &self.repo.git_dir())
             .finish()
     }
 }
 
 impl GitSource {
-    /// Open a repo at `path`. Uses `gix::discover` first (works from a
-    /// worktree subdirectory), falling back to `gix::open` for explicit
+    /// Open a repo at `path`. Uses sley's discovery first (works from a
+    /// worktree subdirectory), falling back to direct open for explicit
     /// `.git` dirs.
     pub fn open(path: impl AsRef<Path>) -> crate::Result<Self> {
         let path = path.as_ref();
@@ -209,12 +219,38 @@ impl GitSource {
         // fall back to `open` for explicit `.git` dirs. Both errors are
         // surfaced through our own string-typed Git variant — we don't care
         // which one fired; the user cares whether the path was usable.
-        let repo = match gix::discover(path) {
+        let repo = match SleyRepository::discover(path) {
             Ok(r) => r,
-            Err(_) => gix::open(path)
+            Err(_) => SleyRepository::open(path)
                 .map_err(|e| IngestError::Git(format!("open {}: {e}", path.display())))?,
         };
         Ok(Self { repo })
+    }
+
+    fn resolve_ref_commit(&self, name: &str, target: &SleyRefTarget) -> RefResolution {
+        let oid = match target {
+            SleyRefTarget::Direct(oid) => *oid,
+            SleyRefTarget::Symbolic(_) => match self.repo.find_reference(name) {
+                Ok(Some(reference)) => match reference.peeled_oid(&self.repo) {
+                    Ok(Some(oid)) => oid,
+                    Ok(None) | Err(_) => return RefResolution::PeelFailed,
+                },
+                Ok(None) | Err(_) => return RefResolution::PeelFailed,
+            },
+        };
+
+        match sley::plumbing::sley_rev::peel_to_commit(
+            self.repo.objects().as_ref(),
+            self.repo.object_format(),
+            &oid,
+        ) {
+            Ok(commit_oid) if is_commit(&self.repo, commit_oid) => {
+                RefResolution::Commit(commit_oid)
+            }
+            Ok(_) => RefResolution::NonCommit,
+            Err(_) if self.repo.read_object(&oid).is_ok() => RefResolution::NonCommit,
+            Err(_) => RefResolution::PeelFailed,
+        }
     }
 
     /// Enumerate every ref that resolves to a commit, alongside the
@@ -228,107 +264,46 @@ impl GitSource {
         let refs = self
             .repo
             .references()
+            .list_refs()
             .map_err(|e| IngestError::Git(format!("references: {e}")))?;
 
-        for branch in refs
-            .local_branches()
-            .map_err(|e| IngestError::Git(format!("local_branches: {e}")))?
-        {
-            let mut branch = branch.map_err(|e| IngestError::Git(format!("branch iter: {e}")))?;
-            // `peel_to_id` follows symbolic refs and tag objects down to a
-            // commit id. Branches almost never point at tag objects, but
-            // calling it uniformly keeps the two loops symmetrical.
-            let Ok(target) = branch.peel_to_id() else {
-                stats.peel_failed += 1;
+        for reference in refs {
+            let full_name = reference.name;
+            let Some((namespace, short_name)) = classify_ref_name(&full_name) else {
                 continue;
             };
-            // Guard: confirm the peeled target is actually a commit before
-            // surfacing it as a head. The downstream rev_walk and per-commit
-            // metadata reads assume commit-shaped tips; a non-commit here
-            // (extremely rare for branches but possible in corrupted repos)
-            // would crash the importer with `Expected commit but got X`.
-            if !is_commit(&self.repo, target.detach()) {
-                stats.non_commit_skipped += 1;
-                continue;
-            }
-            stats.local_branches += 1;
-            out.push(RefHead {
-                short_name: branch.name().shorten().to_string(),
-                full_name: branch.name().as_bstr().to_string(),
-                namespace: RefNamespace::Branch,
-                target_sha: target.detach().to_string(),
-            });
-        }
 
-        for tag in refs
-            .tags()
-            .map_err(|e| IngestError::Git(format!("tags: {e}")))?
-        {
-            let mut tag = tag.map_err(|e| IngestError::Git(format!("tag iter: {e}")))?;
-            // Annotated tags point at a tag *object*, not a commit —
-            // peeling is required so `target_sha` is always a commit SHA
-            // the sha map can translate. `peel_to_id` chases tag-of-tag
-            // chains to their final commit too, so a tag pointing at
-            // another annotated tag round-trips correctly.
-            let Ok(target) = tag.peel_to_id() else {
-                stats.peel_failed += 1;
-                continue;
-            };
-            // Guard: tags pointing at non-commit objects (blob: GPG public
-            // keys; tree: a directory of keys; etc.) are a real-world
-            // pattern in mature OSS repos — `git/git`'s `junio-gpg-pub`
-            // is the canonical example. The importer can't model these
-            // (no commit to translate into a state) but must not crash
-            // the entire walk.
-            if !is_commit(&self.repo, target.detach()) {
-                stats.non_commit_skipped += 1;
-                continue;
-            }
-            stats.tags += 1;
-            out.push(RefHead {
-                short_name: tag.name().shorten().to_string(),
-                full_name: tag.name().as_bstr().to_string(),
-                namespace: RefNamespace::Tag,
-                target_sha: target.detach().to_string(),
-            });
-        }
-
-        // Remote-tracking refs (`refs/remotes/<remote>/<branch>`). Without
-        // these the importer silently dropped every commit reachable only
-        // from origin — a real-world repo can easily lose hundreds of
-        // commits that way. We surface them under their `<remote>/<branch>`
-        // short name so they don't collide with local heads.
-        for remote in refs
-            .remote_branches()
-            .map_err(|e| IngestError::Git(format!("remote_branches: {e}")))?
-        {
-            let mut remote =
-                remote.map_err(|e| IngestError::Git(format!("remote-branch iter: {e}")))?;
-            let Ok(target) = remote.peel_to_id() else {
-                stats.peel_failed += 1;
-                continue;
-            };
-            if !is_commit(&self.repo, target.detach()) {
-                stats.non_commit_skipped += 1;
-                continue;
-            }
-            // `shorten()` on `refs/remotes/origin/main` returns `origin/main`,
-            // which is exactly the form a user types — preserve it.
-            let short = remote.name().shorten().to_string();
             // Skip `refs/remotes/<remote>/HEAD` — it's a symbolic ref to
             // another remote-tracking branch we'll emit separately. Letting
             // it through would create a duplicate thread named `origin/HEAD`
             // pointing at the same commit as `origin/main`.
-            if short.ends_with("/HEAD") {
+            if namespace == RefNamespace::RemoteBranch && short_name.ends_with("/HEAD") {
                 stats.symbolic_skipped += 1;
                 continue;
             }
-            stats.remote_branches += 1;
+
+            let target = match self.resolve_ref_commit(&full_name, &reference.target) {
+                RefResolution::Commit(target) => target,
+                RefResolution::PeelFailed => {
+                    stats.peel_failed += 1;
+                    continue;
+                }
+                RefResolution::NonCommit => {
+                    stats.non_commit_skipped += 1;
+                    continue;
+                }
+            };
+
+            match namespace {
+                RefNamespace::Branch => stats.local_branches += 1,
+                RefNamespace::Tag => stats.tags += 1,
+                RefNamespace::RemoteBranch => stats.remote_branches += 1,
+            }
             out.push(RefHead {
-                short_name: short,
-                full_name: remote.name().as_bstr().to_string(),
-                namespace: RefNamespace::RemoteBranch,
-                target_sha: target.detach().to_string(),
+                short_name,
+                full_name,
+                namespace,
+                target_sha: target.to_string(),
             });
         }
 
@@ -409,40 +384,32 @@ impl ChildIndex {
 impl GitSource {
     /// Read one commit by SHA.
     pub fn read_commit(&self, sha: &str) -> crate::Result<CommitEntry> {
-        let oid = parse_oid(sha)?;
-        let commit = self
+        let oid = parse_oid(self.repo.object_format(), sha)?;
+        let object = self
             .repo
-            .find_commit(oid)
+            .read_object(&oid)
             .map_err(|e| IngestError::Git(format!("find_commit {sha}: {e}")))?;
+        if object.object_type != GitObjectType::Commit {
+            return Err(IngestError::Git(format!(
+                "object {sha} is {}, not a commit",
+                object.object_type.as_str()
+            )));
+        }
+        let commit = sley::CommitObject::parse_ref(self.repo.object_format(), &object.body)
+            .map_err(|e| IngestError::Git(format!("parse commit {sha}: {e}")))?;
 
-        let tree_sha = commit
-            .tree_id()
-            .map_err(|e| IngestError::Git(format!("tree_id {sha}: {e}")))?
-            .detach()
-            .to_string();
+        let tree_sha = commit.tree.to_string();
 
-        let parents: Vec<String> = commit
-            .parent_ids()
-            .map(|p| p.detach().to_string())
-            .collect();
+        let parents: Vec<String> = commit.parents.iter().map(ToString::to_string).collect();
 
-        let author_ref = commit
-            .author()
-            .map_err(|e| IngestError::Git(format!("author {sha}: {e}")))?;
-        let committer_ref = commit
-            .committer()
-            .map_err(|e| IngestError::Git(format!("committer {sha}: {e}")))?;
-        let author = signature_from(author_ref);
-        let committer = signature_from(committer_ref);
+        let author = signature_from_bytes(commit.author, sha, "author")?;
+        let committer = signature_from_bytes(commit.committer, sha, "committer")?;
         let authored_at = author.time;
         let committed_at = committer.time;
 
-        let message = commit
-            .message_raw()
-            .map_err(|e| IngestError::Git(format!("message {sha}: {e}")))?
-            .to_vec();
+        let message = commit.message.to_vec();
 
-        let extra_headers = collect_commit_extra_headers(&commit)?;
+        let extra_headers = collect_commit_extra_headers(&object.body);
 
         Ok(CommitEntry {
             sha: oid.to_string(),
@@ -459,29 +426,37 @@ impl GitSource {
 
     /// Read the direct children of a git tree (non-recursive).
     pub fn read_tree(&self, tree_sha: &str) -> crate::Result<Vec<TreeChild>> {
-        let oid = parse_oid(tree_sha)?;
-        let tree = self
-            .repo
-            .find_tree(oid)
-            .map_err(|e| IngestError::Git(format!("find_tree {tree_sha}: {e}")))?;
+        let oid = parse_oid(self.repo.object_format(), tree_sha)?;
+        let entries = if oid == sley::ObjectId::empty_tree(self.repo.object_format()) {
+            Vec::new()
+        } else {
+            self.repo
+                .read_tree(&oid)
+                .map_err(|e| IngestError::Git(format!("find_tree {tree_sha}: {e}")))?
+                .entries
+        };
 
         let mut out = Vec::new();
-        for entry in tree.iter() {
-            let entry = entry.map_err(|e| IngestError::Git(format!("tree entry: {e}")))?;
-            let kind = match entry.mode().kind() {
-                gix::object::tree::EntryKind::Tree => TreeChildKind::Tree,
-                gix::object::tree::EntryKind::Blob => TreeChildKind::Blob { executable: false },
-                gix::object::tree::EntryKind::BlobExecutable => {
-                    TreeChildKind::Blob { executable: true }
+        for entry in entries {
+            let kind = match entry.mode {
+                0o040000 => TreeChildKind::Tree,
+                0o100644 => TreeChildKind::Blob { executable: false },
+                0o100755 => TreeChildKind::Blob { executable: true },
+                0o120000 => TreeChildKind::Symlink,
+                0o160000 => TreeChildKind::Gitlink,
+                mode => {
+                    return Err(IngestError::Git(format!(
+                        "tree entry {} has unsupported mode {:o}",
+                        String::from_utf8_lossy(entry.name.as_bytes()),
+                        mode
+                    )));
                 }
-                gix::object::tree::EntryKind::Link => TreeChildKind::Symlink,
-                gix::object::tree::EntryKind::Commit => TreeChildKind::Gitlink,
             };
-            let raw_name = entry.filename().to_vec();
+            let raw_name = entry.name.as_bytes().to_vec();
             out.push(TreeChild {
                 name: String::from_utf8_lossy(&raw_name).into_owned(),
                 raw_name,
-                sha: entry.object_id().to_string(),
+                sha: entry.oid.to_string(),
                 kind,
             });
         }
@@ -492,18 +467,18 @@ impl GitSource {
     /// as the authoritative byte stream for the import — subsequent blob
     /// translation hashes these bytes directly.
     pub fn read_blob(&self, blob_sha: &str) -> crate::Result<Vec<u8>> {
-        let oid = parse_oid(blob_sha)?;
+        let oid = parse_oid(self.repo.object_format(), blob_sha)?;
         let object = self
             .repo
-            .find_object(oid)
+            .read_object(&oid)
             .map_err(|e| IngestError::Git(format!("find_object {blob_sha}: {e}")))?;
-        if object.kind != gix::objs::Kind::Blob {
+        if object.object_type != GitObjectType::Blob {
             return Err(IngestError::Git(format!(
-                "object {blob_sha} is {:?}, not a blob",
-                object.kind
+                "object {blob_sha} is {}, not a blob",
+                object.object_type.as_str()
             )));
         }
-        Ok(object.data.clone())
+        Ok(object.body.clone())
     }
 
     /// Iterate every reflog entry across `HEAD` and every local branch/tag
@@ -520,32 +495,18 @@ impl GitSource {
         // HEAD — its reflog captures every checkout/commit/reset the user
         // made through the working tree, which is exactly the honesty
         // signal we care about for the oplog.
-        let head = self
-            .repo
-            .head()
-            .map_err(|e| IngestError::Git(format!("head: {e}")))?;
-        collect_one_reflog(&mut head.log_iter(), "HEAD", &mut out)?;
+        let refs = self.repo.references();
+        collect_one_reflog(&refs, "HEAD", &mut out)?;
 
         // Every local branch + tag.
-        let refs = self
-            .repo
-            .references()
-            .map_err(|e| IngestError::Git(format!("references: {e}")))?;
-        for branch in refs
-            .local_branches()
-            .map_err(|e| IngestError::Git(format!("local_branches: {e}")))?
+        for reference in refs
+            .list_refs()
+            .map_err(|e| IngestError::Git(format!("references: {e}")))?
         {
-            let branch = branch.map_err(|e| IngestError::Git(format!("branch iter: {e}")))?;
-            let full = branch.name().as_bstr().to_string();
-            collect_one_reflog(&mut branch.log_iter(), &full, &mut out)?;
-        }
-        for tag in refs
-            .tags()
-            .map_err(|e| IngestError::Git(format!("tags: {e}")))?
-        {
-            let tag = tag.map_err(|e| IngestError::Git(format!("tag iter: {e}")))?;
-            let full = tag.name().as_bstr().to_string();
-            collect_one_reflog(&mut tag.log_iter(), &full, &mut out)?;
+            if reference.name.starts_with("refs/heads/") || reference.name.starts_with("refs/tags/")
+            {
+                collect_one_reflog(&refs, &reference.name, &mut out)?;
+            }
         }
 
         Ok(out)
@@ -577,13 +538,10 @@ impl GitSource {
     /// `true` if `sha` resolves to a commit still present in the odb.
     /// Used to filter pruned / dangling SHAs out of reflog-derived seeds.
     fn object_is_commit(&self, sha: &str) -> bool {
-        let Ok(oid) = gix::hash::ObjectId::from_hex(sha.as_bytes()) else {
+        let Ok(oid) = parse_oid(self.repo.object_format(), sha) else {
             return false;
         };
-        match self.repo.find_object(oid) {
-            Ok(obj) => obj.kind == gix::objs::Kind::Commit,
-            Err(_) => false,
-        }
+        is_commit(&self.repo, oid)
     }
 
     /// Gather every commit reachable from the given heads, in
@@ -690,18 +648,34 @@ impl GitSource {
     }
 }
 
-/// Drain one reflog platform into `out`. Quietly tolerates a missing log
+fn classify_ref_name(full_name: &str) -> Option<(RefNamespace, String)> {
+    full_name
+        .strip_prefix("refs/heads/")
+        .map(|short| (RefNamespace::Branch, short.to_string()))
+        .or_else(|| {
+            full_name
+                .strip_prefix("refs/tags/")
+                .map(|short| (RefNamespace::Tag, short.to_string()))
+        })
+        .or_else(|| {
+            full_name
+                .strip_prefix("refs/remotes/")
+                .map(|short| (RefNamespace::RemoteBranch, short.to_string()))
+        })
+}
+
+/// Drain one reflog into `out`. Quietly tolerates a missing log
 /// (common for tags and freshly-created refs) by treating it as "no
-/// entries". Malformed lines are skipped via `filter_map` — we'd rather
-/// degrade to fewer oplog entries than abort the whole import.
+/// entries". Malformed lines are skipped — we'd rather degrade to fewer
+/// oplog entries than abort the whole import.
 fn collect_one_reflog(
-    platform: &mut gix::refs::file::log::iter::Platform<'_, '_>,
+    refs: &SleyRefStore,
     ref_name: &str,
     out: &mut Vec<ReflogEntry>,
 ) -> crate::Result<()> {
-    let iter = match platform.all() {
-        Ok(Some(it)) => it,
-        Ok(None) => return Ok(()),
+    let entries = match refs.read_reflog(ref_name) {
+        Ok(entries) if entries.is_empty() => return Ok(()),
+        Ok(entries) => entries,
         Err(e) => {
             // A broken reflog shouldn't sink the rest of the import.
             tracing::debug!(ref_name, error = %e, "reflog read failed; skipping");
@@ -709,40 +683,28 @@ fn collect_one_reflog(
         }
     };
 
-    for line in iter.flatten() {
+    for entry in entries {
         // `null_sha` is 40 zeros; map it to `None` so the caller doesn't
         // have to special-case creation / deletion markers downstream.
-        let prev = bstr_hex_or_none(line.previous_oid);
-        let new = bstr_hex_or_none(line.new_oid);
-        let time = line.signature.time().unwrap_or_default();
-        let signature = GitSignature {
-            name: line.signature.name.to_string(),
-            email: line.signature.email.to_string(),
-            time: Utc
-                .timestamp_opt(time.seconds, 0)
-                .single()
-                .unwrap_or_else(Utc::now),
-            tz_offset: time.offset,
+        let prev = oid_hex_or_none(&entry.old_oid);
+        let new = oid_hex_or_none(&entry.new_oid);
+        let Some(signature) = signature_from_raw(&entry.committer) else {
+            tracing::debug!(ref_name, "malformed reflog signature; skipping entry");
+            continue;
         };
         out.push(ReflogEntry {
             ref_name: ref_name.to_string(),
             previous_sha: prev,
             new_sha: new,
             signature,
-            message: line.message.to_string(),
+            message: String::from_utf8_lossy(&entry.message).into_owned(),
         });
     }
     Ok(())
 }
 
-fn bstr_hex_or_none(bytes: &gix::bstr::BStr) -> Option<String> {
-    let s: &str = std::str::from_utf8(bytes).ok()?;
-    // Git's null-sha marker. Either side being null means "ref didn't exist
-    // before / doesn't exist after" — return None so the caller can filter.
-    if s.chars().all(|c| c == '0') {
-        return None;
-    }
-    Some(s.to_string())
+fn oid_hex_or_none(oid: &SleyObjectId) -> Option<String> {
+    (!oid.is_null()).then(|| oid.to_string())
 }
 
 fn sort_by_time_then_sha(frontier: &mut [&str], entries: &HashMap<String, CommitEntry>) {
@@ -758,37 +720,44 @@ fn sort_by_time_then_sha(frontier: &mut [&str], entries: &HashMap<String, Commit
     });
 }
 
-fn parse_oid(sha: &str) -> crate::Result<gix::hash::ObjectId> {
-    gix::hash::ObjectId::from_hex(sha.as_bytes())
+fn parse_oid(format: ObjectFormat, sha: &str) -> crate::Result<SleyObjectId> {
+    SleyObjectId::from_hex(format, sha)
         .map_err(|e| IngestError::Git(format!("parse oid {sha}: {e}")))
 }
 
-fn signature_from(sig: gix::actor::SignatureRef<'_>) -> GitSignature {
-    let time = sig.time().unwrap_or_default();
-    GitSignature {
-        name: sig.name.to_string(),
-        email: sig.email.to_string(),
+fn signature_from_bytes(raw: &[u8], sha: &str, field: &str) -> crate::Result<GitSignature> {
+    signature_from_raw(raw)
+        .ok_or_else(|| IngestError::Git(format!("{field} {sha}: invalid signature")))
+}
+
+fn signature_from_raw(raw: &[u8]) -> Option<GitSignature> {
+    let sig = SleySignature::from_ident_line(raw)?;
+    let time = sig.time;
+    let tz_offset = i32::from(time.timezone_offset_minutes) * 60;
+    Some(GitSignature {
+        name: String::from_utf8_lossy(sig.name.as_bytes()).into_owned(),
+        email: String::from_utf8_lossy(sig.email.as_bytes()).into_owned(),
         time: Utc
             .timestamp_opt(time.seconds, 0)
             .single()
             .unwrap_or_else(Utc::now),
-        tz_offset: time.offset,
-    }
+        tz_offset,
+    })
 }
 
 /// Collect a commit's extension headers in their original on-the-wire order,
 /// as raw bytes so non-UTF8 values survive. ORDER IS LOAD-BEARING for #566
 /// byte-reconstruction.
 ///
-/// Built straight from the raw commit object bytes (`commit.data`) via
+/// Built straight from the raw commit object bytes via
 /// [`objects::object::parse_commit_extension_headers`] so `encoding` / `gpgsig`
 /// / `mergetag` / any unknown header all land at their TRUE captured position
 /// through one code path — the SAME path the bridge importer uses. We do NOT
-/// stitch the vec from gix's typed accessors (`CommitRef::encoding`, …): gix
-/// surfaces some headers outside `extra_headers`, and re-inserting them by hand
+/// stitch the vec from typed accessors (`CommitRef::encoding`, ...): some
+/// headers are surfaced outside `extra_headers`, and re-inserting them by hand
 /// reorders them (the close-the-class bug this replaces). #564 de-lossy step 1.
-fn collect_commit_extra_headers(commit: &gix::Commit<'_>) -> crate::Result<Vec<(Vec<u8>, Vec<u8>)>> {
-    Ok(objects::object::parse_commit_extension_headers(&commit.data))
+fn collect_commit_extra_headers(raw_commit: &[u8]) -> Vec<(Vec<u8>, Vec<u8>)> {
+    objects::object::parse_commit_extension_headers(raw_commit)
 }
 
 #[cfg(test)]
@@ -1018,7 +987,14 @@ mod tests {
         .join(&b'\n');
 
         let sha = run(
-            &["hash-object", "--literally", "-w", "-t", "commit", "--stdin"],
+            &[
+                "hash-object",
+                "--literally",
+                "-w",
+                "-t",
+                "commit",
+                "--stdin",
+            ],
             Some(&content),
         );
 
@@ -1029,8 +1005,7 @@ mod tests {
             (b"x-custom".to_vec(), b"custom value".to_vec()),
             (
                 b"gpgsig".to_vec(),
-                b"-----BEGIN PGP SIGNATURE-----\nsig-line-1\n-----END PGP SIGNATURE-----"
-                    .to_vec(),
+                b"-----BEGIN PGP SIGNATURE-----\nsig-line-1\n-----END PGP SIGNATURE-----".to_vec(),
             ),
             (b"encoding".to_vec(), b"ISO-8859-1".to_vec()),
             (
@@ -1203,7 +1178,7 @@ mod tests {
         // Commit 1: lightweight files.
         std::fs::write(path.join("a.txt"), "hello").unwrap();
         std::fs::write(path.join("empty.txt"), "").unwrap();
-        // Symlink. macOS + Linux both support `ln -s`; gix reads the
+        // Symlink. macOS + Linux both support `ln -s`; sley reads the
         // resulting tree mode as `Link` regardless of host filesystem.
         #[cfg(unix)]
         std::os::unix::fs::symlink("a.txt", path.join("link.txt")).unwrap();

--- a/crates/ingest/src/reasoning_extract.rs
+++ b/crates/ingest/src/reasoning_extract.rs
@@ -378,9 +378,7 @@ fn harvest_claude(path: &Path, params: &HarvestParams) -> crate::Result<Vec<Harv
 /// the same gate both the Claude and Codex harvesters used to apply
 /// inline. File-touch kinds are dropped; only the paths matter for target
 /// resolution.
-fn assistant_events(
-    stream: Vec<crate::transcript::stream::StreamEvent>,
-) -> Vec<AssistantEvent> {
+fn assistant_events(stream: Vec<crate::transcript::stream::StreamEvent>) -> Vec<AssistantEvent> {
     let mut out = Vec::new();
     for ev in stream {
         let Some(timestamp) = ev.timestamp else {

--- a/crates/ingest/src/ref_emit.rs
+++ b/crates/ingest/src/ref_emit.rs
@@ -32,9 +32,9 @@ use refs::refs::{RefBackend, RefExpectation};
 use tracing::warn;
 
 use crate::{
+    IngestError,
     git_walk::{RefHead, RefNamespace},
     sha_map::ShaMap,
-    IngestError,
 };
 
 /// Rolling tally returned by [`RefEmitter::emit`].

--- a/crates/ingest/src/sha_map.rs
+++ b/crates/ingest/src/sha_map.rs
@@ -337,11 +337,9 @@ impl ShaMap {
         // On primary-key conflict we fall back to a SELECT so we can
         // distinguish idempotent re-inserts (same `heddle_repr`) from
         // genuine conflicts.
-        let mut stmt = self
-            .conn
-            .prepare_cached(
-                "INSERT INTO sha_map (git_sha, kind, heddle_repr, lossy_entries) VALUES (?, ?, ?, ?)",
-            )?;
+        let mut stmt = self.conn.prepare_cached(
+            "INSERT INTO sha_map (git_sha, kind, heddle_repr, lossy_entries) VALUES (?, ?, ?, ?)",
+        )?;
         match stmt.execute(params![git_sha, kind.as_i64(), heddle_repr, lossy_json]) {
             Ok(_) => Ok(()),
             Err(rusqlite::Error::SqliteFailure(err, _))

--- a/crates/ingest/src/transcript/claude.rs
+++ b/crates/ingest/src/transcript/claude.rs
@@ -136,7 +136,10 @@ pub(crate) fn stream_events(text: &str, source_path: &Path) -> Vec<StreamEvent> 
             session_id: event.session_id,
             starting_commit: None,
             cwd: event.cwd.map(|c| CwdSignal::IfUnset(PathBuf::from(c))),
-            is_turn: matches!(event.event_type.as_deref(), Some("user") | Some("assistant")),
+            is_turn: matches!(
+                event.event_type.as_deref(),
+                Some("user") | Some("assistant")
+            ),
             texts,
             touches,
         });

--- a/crates/ingest/src/transcript/mod.rs
+++ b/crates/ingest/src/transcript/mod.rs
@@ -26,6 +26,7 @@ pub mod types;
 use std::path::{Path, PathBuf};
 
 pub use matcher::{Match, MatchParams, TranscriptMatcher};
+use sley::Repository as SleyRepository;
 use tracing::{debug, warn};
 pub use types::{FileTouch, Provider, TouchKind, Transcript};
 
@@ -147,13 +148,13 @@ pub(crate) fn repo_matches_checkout(candidate: &Path, repo_root: &Path) -> bool 
 }
 
 pub(crate) fn repo_workdir(path: &Path) -> Option<PathBuf> {
-    let repo = gix::discover(path).ok()?;
+    let repo = SleyRepository::discover(path).ok()?;
     let workdir = repo.workdir()?;
-    canonicalize_fallback(workdir)
+    canonicalize_fallback(&workdir)
 }
 
 fn repo_common_dir(path: &Path) -> Option<PathBuf> {
-    let repo = gix::discover(path).ok()?;
+    let repo = SleyRepository::discover(path).ok()?;
     canonicalize_fallback(repo.common_dir())
 }
 

--- a/crates/ingest/src/tree_translate.rs
+++ b/crates/ingest/src/tree_translate.rs
@@ -99,7 +99,10 @@ impl<'a, S: ObjectStore> TreeTranslator<'a, S> {
                 .unwrap_or_default();
             if !entries.is_empty() {
                 if !self.options.lossy {
-                    return Err(fail_lossy_entry(&rebase_lossy_entry(path_prefix, &entries[0])));
+                    return Err(fail_lossy_entry(&rebase_lossy_entry(
+                        path_prefix,
+                        &entries[0],
+                    )));
                 }
                 self.lossy_entries.extend(
                     entries

--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -3074,9 +3074,7 @@ impl<S: ObjectStore> MountInner<S> {
 /// weak handle and drains any hot buffer that's been idle longer
 /// than `idle_after`. A `None` `sweep_interval` returns `None`,
 /// meaning event-driven promotion only.
-fn spawn_sweep_worker<S: ObjectStore + 'static>(
-    inner: &Arc<MountInner<S>>,
-) -> Option<SweepHandle> {
+fn spawn_sweep_worker<S: ObjectStore + 'static>(inner: &Arc<MountInner<S>>) -> Option<SweepHandle> {
     let interval = inner
         .promotion
         .read()

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -11,8 +11,8 @@ use std::{
     ffi::OsStr,
     fs,
     sync::{
-        atomic::{AtomicUsize, Ordering},
         Arc,
+        atomic::{AtomicUsize, Ordering},
     },
 };
 
@@ -47,15 +47,15 @@ pub(crate) mod mocks {
     use std::{
         ffi::OsStr,
         sync::{
-            atomic::{AtomicUsize, Ordering},
             Arc,
+            atomic::{AtomicUsize, Ordering},
         },
         time::UNIX_EPOCH,
     };
 
     use crate::{
         error::{MountError, Result},
-        shell::{Attrs, Entry, NodeId, NodeKind, PlatformShell, DIR_UNIX_MODE},
+        shell::{Attrs, DIR_UNIX_MODE, Entry, NodeId, NodeKind, PlatformShell},
     };
 
     /// Trivial in-memory shell that lets adapter unit tests validate
@@ -1778,10 +1778,12 @@ mod write_ops {
         mount
             .rmdir_entry(NodeId::ROOT, OsStr::new("scratch"))
             .expect("rmdir");
-        assert!(mount
-            .lookup(NodeId::ROOT, OsStr::new("scratch"))
-            .unwrap()
-            .is_none());
+        assert!(
+            mount
+                .lookup(NodeId::ROOT, OsStr::new("scratch"))
+                .unwrap()
+                .is_none()
+        );
     }
 
     /// `rmdir_entry` on a directory that has any visible child (pending

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -29,7 +29,9 @@ thiserror.workspace = true
 toml.workspace = true
 tracing.workspace = true
 uuid.workspace = true
-windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Storage_FileSystem"] }
+# Win32_Security: CreateFileW's binding is gated on it in windows-sys 0.61
+# (its signature takes a *const SECURITY_ATTRIBUTES from Win32::Security).
+windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 zstd = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -66,9 +66,11 @@ pub use state_visibility::{
     STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG, StateVisibility, StateVisibilityBlob,
     StateVisibilityError,
 };
-pub use visibility_tier::VisibilityTier;
 pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
 };
-pub use tree::{EntryType, FileMode, Tree, TreeEntry, TreeError, validate_name as validate_tree_entry_name};
+pub use tree::{
+    EntryType, FileMode, Tree, TreeEntry, TreeError, validate_name as validate_tree_entry_name,
+};
 pub use tree_diff::{diff_trees, diff_trees_visit};
+pub use visibility_tier::VisibilityTier;

--- a/crates/objects/src/object/state_core.rs
+++ b/crates/objects/src/object/state_core.rs
@@ -1179,8 +1179,8 @@ mod tests {
         let with_committer = sample_state()
             .with_change_id(base.change_id)
             .with_logical_change_id(base.logical_change_id());
-        let mut with_committer = with_committer
-            .with_committer(Principal::new("Carol", "carol@example.com"));
+        let mut with_committer =
+            with_committer.with_committer(Principal::new("Carol", "carol@example.com"));
         with_committer.created_at = base.created_at;
         assert_ne!(
             with_committer.hash(),

--- a/crates/objects/src/object/state_visibility.rs
+++ b/crates/objects/src/object/state_visibility.rs
@@ -382,8 +382,7 @@ mod tests {
             fork_b.clone()
         };
         // Resolved identically regardless of the order the records appear in.
-        let blob1 =
-            StateVisibilityBlob::new(vec![genesis.clone(), fork_a.clone(), fork_b.clone()]);
+        let blob1 = StateVisibilityBlob::new(vec![genesis.clone(), fork_a.clone(), fork_b.clone()]);
         let blob2 = StateVisibilityBlob::new(vec![genesis, fork_b, fork_a]);
         assert_eq!(blob1.latest().unwrap().unwrap(), &expected);
         assert_eq!(

--- a/crates/objects/src/object/tree_diff.rs
+++ b/crates/objects/src/object/tree_diff.rs
@@ -100,8 +100,7 @@ where
                 from_index += 1;
             }
             std::cmp::Ordering::Greater => {
-                if let ControlFlow::Break(b) =
-                    visit_added_entry(store, prefix, to_entry, visitor)?
+                if let ControlFlow::Break(b) = visit_added_entry(store, prefix, to_entry, visitor)?
                 {
                     return Ok(ControlFlow::Break(b));
                 }

--- a/crates/objects/src/object/versioned_blob.rs
+++ b/crates/objects/src/object/versioned_blob.rs
@@ -40,8 +40,8 @@ macro_rules! versioned_msgpack_blob {
             }
 
             pub fn decode(bytes: &[u8]) -> ::core::result::Result<Self, $Err> {
-                let blob: Self = rmp_serde::from_slice(bytes)
-                    .map_err(|err| <$Err>::$codec(err.to_string()))?;
+                let blob: Self =
+                    rmp_serde::from_slice(bytes).map_err(|err| <$Err>::$codec(err.to_string()))?;
                 blob.validate()?;
                 Ok(blob)
             }

--- a/crates/objects/src/object/visibility_tier.rs
+++ b/crates/objects/src/object/visibility_tier.rs
@@ -97,9 +97,7 @@ mod tests {
     use super::*;
 
     fn team(id: &str) -> VisibilityTier {
-        VisibilityTier::TeamScoped {
-            team_id: id.into(),
-        }
+        VisibilityTier::TeamScoped { team_id: id.into() }
     }
     fn restricted(label: &str) -> VisibilityTier {
         VisibilityTier::Restricted {
@@ -113,27 +111,31 @@ mod tests {
             VisibilityTier::Public.restrictiveness_rank()
                 < VisibilityTier::Internal.restrictiveness_rank()
         );
-        assert!(
-            VisibilityTier::Internal.restrictiveness_rank() < team("a").restrictiveness_rank()
-        );
+        assert!(VisibilityTier::Internal.restrictiveness_rank() < team("a").restrictiveness_rank());
         assert!(team("a").restrictiveness_rank() < restricted("legal").restrictiveness_rank());
     }
 
     #[test]
     fn strictly_less_restrictive_only_when_rank_drops() {
         // Opening transitions (lower rank) are strictly less restrictive.
-        assert!(VisibilityTier::Public.is_strictly_less_restrictive_than(&VisibilityTier::Internal));
+        assert!(
+            VisibilityTier::Public.is_strictly_less_restrictive_than(&VisibilityTier::Internal)
+        );
         assert!(VisibilityTier::Internal.is_strictly_less_restrictive_than(&restricted("legal")));
         assert!(VisibilityTier::Internal.is_strictly_less_restrictive_than(&team("infra")));
 
         // Narrowing transitions (higher rank) are NOT.
         assert!(!restricted("legal").is_strictly_less_restrictive_than(&VisibilityTier::Internal));
-        assert!(!VisibilityTier::Internal.is_strictly_less_restrictive_than(&VisibilityTier::Public));
+        assert!(
+            !VisibilityTier::Internal.is_strictly_less_restrictive_than(&VisibilityTier::Public)
+        );
 
         // Lateral (same rank) is NOT strictly less restrictive — even across
         // different team/scope labels. A re-scope must go through `set`.
         assert!(!team("a").is_strictly_less_restrictive_than(&team("b")));
         assert!(!restricted("legal").is_strictly_less_restrictive_than(&restricted("security")));
-        assert!(!VisibilityTier::Internal.is_strictly_less_restrictive_than(&VisibilityTier::Internal));
+        assert!(
+            !VisibilityTier::Internal.is_strictly_less_restrictive_than(&VisibilityTier::Internal)
+        );
     }
 }

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -12,8 +12,8 @@ use super::{
     FsStore,
     fs_io::{list_hashes_from_dir, read_file_bytes, read_file_header},
     fs_paths::{
-        action_path, actions_dir, blobs_dir, hash_path, redaction_path, redactions_dir,
-        state_path, state_visibility_dir, state_visibility_path, states_dir, trees_dir,
+        action_path, actions_dir, blobs_dir, hash_path, redaction_path, redactions_dir, state_path,
+        state_visibility_dir, state_visibility_path, states_dir, trees_dir,
     },
 };
 use crate::{
@@ -348,9 +348,7 @@ impl FsStore {
         // miss) returns the stale packed body. (Trees/blobs are
         // content-addressed and can't go stale this way, so their read paths
         // deliberately keep pack-first ordering.)
-        if loose_exists
-            && let Some(data) = read_file_bytes(&path)?
-        {
+        if loose_exists && let Some(data) = read_file_bytes(&path)? {
             trace!(
                 size = data.as_slice().len(),
                 "State read from loose object (shadows any packed copy)"
@@ -1042,11 +1040,7 @@ impl ObjectStore for FsStore {
         }
     }
 
-    fn put_state_visibility_bytes_for_state(
-        &self,
-        state: &ChangeId,
-        bytes: &[u8],
-    ) -> Result<()> {
+    fn put_state_visibility_bytes_for_state(&self, state: &ChangeId, bytes: &[u8]) -> Result<()> {
         let dir = state_visibility_dir(&self.root);
         if !dir.exists() {
             fs::create_dir_all(&dir)?;
@@ -1077,5 +1071,4 @@ impl ObjectStore for FsStore {
         }
         Ok(out)
     }
-
 }

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -459,7 +459,10 @@ fn test_state_roundtrip_preserves_non_utf8_raw_message() {
     let (_temp, store) = create_test_store();
 
     let raw = b"caf\xe9\n".to_vec();
-    assert!(String::from_utf8(raw.clone()).is_err(), "fixture must be non-UTF8");
+    assert!(
+        String::from_utf8(raw.clone()).is_err(),
+        "fixture must be non-UTF8"
+    );
 
     let tree_hash = ContentHash::compute(b"tree");
     let attribution = Attribution::human(Principal::new("Test", "test@example.com"));

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -183,11 +183,7 @@ impl ObjectStore for InMemoryStore {
         Ok(self.state_visibility.read().unwrap().get(state).cloned())
     }
 
-    fn put_state_visibility_bytes_for_state(
-        &self,
-        state: &ChangeId,
-        bytes: &[u8],
-    ) -> Result<()> {
+    fn put_state_visibility_bytes_for_state(&self, state: &ChangeId, bytes: &[u8]) -> Result<()> {
         self.state_visibility
             .write()
             .unwrap()
@@ -196,7 +192,13 @@ impl ObjectStore for InMemoryStore {
     }
 
     fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
-        Ok(self.state_visibility.read().unwrap().keys().copied().collect())
+        Ok(self
+            .state_visibility
+            .read()
+            .unwrap()
+            .keys()
+            .copied()
+            .collect())
     }
 }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -202,11 +202,7 @@ impl ObjectStore for AnyStore {
     fn get_state_visibility_bytes_for_state(&self, state: &ChangeId) -> Result<Option<Vec<u8>>> {
         any_store_dispatch!(self, get_state_visibility_bytes_for_state(state))
     }
-    fn put_state_visibility_bytes_for_state(
-        &self,
-        state: &ChangeId,
-        bytes: &[u8],
-    ) -> Result<()> {
+    fn put_state_visibility_bytes_for_state(&self, state: &ChangeId, bytes: &[u8]) -> Result<()> {
         any_store_dispatch!(self, put_state_visibility_bytes_for_state(state, bytes))
     }
     fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
@@ -597,11 +593,7 @@ pub trait ObjectStore: Send + Sync {
     ///
     /// Default impl returns an "unsupported" error so stores that do not
     /// model the sidecar refuse instead of dropping it.
-    fn put_state_visibility_bytes_for_state(
-        &self,
-        _state: &ChangeId,
-        _bytes: &[u8],
-    ) -> Result<()> {
+    fn put_state_visibility_bytes_for_state(&self, _state: &ChangeId, _bytes: &[u8]) -> Result<()> {
         Err(HeddleError::InvalidObject(
             "this object store does not support persisting state visibility".to_string(),
         ))
@@ -641,13 +633,19 @@ mod any_store_tests {
         // ── Blobs ──
         let blob = Blob::from("any-store dispatch blob");
         let blob_hash = store.put_blob(&blob).unwrap();
-        assert_eq!(store.get_blob(&blob_hash).unwrap().unwrap().content(), blob.content());
+        assert_eq!(
+            store.get_blob(&blob_hash).unwrap().unwrap().content(),
+            blob.content()
+        );
         assert!(store.has_blob(&blob_hash).unwrap());
         assert_eq!(
             store.get_blob_bytes(&blob_hash).unwrap().unwrap().as_ref(),
             blob.content()
         );
-        assert_eq!(store.blob_size(&blob_hash).unwrap().unwrap(), blob.content().len() as u64);
+        assert_eq!(
+            store.blob_size(&blob_hash).unwrap().unwrap(),
+            blob.content().len() as u64
+        );
         assert!(store.loose_blob_path(&blob_hash).is_some());
         store.promote_to_loose_uncompressed(&blob_hash).unwrap();
         assert!(store.list_blobs().unwrap().contains(&blob_hash));
@@ -676,7 +674,9 @@ mod any_store_tests {
         let tree2 = Tree::new();
         let tree2_bytes = rmp_serde::to_vec_named(&tree2).unwrap();
         assert_eq!(
-            store.put_tree_serialized(&tree2_bytes, tree2.hash()).unwrap(),
+            store
+                .put_tree_serialized(&tree2_bytes, tree2.hash())
+                .unwrap(),
             tree2.hash()
         );
 
@@ -747,10 +747,18 @@ mod any_store_tests {
             .unwrap();
         assert!(store.has_redactions_for_blob(&blob_hash).unwrap());
         assert_eq!(
-            store.get_redactions_bytes_for_blob(&blob_hash).unwrap().as_deref(),
+            store
+                .get_redactions_bytes_for_blob(&blob_hash)
+                .unwrap()
+                .as_deref(),
             Some(redaction.as_slice())
         );
-        assert!(store.list_blobs_with_redactions().unwrap().contains(&blob_hash));
+        assert!(
+            store
+                .list_blobs_with_redactions()
+                .unwrap()
+                .contains(&blob_hash)
+        );
 
         // ── State visibility ──
         let state_visibility = b"any-store state visibility bytes";

--- a/crates/objects/src/store/pack/mod.rs
+++ b/crates/objects/src/store/pack/mod.rs
@@ -21,10 +21,10 @@ pub use pack_builder::PackBuilder;
 pub use pack_index::PackIndex;
 pub use pack_reader::PackReader;
 pub use shared::{
+    PACK_CHECKSUM_LEN, PackContainerSpec, PackEntryHeader, PackObjectId, PackObjectRecord,
     append_container_checksum, compress_pack_payload, decode_tagged_entry_header,
     decompress_pack_payload, encode_tagged_entry, encode_tagged_entry_parts, has_zstd_magic,
-    try_decode_tagged_entry_header, verify_container, write_container_header, PackContainerSpec,
-    PackEntryHeader, PackObjectId, PackObjectRecord, PACK_CHECKSUM_LEN,
+    try_decode_tagged_entry_header, verify_container, write_container_header,
 };
 pub use streaming_builder::StreamingPackBuilder;
 

--- a/crates/objects/src/store/pack/pack_builder.rs
+++ b/crates/objects/src/store/pack/pack_builder.rs
@@ -4,14 +4,14 @@
 use std::collections::{HashMap, VecDeque};
 
 use super::{
-    append_container_checksum, compress_pack_payload, encode_tagged_entry,
-    encode_tagged_entry_parts, pack_container_spec, pack_index::PackIndex, write_container_header,
-    ObjectType, PackObjectId, PackObjectRecord, PackStats,
+    ObjectType, PackObjectId, PackObjectRecord, PackStats, append_container_checksum,
+    compress_pack_payload, encode_tagged_entry, encode_tagged_entry_parts, pack_container_spec,
+    pack_index::PackIndex, write_container_header,
 };
 use crate::{
     delta::DeltaEncoder,
     object::ContentHash,
-    store::{compression::CompressionConfig, Result},
+    store::{Result, compression::CompressionConfig},
 };
 
 const MIN_DELTA_SIZE: usize = 64;

--- a/crates/objects/src/store/pack/pack_index.rs
+++ b/crates/objects/src/store/pack/pack_index.rs
@@ -2,11 +2,11 @@
 //! Pack index for fast object lookup within packfiles.
 
 use crate::store::{
-    pack::{
-        versioned_header::{HeaderChecksum, VersionedHeader},
-        PackObjectId,
-    },
     Result,
+    pack::{
+        PackObjectId,
+        versioned_header::{HeaderChecksum, VersionedHeader},
+    },
 };
 
 pub(super) const INDEX_MAGIC: &[u8; 4] = b"LMI\0";

--- a/crates/objects/src/store/pack/pack_tests.rs
+++ b/crates/objects/src/store/pack/pack_tests.rs
@@ -3,11 +3,11 @@
 
 use tempfile::TempDir;
 
-use super::{pack_index::PackIndex, ObjectType, PackBuilder, PackObjectId, PackReader};
+use super::{ObjectType, PackBuilder, PackObjectId, PackReader, pack_index::PackIndex};
 use crate::{
     delta::MAX_DELTA_OUTPUT_SIZE,
     object::{ChangeId, ContentHash},
-    store::{compression::CompressionConfig, pack::pack_container_spec, StoreError},
+    store::{StoreError, compression::CompressionConfig, pack::pack_container_spec},
 };
 
 fn create_test_hash(n: u8) -> ContentHash {
@@ -545,7 +545,7 @@ fn test_pack_reader_missing_object_returns_none() {
 /// with the expected diagnostic phrase.
 #[test]
 fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
-    use crate::store::{pack::pack_index::PackIndex, StoreError};
+    use crate::store::{StoreError, pack::pack_index::PackIndex};
 
     let blob_a = b"alpha-payload alpha-payload alpha-payload alpha".to_vec();
     let blob_b = b"bravo-payload bravo-payload bravo-payload bravo".to_vec();

--- a/crates/objects/src/store/pack/shared.rs
+++ b/crates/objects/src/store/pack/shared.rs
@@ -2,13 +2,12 @@
 #![deny(clippy::cast_possible_truncation)]
 
 use super::{
-    varint,
+    ObjectType, varint,
     versioned_header::{HeaderChecksum, VersionedHeader},
-    ObjectType,
 };
 use crate::{
     object::{ChangeId, ContentHash},
-    store::{compression::CompressionConfig, Result, StoreError},
+    store::{Result, StoreError, compression::CompressionConfig},
 };
 
 pub const PACK_CHECKSUM_LEN: usize = 32;

--- a/crates/objects/src/store/pack/streaming_builder.rs
+++ b/crates/objects/src/store/pack/streaming_builder.rs
@@ -63,7 +63,7 @@ use std::{
     path::PathBuf,
 };
 
-use super::{pack_container_spec, write_container_header, ObjectType, PackObjectId, PackStats};
+use super::{ObjectType, PackObjectId, PackStats, pack_container_spec, write_container_header};
 
 /// How many bytes to reserve for the compressed-size varint in the
 /// streaming path. 10 is enough to encode any `u64` (max 9 7-bit
@@ -74,7 +74,7 @@ use super::{pack_container_spec, write_container_header, ObjectType, PackObjectI
 const CSIZE_PLACEHOLDER_LEN: usize = 10;
 use crate::{
     object::ContentHash,
-    store::{compression::CompressionConfig, Result, StoreError},
+    store::{Result, StoreError, compression::CompressionConfig},
 };
 
 /// Number of buckets per id variant. 256 = one bucket per first byte

--- a/crates/objects/src/store/s3/s3_impl/mod.rs
+++ b/crates/objects/src/store/s3/s3_impl/mod.rs
@@ -582,5 +582,4 @@ impl ObjectStore for S3Store {
         }
         Ok(ids)
     }
-
 }

--- a/crates/proto/src/lib.rs
+++ b/crates/proto/src/lib.rs
@@ -57,9 +57,8 @@ pub use object_graph::{
 };
 pub use object_transfer::{
     MAX_PULL_DECODE_MESSAGE_SIZE, MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
-    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, chunk_bounds, chunk_count, chunk_offset,
-    check_received_transfer_blob_size, load_object_data, load_requested_object,
-    store_received_object,
+    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, check_received_transfer_blob_size, chunk_bounds,
+    chunk_count, chunk_offset, load_object_data, load_requested_object, store_received_object,
 };
 pub use scope_match::scope_contains;
 

--- a/crates/proto/src/object_graph.rs
+++ b/crates/proto/src/object_graph.rs
@@ -655,13 +655,15 @@ mod tests {
         .unwrap();
 
         assert!(
-            full.iter().any(|info| info.obj_type == ObjectType::StateVisibility
-                && info.id == ObjectId::ChangeId(state.change_id)),
+            full.iter()
+                .any(|info| info.obj_type == ObjectType::StateVisibility
+                    && info.id == ObjectId::ChangeId(state.change_id)),
             "full closure must include a StateVisibility entry for the visible state"
         );
         assert!(
-            plan.iter().any(|p| p.obj_type == ObjectType::StateVisibility
-                && p.id == ObjectId::ChangeId(state.change_id)),
+            plan.iter()
+                .any(|p| p.obj_type == ObjectType::StateVisibility
+                    && p.id == ObjectId::ChangeId(state.change_id)),
             "plan closure must include a StateVisibility entry for the visible state"
         );
     }

--- a/crates/refs/src/refs/backend.rs
+++ b/crates/refs/src/refs/backend.rs
@@ -352,9 +352,7 @@ mod tests {
 
         // write_head_cas writes through to the head slot.
         let head = Head::Detached { state: head_id };
-        backend
-            .write_head_cas(RefExpectation::Any, &head)
-            .unwrap();
+        backend.write_head_cas(RefExpectation::Any, &head).unwrap();
         assert_eq!(backend.read_head().unwrap(), head);
 
         // set_thread_cas inserts; list_threads + get_thread observe it.

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -7,8 +7,8 @@ mod name;
 pub mod operation_index;
 mod packed_model;
 mod packed_refs;
-mod ref_backend;
 mod reconcile;
+mod ref_backend;
 mod ref_summary_index;
 mod refs_head;
 mod refs_manager;
@@ -39,10 +39,8 @@ pub use operation_index::{IndexedOperation, OperationLogIndex, OperationLogQuery
 pub use packed_model::PackedRefsModel;
 #[cfg(feature = "postgres")]
 pub use pg_refs::PgRefBackend;
+pub use reconcile::{LoadRequest, Loaded, ReconcileOutcome, RefClass, RefCommitter, RefReconciler};
 pub use ref_backend::RefBackend;
-pub use reconcile::{
-    Loaded, LoadRequest, RefClass, RefCommitter, RefReconciler, ReconcileOutcome,
-};
 pub use ref_summary_index::RefSummaryIndexInspection;
 pub use refs_manager::{RefManager, UNDO_RECOVERY_HANDLE};
 pub use reftable_model::{ReftableError, ReftableModel};

--- a/crates/refs/src/refs/name.rs
+++ b/crates/refs/src/refs/name.rs
@@ -27,7 +27,10 @@ pub fn validate_ref_name(name: &str) -> Result<(), RefNameError> {
     // Git refname rule: no path *component* may end in `.lock` (not just
     // the whole ref) — `refs/heads/foo.lock/bar` would collide with the
     // on-disk lockfile of `refs/heads/foo`.
-    if name.split('/').any(|component| component.ends_with(".lock")) {
+    if name
+        .split('/')
+        .any(|component| component.ends_with(".lock"))
+    {
         return Err(invalid(name));
     }
     Ok(())

--- a/crates/refs/src/refs/pg_refs.rs
+++ b/crates/refs/src/refs/pg_refs.rs
@@ -244,7 +244,11 @@ impl CoreRefBackend for PgRefBackend {
         let name = name.to_string();
         self.block(async move { let row = sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = true RETURNING change_id").bind(repo_id).bind(&name).fetch_optional(pool.as_ref()).await.map_err(sqlx_err)?; row.map(|r| { let bytes: Vec<u8> = r.try_get("change_id").map_err(sqlx_err)?; Self::bytes_to_id(bytes) }).transpose() })
     }
-    fn delete_thread_cas(&self, name: &ThreadName, expected: RefExpectation<ChangeId>) -> Result<()> {
+    fn delete_thread_cas(
+        &self,
+        name: &ThreadName,
+        expected: RefExpectation<ChangeId>,
+    ) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -278,7 +282,9 @@ impl CoreRefBackend for PgRefBackend {
             .map_err(sqlx_err)?
             .rows_affected();
         if n == 0 {
-            Err(HeddleError::Conflict(format!("marker '{name}' already exists")))
+            Err(HeddleError::Conflict(format!(
+                "marker '{name}' already exists"
+            )))
         } else {
             Ok(())
         }
@@ -301,7 +307,11 @@ impl CoreRefBackend for PgRefBackend {
         let name = name.to_string();
         self.block(async move { let row = sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = false RETURNING change_id").bind(repo_id).bind(&name).fetch_optional(pool.as_ref()).await.map_err(sqlx_err)?; row.map(|r| { let bytes: Vec<u8> = r.try_get("change_id").map_err(sqlx_err)?; Self::bytes_to_id(bytes) }).transpose() })
     }
-    fn delete_marker_cas(&self, name: &MarkerName, expected: RefExpectation<ChangeId>) -> Result<()> {
+    fn delete_marker_cas(
+        &self,
+        name: &MarkerName,
+        expected: RefExpectation<ChangeId>,
+    ) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let name = name.to_string();
@@ -363,7 +373,11 @@ impl RefBackend for PgRefBackend {
             "remote threading refs are not supported on the server backend".into(),
         ))
     }
-    fn delete_remote_thread(&self, _remote: &str, _thread: &ThreadName) -> Result<Option<ChangeId>> {
+    fn delete_remote_thread(
+        &self,
+        _remote: &str,
+        _thread: &ThreadName,
+    ) -> Result<Option<ChangeId>> {
         Err(HeddleError::Conflict(
             "remote threading refs are not supported on the server backend".into(),
         ))

--- a/crates/refs/src/refs/ref_backend.rs
+++ b/crates/refs/src/refs/ref_backend.rs
@@ -9,7 +9,7 @@ use objects::{
     object::{ChangeId, ThreadName},
 };
 
-use super::{backend::CoreRefBackend, RefSummaryIndexInspection, RefUpdate};
+use super::{RefSummaryIndexInspection, RefUpdate, backend::CoreRefBackend};
 
 /// Backend-agnostic interface for reading and writing repository references.
 pub trait RefBackend: CoreRefBackend<Error = HeddleError> {

--- a/crates/refs/src/refs/refs_head.rs
+++ b/crates/refs/src/refs/refs_head.rs
@@ -6,7 +6,7 @@ use objects::{
     object::{ChangeId, ThreadName},
 };
 
-use super::{parse_change_id_text, Head, RefManager};
+use super::{Head, RefManager, parse_change_id_text};
 
 pub(super) struct HeadState {
     pub head: Head,

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -152,11 +152,7 @@ fn test_corerefbackend_trait_methods_dispatch() {
 
     CoreRefBackend::set_thread(&refs, &ThreadName::new("main"), &thread_id).unwrap();
     assert_eq!(
-        pollster::block_on(CoreRefBackend::get_thread(
-            &refs,
-            &ThreadName::new("main")
-        ))
-        .unwrap(),
+        pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main"))).unwrap(),
         Some(thread_id)
     );
 
@@ -546,8 +542,8 @@ mod chokepoint {
     use tempfile::TempDir;
 
     use super::super::{
-        Loaded, LoadRequest, RefCommitter, RefManager, RefReconciler, ReconcileOutcome,
-        RefExpectation, RefUpdate,
+        LoadRequest, Loaded, ReconcileOutcome, RefCommitter, RefExpectation, RefManager,
+        RefReconciler, RefUpdate,
     };
 
     fn manager() -> (TempDir, std::path::PathBuf) {
@@ -574,7 +570,12 @@ mod chokepoint {
         fn generation(&self) -> Result<u64> {
             Ok(self.generation.load(Ordering::Acquire))
         }
-        fn reconcile(&self, req: &LoadRequest, raw: Loaded, _since: u64) -> Result<ReconcileOutcome> {
+        fn reconcile(
+            &self,
+            req: &LoadRequest,
+            raw: Loaded,
+            _since: u64,
+        ) -> Result<ReconcileOutcome> {
             self.calls.fetch_add(1, Ordering::AcqRel);
             // Project the request's authoritative value out of the configured
             // materialization set (mirrors the real reconciler's per-request fold).
@@ -583,7 +584,9 @@ mod chokepoint {
                     .republish
                     .iter()
                     .find_map(|u| match u {
-                        RefUpdate::Thread { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        RefUpdate::Thread { name: n, new, .. } if n == name => {
+                            Some(Loaded::Point(*new))
+                        }
                         _ => None,
                     })
                     .unwrap_or(raw),
@@ -591,7 +594,9 @@ mod chokepoint {
                     .republish
                     .iter()
                     .find_map(|u| match u {
-                        RefUpdate::Marker { name: n, new, .. } if n == name => Some(Loaded::Point(*new)),
+                        RefUpdate::Marker { name: n, new, .. } if n == name => {
+                            Some(Loaded::Point(*new))
+                        }
                         _ => None,
                     })
                     .unwrap_or(raw),
@@ -648,7 +653,11 @@ mod chokepoint {
         // Generation still 7 ⇒ tip == cached ⇒ reconcile is never invoked.
         let got = refs.get_thread(&ThreadName::new("absent")).unwrap();
         assert_eq!(got, None);
-        assert_eq!(calls.load(Ordering::Acquire), 0, "hot path must not reconcile");
+        assert_eq!(
+            calls.load(Ordering::Acquire),
+            0,
+            "hot path must not reconcile"
+        );
     }
 
     /// The lag path drives `materialize`'s authoritative-apply branches: an
@@ -711,24 +720,37 @@ mod chokepoint {
                 },
             ],
             remote_updates: vec![
-                ("origin".to_string(), ThreadName::new("rt"), Some(remote_state)),
+                (
+                    "origin".to_string(),
+                    ThreadName::new("rt"),
+                    Some(remote_state),
+                ),
                 // `None` value, canonical absent — skipped.
                 ("origin".to_string(), ThreadName::new("gone"), None),
                 // Present-but-stale remote thread ⇒ overwritten with committed value.
-                ("origin".to_string(), ThreadName::new("rt_stale"), Some(remote_stale_new)),
+                (
+                    "origin".to_string(),
+                    ThreadName::new("rt_stale"),
+                    Some(remote_stale_new),
+                ),
                 // Present remote thread the fold deleted ⇒ removed.
                 ("origin".to_string(), ThreadName::new("rt_doomed"), None),
             ],
             undo_recovery: Some(undo_state),
             calls: Arc::clone(&calls),
         });
-        let refs = RefManager::new(&dir).with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
+        let refs = RefManager::new(&dir)
+            .with_reconciler(Arc::clone(&reconciler) as Arc<dyn RefReconciler>);
         refs.init().unwrap();
         // Publish present + stale AFTER injection (raw writes, bypass chokepoint).
-        refs.set_thread(&ThreadName::new("present"), &present_state).unwrap();
-        refs.set_thread(&ThreadName::new("stale"), &stale_old).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt_stale"), &remote_stale_old).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt_doomed"), &remote_doomed).unwrap();
+        refs.set_thread(&ThreadName::new("present"), &present_state)
+            .unwrap();
+        refs.set_thread(&ThreadName::new("stale"), &stale_old)
+            .unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_stale"), &remote_stale_old)
+            .unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt_doomed"), &remote_doomed)
+            .unwrap();
         refs.set_undo_recovery(&undo_old).unwrap();
 
         // Bump generation so the next read lags ⇒ reconcile + materialize run.
@@ -749,19 +771,25 @@ mod chokepoint {
             Some(stale_new),
             "a stale present ref must be overwritten with the committed value"
         );
-        assert_eq!(refs.get_marker(&MarkerName::new("mk")).unwrap(), Some(marker_state));
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt")).unwrap(),
+            refs.get_marker(&MarkerName::new("mk")).unwrap(),
+            Some(marker_state)
+        );
+        assert_eq!(
+            refs.get_remote_thread("origin", &ThreadName::new("rt"))
+                .unwrap(),
             Some(remote_state)
         );
         // The stale remote thread is overwritten; the doomed one is removed.
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt_stale")).unwrap(),
+            refs.get_remote_thread("origin", &ThreadName::new("rt_stale"))
+                .unwrap(),
             Some(remote_stale_new),
             "a stale present remote thread must be overwritten with the committed value"
         );
         assert_eq!(
-            refs.get_remote_thread("origin", &ThreadName::new("rt_doomed")).unwrap(),
+            refs.get_remote_thread("origin", &ThreadName::new("rt_doomed"))
+                .unwrap(),
             None,
             "a committed delete must remove a present remote thread"
         );
@@ -771,7 +799,11 @@ mod chokepoint {
         // Second read: watermark now == generation (2) ⇒ hot path, no new reconcile.
         let before = calls.load(Ordering::Acquire);
         let _ = refs.get_thread(&ThreadName::new("absent")).unwrap();
-        assert_eq!(calls.load(Ordering::Acquire), before, "watermark caught up ⇒ hot path");
+        assert_eq!(
+            calls.load(Ordering::Acquire),
+            before,
+            "watermark caught up ⇒ hot path"
+        );
     }
 
     /// `commit_and_publish` appends the ref-carrying records (phase 4) before
@@ -783,7 +815,8 @@ mod chokepoint {
         let committer = Arc::new(FakeCommitter {
             seen: Mutex::new(Vec::new()),
         });
-        let refs = RefManager::new(&dir).with_committer(Arc::clone(&committer) as Arc<dyn RefCommitter>);
+        let refs =
+            RefManager::new(&dir).with_committer(Arc::clone(&committer) as Arc<dyn RefCommitter>);
         refs.init().unwrap();
 
         let state = ChangeId::generate();
@@ -793,7 +826,8 @@ mod chokepoint {
             expected: RefExpectation::Missing,
             new: Some(state),
         }];
-        refs.commit_and_publish(&records, &updates, Some("lane")).unwrap();
+        refs.commit_and_publish(&records, &updates, Some("lane"))
+            .unwrap();
 
         // The committer saw the records (phase 4) and the ref published (phase 5).
         let seen = committer.seen.lock().unwrap();
@@ -824,7 +858,10 @@ mod chokepoint {
                 None,
             )
             .unwrap();
-        assert_eq!(plain.get_marker(&MarkerName::new("v2")).unwrap(), Some(other));
+        assert_eq!(
+            plain.get_marker(&MarkerName::new("v2")).unwrap(),
+            Some(other)
+        );
     }
 
     /// Fail closed (heddle#354 r9, cid 3330304656): a `commit_and_publish` with
@@ -874,7 +911,10 @@ mod chokepoint {
         // phase-3 read of the still-missing ref (which needs no write perm)
         // succeeds — isolating a publish-after-commit failure.
         let threads_dir = refs.threads_dir();
-        let original = std::fs::metadata(&threads_dir).unwrap().permissions().mode();
+        let original = std::fs::metadata(&threads_dir)
+            .unwrap()
+            .permissions()
+            .mode();
         std::fs::set_permissions(&threads_dir, std::fs::Permissions::from_mode(0o555)).unwrap();
 
         let lock = refs.lock_refs().unwrap();
@@ -913,20 +953,27 @@ mod chokepoint {
         let s2 = ChangeId::generate();
         // RefBackend trait surface for remotes.
         RefBackend::set_remote_thread(&refs, "origin", &ThreadName::new("rt1"), &s1).unwrap();
-        refs.set_remote_thread("origin", &ThreadName::new("rt2"), &s2).unwrap();
+        refs.set_remote_thread("origin", &ThreadName::new("rt2"), &s2)
+            .unwrap();
         assert_eq!(
             RefBackend::get_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap(),
             Some(s1)
         );
-        assert!(RefBackend::list_remotes(&refs).unwrap().contains(&"origin".to_string()));
+        assert!(
+            RefBackend::list_remotes(&refs)
+                .unwrap()
+                .contains(&"origin".to_string())
+        );
         let mut rts = RefBackend::list_remote_threads(&refs, "origin").unwrap();
         rts.sort();
         assert_eq!(rts.len(), 2);
-        let removed = RefBackend::delete_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap();
+        let removed =
+            RefBackend::delete_remote_thread(&refs, "origin", &ThreadName::new("rt1")).unwrap();
         assert_eq!(removed, Some(s1));
         // Deleting an absent remote thread returns None.
         assert_eq!(
-            refs.delete_remote_thread("origin", &ThreadName::new("nope")).unwrap(),
+            refs.delete_remote_thread("origin", &ThreadName::new("nope"))
+                .unwrap(),
             None
         );
 
@@ -944,12 +991,22 @@ mod chokepoint {
         assert_eq!(refs.resolve("rel").unwrap(), Some(m));
 
         // CoreRefBackend async + sync delegations.
-        let got = pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main2"))).unwrap();
+        let got = pollster::block_on(CoreRefBackend::get_thread(&refs, &ThreadName::new("main2")))
+            .unwrap();
         assert_eq!(got, Some(t));
-        let gm = pollster::block_on(CoreRefBackend::get_marker(&refs, &MarkerName::new("rel"))).unwrap();
+        let gm =
+            pollster::block_on(CoreRefBackend::get_marker(&refs, &MarkerName::new("rel"))).unwrap();
         assert_eq!(gm, Some(m));
-        assert!(CoreRefBackend::list_threads(&refs).unwrap().contains(&ThreadName::new("main2")));
-        assert!(CoreRefBackend::list_markers(&refs).unwrap().contains(&MarkerName::new("rel")));
+        assert!(
+            CoreRefBackend::list_threads(&refs)
+                .unwrap()
+                .contains(&ThreadName::new("main2"))
+        );
+        assert!(
+            CoreRefBackend::list_markers(&refs)
+                .unwrap()
+                .contains(&MarkerName::new("rel"))
+        );
         let r = pollster::block_on(CoreRefBackend::resolve(&refs, "main2")).unwrap();
         assert_eq!(r, Some(t));
 
@@ -1239,8 +1296,7 @@ mod write_read_conformance {
     #[test]
     fn read_chokepoint_refreshes_watermark_fresh() {
         assert!(
-            first_body(&[MANAGER_SRC], "reconciled_load")
-                .contains("refresh_persisted_watermark("),
+            first_body(&[MANAGER_SRC], "reconciled_load").contains("refresh_persisted_watermark("),
             "the read chokepoint must re-read the persisted watermark each reconcile"
         );
     }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -255,11 +255,11 @@ impl RefManager {
                 }
                 RefUpdate::Head { expected, new } => {
                     let raw_state = self.read_head_state()?;
-                    let reconciled_head = match self.reconciled_value_under_lock(&LoadRequest::Head)?
-                    {
-                        Loaded::Head(head) => head,
-                        _ => unreachable!("Head request yields Head"),
-                    };
+                    let reconciled_head =
+                        match self.reconciled_value_under_lock(&LoadRequest::Head)? {
+                            Loaded::Head(head) => head,
+                            _ => unreachable!("Head request yields Head"),
+                        };
                     // HEAD "exists" if its file is present OR a committed record
                     // reconstructs a value the stale on-disk HEAD does not reflect.
                     let exists = raw_state.exists || reconciled_head != raw_state.head;

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -14,7 +14,6 @@ anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
-gix.workspace = true
 ignore.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
@@ -28,6 +27,7 @@ semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2",
 state_review = { path = "../state_review", package = "heddle-state-review", version = "0.2", optional = true }
 serde.workspace = true
 serde_json.workspace = true
+sley.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, optional = true }

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -3,21 +3,21 @@
 
 use std::cell::RefCell;
 use std::collections::BTreeSet;
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
 use objects::object::{ChangeId, ContentHash, MarkerName, ThreadName, VisibilityTier};
 use oplog::{
-    isolation_keys_for_record, ConditionalCommitOutcome, IsolationKey, IsolationPrecondition,
-    OpLogBackend, OpRecord, ThreadUpdateSnapshots,
+    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord,
+    ThreadUpdateSnapshots, isolation_keys_for_record,
 };
 use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
 
 use super::{
-    execute, AtomicMutation, Compensator, DeferredMutation, EagerMutation, RewindLedger,
-    StagedCommit, Tx,
+    AtomicMutation, Compensator, DeferredMutation, EagerMutation, RewindLedger, StagedCommit, Tx,
+    execute,
 };
 use crate::Repository;
 
@@ -681,19 +681,22 @@ fn all_ten_readers_reconcile() {
             .unwrap(),
         Some(remote_state)
     );
-    assert!(refs
-        .list_threads()
-        .unwrap()
-        .contains(&ThreadName::new("ft")));
-    assert!(refs
-        .list_markers()
-        .unwrap()
-        .contains(&MarkerName::new("mk")));
+    assert!(
+        refs.list_threads()
+            .unwrap()
+            .contains(&ThreadName::new("ft"))
+    );
+    assert!(
+        refs.list_markers()
+            .unwrap()
+            .contains(&MarkerName::new("mk"))
+    );
     assert!(refs.list_remotes().unwrap().contains(&"origin".to_string()));
-    assert!(refs
-        .list_remote_threads("origin")
-        .unwrap()
-        .contains(&ThreadName::new("rt")));
+    assert!(
+        refs.list_remote_threads("origin")
+            .unwrap()
+            .contains(&ThreadName::new("rt"))
+    );
     assert_eq!(refs.resolve("ft").unwrap(), Some(thread_state));
 }
 
@@ -1566,10 +1569,11 @@ fn reconcile_folds_every_record_shape() {
     let threads = refs.list_threads().unwrap();
     assert!(threads.contains(&ThreadName::new("t_coll")));
     assert!(threads.contains(&ThreadName::new("t_ff")));
-    assert!(refs
-        .list_markers()
-        .unwrap()
-        .contains(&MarkerName::new("mk2")));
+    assert!(
+        refs.list_markers()
+            .unwrap()
+            .contains(&MarkerName::new("mk2"))
+    );
     let remotes = refs.list_remotes().unwrap();
     assert!(remotes.contains(&"origin".to_string()));
     let remote_threads = refs.list_remote_threads("origin").unwrap();

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -12,7 +12,9 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use objects::error::{HeddleError, Result};
-use oplog::{ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord};
+use oplog::{
+    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpRecord,
+};
 
 use super::traits::{DeferredMutation, EagerMutation, StagedCommit};
 use crate::Repository;

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -8,15 +8,15 @@ use std::{
 };
 
 use anyhow::Result;
-use objects::object::{diff_trees, ChangeId, ContentHash, Tree};
+use objects::object::{ChangeId, ContentHash, Tree, diff_trees};
 use tracing::warn;
 
 use super::{
+    Repository,
     bloom_filter::bloom_insert,
     commit_graph_persistence::{
-        commit_graph_path, load_commit_graph, save_commit_graph, PersistedCommitGraphNode,
+        PersistedCommitGraphNode, commit_graph_path, load_commit_graph, save_commit_graph,
     },
-    Repository,
 };
 
 #[derive(Clone, Debug)]

--- a/crates/repo/src/git_worktree_status.rs
+++ b/crates/repo/src/git_worktree_status.rs
@@ -1,49 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Compare a working-copy path against its indexed Git OID + mode.
 //!
-//! Used by every codepath that wants `git status`-equivalent dirtiness
-//! for a single index entry: the plain-Git status probe in
-//! `cli::commands::git_overlay_health`, the overlay status probe in
-//! `repository`, and the worktree-vs-index check in
-//! `cli::commands::git_compat`. Each used to carry its own near-
-//! identical re-implementation, which drifted (the cli/repo copies
-//! lost type-change checks the git_compat copy had, the git_compat
-//! copy lost the chmod check the cli/repo copies needed). This module
-//! is the single source of truth so future fixes land once.
-//!
-//! Semantics mirror `git status --porcelain=v1` for a single index
-//! entry:
-//!
-//! - Path missing from the worktree → [`GitWorktreeEntryState::Deleted`].
-//! - Indexed type doesn't match worktree type (file ↔ symlink, etc.)
-//!   → [`GitWorktreeEntryState::Modified`]. Git would report this as
-//!   a type-change.
-//! - Submodule (`160000`) indexed as a directory present → `Clean`,
-//!   else `Modified` (the actual SHA inside the submodule isn't
-//!   inspected here — that's the caller's job).
-//! - Symlink indexed and present: link target read as raw bytes (NOT
-//!   `to_string_lossy`, which mangles non-UTF-8 paths), hashed,
-//!   compared to `expected_oid`.
-//! - Regular file: on Unix, the worktree exec bit is compared against
-//!   the indexed mode (`100644` vs `100755`) so a `chmod +x` flip is
-//!   caught — git porcelain v1 reports this as ` M f` and porcelain v2
-//!   carries it in the `<mH>` mode field. Then bytes are hashed and
-//!   compared to `expected_oid`.
-//!
-//! On platforms without an executable bit (Windows), the exec-bit
-//! comparison is skipped — git itself ignores `core.filemode` there.
+//! Sley owns the Git-compatible worktree comparison rules: type changes,
+//! executable-bit changes, symlink target hashing, gitlinks, clean filters, and
+//! the racy-clean stat shortcut. Heddle keeps this tiny wrapper so existing repo
+//! and CLI call sites can share one return type while the implementation stays
+//! in the Git substrate.
 
-use std::{fs, io, path::Path};
+use std::path::Path;
 
 use objects::error::{HeddleError, Result};
+pub use sley::IndexStatProbe;
 
-const GIT_MODE_REGULAR: u32 = 0o100644;
-const GIT_MODE_EXECUTABLE: u32 = 0o100755;
-const GIT_MODE_SYMLINK: u32 = 0o120000;
-const GIT_MODE_COMMIT: u32 = 0o160000;
-
-/// State of a single index entry relative to the worktree, mirroring
-/// the three outcomes `git status` cares about for a known-tracked path.
+/// State of a single index entry relative to the worktree, mirroring the three
+/// outcomes `git status` cares about for a known-tracked path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GitWorktreeEntryState {
     /// Worktree matches the indexed blob.
@@ -54,350 +24,40 @@ pub enum GitWorktreeEntryState {
     Deleted,
 }
 
-/// The index-recorded stat for a tracked path plus the index's own write
-/// timestamp (the `.git/index` file mtime, in whole seconds since epoch).
-///
-/// Passed into [`git_worktree_entry_state`] to enable git's stat fast-path:
-/// when the worktree file's stat still matches the index's cached stat — and
-/// the entry isn't inside the racy window — the content is provably unchanged
-/// and the (10k-file) read+SHA-1 is skipped entirely, exactly like
-/// `git status`. Anything uncertain falls back to hashing.
-#[derive(Debug, Clone, Copy)]
-pub struct IndexStatProbe {
-    /// The stat git cached for this entry the last time it refreshed the index.
-    pub stat: gix::index::entry::Stat,
-    /// The index file's own mtime, in whole seconds since the unix epoch.
-    pub index_timestamp_secs: i64,
-}
-
-impl IndexStatProbe {
-    /// Whether the worktree file at `absolute` is *provably* unchanged versus
-    /// the index — i.e. its stat matches the cached stat and it predates the
-    /// index's write time (so it's outside the racy-clean window). Returns
-    /// `false` on any uncertainty (stat mismatch, racy window, stat
-    /// unavailable), leaving the caller to read + hash.
-    fn proves_clean(&self, absolute: &Path) -> bool {
-        let Ok(metadata) = gix::index::fs::Metadata::from_path_no_follow(absolute) else {
-            return false;
-        };
-        let Ok(worktree_stat) = gix::index::entry::Stat::from_fs(&metadata) else {
-            return false;
-        };
-        if !self
-            .stat
-            .matches(&worktree_stat, gix::index::entry::stat::Options::default())
-        {
-            return false;
+impl From<sley::WorktreeEntryState> for GitWorktreeEntryState {
+    fn from(state: sley::WorktreeEntryState) -> Self {
+        match state {
+            sley::WorktreeEntryState::Clean => Self::Clean,
+            sley::WorktreeEntryState::Modified => Self::Modified,
+            sley::WorktreeEntryState::Deleted => Self::Deleted,
         }
-        // Racy-clean guard, mirroring `gix::index::entry::Stat::is_racy` with
-        // `use_nsec = false` (git's Linux default): an entry whose mtime is at
-        // or after the index's own write time could have been modified within
-        // the same second without the stat changing, so it must be hashed.
-        // `is_racy` is true when `index_timestamp <= mtime_secs`.
-        self.index_timestamp_secs > i64::from(self.stat.mtime.secs)
     }
 }
 
-/// Compare the worktree file at `root/path` to its indexed
-/// `expected_oid` + `mode` (a raw Git file mode such as `0o100644`).
-/// See the module-level docs for the rules.
+/// Compare the worktree file at `root/path` to its indexed `expected_oid` +
+/// mode (a raw Git file mode such as `0o100644`).
 pub fn git_worktree_entry_state(
     root: &Path,
     path: &str,
-    expected_oid: gix::ObjectId,
+    expected_oid: sley::ObjectId,
     mode: u32,
     index_probe: Option<IndexStatProbe>,
 ) -> Result<GitWorktreeEntryState> {
-    let absolute = root.join(path);
-    let metadata = match fs::symlink_metadata(&absolute) {
-        Ok(metadata) => metadata,
-        // `NotFound`: the path is simply gone. `NotADirectory`: an ancestor
-        // is no longer a directory (e.g. tracked `data/item.txt` after `data`
-        // became a regular file — a dir→file type change). In both cases the
-        // indexed path cannot exist in the worktree, which is exactly what
-        // `git status` reports as a deletion; the new file arrives as its own
-        // untracked `added` entry.
-        Err(error)
-            if matches!(
-                error.kind(),
-                io::ErrorKind::NotFound | io::ErrorKind::NotADirectory
-            ) =>
-        {
-            return Ok(GitWorktreeEntryState::Deleted);
-        }
-        Err(error) => return Err(error.into()),
-    };
-    let file_type = metadata.file_type();
-
-    if mode == GIT_MODE_COMMIT {
-        return Ok(if file_type.is_dir() {
-            GitWorktreeEntryState::Clean
-        } else {
-            GitWorktreeEntryState::Modified
-        });
-    }
-
-    if mode == GIT_MODE_SYMLINK {
-        // Type-change: indexed as symlink but worktree isn't one.
-        if !file_type.is_symlink() {
-            return Ok(GitWorktreeEntryState::Modified);
-        }
-        let target = fs::read_link(&absolute)?;
-        let target_bytes = objects::util::symlink_target_bytes(&target);
-        return hash_and_compare(expected_oid, &target_bytes);
-    }
-
-    // Indexed as file but worktree is a symlink or directory → type-change.
-    if file_type.is_symlink() || file_type.is_dir() {
-        return Ok(GitWorktreeEntryState::Modified);
-    }
-
-    // Regular file: exec-bit comparison (Unix only) catches `chmod +x`
-    // flips that leave blob bytes identical. Git porcelain v1 reports
-    // these as ` M f`; hash-only comparison would falsely return Clean.
-    #[cfg(unix)]
-    if matches!(mode, GIT_MODE_REGULAR | GIT_MODE_EXECUTABLE) {
-        use std::os::unix::fs::PermissionsExt;
-        let worktree_executable = metadata.permissions().mode() & 0o111 != 0;
-        let indexed_executable = mode == GIT_MODE_EXECUTABLE;
-        if worktree_executable != indexed_executable {
-            return Ok(GitWorktreeEntryState::Modified);
-        }
-    }
-    #[cfg(not(unix))]
-    let _ = (GIT_MODE_REGULAR, GIT_MODE_EXECUTABLE);
-
-    // Stat fast-path: if the index's cached stat still matches the worktree
-    // (and we're outside the racy window), the blob is unchanged — skip the
-    // read + SHA-1. The exec-bit divergence above is already ruled out, and a
-    // chmod bumps ctime, which `matches` (trust_ctime) catches, so this never
-    // masks a mode flip.
-    if let Some(probe) = index_probe
-        && probe.proves_clean(&absolute)
-    {
-        return Ok(GitWorktreeEntryState::Clean);
-    }
-
-    let bytes = fs::read(&absolute)?;
-    hash_and_compare(expected_oid, &bytes)
+    let repo = sley::Repository::discover(root).map_err(sley_error)?;
+    let workdir = repo.workdir().unwrap_or_else(|| root.to_path_buf());
+    let state = sley::plumbing::sley_worktree::worktree_entry_state_by_git_path(
+        &workdir,
+        repo.git_dir(),
+        repo.object_format(),
+        path.as_bytes(),
+        &expected_oid,
+        mode,
+        index_probe.as_ref(),
+    )
+    .map_err(sley_error)?;
+    Ok(state.into())
 }
 
-fn hash_and_compare(expected_oid: gix::ObjectId, bytes: &[u8]) -> Result<GitWorktreeEntryState> {
-    let actual_oid = gix::objs::compute_hash(expected_oid.kind(), gix::objs::Kind::Blob, bytes)
-        .map_err(|error| {
-            HeddleError::Config(format!("failed to hash worktree path: {error}"))
-        })?;
-    Ok(if actual_oid == expected_oid {
-        GitWorktreeEntryState::Clean
-    } else {
-        GitWorktreeEntryState::Modified
-    })
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs;
-
-    use super::*;
-
-    fn write_blob_hash(bytes: &[u8]) -> gix::ObjectId {
-        gix::objs::compute_hash(gix::hash::Kind::Sha1, gix::objs::Kind::Blob, bytes)
-            .expect("hash bytes")
-    }
-
-    #[test]
-    fn missing_path_is_deleted() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let oid = write_blob_hash(b"anything");
-        let state = git_worktree_entry_state(temp.path(), "nope.txt", oid, GIT_MODE_REGULAR, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Deleted);
-    }
-
-    /// A tracked path whose ancestor became a regular file (a dir→file type
-    /// change: `data/item.txt` after `data` is replaced by a file) raises
-    /// `ENOTDIR`, not `NotFound`. The indexed path still cannot exist, so it
-    /// must report `Deleted` rather than propagating an io error.
-    #[test]
-    fn ancestor_turned_into_file_is_deleted() {
-        let temp = tempfile::TempDir::new().unwrap();
-        // `data` is a regular file; `data/item.txt` therefore has a non-dir
-        // ancestor and cannot be statted.
-        fs::write(temp.path().join("data"), b"now a file").unwrap();
-        let oid = write_blob_hash(b"x\ny\n");
-        let state = git_worktree_entry_state(temp.path(), "data/item.txt", oid, GIT_MODE_REGULAR, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Deleted);
-    }
-
-    #[test]
-    fn identical_content_is_clean() {
-        let temp = tempfile::TempDir::new().unwrap();
-        fs::write(temp.path().join("a.txt"), b"hello").unwrap();
-        let oid = write_blob_hash(b"hello");
-        let state =
-            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR, None).expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Clean);
-    }
-
-    #[test]
-    fn changed_content_is_modified() {
-        let temp = tempfile::TempDir::new().unwrap();
-        fs::write(temp.path().join("a.txt"), b"new content").unwrap();
-        let oid = write_blob_hash(b"old content");
-        let state =
-            git_worktree_entry_state(temp.path(), "a.txt", oid, GIT_MODE_REGULAR, None).expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-    }
-
-    /// The defect Codex flagged: a chmod-only change leaves blob bytes
-    /// identical, so hash-only comparison would return Clean. The
-    /// exec-bit comparison catches it.
-    #[cfg(unix)]
-    #[test]
-    fn chmod_only_change_is_modified() {
-        use std::os::unix::fs::PermissionsExt;
-        let temp = tempfile::TempDir::new().unwrap();
-        let path = temp.path().join("script.sh");
-        fs::write(&path, b"#!/bin/sh\necho hi\n").unwrap();
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
-        let oid = write_blob_hash(b"#!/bin/sh\necho hi\n");
-        // Indexed as regular (no exec bit) but worktree has it → Modified.
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_REGULAR, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-
-        // Symmetric: indexed as executable but worktree is plain → Modified.
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-
-        // Same exec bit on both sides → Clean.
-        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
-        let state = git_worktree_entry_state(temp.path(), "script.sh", oid, GIT_MODE_EXECUTABLE, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Clean);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn typechange_file_to_symlink_is_modified() {
-        use std::os::unix::fs::symlink;
-        let temp = tempfile::TempDir::new().unwrap();
-        let target = temp.path().join("target.txt");
-        fs::write(&target, b"target").unwrap();
-        let link = temp.path().join("link");
-        symlink(&target, &link).unwrap();
-        // Index says it's a regular file, but worktree is a symlink.
-        let oid = write_blob_hash(b"anything");
-        let state =
-            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_REGULAR, None).expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn typechange_symlink_to_file_is_modified() {
-        let temp = tempfile::TempDir::new().unwrap();
-        fs::write(temp.path().join("link"), b"now a file").unwrap();
-        // Index says it's a symlink, but worktree is a regular file.
-        let oid = write_blob_hash(b"old target");
-        let state =
-            git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK, None).expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-    }
-
-    /// Symlink target with non-UTF-8 bytes. `to_string_lossy` would
-    /// replace the bytes with U+FFFD and produce a hash that never
-    /// matches; using raw OS bytes hashes to what git would compute.
-    #[cfg(unix)]
-    #[test]
-    fn symlink_with_non_utf8_target_compares_via_raw_bytes() {
-        use std::{ffi::OsStr, os::unix::ffi::OsStrExt, os::unix::fs::symlink};
-        let temp = tempfile::TempDir::new().unwrap();
-        let raw_target = b"target-\xff-bytes";
-        let target_os = OsStr::from_bytes(raw_target);
-        let link = temp.path().join("link");
-        symlink(target_os, &link).unwrap();
-        let oid = write_blob_hash(raw_target);
-        let state = git_worktree_entry_state(temp.path(), "link", oid, GIT_MODE_SYMLINK, None)
-            .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Clean);
-    }
-
-    fn probe_for(path: &Path, index_timestamp_secs: i64) -> IndexStatProbe {
-        let metadata = gix::index::fs::Metadata::from_path_no_follow(path).expect("lstat");
-        let stat = gix::index::entry::Stat::from_fs(&metadata).expect("stat");
-        IndexStatProbe {
-            stat,
-            index_timestamp_secs,
-        }
-    }
-
-    /// When the worktree stat matches the index's cached stat and the entry is
-    /// outside the racy window, the read + hash is skipped — proven here by
-    /// passing a deliberately WRONG oid that would force `Modified` if it were
-    /// ever consulted, yet the entry reads `Clean`.
-    #[cfg(unix)]
-    #[test]
-    fn stat_fastpath_skips_hash_when_unchanged() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let path = temp.path().join("a.txt");
-        fs::write(&path, b"hello").unwrap();
-        let stat = probe_for(&path, 0).stat;
-        // index written strictly after the file's mtime → not racy.
-        let probe = IndexStatProbe {
-            stat,
-            index_timestamp_secs: i64::from(stat.mtime.secs) + 5,
-        };
-        let wrong_oid = write_blob_hash(b"totally different bytes");
-        let state =
-            git_worktree_entry_state(temp.path(), "a.txt", wrong_oid, GIT_MODE_REGULAR, Some(probe))
-                .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Clean);
-    }
-
-    /// The racy-clean window: when the index's own write time is at or before
-    /// the file's mtime, a same-second modification could leave the stat
-    /// unchanged, so the fast-path MUST fall back to hashing. Same setup as the
-    /// test above (stat matches), but a racy timestamp — now the wrong oid is
-    /// consulted and the change is caught as `Modified`.
-    #[cfg(unix)]
-    #[test]
-    fn racy_window_falls_back_to_hashing() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let path = temp.path().join("a.txt");
-        fs::write(&path, b"hello").unwrap();
-        let stat = probe_for(&path, 0).stat;
-        // index timestamp == file mtime → racy: stat is untrustworthy.
-        let probe = IndexStatProbe {
-            stat,
-            index_timestamp_secs: i64::from(stat.mtime.secs),
-        };
-        let stale_oid = write_blob_hash(b"totally different bytes");
-        let state =
-            git_worktree_entry_state(temp.path(), "a.txt", stale_oid, GIT_MODE_REGULAR, Some(probe))
-                .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-    }
-
-    /// A stat mismatch (here, a different size) bypasses the fast-path and
-    /// hashes, so a genuine change is reported even when the index isn't racy.
-    #[cfg(unix)]
-    #[test]
-    fn stat_mismatch_falls_back_to_hashing() {
-        let temp = tempfile::TempDir::new().unwrap();
-        let path = temp.path().join("a.txt");
-        fs::write(&path, b"hello").unwrap();
-        let mut probe = probe_for(&path, 0);
-        probe.index_timestamp_secs = i64::from(probe.stat.mtime.secs) + 5;
-        // Pretend the index cached a different size → stat can't match.
-        probe.stat.size = probe.stat.size.wrapping_add(1);
-        let old_oid = write_blob_hash(b"world");
-        let state =
-            git_worktree_entry_state(temp.path(), "a.txt", old_oid, GIT_MODE_REGULAR, Some(probe))
-                .expect("call");
-        assert_eq!(state, GitWorktreeEntryState::Modified);
-    }
+fn sley_error(error: sley::GitError) -> HeddleError {
+    HeddleError::Config(error.to_string())
 }

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -185,9 +185,9 @@ fn acquire_device_lock(device_path: &Path) -> std::io::Result<objects::lock::Wri
 /// more reason to delete it. Returns `None` when the file is absent.
 fn read_device_record(path: &Path) -> std::io::Result<Option<DeviceIdentity>> {
     match std::fs::read_to_string(path) {
-        Ok(contents) => toml::from_str(&contents).map(Some).map_err(|error| {
-            std::io::Error::other(format!("parsing {}: {error}", path.display()))
-        }),
+        Ok(contents) => toml::from_str(&contents)
+            .map(Some)
+            .map_err(|error| std::io::Error::other(format!("parsing {}: {error}", path.display()))),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
         Err(error) => Err(error),
     }
@@ -402,7 +402,9 @@ mod tests {
         let local_signer = resolve_signer(&local, &device).expect("local signer");
         let local_pubkey = hex::encode(local_signer.public_key());
         let prior_state = signed_state_with(local_signer.as_ref());
-        prior_state.verify_signature().expect("local state verifies");
+        prior_state
+            .verify_signature()
+            .expect("local state verifies");
 
         // Reconcile: record a device key (a distinct keypair).
         let device_signer = Ed25519Signer::generate().expect("device keypair");
@@ -522,8 +524,7 @@ mod tests {
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
             .expect("loosen perms");
 
-        let err =
-            load_local(&path).expect_err("group/world-readable identity must be rejected");
+        let err = load_local(&path).expect_err("group/world-readable identity must be rejected");
         let signer_err = err
             .get_ref()
             .and_then(|source| source.downcast_ref::<SignerError>());
@@ -543,7 +544,11 @@ mod tests {
         // Tightening back to 0600 restores loadability.
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
             .expect("tighten perms");
-        assert!(load_local(&path).expect("re-secured identity loads").is_some());
+        assert!(
+            load_local(&path)
+                .expect("re-secured identity loads")
+                .is_some()
+        );
     }
 
     fn write_device_for(path: &Path, server: &str) -> Ed25519Signer {
@@ -581,7 +586,10 @@ mod tests {
         // Logout for the matching server removes the device identity.
         let removed = unlink_device_key_at(&device, "grpc.S").expect("unlink");
         assert!(removed, "matching-server device identity must be removed");
-        assert!(!device.exists(), "device-identity file must be gone after logout");
+        assert!(
+            !device.exists(),
+            "device-identity file must be gone after logout"
+        );
 
         // The resolver now mints/uses the per-repo local key (a distinct key),
         // so the logged-out device key can no longer sign new states.
@@ -609,7 +617,10 @@ mod tests {
             !removed,
             "logging out of a different server must not remove this device identity",
         );
-        assert!(device.exists(), "non-matching device identity must remain on disk");
+        assert!(
+            device.exists(),
+            "non-matching device identity must remain on disk"
+        );
 
         let still = load_device(&device).expect("load").expect("present");
         assert_eq!(still.public_key, device_pubkey);
@@ -714,8 +725,7 @@ mod tests {
             let b_pem = b.to_pem().expect("b pem");
 
             let logout_path = device.clone();
-            let logout =
-                std::thread::spawn(move || unlink_device_key_at(&logout_path, "grpc.A"));
+            let logout = std::thread::spawn(move || unlink_device_key_at(&logout_path, "grpc.A"));
 
             let login_path = device.clone();
             let login = std::thread::spawn(move || {
@@ -766,8 +776,7 @@ mod tests {
         // refusal, and no key bytes are trusted for signing.
         std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640))
             .expect("loosen perms");
-        let err =
-            load_device(&path).expect_err("group-readable device identity must be rejected");
+        let err = load_device(&path).expect_err("group-readable device identity must be rejected");
         let signer_err = err
             .get_ref()
             .and_then(|source| source.downcast_ref::<SignerError>());

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -48,9 +48,9 @@ mod thread_record_store;
 mod thread_stack;
 mod thread_storage;
 mod thread_worktree_target;
+pub mod visibility;
 mod worktree_ignore;
 pub mod worktree_index;
-pub mod visibility;
 mod worktree_state;
 mod worktree_status_options;
 
@@ -70,55 +70,53 @@ pub use objects::{
 };
 pub use repository::{
     BlobHydrator, ChangeMonitorInspection, ChangedPathFilter, ChangedPathFilters,
-    CheckoutMaterialization, CommitGraphIndex,
-    CommitGraphInspection, ContextSuggestion, ContextSuggestionTier, DiffKind, GitCheckpointRecord,
-    GitOverlayBranchTip, GitOverlayImportHint, GitOverlayOutOfBandCommits,
-    GitRemoteTrackingStatus, HIGH_SUGGESTION_THRESHOLD,
-    HistoryQuery, HostedConfig, MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD,
-    MissingBlob, OperationKind, OperationScope, OutputFormat, PackFilesInspection,
-    PartialFetchInspection, PullPlannerCacheInspection, RedactConfig, RefCountsInspection,
-    RefSummaryIndexInspection, RepoConfig, Repository, RepositoryCapability, ResignOutcome,
+    CheckoutMaterialization, CommitGraphIndex, CommitGraphInspection, ContextSuggestion,
+    ContextSuggestionTier, DiffKind, GitCheckpointRecord, GitOverlayBranchTip,
+    GitOverlayImportHint, GitOverlayOutOfBandCommits, GitRemoteTrackingStatus,
+    HIGH_SUGGESTION_THRESHOLD, HistoryQuery, HostedConfig, MAJOR_REWRITE_THRESHOLD_PCT,
+    MEDIUM_SUGGESTION_THRESHOLD, MissingBlob, OperationKind, OperationScope, OutputFormat,
+    PackFilesInspection, PartialFetchInspection, PullPlannerCacheInspection, RedactConfig,
+    RefCountsInspection, RefSummaryIndexInspection, RepoConfig, Repository, RepositoryCapability,
     RepositoryMaintenanceRunReport, RepositoryOperationStatus,
-    RepositoryPerformanceInspectionReport, SUGGESTION_WINDOW, SnapshotExecution, SnapshotProfile,
-    ThreadCaptureOutcome, TreeBuildProfile, TrustedKey, UntrackedSet, UntrackedSubtree,
-    WarmCanonicalStoreStats, WorktreeCompareProfile, WorktreeIndexInspection,
+    RepositoryPerformanceInspectionReport, ResignOutcome, SUGGESTION_WINDOW, SnapshotExecution,
+    SnapshotProfile, ThreadCaptureOutcome, TreeBuildProfile, TrustedKey, UntrackedSet,
+    UntrackedSubtree, WarmCanonicalStoreStats, WorktreeCompareProfile, WorktreeIndexInspection,
     WorktreeStatusDetailed, compute_rewrite_pct, find_merge_base, is_major_rewrite,
     is_synthetic_root,
 };
 pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
-pub use visibility::{
-    AudienceParseError, AudienceTier, ScopeDropCounts, filter_for_audience,
-    filter_for_audience_with_drops, visible,
-};
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,
-    compute_heavy_impact_paths, format_confidence,
-    refresh_active_thread_metadata, refresh_thread_freshness, summarize_confidence,
-    summarize_verification, update_thread_state_from_state,
+    compute_heavy_impact_paths, format_confidence, refresh_active_thread_metadata,
+    refresh_thread_freshness, summarize_confidence, summarize_verification,
+    update_thread_state_from_state,
 };
-pub use stash::{StashEntry, StashManager};
 pub use stack_snapshot::{
     REPOSITORY_SNAPSHOT_SCHEMA_VERSION, RepositorySnapshot, StackNextAction, ThreadSnapshot,
 };
+pub use stash::{StashEntry, StashManager};
 pub use thread_advice::{
     RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
     shell_quote, thread_flag,
 };
+pub use thread_model::{
+    ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
+    ThreadIdError, ThreadImpactCategory, ThreadIntegrationPolicy, ThreadMode, ThreadRecord,
+    ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView, validate_thread_id,
+};
+pub use thread_record_store::{FilesystemThreadRecordStore, ThreadRecordStore};
 pub use thread_stack::{
     PlanRebaseError, StackNode, StackRebasePlan, StackRebaseStep, ThreadStack, compute_stacks,
     plan_stack_rebase, stack_for,
 };
-pub use thread_model::{
-    ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
-    ThreadIdError, ThreadImpactCategory, ThreadIntegrationPolicy, ThreadMode,
-    ThreadRecord, ThreadRuntimeOverlay, ThreadState, ThreadVerificationSummary, ThreadView,
-    validate_thread_id,
-};
-pub use thread_record_store::{FilesystemThreadRecordStore, ThreadRecordStore};
 pub use thread_storage::{SyncedThreadMetadata, Thread, ThreadManager};
 pub use thread_worktree_target::{
     ThreadWorktreeTargetDisposition, ThreadWorktreeTargetError, validate_thread_worktree_target,
+};
+pub use visibility::{
+    AudienceParseError, AudienceTier, ScopeDropCounts, filter_for_audience,
+    filter_for_audience_with_drops, visible,
 };
 pub use worktree_index::{DirectoryCacheEntry, IndexEntry, WorktreeIndex};
 pub use worktree_state::WorktreeState;

--- a/crates/repo/src/namespace_policy.rs
+++ b/crates/repo/src/namespace_policy.rs
@@ -82,10 +82,7 @@ mod tests {
     #[test]
     fn falls_back_to_internal_when_nothing_set() {
         let ctx = VisibilityResolutionContext::default();
-        assert_eq!(
-            resolve_default_visibility(&ctx),
-            VisibilityTier::Internal
-        );
+        assert_eq!(resolve_default_visibility(&ctx), VisibilityTier::Internal);
     }
 
     #[test]
@@ -94,10 +91,7 @@ mod tests {
             repo_default: Some(VisibilityTier::Public),
             namespace: None,
         };
-        assert_eq!(
-            resolve_default_visibility(&ctx),
-            VisibilityTier::Public
-        );
+        assert_eq!(resolve_default_visibility(&ctx), VisibilityTier::Public);
     }
 
     #[test]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -546,8 +546,8 @@ version = 1
 [output]
 format = "auto"
 "#;
-        let err = toml::from_str::<RepoConfig>(toml_auto)
-            .expect_err("output.format='auto' must reject");
+        let err =
+            toml::from_str::<RepoConfig>(toml_auto).expect_err("output.format='auto' must reject");
         let message = err.to_string();
         assert!(
             message.contains("output.format"),

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -64,10 +64,6 @@ pub use context_suggestions::{
     MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD, SUGGESTION_WINDOW,
     compute_rewrite_pct, is_major_rewrite,
 };
-use gix::{
-    bstr::{BStr, ByteSlice},
-    prelude::ObjectIdExt,
-};
 pub use objects::object::DiffKind;
 use objects::{
     error::{HeddleError, Result},
@@ -80,6 +76,10 @@ use objects::{
 use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
+use sley::{
+    ObjectId as SleyObjectId, Reference as SleyReference, ReferenceTarget as SleyRefTarget,
+    Repository as SleyRepository,
+};
 
 use crate::git_worktree_status::GitWorktreeEntryState;
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
@@ -117,7 +117,7 @@ pub enum RepositoryCapability {
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum GitHeadState {
     Attached(String),
-    Detached(gix::hash::ObjectId),
+    Detached(SleyObjectId),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -258,7 +258,7 @@ struct GitBridgeMappingFile {
 ///
 /// Two production implementations exist:
 /// - Git-overlay clones: `cli::commands::clone::GitOverlayBlobHydrator`
-///   uses gix promisor-fetch semantics against the bare `.git/` repo.
+///   uses sley promisor-fetch semantics against the bare `.git/` repo.
 /// - Hosted clones: `heddle_client::grpc_hosted::LazyHostedHydrator`
 ///   bridges sync `hydrate` calls to async gRPC via a dedicated worker
 ///   thread + private Tokio runtime; on each call the worker invokes
@@ -302,6 +302,7 @@ where
     config: RepoConfig,
     shallow: RwLock<ShallowInfo>,
     blob_hydrator: RwLock<Option<Arc<dyn BlobHydrator>>>,
+    git_overlay_repo: RwLock<Option<SleyRepository>>,
 }
 
 impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repository<R, O, S> {
@@ -342,6 +343,7 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
             config,
             shallow: RwLock::new(shallow),
             blob_hydrator: RwLock::new(None),
+            git_overlay_repo: RwLock::new(None),
         }
     }
 
@@ -612,6 +614,7 @@ impl Repository {
             config,
             shallow: RwLock::new(ShallowInfo::load(&heddle_dir)?),
             blob_hydrator: RwLock::new(None),
+            git_overlay_repo: RwLock::new(None),
         })
     }
 
@@ -850,6 +853,35 @@ impl Repository {
         self.capability
     }
 
+    pub fn git_overlay_sley_repository(&self) -> Result<Option<SleyRepository>> {
+        if self.capability() != RepositoryCapability::GitOverlay {
+            return Ok(None);
+        }
+
+        if let Some(repo) = self
+            .git_overlay_repo
+            .read()
+            .map_err(|_| HeddleError::Config("git overlay repo cache lock poisoned".into()))?
+            .clone()
+        {
+            return Ok(Some(repo));
+        }
+
+        let repo = SleyRepository::discover(&self.root).map_err(|error| {
+            HeddleError::Config(format!(
+                "failed to inspect Git repository at '{}': {}",
+                self.root.display(),
+                error
+            ))
+        })?;
+        *self
+            .git_overlay_repo
+            .write()
+            .map_err(|_| HeddleError::Config("git overlay repo cache lock poisoned".into()))? =
+            Some(repo.clone());
+        Ok(Some(repo))
+    }
+
     pub fn capability_label(&self) -> &'static str {
         match self.capability() {
             RepositoryCapability::GitOverlay => "git-overlay",
@@ -914,27 +946,17 @@ impl Repository {
             None => return Ok(None),
         };
 
-        let git = match gix::discover(&self.root) {
-            Ok(git) => git,
-            Err(_) => return Ok(None),
+        let Some(git) = self.git_overlay_sley_repository()? else {
+            return Ok(None);
         };
         let Some(head) = git_resolve_oid(&git, "HEAD")? else {
             return Ok(None);
         };
 
         let local_ref_name = format!("refs/heads/{branch}");
-        if let Some(local_ref) = git_find_reference(&git, &local_ref_name)?
-            && let Some(tracking_ref_name) =
-                local_ref.remote_tracking_ref_name(gix::remote::Direction::Fetch)
+        if git_find_reference(&git, &local_ref_name)?.is_some()
+            && let Some(tracking_name) = git_configured_tracking_ref(&git, &branch)?
         {
-            let tracking_ref_name = tracking_ref_name.map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to inspect upstream branch at '{}': {error}",
-                    self.root.display()
-                ))
-            })?;
-            let tracking_ref = tracking_ref_name.as_ref();
-            let tracking_name = tracking_ref.as_bstr().to_str_lossy().into_owned();
             if let Some(upstream_head) = git_resolve_oid(&git, &tracking_name)? {
                 let (ahead, behind) = git_ahead_behind(&self.root, &git, upstream_head, head)?;
                 if ahead == 0 && behind == 0 {
@@ -1132,13 +1154,9 @@ impl Repository {
             return Ok(Vec::new());
         }
 
-        let git_repo = gix::discover(&self.root).map_err(|error| {
-            HeddleError::Config(format!(
-                "failed to inspect git branches at '{}': {}",
-                self.root.display(),
-                error
-            ))
-        })?;
+        let Some(git_repo) = self.git_overlay_sley_repository()? else {
+            return Ok(Vec::new());
+        };
 
         let imported_threads: std::collections::HashSet<ThreadName> =
             self.refs().list_threads()?.into_iter().collect();
@@ -1146,34 +1164,19 @@ impl Repository {
         let checkpoint_mapping = self.git_overlay_checkpoint_mapping()?;
         let mut branch_tips = Vec::new();
 
-        for branch in git_repo
-            .references()
-            .map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to read git references at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?
-            .local_branches()
-            .map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to enumerate git branches at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?
-        {
-            let mut branch = branch.map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to inspect git branch at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?;
-            let name = branch.name().shorten().to_string();
+        for branch in git_repo.references().list_refs().map_err(|error| {
+            HeddleError::Config(format!(
+                "failed to enumerate git branches at '{}': {}",
+                self.root.display(),
+                error
+            ))
+        })? {
+            let Some(name) = branch.name.strip_prefix("refs/heads/") else {
+                continue;
+            };
+            let name = name.to_string();
             let Some(target) =
-                self.git_overlay_commit_tip_oid(&git_repo, &mut branch, "branch", &name)?
+                self.git_overlay_commit_tip_oid(&git_repo, &branch, "branch", &name)?
             else {
                 continue;
             };
@@ -1216,7 +1219,6 @@ impl Repository {
                 mapped_change,
             });
         }
-
         branch_tips.sort_by(|a, b| a.branch.cmp(&b.branch));
         Ok(branch_tips)
     }
@@ -1226,13 +1228,9 @@ impl Repository {
             return Ok(Vec::new());
         }
 
-        let git_repo = gix::discover(&self.root).map_err(|error| {
-            HeddleError::Config(format!(
-                "failed to inspect git tags at '{}': {}",
-                self.root.display(),
-                error
-            ))
-        })?;
+        let Some(git_repo) = self.git_overlay_sley_repository()? else {
+            return Ok(Vec::new());
+        };
 
         let imported_markers: std::collections::HashSet<MarkerName> =
             self.refs().list_markers()?.into_iter().collect();
@@ -1240,34 +1238,18 @@ impl Repository {
         let checkpoint_mapping = self.git_overlay_checkpoint_mapping()?;
         let mut tag_tips = Vec::new();
 
-        for tag in git_repo
-            .references()
-            .map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to read git references at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?
-            .tags()
-            .map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to enumerate git tags at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?
-        {
-            let mut tag = tag.map_err(|error| {
-                HeddleError::Config(format!(
-                    "failed to inspect git tag at '{}': {}",
-                    self.root.display(),
-                    error
-                ))
-            })?;
-            let name = tag.name().shorten().to_string();
-            let Some(target) =
-                self.git_overlay_commit_tip_oid(&git_repo, &mut tag, "tag", &name)?
+        for tag in git_repo.references().list_refs().map_err(|error| {
+            HeddleError::Config(format!(
+                "failed to enumerate git tags at '{}': {}",
+                self.root.display(),
+                error
+            ))
+        })? {
+            let Some(name) = tag.name.strip_prefix("refs/tags/") else {
+                continue;
+            };
+            let name = name.to_string();
+            let Some(target) = self.git_overlay_commit_tip_oid(&git_repo, &tag, "tag", &name)?
             else {
                 continue;
             };
@@ -1333,57 +1315,81 @@ impl Repository {
         if self.capability() != RepositoryCapability::GitOverlay {
             return Ok(None);
         }
-        let git_repo = match gix::discover(&self.root) {
-            Ok(repo) => repo,
-            Err(_) => return Ok(None),
+        let git_repo = match self.git_overlay_sley_repository() {
+            Ok(Some(repo)) => repo,
+            Ok(None) | Err(_) => return Ok(None),
         };
         if git_repo.workdir().is_none() {
             return Ok(None);
         }
 
-        let index = git_repo.index_or_empty().map_err(|error| {
+        let index = git_repo.open_index().map_err(|error| {
             HeddleError::Config(format!(
                 "failed to inspect Git index at '{}': {}",
                 self.root.display(),
                 error
             ))
         })?;
-        let head_tree = git_repo.head_tree_id_or_empty().map_err(|error| {
-            HeddleError::Config(format!(
-                "failed to inspect Git HEAD tree at '{}': {}",
-                self.root.display(),
-                error
-            ))
-        })?;
-        let head_index = git_repo
-            .index_from_tree(head_tree.as_ref())
+        let index = index.unwrap_or_else(|| sley::Index {
+            version: 2,
+            entries: Vec::new(),
+            extensions: Vec::new(),
+            checksum: None,
+        });
+        let head_tree = match git_repo
+            .head()
             .map_err(|error| {
                 HeddleError::Config(format!(
                     "failed to inspect Git HEAD tree at '{}': {}",
                     self.root.display(),
                     error
                 ))
-            })?;
+            })?
+            .oid
+        {
+            Some(head) => {
+                git_repo
+                    .read_commit(&head)
+                    .map_err(|error| {
+                        HeddleError::Config(format!(
+                            "failed to inspect Git HEAD commit at '{}': {}",
+                            self.root.display(),
+                            error
+                        ))
+                    })?
+                    .tree
+            }
+            None => sley::ObjectId::empty_tree(git_repo.object_format()),
+        };
+        let head_index = git_repo.index_from_tree(&head_tree).map_err(|error| {
+            HeddleError::Config(format!(
+                "failed to inspect Git HEAD tree at '{}': {}",
+                self.root.display(),
+                error
+            ))
+        })?;
 
         let mut head_entries = BTreeMap::new();
-        for (_, (path, entry)) in head_index.entries_with_paths_by_filter_map(|path, entry| {
-            Some((git_path(path), (entry.id, entry.mode.bits())))
-        }) {
-            head_entries.insert(path, entry);
+        for entry in head_index.entries {
+            let path = git_path(entry.path.as_bytes());
+            head_entries.insert(path, (entry.oid, entry.mode));
         }
-        let index_timestamp_secs = index.timestamp().unix_seconds();
         let mut index_entries = BTreeMap::new();
-        for (_, (path, entry)) in index.entries_with_paths_by_filter_map(|path, entry| {
-            Some((git_path(path), (entry.id, entry.mode.bits(), entry.stat)))
-        }) {
-            index_entries.insert(path, entry);
+        let index_path = sley::plumbing::sley_worktree::repository_index_path(git_repo.git_dir());
+        for entry in index.entries {
+            let path = git_path(entry.path.as_bytes());
+            let probe = crate::git_worktree_status::IndexStatProbe::from_index_entry_and_index_path(
+                entry.clone(),
+                &index_path,
+            );
+            index_entries.insert(path, (entry.oid, entry.mode, probe));
         }
 
         let mut added = BTreeSet::new();
         let mut modified = BTreeSet::new();
         let mut deleted = BTreeSet::new();
 
-        for (path, (oid, mode, _stat)) in &index_entries {
+        for (path, (oid, mode, _probe)) in &index_entries {
             if ignored_git_overlay_status_path(path) {
                 continue;
             }
@@ -1403,20 +1409,16 @@ impl Repository {
             }
         }
 
-        for (path, (oid, mode, stat)) in &index_entries {
+        for (path, (oid, mode, probe)) in &index_entries {
             if ignored_git_overlay_status_path(path) {
                 continue;
             }
-            let probe = crate::git_worktree_status::IndexStatProbe {
-                stat: *stat,
-                index_timestamp_secs,
-            };
             match crate::git_worktree_status::git_worktree_entry_state(
                 &self.root,
                 path,
                 *oid,
                 *mode,
-                Some(probe),
+                Some(probe.clone()),
             )? {
                 GitWorktreeEntryState::Clean => {}
                 GitWorktreeEntryState::Deleted => {
@@ -1497,7 +1499,7 @@ impl Repository {
 
     fn git_overlay_mapped_change_for_git_oid(
         &self,
-        git_oid: gix::hash::ObjectId,
+        git_oid: SleyObjectId,
     ) -> Result<Option<ChangeId>> {
         let git_commit = git_oid.to_string();
         let bridge_mapping = self.git_overlay_bridge_mapping()?;
@@ -1520,11 +1522,11 @@ impl Repository {
         if self.capability() != RepositoryCapability::GitOverlay {
             return Ok(None);
         }
-        let git_repo = match gix::discover(&self.root) {
-            Ok(repo) => repo,
-            Err(_) => return Ok(None),
+        let git_repo = match self.git_overlay_sley_repository() {
+            Ok(Some(repo)) => repo,
+            Ok(None) | Err(_) => return Ok(None),
         };
-        let Ok(tip) = gix::hash::ObjectId::from_hex(tip_git_commit.as_bytes()) else {
+        let Ok(tip) = SleyObjectId::from_hex(git_repo.object_format(), tip_git_commit) else {
             return Ok(None);
         };
 
@@ -1557,15 +1559,11 @@ impl Repository {
                     truncated: true,
                 }));
             }
-            let Some(commit) = git_repo
-                .find_object(oid)
-                .ok()
-                .and_then(|object| object.try_into_commit().ok())
-            else {
+            let Ok(commit) = git_repo.read_commit(&oid) else {
                 continue;
             };
-            for parent in commit.parent_ids() {
-                pending.push(parent.detach());
+            for parent in commit.parents {
+                pending.push(parent);
             }
         }
         Ok(Some(GitOverlayOutOfBandCommits {
@@ -1611,26 +1609,23 @@ impl Repository {
 
     fn git_overlay_commit_tip_oid(
         &self,
-        git_repo: &gix::Repository,
-        reference: &mut gix::Reference,
+        git_repo: &SleyRepository,
+        reference: &sley::plumbing::sley_refs::Ref,
         ref_kind: &str,
         ref_name: &str,
-    ) -> Result<Option<gix::hash::ObjectId>> {
-        if reference.target().try_id().is_none() {
-            return Ok(None);
-        }
-
-        let target = match reference.peel_to_id() {
-            Ok(target) => target.detach(),
+    ) -> Result<Option<SleyObjectId>> {
+        let target = match &reference.target {
+            SleyRefTarget::Direct(oid) => *oid,
+            SleyRefTarget::Symbolic(_) => return Ok(None),
+        };
+        let target = match sley::plumbing::sley_rev::peel_to_commit(
+            git_repo.objects().as_ref(),
+            git_repo.object_format(),
+            &target,
+        ) {
+            Ok(target) => target,
             Err(_) => return Ok(None),
         };
-        let object = match git_repo.find_object(target) {
-            Ok(object) => object,
-            Err(_) => return Ok(None),
-        };
-        if object.kind != gix::objs::Kind::Commit {
-            return Ok(None);
-        }
 
         let _ = (ref_kind, ref_name);
         Ok(Some(target))
@@ -1843,7 +1838,9 @@ impl Repository {
             })
             .collect::<Result<Vec<_>>>()?;
         let scope = self.op_scope();
-        let result = self.refs.commit_and_publish(&encoded, ref_updates, Some(&scope));
+        let result = self
+            .refs
+            .commit_and_publish(&encoded, ref_updates, Some(&scope));
         // The committer appended through a fresh `OpLog` handle (the `refs`→`repo`
         // seam), so this repository's own cached oplog handle is now stale.
         // Refresh it so a same-process read via `self.oplog()` observes the
@@ -2133,7 +2130,9 @@ impl Repository {
                 .git_overlay_mapped_change_for_branch(&branch)?
                 .is_some()
         {
-            return Ok(Head::Attached { thread: branch_thread });
+            return Ok(Head::Attached {
+                thread: branch_thread,
+            });
         }
         Ok(raw)
     }
@@ -2380,7 +2379,7 @@ impl Repository {
 }
 
 fn ensure_git_overlay_exclude(root: &Path) -> Result<()> {
-    let git_dir = match gix::discover(root) {
+    let git_dir = match SleyRepository::discover(root) {
         Ok(repo) if repo.workdir().is_some() => repo.git_dir().to_path_buf(),
         _ => root.join(".git"),
     };
@@ -2465,7 +2464,7 @@ fn has_git_metadata(path: &Path) -> bool {
         return false;
     }
 
-    gix::discover(path).is_ok()
+    SleyRepository::discover(path).is_ok()
 }
 
 /// If `start_path` lies inside a *managed virtualized thread root*
@@ -2501,14 +2500,10 @@ fn metadataless_managed_thread_root(start_path: &Path) -> Option<PathBuf> {
 }
 
 fn git_config_principal(root: &Path) -> Option<Principal> {
-    let git_repo = gix::discover(root).ok()?;
-    let config = git_repo.config_snapshot();
-    let name = config
-        .string("user.name")
-        .map(|value| value.to_str_lossy().into_owned())?;
-    let email = config
-        .string("user.email")
-        .map(|value| value.to_str_lossy().into_owned())?;
+    let git_repo = SleyRepository::discover(root).ok()?;
+    let config = git_repo.config_snapshot().ok()?;
+    let name = config.get("user", None, "name")?.to_string();
+    let email = config.get("user", None, "email")?.to_string();
     if name.trim().is_empty() || email.trim().is_empty() {
         return None;
     }
@@ -2594,8 +2589,8 @@ fn path_to_git_path(path: &Path) -> String {
         .join("/")
 }
 
-fn git_path(path: &BStr) -> String {
-    path.to_str_lossy().into_owned()
+fn git_path(path: &[u8]) -> String {
+    String::from_utf8_lossy(path).into_owned()
 }
 
 fn ignored_git_overlay_status_path(path: &str) -> bool {
@@ -2603,39 +2598,60 @@ fn ignored_git_overlay_status_path(path: &str) -> bool {
 }
 
 fn git_remote_names(root: &Path) -> Result<Vec<String>> {
-    let repo = match gix::discover(root) {
+    let repo = match SleyRepository::discover(root) {
         Ok(repo) => repo,
         Err(_) => return Ok(Vec::new()),
     };
-    Ok(repo
-        .remote_names()
-        .into_iter()
-        .map(|name| name.to_str_lossy().into_owned())
-        .filter(|name| !name.trim().is_empty())
-        .collect())
+    repo.remote_names()
+        .map(|names| {
+            names
+                .into_iter()
+                .filter(|name| !name.trim().is_empty())
+                .collect()
+        })
+        .map_err(|error| HeddleError::Config(error.to_string()))
 }
 
 fn git_find_reference<'repo>(
-    repo: &'repo gix::Repository,
+    repo: &'repo SleyRepository,
     name: &str,
-) -> Result<Option<gix::Reference<'repo>>> {
-    repo.try_find_reference(name).map_err(|error| {
+) -> Result<Option<SleyReference>> {
+    repo.find_reference(name).map_err(|error| {
         HeddleError::Config(format!("failed to inspect Git reference '{name}': {error}"))
     })
 }
 
-fn git_resolve_oid(repo: &gix::Repository, rev: &str) -> Result<Option<gix::ObjectId>> {
-    match repo.rev_parse_single(rev.as_bytes().as_bstr()) {
-        Ok(id) => Ok(Some(id.detach())),
+fn git_resolve_oid(repo: &SleyRepository, rev: &str) -> Result<Option<SleyObjectId>> {
+    match repo.rev_parse(rev) {
+        Ok(id) => Ok(Some(id)),
         Err(_) => Ok(None),
     }
 }
 
+fn git_configured_tracking_ref(repo: &SleyRepository, branch: &str) -> Result<Option<String>> {
+    let config = repo
+        .config_snapshot()
+        .map_err(|error| HeddleError::Config(error.to_string()))?;
+    let Some(remote) = config.get("branch", Some(branch), "remote") else {
+        return Ok(None);
+    };
+    let Some(merge) = config.get("branch", Some(branch), "merge") else {
+        return Ok(None);
+    };
+    if remote == "." {
+        return Ok(Some(merge.to_string()));
+    }
+    let Some(short) = merge.strip_prefix("refs/heads/") else {
+        return Ok(None);
+    };
+    Ok(Some(format!("refs/remotes/{remote}/{short}")))
+}
+
 fn git_ahead_behind(
     root: &Path,
-    repo: &gix::Repository,
-    upstream: gix::ObjectId,
-    head: gix::ObjectId,
+    repo: &SleyRepository,
+    upstream: SleyObjectId,
+    head: SleyObjectId,
 ) -> Result<(usize, usize)> {
     if upstream == head {
         return Ok((0, 0));
@@ -2647,32 +2663,50 @@ fn git_ahead_behind(
 
 fn git_reachable_count(
     root: &Path,
-    repo: &gix::Repository,
-    tip: gix::ObjectId,
-    hidden: gix::ObjectId,
+    repo: &SleyRepository,
+    tip: SleyObjectId,
+    hidden: SleyObjectId,
 ) -> Result<usize> {
-    let walk = tip
-        .attach(repo)
-        .ancestors()
-        .with_hidden([hidden])
-        .all()
-        .map_err(|error| {
-            HeddleError::Config(format!(
-                "failed to inspect Git upstream drift at '{}': {error}",
-                root.display()
-            ))
-        })?;
+    let hidden = git_ancestor_set(root, repo, hidden)?;
+    let mut seen = std::collections::HashSet::new();
+    let mut pending = vec![tip];
     let mut count = 0;
-    for entry in walk {
-        entry.map_err(|error| {
+    while let Some(oid) = pending.pop() {
+        if hidden.contains(&oid) || !seen.insert(oid) {
+            continue;
+        }
+        count += 1;
+        let commit = repo.read_commit(&oid).map_err(|error| {
             HeddleError::Config(format!(
                 "failed to inspect Git upstream drift at '{}': {error}",
                 root.display()
             ))
         })?;
-        count += 1;
+        pending.extend(commit.parents);
     }
     Ok(count)
+}
+
+fn git_ancestor_set(
+    root: &Path,
+    repo: &SleyRepository,
+    start: SleyObjectId,
+) -> Result<std::collections::HashSet<SleyObjectId>> {
+    let mut seen = std::collections::HashSet::new();
+    let mut pending = vec![start];
+    while let Some(oid) = pending.pop() {
+        if !seen.insert(oid) {
+            continue;
+        }
+        let commit = repo.read_commit(&oid).map_err(|error| {
+            HeddleError::Config(format!(
+                "failed to inspect Git upstream drift at '{}': {error}",
+                root.display()
+            ))
+        })?;
+        pending.extend(commit.parents);
+    }
+    Ok(seen)
 }
 
 fn git_remote_tracking_display_name(name: &str) -> String {
@@ -2749,11 +2783,11 @@ fn append_ignore_file_patterns(patterns: &mut Vec<String>, path: &Path) -> Resul
     Ok(())
 }
 
-/// Read git's HEAD ref via `gix::discover` (~25ms — full repository
+/// Read git's HEAD ref via `sley::Repository::discover` (~25ms — full repository
 /// inspection). Used as a fallback when the fast path can't parse the
 /// raw `.git/HEAD` file (e.g. detached HEAD, multi-worktree layouts).
-fn detect_git_head_state_via_gix(path: &Path) -> Result<Option<GitHeadState>> {
-    let repo = gix::discover(path).map_err(|error| {
+fn detect_git_head_state_via_sley(path: &Path) -> Result<Option<GitHeadState>> {
+    let repo = SleyRepository::discover(path).map_err(|error| {
         HeddleError::Config(format!(
             "failed to inspect git repository at '{}': {}",
             path.display(),
@@ -2765,13 +2799,13 @@ fn detect_git_head_state_via_gix(path: &Path) -> Result<Option<GitHeadState>> {
         Err(_) => return Ok(None),
     };
 
-    if let Some(name) = head.referent_name() {
-        return Ok(Some(GitHeadState::Attached(name.shorten().to_string())));
+    if let Some(name) = head.branch_name() {
+        return Ok(Some(GitHeadState::Attached(name.to_string())));
     }
     if head.is_detached()
-        && let Some(id) = head.id()
+        && let Some(id) = head.oid
     {
-        return Ok(Some(GitHeadState::Detached(id.detach())));
+        return Ok(Some(GitHeadState::Detached(id)));
     }
     Ok(None)
 }
@@ -2780,21 +2814,23 @@ fn detect_git_head_state(path: &Path) -> Result<Option<GitHeadState>> {
     if let Some(head) = detect_git_head_fast(path) {
         return Ok(Some(head));
     }
-    detect_git_head_state_via_gix(path)
+    detect_git_head_state_via_sley(path)
 }
 
 /// Detect git's current HEAD branch.
 ///
 /// The fast path reads `.git/HEAD` directly as text. `.git/HEAD` is a
 /// tiny file (~30 bytes for `ref: refs/heads/<name>\n`) and a direct
-/// read is ~50us vs. `gix::discover()`'s ~25ms full repository
-/// inspection. Falls back to gix only for the cases the text parser
+/// read is ~50us vs. repository discovery's ~25ms full repository
+/// inspection. Falls back to sley only for the cases the text parser
 /// can't handle: detached HEAD, multi-worktree `gitdir:` indirections,
 /// and any malformed file (where we'd rather surface the right error
 /// than guess).
 fn detect_git_head(path: &Path) -> Result<Option<Head>> {
     if let Some(GitHeadState::Attached(thread)) = detect_git_head_state(path)? {
-        return Ok(Some(Head::Attached { thread: ThreadName::from(thread) }));
+        return Ok(Some(Head::Attached {
+            thread: ThreadName::from(thread),
+        }));
     }
     Ok(None)
 }
@@ -2803,7 +2839,7 @@ fn detect_git_head(path: &Path) -> Result<Option<Head>> {
 /// when `.git/HEAD` is the simple `ref: refs/heads/<name>` form;
 /// returns `None` for any case we don't trust ourselves to parse
 /// correctly (detached HEAD raw OIDs, `gitdir:` worktree pointers,
-/// missing files), letting the gix fallback handle it.
+/// missing files), letting the sley fallback handle it.
 fn detect_git_head_fast(path: &Path) -> Option<GitHeadState> {
     let head_path = path.join(".git").join("HEAD");
     // `.git` may also be a *file* (the gitdir: pointer used by
@@ -2822,7 +2858,7 @@ fn detect_git_head_fast(path: &Path) -> Option<GitHeadState> {
 }
 
 fn resolve_git_dir(path: &Path) -> Result<PathBuf> {
-    let repo = gix::discover(path).map_err(|error| {
+    let repo = SleyRepository::discover(path).map_err(|error| {
         HeddleError::Config(format!(
             "failed to resolve git dir at '{}': {}",
             path.display(),

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -956,39 +956,38 @@ impl Repository {
         let local_ref_name = format!("refs/heads/{branch}");
         if git_find_reference(&git, &local_ref_name)?.is_some()
             && let Some(tracking_name) = git_configured_tracking_ref(&git, &branch)?
+            && let Some(upstream_head) = git_resolve_oid(&git, &tracking_name)?
         {
-            if let Some(upstream_head) = git_resolve_oid(&git, &tracking_name)? {
-                let (ahead, behind) = git_ahead_behind(&self.root, &git, upstream_head, head)?;
-                if ahead == 0 && behind == 0 {
-                    return Ok(None);
-                }
-                let upstream = git_remote_tracking_display_name(&tracking_name);
-                let local_oid = head.to_string();
-                let upstream_oid = upstream_head.to_string();
-                let upstream_is_undone_checkpoint =
-                    self.remote_tracks_undone_git_checkpoint(&branch, &local_oid, &upstream_oid)?;
-                return Ok(Some(GitRemoteTrackingStatus {
-                    branch: branch.clone(),
-                    upstream: upstream.clone(),
+            let (ahead, behind) = git_ahead_behind(&self.root, &git, upstream_head, head)?;
+            if ahead == 0 && behind == 0 {
+                return Ok(None);
+            }
+            let upstream = git_remote_tracking_display_name(&tracking_name);
+            let local_oid = head.to_string();
+            let upstream_oid = upstream_head.to_string();
+            let upstream_is_undone_checkpoint =
+                self.remote_tracks_undone_git_checkpoint(&branch, &local_oid, &upstream_oid)?;
+            return Ok(Some(GitRemoteTrackingStatus {
+                branch: branch.clone(),
+                upstream: upstream.clone(),
+                ahead,
+                behind,
+                local_oid: Some(local_oid),
+                upstream_oid: Some(upstream_oid),
+                upstream_is_undone_checkpoint,
+                message: git_remote_tracking_message(
+                    &branch,
+                    &upstream,
                     ahead,
                     behind,
-                    local_oid: Some(local_oid),
-                    upstream_oid: Some(upstream_oid),
                     upstream_is_undone_checkpoint,
-                    message: git_remote_tracking_message(
-                        &branch,
-                        &upstream,
-                        ahead,
-                        behind,
-                        upstream_is_undone_checkpoint,
-                    ),
-                    next_action: git_remote_tracking_next_action(
-                        ahead,
-                        behind,
-                        upstream_is_undone_checkpoint,
-                    ),
-                }));
-            }
+                ),
+                next_action: git_remote_tracking_next_action(
+                    ahead,
+                    behind,
+                    upstream_is_undone_checkpoint,
+                ),
+            }));
         }
 
         let remotes = git_remote_names(&self.root)?;
@@ -2612,10 +2611,7 @@ fn git_remote_names(root: &Path) -> Result<Vec<String>> {
         .map_err(|error| HeddleError::Config(error.to_string()))
 }
 
-fn git_find_reference<'repo>(
-    repo: &'repo SleyRepository,
-    name: &str,
-) -> Result<Option<SleyReference>> {
+fn git_find_reference(repo: &SleyRepository, name: &str) -> Result<Option<SleyReference>> {
     repo.find_reference(name).map_err(|error| {
         HeddleError::Config(format!("failed to inspect Git reference '{name}': {error}"))
     })

--- a/crates/repo/src/repository_maintenance.rs
+++ b/crates/repo/src/repository_maintenance.rs
@@ -734,13 +734,15 @@ fn load_ref_snapshots(repo: &Repository, threads: bool) -> Result<Vec<RefSnapsho
         let names = repo.refs().list_threads()?;
         let mut out = Vec::with_capacity(names.len());
         for name in names {
-            let state = repo.refs().get_thread(&name)?
-                .ok_or_else(|| {
-                    HeddleError::Io(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("thread '{}' disappeared while rebuilding pull planner manifest", name),
-                    ))
-                })?;
+            let state = repo.refs().get_thread(&name)?.ok_or_else(|| {
+                HeddleError::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "thread '{}' disappeared while rebuilding pull planner manifest",
+                        name
+                    ),
+                ))
+            })?;
             out.push(RefSnapshotMirror {
                 name: name.to_string(),
                 state_id: state.to_string_full(),
@@ -751,13 +753,15 @@ fn load_ref_snapshots(repo: &Repository, threads: bool) -> Result<Vec<RefSnapsho
         let names = repo.refs().list_markers()?;
         let mut out = Vec::with_capacity(names.len());
         for name in names {
-            let state = repo.refs().get_marker(&name)?
-                .ok_or_else(|| {
-                    HeddleError::Io(io::Error::new(
-                        io::ErrorKind::InvalidData,
-                        format!("marker '{}' disappeared while rebuilding pull planner manifest", name),
-                    ))
-                })?;
+            let state = repo.refs().get_marker(&name)?.ok_or_else(|| {
+                HeddleError::Io(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "marker '{}' disappeared while rebuilding pull planner manifest",
+                        name
+                    ),
+                ))
+            })?;
             out.push(RefSnapshotMirror {
                 name: name.to_string(),
                 state_id: state.to_string_full(),

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -13,8 +13,8 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use objects::store::ObjectStore;
 use objects::object::{Blob, ContentHash, RiskSignalBlob, State};
+use objects::store::ObjectStore;
 use state_review::{
     ReviewSignalsConfig, SemanticContext,
     config::{

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -145,7 +145,11 @@ impl Repository {
     ///   valid-looking one (heddle#570).
     ///
     /// In both cases the caller MUST NOT persist a rewritten version of the state.
-    pub fn resign_if_owned(&self, state: &mut State, prior_hashes: &[ContentHash]) -> ResignOutcome {
+    pub fn resign_if_owned(
+        &self,
+        state: &mut State,
+        prior_hashes: &[ContentHash],
+    ) -> ResignOutcome {
         let Some(existing) = state.signature.clone() else {
             return ResignOutcome::Unsigned;
         };
@@ -418,7 +422,9 @@ mod tests {
             let (temp, repo) = setup_repo();
             std::fs::write(temp.path().join("file.txt"), "hello").expect("write file");
 
-            let state = repo.snapshot(Some("first".to_string()), None).expect("capture");
+            let state = repo
+                .snapshot(Some("first".to_string()), None)
+                .expect("capture");
 
             // Every captured state is signed and verifies, with no auth login.
             assert!(state.signature.is_some(), "capture must auto-sign");
@@ -445,7 +451,9 @@ mod tests {
 
             // Pre-auth capture: signed by the auto-minted local key.
             std::fs::write(temp.path().join("a.txt"), "a").expect("write");
-            let local_state = repo.snapshot(Some("local".to_string()), None).expect("capture");
+            let local_state = repo
+                .snapshot(Some("local".to_string()), None)
+                .expect("capture");
             let local_pubkey = sig_pubkey(&local_state);
             assert_eq!(
                 repo.verify_state_signature(&local_state.change_id)
@@ -467,7 +475,9 @@ mod tests {
             // A fresh handle (fresh signer cache) now signs with the device key.
             let repo2 = Repository::open(temp.path()).expect("reopen repo");
             std::fs::write(temp.path().join("b.txt"), "b").expect("write");
-            let device_state = repo2.snapshot(Some("device".to_string()), None).expect("capture");
+            let device_state = repo2
+                .snapshot(Some("device".to_string()), None)
+                .expect("capture");
             assert_eq!(
                 sig_pubkey(&device_state),
                 device_pubkey,
@@ -516,7 +526,9 @@ mod tests {
 
             // Post-login capture signs with the device key.
             std::fs::write(temp.path().join("a.txt"), "a").expect("write");
-            let signed_in = repo.snapshot(Some("in".to_string()), None).expect("capture");
+            let signed_in = repo
+                .snapshot(Some("in".to_string()), None)
+                .expect("capture");
             assert_eq!(
                 sig_pubkey(&signed_in),
                 device_pubkey,
@@ -524,15 +536,19 @@ mod tests {
             );
 
             // Simulate `auth logout grpc.S`: unlink the device identity.
-            let removed =
-                crate::identity::unlink_device_key("grpc.S").expect("unlink device key");
-            assert!(removed, "logout removes the matching-server device identity");
+            let removed = crate::identity::unlink_device_key("grpc.S").expect("unlink device key");
+            assert!(
+                removed,
+                "logout removes the matching-server device identity"
+            );
 
             // Subsequent capture on the SAME handle no longer uses the device
             // key — it falls back to the per-repo local key (a distinct key),
             // which still verifies.
             std::fs::write(temp.path().join("b.txt"), "b").expect("write");
-            let signed_out = repo.snapshot(Some("out".to_string()), None).expect("capture");
+            let signed_out = repo
+                .snapshot(Some("out".to_string()), None)
+                .expect("capture");
             assert_ne!(
                 sig_pubkey(&signed_out),
                 device_pubkey,
@@ -545,8 +561,7 @@ mod tests {
             );
 
             // Logout is idempotent: a second one finds nothing to remove.
-            let again =
-                crate::identity::unlink_device_key("grpc.S").expect("idempotent unlink");
+            let again = crate::identity::unlink_device_key("grpc.S").expect("idempotent unlink");
             assert!(!again, "second logout finds nothing to remove");
         });
     }
@@ -559,13 +574,19 @@ mod tests {
 
             // Build a fork: A -> B on one side, A -> C on the other.
             std::fs::write(temp.path().join("file.txt"), "a").expect("write");
-            let state_a = repo.snapshot(Some("a".to_string()), None).expect("capture a");
+            let state_a = repo
+                .snapshot(Some("a".to_string()), None)
+                .expect("capture a");
             std::fs::write(temp.path().join("file.txt"), "b").expect("write");
-            let state_b = repo.snapshot(Some("b".to_string()), None).expect("capture b");
+            let state_b = repo
+                .snapshot(Some("b".to_string()), None)
+                .expect("capture b");
 
             repo.goto(&state_a.change_id).expect("goto a");
             std::fs::write(temp.path().join("side.txt"), "c").expect("write");
-            let state_c = repo.snapshot(Some("c".to_string()), None).expect("capture c");
+            let state_c = repo
+                .snapshot(Some("c".to_string()), None)
+                .expect("capture c");
 
             // Merge B into head C -> a real two-parent merge state.
             let attribution = Attribution::human(Principal::new("Merger", "merge@example.com"));
@@ -583,7 +604,8 @@ mod tests {
             // The merge state carries its own signature.
             assert!(merge.signature.is_some(), "merge state must be signed");
             assert_eq!(
-                repo.verify_state_signature(&merge.change_id).expect("verify"),
+                repo.verify_state_signature(&merge.change_id)
+                    .expect("verify"),
                 SignatureStatus::Valid,
             );
 
@@ -866,7 +888,9 @@ mod tests {
 
             // First capture on this handle mints the 0600 local key and signs.
             std::fs::write(temp.path().join("a.txt"), "a").expect("write");
-            let first = repo.snapshot(Some("a".to_string()), None).expect("capture a");
+            let first = repo
+                .snapshot(Some("a".to_string()), None)
+                .expect("capture a");
             assert!(
                 first.signature.is_some(),
                 "first capture signs with the freshly-minted 0600 key",
@@ -887,7 +911,9 @@ mod tests {
             // The SAME handle must refuse to reuse a cached signer: the gate is
             // re-validated per sign, so this capture is unsigned-but-marked.
             std::fs::write(temp.path().join("b.txt"), "b").expect("write");
-            let exposed = repo.snapshot(Some("b".to_string()), None).expect("capture b");
+            let exposed = repo
+                .snapshot(Some("b".to_string()), None)
+                .expect("capture b");
             assert!(
                 exposed.signature.is_none(),
                 "an exposed key must make the next sign fail closed, not reuse a cached signer",
@@ -902,7 +928,9 @@ mod tests {
             std::fs::set_permissions(&identity, std::fs::Permissions::from_mode(0o600))
                 .expect("re-secure perms");
             std::fs::write(temp.path().join("c.txt"), "c").expect("write");
-            let resecured = repo.snapshot(Some("c".to_string()), None).expect("capture c");
+            let resecured = repo
+                .snapshot(Some("c".to_string()), None)
+                .expect("capture c");
             assert!(
                 resecured.signature.is_some(),
                 "re-securing the key lets the same handle sign again",

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -500,8 +500,7 @@ impl Repository {
             return Ok(StateVisibilityBlob::empty());
         }
         let bytes = fs::read(&path).with_context(|| format!("read '{}'", path.display()))?;
-        StateVisibilityBlob::decode(&bytes)
-            .with_context(|| format!("decode '{}'", path.display()))
+        StateVisibilityBlob::decode(&bytes).with_context(|| format!("decode '{}'", path.display()))
     }
 
     /// Whether `state` resolves to a **non-public** effective tier. `false`
@@ -525,11 +524,11 @@ impl Repository {
     /// Pure over the persisted records — never wall-clock (an `embargo_until`
     /// is materialized into a superseding record before it can change the
     /// effective tier, see the spike §5.4).
-    pub fn effective_state_visibility(
-        &self,
-        state: &ChangeId,
-    ) -> Result<Option<StateVisibility>> {
-        Ok(self.get_state_visibility_for_state(state)?.latest()?.cloned())
+    pub fn effective_state_visibility(&self, state: &ChangeId) -> Result<Option<StateVisibility>> {
+        Ok(self
+            .get_state_visibility_for_state(state)?
+            .latest()?
+            .cloned())
     }
 
     /// The effective tier of `state`: the latest declaration's tier, or
@@ -656,9 +655,9 @@ impl Repository {
         let _own_lock = if lock_held {
             None
         } else {
-            Some(self.locker().write().with_context(|| {
-                "acquire repo write lock for capture-time default visibility binding"
-            })?)
+            Some(self.locker().write().with_context(
+                || "acquire repo write lock for capture-time default visibility binding",
+            )?)
         };
         let record = StateVisibility {
             state: *state,
@@ -760,9 +759,10 @@ impl Repository {
         expected_current: &Option<Vec<u8>>,
         target: Option<Vec<u8>>,
     ) -> Result<VisibilitySidecarRestore> {
-        let _lock = self.locker().write().with_context(|| {
-            "acquire repo write lock for undo/redo visibility sidecar restore"
-        })?;
+        let _lock = self
+            .locker()
+            .write()
+            .with_context(|| "acquire repo write lock for undo/redo visibility sidecar restore")?;
         let current = self.get_state_visibility_bytes_for_state(state)?;
         if &current != expected_current {
             // A concurrent visibility commit superseded the sidecar since the
@@ -1308,7 +1308,11 @@ mod tests {
         let stored = repo
             .get_state_visibility_for_state(&state)
             .expect("read stored");
-        assert_eq!(stored.records.len(), 1, "no spurious second record appended");
+        assert_eq!(
+            stored.records.len(),
+            1,
+            "no spurious second record appended"
+        );
         assert_eq!(
             stored.records[0], existing,
             "bind must not overwrite the user's declared tier"
@@ -1332,9 +1336,15 @@ mod tests {
         );
         match staged.record {
             OpRecord::StateVisibilitySet {
-                tier, prior_sidecar, ..
+                tier,
+                prior_sidecar,
+                ..
             } => {
-                assert_eq!(tier, VisibilityTier::Internal, "bound the configured default");
+                assert_eq!(
+                    tier,
+                    VisibilityTier::Internal,
+                    "bound the configured default"
+                );
                 assert!(
                     prior_sidecar.is_none(),
                     "the staged oplog record's before-image is None for a fresh state"
@@ -1688,7 +1698,9 @@ mod tests {
             "a failed append on a fresh state must leave NO orphaned sidecar"
         );
         assert!(
-            !repo.has_visibility_for_state(&fresh).expect("has visibility"),
+            !repo
+                .has_visibility_for_state(&fresh)
+                .expect("has visibility"),
             "the state must read public-by-absence after the rollback"
         );
         assert!(
@@ -1750,7 +1762,9 @@ mod tests {
         let (_dir, repo) = repo_with_default("\"Internal\"");
         let state = ChangeId::from_bytes([88u8; 16]);
         assert!(
-            !repo.has_visibility_for_state(&state).expect("has visibility"),
+            !repo
+                .has_visibility_for_state(&state)
+                .expect("has visibility"),
             "the state starts public-by-absence"
         );
 
@@ -1767,7 +1781,9 @@ mod tests {
             "a failed snapshot commit must rewind the staged visibility sidecar — no orphan"
         );
         assert!(
-            !repo.has_visibility_for_state(&state).expect("has visibility"),
+            !repo
+                .has_visibility_for_state(&state)
+                .expect("has visibility"),
             "the state must read public-by-absence again after the rewind"
         );
     }

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use tempfile::TempDir;
 
 use super::repo_config::SUPPORTED_REPO_FORMAT;
-use super::repository_snapshot::{with_snapshot_fault, SnapshotFault};
+use super::repository_snapshot::{SnapshotFault, with_snapshot_fault};
 use crate::{
     ChangedPathFilters, HeddleError, HistoryQuery, RepoConfig, Repository, RepositoryCapability,
     ThreadFreshness, ThreadManager, WorktreeIndex,
@@ -42,7 +42,10 @@ fn test_init_creates_structure() {
     assert!(temp_dir.path().join(".heddle/objects/trees").exists());
     assert!(temp_dir.path().join(".heddle/objects/states").exists());
     let root_state = repo.head().unwrap().expect("init should seed main state");
-    assert_eq!(repo.refs().get_thread(&ThreadName::new("main")).unwrap(), Some(root_state));
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
+        Some(root_state)
+    );
     let state = repo.store().get_state(&root_state).unwrap().unwrap();
     assert!(state.parents.is_empty());
     let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
@@ -63,8 +66,7 @@ fn test_open_with_store_threads_a_custom_object_store() {
     drop(repo);
 
     let store = FsStore::new(&heddle_dir);
-    let repo: Repository<_, _, FsStore> =
-        Repository::open_with_store(&heddle_dir, store).unwrap();
+    let repo: Repository<_, _, FsStore> = Repository::open_with_store(&heddle_dir, store).unwrap();
 
     let blob = objects::object::Blob::from("open_with_store round-trip");
     let hash = repo.store().put_blob(&blob).unwrap();
@@ -205,7 +207,10 @@ fn courtesy_filename_scoped_root_only() {
         .expect("snapshot tree");
 
     assert!(
-        !tree.entries().iter().any(|e| e.name == "HEDDLE-EMBARGO.txt"),
+        !tree
+            .entries()
+            .iter()
+            .any(|e| e.name == "HEDDLE-EMBARGO.txt"),
         "the root-level courtesy stub must stay ignored at the worktree root"
     );
     let sub = tree
@@ -355,7 +360,10 @@ fn snapshot_atomic_mutation_fault_and_exactly_once_contract() {
         .iter()
         .filter(|entry| matches!(entry.operation, OpRecord::TransactionCommit { .. }))
         .count();
-    assert_eq!(snapshot_count, 1, "capture batch must contain one snapshot record");
+    assert_eq!(
+        snapshot_count, 1,
+        "capture batch must contain one snapshot record"
+    );
     assert_eq!(
         transaction_count, 1,
         "capture batch must contain one transaction marker"
@@ -1248,7 +1256,9 @@ fn test_fast_forward_attached_preserves_head_and_advances_thread() {
     // Repo::init_default attaches HEAD to "main"; explicitly rewind the
     // thread ref to state1 so a fast-forward to state2 is meaningful.
     let state1 = repo.head().unwrap().expect("base state should exist");
-    repo.refs().set_thread(&ThreadName::new("main"), &state1).unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("main"), &state1)
+        .unwrap();
     repo.refs()
         .write_head(&Head::Attached {
             thread: ThreadName::new("main"),
@@ -1324,7 +1334,7 @@ fn test_fast_forward_attached_when_detached_stays_detached() {
 #[test]
 fn test_open_preserves_explicit_detached_head_in_git_overlay() {
     let temp_dir = TempDir::new().unwrap();
-    gix::init(temp_dir.path()).expect("init real git repository");
+    sley::Repository::init(temp_dir.path()).expect("init real git repository");
 
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     assert_eq!(repo.capability(), RepositoryCapability::GitOverlay);
@@ -1366,7 +1376,7 @@ fn test_open_preserves_explicit_detached_head_in_git_overlay() {
 fn git_overlay_worktree_status_is_none_when_embedded_git_is_bare() {
     let temp_dir = TempDir::new().unwrap();
     let git_dir = temp_dir.path().join(".git");
-    gix::init_bare(&git_dir).expect("init bare .git");
+    sley::Repository::init_bare(&git_dir).expect("init bare .git");
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     assert_eq!(
         repo.capability(),
@@ -1954,12 +1964,18 @@ fn dir_only_ignore_covers_node_modules_symlink_native() {
     let status = repo.compare_worktree_cached(&tree).unwrap();
 
     assert!(
-        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        !status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules")),
         "node_modules symlink must be ignored by `node_modules/`, not reported as added: {:?}",
         status.added,
     );
     assert!(
-        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "a non-ignored sibling must still be reported (proves the scan ran): {:?}",
         status.added,
     );
@@ -1988,7 +2004,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_native() {
     // First status: no ignore yet, so the dep file is seen as untracked.
     let before = repo.compare_worktree_cached(&tree).unwrap();
     assert!(
-        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        before
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules/dep.js")),
         "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
         before.added,
     );
@@ -2003,7 +2022,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_native() {
         after.added,
     );
     assert!(
-        after.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        after
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "non-ignored sibling must still be reported after the refresh: {:?}",
         after.added,
     );
@@ -2020,7 +2042,7 @@ fn dir_only_ignore_covers_node_modules_symlink_git_overlay() {
 
     let temp = TempDir::new().unwrap();
     let root = temp.path();
-    gix::init(root).expect("init real git repository");
+    sley::Repository::init(root).expect("init real git repository");
     let repo = Repository::init_default(root).unwrap();
     assert_eq!(repo.capability(), RepositoryCapability::GitOverlay);
 
@@ -2033,12 +2055,18 @@ fn dir_only_ignore_covers_node_modules_symlink_git_overlay() {
 
     let status = repo.git_overlay_worktree_status().unwrap().unwrap();
     assert!(
-        !status.added.iter().any(|p| p == std::path::Path::new("node_modules")),
+        !status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules")),
         "node_modules symlink must be ignored in git-overlay status: {:?}",
         status.added,
     );
     assert!(
-        status.added.iter().any(|p| p == std::path::Path::new("keep.txt")),
+        status
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("keep.txt")),
         "a non-ignored sibling must still be reported in git-overlay status: {:?}",
         status.added,
     );
@@ -2052,7 +2080,7 @@ fn dir_only_ignore_covers_node_modules_symlink_git_overlay() {
 fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
     let temp = TempDir::new().unwrap();
     let root = temp.path();
-    gix::init(root).expect("init real git repository");
+    sley::Repository::init(root).expect("init real git repository");
     let repo = Repository::init_default(root).unwrap();
     assert_eq!(repo.capability(), RepositoryCapability::GitOverlay);
 
@@ -2063,7 +2091,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
 
     let before = repo.git_overlay_worktree_status().unwrap().unwrap();
     assert!(
-        before.added.iter().any(|p| p == std::path::Path::new("node_modules/dep.js")),
+        before
+            .added
+            .iter()
+            .any(|p| p == std::path::Path::new("node_modules/dep.js")),
         "precondition: node_modules/dep.js should be untracked before the ignore: {:?}",
         before.added,
     );
@@ -2096,7 +2127,9 @@ fn open_refuses_metadataless_virtualized_thread_mount() {
 
     // `Repository` isn't `Debug`, so match rather than `expect_err`.
     let err = match Repository::open(&mount_root) {
-        Ok(_) => panic!("opening from a metadata-less virtualized mount must refuse the parent climb"),
+        Ok(_) => {
+            panic!("opening from a metadata-less virtualized mount must refuse the parent climb")
+        }
         Err(e) => e,
     };
     assert!(
@@ -2143,7 +2176,7 @@ fn open_refuses_metadataless_virtualized_thread_mount() {
 #[test]
 fn open_solid_checkout_roots_at_boundary_not_git_overlay_parent() {
     let temp_dir = TempDir::new().unwrap();
-    gix::init(temp_dir.path()).expect("init real git repository");
+    sley::Repository::init(temp_dir.path()).expect("init real git repository");
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     assert_eq!(
         repo.capability(),

--- a/crates/repo/src/snapshot_metadata.rs
+++ b/crates/repo/src/snapshot_metadata.rs
@@ -23,8 +23,8 @@ use objects::{
 };
 
 use crate::{
-    repository::Repository, ConfidenceBand, Thread, ThreadConfidenceSummary, ThreadFreshness,
-    ThreadImpactCategory, ThreadManager, ThreadState, ThreadVerificationSummary,
+    ConfidenceBand, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadImpactCategory,
+    ThreadManager, ThreadState, ThreadVerificationSummary, repository::Repository,
 };
 
 /// Result of a metadata refresh: derived signal the caller may want

--- a/crates/repo/src/stack_snapshot.rs
+++ b/crates/repo/src/stack_snapshot.rs
@@ -159,9 +159,7 @@ impl RepositorySnapshot {
     /// Look up the stack containing `thread_name`. Returns `None` if the
     /// thread is unknown to this snapshot.
     pub fn stack_containing(&self, thread_name: &str) -> Option<&ThreadStack> {
-        self.stacks
-            .iter()
-            .find(|stack| stack.contains(thread_name))
+        self.stacks.iter().find(|stack| stack.contains(thread_name))
     }
 
     /// Decide the next stack-level action for the stack containing
@@ -397,7 +395,10 @@ mod tests {
             snap("b", Some("a"), ThreadState::Ready),
             snap("c", Some("b"), ThreadState::Merged),
         ]);
-        assert_eq!(snapshot.next_action_for("a").unwrap(), StackNextAction::Ready);
+        assert_eq!(
+            snapshot.next_action_for("a").unwrap(),
+            StackNextAction::Ready
+        );
     }
 
     #[test]

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -212,10 +212,7 @@ pub fn describe_thread_advice_with_initial(
         return ThreadAdvice {
             thread_health: "ready".to_string(),
             blockers,
-            recommended_action: format!(
-                "heddle land {} --no-push",
-                thread_flag(&thread.id)
-            ),
+            recommended_action: format!("heddle land {} --no-push", thread_flag(&thread.id)),
         };
     } else if clean_ready_merges_to_apply || thread.state == ThreadState::Ready {
         RecommendedAction::Land

--- a/crates/repo/src/thread_manifest.rs
+++ b/crates/repo/src/thread_manifest.rs
@@ -460,10 +460,7 @@ fn withheld_marker_path(heddle_dir: &Path, canonical_worktree_root: &Path) -> Pa
 /// must be a no-op. Keyed per worktree root (see [`withheld_marker_path`]), so a
 /// sibling worktree of the same thread is unaffected. The marker body is the
 /// human-readable root for diagnostics; presence is the signal.
-pub fn mark_withheld_checkout(
-    heddle_dir: &Path,
-    canonical_worktree_root: &Path,
-) -> io::Result<()> {
+pub fn mark_withheld_checkout(heddle_dir: &Path, canonical_worktree_root: &Path) -> io::Result<()> {
     let path = withheld_marker_path(heddle_dir, canonical_worktree_root);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent).map_err(|e| enrich_fs_error(parent, "creating", e))?;
@@ -736,7 +733,10 @@ mod tests {
         assert_eq!(dir, Path::new("/repo/.heddle/threads/feature%2Ffoo"));
         // The manifest is a child of the shared per-thread dir, so a checkout
         // root at `<dir>/root` is its sibling.
-        assert_eq!(manifest_path(heddle, "feature/foo"), dir.join("manifest.toml"));
+        assert_eq!(
+            manifest_path(heddle, "feature/foo"),
+            dir.join("manifest.toml")
+        );
         assert!(manifest_path(heddle, "feature/foo").starts_with(heddle.join("threads")));
     }
 
@@ -790,8 +790,14 @@ mod tests {
         ] {
             let seg = encode_thread_segment(id);
             assert!(!seg.contains('/'), "{id:?} → {seg:?} must be one segment");
-            assert_ne!(seg, ".", "{id:?} must not encode to a current-dir component");
-            assert_ne!(seg, "..", "{id:?} must not encode to a parent-dir component");
+            assert_ne!(
+                seg, ".",
+                "{id:?} must not encode to a current-dir component"
+            );
+            assert_ne!(
+                seg, "..",
+                "{id:?} must not encode to a parent-dir component"
+            );
             assert_eq!(
                 decode_thread_segment(&seg).as_deref(),
                 Some(id),
@@ -882,7 +888,9 @@ mod tests {
             "a slash-namespaced sibling must be completely untouched by the drop"
         );
         assert!(
-            read_manifest(dir.path(), "feature/keeper").unwrap().is_some(),
+            read_manifest(dir.path(), "feature/keeper")
+                .unwrap()
+                .is_some(),
             "the sibling's manifest must survive"
         );
 

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -419,7 +419,6 @@ impl ThreadRecord {
         // A persisted record's id was validated at creation — trust it.
         ThreadId::new_unchecked(self.id.clone())
     }
-
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -504,7 +503,14 @@ mod thread_id_tests {
 
     #[test]
     fn accepts_safe_slugs() {
-        for ok in ["feature/x", "v1.2", "a_b-c.d", "team@scope", "main", "wip+1=2"] {
+        for ok in [
+            "feature/x",
+            "v1.2",
+            "a_b-c.d",
+            "team@scope",
+            "main",
+            "wip+1=2",
+        ] {
             assert!(
                 ThreadId::new(ok).is_ok(),
                 "expected '{ok}' to be a valid thread id"
@@ -540,7 +546,10 @@ mod thread_id_tests {
     fn error_message_carries_a_valid_rename_hint() {
         let err = ThreadId::new("my feature").unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("my feature"), "names the offending input: {msg}");
+        assert!(
+            msg.contains("my feature"),
+            "names the offending input: {msg}"
+        );
         assert!(msg.contains("try 'my-feature'"), "suggests a rename: {msg}");
         // The suggestion itself must be a valid thread id.
         assert!(ThreadId::new(err.suggestion.as_str()).is_ok());

--- a/crates/repo/src/thread_stack.rs
+++ b/crates/repo/src/thread_stack.rs
@@ -395,9 +395,7 @@ impl Repository {
             }
         }
         let plan = plan_stack_rebase(&records, root_thread, onto, |name| {
-            tips.get(name)
-                .cloned()
-                .unwrap_or_else(|| name.to_string())
+            tips.get(name).cloned().unwrap_or_else(|| name.to_string())
         });
         Ok(plan)
     }
@@ -445,9 +443,7 @@ mod tests {
         r
     }
 
-    fn current_states<'a>(
-        map: &'a HashMap<&'a str, &'a str>,
-    ) -> impl FnMut(&str) -> String + 'a {
+    fn current_states<'a>(map: &'a HashMap<&'a str, &'a str>) -> impl FnMut(&str) -> String + 'a {
         move |name: &str| map.get(name).copied().unwrap_or(name).to_string()
     }
 
@@ -528,8 +524,8 @@ mod tests {
     #[test]
     fn plan_rejects_unknown_root() {
         let records: Vec<ThreadRecord> = Vec::new();
-        let err = plan_stack_rebase(&records, "missing", "new-base", |_| String::new())
-            .unwrap_err();
+        let err =
+            plan_stack_rebase(&records, "missing", "new-base", |_| String::new()).unwrap_err();
         assert_eq!(err, PlanRebaseError::ThreadNotFound("missing".into()));
     }
 
@@ -539,8 +535,8 @@ mod tests {
             record_at("feature-a", None, "main-1"),
             record_at("feature-b", Some("feature-a"), "feature-a-tip"),
         ];
-        let err = plan_stack_rebase(&records, "feature-b", "main-2", |n| n.to_string())
-            .unwrap_err();
+        let err =
+            plan_stack_rebase(&records, "feature-b", "main-2", |n| n.to_string()).unwrap_err();
         assert_eq!(
             err,
             PlanRebaseError::NotARoot("feature-b".into(), "feature-a".into())
@@ -552,8 +548,8 @@ mod tests {
         let records = vec![record_at("feature-a", None, "main-1")];
         let mut current = HashMap::new();
         current.insert("feature-a", "feature-a-tip");
-        let plan = plan_stack_rebase(&records, "feature-a", "main-2", current_states(&current))
-            .unwrap();
+        let plan =
+            plan_stack_rebase(&records, "feature-a", "main-2", current_states(&current)).unwrap();
         assert_eq!(plan.step_count(), 1);
         let step = &plan.steps[0];
         assert_eq!(step.thread, "feature-a");
@@ -579,8 +575,7 @@ mod tests {
         current.insert("b", "b-tip");
         current.insert("c", "c-tip");
         current.insert("d", "d-tip");
-        let plan =
-            plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
+        let plan = plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
         let order: Vec<&str> = plan.steps.iter().map(|s| s.thread.as_str()).collect();
         assert_eq!(order, vec!["a", "b", "d", "c"]);
 
@@ -626,8 +621,7 @@ mod tests {
         let records = vec![record_at("a", None, "main-2")];
         let mut current = HashMap::new();
         current.insert("a", "main-2");
-        let plan =
-            plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
+        let plan = plan_stack_rebase(&records, "a", "main-2", current_states(&current)).unwrap();
         assert!(plan.is_no_op());
     }
 }

--- a/crates/repo/src/visibility.rs
+++ b/crates/repo/src/visibility.rs
@@ -175,10 +175,9 @@ pub fn visible(visibility: &VisibilityTier, audience: &AudienceTier) -> bool {
         (VisibilityTier::TeamScoped { team_id }, AudienceTier::Team(name)) => team_id == name,
         (VisibilityTier::TeamScoped { .. }, _) => false,
         // Restricted: visible only to a viewer holding the matching label.
-        (
-            VisibilityTier::Restricted { scope_label },
-            AudienceTier::Restricted(viewer_label),
-        ) => scope_label == viewer_label,
+        (VisibilityTier::Restricted { scope_label }, AudienceTier::Restricted(viewer_label)) => {
+            scope_label == viewer_label
+        }
         (VisibilityTier::Restricted { .. }, _) => false,
     }
 }
@@ -313,7 +312,10 @@ mod tests {
             scope_label: "sec-embargo".into(),
         };
         // The one authorized scope sees it.
-        assert!(visible(&vis, &AudienceTier::Restricted("sec-embargo".into())));
+        assert!(visible(
+            &vis,
+            &AudienceTier::Restricted("sec-embargo".into())
+        ));
         // A non-matching restricted label does not.
         assert!(!visible(&vis, &AudienceTier::Restricted("legal".into())));
     }

--- a/crates/review/src/github/rest.rs
+++ b/crates/review/src/github/rest.rs
@@ -971,12 +971,10 @@ mod tests {
         // status and the fetch fails loudly *without* ever connecting to
         // the dead port — proving the redirect was not chased.
         let base_url = spawn_server(|_| {
-            vec![
-                MockResponse::json(302, String::new()).with_header(
-                    "Location",
-                    "http://127.0.0.1:1/repos/heddle/repo/pulls/439/files?per_page=100&page=2",
-                ),
-            ]
+            vec![MockResponse::json(302, String::new()).with_header(
+                "Location",
+                "http://127.0.0.1:1/repos/heddle/repo/pulls/439/files?per_page=100&page=2",
+            )]
         })
         .await;
         let err = client_for(&base_url)

--- a/crates/semantic/src/diff/diff_engine.rs
+++ b/crates/semantic/src/diff/diff_engine.rs
@@ -404,8 +404,16 @@ mod tests {
 
         // f0 (200) is under budget, f1 tips the running total to 400 > 350 and
         // is the last load; f2..f4 are skipped entirely.
-        assert_eq!(old_loads.get(), 2, "only the under-budget prefix + tipping file load");
-        assert_eq!(new_loads.get(), 2, "only the under-budget prefix + tipping file load");
+        assert_eq!(
+            old_loads.get(),
+            2,
+            "only the under-budget prefix + tipping file load"
+        );
+        assert_eq!(
+            new_loads.get(),
+            2,
+            "only the under-budget prefix + tipping file load"
+        );
         assert!(
             result
                 .fallback_reasons
@@ -483,8 +491,16 @@ mod tests {
                 _ => None,
             })
         };
-        assert_eq!(classification_of("f0.rs"), Some(true), "loaded prefix keeps detail");
-        assert_eq!(classification_of("f1.rs"), Some(true), "loaded prefix keeps detail");
+        assert_eq!(
+            classification_of("f0.rs"),
+            Some(true),
+            "loaded prefix keeps detail"
+        );
+        assert_eq!(
+            classification_of("f1.rs"),
+            Some(true),
+            "loaded prefix keeps detail"
+        );
         for name in ["f2.rs", "f3.rs", "f4.rs"] {
             assert_eq!(
                 classification_of(name),

--- a/crates/semantic/src/lib.rs
+++ b/crates/semantic/src/lib.rs
@@ -14,10 +14,10 @@ pub mod symbol_resolver;
 
 pub use analysis::{
     AggregateKind, AggregatedChange, AggregationResult, HotEventKind, HotSpot, HotSpotKey,
-    HotSpotKeyValue, HotSpotParams, HotSpotsReport,
-    SimilarityMethod, aggregate_changes, analyze_actor_histogram, analyze_hot_spots,
-    classify_modification, classify_modification_with_confidence, compute_similarity,
-    detect_file_renames, detect_function_changes,
+    HotSpotKeyValue, HotSpotParams, HotSpotsReport, SimilarityMethod, aggregate_changes,
+    analyze_actor_histogram, analyze_hot_spots, classify_modification,
+    classify_modification_with_confidence, compute_similarity, detect_file_renames,
+    detect_function_changes,
 };
 pub use cache::{SemanticParseCache, SemanticParseCacheStats};
 pub use diff::{

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -26,8 +26,8 @@ use std::rc::Rc;
 
 use tree_sitter::Node;
 
+use super::language_rules::{Classified, MetadataBinding, USE_POISON_KEY, rules_for};
 pub(super) use super::language_rules::{ItemKind, UseIdentity};
-use super::language_rules::{rules_for, Classified, MetadataBinding, USE_POISON_KEY};
 use crate::parser::{Language, ParsedFile};
 
 /// Stable identifier for an item across the three sides. Two items match iff
@@ -267,7 +267,12 @@ fn collect_raw_items(language: Language, source: &str, root: Node<'_>) -> Vec<Ra
                         use_identity: None,
                         container: recurse.then(|| {
                             let (content_start, content_end) = body_content_bounds(body);
-                            (body.start_byte(), body.end_byte(), content_start, content_end)
+                            (
+                                body.start_byte(),
+                                body.end_byte(),
+                                content_start,
+                                content_end,
+                            )
                         }),
                     });
                     if recurse {
@@ -337,7 +342,10 @@ fn assemble_tree(mut raws: Vec<RawItem>) -> Vec<Item> {
     }
 
     for raw in raws {
-        while open.last().is_some_and(|(_, _, end)| raw.start_byte >= *end) {
+        while open
+            .last()
+            .is_some_and(|(_, _, end)| raw.start_byte >= *end)
+        {
             close_one(&mut open, &mut top);
         }
         match raw.container {

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -467,7 +467,11 @@ fn rust_use_leaves(source: &str, argument: Node<'_>) -> Option<Vec<String>> {
 /// partial-signal field — any non-byte difference conflicts; heddle#468
 /// r4). An `Unanalyzable` item poisons its region so the leaf union never
 /// runs there at all (heddle#468 r6).
-pub(super) fn use_identity(language: Language, source: &str, node: Node<'_>) -> Option<UseIdentity> {
+pub(super) fn use_identity(
+    language: Language,
+    source: &str,
+    node: Node<'_>,
+) -> Option<UseIdentity> {
     if language != Language::Rust || node.kind() != "use_declaration" {
         return None;
     }

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -17,9 +17,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use merge::{text_hunk_merge_with_markers, ConflictMarkers, MergeOutcome};
+use merge::{ConflictMarkers, MergeOutcome, text_hunk_merge_with_markers};
 
-use super::items::{inter_ranges, FileSegments, Item, ItemKey, ItemKind};
+use super::items::{FileSegments, Item, ItemKey, ItemKind, inter_ranges};
 
 /// Three sides of the merge: `[base, ours, theirs]`. Each per-iteration
 /// segment contribution is indexed by [`Side`] so emission tracking can
@@ -351,7 +351,10 @@ fn build_aligned_match_keys(
         let mut base_by_key: BTreeMap<&ItemKey, Vec<(usize, &Item)>> = BTreeMap::new();
         for (i, it) in base.iter().enumerate() {
             if container_keys.contains(&it.key) {
-                base_by_key.entry(&it.key).or_default().push((base_mks[i].1, it));
+                base_by_key
+                    .entry(&it.key)
+                    .or_default()
+                    .push((base_mks[i].1, it));
             }
         }
         let mut used: BTreeMap<&ItemKey, BTreeSet<usize>> = BTreeMap::new();
@@ -442,7 +445,10 @@ fn build_aligned_match_keys(
                 } else {
                     let used_set = used.entry(&it.key).or_default();
                     let next_unused = base_by_key.get(&it.key).and_then(|cands| {
-                        cands.iter().map(|(d, _)| *d).find(|d| !used_set.contains(d))
+                        cands
+                            .iter()
+                            .map(|(d, _)| *d)
+                            .find(|d| !used_set.contains(d))
                     });
                     if let Some(d) = next_unused {
                         used_set.insert(d);
@@ -687,7 +693,10 @@ fn resolve_node(
     theirs_item: Option<&Item>,
     markers: ConflictMarkers<'_>,
 ) -> (Option<Vec<u8>>, usize) {
-    let mut present = [base_item, ours_item, theirs_item].into_iter().flatten().peekable();
+    let mut present = [base_item, ours_item, theirs_item]
+        .into_iter()
+        .flatten()
+        .peekable();
     let all_containers = present.peek().is_some() && present.all(|i| i.body.is_some());
     if all_containers {
         resolve_container(sides, base_item, ours_item, theirs_item, markers)
@@ -1025,7 +1034,12 @@ fn resolve_use_component(
     // Both sides changed the component, differently. Conflict the whole
     // unit — see the outcome list above.
     (
-        Some(emit_addadd_conflict(&ours_bytes, &theirs_bytes, markers, sides)),
+        Some(emit_addadd_conflict(
+            &ours_bytes,
+            &theirs_bytes,
+            markers,
+            sides,
+        )),
         1,
     )
 }

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -2501,8 +2501,16 @@ fn add_add_container_identical_no_base_takes_one() {
     let ours = "mod foo {\n    fn a() {}\n}\n";
     let theirs = "mod foo {\n    fn a() {}\n}\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
-    assert_eq!(merged.matches("mod foo").count(), 1, "module duplicated: {merged}");
-    assert_eq!(merged.matches("fn a()").count(), 1, "body duplicated: {merged}");
+    assert_eq!(
+        merged.matches("mod foo").count(),
+        1,
+        "module duplicated: {merged}"
+    );
+    assert_eq!(
+        merged.matches("fn a()").count(),
+        1,
+        "body duplicated: {merged}"
+    );
     assert!(
         !merged.contains("<<<<<<<"),
         "no spurious conflict on identical add/add containers: {merged}"
@@ -2519,7 +2527,10 @@ fn add_add_container_divergent_header_no_base_conflicts() {
     let ours = "pub mod foo {\n    fn a() {}\n}\n";
     let theirs = "mod foo {\n    fn a() {}\n}\n";
     let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
-    assert!(count >= 1, "expected ≥1 conflict on the divergent header, got {count}: {text}");
+    assert!(
+        count >= 1,
+        "expected ≥1 conflict on the divergent header, got {count}: {text}"
+    );
     assert!(
         text.contains("<<<<<<<") && text.contains("=======") && text.contains(">>>>>>>"),
         "expected canonical conflict markers around the divergent module: {text}"
@@ -2566,8 +2577,16 @@ fn base_anchored_container_merges_structurally_clean() {
     let ours = "mod foo {\n    fn a() {}\n    fn b() {}\n}\n";
     let theirs = "mod foo {\n    fn a() {}\n    fn c() {}\n}\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
-    assert_eq!(merged.matches("mod foo").count(), 1, "module duplicated: {merged}");
-    assert_eq!(merged.matches("mod foo {").count(), 1, "delimiter duplicated: {merged}");
+    assert_eq!(
+        merged.matches("mod foo").count(),
+        1,
+        "module duplicated: {merged}"
+    );
+    assert_eq!(
+        merged.matches("mod foo {").count(),
+        1,
+        "delimiter duplicated: {merged}"
+    );
     assert!(
         merged.contains("fn a()") && merged.contains("fn b()") && merged.contains("fn c()"),
         "base child + both disjoint additions must weave into the single module: {merged}"
@@ -2657,7 +2676,10 @@ fn empty_base_container_divergent_header_conflict_is_well_formed() {
     let ours = "pub mod foo {\n    fn a() {}\n}\n";
     let theirs = "pub(crate) mod foo {\n    fn b() {}\n}\n";
     let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
-    assert!(count >= 1, "expected ≥1 conflict on the divergent header: {text}");
+    assert!(
+        count >= 1,
+        "expected ≥1 conflict on the divergent header: {text}"
+    );
     assert!(
         text.contains("<<<<<<<") && text.contains("=======") && text.contains(">>>>>>>"),
         "expected canonical conflict markers: {text}"
@@ -2675,7 +2697,8 @@ fn empty_base_container_divergent_header_conflict_is_well_formed() {
             "a resolved side has unbalanced braces: {side}"
         );
         assert!(
-            crate::parser::ParsedFile::parse(side.as_str(), crate::parser::Language::Rust).is_some(),
+            crate::parser::ParsedFile::parse(side.as_str(), crate::parser::Language::Rust)
+                .is_some(),
             "a resolved side does not parse: {side}"
         );
     }
@@ -2705,7 +2728,8 @@ fn conflict_output_resolved_sides_always_reparse() {
     };
     for side in resolve_both_sides(&text) {
         assert!(
-            crate::parser::ParsedFile::parse(side.as_str(), crate::parser::Language::Rust).is_some(),
+            crate::parser::ParsedFile::parse(side.as_str(), crate::parser::Language::Rust)
+                .is_some(),
             "driver emitted a conflict whose resolved side does not parse: {side}"
         );
     }
@@ -3732,8 +3756,14 @@ interface Foo {
                 .is_some(),
                 "clean merge must re-parse (no silent corruption): {text}"
             );
-            assert!(text.contains("a(x: number)"), "theirs's edit on a lost: {text}");
-            assert!(text.contains("f(y: string)"), "theirs's edit on f lost: {text}");
+            assert!(
+                text.contains("a(x: number)"),
+                "theirs's edit on a lost: {text}"
+            );
+            assert!(
+                text.contains("f(y: string)"),
+                "theirs's edit on f lost: {text}"
+            );
             for m in ["a(", "b(", "c(", "d(", "e(", "f("] {
                 assert_eq!(text.matches(m).count(), 1, "{m} not once: {text}");
             }
@@ -3743,8 +3773,14 @@ interface Foo {
             ..
         } => {
             let text = String::from_utf8(merged_bytes_with_markers).unwrap();
-            assert!(text.contains("a(x: number)"), "theirs's edit on a lost: {text}");
-            assert!(text.contains("f(y: string)"), "theirs's edit on f lost: {text}");
+            assert!(
+                text.contains("a(x: number)"),
+                "theirs's edit on a lost: {text}"
+            );
+            assert!(
+                text.contains("f(y: string)"),
+                "theirs's edit on f lost: {text}"
+            );
             for m in ["a(", "b(", "c(", "d(", "e(", "f("] {
                 assert!(text.contains(m), "{m} silently dropped: {text}");
             }
@@ -3817,8 +3853,14 @@ abstract class Foo {
                 .is_some(),
                 "clean merge must re-parse (no silent corruption): {text}"
             );
-            assert!(text.contains("abstract a(x: number)"), "abstract a edit lost: {text}");
-            assert!(text.contains("abstract f(y: string)"), "abstract f edit lost: {text}");
+            assert!(
+                text.contains("abstract a(x: number)"),
+                "abstract a edit lost: {text}"
+            );
+            assert!(
+                text.contains("abstract f(y: string)"),
+                "abstract f edit lost: {text}"
+            );
             for m in methods {
                 assert_eq!(text.matches(m).count(), 1, "{m} not once: {text}");
             }
@@ -3828,8 +3870,14 @@ abstract class Foo {
             ..
         } => {
             let text = String::from_utf8(merged_bytes_with_markers).unwrap();
-            assert!(text.contains("abstract a(x: number)"), "abstract a edit lost: {text}");
-            assert!(text.contains("abstract f(y: string)"), "abstract f edit lost: {text}");
+            assert!(
+                text.contains("abstract a(x: number)"),
+                "abstract a edit lost: {text}"
+            );
+            assert!(
+                text.contains("abstract f(y: string)"),
+                "abstract f edit lost: {text}"
+            );
             for m in methods {
                 assert!(text.contains(m), "{m} silently dropped: {text}");
             }
@@ -4904,8 +4952,14 @@ fn rust_identical_use_addition_dedups_clean() {
         1,
         "identical re-export must appear exactly once: {merged}"
     );
-    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
-    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() { 10 }"),
+        "ours edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn beta() { 20 }"),
+        "theirs edit lost: {merged}"
+    );
 }
 
 // heddle#468 r1 (Codex P2): grouped-vs-ungrouped imports must be normalized
@@ -4946,8 +5000,14 @@ fn rust_identical_grouped_use_dedups_clean() {
         1,
         "identical grouped re-export must appear exactly once: {merged}"
     );
-    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
-    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() { 10 }"),
+        "ours edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn beta() { 20 }"),
+        "theirs edit lost: {merged}"
+    );
 }
 
 // Distinct single re-exports on different leaf paths still auto-combine —
@@ -4958,8 +5018,14 @@ fn rust_distinct_reexports_still_auto_combine() {
     let ours = "pub use crate::a::X;\nfn anchor() { 0 }\n";
     let theirs = "pub use crate::b::Y;\nfn anchor() { 0 }\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
-    assert!(merged.contains("crate::a::X"), "ours re-export lost: {merged}");
-    assert!(merged.contains("crate::b::Y"), "theirs re-export lost: {merged}");
+    assert!(
+        merged.contains("crate::a::X"),
+        "ours re-export lost: {merged}"
+    );
+    assert!(
+        merged.contains("crate::b::Y"),
+        "theirs re-export lost: {merged}"
+    );
     assert!(
         !merged.contains("<<<<<<<"),
         "distinct re-exports must merge cleanly: {merged}"
@@ -5124,8 +5190,14 @@ fn rust_identical_attributed_use_addition_dedups_clean() {
         1,
         "the shared attribute must appear exactly once: {merged}"
     );
-    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
-    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() { 10 }"),
+        "ours edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn beta() { 20 }"),
+        "theirs edit lost: {merged}"
+    );
 }
 
 // SAME leaf set spelled differently AND with divergent visibility
@@ -5266,8 +5338,14 @@ fn rust_use_identical_multiline_component_dedups_clean() {
         1,
         "Baz must appear exactly once after dedup: {merged}"
     );
-    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
-    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() { 10 }"),
+        "ours edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn beta() { 20 }"),
+        "theirs edit lost: {merged}"
+    );
 }
 
 // heddle#468 r6 (Codex cid 3350239933): the clever leaf-component union is
@@ -5382,8 +5460,14 @@ fn rust_use_identical_glob_both_sides_dedups_clean() {
         1,
         "byte-identical glob must dedup to one line, not conflict: {merged}"
     );
-    assert!(merged.contains("fn alpha() { 10 }"), "ours edit lost: {merged}");
-    assert!(merged.contains("fn beta() { 20 }"), "theirs edit lost: {merged}");
+    assert!(
+        merged.contains("fn alpha() { 10 }"),
+        "ours edit lost: {merged}"
+    );
+    assert!(
+        merged.contains("fn beta() { 20 }"),
+        "theirs edit lost: {merged}"
+    );
 }
 
 // heddle#490 r7 — per-scope use-poison. An unanalyzable glob nested in
@@ -5399,8 +5483,14 @@ fn rust_use_nested_glob_does_not_poison_disjoint_top_level_adds() {
     let ours = "use a::A;\nmod m {\n    use x::*;\n}\nfn anchor() { 0 }\n";
     let theirs = "use b::B;\nmod m {\n    use x::*;\n}\nfn anchor() { 0 }\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
-    assert!(merged.contains("use a::A;"), "ours top-level add lost: {merged}");
-    assert!(merged.contains("use b::B;"), "theirs top-level add lost: {merged}");
+    assert!(
+        merged.contains("use a::A;"),
+        "ours top-level add lost: {merged}"
+    );
+    assert!(
+        merged.contains("use b::B;"),
+        "theirs top-level add lost: {merged}"
+    );
     assert_eq!(
         merged.matches("use x::*;").count(),
         1,
@@ -5432,7 +5522,6 @@ fn rust_use_nested_glob_still_poisons_its_own_scope() {
         "expected a conflict region in the poisoned nested scope: {text}"
     );
 }
-
 
 // =====================================================================
 // heddle#484 / #490 — close-the-class conformance harness (ported from the
@@ -5580,13 +5669,26 @@ fn repro_484_bug1_trailing_postamble_not_duplicated() {
     let ours = "pub fn a() {}\n\npub fn c() {}\n\n// MARK\n";
     let theirs = "pub fn a() {}\n\npub fn b() {}\n\n// MARK\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert_eq!(merged.matches("// MARK").count(), 1, "marker duplicated:\n{merged}");
-    assert!(merged.contains("pub fn b() {}"), "theirs add lost:\n{merged}");
+    assert_eq!(
+        merged.matches("// MARK").count(),
+        1,
+        "marker duplicated:\n{merged}"
+    );
+    assert!(
+        merged.contains("pub fn b() {}"),
+        "theirs add lost:\n{merged}"
+    );
     assert!(merged.contains("pub fn c() {}"), "ours add lost:\n{merged}");
     // both additions precede the single marker.
     let mark = merged.find("// MARK").unwrap();
-    assert!(merged.find("pub fn b() {}").unwrap() < mark, "b after marker:\n{merged}");
-    assert!(merged.find("pub fn c() {}").unwrap() < mark, "c after marker:\n{merged}");
+    assert!(
+        merged.find("pub fn b() {}").unwrap() < mark,
+        "b after marker:\n{merged}"
+    );
+    assert!(
+        merged.find("pub fn c() {}").unwrap() < mark,
+        "c after marker:\n{merged}"
+    );
 }
 
 #[test]
@@ -5597,11 +5699,21 @@ fn repro_484_bug2_trailing_module_not_nested_or_duplicated() {
     let ours = "pub fn a() {}\n\npub fn c() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
     let theirs = "pub fn a() {}\n\npub fn b() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert_eq!(merged.matches("mod tests").count(), 1, "module duplicated:\n{merged}");
+    assert_eq!(
+        merged.matches("mod tests").count(),
+        1,
+        "module duplicated:\n{merged}"
+    );
     // both added fns stay at top level, BEFORE the module.
     let m = merged.find("mod tests").unwrap();
-    assert!(merged.find("pub fn b() {}").unwrap() < m, "b nested/after module:\n{merged}");
-    assert!(merged.find("pub fn c() {}").unwrap() < m, "c nested/after module:\n{merged}");
+    assert!(
+        merged.find("pub fn b() {}").unwrap() < m,
+        "b nested/after module:\n{merged}"
+    );
+    assert!(
+        merged.find("pub fn c() {}").unwrap() < m,
+        "c nested/after module:\n{merged}"
+    );
     assert!(merged.contains("fn t() {}"), "module body lost:\n{merged}");
 }
 
@@ -5611,18 +5723,33 @@ fn repro_484_bug3_nested_pub_use_stays_inside_module() {
     // top-level fn. Pre-fix one re-export escaped `prelude`.
     let base = "pub mod prelude {\n    pub use crate::a;\n}\n";
     let ours = "pub mod prelude {\n    pub use crate::a;\n    pub use crate::b;\n}\n\npub fn ours_fn() {}\n";
-    let theirs =
-        "pub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n}\n\npub fn theirs_fn() {}\n";
+    let theirs = "pub mod prelude {\n    pub use crate::a;\n    pub use crate::c;\n}\n\npub fn theirs_fn() {}\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert_eq!(merged.matches("pub mod prelude").count(), 1, "module duplicated:\n{merged}");
+    assert_eq!(
+        merged.matches("pub mod prelude").count(),
+        1,
+        "module duplicated:\n{merged}"
+    );
     // The two re-exports stay INSIDE the module (before its closing brace),
     // and the sibling fns stay OUTSIDE (after it). conformance already pins
     // the scopes; this pins the byte order.
     let close = merged.find("}").unwrap();
-    assert!(merged.find("pub use crate::b").unwrap() < close, "b escaped module:\n{merged}");
-    assert!(merged.find("pub use crate::c").unwrap() < close, "c escaped module:\n{merged}");
-    assert!(merged.find("pub fn ours_fn").unwrap() > close, "ours_fn inside module:\n{merged}");
-    assert!(merged.find("pub fn theirs_fn").unwrap() > close, "theirs_fn inside module:\n{merged}");
+    assert!(
+        merged.find("pub use crate::b").unwrap() < close,
+        "b escaped module:\n{merged}"
+    );
+    assert!(
+        merged.find("pub use crate::c").unwrap() < close,
+        "c escaped module:\n{merged}"
+    );
+    assert!(
+        merged.find("pub fn ours_fn").unwrap() > close,
+        "ours_fn inside module:\n{merged}"
+    );
+    assert!(
+        merged.find("pub fn theirs_fn").unwrap() > close,
+        "theirs_fn inside module:\n{merged}"
+    );
 }
 
 #[test]
@@ -5634,15 +5761,34 @@ fn repro_484_reopened_rust_impl_keeps_top_level_between_blocks() {
     let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n    fn a2(&self) {}\n}\n\nfn top_level() {}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nfn top_level() {}\n\nimpl Foo {\n    fn b(&self) {}\n    fn b2(&self) {}\n}\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert!(merged.contains("fn a2(&self) {}"), "ours add lost:\n{merged}");
-    assert!(merged.contains("fn b2(&self) {}"), "theirs add lost:\n{merged}");
-    assert_eq!(merged.matches("impl Foo").count(), 2, "reopened impls collapsed:\n{merged}");
+    assert!(
+        merged.contains("fn a2(&self) {}"),
+        "ours add lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn b2(&self) {}"),
+        "theirs add lost:\n{merged}"
+    );
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "reopened impls collapsed:\n{merged}"
+    );
     let first = merged.find("impl Foo").unwrap();
     let top = merged.find("fn top_level()").unwrap();
     let last = merged.rfind("impl Foo").unwrap();
-    assert!(first < top && top < last, "top-level fn must sit between impls:\n{merged}");
-    assert!(merged.find("fn a2(&self) {}").unwrap() < top, "a2 escaped first impl:\n{merged}");
-    assert!(merged.find("fn b2(&self) {}").unwrap() > top, "b2 escaped second impl:\n{merged}");
+    assert!(
+        first < top && top < last,
+        "top-level fn must sit between impls:\n{merged}"
+    );
+    assert!(
+        merged.find("fn a2(&self) {}").unwrap() < top,
+        "a2 escaped first impl:\n{merged}"
+    );
+    assert!(
+        merged.find("fn b2(&self) {}").unwrap() > top,
+        "b2 escaped second impl:\n{merged}"
+    );
 }
 
 #[test]
@@ -5654,13 +5800,26 @@ fn repro_484_reopened_rust_impl_add_first_modify_second_keeps_order() {
     let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n    fn a2(&self) {}\n}\n\nfn top_level() {}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nfn top_level() {}\n\nimpl Foo {\n    fn b(&self) { let _ = 1; }\n}\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert!(merged.contains("fn a2(&self) {}"), "ours add lost:\n{merged}");
-    assert!(merged.contains("fn b(&self) { let _ = 1; }"), "theirs edit lost:\n{merged}");
-    assert_eq!(merged.matches("impl Foo").count(), 2, "reopened impls collapsed:\n{merged}");
+    assert!(
+        merged.contains("fn a2(&self) {}"),
+        "ours add lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn b(&self) { let _ = 1; }"),
+        "theirs edit lost:\n{merged}"
+    );
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "reopened impls collapsed:\n{merged}"
+    );
     let first = merged.find("impl Foo").unwrap();
     let top = merged.find("fn top_level()").unwrap();
     let last = merged.rfind("impl Foo").unwrap();
-    assert!(first < top && top < last, "top-level fn must sit between impls:\n{merged}");
+    assert!(
+        first < top && top < last,
+        "top-level fn must sit between impls:\n{merged}"
+    );
 }
 
 /// A reopened-`impl Foo` triple whose two blocks are joined by `sep`. ours
@@ -5697,8 +5856,14 @@ fn conformance_484_reopened_rust_impl_separator_matrix() {
             2,
             "[{label}] reopened impls collapsed:\n{merged}"
         );
-        assert!(merged.contains("fn a2(&self) {}"), "[{label}] ours add lost:\n{merged}");
-        assert!(merged.contains("fn b2(&self) {}"), "[{label}] theirs add lost:\n{merged}");
+        assert!(
+            merged.contains("fn a2(&self) {}"),
+            "[{label}] ours add lost:\n{merged}"
+        );
+        assert!(
+            merged.contains("fn b2(&self) {}"),
+            "[{label}] theirs add lost:\n{merged}"
+        );
         let second_impl = merged.rfind("impl Foo").unwrap();
         assert!(
             merged.find("fn a2(&self) {}").unwrap() < second_impl,
@@ -5732,12 +5897,23 @@ fn repro_484_r3_prepend_new_impl_before_base_block_no_collapse() {
     // before it; theirs edits fn b's body. Pre-fix the prepended block and the
     // base block collapsed into a single `impl Foo`.
     let base = "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
-    let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
+    let ours =
+        "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn b(&self) { let _ = 1; }\n}\n";
     let merged = assert_conformant(base, ours, theirs);
-    assert_eq!(merged.matches("impl Foo").count(), 2, "prepended impl collapsed:\n{merged}");
-    assert!(merged.contains("fn a(&self) {}"), "ours add lost:\n{merged}");
-    assert!(merged.contains("fn b(&self) { let _ = 1; }"), "theirs edit lost:\n{merged}");
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        2,
+        "prepended impl collapsed:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn a(&self) {}"),
+        "ours add lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn b(&self) { let _ = 1; }"),
+        "theirs edit lost:\n{merged}"
+    );
     assert!(
         merged.find("fn a(&self) {}").unwrap() < merged.find("fn b(&self)").unwrap(),
         "prepended block must precede base block:\n{merged}"
@@ -5769,7 +5945,10 @@ fn conformance_484_r3_cross_side_container_alignment_matrix() {
     for (label, base, ours, theirs) in cases {
         let merged = assert_conformant(base, ours, theirs);
         for needle in ["fn a", "fn b"] {
-            assert!(merged.contains(needle), "[{label}] {needle} lost:\n{merged}");
+            assert!(
+                merged.contains(needle),
+                "[{label}] {needle} lost:\n{merged}"
+            );
         }
         assert!(
             crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some(),
@@ -5792,8 +5971,10 @@ fn conformance_484_r3_cross_side_container_alignment_matrix() {
 #[test]
 fn reopened_impl_both_add_new_block_no_base_conflicts() {
     let base = "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
-    let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
-    let theirs = "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn c(&self) {}\n}\n";
+    let ours =
+        "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
+    let theirs =
+        "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn c(&self) {}\n}\n";
     let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
     assert!(count >= 1, "expected ≥1 conflict, got {count}: {text}");
     assert!(
@@ -5805,7 +5986,10 @@ fn reopened_impl_both_add_new_block_no_base_conflicts() {
         "both new blocks' bodies must survive inside the conflict: {text}"
     );
     // The base-anchored `fn b` block resolves cleanly, outside the markers.
-    assert!(text.contains("fn b(&self)"), "base-anchored block lost: {text}");
+    assert!(
+        text.contains("fn b(&self)"),
+        "base-anchored block lost: {text}"
+    );
 }
 
 #[test]
@@ -5813,11 +5997,16 @@ fn repro_484_r3_reordered_container_no_silent_collapse() {
     // ours REORDERS the two same-name `impl Foo` blocks; theirs edits the first
     // disjointly. Never a silent corruption: the outcome is a conflict OR a
     // clean merge that re-parses with both blocks intact.
-    let base = "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
-    let ours = "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn a(&self) {}\n}\n";
+    let base =
+        "struct Foo;\n\nimpl Foo {\n    fn a(&self) {}\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
+    let ours =
+        "struct Foo;\n\nimpl Foo {\n    fn b(&self) {}\n}\n\nimpl Foo {\n    fn a(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn a(&self) { let _ = 1; }\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     let text = match merge_rust(base, ours, theirs) {
-        MergeOutcome::Conflicts { merged_bytes_with_markers, conflict_count } => {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
             assert!(conflict_count >= 1);
             String::from_utf8(merged_bytes_with_markers).unwrap()
         }
@@ -5845,7 +6034,10 @@ fn repro_484_r3_ambiguous_block_merge_no_silent_collapse() {
     let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) -> u32 { 9 }\n    fn b(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn a(&self) -> u32 { 1 }\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     match merge_rust(base, ours, theirs) {
-        MergeOutcome::Conflicts { merged_bytes_with_markers, conflict_count } => {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
             let text = String::from_utf8(merged_bytes_with_markers).unwrap();
             assert!(conflict_count >= 1, "expected a real conflict");
             assert!(text.contains("fn a(&self)"), "fn a lost:\n{text}");
@@ -5875,7 +6067,10 @@ fn repro_484_r3_ambiguous_block_split_no_silent_collapse() {
     let ours = "struct Foo;\n\nimpl Foo {\n    fn a(&self) -> u32 { 9 }\n}\n\nimpl Foo {\n    fn b(&self) {}\n}\n";
     let theirs = "struct Foo;\n\nimpl Foo {\n    fn a(&self) -> u32 { 1 }\n    fn b(&self) {}\n}\n";
     let text = match merge_rust(base, ours, theirs) {
-        MergeOutcome::Conflicts { merged_bytes_with_markers, conflict_count } => {
+        MergeOutcome::Conflicts {
+            merged_bytes_with_markers,
+            conflict_count,
+        } => {
             assert!(conflict_count >= 1);
             String::from_utf8(merged_bytes_with_markers).unwrap()
         }
@@ -5927,12 +6122,18 @@ fn repro_490_r1_two_empty_impl_blocks_one_side_adds_method_clean() {
         2,
         "empty blocks dropped/duplicated:\n{merged}"
     );
-    assert!(merged.contains("fn m(&self) {}"), "ours add lost:\n{merged}");
+    assert!(
+        merged.contains("fn m(&self) {}"),
+        "ours add lost:\n{merged}"
+    );
     // The method lands in the FIRST block; the second stays empty.
     let first = merged.find("impl Foo").unwrap();
     let second = merged.rfind("impl Foo").unwrap();
     let m = merged.find("fn m(&self) {}").unwrap();
-    assert!(first < m && m < second, "method escaped the first block:\n{merged}");
+    assert!(
+        first < m && m < second,
+        "method escaped the first block:\n{merged}"
+    );
 }
 
 #[test]
@@ -5948,8 +6149,14 @@ fn repro_490_r1_two_empty_impl_blocks_each_side_edits_different_block_clean() {
         2,
         "empty blocks dropped/duplicated:\n{merged}"
     );
-    assert!(merged.contains("fn ours_m(&self) {}"), "ours edit lost:\n{merged}");
-    assert!(merged.contains("fn theirs_m(&self) {}"), "theirs edit lost:\n{merged}");
+    assert!(
+        merged.contains("fn ours_m(&self) {}"),
+        "ours edit lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn theirs_m(&self) {}"),
+        "theirs edit lost:\n{merged}"
+    );
     assert!(
         merged.find("fn ours_m(&self) {}").unwrap() < merged.find("fn theirs_m(&self) {}").unwrap(),
         "edits landed in the wrong blocks:\n{merged}"
@@ -5972,10 +6179,23 @@ fn repro_490_r1_fully_replaced_impl_children_align_to_base_slot_no_conflict() {
         crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some(),
         "unparseable merge:\n{merged}"
     );
-    assert_eq!(merged.matches("impl Foo").count(), 1, "block duplicated:\n{merged}");
-    assert!(merged.contains("fn y(&self) {}"), "ours replacement lost:\n{merged}");
-    assert!(merged.contains("fn z(&self) {}"), "theirs add lost:\n{merged}");
-    assert!(!merged.contains("fn x(&self) {}"), "ours deletion of fn x dropped:\n{merged}");
+    assert_eq!(
+        merged.matches("impl Foo").count(),
+        1,
+        "block duplicated:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn y(&self) {}"),
+        "ours replacement lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn z(&self) {}"),
+        "theirs add lost:\n{merged}"
+    );
+    assert!(
+        !merged.contains("fn x(&self) {}"),
+        "ours deletion of fn x dropped:\n{merged}"
+    );
 }
 
 #[test]
@@ -5992,10 +6212,20 @@ fn repro_490_r1_fully_replaced_mod_children_align_to_base_slot_no_conflict() {
         crate::parser::ParsedFile::parse(&merged, crate::parser::Language::Rust).is_some(),
         "unparseable merge:\n{merged}"
     );
-    assert_eq!(merged.matches("mod m").count(), 1, "mod duplicated:\n{merged}");
-    assert!(merged.contains("fn y() {}"), "ours replacement lost:\n{merged}");
+    assert_eq!(
+        merged.matches("mod m").count(),
+        1,
+        "mod duplicated:\n{merged}"
+    );
+    assert!(
+        merged.contains("fn y() {}"),
+        "ours replacement lost:\n{merged}"
+    );
     assert!(merged.contains("fn z() {}"), "theirs add lost:\n{merged}");
-    assert!(!merged.contains("fn x() {}"), "ours deletion of fn x dropped:\n{merged}");
+    assert!(
+        !merged.contains("fn x() {}"),
+        "ours deletion of fn x dropped:\n{merged}"
+    );
 }
 
 #[cfg(feature = "lang-cpp")]
@@ -6017,7 +6247,10 @@ fn repro_490_r1_two_empty_cpp_namespaces_one_side_adds_clean() {
     let first = merged.find("namespace N").unwrap();
     let second = merged.rfind("namespace N").unwrap();
     let m = merged.find("void m() {}").unwrap();
-    assert!(first < m && m < second, "function escaped the first namespace:\n{merged}");
+    assert!(
+        first < m && m < second,
+        "function escaped the first namespace:\n{merged}"
+    );
 }
 
 #[test]
@@ -6037,8 +6270,14 @@ fn repro_490_r1_modify_vs_delete_empty_container_conflicts() {
     let theirs = "struct Foo;\n";
     let (text, count) = assert_conflicts(merge_rust(base, ours, theirs));
     assert!(count >= 1, "expected a modify/delete conflict, got {count}");
-    assert!(text.contains("fn m(&self) {}"), "ours modification lost from conflict:\n{text}");
-    assert!(text.contains("<<<<<<<") && text.contains(">>>>>>>"), "missing conflict markers:\n{text}");
+    assert!(
+        text.contains("fn m(&self) {}"),
+        "ours modification lost from conflict:\n{text}"
+    );
+    assert!(
+        text.contains("<<<<<<<") && text.contains(">>>>>>>"),
+        "missing conflict markers:\n{text}"
+    );
 }
 
 // =====================================================================
@@ -6082,8 +6321,14 @@ fn repro_490_r2_delete_earlier_edit_later_zero_overlap_separator_not_moved() {
         1,
         "block dropped/duplicated:\n{merged}"
     );
-    assert!(merged.contains("fn m(&self) {}"), "ours method lost:\n{merged}");
-    assert!(merged.contains("// edited sep"), "theirs separator edit lost:\n{merged}");
+    assert!(
+        merged.contains("fn m(&self) {}"),
+        "ours method lost:\n{merged}"
+    );
+    assert!(
+        merged.contains("// edited sep"),
+        "theirs separator edit lost:\n{merged}"
+    );
     assert_eq!(
         merged.matches("sep").count(),
         1,
@@ -6107,9 +6352,16 @@ fn repro_490_r2_prepend_zero_overlap_keeps_survivor_base_slot() {
         2,
         "block dropped/duplicated:\n{merged}"
     );
-    assert!(merged.contains("fn m(&self) {}"), "theirs method lost:\n{merged}");
+    assert!(
+        merged.contains("fn m(&self) {}"),
+        "theirs method lost:\n{merged}"
+    );
     // The method lands on the `// orig` (base) block; the comment survives once.
-    assert_eq!(merged.matches("// orig").count(), 1, "comment moved/duplicated:\n{merged}");
+    assert_eq!(
+        merged.matches("// orig").count(),
+        1,
+        "comment moved/duplicated:\n{merged}"
+    );
     assert!(
         merged.find("// orig").unwrap() < merged.find("fn m(&self) {}").unwrap(),
         "method escaped the original block:\n{merged}"
@@ -6132,7 +6384,10 @@ fn repro_490_r2_reorder_zero_overlap_blocks_keep_identity_by_header() {
         2,
         "block dropped/duplicated:\n{merged}"
     );
-    assert!(merged.contains("fn am(&self) {}"), "theirs method lost:\n{merged}");
+    assert!(
+        merged.contains("fn am(&self) {}"),
+        "theirs method lost:\n{merged}"
+    );
     // The method stays bound to the `// a` block, not `// b`.
     assert!(
         merged.find("// a").unwrap() < merged.find("fn am(&self) {}").unwrap()
@@ -6264,8 +6519,14 @@ class C:
         other => panic!("expected Clean, got {other:?}"),
     };
     assert!(merged.contains("@deco"), "ours decorator lost:\n{merged}");
-    assert!(merged.contains("return 2"), "theirs body edit lost:\n{merged}");
-    assert!(!merged.contains("<<<<<<<"), "unexpected conflict markers:\n{merged}");
+    assert!(
+        merged.contains("return 2"),
+        "theirs body edit lost:\n{merged}"
+    );
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "unexpected conflict markers:\n{merged}"
+    );
 }
 
 #[test]
@@ -6297,8 +6558,14 @@ class C:
         "missing conflict markers:\n{text}"
     );
     // Both sides' divergent bodies are represented in the conflict, none lost.
-    assert!(text.contains("return 10"), "ours side lost from conflict:\n{text}");
-    assert!(text.contains("return 20"), "theirs side lost from conflict:\n{text}");
+    assert!(
+        text.contains("return 10"),
+        "ours side lost from conflict:\n{text}"
+    );
+    assert!(
+        text.contains("return 20"),
+        "theirs side lost from conflict:\n{text}"
+    );
 }
 
 #[test]
@@ -6322,8 +6589,14 @@ fn repro_490_r3_rust_mod_block_to_decl_mixed_kind_no_panic() {
     );
     // Both forms appear inside the conflict block — `mod foo;` (ours) and the
     // edited block body (theirs) — so neither side is silently dropped.
-    assert!(text.contains("mod foo;"), "ours leaf form lost from conflict:\n{text}");
-    assert!(text.contains("let x = 1;"), "theirs edit lost from conflict:\n{text}");
+    assert!(
+        text.contains("mod foo;"),
+        "ours leaf form lost from conflict:\n{text}"
+    );
+    assert!(
+        text.contains("let x = 1;"),
+        "theirs edit lost from conflict:\n{text}"
+    );
 }
 
 #[test]
@@ -6337,8 +6610,14 @@ fn repro_490_r3_rust_mod_decl_to_block_mixed_kind_disjoint_clean() {
     let ours = "mod foo {\n    fn a() {}\n}\n";
     let theirs = "mod foo;\n";
     let merged = assert_clean(merge_rust(base, ours, theirs));
-    assert!(merged.contains("fn a() {}"), "ours expansion lost:\n{merged}");
-    assert!(!merged.contains("<<<<<<<"), "unexpected conflict markers:\n{merged}");
+    assert!(
+        merged.contains("fn a() {}"),
+        "ours expansion lost:\n{merged}"
+    );
+    assert!(
+        !merged.contains("<<<<<<<"),
+        "unexpected conflict markers:\n{merged}"
+    );
 }
 
 // C++ `namespace N {…} namespace N {…}` is the same close-the-class shape in
@@ -6375,8 +6654,14 @@ fn conformance_484_reopened_cpp_namespace_separator_matrix() {
             2,
             "[{label}] reopened namespaces collapsed:\n{merged}"
         );
-        assert!(merged.contains("void a2() {}"), "[{label}] ours add lost:\n{merged}");
-        assert!(merged.contains("void b2() {}"), "[{label}] theirs add lost:\n{merged}");
+        assert!(
+            merged.contains("void a2() {}"),
+            "[{label}] ours add lost:\n{merged}"
+        );
+        assert!(
+            merged.contains("void b2() {}"),
+            "[{label}] theirs add lost:\n{merged}"
+        );
         let second_ns = merged.rfind("namespace N").unwrap();
         assert!(
             merged.find("void a2() {}").unwrap() < second_ns,
@@ -6419,7 +6704,10 @@ fn conformance_484_r3_cross_side_cpp_namespace_prepend_no_collapse() {
         "prepended namespace collapsed into base block:\n{merged}"
     );
     assert!(merged.contains("void a() {}"), "ours add lost:\n{merged}");
-    assert!(merged.contains("void b() { int x = 1; }"), "theirs edit lost:\n{merged}");
+    assert!(
+        merged.contains("void b() { int x = 1; }"),
+        "theirs edit lost:\n{merged}"
+    );
     assert!(
         merged.find("void a()").unwrap() < merged.find("void b()").unwrap(),
         "prepended block must precede the base block:\n{merged}"

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
 use semantic::{
-    analysis::{compute_similarity, SimilarityMethod},
+    analysis::{SimilarityMethod, compute_similarity},
     parser::FunctionDef,
 };
 
@@ -142,7 +142,10 @@ mod tests {
         let mut ctx = SemanticContext::new();
         ctx.new_functions.insert(
             PathBuf::from("a.rs"),
-            vec![fdef("alpha", "let total = first + second + third + fourth;")],
+            vec![fdef(
+                "alpha",
+                "let total = first + second + third + fourth;",
+            )],
         );
         ctx.new_functions.insert(
             PathBuf::from("b.rs"),
@@ -150,11 +153,17 @@ mod tests {
         );
         ctx.new_functions.insert(
             PathBuf::from("c.rs"),
-            vec![fdef("gamma", "match colour { Red => stop(), Green => go() }")],
+            vec![fdef(
+                "gamma",
+                "match colour { Red => stop(), Green => go() }",
+            )],
         );
         ctx.new_functions.insert(
             PathBuf::from("changed.rs"),
-            vec![fdef("delta", "while pending { dequeue().handle(); } flush();")],
+            vec![fdef(
+                "delta",
+                "while pending { dequeue().handle(); } flush();",
+            )],
         );
         ctx.changed_paths.insert(PathBuf::from("changed.rs"));
 

--- a/crates/state_review/src/modules/pattern_deviation.rs
+++ b/crates/state_review/src/modules/pattern_deviation.rs
@@ -8,7 +8,7 @@
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
 use semantic::{
-    analysis::{compute_similarity, SimilarityMethod},
+    analysis::{SimilarityMethod, compute_similarity},
     parser::FunctionDef,
 };
 

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -18,14 +18,13 @@ use std::{
 };
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
-use semantic::{parser::FunctionDef, Language};
+use semantic::{Language, parser::FunctionDef};
 
 use crate::{config::ReviewSignalsConfig, registry::SemanticContext};
 
 const VERSION: u32 = 1;
 const MODULE_ID: &str = "test_reachability.tree_sitter";
-const REASON_TEXT: &str =
-    "no test reaches this symbol via static reachability via tree-sitter call graph; \
+const REASON_TEXT: &str = "no test reaches this symbol via static reachability via tree-sitter call graph; \
      this is not runtime coverage";
 
 pub fn run(

--- a/deny.toml
+++ b/deny.toml
@@ -159,4 +159,5 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Git deps must be explicitly listed. Empty list means "crates.io only" — if
 # you add a `git = "..."` dependency, add the remote here with a comment
 # explaining why crates.io isn't sufficient.
-allow-git = []
+# sley: native-git substrate; not yet published to crates.io
+allow-git = ["https://github.com/HeddleCo/sley"]

--- a/deny.toml
+++ b/deny.toml
@@ -159,5 +159,4 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # Git deps must be explicitly listed. Empty list means "crates.io only" — if
 # you add a `git = "..."` dependency, add the remote here with a comment
 # explaining why crates.io isn't sufficient.
-# sley: native-git substrate; not yet published to crates.io
-allow-git = ["https://github.com/HeddleCo/sley"]
+allow-git = []

--- a/docs/CLI_WORLD_CLASS_AUDIT_2026-05-21.md
+++ b/docs/CLI_WORLD_CLASS_AUDIT_2026-05-21.md
@@ -66,7 +66,7 @@ extract time.
 ## Fixes Made During This Audit Pass
 
 - Replaced `git symbolic-ref` usage in `Repository::git_overlay_current_branch`
-  with native `.git/HEAD` / `gix` detection.
+  with native `.git/HEAD` / Sley-backed detection.
 - Made Git-overlay worktree status fall back to Heddle's native tree comparison
   when the `git` executable is absent.
 - Made upstream drift probing degrade to `remote_tracking=null` when the `git`
@@ -340,12 +340,12 @@ Enforced by `cargo test -p heddle-cli --test git_process_lint`.
 
 The hard gate is no `git` executable dependency for supported Git-overlay
 workflows. The default CLI runtime has an empty allowlist for `git`
-subprocesses; Git-format operations use native code and `gix`.
+subprocesses; Git-format operations use native code through Sley.
 
 | Location | Classification | Rationale |
 |---|---|---|
-| `repo::Repository::git_remote_tracking_status` / `git_overlay_worktree_status` | Native/gix read path | Remote tracking, HEAD, and worktree/index checks do not invoke the Git binary. |
-| `bridge::git_core::resolve_remote_default_branch` | Native/gix remote default-branch hint | Clone/import use protocol/ref inspection without invoking the Git binary. |
+| `repo::Repository::git_remote_tracking_status` / `git_overlay_worktree_status` | Native/Sley read path | Remote tracking, HEAD, and worktree/index checks do not invoke the Git binary. |
+| `bridge::git_core::resolve_remote_default_branch` | Native/Sley remote default-branch hint | Clone/import use protocol/ref inspection without invoking the Git binary. |
 | `bridge::git_core::clone_url_to_bare` filtered clone | Unsupported native capability | Filtered/lazy Git-overlay clones now fail closed instead of shelling out to `git clone`; ordinary local/bare clone no-git workflows are covered by real fixtures. |
 | `clone::GitOverlayBlobHydrator::read_blob_bytes` | Local-only native hydration | Local object lookup is attempted first; missing promisor blobs report the native lazy-hydration boundary instead of invoking `git cat-file`. |
 | `merge --git-commit` / `merge::git_commit` | Native Git object/ref write | The flag asks Heddle to create a Git commit, and the implementation writes Git objects, index, and refs through native libraries. |

--- a/docs/SLEY_INTEGRATION.md
+++ b/docs/SLEY_INTEGRATION.md
@@ -1,0 +1,212 @@
+# Sley Integration Contract
+
+Status: current Heddle hardening note. Heddle now treats Sley as the Git-format
+engine for Git overlay, Git bridge, plain-Git inspection, and no-`git` runtime
+paths. This page records the Sley-side ergonomics Heddle wants next and the
+Heddle-side gates that should stay required while the integration settles.
+
+## Sley Asks
+
+### Exact Repository Open
+
+Heddle has two distinct intents:
+
+- discover a checkout from a user path, such as `heddle status` in a subdir
+- open one already-known Git directory exactly, such as a scratch bare repo
+
+The second intent should never discover a parent repo.
+
+Desired Sley shape:
+
+```rust
+let git = SleyRepository::open_exact_bare(dest)
+    .context("open Git scratch destination")?;
+```
+
+or:
+
+```rust
+let git = SleyRepository::open_with(
+    dest,
+    OpenOptions::new().exact_path(true).bare(true),
+)?;
+```
+
+Heddle would use this in bridge clone/import/export scratch paths instead of
+choosing between `open` and `discover` locally.
+
+### Explicit Missing-Reference APIs
+
+`find_reference(name) -> Result<Option<_>>` is correct but easy to misuse in
+call sites that only need existence or a typed "required ref" failure.
+
+Desired Sley shape:
+
+```rust
+if git.reference_exists("refs/heads/main")? {
+    // render the branch as present
+}
+
+let head = git.require_reference("refs/remotes/origin/main")?;
+```
+
+Heddle would use `reference_exists` in health/verify checks and
+`require_reference` in import/export paths where absence is a hard Git boundary.
+
+### Separate Ref Resolution From Object Peeling
+
+Heddle needs to preserve annotated tag object IDs in tag refs, but also often
+needs to peel a ref target to the commit it names.
+
+Desired Sley shape:
+
+```rust
+let tag_ref = git.require_reference("refs/tags/v1.0")?;
+let ref_target = tag_ref.direct_target()?;
+
+let object_oid = git.peel_to_object_oid(ref_target)?;
+let commit_oid = git.peel_to_commit_oid(ref_target)?;
+```
+
+Heddle would use `peel_to_object_oid` when writing tag refs and
+`peel_to_commit_oid` when deciding ancestry or branch-frontier behavior. The
+important ergonomic split is that symbolic-ref resolution and annotated-tag
+object peeling are visibly different operations.
+
+### Porcelain Ref Updates With Attached-HEAD Reflog Parity
+
+When Heddle advances the currently checked-out branch through Sley, users expect
+both the branch reflog and direct `HEAD` reflog to look like ordinary Git
+porcelain updated the branch.
+
+Desired Sley shape:
+
+```rust
+git.update_branch_checked_out_as_head(
+    "main",
+    new_oid,
+    RefUpdateOptions::new()
+        .expect_old(old_oid)
+        .reflog("heddle: checkpoint"),
+)?;
+```
+
+or a transaction option:
+
+```rust
+git.refs()
+    .transaction()
+    .update("refs/heads/main", new_oid)
+    .mirror_attached_head_reflog(true)
+    .message("heddle: checkpoint")
+    .commit()?;
+```
+
+Heddle would remove its direct `HEAD` reflog append sites and route Git-overlay
+checkpoint, undo/redo, merge `--git-commit`, and branch sync through this
+porcelain-level operation.
+
+### Git Config Stack With Editable Origins
+
+Remote mutation needs the same view Git users expect: includes followed,
+worktree config included only when `extensions.worktreeConfig = true`, and
+each value tied back to the file that defined it so Heddle can refuse unsafe
+external include writes.
+
+Desired Sley shape:
+
+```rust
+let config = git.config_stack(
+    ConfigStackOptions::git_default()
+        .follow_includes(true)
+        .worktree_config(WorktreeConfig::WhenEnabled)
+        .track_origins(true),
+)?;
+
+let origin = config.remote("origin")?;
+let editable = config.editable_section_file(origin.section_id())?;
+```
+
+Heddle would use this in `heddle remote add/remove/set-url` instead of owning
+config-layer reconstruction.
+
+### Lazy Blob Hydration Boundary
+
+Heddle can read local Git blobs through Sley today. When a promisor object is
+missing, Heddle wants one native Sley boundary that either fetches the promised
+blob or returns a typed unsupported/missing-object error.
+
+Desired Sley shape:
+
+```rust
+let bytes = git.blobs()
+    .read_or_fetch(oid, BlobFetchOptions::from_remote("origin"))
+    .await?;
+```
+
+Heddle would use this in clone checkout, status/diff patch rendering, and any
+future partial-clone materialization path.
+
+### Reusable Status/Index Work Plans
+
+The Git-overlay hot path repeatedly needs "HEAD tree + index + worktree"
+classification without rebuilding all maps for every command.
+
+Desired Sley shape:
+
+```rust
+let status = git.status_plan()
+    .include_untracked(true)
+    .reuse_index_cache(cache_key)
+    .build()?;
+
+let changes = status.collect()?;
+```
+
+Heddle would use this under status, diff, verify, and thread-list health so the
+same Sley primitive backs all Git-overlay worktree reads.
+
+## Heddle Hardening Gates
+
+Keep these Heddle-side checks required while Sley settles in:
+
+- `cargo test --locked -p heddle-cli --test git_process_lint -- --nocapture`
+- `cargo test --locked -p heddle-cli --test cli_integration git_replacement_matrix -- --nocapture`
+- `cargo test --locked -p heddle-cli --test git_bridge_integration round_trip_preserves_annotated_tag_object_sha -- --nocapture`
+- `cargo test --locked -p heddle-cli --test git_bridge_integration import_populates_mirror_with_identical_annotated_tag_object -- --nocapture`
+- `cargo test --locked -p heddle-cli --test cli_integration remotes::test_cli_raw_git_clone_adopt_fetches_notes_before_import -- --nocapture`
+- `cargo test --locked -p heddle-cli --test cli_integration remotes::git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated -- --nocapture`
+
+The default workspace test run already covers these, but naming them in CI makes
+Sley-integration regressions fail in a step with the right mental model.
+
+## Heddle Cleanup Once Sley APIs Land
+
+When the Sley-side asks above exist, Heddle should delete local compensating code
+instead of preserving a second Git-engine abstraction:
+
+- Replace scratch-repo `open`/`discover` choices with Sley's exact-open API.
+- Replace local `find_reference(...).is_some()` helpers with Sley's
+  `reference_exists` / `require_reference` helpers.
+- Replace local tag/ref peeling helpers with explicit Sley object-peel and
+  commit-peel APIs.
+- Replace direct `HEAD` reflog appends with a Sley porcelain branch update or
+  ref-transaction option.
+- Replace `remote_ops` config-layer reconstruction with Sley's editable-origin
+  config stack.
+- Replace the lazy-hydration refusal boundary with Sley's native
+  read-or-fetch blob API.
+- Replace Heddle-local status/index memoization scaffolding with Sley reusable
+  status/index work plans where the command needs Git-overlay status.
+
+## Ignored Suites To Keep Scheduled
+
+The default test loop is green without these, but they are the remaining
+confidence multipliers:
+
+- CLI fault-injection tests
+- release-mode command-loop perf smoke
+- release-mode pack/object perf tests
+- real-world Git fixture matrix
+- large-blob stress with `HEDDLE_LARGE_BLOB_MB`
+- lazy hydration against a large public repo fixture

--- a/docs/perf/cli-core-loop.md
+++ b/docs/perf/cli-core-loop.md
@@ -19,8 +19,10 @@ import hints, and worktree scan time.
 
 Use this when a real repository feels slow and the next move is unclear. The
 phase split should make it obvious whether to inspect startup/config overhead,
-worktree scanning, ref/thread summary work, Git subprocess fallbacks, or
+worktree scanning, ref/thread summary work, Sley-backed Git engine work, or
 rendering.
+Sley-backed Git engine work should show up inside the command-specific phases
+rather than as a hidden subprocess floor.
 
 ## Release Smoke Benchmark
 


### PR DESCRIPTION
## Summary

Final cutover of the CLI and object stack off `gix` onto **sley** (heddle's native Git-format engine). Replaces the remaining `gix`-backed code paths across the CLI bridge, ingest, object store, refs, and repo crates — `git_import` / `git_export`, the Git overlay, plain-Git inspection, and health/verify now run on `sley::Repository`.

## Dependency

Requires the sley-side facade APIs in **HeddleCo/sley#75** (`open_exact_bare`, `reference_exists` / `require_reference`, ref-resolution-vs-peeling). The `sley` workspace dependency must be pinned to a sley revision that includes #75 — CI cannot resolve a local-path dependency, which is why the current checks are red.

## Testing

- Expanded and updated CLI/integration coverage for bridge, Git overlay, replacement matrix, and real-world Git scenarios.
- Ran the relevant Rust test suites and validation checks for the touched packages.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783994819&installation_id=132405951&pr_number=733&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F733&signature=9360e1e8c14062c5c73d47a8f0150c67180127db80964b82b4968e64b54196bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
