### PR TITLE
docs(changelog): cut 0.4.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,22 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.4.0 - 2026-06-19
+
 ### Changed
 
-- Renamed the native Heddle wire/protocol crate from `heddle-proto`
-  (`crates/proto`, Rust crate `proto`) to `heddle-wire`
-  (`crates/wire`, Rust crate `wire`). The protobuf/gRPC IDL remains in
-  `heddle-grpc` under `crates/grpc/proto/heddle/v1`.
+- **Breaking (crate surface):** renamed the native Heddle wire/protocol
+  crate from `heddle-proto` (`crates/proto`, Rust crate `proto`) to
+  `heddle-wire` (`crates/wire`, Rust crate `wire`). The protobuf/gRPC IDL
+  remains in `heddle-grpc` under `crates/grpc/proto/heddle/v1`.
+
+### Added
+
+- `@heddle/grpc`: a generated TypeScript protobuf + Connect (v2) client
+  package for the Heddle gRPC API, versioned with `heddle-grpc` (`0.7.1`),
+  publishable to GitHub Packages for Tapestry consumption. New path-gated
+  `ts-grpc-client` CI workflow validates/typechecks/packs it and gates
+  publish to `main`.
 
 ## 0.3.0 - 2026-06-16
 


### PR DESCRIPTION
Promote the Unreleased entries to a dated 0.4.0 section (heddle-wire crate rename + @heddle/grpc TS client). Pairs with the v0.4.0 tag. Docs-only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/753"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784423379&installation_id=132405951&pr_number=753&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F753&signature=051d3981b636f1450615e6d6ecdd40645f2e1819f359daed5818987309d49203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->