### PR TITLE
test(ci): assert serve_local mechanism not wall-clock (fix #722 flake)

### DIFF
--- a/crates/cli/src/client/local_daemon.rs
+++ b/crates/cli/src/client/local_daemon.rs
@@ -29,6 +29,10 @@
 use std::{
     io,
     path::{Path, PathBuf},
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
     time::Duration,
 };
 
@@ -134,6 +138,35 @@ pub async fn detect_local_daemon_with_connect_probe(
 #[cfg(unix)]
 static CHANNEL_CACHE: OnceMap<ProbeCacheKey, tonic::transport::Channel> = OnceMap::new();
 
+/// Per-heddle-dir count of how many times [`build_channel`] has
+/// actually opened a UDS, constructed a tonic channel, and run the
+/// `Health.Check` handshake. A cache hit in
+/// [`connect_local_daemon_channel`] returns a clone of the cached
+/// channel without entering `build_channel`, so it does not bump this
+/// counter.
+///
+/// Keyed per heddle dir (not process-global) so the count is
+/// deterministic regardless of which other tests run concurrently.
+///
+/// Test-support only — lets the serve_local test assert that the second
+/// `connect_local_daemon_channel` is a true O(1) cache hit (no rebuild)
+/// instead of comparing wall-clock time, which flakes on shared CI
+/// runners (issue #722).
+#[cfg(unix)]
+#[doc(hidden)]
+static CHANNEL_BUILD_COUNT: OnceMap<ProbeCacheKey, Arc<AtomicU64>> = OnceMap::new();
+
+/// Read the [`build_channel`] run count for `heddle_dir`. See
+/// [`CHANNEL_BUILD_COUNT`]. A dir whose channel was never built reads 0.
+#[cfg(unix)]
+#[doc(hidden)]
+pub fn channel_build_count(heddle_dir: &Path) -> u64 {
+    CHANNEL_BUILD_COUNT
+        .get(&heddle_dir.to_path_buf())
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(0)
+}
+
 /// Connect-and-handshake outcome for [`connect_local_daemon_channel`].
 ///
 /// `target` is repeated for the convenience of callers that only need
@@ -208,6 +241,9 @@ async fn build_channel(
     heddle_dir: &Path,
     connect_timeout: Duration,
 ) -> std::result::Result<LocalDaemonChannel, ChannelError> {
+    CHANNEL_BUILD_COUNT
+        .get_or_init_with(&heddle_dir.to_path_buf(), || Arc::new(AtomicU64::new(0)))
+        .fetch_add(1, Ordering::Relaxed);
     let target = detect_local_daemon(heddle_dir).ok_or(ChannelError::NoDaemon)?;
     // `unix:` URIs aren't usable as the *origin* on a HTTP/2 channel
     // (the authority pseudo-header has to be a plausible host). The
@@ -312,9 +348,39 @@ pub enum LocalDaemonStatus {
     Absent,
 }
 
+/// Per-heddle-dir count of how many times [`probe`] has actually run
+/// the file-stat / liveness syscalls (the "cold setup step"). The
+/// `DETECT_CACHE` lets the warm path skip this: a warm
+/// [`detect_local_daemon`] hit returns the cached `Option<UdsTarget>`
+/// without entering `probe` at all, so it does not bump this counter.
+///
+/// Keyed per heddle dir (not process-global) so a test reading the
+/// count for *its* daemon is unaffected by probes that a concurrently
+/// running test issues against a *different* temp dir — the counter is
+/// deterministic regardless of test parallelism.
+///
+/// Test-support only — lets the serve_local test assert the *mechanism*
+/// (warm path skips the probe) instead of comparing wall-clock time,
+/// which flakes on shared CI runners (issue #722).
+#[doc(hidden)]
+static PROBE_RUN_COUNT: OnceMap<ProbeCacheKey, Arc<AtomicU64>> = OnceMap::new();
+
+/// Read the [`probe`] run count for `heddle_dir`. See
+/// [`PROBE_RUN_COUNT`]. A never-probed dir reads 0.
+#[doc(hidden)]
+pub fn probe_run_count(heddle_dir: &Path) -> u64 {
+    PROBE_RUN_COUNT
+        .get(&heddle_dir.to_path_buf())
+        .map(|c| c.load(Ordering::Relaxed))
+        .unwrap_or(0)
+}
+
 /// Probe the per-repo daemon directory. Cheap (two file stats, `kill(pid, 0)`,
 /// and same-executable identity for live pids).
 pub fn probe(heddle_dir: &Path) -> LocalDaemonProbe {
+    PROBE_RUN_COUNT
+        .get_or_init_with(&heddle_dir.to_path_buf(), || Arc::new(AtomicU64::new(0)))
+        .fetch_add(1, Ordering::Relaxed);
     let socket_path = heddle_dir.join("sockets").join("grpc.sock");
     let pid_path = heddle_dir.join("sockets").join("grpc.pid");
     let status = match read_pid(&pid_path) {

--- a/crates/cli/tests/serve_local.rs
+++ b/crates/cli/tests/serve_local.rs
@@ -1,28 +1,24 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Local daemon UDS bench: cold-stat probes vs warm cached
-//! detect calls.
+//! Local daemon UDS cache mechanism tests.
 //!
-//! The target is "100 sequential `heddle status` calls cold-vs-warm
-//! ≥5×". A full end-to-end benchmark would need the status command
-//! itself routed through the gRPC surface, which is a follow-up (the
-//! channel-construction primitive landed in this patch — see
-//! `crates/cli/src/client/local_daemon.rs`). What we benchmark here
-//! is the cache that primitive sits on top of:
+//! The caches in `crates/cli/src/client/local_daemon.rs` exist to make
+//! a hot agent loop cheap: the first daemon detection / channel build
+//! pays the filesystem + connect cost, every subsequent call in the
+//! process is an O(1) cache hit.
 //!
-//! * Cold: 100 fresh `probe()` calls. Each one re-stats the pidfile
-//!   and re-issues `kill(pid, 0)`.
-//! * Warm: 100 `detect_local_daemon()` calls. The first hits the
-//!   filesystem and primes the process-wide `OnceLock`; the next 99
-//!   are pointer comparisons.
+//! These tests assert that property by the *mechanism*, not the clock.
+//! Earlier revisions compared wall-clock time (warm ≥5× faster than
+//! cold), which flaked on shared CI runners — worse under `llvm-cov` —
+//! and became merge-blocking once `Check & test` was made a required
+//! check (see issue #722). Wall-clock ratios are nondeterministic; the
+//! cache hit/miss is not. So instead we count the underlying expensive
+//! operations via process-wide instrumentation
+//! (`probe_run_count` / `channel_build_count`) and assert the warm path
+//! skips them entirely. This proves the exact same O(1)/warm-skip
+//! behavior, deterministically.
 //!
-//! Both loops run against the same daemon, started in-process via
-//! `daemon::local_daemon::serve`. We assert the warm path is at
-//! least 5× faster than the cold path — the same speedup ratio the
-//! plan calls out for the end-to-end case.
-//!
-//! Bench-shaped tests are noisy on shared CI; the assertion has a
-//! generous floor (≥5×) and the cold loop runs 100 syscalls so its
-//! wall-clock floor is high enough to dwarf scheduler jitter.
+//! Both tests run against a daemon started in-process via
+//! `daemon::local_daemon::serve`.
 
 #![cfg(unix)]
 
@@ -32,7 +28,8 @@ use std::{
 };
 
 use cli::client::local_daemon::{
-    LocalDaemonStatus, connect_local_daemon_channel, detect_local_daemon, probe,
+    LocalDaemonStatus, channel_build_count, connect_local_daemon_channel, detect_local_daemon,
+    probe, probe_run_count,
 };
 use daemon::local_daemon::{LocalDaemonConfig, serve};
 use repo::Repository;
@@ -87,72 +84,63 @@ async fn spawn_local_daemon() -> (
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn detect_local_daemon_warm_is_significantly_faster_than_cold() {
+async fn detect_local_daemon_warm_path_skips_the_cold_probe() {
     let (_temp, heddle_dir, shutdown, task) = spawn_local_daemon().await;
 
-    // Warm-up: prime the process-wide cache so the first call doesn't
-    // contaminate the warm sample. The brief asks for 100 sequential
-    // calls; we measure exactly that.
-    let _ = detect_local_daemon(&heddle_dir);
+    // Prime the process-wide `DETECT_CACHE` so the first (cache-filling)
+    // call doesn't count against the warm sample. After this, the entry
+    // for `heddle_dir` is resident and every later `detect_local_daemon`
+    // is a pure cache hit.
+    let primed = detect_local_daemon(&heddle_dir).expect("daemon present");
 
-    let warm_iters = 100;
-    let warm_start = Instant::now();
+    // Warm path: N `detect_local_daemon` calls. The mechanism under
+    // test is the cache short-circuit — a warm hit returns the cached
+    // `Option<UdsTarget>` WITHOUT running `probe` (the "cold setup
+    // step": two file stats + `kill(pid, 0)` + executable-identity
+    // check). We prove that by snapshotting the process-wide probe
+    // counter around the loop and asserting it does not move.
+    let warm_iters = 100u64;
+    let probe_before_warm = probe_run_count(&heddle_dir);
     for _ in 0..warm_iters {
         let target = detect_local_daemon(&heddle_dir).expect("daemon present");
-        // Touch the result so the optimizer can't elide the call.
+        // The cache must hand back the same target each time, not a
+        // freshly-probed (and possibly divergent) one.
+        assert_eq!(target, primed, "warm detect must return the cached target");
         std::hint::black_box(target);
     }
-    let warm_elapsed = warm_start.elapsed();
+    let warm_probe_runs = probe_run_count(&heddle_dir) - probe_before_warm;
+    assert_eq!(
+        warm_probe_runs, 0,
+        "warm detect_local_daemon must skip the cold probe entirely \
+         (cache hit), but probe ran {warm_probe_runs} time(s) over \
+         {warm_iters} warm calls"
+    );
 
-    // Cold: 100 fresh `probe()` calls. Each does two file stats
-    // (`grpc.sock`, `grpc.pid`) plus one `kill(pid, 0)` — exactly the
-    // work `detect_local_daemon` would do without the cache.
-    let cold_iters = 100;
-    let cold_start = Instant::now();
+    // Cold path, for contrast: N fresh `probe()` calls. Each one is the
+    // cold setup step the warm path skipped, so the counter must move
+    // by exactly N. This nails down that the counter actually tracks
+    // the work — a counter that never moves would make the warm
+    // assertion vacuous.
+    let cold_iters = 100u64;
+    let probe_before_cold = probe_run_count(&heddle_dir);
     for _ in 0..cold_iters {
         let result = probe(&heddle_dir);
+        assert!(matches!(result.status, LocalDaemonStatus::Running { .. }));
         std::hint::black_box(result);
     }
-    let cold_elapsed = cold_start.elapsed();
-
-    // The cache must be measurably cheaper than the syscall path, but
-    // the multiplicative floor depends on how hot the OS file cache is:
-    // on a busy laptop with `grpc.sock`/`grpc.pid` already in cache
-    // each cold probe runs in ~50µs, which compresses the headroom for
-    // a multiplier check. So we defend two complementary properties:
-    //   * Warm latency stays in the low microseconds in *absolute*
-    //     terms — that's what users actually feel — capped at
-    //     50µs per call (warm runs ~1µs in dev).
-    //   * Warm beats cold by at least 1.5× — anything less means the
-    //     cache is doing nothing.
-    // Calibration history: 5× → 2× → 1.5×. The original 5× target
-    // held in dev observations but proved brittle under hot-FS-cache
-    // CI runs where cold is unusually fast. 2× still flaked (~1.8×
-    // observed on shared Blacksmith runners). 1.5× is the floor below
-    // which the cache is provably not paying off; the absolute warm
-    // latency cap above is the real defense — this assertion exists
-    // only as a sanity that the cache is doing *some* work.
-    let cold_ns = cold_elapsed.as_nanos();
-    let warm_ns = warm_elapsed.as_nanos().max(1);
-    let ratio = cold_ns as f64 / warm_ns as f64;
-    let warm_per_call = warm_elapsed / warm_iters;
-    assert!(
-        warm_per_call < Duration::from_micros(50),
-        "warm detect_local_daemon should be in low-µs territory; \
-         warm_per_call={warm_per_call:?}, total warm={warm_elapsed:?}"
-    );
-    assert!(
-        ratio >= 1.5,
-        "expected warm detect_local_daemon to be at least 1.5x faster than cold probe; \
-         warm={warm_elapsed:?}, cold={cold_elapsed:?}, ratio={ratio:.2}x"
+    let cold_probe_runs = probe_run_count(&heddle_dir) - probe_before_cold;
+    assert_eq!(
+        cold_probe_runs, cold_iters,
+        "each cold probe() must run the setup step exactly once; \
+         expected {cold_iters} runs, saw {cold_probe_runs}"
     );
 
-    // Also exercise the channel path so the bench file isn't only
-    // testing the cheap file-stat cache. This validates that the
-    // tonic UDS channel + Health.Check actually round-trip against
-    // the live `serve()` daemon (which doesn't install a health
-    // reporter — Unimplemented is the expected status code, treated
-    // as "channel is alive" by the client).
+    // Also exercise the channel path so this file isn't only testing
+    // the cheap file-stat cache. This validates that the tonic UDS
+    // channel + Health.Check actually round-trip against the live
+    // `serve()` daemon (which doesn't install a health reporter —
+    // Unimplemented is the expected status code, treated as "channel is
+    // alive" by the client).
     let connected = connect_local_daemon_channel(&heddle_dir, Duration::from_millis(500)).await;
     assert!(
         connected.is_some(),
@@ -164,35 +152,49 @@ async fn detect_local_daemon_warm_is_significantly_faster_than_cold() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn channel_cache_returns_clones_in_o1() {
-    // The first `connect_local_daemon_channel` does the connect +
-    // Health.Check; subsequent calls should be free. We don't assert
-    // a hard time bound (CI noise) — only that it succeeds twice and
-    // that the second call is at least an order of magnitude faster
-    // than the first, which would fail loudly if the cache was
-    // missing.
+async fn channel_cache_returns_clones_without_rebuilding() {
+    // The first `connect_local_daemon_channel` does the real work:
+    // open the UDS, build the tonic channel, run the `Health.Check`
+    // handshake (all of it inside `build_channel`). Every subsequent
+    // call should hit `CHANNEL_CACHE` and hand back a *clone* of the
+    // cached channel in O(1) — no second connect/handshake.
+    //
+    // We assert that by the mechanism, not the clock: `build_channel`
+    // bumps a process-wide counter, so a cache hit leaves the counter
+    // untouched. (The old revision compared wall-clock ratios, which
+    // flaked under CI load — issue #722.)
     let (_temp, heddle_dir, shutdown, task) = spawn_local_daemon().await;
 
-    let cold = Instant::now();
+    let builds_before = channel_build_count(&heddle_dir);
+
     let first = connect_local_daemon_channel(&heddle_dir, Duration::from_millis(500))
         .await
         .expect("first connect");
-    let cold_elapsed = cold.elapsed();
+    let builds_after_first = channel_build_count(&heddle_dir);
+    assert_eq!(
+        builds_after_first - builds_before,
+        1,
+        "first connect_local_daemon_channel must build the channel exactly once"
+    );
 
-    let warm = Instant::now();
     let second = connect_local_daemon_channel(&heddle_dir, Duration::from_millis(500))
         .await
         .expect("cached connect");
-    let warm_elapsed = warm.elapsed();
+    let builds_after_second = channel_build_count(&heddle_dir);
+    assert_eq!(
+        builds_after_second - builds_after_first,
+        0,
+        "second connect_local_daemon_channel must be an O(1) cache hit \
+         that returns a clone WITHOUT rebuilding the channel; \
+         build ran {} extra time(s)",
+        builds_after_second - builds_after_first
+    );
 
-    assert_eq!(first.target.socket_path, second.target.socket_path);
-    let cold_ns = cold_elapsed.as_nanos();
-    let warm_ns = warm_elapsed.as_nanos().max(1);
-    let ratio = cold_ns as f64 / warm_ns as f64;
-    assert!(
-        ratio >= 5.0,
-        "expected channel cache to be at least 5x faster on the second call; \
-         cold={cold_elapsed:?}, warm={warm_elapsed:?}, ratio={ratio:.2}x"
+    // The cache hit must hand back the same target the first build
+    // produced — a clone, not a divergent re-detection.
+    assert_eq!(
+        first.target, second.target,
+        "cached channel must carry the same UdsTarget as the first build"
     );
 
     let _ = shutdown.send(());


### PR DESCRIPTION
Closes #722.

## Problem
`crates/cli/tests/serve_local.rs` had two **wall-clock timing assertions** (warm-vs-cold relative speed) that flake on shared CI runners — worse under `llvm-cov`. Now that `Check & test` is a required check, these flakes block unrelated PRs (e.g. comment-only changes) until a lucky green re-run.

## Fix — option (a): assert the mechanism, not the clock
Both caches in `crates/cli/src/client/local_daemon.rs` exist so a hot agent loop pays the filesystem/connect cost once and every later call is an O(1) cache hit. We now assert that property by **counting the underlying expensive operations** instead of comparing nanoseconds.

- Added two `#[doc(hidden)]`, **per-heddle-dir** test-support counters at the single chokepoints:
  - `probe()` — the "cold setup step" (two file stats + `kill(pid,0)` + executable-identity check).
  - `build_channel()` — the real UDS connect + tonic channel + `Health.Check` handshake.
  - Keyed per heddle dir via the existing `OnceMap` shape, so each test's count is **immune to probes a concurrently-running test issues against a different temp dir** — deterministic regardless of test parallelism.
- `detect_local_daemon_warm_path_skips_the_cold_probe`: prime the cache, then assert 100 warm `detect_local_daemon` calls move the probe counter by **0** (warm path skips the cold probe), while 100 cold `probe()` calls move it by exactly **100** (the contrast keeps the warm assertion non-vacuous).
- `channel_cache_returns_clones_without_rebuilding`: assert the first connect runs `build_channel` exactly **once** and the second runs it **zero** times (O(1) cache hit returning a clone), carrying the same `UdsTarget`.

These do not weaken what the tests verify — they still prove the exact O(1) / warm-skip behavior, just deterministically. Tests stay in `Check & test` (not moved to `--ignored`); option (a) is the durable fix.

## Test evidence
- `cargo test -p heddle-cli --test serve_local`: 2/2 pass.
- Stress: **55 consecutive green runs** — 30 with both tests in parallel (`--test-threads=2`), then 25 more under full 8-core CPU saturation (the scheduler-contention condition that triggered the original flake). 0 failures.
- `cargo build --locked --workspace` (default features): clean.
- `bash scripts/check-no-silent-default-tree-load.sh`: clean.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo test -p heddle-cli --lib client::local_daemon`: 12/12 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/735"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784091298&installation_id=132405951&pr_number=735&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F735&signature=b7fe056086028d33cac8f62f0ca8d1450be08c7a8fb4bb8d6e6928269ad8b371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->