### PR TITLE
[codex] Improve macOS FSKit release flow and CI gates

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,20 +4,20 @@ name: Supply-chain audit
 #
 # - cargo-deny enforces the policy in deny.toml (licenses, banned crates,
 #   advisories, registry/git sources).
-# - cargo-audit cross-checks the RustSec advisory DB. cargo-deny already
-#   reads the same DB; running cargo-audit too gives us a second tool's
-#   take and surfaces yanked-crate warnings explicitly.
+# - cargo-audit cross-checks the RustSec advisory DB on main/schedule/manual.
+#   cargo-deny already reads the same DB, so it remains the PR gate while
+#   cargo-audit gives us a second tool's take outside the hot PR path.
 #
 # The weekly cron catches advisories filed against unchanged dependencies
 # (a new CVE against a crate we already ship will trip the gate on Monday
 # even if no one has pushed code).
 
 on:
-  # Run on every PR (no paths filter). If we limited to Cargo*/deny.toml
+  # cargo-deny runs on every PR (no paths filter). If we limited to Cargo*/deny.toml
   # changes and this workflow is set as a Required check, GitHub leaves the
   # required-but-skipped run pending forever for PRs that don't touch those
   # files, blocking merge. Always-run keeps the gate workable as a Required
-  # check; the work itself is fast enough that it doesn't matter.
+  # check; cargo-audit is scheduled/main/manual only below.
   pull_request:
     branches:
       - main
@@ -58,6 +58,7 @@ jobs:
 
   cargo-audit:
     name: cargo-audit
+    if: github.event_name != 'pull_request'
     runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release-pipeline-check.yml
+++ b/.github/workflows/release-pipeline-check.yml
@@ -49,17 +49,16 @@ jobs:
       - name: Assert publish pipeline contract
         run: bash scripts/check-publish-pipeline.sh
 
-  no-silent-default-tree-load:
-    name: no silent-default tree load (heddle#90 + #93)
+  rust-ast-invariants:
+    name: Rust AST invariant checks
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
-      # The asserter is now a Rust binary (heddle-devtools subcommand)
-      # using `syn` to walk the AST — replaced the regex implementation
-      # after three rounds of bypass-and-patch (heddle#103). Rust
-      # toolchain + cache so the build is fast on warm caches.
+      # The asserters are Rust binaries (heddle-devtools subcommands) using
+      # `syn` to walk the AST. Build once, then run every AST-backed invariant
+      # check so PRs do not pay for duplicate toolchain/cache setup.
       - uses: dtolnay/rust-toolchain@stable
 
       - uses: Swatinem/rust-cache@v2
@@ -70,37 +69,22 @@ jobs:
       - name: Build asserter binary
         run: cargo build -p heddle-devtools --quiet
 
-      # The mutation tests run first: if a future edit defeats the
-      # asserter (e.g. by loosening the chain walk or widening the
-      # allowlist to prefix match), the self-tests fail before the
+      # Silent-default tree load (heddle#90 + heddle#93): reject the bug
+      # class where `get_tree(...)?.unwrap_or_default()` silently substituted
+      # `Tree::default()` for a missing subtree, masking store corruption as
+      # empty content / silent erase / silent no-op. The mutation tests run
+      # first so a future edit that defeats the asserter fails before the
       # asserter has a chance to silently pass on production code.
-      - name: Asserter self-tests (mutation fixtures)
+      - name: Silent-default tree-load asserter self-tests
         run: bash scripts/test-check-no-silent-default-tree-load.sh
 
-      - name: Assert no `get_tree(...)?.unwrap_or_default()` regressions
+      - name: Assert no silent-default tree-load regressions
         run: bash scripts/check-no-silent-default-tree-load.sh
 
-  no-publish-first-snapshot:
-    name: no cross-crate publish-first snapshot (heddle#354 r8)
-    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v4
-
-      # Workspace-wide `syn` AST walker (heddle-devtools subcommand): a
-      # snapshot must record its `OpRecord::Snapshot` before publishing
-      # the paired ref. Closes the cross-crate coverage hole the
-      # refs-internal r7 conformance left.
-      - uses: dtolnay/rust-toolchain@stable
-
-      - uses: Swatinem/rust-cache@v2
-        with:
-          shared-key: asserter-${{ runner.os }}
-          cache-on-failure: true
-
-      - name: Build asserter binary
-        run: cargo build -p heddle-devtools --quiet
-
+      # Cross-crate publish-first snapshot (heddle#354 r8): a snapshot must
+      # record its `OpRecord::Snapshot` before publishing the paired ref.
+      # Closes the cross-crate coverage hole the refs-internal r7 conformance
+      # left.
       - name: Assert no cross-crate publish-first snapshot regressions
         run: bash scripts/check-snapshot-atomicity.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ name: Release binaries
 # Trigger: stable-semver tag push (vX.Y.Z) OR manual workflow_dispatch
 # with an existing tag (used for RC dry-runs). The job tree:
 #
-#   validate-tag ──► build (matrix, 5 CLI targets) ──┐
-#              └──► build-macos-cask ────────────────┤
+#   validate-tag ──► build (matrix, non-mac CLI targets) ─┐
+#              └──► build-macos-cask (macOS CLI + DMG) ───┤
 #                                                    ├─► sign + checksum
 #                                                    ├─► release (aggregates, publishes, posts SHA256SUMS)
 #                                                    └─► publish-manifests (stable only)
@@ -19,10 +19,12 @@ name: Release binaries
 # the raw trigger ref. This keeps the answer to "is this a sanctioned
 # release?" in exactly one place.
 #
-# Strategy: one build-matrix leg per target. Rationale lives in
-# RELEASING.md — short version: Linux keeps a pinned glibc floor,
-# Windows stays on an MSVC host, and macOS legs run on macos-26 so
-# every Apple artifact compiles against the same FSKit SDK floor.
+# Strategy: one build-matrix leg per non-mac target; the macOS cask job owns
+# the Apple builds once and packages both the standalone CLI tarballs and the
+# signed DMG from those same binaries. Rationale lives in RELEASING.md —
+# short version: Linux keeps a pinned glibc floor, Windows stays on an MSVC
+# host, and macOS runs on macos-26 so every Apple artifact compiles against
+# the same FSKit SDK floor.
 #
 # Signing: cosign keyless via the Sigstore public-good instance. No
 # stored secrets — the GitHub OIDC token is the trust anchor. Verifying
@@ -208,23 +210,15 @@ jobs:
           echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"
 
   build:
-    name: build ${{ matrix.target }}
+    name: build non-mac ${{ matrix.target }}
     needs: validate-tag
+    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.branch_dry_run }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
-          - target: aarch64-apple-darwin
-            runner: macos-26
-            archive: tar.gz
-          - target: x86_64-apple-darwin
-            # Keep standalone CLI tarballs on the same macOS 26 image
-            # as the cask builder so FSKit's SDK/deployment floor never
-            # splits across release artifacts.
-            runner: macos-26
-            archive: tar.gz
           - target: aarch64-unknown-linux-gnu
             # glibc floor: ubuntu-22.04 ships glibc 2.35, so the -gnu
             # binaries run on Debian 12 (2.36) and Ubuntu 22.04+ forward.
@@ -439,30 +433,59 @@ jobs:
           HEDDLE_NOTARY_ISSUER_ID: ${{ secrets.HEDDLE_NOTARY_ISSUER_ID }}
         run: scripts/build-macos-cask-artifact.sh
 
-      - name: Install cosign
-        uses: sigstore/cosign-installer@v3
-
-      - name: Sign macOS cask artifact (cosign keyless)
+      - name: Stage macOS CLI artifacts
         shell: bash
         env:
           TAG: ${{ needs.validate-tag.outputs.tag }}
         run: |
           set -euo pipefail
-          asset="dist/Heddle-${TAG}-macos-universal.dmg"
-          cosign sign-blob --yes \
-            --output-signature "${asset}.sig" \
-            --output-certificate "${asset}.pem" \
-            "$asset"
+          for target in aarch64-apple-darwin x86_64-apple-darwin; do
+            stage="heddle-${TAG}-${target}"
+            mkdir -p "dist/${stage}"
+            cp "target/${target}/release/${BIN_NAME}" "dist/${stage}/"
+            cp README.md LICENSE NOTICE "dist/${stage}/"
+            tar -C dist -czf "dist/${stage}.tar.gz" "${stage}"
+            ( cd dist && shasum -a 256 "${stage}.tar.gz" > "${stage}.tar.gz.sha256" )
+          done
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign macOS artifacts (cosign keyless)
+        shell: bash
+        env:
+          TAG: ${{ needs.validate-tag.outputs.tag }}
+        run: |
+          set -euo pipefail
+          assets=(
+            "dist/Heddle-${TAG}-macos-universal.dmg"
+            "dist/heddle-${TAG}-aarch64-apple-darwin.tar.gz"
+            "dist/heddle-${TAG}-x86_64-apple-darwin.tar.gz"
+          )
+          for asset in "${assets[@]}"; do
+            cosign sign-blob --yes \
+              --output-signature "${asset}.sig" \
+              --output-certificate "${asset}.pem" \
+              "$asset"
+          done
 
       - name: Upload macOS cask outputs
         uses: actions/upload-artifact@v4
         with:
-          name: heddle-macos-cask
+          name: heddle-macos-artifacts
           path: |
             dist/Heddle-${{ needs.validate-tag.outputs.tag }}-macos-universal.dmg
             dist/Heddle-${{ needs.validate-tag.outputs.tag }}-macos-universal.dmg.sha256
             dist/Heddle-${{ needs.validate-tag.outputs.tag }}-macos-universal.dmg.sig
             dist/Heddle-${{ needs.validate-tag.outputs.tag }}-macos-universal.dmg.pem
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-aarch64-apple-darwin.tar.gz
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-aarch64-apple-darwin.tar.gz.sha256
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-aarch64-apple-darwin.tar.gz.sig
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-aarch64-apple-darwin.tar.gz.pem
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-x86_64-apple-darwin.tar.gz
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-x86_64-apple-darwin.tar.gz.sha256
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-x86_64-apple-darwin.tar.gz.sig
+            dist/heddle-${{ needs.validate-tag.outputs.tag }}-x86_64-apple-darwin.tar.gz.pem
           if-no-files-found: error
           retention-days: 7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,13 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to build (vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]). Dispatch-triggered runs always publish as prerelease+draft.'
