### PR TITLE
refactor(seam P2): lift staleness + context-suggestion pure cores into objects; fold codec retry nit

### DIFF
--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -25,6 +25,7 @@ mod state_review;
 mod state_visibility;
 mod staleness_core;
 mod structured_conflict;
+mod suggestion_core;
 mod timeline;
 mod tree;
 mod tree_diff;
@@ -74,6 +75,11 @@ pub use staleness_core::{
 };
 pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
+};
+pub use suggestion_core::{
+    ContextSuggestion, ContextSuggestionTier, HIGH_SUGGESTION_THRESHOLD,
+    MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD, SUGGESTION_WINDOW,
+    SuggestionInputs, SuggestionSignal, score_suggestions,
 };
 pub use timeline::{
     BranchCreatedV1, CursorMovedV1, NativeToolCallRefV1, TIMELINE_OPERATION_SCHEMA_VERSION,

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -23,6 +23,7 @@ mod state_core;
 mod state_provenance;
 mod state_review;
 mod state_visibility;
+mod staleness_core;
 mod structured_conflict;
 mod timeline;
 mod tree;
@@ -66,6 +67,10 @@ pub use state_review::{
 pub use state_visibility::{
     STATE_VISIBILITY_SIGNING_PAYLOAD_VERSION_TAG, StateVisibility, StateVisibilityBlob,
     StateVisibilityError,
+};
+pub use staleness_core::{
+    StalenessStatus, annotation_status_for_source,
+    annotation_status_for_source_with_symbol_resolver, extract_line_range, resolve_current_symbol,
 };
 pub use structured_conflict::{
     ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,

--- a/crates/objects/src/object/staleness_core.rs
+++ b/crates/objects/src/object/staleness_core.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Pure staleness checks for annotation source hashes.
+
+use std::path::Path;
+
+use super::{Annotation, AnnotationScope, ContentHash};
+
+/// Result of checking an annotation's freshness against current code.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StalenessStatus {
+    /// Source hash matches -- annotation is current.
+    Fresh,
+    /// Source at the annotated scope has changed since the annotation was written.
+    SourceChanged {
+        old_hash: ContentHash,
+        new_hash: ContentHash,
+    },
+    /// The file referenced by the annotation no longer exists in the tree.
+    FileMissing,
+    /// Symbol referenced by annotation no longer exists in the file.
+    SymbolMissing { symbol: String },
+    /// No provenance data stored -- staleness cannot be determined.
+    Unknown,
+}
+
+/// Check an annotation's staleness against already-loaded source bytes.
+pub fn annotation_status_for_source(
+    annotation: &Annotation,
+    scope: &AnnotationScope,
+    source: &[u8],
+    file_path: &Path,
+) -> StalenessStatus {
+    annotation_status_for_source_with_symbol_resolver(
+        annotation,
+        scope,
+        source,
+        file_path,
+        resolve_current_symbol,
+    )
+}
+
+/// Check an annotation's staleness with an injected symbol resolver.
+pub fn annotation_status_for_source_with_symbol_resolver(
+    annotation: &Annotation,
+    scope: &AnnotationScope,
+    source: &[u8],
+    file_path: &Path,
+    mut resolve_symbol: impl FnMut(&[u8], &Path, &str, Option<(u32, u32)>) -> Option<(u32, u32)>,
+) -> StalenessStatus {
+    let Some(revision) = annotation.current_revision() else {
+        return StalenessStatus::Unknown;
+    };
+    let expected_hash = match &revision.source_hash {
+        Some(h) => h,
+        None => return StalenessStatus::Unknown,
+    };
+
+    let scoped_bytes = match scope {
+        AnnotationScope::File => source.to_vec(),
+        AnnotationScope::Lines(start, end) => extract_line_range(source, *start, *end),
+        AnnotationScope::Symbol {
+            name,
+            resolved_lines,
+        } => match resolve_symbol(source, file_path, name, *resolved_lines) {
+            Some((start, end)) => extract_line_range(source, start, end),
+            None => {
+                return StalenessStatus::SymbolMissing {
+                    symbol: name.clone(),
+                };
+            }
+        },
+    };
+
+    let current_hash = ContentHash::compute(&scoped_bytes);
+    if current_hash == *expected_hash {
+        StalenessStatus::Fresh
+    } else {
+        StalenessStatus::SourceChanged {
+            old_hash: *expected_hash,
+            new_hash: current_hash,
+        }
+    }
+}
+
+/// Extract bytes for a line range from source content.
+///
+/// Lines are 1-indexed. Returns the bytes spanning `start..=end` lines
+/// (inclusive on both ends), joined with newlines.
+pub fn extract_line_range(source: &[u8], start: u32, end: u32) -> Vec<u8> {
+    let text = std::str::from_utf8(source).unwrap_or("");
+    let lines: Vec<&str> = text.lines().collect();
+    let start_idx = (start as usize).saturating_sub(1);
+    let end_idx = (end as usize).min(lines.len());
+    if start_idx >= end_idx {
+        return Vec::new();
+    }
+    lines[start_idx..end_idx].join("\n").into_bytes()
+}
+
+/// Resolve a symbol using the stored line range.
+///
+/// Repository builds with semantic support inject a tree-sitter resolver at the
+/// I/O boundary; the no-store core keeps this fallback pure and dependency-free.
+pub fn resolve_current_symbol(
+    _source: &[u8],
+    _file_path: &Path,
+    _symbol: &str,
+    stored: Option<(u32, u32)>,
+) -> Option<(u32, u32)> {
+    stored
+}

--- a/crates/objects/src/object/suggestion_core.rs
+++ b/crates/objects/src/object/suggestion_core.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Pure context suggestion scoring.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use super::StalenessStatus;
+
+pub const SUGGESTION_WINDOW: usize = 24;
+pub const MEDIUM_SUGGESTION_THRESHOLD: u32 = 45;
+pub const HIGH_SUGGESTION_THRESHOLD: u32 = 70;
+pub const MAJOR_REWRITE_THRESHOLD_PCT: u32 = 50;
+
+const CHANGE_WEIGHT: u32 = 16;
+const DISTINCT_STATE_WEIGHT: u32 = 8;
+const DISTINCT_AGENT_WEIGHT: u32 = 10;
+const RECENCY_WEIGHT: u32 = 12;
+const STALE_WEIGHT: u32 = 18;
+const HAS_CONTEXT_PENALTY: u32 = 35;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ContextSuggestionTier {
+    Medium,
+    High,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ContextSuggestion {
+    pub path: String,
+    pub score: u32,
+    pub tier: ContextSuggestionTier,
+    pub reasons: Vec<String>,
+    pub recent_changes: u32,
+    pub distinct_states: u32,
+    pub distinct_agents: u32,
+    pub has_context: bool,
+    pub stale_annotations: u32,
+}
+
+#[derive(Default)]
+pub struct SuggestionSignal {
+    pub recent_changes: u32,
+    pub distinct_states: BTreeSet<String>,
+    pub distinct_agents: BTreeSet<String>,
+    pub latest_seen_index: Option<usize>,
+}
+
+pub struct SuggestionInputs {
+    pub signals: BTreeMap<String, SuggestionSignal>,
+    pub stale_map: HashMap<String, StalenessStatus>,
+    pub active_paths: BTreeSet<String>,
+    pub history_len: usize,
+}
+
+pub fn score_suggestions(inputs: SuggestionInputs, limit: usize) -> Vec<ContextSuggestion> {
+    let SuggestionInputs {
+        signals,
+        stale_map,
+        active_paths,
+        history_len,
+    } = inputs;
+    let mut suggestions = Vec::new();
+
+    for (path, signal) in signals {
+        let has_context = active_paths.contains(&path);
+        let stale_annotations = stale_map
+            .iter()
+            .filter(|(key, status)| {
+                key.starts_with(&format!("{path}:"))
+                    && !matches!(status, StalenessStatus::Fresh)
+            })
+            .count() as u32;
+
+        let mut score = signal.recent_changes.saturating_mul(CHANGE_WEIGHT);
+        score += (signal.distinct_states.len() as u32).saturating_mul(DISTINCT_STATE_WEIGHT);
+        score += (signal.distinct_agents.len() as u32).saturating_mul(DISTINCT_AGENT_WEIGHT);
+        if signal.latest_seen_index.unwrap_or(usize::MAX) <= 3 {
+            score += RECENCY_WEIGHT;
+        }
+        if stale_annotations > 0 {
+            score += stale_annotations.saturating_mul(STALE_WEIGHT);
+        }
+        if has_context && stale_annotations == 0 {
+            score = score.saturating_sub(HAS_CONTEXT_PENALTY);
+        }
+
+        let tier = if score >= HIGH_SUGGESTION_THRESHOLD {
+            Some(ContextSuggestionTier::High)
+        } else if score >= MEDIUM_SUGGESTION_THRESHOLD {
+            Some(ContextSuggestionTier::Medium)
+        } else {
+            None
+        };
+
+        let Some(tier) = tier else {
+            continue;
+        };
+
+        let mut reasons = Vec::new();
+        if signal.recent_changes >= 3 {
+            reasons.push(format!(
+                "{} recent changes across the last {} states",
+                signal.recent_changes, history_len
+            ));
+        }
+        if signal.distinct_agents.len() >= 2 {
+            reasons.push(format!(
+                "{} distinct agents touched this file",
+                signal.distinct_agents.len()
+            ));
+        }
+        if stale_annotations > 0 {
+            reasons.push(format!("{stale_annotations} annotation(s) may be stale"));
+        }
+        if !has_context {
+            reasons.push("no active file guidance exists yet".to_string());
+        }
+
+        suggestions.push(ContextSuggestion {
+            path,
+            score,
+            tier,
+            reasons,
+            recent_changes: signal.recent_changes,
+            distinct_states: signal.distinct_states.len() as u32,
+            distinct_agents: signal.distinct_agents.len() as u32,
+            has_context,
+            stale_annotations,
+        });
+    }
+
+    suggestions.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
+    suggestions.truncate(limit);
+    suggestions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn score_suggestions_hits_tier_boundaries_and_context_penalty() {
+        let mut signals = BTreeMap::new();
+        signals.insert(
+            "high.rs".to_string(),
+            signal(2, [], ["anthropic/claude", "openai/codex"], None),
+        );
+        signals.insert(
+            "penalty.rs".to_string(),
+            signal(5, [], [], None),
+        );
+        signals.insert("low.rs".to_string(), signal(1, ["s1"], [], None));
+
+        let mut stale_map = HashMap::new();
+        stale_map.insert("high.rs:File".to_string(), StalenessStatus::Unknown);
+        stale_map.insert("penalty.rs:File".to_string(), StalenessStatus::Fresh);
+
+        let inputs = SuggestionInputs {
+            signals,
+            stale_map,
+            active_paths: BTreeSet::from(["penalty.rs".to_string()]),
+            history_len: 9,
+        };
+
+        let suggestions = score_suggestions(inputs, 10);
+
+        assert_eq!(
+            suggestions,
+            vec![
+                ContextSuggestion {
+                    path: "high.rs".to_string(),
+                    score: HIGH_SUGGESTION_THRESHOLD,
+                    tier: ContextSuggestionTier::High,
+                    reasons: vec![
+                        "2 distinct agents touched this file".to_string(),
+                        "1 annotation(s) may be stale".to_string(),
+                        "no active file guidance exists yet".to_string(),
+                    ],
+                    recent_changes: 2,
+                    distinct_states: 0,
+                    distinct_agents: 2,
+                    has_context: false,
+                    stale_annotations: 1,
+                },
+                ContextSuggestion {
+                    path: "penalty.rs".to_string(),
+                    score: MEDIUM_SUGGESTION_THRESHOLD,
+                    tier: ContextSuggestionTier::Medium,
+                    reasons: vec!["5 recent changes across the last 9 states".to_string()],
+                    recent_changes: 5,
+                    distinct_states: 0,
+                    distinct_agents: 0,
+                    has_context: true,
+                    stale_annotations: 0,
+                },
+            ]
+        );
+    }
+
+    fn signal<const S: usize, const A: usize>(
+        recent_changes: u32,
+        states: [&str; S],
+        agents: [&str; A],
+        latest_seen_index: Option<usize>,
+    ) -> SuggestionSignal {
+        SuggestionSignal {
+            recent_changes,
+            distinct_states: states.into_iter().map(str::to_string).collect(),
+            distinct_agents: agents.into_iter().map(str::to_string).collect(),
+            latest_seen_index,
+        }
+    }
+}

--- a/crates/objects/src/store/s3/s3_impl/mod.rs
+++ b/crates/objects/src/store/s3/s3_impl/mod.rs
@@ -82,6 +82,8 @@ impl ObjectStore for S3Store {
         let hash = blob.hash();
         let key = self.blob_key(&hash);
         let content = blob.content().to_vec();
+        let compression_config = CompressionConfig::default();
+        let data = codec::encode_blob_content(&content, &compression_config)?;
         let client = Arc::clone(&self.client);
         let bucket = self.bucket.clone();
         self.block(async move {
@@ -104,13 +106,11 @@ impl ObjectStore for S3Store {
                             }
                         }
                     }
-                    let compression_config = CompressionConfig::default();
-                    let data = codec::encode_blob_content(&content, &compression_config)?;
                     client
                         .put_object()
                         .bucket(&bucket)
                         .key(&key)
-                        .body(ByteStream::from(data))
+                        .body(ByteStream::from(data.clone()))
                         .send()
                         .await
                         .map_err(|e| {
@@ -232,6 +232,8 @@ impl ObjectStore for S3Store {
         let hash = tree.hash();
         let key = self.tree_key(&hash);
         let tree = tree.clone();
+        let compression_config = CompressionConfig::default();
+        let (_, data) = codec::encode_tree(&tree, &compression_config)?;
         let client = Arc::clone(&self.client);
         let bucket = self.bucket.clone();
         self.block(async move {
@@ -254,13 +256,11 @@ impl ObjectStore for S3Store {
                             }
                         }
                     }
-                    let compression_config = CompressionConfig::default();
-                    let (_, data) = codec::encode_tree(&tree, &compression_config)?;
                     client
                         .put_object()
                         .bucket(&bucket)
                         .key(&key)
-                        .body(ByteStream::from(data))
+                        .body(ByteStream::from(data.clone()))
                         .send()
                         .await
                         .map_err(|e| {
@@ -375,6 +375,8 @@ impl ObjectStore for S3Store {
     fn put_state(&self, state: &State) -> Result<()> {
         let key = self.state_key(&state.change_id);
         let state = state.clone();
+        let compression_config = CompressionConfig::default();
+        let data = codec::encode_state(&state, &compression_config)?;
         let client = Arc::clone(&self.client);
         let bucket = self.bucket.clone();
         self.block(async move {
@@ -382,13 +384,11 @@ impl ObjectStore for S3Store {
                 RetryPolicy::S3_DEFAULT,
                 should_retry_store_error,
                 || async {
-                    let compression_config = CompressionConfig::default();
-                    let data = codec::encode_state(&state, &compression_config)?;
                     client
                         .put_object()
                         .bucket(&bucket)
                         .key(&key)
-                        .body(ByteStream::from(data))
+                        .body(ByteStream::from(data.clone()))
                         .send()
                         .await
                         .map_err(|e| {
@@ -504,7 +504,9 @@ impl ObjectStore for S3Store {
     fn put_action(&self, action: &mut Action) -> Result<ActionId> {
         let id = action.id();
         let key = self.action_key(&id);
-        let action = action.clone();
+        let mut action = action.clone();
+        let compression_config = CompressionConfig::default();
+        let (_, data) = codec::encode_action(&mut action, &compression_config)?;
         let client = Arc::clone(&self.client);
         let bucket = self.bucket.clone();
         self.block(async move {
@@ -515,10 +517,8 @@ impl ObjectStore for S3Store {
                     let client = Arc::clone(&client);
                     let bucket = bucket.clone();
                     let key = key.clone();
-                    let mut action = action.clone();
+                    let data = data.clone();
                     async move {
-                        let compression_config = CompressionConfig::default();
-                        let (_, data) = codec::encode_action(&mut action, &compression_config)?;
                         client
                             .put_object()
                             .bucket(&bucket)

--- a/crates/repo/src/context_suggestions.rs
+++ b/crates/repo/src/context_suggestions.rs
@@ -4,50 +4,18 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use objects::{
-    object::{ContextTarget, State},
+    object::{
+        ContextTarget, State, SuggestionInputs, SuggestionSignal, score_suggestions,
+    },
     store::ObjectStore,
 };
 
 use crate::{HistoryQuery, Repository, staleness};
 
-pub const SUGGESTION_WINDOW: usize = 24;
-pub const MEDIUM_SUGGESTION_THRESHOLD: u32 = 45;
-pub const HIGH_SUGGESTION_THRESHOLD: u32 = 70;
-pub const MAJOR_REWRITE_THRESHOLD_PCT: u32 = 50;
-
-const CHANGE_WEIGHT: u32 = 16;
-const DISTINCT_STATE_WEIGHT: u32 = 8;
-const DISTINCT_AGENT_WEIGHT: u32 = 10;
-const RECENCY_WEIGHT: u32 = 12;
-const STALE_WEIGHT: u32 = 18;
-const HAS_CONTEXT_PENALTY: u32 = 35;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum ContextSuggestionTier {
-    Medium,
-    High,
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct ContextSuggestion {
-    pub path: String,
-    pub score: u32,
-    pub tier: ContextSuggestionTier,
-    pub reasons: Vec<String>,
-    pub recent_changes: u32,
-    pub distinct_states: u32,
-    pub distinct_agents: u32,
-    pub has_context: bool,
-    pub stale_annotations: u32,
-}
-
-#[derive(Default)]
-struct SuggestionSignal {
-    recent_changes: u32,
-    distinct_states: BTreeSet<String>,
-    distinct_agents: BTreeSet<String>,
-    latest_seen_index: Option<usize>,
-}
+pub use objects::object::{
+    ContextSuggestion, ContextSuggestionTier, HIGH_SUGGESTION_THRESHOLD,
+    MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD, SUGGESTION_WINDOW,
+};
 
 impl Repository {
     pub fn suggest_context_targets(
@@ -103,79 +71,15 @@ impl Repository {
             })
             .collect();
 
-        let mut suggestions = Vec::new();
-        for (path, signal) in signals {
-            let has_context = active_paths.contains(&path);
-            let stale_annotations = stale_map
-                .iter()
-                .filter(|(key, status)| {
-                    key.starts_with(&format!("{path}:"))
-                        && !matches!(status, staleness::StalenessStatus::Fresh)
-                })
-                .count() as u32;
-
-            let mut score = signal.recent_changes.saturating_mul(CHANGE_WEIGHT);
-            score += (signal.distinct_states.len() as u32).saturating_mul(DISTINCT_STATE_WEIGHT);
-            score += (signal.distinct_agents.len() as u32).saturating_mul(DISTINCT_AGENT_WEIGHT);
-            if signal.latest_seen_index.unwrap_or(usize::MAX) <= 3 {
-                score += RECENCY_WEIGHT;
-            }
-            if stale_annotations > 0 {
-                score += stale_annotations.saturating_mul(STALE_WEIGHT);
-            }
-            if has_context && stale_annotations == 0 {
-                score = score.saturating_sub(HAS_CONTEXT_PENALTY);
-            }
-
-            let tier = if score >= HIGH_SUGGESTION_THRESHOLD {
-                Some(ContextSuggestionTier::High)
-            } else if score >= MEDIUM_SUGGESTION_THRESHOLD {
-                Some(ContextSuggestionTier::Medium)
-            } else {
-                None
-            };
-
-            let Some(tier) = tier else {
-                continue;
-            };
-
-            let mut reasons = Vec::new();
-            if signal.recent_changes >= 3 {
-                reasons.push(format!(
-                    "{} recent changes across the last {} states",
-                    signal.recent_changes,
-                    history.len()
-                ));
-            }
-            if signal.distinct_agents.len() >= 2 {
-                reasons.push(format!(
-                    "{} distinct agents touched this file",
-                    signal.distinct_agents.len()
-                ));
-            }
-            if stale_annotations > 0 {
-                reasons.push(format!("{stale_annotations} annotation(s) may be stale"));
-            }
-            if !has_context {
-                reasons.push("no active file guidance exists yet".to_string());
-            }
-
-            suggestions.push(ContextSuggestion {
-                path,
-                score,
-                tier,
-                reasons,
-                recent_changes: signal.recent_changes,
-                distinct_states: signal.distinct_states.len() as u32,
-                distinct_agents: signal.distinct_agents.len() as u32,
-                has_context,
-                stale_annotations,
-            });
-        }
-
-        suggestions.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
-        suggestions.truncate(limit);
-        Ok(suggestions)
+        Ok(score_suggestions(
+            SuggestionInputs {
+                signals,
+                stale_map,
+                active_paths,
+                history_len: history.len(),
+            },
+            limit,
+        ))
     }
 
     fn collect_state_window(
@@ -231,6 +135,7 @@ fn normalize_tokens(input: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
 
     #[test]
     fn rewrite_pct_is_zero_for_identical_content() {
@@ -242,5 +147,44 @@ mod tests {
         let pct = compute_rewrite_pct("alpha beta gamma", "delta epsilon zeta");
         assert!(pct >= MAJOR_REWRITE_THRESHOLD_PCT);
         assert!(is_major_rewrite(pct));
+    }
+
+    #[test]
+    fn suggest_context_targets_matches_golden_fixture() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init_default(dir.path()).unwrap();
+
+        fs::create_dir_all(dir.path().join("src")).unwrap();
+        fs::write(dir.path().join("src/a.rs"), "one\n").unwrap();
+        repo.snapshot(Some("add a".to_string()), None).unwrap();
+
+        fs::write(dir.path().join("src/b.rs"), "one\n").unwrap();
+        repo.snapshot(Some("add b".to_string()), None).unwrap();
+
+        fs::write(dir.path().join("src/a.rs"), "two\n").unwrap();
+        repo.snapshot(Some("update a".to_string()), None).unwrap();
+
+        fs::write(dir.path().join("src/a.rs"), "three\n").unwrap();
+        let head = repo.snapshot(Some("update a again".to_string()), None).unwrap();
+
+        let suggestions = repo.suggest_context_targets(&head, 10).unwrap();
+
+        assert_eq!(
+            suggestions,
+            vec![ContextSuggestion {
+                path: "src/a.rs".to_string(),
+                score: 84,
+                tier: ContextSuggestionTier::High,
+                reasons: vec![
+                    "3 recent changes across the last 5 states".to_string(),
+                    "no active file guidance exists yet".to_string(),
+                ],
+                recent_changes: 3,
+                distinct_states: 3,
+                distinct_agents: 0,
+                has_context: false,
+                stale_annotations: 0,
+            }]
+        );
     }
 }

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -7,29 +7,18 @@
 use std::{collections::HashMap, path::Path};
 
 use objects::{
-    object::{Annotation, AnnotationScope, Blob, ContentHash, ContextTarget, State, Tree},
+    object::{
+        Annotation, Blob, ContextTarget, State, Tree,
+        annotation_status_for_source_with_symbol_resolver,
+    },
     store::ObjectStore,
 };
 
 use crate::Repository;
 
-/// Result of checking an annotation's freshness against current code.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StalenessStatus {
-    /// Source hash matches -- annotation is current.
-    Fresh,
-    /// Source at the annotated scope has changed since the annotation was written.
-    SourceChanged {
-        old_hash: ContentHash,
-        new_hash: ContentHash,
-    },
-    /// The file referenced by the annotation no longer exists in the tree.
-    FileMissing,
-    /// Symbol referenced by annotation no longer exists in the file.
-    SymbolMissing { symbol: String },
-    /// No provenance data stored -- staleness cannot be determined.
-    Unknown,
-}
+pub use objects::object::{
+    StalenessStatus, annotation_status_for_source, extract_line_range, resolve_current_symbol,
+};
 
 /// Check a single annotation's staleness against current code.
 ///
@@ -45,14 +34,13 @@ pub fn check_annotation_staleness(
         return Ok(StalenessStatus::Unknown);
     };
     let file_path = Path::new(file_path);
-    let Some(revision) = annotation.current_revision() else {
+    if annotation
+        .current_revision()
+        .and_then(|revision| revision.source_hash.as_ref())
+        .is_none()
+    {
         return Ok(StalenessStatus::Unknown);
-    };
-    // If no source_hash stored, annotation predates provenance tracking.
-    let expected_hash = match &revision.source_hash {
-        Some(h) => h,
-        None => return Ok(StalenessStatus::Unknown),
-    };
+    }
 
     // Load the current code tree.
     let tree = match repo.store().get_tree(&current_state.tree)? {
@@ -68,62 +56,13 @@ pub fn check_annotation_staleness(
     };
 
     let source = blob.content();
-
-    // Extract the bytes at the annotation's scope.
-    let scoped_bytes = match &annotation.scope {
-        AnnotationScope::File => source.to_vec(),
-        AnnotationScope::Lines(start, end) => extract_line_range(source, *start, *end),
-        AnnotationScope::Symbol {
-            name,
-            resolved_lines,
-        } => {
-            // Re-resolve the symbol against the current tree when tree-
-            // sitter is available: this tracks symbols that moved within
-            // the file (e.g. an unrelated function was added above).
-            //   - resolver succeeds → use the current line range (handles
-            //     "symbol moved but body unchanged" as Fresh).
-            //   - resolver reports SymbolNotFound → report SymbolMissing
-            //     even if we have stale `resolved_lines` from creation time.
-            //   - resolver errors for parse/language reasons → fall back to
-            //     stored `resolved_lines` (best effort).
-            // When the feature is disabled, fall back to the stored range.
-            let current_lines = resolve_current_symbol(source, file_path, name, *resolved_lines);
-            match current_lines {
-                Some((start, end)) => extract_line_range(source, start, end),
-                None => {
-                    return Ok(StalenessStatus::SymbolMissing {
-                        symbol: name.clone(),
-                    });
-                }
-            }
-        }
-    };
-
-    // BLAKE3 hash the current bytes and compare with expected.
-    let current_hash = ContentHash::compute(&scoped_bytes);
-    if current_hash == *expected_hash {
-        Ok(StalenessStatus::Fresh)
-    } else {
-        Ok(StalenessStatus::SourceChanged {
-            old_hash: *expected_hash,
-            new_hash: current_hash,
-        })
-    }
-}
-
-/// Extract bytes for a line range from source content.
-///
-/// Lines are 1-indexed. Returns the bytes spanning `start..=end` lines
-/// (inclusive on both ends), joined with newlines.
-pub fn extract_line_range(source: &[u8], start: u32, end: u32) -> Vec<u8> {
-    let text = std::str::from_utf8(source).unwrap_or("");
-    let lines: Vec<&str> = text.lines().collect();
-    let start_idx = (start as usize).saturating_sub(1);
-    let end_idx = (end as usize).min(lines.len());
-    if start_idx >= end_idx {
-        return Vec::new();
-    }
-    lines[start_idx..end_idx].join("\n").into_bytes()
+    Ok(annotation_status_for_source_with_symbol_resolver(
+        annotation,
+        &annotation.scope,
+        source,
+        file_path,
+        resolve_current_symbol_for_repo,
+    ))
 }
 
 /// Batch check: check staleness for all annotations across all files in a context tree.
@@ -177,7 +116,7 @@ pub fn live_symbol_lines(
     let tree = repo.store().get_tree(&state.tree).ok().flatten()?;
     let blob = get_blob_at_path(repo.store(), &tree, path).ok().flatten()?;
     let file_path = std::path::Path::new(path);
-    resolve_current_symbol(blob.content(), file_path, symbol, None)
+    resolve_current_symbol_for_repo(blob.content(), file_path, symbol, None)
 }
 
 /// Internal: tree-sitter resolution with a fallback. When the feature is
@@ -185,7 +124,7 @@ pub fn live_symbol_lines(
 /// language/parse errors fall back to `stored`. When the feature is
 /// disabled, simply return `stored`.
 #[cfg(feature = "tree-sitter-symbols")]
-fn resolve_current_symbol(
+fn resolve_current_symbol_for_repo(
     source: &[u8],
     file_path: &std::path::Path,
     symbol: &str,
@@ -202,7 +141,7 @@ fn resolve_current_symbol(
 }
 
 #[cfg(not(feature = "tree-sitter-symbols"))]
-fn resolve_current_symbol(
+fn resolve_current_symbol_for_repo(
     _source: &[u8],
     _file_path: &std::path::Path,
     _symbol: &str,
@@ -252,6 +191,7 @@ fn get_blob_recursive(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use objects::object::{AnnotationScope, ContentHash};
 
     fn make_annotation(scope: AnnotationScope, source_hash: Option<ContentHash>) -> Annotation {
         Annotation::new(
@@ -307,6 +247,43 @@ mod tests {
     fn extract_line_range_empty_source() {
         let result = extract_line_range(b"", 1, 5);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn annotation_status_for_source_matches_legacy_inline_tail() {
+        let source = b"fn kept() {\n    println!(\"kept\");\n}\n\nfn other() {}\n";
+        let file_path = Path::new("src/lib.rs");
+        let file_hash = ContentHash::compute(source);
+        let lines_hash = ContentHash::compute(&extract_line_range(source, 1, 3));
+        let symbol_hash = ContentHash::compute(&extract_line_range(source, 1, 3));
+        let changed_hash = ContentHash::compute(b"old bytes");
+
+        let cases = vec![
+            make_annotation(AnnotationScope::File, Some(file_hash)),
+            make_annotation(AnnotationScope::Lines(1, 3), Some(lines_hash)),
+            make_annotation(
+                AnnotationScope::Symbol {
+                    name: "kept".to_string(),
+                    resolved_lines: Some((1, 3)),
+                },
+                Some(symbol_hash),
+            ),
+            make_annotation(
+                AnnotationScope::Symbol {
+                    name: "missing".to_string(),
+                    resolved_lines: None,
+                },
+                Some(changed_hash),
+            ),
+            make_annotation(AnnotationScope::File, None),
+        ];
+
+        for annotation in cases {
+            let legacy = legacy_annotation_status_for_source(&annotation, source, file_path);
+            let lifted =
+                annotation_status_for_source(&annotation, &annotation.scope, source, file_path);
+            assert_eq!(lifted, legacy, "scope {}", annotation.scope);
+        }
     }
 
     #[test]
@@ -504,6 +481,46 @@ mod tests {
     }
 
     // -- test helpers --
+
+    fn legacy_annotation_status_for_source(
+        annotation: &Annotation,
+        source: &[u8],
+        file_path: &Path,
+    ) -> StalenessStatus {
+        let Some(revision) = annotation.current_revision() else {
+            return StalenessStatus::Unknown;
+        };
+        let expected_hash = match &revision.source_hash {
+            Some(h) => h,
+            None => return StalenessStatus::Unknown,
+        };
+
+        let scoped_bytes = match &annotation.scope {
+            AnnotationScope::File => source.to_vec(),
+            AnnotationScope::Lines(start, end) => extract_line_range(source, *start, *end),
+            AnnotationScope::Symbol {
+                name,
+                resolved_lines,
+            } => match resolve_current_symbol_for_repo(source, file_path, name, *resolved_lines) {
+                Some((start, end)) => extract_line_range(source, start, end),
+                None => {
+                    return StalenessStatus::SymbolMissing {
+                        symbol: name.clone(),
+                    };
+                }
+            },
+        };
+
+        let current_hash = ContentHash::compute(&scoped_bytes);
+        if current_hash == *expected_hash {
+            StalenessStatus::Fresh
+        } else {
+            StalenessStatus::SourceChanged {
+                old_hash: *expected_hash,
+                new_hash: current_hash,
+            }
+        }
+    }
 
     fn make_test_repo() -> (tempfile::TempDir, Repository) {
         let dir = tempfile::TempDir::new().unwrap();


### PR DESCRIPTION
## What
Phase 2 of the storage-seam refactor — the **I/O split**. Lifts heddle's last two I/O-coupled repository algorithms' PURE cores into `crates/objects` (no new crate), so `Repository` — and later weft — call shared logic instead of forking it. **Behavior-neutral** (byte-identical outputs, proven by characterization tests).

Context: heddle had already extracted tree-diff/closure/ancestor/merge into pure free-fns; this finishes the remaining two.

## Commits
1. **Hoist S3 encoding out of retries** (the P1 follow-up nit) — `codec::encode_*` was called *inside* the s3 retry closure, re-serializing+re-compressing per attempt. Hoisted above `retry_with`, encode once. Byte-identical, fewer CPU cycles on retry.
2. **Extract annotation-staleness core** — `objects::staleness_core::annotation_status_for_source(&Annotation, &AnnotationScope, source: &[u8], path)` (store-free). `Repository::check_annotation_staleness` now fetches tree+blob then delegates. Semantic symbol-resolution is *injected from repo* to keep the objects core free of `Repository`/`semantic` (avoids a feature cycle).
3. **Extract context-suggestion scoring core** — `objects::suggestion_core::score_suggestions(SuggestionInputs, limit)` (the pure scoring/tiering block + weight constants). `suggest_context_targets` builds `SuggestionInputs` via I/O then delegates.

## Why
This sets up Phase 3 (the sync/async `ObjectSource` trait), which is what finally lets **weft delete its forked `WeftRepository` algorithms** rather than maintain a parallel async copy. Every walker stays on `ObjectStore` getters so that swap is one signature edit per core.

## Proof
- **Characterization test**: `annotation_status_for_source` == old inline logic across all `AnnotationScope` variants (both default + `tree-sitter-symbols` features). PASS.
- **Golden test**: `score_suggestions` tier-boundary snapshots + `suggest_context_targets` fixture golden. PASS.
- All gates green: default + `--all-features` build, silent-default check, mount tests, `clippy -D warnings`, `cargo test --workspace`, s3 compliance.

Types get one home in `objects` with `pub use` re-exports at the old `repo` paths (re-export, not a back-compat shim). No new crate; no `ObjectSource` trait (that's Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/762"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784525605&installation_id=132405951&pr_number=762&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F762&signature=7ce4698380d84dc884b8d223c6ee91ca7db676c46f7a1f056bb77e7a3060fda0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->