### PR TITLE
release: heddle v0.3.1 — workspace versioning + sley 0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -2008,7 +2008,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -2021,7 +2021,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -2068,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "futures",
@@ -2098,7 +2098,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "libc",
@@ -2124,7 +2124,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2149,14 +2149,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "heddle-mount"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2185,7 +2185,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "aws-sdk-s3",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -2240,7 +2240,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-proto"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2253,7 +2253,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "chrono",
  "criterion",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2323,14 +2323,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-semantic"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -5066,9 +5066,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609a0742d8c9213161f37bcbf09ffba028f036261bcb7747ac9b3c7af08134c5"
+checksum = "e60cbfebc73b32114e5d24169fe02164361e187bbf93d1f36f8fcc57e3b58cf1"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5087,27 +5087,27 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c48548e169425d129f957891ecb69189526292025082d953bd35c306c39669"
+checksum = "0224ea1e75a836d7a6091c25c61478ce9857a96e5ffba582638d4972976da8d0"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1eeca533ae6c9f34d9e511c612ac2ad1408d5f354eb07a5b3a68672221aaf4"
+checksum = "906b093aebd1ea9f5e47f03be6786cb1f70a07e1f707ca1c1290af7c3a4400ef"
 dependencies = [
  "sha1 0.10.6",
 ]
 
 [[package]]
 name = "sley-diff-merge"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1c3f992a5bdd959a696b8e7511a52290bfd1ccc26a1a7458b82f241d0287ea"
