### PR TITLE
fix(ci): publish-crates reads workspace-inherited versions

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -188,6 +188,12 @@ jobs:
             # First version line under [package] (the [[bin]] /
             # [[example]] sections don't carry a version key).
             local_version=$(awk -F'"' '/^\[package\]/{in_pkg=1; next} /^\[/{in_pkg=0} in_pkg && /^version\s*=/{print $2; exit}' "$manifest")
+            # Workspace-inherited version (version.workspace = true): the awk
+            # above only reads a literal [package] version, so fall back to the
+            # shared version in the root [workspace.package] table.
+            if [[ -z "$local_version" ]] && grep -qE '^version\.workspace[[:space:]]*=[[:space:]]*true' "$manifest"; then
+              local_version=$(awk -F'"' '/^\[workspace.package\]/{in_ws=1; next} /^\[/{in_ws=0} in_ws && /^version[[:space:]]*=/{print $2; exit}' Cargo.toml)
+            fi
             if [[ -z "$local_version" ]]; then
               echo "::error::${manifest} has no [package] version"
               exit 1


### PR DESCRIPTION
## Problem
After the v0.3.1 workspace-versioning conversion (#747), the `publish-crates.yml` validate step failed with `crates/objects/Cargo.toml has no [package] version`, so the 0.3.1 lib publish to crates.io never ran (binaries + brew released fine; libs are still at 0.2.4).

The validate parser reads a **literal** `[package] version` via `awk '/^version\s*=/'`, which can't match `version.workspace = true`.

## Fix
When the literal read is empty *and* the crate has `version.workspace = true`, fall back to the shared version in the root `[workspace.package]` table. Pure bash/awk (the validate job has no cargo). Verified locally:
- `crates/objects` (workspace-inherited) → resolves `0.3.1`
- `crates/grpc` (literal) → still reads `0.7.0` (no fallback, stays independent)

Merging this re-triggers `publish-crates.yml` on the main push, which then publishes the 0.3.1 libs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784345735&installation_id=132405951&pr_number=748&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F748&signature=7f1d86fc9ea8e329d94f96dfa41e4c8ed81ab858e26b7c209482526555851e4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->