### PR TITLE
fix(release): generate brew-audit-clean Homebrew cask

### DIFF
--- a/scripts/render-homebrew-cask.sh
+++ b/scripts/render-homebrew-cask.sh
@@ -48,19 +48,26 @@ cask "heddle" do
   version "$VERSION"
   sha256 "$SHA256"
 
-  url "https://github.com/HeddleCo/heddle/releases/download/v#{version}/Heddle-v#{version}-macos-universal.dmg"
+  url "https://github.com/HeddleCo/heddle/releases/download/v#{version}/Heddle-v#{version}-macos-universal.dmg",
+      verified: "github.com/HeddleCo/heddle/"
   name "Heddle"
   desc "AI-native version control system"
-  homepage "https://heddle.sh"
+  homepage "https://heddle.sh/"
 
-  depends_on macos: ">= :tahoe"
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  depends_on macos: :tahoe
 
   app "Heddle.app"
   binary "#{appdir}/Heddle.app/Contents/Resources/bin/heddle", target: "heddle"
 
   postflight do
-    system_command "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister",
-                   args: ["-f", "#{appdir}/Heddle.app"]
+    lsregister = "/System/Library/Frameworks/CoreServices.framework/" \\
+                 "Frameworks/LaunchServices.framework/Support/lsregister"
+    system_command lsregister, args: ["-f", "#{appdir}/Heddle.app"]
   end
 
   zap trash: [


### PR DESCRIPTION
render-homebrew-cask.sh emitted a cask that failed `brew style` + `brew audit --cask --strict` (5 defects: homepage trailing slash, `depends_on macos: :tahoe`, missing `verified:` url param [github.com download ≠ heddle.sh homepage], missing `livecheck`, over-long lsregister line). Fixed the generator to emit the corrected form — **verified byte-identical** to the hand-fixed cask now passing tap CI in HeddleCo/homebrew-heddle (green run 27635551480). Prevents the next release's auto-generated cask PR from regenerating the broken form.

Found while landing the v0.3.0 Homebrew cask. The 0.3.0 cask is already hand-fixed + green in the tap; this keeps future releases clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/740"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784222971&installation_id=132405951&pr_number=740&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F740&signature=8fe43967a5ffe64c8d7c02e8c0b0ffd2d7b2176a4242511241e19a254e27104d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->