+checksum = "4f1de9f1ace3692f3a0c0ede4d90ccc1a749147b15417ca39fe3054e15abf6ff"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5119,9 +5119,9 @@ dependencies = [
 
 [[package]]
 name = "sley-fetch"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3dbc9235a3f0cda96beb59753f152c3d4cd10d3d74eb0b1b9d8255f0a3a9aa9"
+checksum = "bba11a97de2c7cd961965636ee740ca16ebab02db8e33f1de4e855c402434e8c"
 dependencies = [
  "sley-core",
  "sley-odb",
@@ -5131,10 +5131,11 @@ dependencies = [
 
 [[package]]
 name = "sley-formats"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "689f75e5528d4cecbcfffd5f6bef3dfb021ce37aa6ee113281a97bcb21552f64"
+checksum = "dd6eceaac8564232658d08d3126b2c353fb2fbaf94a534cc380d9020693d744e"
 dependencies = [
+ "flate2",
  "sley-config",
  "sley-core",
  "sley-index",
@@ -5143,27 +5144,27 @@ dependencies = [
 
 [[package]]
 name = "sley-index"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573e911b5a4367217bb3a1a056d4440b7d3adb5af122cdbcbbd1d927d041fd29"
+checksum = "c763f50f10a86f63e6f78234c0d63befa5b46b782d5138f743f389b1a243d63b"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-mmap"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1124e4be4c45d8273f9f28681c24ae5a3b393441b30c10cf2c3f7692707004"
+checksum = "faf3591b4795ae6740f4ad4b8d365a4f9bf1b77799d430c822e8c1f738e18126"
 dependencies = [
  "memmap2",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aeaded913fa693dc145f7c3a378b49e195b226e0c2c9318d282ca423f8f4b2b"
+checksum = "30d9fa6335bce790ec5f57b1bd762a2c54520195f2e378fffde54630b2a957a8"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5175,18 +5176,18 @@ dependencies = [
 
 [[package]]
 name = "sley-object"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74167af96f5f784a2122ba3506cb2f8019a8b2cc107f81c8d3430a818d1244c"
+checksum = "18cbcd54d6aef27a6e3627f83ce68bbfc033ac0f075dc5859dc2a26333a94606"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4a10fbaddd0c8709e1f6098469d69d03b3446d8e1a13e380b76b1929ae489a"
+checksum = "4fd3047404e77f7ee53efa2fc2606ba8443665b5358a76500229ab926be96cc7"
 dependencies = [
  "flate2",
  "sley-core",
@@ -5198,9 +5199,9 @@ dependencies = [
 
 [[package]]
 name = "sley-pack"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431fbde30a6cb73bf8d301477a16b755033165abbbc52fe29fcc9eeed8b5456"
+checksum = "68f205452264d24418b51d77b811165ae092e523ad9ba95595696e97c2e6c8fa"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -5211,27 +5212,27 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd642bcd02a72dd870e74e623cc42beaea82ab503fafb13f519b95cd0e15be"
+checksum = "9bb6e40c786240da63141b1fb267fd3cf2c73ecc6965aff359716eb4cea56692"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-protocol"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b6b7a1909dd14100c770cd644df8f147968e48d1cf9b33b69d5363793645448"
+checksum = "a555d68141bc1453483b02e31719dafae04e3a87df691955fa444e204accc785"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-refs"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7759dd3da75c96bbdfd0e6a5a5b272374b7fc83032350067d3111a162e4b3f2"
+checksum = "2b91093b5d94762504689c94baffabad7b7fee410a60953b5c68b0f70494f191"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5240,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b029cf50f2a906b2f6f6e39129426e39156f60d2d24924eb4a26078500a575b8"
+checksum = "4bd9386a28273f15b6ba1edde56aaa4c22ba71078034c51688d4eb42014d1392"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5260,9 +5261,9 @@ dependencies = [
 
 [[package]]
 name = "sley-rev"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3d898c81f739d8403372b1e61b9213ecf3f026573008f7e3793f2ff1c608ae"
+checksum = "ba1cf41b88091983e87de5a8d136378176678e63d4579e9fb6517dacf78dd93d"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5278,9 +5279,9 @@ dependencies = [
 
 [[package]]
 name = "sley-sequencer"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82eeccc819fbbce5d8c836c1acb3186d1bce8771de3cbcae0a7835743b9f3ee4"
+checksum = "42ee1cfb5f8d71c2717b380cb7f52f89856d5a9cf2203627b2d35af8516c499f"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -5292,9 +5293,9 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60782fd96e7c7f83b35ced0c71875bc670833514072ffb2faad28efd950a0d3d"
+checksum = "3c9e1a8e4b9c081c3d2ef6690c9ed5367082060ee978c2cb69e97f1c87f57351"
 dependencies = [
  "sley-core",
  "sley-protocol",
@@ -5303,9 +5304,9 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.0.3"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8094d80b0b36e8f1f1bf35afcd8a6bca2a37f1ddf163034d64b0a168ae7928d"
+checksum = "b1b0bf1828a45149ecba5b8bcb503efdb4188add474bb6df82bb9f2e0ee2b74f"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -5316,6 +5317,7 @@ dependencies = [
  "sley-odb",
  "sley-pathspec",
  "sley-refs",
+ "sley-rev",
 ]
 
 [[package]]
@@ -6718,7 +6720,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.2.4"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
+version = "0.3.1"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"
@@ -50,7 +51,7 @@ clap_complete = "4"
 ed25519-dalek = { version = "2", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
-sley = { version = "0.0.3", features = ["mmap", "fast-sha1"] }
+sley = { version = "0.1.0", features = ["mmap", "fast-sha1"] }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.3.0",
+  "schemaVersion": "0.3.1",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.3.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.3.1" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli-shared"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "CLI-side utilities shared between Heddle's OSS cli crate and the closed heddle-client crate: user config, remote target resolution, client config."
@@ -11,9 +11,9 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+proto = { path = "../proto", package = "heddle-proto", version = "0.3", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-cli"
-version = "0.3.0"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -32,30 +32,30 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.3" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.3" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.3" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
-heddle-client = { path = "../client", version = "0.2", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.3" }
+heddle-client = { path = "../client", version = "0.3", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.3" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.2", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2" }
-proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.3", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.3" }
+proto = { path = "../proto", package = "heddle-proto", version = "0.3", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.3", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -104,13 +104,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.2", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.3", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.2", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.3", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.2", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.3", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-client"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Heddle hosted-backend client: auth, support, presence, the gRPC client wrappers, and the global credential store."
@@ -29,14 +29,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.2" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.3" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.3" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+proto = { path = "../proto", package = "heddle-proto", version = "0.3", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.3" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-crypto"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-daemon"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Heddle local-mode gRPC daemon and service implementations"
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.3" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.3", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.2", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.2" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.3" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.3", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/devtools/Cargo.toml
+++ b/crates/devtools/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-devtools"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Developer tooling for the Heddle workspace"

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-ingest"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Import git history (commits, refs, reflogs) into a native Heddle repository with agent attribution and reasoning annotations."
@@ -16,14 +16,14 @@ name = "heddle-ingest"
 path = "src/bin/main.rs"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.2", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.3" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.3" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-merge"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-mount"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.3" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-objects"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -37,7 +37,7 @@ tokio = { workspace = true, optional = true }
 
 aws-sdk-s3 = { workspace = true, optional = true }
 aws-smithy-async = { workspace = true, optional = true }
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.3", optional = true }
 
 [features]
 bench = []

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-oplog"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -11,11 +11,11 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.3", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/proto/Cargo.toml
+++ b/crates/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-proto"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-refs"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -12,14 +12,14 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.2", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.3", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-repo"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.2" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.2" }
-proto = { path = "../proto", package = "heddle-proto", version = "0.2", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.3" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.3" }
+proto = { path = "../proto", package = "heddle-proto", version = "0.3", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.3" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.2", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.3", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.3", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true

--- a/crates/review/Cargo.toml
+++ b/crates/review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-review"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/runtime-bridge/Cargo.toml
+++ b/crates/runtime-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-runtime-bridge"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Sync→async runtime bridge for Heddle: worker thread + private Tokio runtime, safe to call from any caller flavor."

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-semantic"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.2" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.2", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.3" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-state-review"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description.workspace = true
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.2" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.2" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.3" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.3" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weft-client-shim"
-version = "0.2.4"
+version.workspace = true
 edition.workspace = true
 authors.workspace = true
 description = "Trait surface for client extensions to the Heddle CLI. OSS default is a noop impl; closed builds replace it via [patch.crates-io]."
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.2", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.3", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
Cut heddle **v0.3.1** and move the workspace to unified versioning.

## Changes
- **Workspace versioning**: `[workspace.package].version = "0.3.1"`; the 19 app/lib crates (incl. the `heddle` CLI, previously 0.3.0; libs were lagging at 0.2.4) now use `version.workspace = true`. Sibling dep requirements bumped `"0.2" → "0.3"`.
- **Left independent** (forced by crates.io monotonicity): `heddle-grpc` stays `0.7.0` (protocol crate on its own semver axis, already published higher), `heddle-cli-macro-poc` stays `0.0.0` (publish=false POC).
- **sley dependency `0.0.3 → 0.1.0`** — picks up the wave-1 parity release (difftool/mergetool/maintenance/status-cache/grep gains). heddle compiles clean against it and `heddle-mount` tests pass (no API or behavior break).

## Local gates (CI does the full run)
- `cargo build --locked --workspace` (default features) ✓
- `cargo build --workspace` ✓ (sley 0.1.0)
- `scripts/check-no-silent-default-tree-load.sh` ✓ (552 files)
- `cargo test -p heddle-mount` ✓

On merge, `publish-crates.yml` auto-publishes the bumped crates to crates.io; tag `v0.3.1` then drives the `release.yml` binary builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784342816&installation_id=132405951&pr_number=747&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F747&signature=70d7cd11473a9f0f93162e29f90ac35a4c0f919adc8cd15489ddd9cbf7d7b8d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->