### PR TITLE
fix(ci): publish heddle-runtime-bridge before heddle-objects

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -74,6 +74,7 @@ env:
   # `publish = true` in Cargo.toml is invisible at PR review time, and
   # accidentally flipping it would silently expand the public surface.
   PUBLISHABLE_CRATES: |
+    heddle-runtime-bridge
     heddle-objects
     heddle-crypto
     heddle-refs


### PR DESCRIPTION
heddle-objects optionally depends on heddle-runtime-bridge (s3 feature) with a version requirement, so cargo publish requires it on crates.io — but it was missing from PUBLISHABLE_CRATES, failing the 0.3.1 lib publish with 'no matching package named heddle-runtime-bridge'. Add it first (leaf crate, no sibling deps). Merging re-triggers publish-crates.yml which then publishes the full 0.3.1 lib set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/749"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784348619&installation_id=132405951&pr_number=749&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F749&signature=1377a4363bfc1dcda95e6598493c3f19701dfd61cccdd9f258aa310623d33085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->