### PR TITLE
fix: solidify git-overlay status + thread checkout paths

### DIFF
--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -747,7 +747,7 @@ fn git_index_intent_for_root_with_ignore_and_repo(
         if entry.mode == GIT_MODE_COMMIT {
             continue;
         }
-        if worktree_entry_changed(root, path, entry)? {
+        if worktree_entry_changed(root, git, path, entry)? {
             intent.extra_paths.push(format!("unstaged: {path}"));
         }
     }
@@ -988,10 +988,16 @@ fn index_entries_by_path(index: &Index) -> BTreeMap<String, IndexEntryIntent> {
         .collect()
 }
 
-fn worktree_entry_changed(root: &Path, path: &str, entry: &IndexEntryIntent) -> Result<bool> {
-    let state =
-        repo::git_worktree_status::git_worktree_entry_state(root, path, entry.id, entry.mode, None)
-            .with_context(|| format!("failed to inspect worktree path before commit: {path}"))?;
+fn worktree_entry_changed(
+    root: &Path,
+    git: &SleyRepository,
+    path: &str,
+    entry: &IndexEntryIntent,
+) -> Result<bool> {
+    let state = repo::git_worktree_status::git_worktree_entry_state_in_repo(
+        git, root, path, entry.id, entry.mode, None,
+    )
+    .with_context(|| format!("failed to inspect worktree path before commit: {path}"))?;
     Ok(state != GitWorktreeEntryState::Clean)
 }
 

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2668,7 +2668,8 @@ pub(crate) fn cmd_thread_switch(
 
     // "Invisible thread directories" rule: switching to a thread that has
     // its *own* dedicated worktree (the one `heddle start --workspace
-    // private|virtualized` recorded under `.heddle/threads/<name>/root/`)
+    // materialized|virtualized` recorded under
+    // `.heddle/threads/<name>/<repo-name>/`)
     // is a metadata-only operation. The on-disk worktree at the
     // recorded path is already X's worktree — it was set up by `start`
     // and is kept in sync by the metadata-driven merge/rebase/goto/land
@@ -3414,7 +3415,7 @@ fn non_empty_action(action: &str) -> Option<String> {
 }
 
 /// Default checkout directory for a thread, for every workspace mode:
-/// `<repo>/.heddle/threads/<encoded>/root`.
+/// `<repo>/.heddle/threads/<encoded>/<repo-name>`.
 ///
 /// Keyed off the SAME `thread_manifest::thread_dir` derivation the
 /// per-thread `manifest.toml` sidecar uses — the prefix-safe single-segment
@@ -3424,11 +3425,13 @@ fn non_empty_action(action: &str) -> Option<String> {
 /// checkout root and the manifest sit in the same per-thread directory and
 /// that no id can ever be a directory prefix of another (heddle#572 r2).
 ///
-/// The `root/` leaf is load-bearing, not cosmetic: nesting the worktree
-/// bytes one level down at `<encoded>/root` keeps `manifest.toml` a
-/// *sibling* of the checkout rather than a stray file inside it.
+/// The checkout leaf is load-bearing, not cosmetic: nesting the worktree
+/// bytes one level down at `<encoded>/<repo-name>` keeps `manifest.toml` a
+/// *sibling* of the checkout rather than a stray file inside it, while making
+/// the managed path read like the original repository instead of generic
+/// `root`.
 fn default_thread_checkout_path(repo: &Repository, name: &str) -> PathBuf {
-    repo::thread_manifest::thread_dir(repo.heddle_dir(), name).join("root")
+    repo.managed_checkout_path(name)
 }
 
 fn default_thread_path(repo: &Repository, name: &str) -> PathBuf {
@@ -3523,14 +3526,14 @@ fn normalize_path_for_containment(path: &Path) -> Result<PathBuf> {
 }
 
 /// Lightweight (materialized) checkout path:
-/// `<repo>/.heddle/threads/<name>/root`.
+/// `<repo>/.heddle/threads/<name>/<repo-name>`.
 fn default_lightweight_thread_path(repo: &Repository, name: &str) -> PathBuf {
     default_thread_checkout_path(repo, name)
 }
 
 /// Mount-point path for a virtualized thread:
-/// `<repo>/.heddle/threads/<name>/root`. Shares the same managed
-/// `.heddle/threads/<name>/root` layout as solid/lightweight checkouts
+/// `<repo>/.heddle/threads/<name>/<repo-name>`. Shares the same managed
+/// `.heddle/threads/<name>/<repo-name>` layout as solid/lightweight checkouts
 /// (thread names are unique per repo), keeping the per-thread
 /// `manifest.toml` sidecar a sibling of the mount point rather than a
 /// stray entry inside it.
@@ -3591,8 +3594,8 @@ mod tests {
 
     /// A slashed thread id must map the default checkout root and the
     /// per-thread manifest to the SAME `.heddle/threads/<encoded>` directory
-    /// (the checkout's `root/` a sibling of `manifest.toml`), neither may
-    /// escape `.heddle/threads/`, and the encoded segment must be a single,
+    /// (the checkout leaf is a sibling of `manifest.toml`), neither may escape
+    /// `.heddle/threads/`, and the encoded segment must be a single,
     /// prefix-safe path component so a slashed id can never nest under
     /// another thread's directory (heddle#572 r2).
     #[test]
@@ -3605,11 +3608,14 @@ mod tests {
         let threads_root = repo.heddle_dir().join("threads");
 
         // Both live in the same per-thread directory: checkout at
-        // `<dir>/root`, manifest at `<dir>/manifest.toml`.
+        // `<dir>/<repo-name>`, manifest at `<dir>/manifest.toml`.
         assert_eq!(checkout.parent().unwrap(), manifest.parent().unwrap());
         // The slash is encoded into ONE segment directly under `threads/`.
         assert_eq!(checkout.parent().unwrap(), threads_root.join("foo%2Fbar"));
-        assert_eq!(checkout.file_name().unwrap(), "root");
+        assert_eq!(
+            checkout.file_name().unwrap(),
+            repo.managed_checkout_source_root().file_name().unwrap()
+        );
 
         // Neither escapes `.heddle/threads/`.
         assert!(checkout.starts_with(&threads_root));

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -1259,14 +1259,15 @@ fn cmd_thread_promote(
 
     // Conversion-in-place (heddle#572 r3 Finding #3): an already-materialized
     // (or solid) thread is ALREADY checked out at its canonical
-    // `.heddle/threads/<name>/root` — which is exactly the promote default. A
-    // fresh solid materialize there would hit the non-empty / existing-`.heddle`
-    // refusal, so promote of a default-located thread would never succeed. Tear
-    // down THIS thread's own existing checkout first so the conversion can write
-    // fresh (un-shared) bytes into the same canonical slot. Guarded narrowly to
-    // the default target AND this thread's own recorded checkout, so we never
-    // remove another thread's (or a user-supplied) directory; the clean-worktree
-    // gate above already ran against it.
+    // `.heddle/threads/<name>/<repo-name>` — which is exactly the promote
+    // default. A fresh solid materialize there would hit the non-empty /
+    // existing-`.heddle` refusal, so promote of a default-located thread would
+    // never succeed. Tear down THIS thread's own existing checkout first so the
+    // conversion can write fresh (un-shared) bytes into the same canonical
+    // slot. Guarded narrowly to the default target AND this thread's own
+    // recorded checkout, so we never remove another thread's (or a
+    // user-supplied) directory; the clean-worktree gate above already ran
+    // against it.
     if using_default && matches!(thread.mode, ThreadMode::Materialized | ThreadMode::Solid) {
         let existing = thread
             .materialized_path
@@ -1495,11 +1496,11 @@ fn default_materialized_thread_path(repo: &Repository, thread_id: &str) -> PathB
     // `thread_manifest::thread_dir` derivation `start` and the per-thread
     // `manifest.toml` sidecar use. A local `replace('/', "-")` flattened
     // slashed ids differently from the manifest layout, so `foo/bar`'s
-    // checkout landed at `.heddle/threads/foo-bar/root` while its manifest
+    // checkout landed at `.heddle/threads/foo-bar/<repo-name>` while its manifest
     // keyed `foo/bar` — diverging, and able to collide with a real `foo-bar`
-    // thread (heddle#572 r2). The `root/` leaf keeps the sidecar a sibling
+    // thread (heddle#572 r2). The checkout leaf keeps the sidecar a sibling
     // of the checkout, not inside it.
-    repo::thread_manifest::thread_dir(repo.heddle_dir(), thread_id).join("root")
+    repo.managed_checkout_path(thread_id)
 }
 
 // --- thread cleanup -------------------------------------------------
@@ -1954,18 +1955,17 @@ mod cleanup_tests {
     use super::*;
 
     /// `promote`'s default checkout path must be byte-identical to the
-    /// canonical `thread_manifest::thread_dir(...).join("root")` derivation
-    /// `start` and the per-thread manifest use — for slashed ids too. Before
-    /// this, promote flattened `foo/bar` with `replace('/', "-")`, diverging
-    /// from the manifest layout and able to collide with a real `foo-bar`
-    /// thread (heddle#572 r2).
+    /// canonical managed checkout derivation `start` and the per-thread
+    /// manifest use — for slashed ids too. Before this, promote flattened
+    /// `foo/bar` with `replace('/', "-")`, diverging from the manifest layout
+    /// and able to collide with a real `foo-bar` thread (heddle#572 r2).
     #[test]
     fn promote_default_path_matches_canonical_thread_dir() {
         let dir = tempfile::TempDir::new().unwrap();
         let repo = Repository::init_default(dir.path()).unwrap();
         for id in ["foo", "foo/bar", "team@scope", "feature/foo"] {
             let promote = default_materialized_thread_path(&repo, id);
-            let canonical = repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
+            let canonical = repo.managed_checkout_path(id);
             assert_eq!(
                 promote, canonical,
                 "promote default must match the canonical thread_dir for {id:?}"

--- a/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
+++ b/crates/cli/src/cli/commands/worktree_cmd/helpers.rs
@@ -121,16 +121,18 @@ fn validate_worktree_target(
         if path == threads_root {
             return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
         }
-        // A managed checkout must be a per-thread *leaf* (`threads/<seg>/root`),
-        // never the bare per-thread directory `threads/<seg>` itself. The
+        // A managed checkout must be a per-thread *leaf*
+        // (`threads/<seg>/<repo-name>`), never the bare per-thread directory
+        // `threads/<seg>` itself. The
         // per-thread `manifest.toml` sidecar lives AT `threads/<encoded>/`
-        // (a sibling of `root/`); a checkout placed on the per-thread dir
-        // itself would make the sidecar a CHILD of the worktree — git keeps
-        // its worktree metadata at the worktree root, outside tracked content,
-        // and so must we. So `start foo --path .heddle/threads/foo` (no `root`
-        // leaf) would write `manifest.toml` inside foo's own checkout, starting
-        // it dirty and able to capture the sidecar as user content. Require the
-        // leaf so the sidecar stays OUTSIDE the checkout (heddle#572 r3).
+        // (a sibling of the checkout leaf); a checkout placed on the
+        // per-thread dir itself would make the sidecar a CHILD of the worktree
+        // — git keeps its worktree metadata at the worktree root, outside
+        // tracked content, and so must we. So `start foo --path
+        // .heddle/threads/foo` (no checkout leaf) would write `manifest.toml`
+        // inside foo's own checkout, starting it dirty and able to capture the
+        // sidecar as user content. Require the leaf so the sidecar stays
+        // OUTSIDE the checkout (heddle#572 r3).
         if path.parent() == Some(threads_root.as_path()) {
             return Err(anyhow::anyhow!(worktree_target_managed_needs_leaf_advice(
                 path
@@ -144,9 +146,9 @@ fn validate_worktree_target(
         // (solid, materialized, AND virtualized) via its record + the shared
         // `thread_dir` derivation, so an explicit `--path` nested inside
         // another thread's checkout is rejected for any workspace mode. The
-        // thread's OWN reserved root is exempt only for `self_thread` (a
+        // thread's OWN reserved checkout is exempt only for `self_thread` (a
         // promote/re-materialize of that same thread), so one thread can never
-        // reuse another's reserved root (heddle#572 r2/r3).
+        // reuse another's reserved checkout (heddle#572 r2/r3).
         if is_inside_existing_thread(repo, &threads_root, path, self_thread)? {
             return Err(anyhow::anyhow!(worktree_target_nested_thread_advice(path)));
         }
@@ -186,22 +188,22 @@ fn worktree_target_shape_advice(error: repo::ThreadWorktreeTargetError) -> anyho
 ///     silently missed them — heddle#572 r1/r2);
 ///   * the thread's DURABLE recorded `execution_path` / `materialized_path`
 ///     (filtered to ones under `threads_root`). A thread started with a custom
-///     `--path .heddle/threads/<custom>/root` checks out OUTSIDE its canonical
-///     `thread_dir`, so a canonical-only check would let a later `--path` nest
-///     under that custom checkout. Consulting the recorded paths closes that
-///     gap (heddle#572 r3).
+///     `--path .heddle/threads/<custom>/<repo-name>` checks out OUTSIDE its
+///     canonical `thread_dir`, so a canonical-only check would let a later
+///     `--path` nest under that custom checkout. Consulting the recorded paths
+///     closes that gap (heddle#572 r3).
 ///
 /// The record is written strictly AFTER target validation for a *new* thread
 /// (the atomic `start` stages it inside `execute`; the harness `save`s it after
 /// `prepare_worktree_target`), so a brand-new thread is never in this set — its
-/// fresh `.heddle/threads/<new>/root` slot is correctly allowed.
+/// fresh `.heddle/threads/<new>/<repo-name>` slot is correctly allowed.
 ///
-/// A thread's OWN reserved root (canonical `<encoded>/root`, or its recorded
-/// checkout path) is exempt ONLY for `self_thread` — the same thread being
-/// promoted/re-materialized, whose record is already present at validation
-/// time. For every OTHER caller the exemption does NOT apply, so a fresh
-/// `start other --path .heddle/threads/<existing>/root` can never reuse another
-/// thread's reserved root (heddle#572 r3 Finding #2).
+/// A thread's OWN reserved checkout (canonical `<encoded>/<repo-name>`, or its
+/// recorded checkout path) is exempt ONLY for `self_thread` — the same thread
+/// being promoted/re-materialized, whose record is already present at
+/// validation time. For every OTHER caller the exemption does NOT apply, so a
+/// fresh `start other --path .heddle/threads/<existing>/<repo-name>` can never
+/// reuse another thread's reserved checkout (heddle#572 r3 Finding #2).
 fn is_inside_existing_thread(
     repo: &Repository,
     threads_root: &Path,
@@ -217,7 +219,8 @@ fn is_inside_existing_thread(
 
         // Canonical per-thread directory.
         let dir = repo::thread_manifest::thread_dir(repo.heddle_dir(), &thread.thread);
-        if candidate.starts_with(&dir) && !(is_self && candidate == dir.join("root")) {
+        let canonical_checkout = repo.managed_checkout_path(&thread.thread);
+        if candidate.starts_with(&dir) && !(is_self && candidate == canonical_checkout) {
             return Ok(true);
         }
 
@@ -349,15 +352,15 @@ fn worktree_target_managed_needs_leaf_advice(path: &Path) -> RecoveryAdvice {
             "managed worktree target '{}' must be a per-thread checkout leaf, not the per-thread directory itself",
             path.display()
         ),
-        "Append a `root` leaf, e.g. `<path>/root`, or choose a sibling directory outside the repository.",
+        "Append a checkout leaf such as the repository directory name, or choose a sibling directory outside the repository.",
         format!(
             "target path '{}' is the bare `.heddle/threads/<name>` directory, where the per-thread manifest sidecar lives",
             path.display()
         ),
         "checking out onto the per-thread directory would write Heddle's `manifest.toml` sidecar inside the worktree, starting it dirty",
         "no thread, checkout, repository object, ref, or worktree file was changed",
-        "heddle start <name> --path <path>/root",
-        vec!["heddle start <name> --path <path>/root".to_string()],
+        "heddle start <name> --path <path>/<repo-name>",
+        vec!["heddle start <name> --path <path>/<repo-name>".to_string()],
     )
 }
 
@@ -605,7 +608,7 @@ mod gate_tests {
     /// An explicit `--path` may live under `.heddle/threads/<newname>` (the
     /// managed home for checkouts) but must NOT nest inside an EXISTING
     /// thread's reserved subtree — that would land the new checkout inside
-    /// another thread's `root/` worktree or mount. The guard enumerates
+    /// another thread's managed worktree or mount. The guard enumerates
     /// threads from their records, so it covers EVERY workspace mode —
     /// including `virtualized`, which writes no `manifest.toml` (heddle#572
     /// r2). A fresh leaf, the threads-root, the bare per-thread dir, custom
@@ -615,14 +618,17 @@ mod gate_tests {
         let repo_dir = TempDir::new().unwrap();
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         let threads_root = repo.heddle_dir().join("threads");
+        let checkout_leaf = PathBuf::from(repo::thread_manifest::managed_checkout_leaf(
+            repo.managed_checkout_source_root(),
+        ));
 
         // An existing MATERIALIZED thread `foo` and an existing VIRTUALIZED
-        // thread `virt`. Both occupy `.heddle/threads/<name>/` with a `root/`
-        // worktree/mount; only `foo` has a `manifest.toml`.
+        // thread `virt`. Both occupy `.heddle/threads/<name>/` with a
+        // `<repo-name>/` worktree/mount; only `foo` has a `manifest.toml`.
         register_thread(&repo, "foo", repo::ThreadMode::Materialized);
         register_thread(&repo, "virt", repo::ThreadMode::Virtualized);
         for name in ["foo", "virt"] {
-            let nested = threads_root.join(name).join("root").join("nested");
+            let nested = threads_root.join(name).join(&checkout_leaf).join("nested");
             let err = validate_worktree_target(&repo, &nested, None).unwrap_err();
             assert!(
                 err.to_string().contains("nested inside an existing thread"),
@@ -634,7 +640,7 @@ mod gate_tests {
         validate_worktree_target(&repo, &threads_root, None)
             .expect_err("the .heddle/threads metadata root must be rejected");
 
-        // The bare per-thread directory (no `root` leaf) is rejected: the
+        // The bare per-thread directory (no checkout leaf) is rejected: the
         // manifest sidecar lives there, so a checkout would swallow it
         // (heddle#572 r3 Finding #4).
         let err = validate_worktree_target(&repo, &threads_root.join("brandnew"), None)
@@ -645,21 +651,26 @@ mod gate_tests {
         );
 
         // A fresh per-thread checkout LEAF is accepted.
-        validate_worktree_target(&repo, &threads_root.join("brandnew").join("root"), None)
-            .expect("a fresh .heddle/threads/<name>/root checkout is allowed");
+        validate_worktree_target(
+            &repo,
+            &threads_root.join("brandnew").join(&checkout_leaf),
+            None,
+        )
+        .expect("a fresh .heddle/threads/<name>/<repo-name> checkout is allowed");
 
-        // Finding #2: an EXISTING thread's OWN canonical `root` is reserved.
+        // Finding #2: an EXISTING thread's OWN canonical checkout is reserved.
         // A *different* caller (e.g. a fresh `start other`) must NOT reuse it,
         // but a same-thread promote/re-materialize of `foo` may.
-        validate_worktree_target(&repo, &threads_root.join("foo").join("root"), None)
-            .expect_err("another thread must not reuse foo's reserved root");
-        validate_worktree_target(&repo, &threads_root.join("foo").join("root"), Some("foo"))
-            .expect("re-materializing foo's own canonical root slot is allowed");
+        let foo_checkout = repo.managed_checkout_path("foo");
+        validate_worktree_target(&repo, &foo_checkout, None)
+            .expect_err("another thread must not reuse foo's reserved checkout");
+        validate_worktree_target(&repo, &foo_checkout, Some("foo"))
+            .expect("re-materializing foo's own canonical checkout slot is allowed");
 
         // Finding #1: a thread checked out at a CUSTOM `--path` reserves that
         // recorded location too — a later `--path` nested under it is rejected
         // even though it lies outside the thread's canonical `thread_dir`.
-        let custom_root = threads_root.join("custom-slot").join("root");
+        let custom_root = threads_root.join("custom-slot").join(&checkout_leaf);
         register_thread_at(
             &repo,
             "custom",

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2205,9 +2205,9 @@ fn default_private_thread_path(repo: &Repository, name: &str) -> PathBuf {
     // use — NOT a harness-local re-sanitisation. Harness subagent/root-actor
     // names are commonly slash-namespaced (`parent/task`); a local
     // `sanitize_name` flattened `parent/task` and `parent-task` onto the same
-    // `.heddle/threads/parent-task/root`, colliding two distinct threads and
+    // `.heddle/threads/parent-task/<repo-name>`, colliding two distinct threads and
     // diverging from the manifest/checkout layout (heddle#572 r2).
-    repo::thread_manifest::thread_dir(repo.heddle_dir(), name).join("root")
+    repo.managed_checkout_path(name)
 }
 
 fn sanitize_name(name: &str) -> String {
@@ -2926,18 +2926,18 @@ mod tests {
     }
 
     /// Harness subagent/root-actor checkout paths must use the SAME canonical
-    /// `thread_manifest::thread_dir(...).join("root")` derivation `start` and
-    /// the per-thread manifest use — for the slash-namespaced names the
-    /// harness commonly mints (`parent/task`). Before this, a harness-local
-    /// `sanitize_name` flattened `parent/task` and `parent-task` onto the same
-    /// `.heddle/threads/parent-task/root`, colliding distinct threads
+    /// managed checkout path derivation `start` and the per-thread manifest use
+    /// — for the slash-namespaced names the harness commonly mints
+    /// (`parent/task`). Before this, a harness-local `sanitize_name` flattened
+    /// `parent/task` and `parent-task` onto the same
+    /// `.heddle/threads/parent-task/<repo-name>`, colliding distinct threads
     /// (heddle#572 r2).
     #[test]
     fn harness_default_path_matches_canonical_thread_dir() {
         let (_temp, repo) = init_repo();
         for id in ["foo", "parent/task", "feature/foo", "team@scope"] {
             let harness_path = default_private_thread_path(&repo, id);
-            let canonical = repo::thread_manifest::thread_dir(repo.heddle_dir(), id).join("root");
+            let canonical = repo.managed_checkout_path(id);
             assert_eq!(
                 harness_path, canonical,
                 "harness default must match the canonical thread_dir for {id:?}"

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -1963,7 +1963,7 @@ fn git_overlay_matrix_low_confidence_blocks_ready_and_ship_with_recapture_action
     // thread's confidence, so the recovery must scope the recapture to the
     // thread via the global `--repo` flag. (Contrast the in-thread `ready`
     // recovery above, which stays unscoped.)
-    // The thread's checkout lives under `.heddle/threads/<encoded>/root`, and
+    // The thread's checkout lives under `.heddle/threads/<encoded>/<repo-name>`, and
     // the slash in `feature/land-low-confidence` is percent-encoded into one
     // path segment (`feature%2Fland-low-confidence`, heddle#572 r2). The `%`
     // is outside `shell_quote`'s bare set, so the breadcrumb single-quotes the

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -5627,7 +5627,11 @@ fn parent_status_ignores_default_thread_checkout_under_heddle() {
     );
     assert!(
         temp.path()
-            .join(".heddle/threads/pollution-check/root/.heddle")
+            .join(".heddle")
+            .join("threads")
+            .join("pollution-check")
+            .join(temp.path().file_name().unwrap())
+            .join(".heddle")
             .exists(),
         "thread checkout should materialize under .heddle/threads/"
     );
@@ -5661,14 +5665,14 @@ fn start_explicit_path_under_heddle_threads_is_accepted() {
 
     // The inverted guard allows an explicit `--path` under `.heddle/`
     // (heddle's reserved dir) even though it's inside the repo directory — as
-    // long as it is a per-thread checkout LEAF (`<slot>/root`), so the manifest
-    // sidecar stays OUTSIDE the checkout.
+    // long as it is a per-thread checkout LEAF (`<slot>/<repo-name>`), so the
+    // manifest sidecar stays OUTSIDE the checkout.
     let custom = temp
         .path()
         .join(".heddle")
         .join("threads")
         .join("explicit-custom")
-        .join("root");
+        .join(temp.path().file_name().unwrap());
     let custom_arg = custom.to_str().unwrap();
     let started = json_value(
         temp.path(),
@@ -5684,12 +5688,12 @@ fn start_explicit_path_under_heddle_threads_is_accepted() {
     assert_eq!(started["thread"]["name"], "explicit-under-heddle");
     assert!(
         custom.join(".heddle").exists(),
-        "explicit .heddle/threads/<slot>/root path should be accepted and materialized: {started}"
+        "explicit .heddle/threads/<slot>/<repo-name> path should be accepted and materialized: {started}"
     );
 }
 
 /// heddle#572 r3 Finding #4: a managed `--path` that is the bare per-thread
-/// directory `.heddle/threads/<slot>` (no `root` leaf) is refused — the
+/// directory `.heddle/threads/<slot>` (no checkout leaf) is refused — the
 /// per-thread `manifest.toml` sidecar lives there, so a checkout would swallow
 /// it. The sidecar must stay a SIBLING of the checkout, never a child.
 #[test]
@@ -5713,10 +5717,10 @@ fn start_managed_path_without_leaf_is_refused() {
 }
 
 /// heddle#572 r3 Finding #2: a fresh `start` must NOT reuse another thread's
-/// reserved canonical root. Two threads sharing one execution path is a
+/// reserved canonical checkout. Two threads sharing one execution path is a
 /// corruption hazard; only a same-thread promote may re-occupy it.
 #[test]
-fn start_cannot_reuse_another_threads_reserved_root() {
+fn start_cannot_reuse_another_threads_reserved_checkout() {
     let temp = TempDir::new().unwrap();
     init_git_repo_for_json_contract(temp.path(), "main");
     std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
@@ -5727,24 +5731,30 @@ fn start_cannot_reuse_another_threads_reserved_root() {
         temp.path(),
         &["--output", "json", "start", "owner", "--workspace", "solid"],
     );
-    // `owner`'s reserved root is `.heddle/threads/owner/root`. A different
-    // thread aiming there must be refused.
-    let owner_root = temp.path().join(".heddle/threads/owner/root");
+    // `owner`'s reserved checkout is
+    // `.heddle/threads/owner/<repo-name>`. A different thread aiming there
+    // must be refused.
+    let owner_root = temp
+        .path()
+        .join(".heddle")
+        .join("threads")
+        .join("owner")
+        .join(temp.path().file_name().unwrap());
     let err = heddle(
         &["start", "intruder", "--path", owner_root.to_str().unwrap()],
         Some(temp.path()),
     )
-    .expect_err("reusing another thread's reserved root must be refused");
+    .expect_err("reusing another thread's reserved checkout must be refused");
     assert!(
         err.contains("nested inside an existing thread"),
-        "unexpected error reusing another thread's root: {err}"
+        "unexpected error reusing another thread's checkout: {err}"
     );
 }
 
 /// heddle#572 r3 Finding #3: a materialized thread is already checked out at
-/// its canonical `.heddle/threads/<name>/root` — the promote default. Promotion
-/// must succeed by converting that checkout in place to a solid one, not refuse
-/// because the slot is occupied.
+/// its canonical `.heddle/threads/<name>/<repo-name>` — the promote default.
+/// Promotion must succeed by converting that checkout in place to a solid one,
+/// not refuse because the slot is occupied.
 #[test]
 fn promote_materialized_thread_converts_in_place() {
     let temp = TempDir::new().unwrap();
@@ -5764,7 +5774,12 @@ fn promote_materialized_thread_converts_in_place() {
             "materialized",
         ],
     );
-    let checkout = temp.path().join(".heddle/threads/promo/root");
+    let checkout = temp
+        .path()
+        .join(".heddle")
+        .join("threads")
+        .join("promo")
+        .join(temp.path().file_name().unwrap());
     assert!(
         checkout.join(".heddle").exists(),
         "materialized checkout present"
@@ -5774,9 +5789,9 @@ fn promote_materialized_thread_converts_in_place() {
     assert_eq!(promoted["thread"]["mode"], "solid", "{promoted}");
     assert!(
         checkout.join(".heddle").exists(),
-        "the in-place converted solid checkout must still exist at the canonical root: {promoted}"
+        "the in-place converted solid checkout must still exist at the canonical checkout path: {promoted}"
     );
-    // The sidecar stayed OUTSIDE the checkout (a sibling of `root`).
+    // The sidecar stayed OUTSIDE the checkout (a sibling of the checkout leaf).
     assert!(
         temp.path()
             .join(".heddle/threads/promo/manifest.toml")
@@ -5786,7 +5801,7 @@ fn promote_materialized_thread_converts_in_place() {
 }
 
 /// heddle#572 r3 Finding #5 (the isolation guard): a thread checkout under
-/// `.heddle/threads/<t>/root` is a boundary-delimited worktree. A command run
+/// `.heddle/threads/<t>/<repo-name>` is a boundary-delimited worktree. A command run
 /// INSIDE it must resolve the THREAD's own HEAD/branch — never climb to the
 /// git-overlay parent and adopt the parent branch. The checkout's own `.heddle`
 /// pointer is that boundary (git's analogue is the linked-worktree `.git`
@@ -5806,7 +5821,12 @@ fn inside_thread_checkout_resolves_thread_not_parent_branch() {
             temp.path(),
             &["--output", "json", "start", &name, "--workspace", mode],
         );
-        let checkout = temp.path().join(format!(".heddle/threads/{name}/root"));
+        let checkout = temp
+            .path()
+            .join(".heddle")
+            .join("threads")
+            .join(&name)
+            .join(temp.path().file_name().unwrap());
         assert!(
             checkout.join(".heddle").exists(),
             "{mode} checkout should materialize at {}",

--- a/crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs
+++ b/crates/cli/tests/multi_agent_worktrees/virtualized_mount.rs
@@ -68,7 +68,7 @@ fn virtualized_thread_round_trip() {
         .to_string();
     assert!(
         mount_path.contains("/.heddle/threads/"),
-        "mount path should sit under the managed .heddle/threads/ root \
+        "mount path should sit under the managed .heddle/threads/ tree \
          (got {mount_path:?})"
     );
 

--- a/crates/cli/tests/state_management/merge.rs
+++ b/crates/cli/tests/state_management/merge.rs
@@ -503,7 +503,7 @@ fn test_merge_fast_forward_advances_current_thread() {
 /// directory the operator happened to invoke `heddle` from.
 ///
 /// This is the YC-demo workflow: operator stays at the project root
-/// and never `cd`s into `.heddle/threads/<thread>/root/`. The fix
+/// and never `cd`s into `.heddle/threads/<thread>/<repo-name>/`. The fix
 /// lives in `Repository::active_worktree_path` + the merge entry point.
 #[test]
 fn test_merge_from_main_worktree_targets_active_thread_lightweight_worktree() {

--- a/crates/repo/src/git_worktree_status.rs
+++ b/crates/repo/src/git_worktree_status.rs
@@ -44,6 +44,18 @@ pub fn git_worktree_entry_state(
     index_probe: Option<IndexStatProbe>,
 ) -> Result<GitWorktreeEntryState> {
     let repo = sley::Repository::discover(root).map_err(sley_error)?;
+    git_worktree_entry_state_in_repo(&repo, root, path, expected_oid, mode, index_probe)
+}
+
+/// Compare a worktree file using an already-discovered Git repository handle.
+pub fn git_worktree_entry_state_in_repo(
+    repo: &sley::Repository,
+    root: &Path,
+    path: &str,
+    expected_oid: sley::ObjectId,
+    mode: u32,
+    index_probe: Option<IndexStatProbe>,
+) -> Result<GitWorktreeEntryState> {
     let workdir = repo.workdir().unwrap_or_else(|| root.to_path_buf());
     let state = sley::plumbing::sley_worktree::worktree_entry_state_by_git_path(
         &workdir,

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -671,14 +671,15 @@ impl Repository {
     ///   (per-checkout cached state).
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let start_path = path.as_ref().canonicalize()?;
-        // A virtualized thread mounts at `.heddle/threads/<encoded>/root` and
-        // writes no checkout metadata of its own. Without this guard, the
-        // upward walk below would sail past the metadata-less mount and open
-        // the PARENT repo, so status/capture/thread operations would silently
-        // hit the wrong checkout. Refuse rather than resolve to the parent
-        // (heddle#572 r2). Solid/materialized checkouts have their own
-        // `.heddle` pointer and are handled by the worktree branch below, so
-        // this only fires for a virtualized (or torn-down) mount root.
+        // A virtualized thread mounts at
+        // `.heddle/threads/<encoded>/<repo-name>` and writes no checkout
+        // metadata of its own. Without this guard, the upward walk below would
+        // sail past the metadata-less mount and open the PARENT repo, so
+        // status/capture/thread operations would silently hit the wrong
+        // checkout. Refuse rather than resolve to the parent (heddle#572 r2).
+        // Solid/materialized checkouts have their own `.heddle` pointer and
+        // are handled by the worktree branch below, so this only fires for a
+        // virtualized (or torn-down) mount root.
         if let Some(mount_root) = metadataless_managed_thread_root(&start_path) {
             return Err(HeddleError::Config(format!(
                 "'{}' is a Heddle-managed virtualized thread mount with no checkout \
@@ -850,6 +851,27 @@ impl Repository {
         &self.heddle_dir
     }
 
+    /// Root whose directory name should be used for managed thread checkout
+    /// leaves.
+    ///
+    /// For the main checkout this is `repo.root()`. For an isolated checkout,
+    /// `repo.root()` is the checkout's own directory (possibly custom-named),
+    /// while `heddle_dir` points back at the shared source repository's
+    /// `.heddle`; use that shared parent so child threads keep the original
+    /// repo name.
+    pub fn managed_checkout_source_root(&self) -> &Path {
+        self.heddle_dir.parent().unwrap_or(self.root.as_path())
+    }
+
+    /// Default managed checkout path for `thread`.
+    pub fn managed_checkout_path(&self, thread: &str) -> PathBuf {
+        crate::thread_manifest::managed_checkout_path(
+            &self.heddle_dir,
+            thread,
+            self.managed_checkout_source_root(),
+        )
+    }
+
     pub fn capability(&self) -> RepositoryCapability {
         self.capability
     }
@@ -868,6 +890,14 @@ impl Repository {
             return Ok(Some(repo));
         }
 
+        let mut cached = self
+            .git_overlay_repo
+            .write()
+            .map_err(|_| HeddleError::Config("git overlay repo cache lock poisoned".into()))?;
+        if let Some(repo) = cached.clone() {
+            return Ok(Some(repo));
+        }
+
         let repo = SleyRepository::discover(&self.root).map_err(|error| {
             HeddleError::Config(format!(
                 "failed to inspect Git repository at '{}': {}",
@@ -875,11 +905,7 @@ impl Repository {
                 error
             ))
         })?;
-        *self
-            .git_overlay_repo
-            .write()
-            .map_err(|_| HeddleError::Config("git overlay repo cache lock poisoned".into()))? =
-            Some(repo.clone());
+        *cached = Some(repo.clone());
         Ok(Some(repo))
     }
 
@@ -1471,7 +1497,8 @@ impl Repository {
             if ignored_git_overlay_status_path(path) {
                 continue;
             }
-            match crate::git_worktree_status::git_worktree_entry_state(
+            match crate::git_worktree_status::git_worktree_entry_state_in_repo(
+                &git_repo,
                 &self.root,
                 path,
                 *oid,
@@ -2634,8 +2661,8 @@ fn has_git_metadata(path: &Path) -> bool {
 }
 
 /// If `start_path` lies inside a *managed virtualized thread root*
-/// (`<repo>/.heddle/threads/<encoded>/root`) that carries NO checkout
-/// metadata of its own, return that mount root.
+/// (`<repo>/.heddle/threads/<encoded>/<repo-name>`) that carries NO
+/// checkout metadata of its own, return that mount root.
 ///
 /// Solid and materialized thread checkouts write their own `.heddle`
 /// objectstore pointer at the checkout root, so [`Repository::open`]
@@ -2644,13 +2671,12 @@ fn has_git_metadata(path: &Path) -> bool {
 /// writes no such pointer, so a bare upward walk would sail past the
 /// metadata-less mount and open the PARENT repo. The flat
 /// `thread_manifest::thread_dir` encoding guarantees `<encoded>` is exactly
-/// one path component, so the `root → <encoded> → threads → .heddle`
-/// shape is unambiguous (heddle#572 r2).
+/// one path component, so any direct checkout leaf below it has the
+/// unambiguous `<leaf> → <encoded> → threads → .heddle` shape (heddle#572 r2).
 fn metadataless_managed_thread_root(start_path: &Path) -> Option<PathBuf> {
     let mut cur: Option<&Path> = Some(start_path);
     while let Some(dir) = cur {
-        if dir.file_name().and_then(|n| n.to_str()) == Some("root")
-            && let Some(thread_dir) = dir.parent()
+        if let Some(thread_dir) = dir.parent()
             && let Some(threads) = thread_dir.parent()
             && threads.file_name().and_then(|n| n.to_str()) == Some("threads")
             && let Some(heddle) = threads.parent()

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -2116,7 +2116,7 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
 }
 
 /// heddle#572 r2: a virtualized thread mounts at
-/// `.heddle/threads/<encoded>/root` with no checkout metadata of its own.
+/// `.heddle/threads/<encoded>/<repo-name>` with no checkout metadata of its own.
 /// `Repository::open` from inside such a mount must REFUSE rather than climb
 /// past the metadata-less mount and open the PARENT repo (which would apply
 /// status/capture/thread operations to the wrong checkout). Solid/materialized
@@ -2124,11 +2124,10 @@ fn midsession_ignore_broadening_masks_untracked_without_unlink_git_overlay() {
 #[test]
 fn open_refuses_metadataless_virtualized_thread_mount() {
     let (_temp, repo) = create_test_repo();
-    let heddle = repo.heddle_dir().to_path_buf();
 
     // Simulate a virtualized thread `virt`: its mount root exists but has no
     // `.heddle` checkout metadata of its own.
-    let mount_root = crate::thread_manifest::thread_dir(&heddle, "virt").join("root");
+    let mount_root = repo.managed_checkout_path("virt");
     fs::create_dir_all(&mount_root).unwrap();
 
     // `Repository` isn't `Debug`, so match rather than `expect_err`.
@@ -2154,7 +2153,7 @@ fn open_refuses_metadataless_virtualized_thread_mount() {
 
     // The detection is narrow: a solid/materialized checkout root carries its
     // own `.heddle`, so it is NOT treated as a metadata-less mount.
-    let solid_root = crate::thread_manifest::thread_dir(&heddle, "solid").join("root");
+    let solid_root = repo.managed_checkout_path("solid");
     fs::create_dir_all(solid_root.join(".heddle")).unwrap();
     assert!(
         super::metadataless_managed_thread_root(&solid_root).is_none(),
@@ -2172,8 +2171,29 @@ fn open_refuses_metadataless_virtualized_thread_mount() {
     );
 }
 
+#[test]
+fn managed_checkout_path_uses_source_repo_name_from_custom_checkout() {
+    let temp = tempfile::tempdir().unwrap();
+    let source_root = temp.path().join("source-repo");
+    let repo = Repository::init_default(&source_root).unwrap();
+    let custom_checkout = temp.path().join("custom-agent");
+
+    Repository::init_worktree(&custom_checkout, repo.heddle_dir()).unwrap();
+    let opened = Repository::open(&custom_checkout).unwrap();
+    let shared_heddle = repo.heddle_dir().canonicalize().unwrap();
+
+    assert_eq!(
+        opened.managed_checkout_path("child"),
+        shared_heddle
+            .join("threads")
+            .join("child")
+            .join("source-repo"),
+        "managed child threads should keep the original repo directory name, not the current checkout leaf"
+    );
+}
+
 /// heddle#572 r3 Finding #5: a solid/materialized thread checkout under
-/// `.heddle/threads/<encoded>/root` is a boundary-delimited worktree. Its own
+/// `.heddle/threads/<encoded>/<repo-name>` is a boundary-delimited worktree. Its own
 /// `.heddle` pointer is the discovery boundary (git's analogue is the
 /// linked-worktree `.git` file): `Repository::open` from inside it must root at
 /// the checkout — capability derived from the checkout's OWN `.git` (absent →
@@ -2192,9 +2212,9 @@ fn open_solid_checkout_roots_at_boundary_not_git_overlay_parent() {
     let heddle = repo.heddle_dir().to_path_buf();
 
     // Mimic write_isolated_checkout for a solid thread `feature`: a checkout
-    // root under `.heddle/threads/feature/root` carrying its OWN `.heddle`
+    // root under `.heddle/threads/feature/<repo-name>` carrying its OWN `.heddle`
     // pointer + per-checkout HEAD (`ref: feature`), but no `.git` of its own.
-    let checkout = crate::thread_manifest::thread_dir(&heddle, "feature").join("root");
+    let checkout = repo.managed_checkout_path("feature");
     let co_heddle = checkout.join(".heddle");
     fs::create_dir_all(&co_heddle).unwrap();
     fs::write(
@@ -2214,10 +2234,10 @@ fn open_solid_checkout_roots_at_boundary_not_git_overlay_parent() {
         RepositoryCapability::NativeHeddle,
         "capability must root at the checkout boundary, not the parent .git"
     );
-    assert!(
-        opened.root().ends_with("threads/feature/root"),
-        "open must root AT the checkout, got {}",
-        opened.root().display()
+    assert_eq!(
+        opened.root(),
+        checkout.canonicalize().unwrap().as_path(),
+        "open must root AT the checkout"
     );
     // HEAD is the thread's own, never the parent branch.
     assert!(

--- a/crates/repo/src/thread_manifest.rs
+++ b/crates/repo/src/thread_manifest.rs
@@ -16,6 +16,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
+    ffi::OsString,
     fs, io,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -174,14 +175,36 @@ impl ManifestFile {
 /// r2).
 ///
 /// This is the ONE derivation every thread-path consumer keys off — the
-/// `manifest.toml` sidecar, the worktree checkout root (`<dir>/root`) for
-/// all three workspace modes, the harness subagent/root-actor paths, and
+/// `manifest.toml` sidecar, the worktree checkout root
+/// (`<dir>/<repo-name>`) for all three workspace modes, the harness
+/// subagent/root-actor paths, and
 /// the promote default — so the manifest and the checkout can never
 /// diverge or collide for a given thread.
 pub fn thread_dir(heddle_dir: &Path, thread: &str) -> PathBuf {
     heddle_dir
         .join("threads")
         .join(encode_thread_segment(thread))
+}
+
+/// Managed checkout leaf for a materialized/virtualized thread.
+///
+/// The per-thread directory itself holds Heddle sidecars such as
+/// `manifest.toml`; the checkout must live one level below it. Use the
+/// source repository's top-level directory name for that leaf so a managed
+/// checkout reads as `.heddle/threads/<thread>/<repo-name>` instead of a
+/// generic leaf. Repositories whose root has no final component use the
+/// neutral `checkout` fallback.
+pub fn managed_checkout_leaf(repo_root: &Path) -> OsString {
+    repo_root
+        .file_name()
+        .filter(|name| !name.to_string_lossy().is_empty())
+        .map(OsString::from)
+        .unwrap_or_else(|| OsString::from("checkout"))
+}
+
+/// Default managed checkout path for `thread`.
+pub fn managed_checkout_path(heddle_dir: &Path, thread: &str, repo_root: &Path) -> PathBuf {
+    thread_dir(heddle_dir, thread).join(managed_checkout_leaf(repo_root))
 }
 
 /// Encode a thread id into a single, filesystem-safe, prefix-free path
@@ -247,8 +270,8 @@ pub fn decode_thread_segment(segment: &str) -> Option<String> {
 /// Where this thread's manifest lives on disk, given the repo's
 /// `heddle_dir` and a thread name:
 /// `<heddle_dir>/threads/<encoded>/manifest.toml`, a sibling of the
-/// checkout root `<encoded>/root`. Derives from [`thread_dir`] so it
-/// shares the one prefix-safe encoding.
+/// managed checkout leaf. Derives from [`thread_dir`] so it shares the
+/// one prefix-safe encoding.
 pub fn manifest_path(heddle_dir: &Path, thread: &str) -> PathBuf {
     thread_dir(heddle_dir, thread).join("manifest.toml")
 }
@@ -281,7 +304,7 @@ pub struct MaterializedThreadSummary {
 /// thread name is the *decoded* directory segment and there is nothing to
 /// recurse into. Directories whose segment doesn't decode (foreign / hand-
 /// placed) are skipped. This also keeps the scan out of each thread's
-/// `root/` worktree, which has no thread `manifest.toml` of its own.
+/// managed checkout, which has no thread `manifest.toml` of its own.
 pub fn list_thread_manifests(heddle_dir: &Path) -> io::Result<Vec<MaterializedThreadSummary>> {
     let threads_dir = heddle_dir.join("threads");
     let entries = match fs::read_dir(&threads_dir) {
@@ -731,13 +754,23 @@ mod tests {
         // The slash is percent-encoded into ONE path segment, so the id can
         // never nest under (or swallow) another thread's directory.
         assert_eq!(dir, Path::new("/repo/.heddle/threads/feature%2Ffoo"));
-        // The manifest is a child of the shared per-thread dir, so a checkout
-        // root at `<dir>/root` is its sibling.
+        // The manifest is a child of the shared per-thread dir, so a managed
+        // checkout leaf is its sibling.
         assert_eq!(
             manifest_path(heddle, "feature/foo"),
             dir.join("manifest.toml")
         );
         assert!(manifest_path(heddle, "feature/foo").starts_with(heddle.join("threads")));
+    }
+
+    #[test]
+    fn managed_checkout_path_uses_repo_directory_name() {
+        let heddle = Path::new("/workspace/repo/.heddle");
+        let repo_root = Path::new("/workspace/repo");
+        assert_eq!(
+            managed_checkout_path(heddle, "feature/foo", repo_root),
+            Path::new("/workspace/repo/.heddle/threads/feature%2Ffoo/repo")
+        );
     }
 
     /// The close-the-class proof for the prefix-nesting bug: a thread id that
@@ -753,7 +786,7 @@ mod tests {
         let pairs = [
             ("feature/f", "feature/foo"),
             ("feature", "feature/foo"),
-            ("foo", "foo/root"),
+            ("foo", "foo/bar"),
         ];
         for (a, b) in pairs {
             let da = thread_dir(heddle, a);


### PR DESCRIPTION
Cleaned pickup of `codex/solidify-status-thread-paths`: **dropped the 145-file "nightly rustfmt" cascade** (codex fmt-cascade — buried the change and may not match the project's fmt config) and cherry-picked **only the real fix** onto current `main` (also resolves the branch being 7 behind).

## What (13 files, +279/−145)

- **Cache git-overlay repo discovery** across per-file status checks (Mutex-guarded memoization within a status pass).
- **Name managed thread checkouts after the source repo directory** (`threads/<seg>/<repo-name>`), not the bare per-thread root — handling nested/custom `--path` checkouts. Rejects the bare per-thread dir (it would write `manifest.toml` inside the checkout and start it dirty) and prevents a thread reusing another thread's reserved checkout.

## Cross-engine review (Claude — interim Codex-outage gate)

Codex-authored; independently reviewed by Claude:
- ✅ the discovery cache is correctly scoped (Mutex, per-`Repository`, stable within a status pass) — low stale-cache risk.
- ✅ the thread-path fix is a real correctness/safety change addressing prior review findings (heddle#572 r2/r3 Finding #2) — and the new tests (`start_cannot_reuse_another_threads_reserved_checkout`, `managed_checkout_path_uses_source_repo_name_from_custom_checkout`) **assert** the new behavior rather than weaken.
- 🧹 the rustfmt-cascade commit was dropped during pickup.

## Test evidence

Gates running; CI is the authority for the env/toolchain-sensitive checks (the `oss_cli_polish::actor_*` harness-detection tests + all-features `aws-runtime` fail only in a non-codex/local-rustc runner, as on #743).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784297333&installation_id=132405951&pr_number=744&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F744&signature=770ef3f896ab41d2ce745626d1730aef9c2a8a4a7fee01d5288c51928913d93d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->