### PR TITLE
fix(land): don't say 'manually resolved' for auto-clean merges

### DIFF
--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -1261,6 +1261,9 @@ fn mark_merge_previewed(repo: &Repository, thread_id: &str) -> Result<()> {
         status: Some("previewed".to_string()),
         reason: Some("clean merge preview established land path".to_string()),
         manual_resolution_state: thread.integration_policy_result.manual_resolution_state,
+        conflicts_resolved_manually: thread
+            .integration_policy_result
+            .conflicts_resolved_manually,
     };
     manager.save(&thread)?;
     Ok(())

--- a/crates/cli/src/cli/commands/operator_core.rs
+++ b/crates/cli/src/cli/commands/operator_core.rs
@@ -517,6 +517,7 @@ fn complete_current_thread_manual_resolution(repo: &Repository) -> Result<Option
         status: Some("manual_resolved".to_string()),
         reason: Some("manual conflict resolution captured".to_string()),
         manual_resolution_state: Some(current_state.short()),
+        conflicts_resolved_manually: true,
     };
     thread.updated_at = Utc::now();
     let thread_id = thread.id.clone();

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -571,6 +571,7 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
             thread.integration_policy_result.reason =
                 Some("manual integration resolution captured".to_string());
             thread.integration_policy_result.manual_resolution_state = Some(current_state.short());