+        description: 'Existing tag to build (vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]); or a synthetic prerelease tag when branch_dry_run is true.'
         required: true
+      branch_dry_run:
+        description: 'TEMP: build from the selected branch/ref without publishing a GitHub Release.'
+        type: boolean
+        required: false
+        default: false
 
 permissions:
   contents: write   # create release + upload assets
@@ -66,6 +71,7 @@ jobs:
       # SHA, not refs/tags/<tag> — see TOCTOU note in the classify step.
       tag_sha: ${{ steps.classify.outputs.tag_sha }}
       kind: ${{ steps.classify.outputs.kind }}
+      publish_release: ${{ steps.classify.outputs.publish_release }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -80,6 +86,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           PUSH_REF: ${{ github.ref }}
           DISPATCH_TAG: ${{ inputs.tag }}
+          BRANCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.branch_dry_run }}
         run: |
           set -euo pipefail
 
@@ -106,26 +113,7 @@ jobs:
             exit 1
           fi
 
-          # 2. Reject anything that is not a real tag in this repo. This
-          #    catches workflow_dispatch with 'main', a typo, or a
-          #    deleted tag — none of which should reach the build job.
-          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
-            echo "::error::'${tag}' is not a tag in this repository"
-            exit 1
-          fi
-
-          # 3. The pipeline only ships releases from main. A tag pointed
-          #    at a feature branch (deliberately or accidentally) must
-          #    not produce signed binaries with the heddle release OIDC
-          #    identity. The tag-push trigger does not enforce branch
-          #    ancestry on its own, so we do it here.
-          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
-            echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
-            exit 1
-          fi
-
-          # 4. Classify. Tag pattern decides the *shape* of release;
+          # 2. Classify. Tag pattern decides the *shape* of release;
           #    event source decides whether it ships as a final release.
           #    Dispatch runs are *always* prerelease+draft so an operator
           #    dry-run cannot accidentally publish a public, non-draft
@@ -140,7 +128,49 @@ jobs:
             exit 1
           fi
 
