### PR TITLE
build: enable sley mmap + fast-sha1 features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5098,6 +5098,9 @@ name = "sley-core"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc817cfe54cea21211600ba24e30c5ac611ddebf5299effa950cdefc29db19ba"
+dependencies = [
+ "sha1 0.10.6",
+]
 
 [[package]]
 name = "sley-diff-merge"
@@ -5147,6 +5150,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sley-mmap"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44a922559f5bef1e1b48db5b5025afdb9b83c406ee9a4ca586f8172360eae6b2"
+dependencies = [
+ "memmap2",
+]
+
+[[package]]
 name = "sley-notes"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5178,6 +5190,7 @@ dependencies = [
  "flate2",
  "sley-core",
  "sley-formats",
+ "sley-mmap",
  "sley-object",
  "sley-pack",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-sley = "0.0.1"
+sley = { version = "0.0.1", features = ["mmap", "fast-sha1"] }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"


### PR DESCRIPTION
## What
heddle's sley dep was bare `sley = "0.0.1"` (default features = `remote` only). Enable `mmap` (memory-mapped pack reads — large-repo cold-start/memory) and `fast-sha1` (hardware/asm SHA-1; **OIDs byte-identical** to the pure-Rust default) since heddle does heavy object I/O + hashing.

`sley = { version = "0.0.1", features = ["mmap", "fast-sha1"] }`

## Verified
`cargo check --workspace` green; `cargo-deny check` clean (advisories/bans/licenses/sources — the new `sha1` asm backend + `sley-mmap` clear). heddle already ships unsafe `memmap2` in objects/mount, so `sley-mmap`'s unsafe is not a new risk category.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784067991&installation_id=132405951&pr_number=734&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F734&signature=c0e0067b0ba02a11d31b675b332a37991c98e17075ba16c331f2f545d9808fa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->