+            thread.integration_policy_result.conflicts_resolved_manually = true;
         } else {
             // Rebase replays commits one at a time and can flag a
             // conflict on intermediate states even when the *final*
@@ -594,6 +595,10 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
                         Some("thread refreshed cleanly via 3-way merge fallback".to_string());
                     thread.integration_policy_result.manual_resolution_state =
                         Some(new_state.short());
+                    // Conflict-free auto-merge of disjoint changes: no human
+                    // resolved anything, so this must NOT be reported as a
+                    // manual resolution at land time.
+                    thread.integration_policy_result.conflicts_resolved_manually = false;
                 }
                 Ok(ThreeWayMergeRefresh::Conflicted {
                     tree,
@@ -639,6 +644,8 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
     thread.integration_policy_result.reason =
         Some("thread refreshed cleanly onto target".to_string());
     thread.integration_policy_result.manual_resolution_state = Some(current_state.short());
+    // Clean rebase/refresh onto target — automatic, nothing manually resolved.
+    thread.integration_policy_result.conflicts_resolved_manually = false;
     thread.updated_at = Utc::now();
     thread.freshness = ThreadFreshness::Current;
     save_thread_update_with_oplog(repo, &manager, &thread, before_update, current_state)?;

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -301,6 +301,12 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
                 refreshed_thread
                     .integration_policy_result
                     .manual_resolution_state = resolved_state;
+                // The stale thread refreshed cleanly (no conflicts surfaced
+                // for the user to resolve), so the land message must not
+                // claim a manual resolution.
+                refreshed_thread
+                    .integration_policy_result
+                    .conflicts_resolved_manually = false;
                 save_thread_update_with_oplog(
                     &repo,
                     &manager,
@@ -422,6 +428,10 @@ pub fn cmd_thread_resolve(cli: &Cli, thread_id: String) -> Result<()> {
             .refs()
             .get_thread(&ThreadName::new(&thread.thread))?
             .map(|id| id.short());
+        // Reached only after the conflict preview above came back clean
+        // because the operator had captured a resolution in their checkout —
+        // this is the genuine `heddle resolve` manual-resolution path.
+        thread.integration_policy_result.conflicts_resolved_manually = true;
         save_thread_update_with_oplog(&repo, &manager, &thread, before_update, thread_state)?;
     }
     let recommended_action = if blockers.is_empty() {

--- a/crates/cli/src/cli/commands/undo_apply.rs
+++ b/crates/cli/src/cli/commands/undo_apply.rs
@@ -1700,6 +1700,9 @@ fn mark_source_thread_integrated(
         status: Some("auto_integrated".to_string()),
         reason: Some("redo restored integrated target state".to_string()),
         manual_resolution_state: thread.integration_policy_result.manual_resolution_state,
+        conflicts_resolved_manually: thread
+            .integration_policy_result
+            .conflicts_resolved_manually,
     };
     thread.freshness = ThreadFreshness::Current;
     thread.updated_at = chrono::Utc::now();

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -502,16 +502,33 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             pushed = true;
             pushed_remote = Some(remote_name);
         }
+        let resolved_manually = merge_thread
+            .integration_policy_result
+            .conflicts_resolved_manually;
         clear_manual_resolution_state(&repo, &merge_thread.id)?;
         let trust = build_repository_verification_state(&repo);
         let post_land_action = integrated_land_next_action(true, pushed, &trust);
         let mut operator = OperatorCommandOutput {
             status: "landed".to_string(),
             action: OperatorAction::Land,
-            message: format!(
-                "Landed thread '{}' from a manually resolved integration state",
-                merge_thread.id
-            ),
+            // Both genuine manual resolutions and fully-automatic conflict-free
+            // integrations are adopted through this `manual_resolution_state`
+            // branch (e.g. two threads forked from the same base that touch
+            // disjoint files merge cleanly via a 3-way merge, yet still record a
+            // resolution state to mark the thread land-ready). Only the former
+            // should be reported as "manually resolved" — claiming a manual
+            // resolution for an auto-clean merge is misleading.
+            message: if resolved_manually {
+                format!(
+                    "Landed thread '{}' from a manually resolved integration state",
+                    merge_thread.id
+                )
+            } else {
+                format!(
+                    "Landed thread '{}' via an automatic integration merge",
+                    merge_thread.id
+                )
+            },
             blockers: Vec::new(),
             warnings: Vec::new(),
             next_action: post_land_action.clone(),
@@ -1061,6 +1078,9 @@ fn update_integration_policy(
         status: Some(next_status.to_string()),
         reason: Some(next_reason),
         manual_resolution_state: thread.integration_policy_result.manual_resolution_state,
+        conflicts_resolved_manually: thread
+            .integration_policy_result
+            .conflicts_resolved_manually,
     };
     manager.save(&thread)?;
     Ok(())
@@ -1075,6 +1095,7 @@ fn clear_manual_resolution_state(repo: &Repository, thread_id: &str) -> Result<(
         ))
     })?;
     thread.integration_policy_result.manual_resolution_state = None;
+    thread.integration_policy_result.conflicts_resolved_manually = false;
     Ok(manager.save(&thread)?)
 }
 

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -6055,6 +6055,101 @@ fn git_overlay_matrix_stale_thread_can_recover_via_sync_then_ship() {
             "push(not requested)"
         ])
     );
