### PR TITLE
fix(ci): complete the PUBLISHABLE_CRATES list (close the publish-drip class)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -74,23 +74,25 @@ env:
   # `publish = true` in Cargo.toml is invisible at PR review time, and
   # accidentally flipping it would silently expand the public surface.
   PUBLISHABLE_CRATES: |
+    heddle-devtools
+    heddle-grpc
+    heddle-merge
+    heddle-review
     heddle-runtime-bridge
     heddle-objects
     heddle-crypto
-    heddle-refs
     heddle-oplog
     heddle-proto
+    heddle-refs
     heddle-semantic
-    heddle-devtools
-    heddle-grpc
-    heddle-review
     heddle-state-review
     heddle-repo
-    heddle-mount
-    heddle-ingest
     heddle-cli-shared
-    weft-client-shim
     heddle-daemon
+    heddle-ingest
+    heddle-mount
+    weft-client-shim
+    heddle-client
     heddle-cli
 
 jobs:


### PR DESCRIPTION
The hardcoded `PUBLISHABLE_CRATES` list drifted incomplete — missing `heddle-merge` + `heddle-client` (and `heddle-runtime-bridge`, added #749) from the true 20-crate publish closure. Each missing crate fails the 0.3.1 publish at its first dependent ('no matching package named X'), one drip per run (runtime-bridge → objects → now heddle-merge via heddle-semantic). 

Replace the list with the **complete publish closure** (all publish!=false crates), **topologically ordered** (normal+build deps, deps-first) so each crate's deps are live before it publishes. Computed via cargo metadata; the workflow's runtime topo-validation guards correctness. Merging re-triggers the publish, which should now complete the full 0.3.1 lib set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784351560&installation_id=132405951&pr_number=750&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F750&signature=dfb141e033343e1cbf58b02e333535ee67feea43879a333bfc07997f42551068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->