-          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+          # TEMP: branch_dry_run is for PR validation of release-only
+          # signing/notarization paths. It builds artifacts from the
+          # manually selected workflow ref, skips the GitHub Release job,
+          # and still requires a prerelease-shaped synthetic tag so asset
+          # names remain realistic. Remove once the release artifact guard
+          # has been verified in CI.
+          if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" == "true" ]]; then
+            if [[ "$PUSH_REF" != refs/heads/* ]]; then
+              echo "::error::branch_dry_run must be dispatched from a branch ref, got: $PUSH_REF"
+              exit 1
+            fi
+            if [[ "$tag" =~ $stable_re ]]; then
+              echo "::error::branch_dry_run requires a prerelease-shaped synthetic tag (vX.Y.Z-rc.N), got stable tag '${tag}'"
+              exit 1
+            fi
+            tag_sha="$(git rev-parse HEAD)"
+            kind=prerelease
+            publish_release=false
+            echo "::notice::TEMP branch_dry_run building ${tag} from ${PUSH_REF} (${tag_sha}) without publishing a GitHub Release"
+          else
+            # 3. Reject anything that is not a real tag in this repo. This
+            #    catches workflow_dispatch with 'main', a typo, or a
+            #    deleted tag — none of which should reach the release job.
+            if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+              echo "::error::'${tag}' is not a tag in this repository"
+              exit 1
+            fi
+
+            # 4. The pipeline only ships releases from main. A tag pointed
+            #    at a feature branch (deliberately or accidentally) must
+            #    not produce signed release assets with the heddle release
+            #    OIDC identity. The tag-push trigger does not enforce
+            #    branch ancestry on its own, so we do it here.
+            tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+            if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
+              echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
+              exit 1
+            fi
+
+            publish_release=true
+          fi
+
+          if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" != "true" ]]; then
             # Dispatch is the RC/dry-run path. Stable tags MUST go through
             # the push trigger so they cannot be retroactively downgraded:
             # softprops/action-gh-release UPDATES an existing release when
@@ -154,9 +184,9 @@ jobs:
               exit 1
             fi
             kind=prerelease
-          elif [[ "$tag" =~ $stable_re ]]; then
+          elif [[ "$EVENT" == "push" && "$tag" =~ $stable_re ]]; then
             kind=stable
-          else
+          elif [[ "$EVENT" == "push" ]]; then
             # Push trigger but the tag is not strict semver. The push
             # filter should have blocked this; if it slipped through,
             # fail loudly rather than silently downgrading.
@@ -175,6 +205,7 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
           echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+          echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"
 
   build:
     name: build ${{ matrix.target }}
@@ -438,6 +469,7 @@ jobs:
   release:
     name: publish release
     needs: [validate-tag, build, build-macos-cask]
+    if: needs.validate-tag.outputs.publish_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -40,7 +40,9 @@ jobs:
   #
   # Outputs:
   #   docs_only — every changed path is doc-only (see below); skip all Rust.
-  #   rust      — !docs_only; gates check-and-test / coverage / postgres / CLI fault-injection.
+  #   release_only — every changed path is release/publish workflow plumbing.
+  #   rust      — !docs_only && !release_only; gates check-and-test / postgres / CLI fault-injection.
+  #   coverage  — Rust source or coverage config changed; gates instrumented coverage.
   #   mount     — a mount-relevant path changed; gates fuse/projfs/fskit checks.
   changes:
     name: Detect changed paths
@@ -48,8 +50,10 @@ jobs:
     timeout-minutes: 5
     outputs:
       rust: ${{ steps.decide.outputs.rust }}
+      coverage: ${{ steps.decide.outputs.coverage }}
       mount: ${{ steps.decide.outputs.mount }}
       docs_only: ${{ steps.decide.outputs.docs_only }}
+      release_only: ${{ steps.decide.outputs.release_only }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,12 +66,14 @@ jobs:
           # diff failure, empty diff) run the full matrix. The alternative
           # — silently skipping because an errored/empty diff matched no
           # path regex — is the "infrastructure failure removes coverage"
-          # pattern Codex hardened `fuse-bench-gate` against (heddle#89).
+          # pattern hardened in heddle#89.
           run_all() {
             echo "$1; running full matrix fail-closed" >&2
             echo "rust=true" >> "$GITHUB_OUTPUT"
+            echo "coverage=true" >> "$GITHUB_OUTPUT"
             echo "mount=true" >> "$GITHUB_OUTPUT"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            echo "release_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           }
           if [ "${{ github.event_name }}" != "pull_request" ]; then
@@ -99,16 +105,40 @@ jobs:
           # and are NOT doc-only — only `docs/spikes/**` is exempt there,
           # making it the sole doc-only prefix. Fail-safe: any path outside
           # it ⇒ not doc-only ⇒ rust=true (run the suite).
-          if printf '%s\n' "$diff_output" | grep -vE '^(docs/spikes/|[[:space:]]*$)' \
+          if ! printf '%s\n' "$diff_output" | grep -vE '^(docs/spikes/|[[:space:]]*$)' \
               > /dev/null; then
-            docs_only=false
-            rust=true
-          else
             docs_only=true
-            rust=false
+          else
+            docs_only=false
           fi
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
+
+          # release_only: release/publish workflow plumbing that has its own
+          # static contract workflow and should not burn the Rust test matrix.
+          # Any source, Cargo, non-release script, or product doc path falls
+          # through to rust=true below.
+          if ! printf '%s\n' "$diff_output" | grep -vE '^((\.github/workflows/(release|release-pipeline-check|publish-crates)\.yml|RELEASING\.md|scripts/(check-release-pipeline|check-publish-pipeline|render-homebrew-cask|build-macos-cask-artifact)\.sh|crates/mount/swift/HeddleHost/(README\.md|dmg/.*))|[[:space:]]*)$' \
+              > /dev/null; then
+            release_only=true
+          else
+            release_only=false
+          fi
+          echo "release_only=$release_only" >> "$GITHUB_OUTPUT"
+
+          if [ "$docs_only" = "true" ] || [ "$release_only" = "true" ]; then
+            rust=false
+          else
+            rust=true
+          fi
           echo "rust=$rust" >> "$GITHUB_OUTPUT"
+
+          if [ "$rust" = "true" ] && printf '%s\n' "$diff_output" | grep -E \
+              '^(crates/|Cargo\.lock$|Cargo\.toml$|codecov\.yml$|docs/contributor-guide/coverage\.md$|\.github/workflows/rust-tests\.yml)' \
+              > /dev/null; then
+            echo "coverage=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "coverage=false" >> "$GITHUB_OUTPUT"
+          fi
 
           # mount: use the transitive mount-relevant path set (mount → repo →
           # {crypto, oplog, proto, objects, refs} → optional runtime-bridge,
@@ -189,7 +219,7 @@ jobs:
           while IFS=$'\t' read -r package bench features; do
             [ -n "$package" ] || continue
             if [ "$features" = "fuse" ] || [[ "$features" == fuse,* ]] || [[ "$features" == *,fuse ]] || [[ "$features" == *,fuse,* ]]; then
-              echo "skipping $package/$bench: fuse benches are covered by the fuse-bench job"
+              echo "skipping $package/$bench: fuse benches are covered by the fuse-smoke job"
               continue
             fi
             echo "::group::$package/$bench"
@@ -525,26 +555,6 @@ jobs:
         shell: pwsh
         run: sccache --show-stats
 
-  # FUSE end-to-end bench gate. PRs compile-check FUSE benches in
-  # `fuse-smoke` when mount-relevant paths change; actual performance
-  # measurements live in the scheduled/manual `Benchmarks` workflow and on
-  # pushes to main. That keeps PRs from waiting on noisy timing measurements
-  # while still refreshing the baseline after merge.
-  fuse-bench-gate:
-    name: FUSE bench gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      run: ${{ steps.decide.outputs.run }}
-    steps:
-      - id: decide
-        run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
-
   # FUSE end-to-end bench. Drives the `fuse_e2e` criterion suite
   # through a real `FuseShell::mount_background` session, then
   # `scripts/fuse-bench-compare.py` flags any workload that
@@ -556,8 +566,10 @@ jobs:
   fuse-bench:
     name: FUSE bench (Linux)
     runs-on: ubuntu-latest
-    needs: fuse-bench-gate
-    if: needs.fuse-bench-gate.outputs.run == 'true'
+    # PRs compile-check FUSE benches in `fuse-smoke` when mount-relevant paths
+    # change. Run noisy timing measurements only after merge to refresh the
+    # committed baseline signal.
+    if: github.event_name == 'push'
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -642,7 +654,7 @@ jobs:
   coverage:
     name: Coverage
     needs: changes
-    if: needs.changes.outputs.rust == 'true'
+    if: needs.changes.outputs.coverage == 'true'
     runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 60
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -33,17 +33,15 @@ env:
   SCCACHE_GHA_ENABLED: "false"
 
 jobs:
-  # Path gate for the heavy Rust jobs. Mirrors `fuse-bench-gate`'s
-  # fail-closed contract (push ⇒ run everything; any fetch/diff error ⇒
-  # run everything) but emits a broader set of outputs so check-and-test,
-  # coverage, postgres-tests, and the two mount-smoke jobs can skip on PRs
-  # that can't affect them. Most of the CI bill on this repo is doc/spike
-  # PRs (often several Codex rounds) re-running the full matrix per round.
+  # Path gate for the heavy Rust jobs. Pushes run everything; PRs fetch/diff
+  # against the base branch, and any uncertainty falls back to running the full
+  # matrix. Most of the CI bill on this repo is doc/spike PRs (often several
+  # Codex rounds) re-running the full matrix per round.
   #
   # Outputs:
   #   docs_only — every changed path is doc-only (see below); skip all Rust.
   #   rust      — !docs_only; gates check-and-test / coverage / postgres / CLI fault-injection.
-  #   mount     — a mount-relevant path changed; gates fuse/projfs smoke.
+  #   mount     — a mount-relevant path changed; gates fuse/projfs/fskit checks.
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
@@ -112,11 +110,11 @@ jobs:
           echo "docs_only=$docs_only" >> "$GITHUB_OUTPUT"
           echo "rust=$rust" >> "$GITHUB_OUTPUT"
 
-          # mount: reuse the exact transitive mount-relevant path set
-          # `fuse-bench-gate` computes (mount → repo → {crypto, oplog,
-          # proto, objects, refs} → optional runtime-bridge, plus the
-          # compare script, the workflow, and shared workspace inputs).
-          # Keep this regex in sync with the one in `fuse-bench-gate`.
+          # mount: use the transitive mount-relevant path set (mount → repo →
+          # {crypto, oplog, proto, objects, refs} → optional runtime-bridge,
+          # plus the compare script, the workflow, and shared workspace
+          # inputs) so mount adapters and their read-path dependencies trigger
+          # the kernel adapter checks.
           if printf '%s\n' "$diff_output" | grep -E \
               '^(crates/(mount|objects|repo|refs|oplog|crypto|proto|runtime-bridge)/|scripts/fuse-bench-compare\.py|scripts/tests/|\.github/workflows/rust-tests\.yml|Cargo\.lock$|Cargo\.toml$)' \
               > /dev/null; then
@@ -159,61 +157,21 @@ jobs:
       - name: Clippy (OSS features)
         run: cargo clippy --locked --workspace --all-targets -- -D warnings
 
-      # 3a-bis. Round-trip fidelity conformance gate (heddle#533) — run BEFORE
-      #     the broad `cargo test --workspace` so a fidelity regression fails
-      #     THIS clearly-named step first instead of being buried in the
-      #     generic Tests run. heddle's foundational promise is lossless git
-      #     overlay: adopt/import a public repo and export it back must
-      #     reproduce byte-identical git object SHAs (commit/tree/blob/
-      #     annotated-tag) and be `git fsck` clean, across a spread of
-      #     generated repos (linear / merge / octopus / tags / notes /
-      #     submodule-gitlink / binary / unicode / exec-bit / nested trees).
-      #     Correctness, asserted per-PR — NOT a weekly perf bench.
-      - name: Round-trip fidelity conformance gate
-        run: cargo test --locked -p heddle-cli --test roundtrip_fidelity -- --nocapture
-
-      # 3. Run tests — test binaries already compiled in step 1.
+      # 3. Run tests — test binaries already compiled in step 1. This covers
+      #    the round-trip fidelity and CLI release-gate integration tests; keep
+      #    targeted re-runs out of this job unless they add coverage rather than
+      #    just a friendlier step name.
       - name: Tests
         run: cargo test --locked --workspace
 
-      # 3a. World-class CLI release gates. These duplicate a narrow slice
-      #     of the full test run on purpose: the job log names the hard
-      #     gates from docs/CLI_WORLD_CLASS_RUBRIC.md directly, so schema
-      #     drift, docs drift, hidden runtime git dependencies, no-git
-      #     overlay workflows, Sley Git-engine parity, public help
-      #     reachability, auto output, TTY output, exit-code,
-      #     corrupt-repo recovery, and destructive-safety regressions are
-      #     easy to diagnose.
-      - name: CLI world-class release gates
-        run: |
-          cargo test --locked -p heddle-cli --test git_process_lint -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration git_replacement_matrix -- --nocapture
-          cargo test --locked -p heddle-cli --test git_bridge_integration round_trip_preserves_annotated_tag_object_sha -- --nocapture
-          cargo test --locked -p heddle-cli --test git_bridge_integration import_populates_mirror_with_identical_annotated_tag_object -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration remotes::test_cli_raw_git_clone_adopt_fetches_notes_before_import -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration remotes::git_overlay_remote_remove_uneditable_include_leaves_both_configs_unmutated -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration public_command_paths_have_all_required_help_entrypoints -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration default_auto_output_is_json_when_stdout_is_piped_and_text_when_forced -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration narrow_no_color_text_outputs_cover_everyday_read_surfaces -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration tty_auto_mode_renders_text_and_explicit_json_stays_json -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration global_exit_codes_and_failure_streams_are_predictable -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration start_merge_undo_json_workflow_keeps_machine_streams_clean -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration thread_cleanup -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration test_cli_capture_blocks_large_git_overlay_deletion_without_force -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration doctor_schemas_has_no_drift_or_unmatched_registered_verbs -- --nocapture
-          cargo test --locked -p heddle-cli --test cli_integration doctor_docs -- --nocapture
-          target/debug/heddle --repo "$PWD" doctor schemas --output json
-          target/debug/heddle --repo "$PWD" doctor docs --all --output json
-
-      # 3b. Unit tests for `scripts/fuse-bench-compare.py`. The perf gate
+      # 3a. Unit tests for `scripts/fuse-bench-compare.py`. The perf gate
       #     is only as honest as the compare script; these tests pin the
       #     "missing or corrupt estimates fail closed" contract (Codex r1
       #     P1 on heddle#89). Plain `unittest`, no third-party deps.
       - name: Bench-compare script unit tests
         run: python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
 
-      # 3c. Compile every workspace benchmark target in the dev profile
+      # 3b. Compile every workspace benchmark target in the dev profile
       #     without running the measurements. The weekly benchmark workflow
       #     owns optimized performance trend tracking and shares the same
       #     discovery helper. This cheap PR-safe guard catches rotten bench
@@ -221,9 +179,9 @@ jobs:
       #     including non-default required features.
       #     Invariant: every target enumerated by `discover-benches.py` is
       #     compile-checked by a PR-time gate. Non-FUSE benches are checked
-      #     here; FUSE benches are skipped here only because the dedicated
-      #     `fuse-bench` job below has libfuse and compile-checks all
-      #     `heddle-mount` benches with `cargo build --features fuse --benches`.
+      #     here; FUSE benches are compile-checked by `fuse-smoke` when
+      #     mount-relevant paths change because that job already installs
+      #     libfuse.
       - name: Compile benchmark targets
         run: |
           python3 scripts/discover-benches.py > benchmark-plan.tsv
@@ -246,7 +204,7 @@ jobs:
             echo "::endgroup::"
           done < benchmark-plan.tsv
 
-      # 3d. Compile gate for the `postgres` storage backends used by hosted /
+      # 3c. Compile gate for the `postgres` storage backends used by hosted /
       #     weft code. This is the silent-rot guard: these backends are not
       #     exercised by the default-feature build above, so a server-path
       #     regression (e.g. a backend that wasn't updated after a newtype
@@ -422,6 +380,15 @@ jobs:
           fusermount3 --version
           ls -l /dev/fuse
 
+      # Compile-check all FUSE benchmark targets without running the
+      # measurements. The scheduled/manual `Benchmarks` workflow owns perf
+      # trends; this PR gate only keeps FUSE bench code from rotting.
+      - name: Compile FUSE benchmark targets
+        env:
+          RUSTC_WRAPPER: sccache
+          SCCACHE_GHA_ENABLED: "false"
+        run: cargo build --locked --features fuse -p heddle-mount --benches
+
       # Single-threaded so a kernel-side hang on one mount can't
       # cascade into the others' tempdir lifetimes. `--nocapture` so
       # the CI log shows the FUSE write/release path if a test
@@ -558,13 +525,11 @@ jobs:
         shell: pwsh
         run: sccache --show-stats
 
-  # FUSE end-to-end bench gate. Decides whether the (expensive)
-  # `fuse-bench` job needs to run for this PR. Skipping the bench on
-  # docs-only / unrelated-crate PRs keeps the CI bill manageable, but
-  # any change that could plausibly move FUSE perf numbers — the
-  # mount adapter itself, or one of its read-path dependencies
-  # (objects, repo, refs) — has to be measured. On `push` to main the
-  # bench always runs so the cache + baseline stay current.
+  # FUSE end-to-end bench gate. PRs compile-check FUSE benches in
+  # `fuse-smoke` when mount-relevant paths change; actual performance
+  # measurements live in the scheduled/manual `Benchmarks` workflow and on
+  # pushes to main. That keeps PRs from waiting on noisy timing measurements
+  # while still refreshing the baseline after merge.
   fuse-bench-gate:
     name: FUSE bench gate
     runs-on: ubuntu-latest
@@ -572,59 +537,9 @@ jobs:
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # Two commits is enough for a PR diff; pushes set run=true
-          # unconditionally so depth doesn't matter there.
-          fetch-depth: 2
       - id: decide
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # PR: diff against base. Bench runs if any mount-relevant
-          # path is touched.
-          #
-          # Fail-closed contract: if `git diff` itself errors (shallow
-          # history, missing merge-base, network flake on the fetch),
-          # we run the bench. The alternative — silently `run=false`
-          # because the regex didn't match an empty/error diff — is
-          # exactly the "infrastructure failure removes perf coverage"
-          # pattern Codex r1 flagged. Capture diff output + check
-          # exit codes separately so we can distinguish "no matching
-          # files" from "diff failed". (heddle#89 / PR #91 r1.)
-          if ! git fetch --no-tags --depth=1 origin "${{ github.base_ref }}"; then
-            echo "fetch failed; running bench fail-closed" >&2
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          set +e
-          diff_output=$(git diff --name-only "origin/${{ github.base_ref }}"...HEAD)
-          diff_rc=$?
-          set -e
-          if [ "$diff_rc" -ne 0 ]; then
-            echo "git diff exited $diff_rc; running bench fail-closed" >&2
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Mount-relevant paths include the bench's own crate + every
-          # transitive read-path dependency, the compare script, the
-          # workflow, AND shared workspace inputs (Cargo.lock, root
-          # Cargo.toml) that can move codegen / dependency versions
-          # under the bench without touching the per-crate sources.
-          #
-          # Transitive set (mount → repo → {crypto, oplog, proto,
-          # objects, refs} → optional runtime-bridge). Keep this in
-          # sync with `crates/mount/Cargo.toml` + the transitive
-          # closure under it; Codex r3 P2 flagged that the original
-          # list (mount|objects|repo|refs) skipped the perf gate when
-          # a PR touched only `crypto`, `oplog`, or `proto` — all of
-          # which compile into the bench binary via `Repository`'s
-          # use sites in `build_heddle_mount`.
-          if printf '%s\n' "$diff_output" | grep -E \
-              '^(crates/(mount|objects|repo|refs|oplog|crypto|proto|runtime-bridge)/|scripts/fuse-bench-compare\.py|scripts/tests/|\.github/workflows/rust-tests\.yml|Cargo\.lock$|Cargo\.toml$)' \
-              > /dev/null; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
@@ -836,6 +751,8 @@ jobs:
   # the HeddleFSKit bridge, so the Swift side is validated too.
   fskit-check:
     name: FSKit compile check (macOS)
+    needs: changes
+    if: needs.changes.outputs.mount == 'true'
     runs-on: macos-26
     timeout-minutes: 30
     env:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,14 +55,16 @@ release-plz → push-to-main flow documented in
      the commit that passed the ancestry check.
 
    If `validate-tag` fails, no build, sign, or publish step runs. If it
-   passes, the matrix proceeds to:
+   passes, the release jobs proceed to:
 
-   - build the `heddle` binary natively on five GitHub-hosted runners
+   - build the non-mac `heddle` binaries natively on Linux/Windows
+     GitHub-hosted runners
    - package each into a versioned archive (`.tar.gz` for unix,
      `.zip` for windows)
-   - build a signed, notarized universal macOS DMG containing
+   - build macOS once in `build-macos-cask`, then package both standalone
+     macOS CLI tarballs and the signed, notarized universal DMG containing
      `Heddle.app`, with the CLI bundled at
-     `Heddle.app/Contents/Resources/bin/heddle`
+     `Heddle.app/Contents/Resources/bin/heddle`, from those same binaries
    - emit a `.sha256` next to each archive
    - sign each archive/DMG with `cosign` keyless (Sigstore public-good
      instance; trust is rooted in the GitHub OIDC token for this run)
@@ -256,15 +258,18 @@ cosign verify-blob \
 
 ## Build strategy: native matrix vs. cross-compilation
 
-We build natively (one GitHub-hosted runner per target) rather than
-cross-compiling from a single host. Trade-off:
+We build natively rather than cross-compiling from a single host, but
+macOS is intentionally consolidated into one job: `build-macos-cask`
+builds both Apple targets once, packages the standalone CLI tarballs, and
+then signs/notarizes the universal app DMG from the same build outputs.
+Trade-off:
 
-- **Targeted matrix (chosen)**: five parallel runners (~5–10 min each
-  with `Swatinem/rust-cache`). No `cross`, no sysroot juggling, no
-  Apple-codesign-on-Linux contortions later if/when we add notarization.
-  Linux ARM stays on `ubuntu-22.04-arm` for the glibc floor; both macOS
-  CLI legs run on `macos-26` so the standalone tarballs and cask app use
-  the same FSKit SDK/deployment floor.
+- **Targeted native jobs (chosen)**: Linux/Windows use a small parallel
+  matrix, while Apple artifacts are built once on `macos-26`. No `cross`,
+  no sysroot juggling, no duplicate macOS CLI builds. Linux ARM stays on
+  `ubuntu-22.04-arm` for the glibc floor; macOS stays on `macos-26` so
+  the standalone tarballs and cask app use the same FSKit SDK/deployment
+  floor.
 - **Cross-compilation**: one runner, more setup. Wins on cost only if
   we hit a parallelism cap, which we won't at our release cadence.
 
@@ -283,9 +288,10 @@ passes:
 - **Smoke (grep).** Cheap content checks: the five target triples, the
   strict-semver push trigger, presence of the `validate-tag` trust gate
   with its ancestry check, packaging/checksum/signing/upload steps, the
-  macOS cask DMG job, the Homebrew cask PR wiring, the
-  draft+prerelease keying off `validate-tag.outputs.kind`, and the
-  stable-tag-refusal on the dispatch path.
+  macOS cask DMG job, the macOS archive ownership by that cask job, the
+  Homebrew cask PR wiring, the draft+prerelease keying off
+  `validate-tag.outputs.kind`, and the stable-tag-refusal on the dispatch
+  path.
 - **Strict (parsed YAML).** Per-job structural checks: `validate-tag`
   exports `tag_sha`, and every downstream job (`build`,
   `build-macos-cask`, `release`, `publish-manifests`) both declares

--- a/crates/cli/src/cli/commands/mount_lifecycle.rs
+++ b/crates/cli/src/cli/commands/mount_lifecycle.rs
@@ -278,10 +278,11 @@ mod linux {
 #[cfg(all(target_os = "macos", feature = "mount"))]
 mod macos {
     use std::{
+        io::{self, IsTerminal, Write},
         path::{Path, PathBuf},
         process::Command,
         sync::Mutex,
-        time::{Duration, Instant},
+        time::Duration,
     };
 
     use anyhow::{Context, Result, anyhow};
@@ -295,14 +296,18 @@ mod macos {
     use crate::{cli::commands::mount_lifecycle::FskitReadinessReport, util::OnceMap};
 
     const MIN_FSKIT_MACOS_MAJOR: u64 = 26;
-    const SETTINGS_PATH: &str = "System Settings → General → Login Items & Extensions → File System Extensions → enable 'Heddle'";
+    const SETTINGS_PATH: &str =
+        "System Settings → General → Login Items & Extensions → File System Extensions";
     const SETTINGS_LOGIN_ITEMS_URL: &str =
         "x-apple.systempreferences:com.apple.LoginItems-Settings.extension";
     const SETTINGS_SEQUOIA_FILE_EXTENSIONS_URL: &str =
         "x-apple.systempreferences:com.apple.LoginItems-Settings.extension?Extensions";
     const FSKIT_INSTALL_HINT: &str = "FSKit fast path available — install the host app: brew install --cask heddle (or download from https://github.com/HeddleCo/heddle/releases)";
     const FSKIT_POLL_INTERVAL: Duration = Duration::from_millis(1_500);
-    const FSKIT_POLL_CAP: Duration = Duration::from_secs(60);
+    const FSKIT_WAIT_MESSAGE: &str =
+        "Waiting for macOS to report Heddle enabled in File System Extensions";
+    const FSKIT_SPINNER_FRAMES: [char; 4] = ['|', '/', '-', '\\'];
+    const FSKIT_LINE_CLEAR_PADDING: &str = "                                                ";
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     struct MacOsVersion {
@@ -489,36 +494,23 @@ mod macos {
                 Readiness::NeedsApproval => {
                     let settings_url = settings_deep_link().url;
                     print_needs_approval_block(settings_url);
+                    wait_for_enter_to_open_settings(settings_url);
                     open_settings(settings_url);
-                    if wait_for_fskit_ready() {
-                        info!(
-                            thread = thread_id,
-                            "FSKit extension enabled during poll; using `mount -F -t heddle`"
-                        );
-                        mount_via_fskit_or_nfs(
-                            &root,
-                            thread_id,
-                            mountpoint,
-                            FsKitMountReport {
-                                state: "ready_after_approval",
-                                action: "mounted_after_poll",
-                                settings_url: Some(settings_url),
-                            },
-                        )?
-                    } else {
-                        eprintln!(
-                            "Heddle FSKit extension still disabled after 60s; using NFS for this run. Enable it and re-run for the fast path."
-                        );
-                        MacOsMountOutcome::nfs(
-                            mount_via_nfs(&root, thread_id, mountpoint)?,
-                            Some(FskitReadinessReport {
-                                state: "needs_approval",
-                                backend: "nfs",
-                                action: "poll_timeout_fell_back",
-                                settings_url: Some(settings_url),
-                            }),
-                        )
-                    }
+                    wait_for_fskit_ready();
+                    info!(
+                        thread = thread_id,
+                        "FSKit extension enabled during poll; using `mount -F -t heddle`"
+                    );
+                    mount_via_fskit_or_nfs(
+                        &root,
+                        thread_id,
+                        mountpoint,
+                        FsKitMountReport {
+                            state: "ready_after_approval",
+                            action: "mounted_after_poll",
+                            settings_url: Some(settings_url),
+                        },
+                    )?
                 }
                 Readiness::NotInstalled => {
                     eprintln!("{FSKIT_INSTALL_HINT}");
@@ -638,32 +630,74 @@ mod macos {
 
     fn print_needs_approval_block(settings_url: &'static str) {
         eprintln!(
-            "\nHeddle FSKit extension is installed but disabled.\n\
+            "\nHeddle FSKit extension is installed, but macOS has not enabled it yet.\n\
+             \n\
+             macOS requires this approval in System Settings; Heddle cannot turn this permission on itself.\n\
              \n\
              Enable the fast path:\n\
-             1. {SETTINGS_PATH}\n\
-             2. Return here; this command will continue automatically when FSKit is ready.\n\
+             1. Open {SETTINGS_PATH}.\n\
+             2. In that sheet, switch the picker to By Category / Extension Type, then turn on Heddle.\n\
+             3. If the By App view does not apply the change, stay on By Category / Extension Type; macOS controls this approval UI.\n\
              \n\
-             Opening System Settings: {settings_url}\n"
+             Settings URL: {settings_url}\n\
+             Heddle will keep waiting here until macOS reports the extension enabled. Press Ctrl-C to stop.\n"
         );
+    }
+
+    fn wait_for_enter_to_open_settings(settings_url: &str) {
+        if io::stdin().is_terminal() {
+            let mut stderr = io::stderr();
+            let _ = write!(
+                stderr,
+                "Press Enter to open System Settings, or Ctrl-C to stop."
+            );
+            let _ = stderr.flush();
+
+            let mut input = String::new();
+            let _ = io::stdin().read_line(&mut input);
+            let _ = writeln!(stderr, "Opening System Settings: {settings_url}");
+        } else {
+            eprintln!("Opening System Settings: {settings_url}");
+        }
     }
 
     fn open_settings(url: &str) {
         let _ = Command::new("open").arg(url).status();
     }
 
-    fn wait_for_fskit_ready() -> bool {
-        let started = Instant::now();
+    fn wait_for_fskit_ready() {
+        let mut stderr = io::stderr();
+        let interactive = stderr.is_terminal();
+        let mut frame_index = 0usize;
+
+        if !interactive {
+            eprintln!("{FSKIT_WAIT_MESSAGE}. Press Ctrl-C to stop waiting.");
+        }
+
         loop {
             if readiness::probe() == Readiness::Ready {
-                return true;
+                if interactive {
+                    let _ = writeln!(
+                        stderr,
+                        "\rHeddle FSKit extension enabled; continuing. {FSKIT_LINE_CLEAR_PADDING}"
+                    );
+                } else {
+                    eprintln!("Heddle FSKit extension enabled; continuing.");
+                }
+                return;
             }
-            let elapsed = started.elapsed();
-            if elapsed >= FSKIT_POLL_CAP {
-                return false;
+
+            if interactive {
+                let frame = FSKIT_SPINNER_FRAMES[frame_index % FSKIT_SPINNER_FRAMES.len()];
+                let _ = write!(
+                    stderr,
+                    "\r{frame} {FSKIT_WAIT_MESSAGE}. Press Ctrl-C to stop."
+                );
+                let _ = stderr.flush();
+                frame_index = frame_index.wrapping_add(1);
             }
-            let remaining = FSKIT_POLL_CAP - elapsed;
-            std::thread::sleep(std::cmp::min(FSKIT_POLL_INTERVAL, remaining));
+
+            std::thread::sleep(FSKIT_POLL_INTERVAL);
         }
     }
 

--- a/crates/mount/src/fskit/readiness.rs
+++ b/crates/mount/src/fskit/readiness.rs
@@ -95,12 +95,11 @@ pub fn open_settings() {
 }
 
 /// One-line setup hint to print to stderr when the extension
-/// isn't ready. Kept here so the wording stays consistent across
-/// every call site that hits the prompt.
+/// isn't ready. The CLI's full approval flow expands this into the
+/// System Settings path, the By Category / Extension Type instruction,
+/// and a wait spinner.
 pub fn setup_hint() -> &'static str {
-    "Heddle FSKit extension not enabled.\n\
-     Opening System Settings — toggle \"Heddle\" on under \
-     File System Extensions, then re-run."
+    "Heddle FSKit extension is installed, but macOS has not enabled it yet."
 }
 
 /// One-line notice when a Mac is too old for Heddle's native FSKit

--- a/crates/mount/swift/HeddleHost/README.md
+++ b/crates/mount/swift/HeddleHost/README.md
@@ -11,7 +11,7 @@ is to be a discoverable bundle in `/Applications` so LaunchServices
 can register the embedded `.appex`. The app remains quiet by default: the
 `LSUIElement = YES` Info.plist key suppresses the Dock icon, and
 no window opens on launch unless the user explicitly opens the
-app from Finder or the CLI deep-links to it after FSKit needs approval.
+app from Finder for the visual setup guide.
 
 ## Target user experience
 
@@ -19,8 +19,10 @@ app from Finder or the CLI deep-links to it after FSKit needs approval.
 $ brew install --cask heddleco/heddle/heddle
 $ heddle start mybranch --workspace virtualized
    ⚠  Heddle FSKit extension not enabled.
-      Opening System Settings — toggle "Heddle" on under
-      File System Extensions.
+      Press Enter to open System Settings.
+[user presses Enter]
+      Opening System Settings — switch File System Extensions to
+      By Category / Extension Type, then toggle "Heddle" on.
 [user toggles while the command is still running]
    ✓ mounted at .repo-heddle-mounts/mybranch (via FSKit)
 ```
@@ -83,7 +85,7 @@ Possible results:
 | State | What CLI does |
 |---|---|
 | `Ready` (line starts with `+`) | Runs `mount -F -t heddle -o t=<thread> <repo> <mp>` via the kernel route; `-F` forces FSKit routing, and the extension declares `-o` in `FSActivateOptionSyntax` and parses `t=` from that payload |
-| `NeedsApproval` (line starts with `-`) | Prints a setup block with `System Settings → General → Login Items & Extensions → File System Extensions → enable 'Heddle'`, opens System Settings with a version-aware deep link, polls readiness for about 60 seconds, then mounts via FSKit as soon as the probe reports `Ready`; if the timer elapses, falls back to NFS for this run |
+| `NeedsApproval` (line starts with `-`) | Prints a setup block with `System Settings → General → Login Items & Extensions → File System Extensions`, explains that macOS owns the approval gate, tells the user to switch the sheet to By Category / Extension Type before enabling `Heddle`, lets interactive users press Enter before Heddle opens System Settings with a version-aware deep link, then waits with an inline spinner until the probe reports `Ready` |
 | `NotInstalled` (no line for our ID) | Prints a one-line host-app install hint, then falls back to NFS |
 | `UnsupportedMacOS` (macOS < 26.0) | Prints an older-macOS notice, then falls back to NFS because URL-backed FSKit resources are unavailable |
 | `Unknown` (`pluginkit` failed) | Silent fallback to NFS |
@@ -231,8 +233,9 @@ In `System Settings → General → Login Items & Extensions → File
 System Extensions`, the **app-grouped** view (default) shows the
 toggle but tapping it does nothing — the module stays disabled.
 Switching to the **category-grouped** view (the picker at the top
-of the panel) makes the toggle work. Tell users this in the setup
-hint.
+of the panel) makes the toggle work. The CLI setup hint calls this
+out as macOS-controlled permission UI so users do not treat it as a
+Heddle mount failure.
 
 If even that fails, the toggle state lives in:
 ```

--- a/crates/mount/swift/HeddleHost/dmg/make-dmg.sh
+++ b/crates/mount/swift/HeddleHost/dmg/make-dmg.sh
@@ -10,6 +10,7 @@ APPEARANCE="${HEDDLE_DMG_APPEARANCE:-light}"
 VOLNAME="${HEDDLE_DMG_VOLUME:-Heddle}"
 DMG_FORMAT="${HEDDLE_DMG_FORMAT:-UDZO}"
 ZLIB_LEVEL="${HEDDLE_DMG_ZLIB_LEVEL:-9}"
+VERIFY_APP_SIGNATURE="${HEDDLE_DMG_VERIFY_APP_SIGNATURE:-0}"
 
 if [[ -d "$INPUT_PATH" && "$INPUT_PATH" == *.app ]]; then
   LAYOUT="app"
@@ -46,9 +47,21 @@ cleanup() {
 }
 trap cleanup EXIT
 
+verify_app_signature() {
+  local app="$1"
+
+  if [[ "$VERIFY_APP_SIGNATURE" != "1" ]]; then
+    return 0
+  fi
+
+  echo "Verifying DMG app signature: $app"
+  codesign --verify --deep --strict --verbose=4 "$app" || return $?
+}
+
 mkdir -p "$STAGE_DIR" "$MOUNT_DIR"
 if [[ "$LAYOUT" == "app" ]]; then
-  ditto "$INPUT_PATH" "$STAGE_DIR/$STAGED_ITEM"
+  ditto --norsrc --noextattr --noqtn --noacl "$INPUT_PATH" "$STAGE_DIR/$STAGED_ITEM"
+  verify_app_signature "$STAGE_DIR/$STAGED_ITEM"
   ln -s /Applications "$STAGE_DIR/Applications"
 else
   cp "$INPUT_PATH" "$STAGE_DIR/$STAGED_ITEM"
@@ -113,6 +126,9 @@ end tell
 APPLESCRIPT
 
 sync
+if [[ "$LAYOUT" == "app" ]]; then
+  verify_app_signature "$MOUNT_DIR/$STAGED_ITEM"
+fi
 hdiutil detach "$MOUNT_DIR" -quiet
 CONVERT_ARGS=(
   -format "$DMG_FORMAT"

--- a/scripts/build-macos-cask-artifact.sh
+++ b/scripts/build-macos-cask-artifact.sh
@@ -35,6 +35,67 @@ require_file() {
   fi
 }
 
+bundle_executable() {
+  local bundle="$1"
+  /usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$bundle/Contents/Info.plist"
+}
+
+verify_app_signature() {
+  local app="$1"
+  local app_exe
+  local extension
+  local extension_exe
+
+  if [[ ! -d "$app" ]]; then
+    echo "error: app bundle not found: $app" >&2
+    return 1
+  fi
+
+  echo "Verifying app signature: $app"
+  codesign --verify --deep --strict --verbose=4 "$app" || return $?
+
+  app_exe="$(bundle_executable "$app")" || return $?
+  codesign --verify --strict --verbose=4 "$app/Contents/MacOS/$app_exe" || return $?
+
+  codesign --verify --strict --verbose=4 "$app/Contents/Resources/bin/heddle" || return $?
+
+  extension="$app/Contents/Extensions/HeddleFSModule.appex"
+  codesign --verify --deep --strict --verbose=4 "$extension" || return $?
+
+  extension_exe="$(bundle_executable "$extension")" || return $?
+  codesign --verify --strict --verbose=4 "$extension/Contents/MacOS/$extension_exe" || return $?
+}
+
+verify_dmg_app_signature() {
+  local dmg="$1"
+  local mount_dir
+  local status=0
+
+  if [[ ! -f "$dmg" ]]; then
+    echo "error: DMG not found: $dmg" >&2
+    return 1
+  fi
+
+  mount_dir="$(mktemp -d "${TMPDIR:-/tmp}/heddle-release-dmg.XXXXXX")"
+  if ! hdiutil attach "$dmg" \
+    -mountpoint "$mount_dir" \
+    -nobrowse \
+    -readonly \
+    -noautoopen \
+    -quiet; then
+    rm -rf "$mount_dir"
+    return 1
+  fi
+
+  if ! verify_app_signature "$mount_dir/Heddle.app"; then
+    status=1
+  fi
+
+  hdiutil detach "$mount_dir" -quiet || status=1
+  rm -rf "$mount_dir"
+  return "$status"
+}
+
 require_env HEDDLE_TAG "$TAG"
 require_env HEDDLE_VERSION "$VERSION"
 require_env HEDDLE_TEAM_ID "$TEAM_ID"
@@ -130,7 +191,7 @@ codesign --force --timestamp --options runtime \
   --sign "$DEVELOPER_ID" \
   "$STAGED_APP"
 
-codesign --verify --deep --strict --verbose=2 "$STAGED_APP"
+verify_app_signature "$STAGED_APP"
 
 ditto -c -k --keepParent "$STAGED_APP" "$NOTARY_ZIP"
 xcrun notarytool submit "$NOTARY_ZIP" \
@@ -141,17 +202,23 @@ xcrun notarytool submit "$NOTARY_ZIP" \
 xcrun stapler staple "$STAGED_APP"
 xcrun stapler validate "$STAGED_APP"
 spctl -a -vvv -t install "$STAGED_APP"
+verify_app_signature "$STAGED_APP"
 
-"$HOST_DIR/dmg/make-dmg.sh" "$STAGED_APP" "$DMG_PATH"
+HEDDLE_DMG_VERIFY_APP_SIGNATURE=1 "$HOST_DIR/dmg/make-dmg.sh" "$STAGED_APP" "$DMG_PATH"
+verify_dmg_app_signature "$DMG_PATH"
 codesign --force --timestamp --sign "$DEVELOPER_ID" "$DMG_PATH"
+codesign --verify --strict --verbose=4 "$DMG_PATH"
 xcrun notarytool submit "$DMG_PATH" \
   --key "$NOTARY_KEY" \
   --key-id "$NOTARY_KEY_ID" \
   --issuer "$NOTARY_ISSUER_ID" \
   --wait
 xcrun stapler staple "$DMG_PATH"
+xcrun stapler validate "$DMG_PATH"
+codesign --verify --strict --verbose=4 "$DMG_PATH"
 hdiutil verify "$DMG_PATH"
 spctl -a -vvv -t open --context context:primary-signature "$DMG_PATH"
+verify_dmg_app_signature "$DMG_PATH"
 
 ( cd "$OUTPUT_DIR" && shasum -a 256 "$(basename "$DMG_PATH")" > "$(basename "$DMG_PATH").sha256" )
 echo "Created $DMG_PATH"

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -10,6 +10,7 @@
 #   - all 5 target triples
 #   - tarball/zip packaging for CLI targets
 #   - signed/notarized macOS cask DMG
+#   - final-DMG app signature verification
 #   - sha256 checksums
 #   - signing step
 #   - GitHub Release upload
@@ -170,6 +171,30 @@ if ! grep -F "com.apple.security.temporary-exception.files." \
   ok "FSKit extension avoids profile-gated temporary path exceptions"
 else
   err "FSKit extension must not request temporary-exception.files entitlements; Developer ID profiles do not authorize them"
+fi
+
+staged_app_verify_count="$(grep -F 'verify_app_signature "$STAGED_APP"' scripts/build-macos-cask-artifact.sh | wc -l | tr -d ' ')"
+if [[ "$staged_app_verify_count" -ge 2 ]]; then
+  ok "macOS cask build verifies app signature before and after app notarization"
+else
+  err "macOS cask build must verify Heddle.app signature before and after app notarization/stapling"
+fi
+
+final_dmg_app_verify_count="$(grep -F 'verify_dmg_app_signature "$DMG_PATH"' scripts/build-macos-cask-artifact.sh | wc -l | tr -d ' ')"
+if [[ "$final_dmg_app_verify_count" -ge 2 ]] \
+   && grep -F 'HEDDLE_DMG_VERIFY_APP_SIGNATURE=1' scripts/build-macos-cask-artifact.sh >/dev/null \
+   && grep -F 'HEDDLE_DMG_VERIFY_APP_SIGNATURE' crates/mount/swift/HeddleHost/dmg/make-dmg.sh >/dev/null; then
+  ok "macOS cask build verifies app signature inside staged and final DMGs"
+else
+  err "macOS cask build must verify Heddle.app inside the staged and final DMG, not only before packaging"
+fi
+
+dmg_signature_verify_count="$(grep -F 'codesign --verify --strict --verbose=4 "$DMG_PATH"' scripts/build-macos-cask-artifact.sh | wc -l | tr -d ' ')"
+if [[ "$dmg_signature_verify_count" -ge 2 ]] \
+   && grep -F 'xcrun stapler validate "$DMG_PATH"' scripts/build-macos-cask-artifact.sh >/dev/null; then
+  ok "macOS cask build verifies DMG signature before and after DMG notarization"
+else
+  err "macOS cask build must verify the DMG code signature before and after DMG notarization/stapling"
 fi
 
 if [[ -x scripts/render-homebrew-cask.sh ]] \

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -11,6 +11,7 @@
 #   - tarball/zip packaging for CLI targets
 #   - signed/notarized macOS cask DMG
 #   - final-DMG app signature verification
+#   - non-publishing branch dry-run path for release-only verification
 #   - sha256 checksums
 #   - signing step
 #   - GitHub Release upload
@@ -85,6 +86,14 @@ if grep -F 'workflow_dispatch refuses stable tag' "$WF" >/dev/null; then
   ok "validate-tag refuses stable tags from workflow_dispatch (downgrade-attack guard)"
 else
   err "validate-tag must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
+fi
+
+if grep -F 'branch_dry_run:' "$WF" >/dev/null \
+   && grep -F 'publish_release=false' "$WF" >/dev/null \
+   && grep -F "if: needs.validate-tag.outputs.publish_release == 'true'" "$WF" >/dev/null; then
+  ok "temporary branch dry-run path skips GitHub Release publication"
+else
+  err "temporary branch dry-run path must be explicit and must skip GitHub Release publication"
 fi
 
 # All five active target triples (win-arm64 parked, see below).
@@ -308,7 +317,7 @@ else
   else
     oks << "validate-tag exports tag_sha output"
   end
-  errors << "validate-tag must declare 'tag' and 'kind' outputs" unless outs.key?("tag") && outs.key?("kind")
+  errors << "validate-tag must declare 'tag', 'kind', and 'publish_release' outputs" unless outs.key?("tag") && outs.key?("kind") && outs.key?("publish_release")
 end
 
 downstream = ["build", "build-macos-cask", "release", "publish-manifests"]
@@ -461,6 +470,8 @@ else:
         oks.append("validate-tag exports tag_sha output")
     if "tag" not in outs or "kind" not in outs:
         errors.append("validate-tag must declare 'tag' and 'kind' outputs")
+    if "publish_release" not in outs:
+        errors.append("validate-tag must declare a 'publish_release' output so dry-runs cannot publish releases")
 
 # Every job that runs AFTER validate-tag (i.e. that produces or ships
 # artifacts) must declare it as a needs dependency. Listing the set

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -8,7 +8,8 @@
 #
 #   - tag-push trigger
 #   - all 5 target triples
-#   - tarball/zip packaging for CLI targets
+#   - tarball/zip packaging for CLI targets, with macOS archives produced by
+#     the cask job so Apple binaries are built once
 #   - signed/notarized macOS cask DMG
 #   - final-DMG app signature verification
 #   - non-publishing branch dry-run path for release-only verification
@@ -90,10 +91,11 @@ fi
 
 if grep -F 'branch_dry_run:' "$WF" >/dev/null \
    && grep -F 'publish_release=false' "$WF" >/dev/null \
+   && grep -F "if: \${{ github.event_name != 'workflow_dispatch' || !inputs.branch_dry_run }}" "$WF" >/dev/null \
    && grep -F "if: needs.validate-tag.outputs.publish_release == 'true'" "$WF" >/dev/null; then
-  ok "temporary branch dry-run path skips GitHub Release publication"
+  ok "temporary branch dry-run path skips generic builds and GitHub Release publication"
 else
-  err "temporary branch dry-run path must be explicit and must skip GitHub Release publication"
+  err "temporary branch dry-run path must be explicit and must skip generic builds and GitHub Release publication"
 fi
 
 # All five active target triples (win-arm64 parked, see below).
@@ -173,6 +175,15 @@ if grep -F "cargo build --release --locked -p heddle-mount --features fskit --ta
   ok "macOS cask build explicitly enables FSKit/mount features"
 else
   err "macOS cask build must compile heddle-mount with --features fskit and heddle-cli with --features mount"
+fi
+
+if ! grep -F "target: aarch64-apple-darwin" "$WF" >/dev/null \
+   && ! grep -F "target: x86_64-apple-darwin" "$WF" >/dev/null \
+   && grep -F "dist/heddle-\${{ needs.validate-tag.outputs.tag }}-aarch64-apple-darwin.tar.gz" "$WF" >/dev/null \
+   && grep -F "dist/heddle-\${{ needs.validate-tag.outputs.tag }}-x86_64-apple-darwin.tar.gz" "$WF" >/dev/null; then
+  ok "macOS CLI archives are packaged by the cask job from the single Apple build"
+else
+  err "macOS CLI archives must be packaged by build-macos-cask, and Apple targets must not be duplicated in the generic build matrix"
 fi
 
 if ! grep -F "com.apple.security.temporary-exception.files." \
@@ -400,15 +411,10 @@ if build_job.is_a?(Hash)
   apple_legs = include.select do |entry|
     entry.is_a?(Hash) && entry.fetch("target", "").to_s.end_with?("-apple-darwin")
   end
-  errors << "build matrix has no *-apple-darwin legs to pin to macos-26" if apple_legs.empty?
-  apple_legs.each do |entry|
-    runner = entry.fetch("runner", "").to_s
-    target = entry["target"]
-    if runner == "macos-26"
-      oks << "#{target} pinned to macos-26 (FSKit SDK floor)"
-    else
-      errors << "#{target} builds on '#{runner}', not macos-26 - risks missing the FSKit SDK floor"
-    end
+  if apple_legs.empty?
+    oks << "generic build matrix omits Apple targets; build-macos-cask owns the single macOS build"
+  else
+    errors << "generic build matrix still includes Apple targets: #{apple_legs.map { |entry| entry["target"] }.join(", ")}"
   end
   cask = jobs["build-macos-cask"]
   if cask.is_a?(Hash)
@@ -417,6 +423,14 @@ if build_job.is_a?(Hash)
       oks << "build-macos-cask runs on macos-26"
     else
       errors << "build-macos-cask runs on '#{runner}', not macos-26"
+    end
+    cask_text = cask.inspect
+    if cask_text.include?("aarch64-apple-darwin,x86_64-apple-darwin") &&
+       cask_text.include?("heddle-${TAG}-aarch64-apple-darwin.tar.gz") &&
+       cask_text.include?("heddle-${TAG}-x86_64-apple-darwin.tar.gz")
+      oks << "build-macos-cask builds both Apple targets and packages standalone macOS CLI archives"
+    else
+      errors << "build-macos-cask must build both Apple targets and package standalone macOS CLI archives"
     end
   end
 end
@@ -566,16 +580,12 @@ if isinstance(build_job, dict):
     apple_legs = [e for e in include if isinstance(e, dict)
                   and str(e.get("target", "")).endswith("-apple-darwin")]
     if not apple_legs:
-        errors.append("build matrix has no *-apple-darwin legs to pin to macos-26")
-    for e in apple_legs:
-        runner = str(e.get("runner", ""))
-        target = e.get("target")
-        if runner == "macos-26":
-            oks.append(f"{target} pinned to macos-26 (FSKit SDK floor)")
-        else:
-            errors.append(
-                f"{target} builds on '{runner}', not macos-26 — risks missing the FSKit SDK floor"
-            )
+        oks.append("generic build matrix omits Apple targets; build-macos-cask owns the single macOS build")
+    else:
+        errors.append(
+            "generic build matrix still includes Apple targets: "
+            + ", ".join(str(e.get("target")) for e in apple_legs)
+        )
     cask = jobs.get("build-macos-cask")
     if isinstance(cask, dict):
         runner = str(cask.get("runs-on", ""))
@@ -583,6 +593,15 @@ if isinstance(build_job, dict):
             oks.append("build-macos-cask runs on macos-26")
         else:
             errors.append(f"build-macos-cask runs on '{runner}', not macos-26")
+        cask_text = repr(cask)
+        if (
+            "aarch64-apple-darwin,x86_64-apple-darwin" in cask_text
+            and "heddle-${TAG}-aarch64-apple-darwin.tar.gz" in cask_text
+            and "heddle-${TAG}-x86_64-apple-darwin.tar.gz" in cask_text
+        ):
+            oks.append("build-macos-cask builds both Apple targets and packages standalone macOS CLI archives")
+        else:
+            errors.append("build-macos-cask must build both Apple targets and package standalone macOS CLI archives")
 
 print("OKS:")
 for o in oks:


### PR DESCRIPTION
## Summary

- make the macOS FSKit approval flow explicit that System Settings owns the enablement permission, with a user-driven Enter prompt before opening settings
- wait indefinitely with an inline spinner until macOS reports the FSKit extension enabled instead of timing out to NFS
- add branch dry-run support for Release Binaries so signed mac artifacts can be validated before tagging
- verify the Heddle.app, bundled CLI, FSKit extension, and DMG signatures before and after notarization/stapling
- avoid duplicate Apple release builds by making the macOS cask job own both Apple tarballs and the universal DMG
- streamline CI gates: remove duplicate Rust test reruns, compile-check FUSE benches on PRs, gate FSKit/coverage by changed paths, skip cargo-audit on PRs, and combine release invariant jobs

## Root Cause

The FSKit permission prompt is owned by macOS, so Heddle can guide the user but cannot grant that permission itself. Separately, the published macOS DMG path verified the staged app before packaging but did not mount the final DMG and verify the embedded app, CLI, and extension signatures after packaging and stapling.

The release and test workflows also had overlapping work: Apple targets were built in both the generic release matrix and the cask job, and several CI gates repeated coverage that the workspace test/check jobs already provided.

## Validation

- `cargo check -p heddle-cli --features mount`
- `bash scripts/check-release-pipeline.sh`
- `bash -n scripts/check-release-pipeline.sh`
- `bash -n scripts/build-macos-cask-artifact.sh`
- `bash -n crates/mount/swift/HeddleHost/dmg/make-dmg.sh`
- YAML parse for release, release-pipeline-check, audit, and rust-tests workflows
- classifier smoke test for release-only, Rust, mount, docs-only, and coverage path decisions
- Release Binaries dry run 27793151073 succeeded for the macOS cask artifact
- downloaded `heddle-macos-cask` artifact SHA matched its `.sha256`
- local verification of the downloaded artifact passed: `codesign` for app and DMG, `xcrun stapler validate` for app and DMG, and `spctl` accepted both as Notarized Developer ID