+
+    // The thread refreshed cleanly via an automatic conflict-free 3-way merge
+    // (thread touched feature.txt; main advanced base.txt — disjoint paths).
+    // No human resolved anything, so the land message must NOT claim a manual
+    // resolution. HeddleCo/heddle: misleading "manually resolved" wording.
+    let message = land["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("via an automatic integration merge"),
+        "auto-clean land must report an automatic integration merge: {land}"
+    );
+    assert!(
+        !message.contains("manually resolved"),
+        "auto-clean land must not claim a manual resolution: {land}"
+    );
+}
+
+// Companion to `..._stale_thread_can_recover_via_sync_then_ship` above: that
+// test lands a *conflict-free* (automatic 3-way) integration; this one lands a
+// thread whose conflicts the operator *actually resolved by hand*. The land
+// message must differ between the two — only the genuine manual-resolution path
+// may say "from a manually resolved integration state". Both threads reach land
+// through the same `manual_resolution_state` adoption branch, so the wording is
+// driven by `conflicts_resolved_manually`, not by which branch ran.
+#[test]
+fn git_overlay_matrix_manual_conflict_land_reports_manual_resolution() {
+    let temp = TempDir::new().unwrap();
+    init_git_repo_with_branch(temp.path(), "feature/drop-in");
+    std::fs::write(temp.path().join("conflict.txt"), "base\n").unwrap();
+    git_commit_all(temp.path(), "seed branch");
+    heddle_adopt(temp.path());
+
+    let started = json(
+        temp.path(),
+        &[
+            "--output",
+            "json",
+            "start",
+            "feature/manual",
+            "--workspace",
+            "materialized",
+        ],
+    );
+    let thread_path = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
+
+    // Both sides edit the SAME file divergently so the refresh genuinely
+    // conflicts and forces a manual resolution (disjoint edits would 3-way
+    // merge cleanly — that is the auto-clean test above).
+    std::fs::write(thread_path.join("conflict.txt"), "thread change\n").unwrap();
+    heddle(&["capture", "-m", "thread change"], Some(&thread_path)).unwrap();
+
+    std::fs::write(temp.path().join("conflict.txt"), "main change\n").unwrap();
+    json(
+        temp.path(),
+        &["--output", "json", "commit", "-m", "advance main"],
+    );
+
+    // sync materializes the conflict in the thread's own checkout and blocks.
+    let sync = json(
+        temp.path(),
+        &["--output", "json", "sync", "--thread", "feature/manual"],
+    );
+    assert_eq!(sync["status"], "blocked", "{sync}");
+
+    // The operator resolves the conflict by hand (here: take the thread side)
+    // and finishes the in-progress merge in the thread checkout.
+    let resolve = json(
+        &thread_path,
+        &["--output", "json", "resolve", "--all", "--theirs"],
+    );
+    assert_eq!(resolve["remaining"], serde_json::json!([]), "{resolve}");
+    let continued = json(&thread_path, &["--output", "json", "continue"]);
+    assert_eq!(continued["status"], "continued", "{continued}");
+
+    let after_resolve = json(
+        temp.path(),
+        &["thread", "show", "feature/manual", "--output", "json"],
+    );
+    assert_eq!(after_resolve["freshness"], "current", "{after_resolve}");
+
+    let land = json(
+        temp.path(),
+        &["--output", "json", "land", "--thread", "feature/manual", "--no-push"],
+    );
+    assert_eq!(land["status"], "landed", "{land}");
+
+    let message = land["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("from a manually resolved integration state"),
+        "a land after genuine manual conflict resolution must report the manual \
+         resolution: {land}"
+    );
+    assert!(
+        !message.contains("automatic integration merge"),
+        "a manually resolved land must not be reported as automatic: {land}"
+    );
 }
 
 #[test]

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -293,6 +293,17 @@ pub struct ThreadIntegrationPolicy {
     pub reason: Option<String>,
     #[serde(default)]
     pub manual_resolution_state: Option<String>,
+    /// True only when `manual_resolution_state` was captured by an actual
+    /// human conflict resolution (`heddle sync` materialized conflicts, then
+    /// `heddle resolve` cleared them). False when the same field was set by a
+    /// fully-automatic conflict-free integration (e.g. a clean 3-way merge of
+    /// two threads that touch disjoint files). Both populate
+    /// `manual_resolution_state` to mark the thread land-ready, but only the
+    /// former should be reported as "manually resolved" to the operator.
+    /// Pre-existing on-disk records have no field and serde defaults to
+    /// `false`, so a stale clean-merge record never claims a manual resolution.
+    #[serde(default)]
+    pub conflicts_resolved_manually: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
heddle land wrongly reported 'from a manually resolved integration state' for fully-automatic conflict-free 3-way merges. Now threads a conflicts_resolved_manually flag so the message distinguishes auto-clean integration from actual manual conflict resolution. Wording-only (output_kind contract unchanged) + a git_overlay_matrix test. Found while dogfooding 0.3.0.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/741"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784228957&installation_id=132405951&pr_number=741&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F741&signature=cbb3258c10c67ff0aa0785695f444b6433cb029dc6f613cad947b0c4cf15af4b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->