### PR TITLE
seam P3a: ObjectSource sync/async read seam (tree_diff + staleness)

### DIFF
--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -41,6 +41,7 @@ aws-smithy-async = { workspace = true, optional = true }
 runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.4", optional = true }
 
 [features]
+async-source = []
 bench = ["heddle-format/bench"]
 s3 = ["dep:aws-sdk-s3", "dep:aws-smithy-async", "dep:tokio", "dep:runtime-bridge"]
 memory-backend = []

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -91,5 +91,7 @@ pub use timeline::{
 pub use tree::{
     EntryType, FileMode, Tree, TreeEntry, TreeError, validate_name as validate_tree_entry_name,
 };
+#[cfg(feature = "async-source")]
+pub use tree_diff::diff_trees_visit_async;
 pub use tree_diff::{diff_trees, diff_trees_visit};
 pub use visibility_tier::VisibilityTier;

--- a/crates/objects/src/object/tree_diff.rs
+++ b/crates/objects/src/object/tree_diff.rs
@@ -9,8 +9,11 @@ use std::ops::ControlFlow;
 use super::FileChangeSet;
 use crate::{
     object::{DiffKind, EntryType, FileChange, Tree, TreeEntry},
-    store::ObjectStore,
+    store::ObjectSource,
 };
+
+#[cfg(feature = "async-source")]
+use crate::store::AsyncObjectSource;
 
 /// Collect all file changes between two trees.
 ///
@@ -18,7 +21,7 @@ use crate::{
 /// [`diff_trees_visit`] and collects every [`FileChange`] into a
 /// [`FileChangeSet`]. Streaming or early-exit consumers should prefer
 /// [`diff_trees_visit`], which avoids allocating the full change list.
-pub fn diff_trees<S: ObjectStore + ?Sized>(
+pub fn diff_trees<S: ObjectSource + ?Sized>(
     store: &S,
     from: &crate::object::ContentHash,
     to: &crate::object::ContentHash,
@@ -54,7 +57,7 @@ pub fn diff_trees_visit<S, V, B>(
     mut visitor: V,
 ) -> Result<ControlFlow<B>, anyhow::Error>
 where
-    S: ObjectStore + ?Sized,
+    S: ObjectSource + ?Sized,
     V: FnMut(FileChange) -> ControlFlow<B>,
 {
     if from == to {
@@ -78,7 +81,7 @@ fn diff_trees_recursive<S, V, B>(
     visitor: &mut V,
 ) -> Result<ControlFlow<B>, anyhow::Error>
 where
-    S: ObjectStore + ?Sized,
+    S: ObjectSource + ?Sized,
     V: FnMut(FileChange) -> ControlFlow<B>,
 {
     let from_entries = from.as_ref().map_or(&[][..], Tree::entries);
@@ -156,7 +159,7 @@ fn visit_added_entry<S, V, B>(
     visitor: &mut V,
 ) -> Result<ControlFlow<B>, anyhow::Error>
 where
-    S: ObjectStore + ?Sized,
+    S: ObjectSource + ?Sized,
     V: FnMut(FileChange) -> ControlFlow<B>,
 {
     // Symmetric with the delete branch below: if the added entry is itself a
@@ -177,13 +180,181 @@ fn visit_deleted_entry<S, V, B>(
     visitor: &mut V,
 ) -> Result<ControlFlow<B>, anyhow::Error>
 where
-    S: ObjectStore + ?Sized,
+    S: ObjectSource + ?Sized,
     V: FnMut(FileChange) -> ControlFlow<B>,
 {
     let path = child_path(prefix, &from_entry.name);
     if from_entry.entry_type == EntryType::Tree {
         let from_subtree = store.get_tree(&from_entry.hash)?;
         diff_trees_recursive(store, &from_subtree, &None, &path, visitor)
+    } else {
+        Ok(visitor(FileChange::new(path, DiffKind::Deleted)))
+    }
+}
+
+#[cfg(feature = "async-source")]
+pub async fn diff_trees_visit_async<S, V, B>(
+    store: &S,
+    from: &crate::object::ContentHash,
+    to: &crate::object::ContentHash,
+    mut visitor: V,
+) -> Result<ControlFlow<B>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+    V: FnMut(FileChange) -> ControlFlow<B> + Send,
+    B: Send,
+{
+    if from == to {
+        return Ok(ControlFlow::Continue(()));
+    }
+    let from_tree = store.get_tree(from).await?;
+    let to_tree = store.get_tree(to).await?;
+    diff_trees_recursive_async(store, &from_tree, &to_tree, "", &mut visitor).await
+}
+
+#[cfg(feature = "async-source")]
+async fn diff_trees_recursive_async<S, V, B>(
+    store: &S,
+    from: &Option<Tree>,
+    to: &Option<Tree>,
+    prefix: &str,
+    visitor: &mut V,
+) -> Result<ControlFlow<B>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+    V: FnMut(FileChange) -> ControlFlow<B> + Send,
+    B: Send,
+{
+    let from_entries = from.as_ref().map_or(&[][..], Tree::entries);
+    let to_entries = to.as_ref().map_or(&[][..], Tree::entries);
+
+    let mut from_index = 0;
+    let mut to_index = 0;
+
+    while let (Some(from_entry), Some(to_entry)) =
+        (from_entries.get(from_index), to_entries.get(to_index))
+    {
+        match from_entry.name.cmp(&to_entry.name) {
+            std::cmp::Ordering::Less => {
+                if let ControlFlow::Break(b) =
+                    visit_deleted_entry_async(store, prefix, from_entry, visitor).await?
+                {
+                    return Ok(ControlFlow::Break(b));
+                }
+                from_index += 1;
+            }
+            std::cmp::Ordering::Greater => {
+                if let ControlFlow::Break(b) =
+                    visit_added_entry_async(store, prefix, to_entry, visitor).await?
+                {
+                    return Ok(ControlFlow::Break(b));
+                }
+                to_index += 1;
+            }
+            std::cmp::Ordering::Equal => {
+                if from_entry.hash != to_entry.hash {
+                    if from_entry.entry_type == EntryType::Tree
+                        && to_entry.entry_type == EntryType::Tree
+                    {
+                        let from_subtree = store.get_tree(&from_entry.hash).await?;
+                        let to_subtree = store.get_tree(&to_entry.hash).await?;
+                        let path = child_path(prefix, &to_entry.name);
+                        if let ControlFlow::Break(b) = Box::pin(diff_trees_recursive_async(
+                            store,
+                            &from_subtree,
+                            &to_subtree,
+                            &path,
+                            visitor,
+                        ))
+                        .await?
+                        {
+                            return Ok(ControlFlow::Break(b));
+                        }
+                    } else {
+                        let path = child_path(prefix, &to_entry.name);
+                        if let ControlFlow::Break(b) =
+                            visitor(FileChange::new(path, DiffKind::Modified))
+                        {
+                            return Ok(ControlFlow::Break(b));
+                        }
+                    }
+                }
+                from_index += 1;
+                to_index += 1;
+            }
+        }
+    }
+
+    for from_entry in &from_entries[from_index..] {
+        if let ControlFlow::Break(b) =
+            visit_deleted_entry_async(store, prefix, from_entry, visitor).await?
+        {
+            return Ok(ControlFlow::Break(b));
+        }
+    }
+
+    for to_entry in &to_entries[to_index..] {
+        if let ControlFlow::Break(b) =
+            visit_added_entry_async(store, prefix, to_entry, visitor).await?
+        {
+            return Ok(ControlFlow::Break(b));
+        }
+    }
+
+    Ok(ControlFlow::Continue(()))
+}
+
+#[cfg(feature = "async-source")]
+async fn visit_added_entry_async<S, V, B>(
+    store: &S,
+    prefix: &str,
+    to_entry: &TreeEntry,
+    visitor: &mut V,
+) -> Result<ControlFlow<B>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+    V: FnMut(FileChange) -> ControlFlow<B> + Send,
+    B: Send,
+{
+    let path = child_path(prefix, &to_entry.name);
+    if to_entry.entry_type == EntryType::Tree {
+        let to_subtree = store.get_tree(&to_entry.hash).await?;
+        Box::pin(diff_trees_recursive_async(
+            store,
+            &None,
+            &to_subtree,
+            &path,
+            visitor,
+        ))
+        .await
+    } else {
+        Ok(visitor(FileChange::new(path, DiffKind::Added)))
+    }
+}
+
+#[cfg(feature = "async-source")]
+async fn visit_deleted_entry_async<S, V, B>(
+    store: &S,
+    prefix: &str,
+    from_entry: &TreeEntry,
+    visitor: &mut V,
+) -> Result<ControlFlow<B>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+    V: FnMut(FileChange) -> ControlFlow<B> + Send,
+    B: Send,
+{
+    let path = child_path(prefix, &from_entry.name);
+    if from_entry.entry_type == EntryType::Tree {
+        let from_subtree = store.get_tree(&from_entry.hash).await?;
+        Box::pin(diff_trees_recursive_async(
+            store,
+            &from_subtree,
+            &None,
+            &path,
+            visitor,
+        ))
+        .await
     } else {
         Ok(visitor(FileChange::new(path, DiffKind::Deleted)))
     }
@@ -206,7 +377,7 @@ mod tests {
     use super::*;
     use crate::{
         object::{Blob, ContentHash, FileMode, Tree, TreeEntry},
-        store::InMemoryStore,
+        store::{InMemoryStore, ObjectStore},
     };
 
     fn create_blob(store: &InMemoryStore, content: &str) -> ContentHash {

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -15,6 +15,7 @@ pub mod liveness;
 pub mod memory;
 pub mod pack;
 pub mod shallow;
+pub mod source;
 pub mod store_compliance;
 
 #[cfg(feature = "s3")]
@@ -33,6 +34,9 @@ pub use pack::{PackBuilder, PackObjectId, PackReader, PackStats};
 #[cfg(feature = "s3")]
 pub use s3::{S3Store, S3StoreBuilder};
 pub use shallow::ShallowInfo;
+#[cfg(feature = "async-source")]
+pub use source::AsyncObjectSource;
+pub use source::ObjectSource;
 
 pub use crate::error::{HeddleError as StoreError, HeddleError, Result};
 
@@ -77,13 +81,21 @@ macro_rules! any_store_dispatch {
 
 impl ObjectStore for AnyStore {
     fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
-        any_store_dispatch!(self, get_blob(hash))
+        match self {
+            AnyStore::Fs(inner) => ObjectStore::get_blob(inner, hash),
+            #[cfg(feature = "s3")]
+            AnyStore::S3(inner) => ObjectStore::get_blob(inner, hash),
+        }
     }
     fn put_blob(&self, blob: &Blob) -> Result<ContentHash> {
         any_store_dispatch!(self, put_blob(blob))
     }
     fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
-        any_store_dispatch!(self, get_blob_bytes(hash))
+        match self {
+            AnyStore::Fs(inner) => ObjectStore::get_blob_bytes(inner, hash),
+            #[cfg(feature = "s3")]
+            AnyStore::S3(inner) => ObjectStore::get_blob_bytes(inner, hash),
+        }
     }
     fn blob_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
         any_store_dispatch!(self, blob_size(hash))
@@ -104,7 +116,11 @@ impl ObjectStore for AnyStore {
         any_store_dispatch!(self, has_blob(hash))
     }
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        any_store_dispatch!(self, get_tree(hash))
+        match self {
+            AnyStore::Fs(inner) => ObjectStore::get_tree(inner, hash),
+            #[cfg(feature = "s3")]
+            AnyStore::S3(inner) => ObjectStore::get_tree(inner, hash),
+        }
     }
     fn put_tree(&self, tree: &Tree) -> Result<ContentHash> {
         any_store_dispatch!(self, put_tree(tree))
@@ -113,7 +129,11 @@ impl ObjectStore for AnyStore {
         any_store_dispatch!(self, has_tree(hash))
     }
     fn get_state(&self, id: &ChangeId) -> Result<Option<State>> {
-        any_store_dispatch!(self, get_state(id))
+        match self {
+            AnyStore::Fs(inner) => ObjectStore::get_state(inner, id),
+            #[cfg(feature = "s3")]
+            AnyStore::S3(inner) => ObjectStore::get_state(inner, id),
+        }
     }
     fn put_state(&self, state: &State) -> Result<()> {
         any_store_dispatch!(self, put_state(state))

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -655,12 +655,18 @@ mod any_store_tests {
         let blob = Blob::from("any-store dispatch blob");
         let blob_hash = store.put_blob(&blob).unwrap();
         assert_eq!(
-            store.get_blob(&blob_hash).unwrap().unwrap().content(),
+            ObjectStore::get_blob(&store, &blob_hash)
+                .unwrap()
+                .unwrap()
+                .content(),
             blob.content()
         );
         assert!(store.has_blob(&blob_hash).unwrap());
         assert_eq!(
-            store.get_blob_bytes(&blob_hash).unwrap().unwrap().as_ref(),
+            ObjectStore::get_blob_bytes(&store, &blob_hash)
+                .unwrap()
+                .unwrap()
+                .as_ref(),
             blob.content()
         );
         assert_eq!(
@@ -689,7 +695,7 @@ mod any_store_tests {
         // ── Trees ──
         let tree = Tree::new();
         let tree_hash = store.put_tree(&tree).unwrap();
-        assert!(store.get_tree(&tree_hash).unwrap().is_some());
+        assert!(ObjectStore::get_tree(&store, &tree_hash).unwrap().is_some());
         assert!(store.has_tree(&tree_hash).unwrap());
         assert!(store.list_trees().unwrap().contains(&tree_hash));
         let tree2 = Tree::new();
@@ -707,7 +713,7 @@ mod any_store_tests {
         let state = State::new(tree_hash, vec![], attribution.clone());
         let change_id = state.change_id;
         store.put_state(&state).unwrap();
-        assert!(store.get_state(&change_id).unwrap().is_some());
+        assert!(ObjectStore::get_state(&store, &change_id).unwrap().is_some());
         assert!(store.has_state(&change_id).unwrap());
         assert!(store.list_states().unwrap().contains(&change_id));
         let state2 = State::new(tree2.hash(), vec![], attribution.clone());

--- a/crates/objects/src/store/source.rs
+++ b/crates/objects/src/store/source.rs
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Read-only object source traits for graph walkers.
+
+use crate::{
+    object::{Blob, ChangeId, ContentHash, State, Tree},
+    store::ObjectStore,
+};
+
+use super::Result;
+
+/// Read-only subset of [`ObjectStore`] needed by object graph walkers.
+pub trait ObjectSource {
+    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>>;
+    fn get_state(&self, id: &ChangeId) -> Result<Option<State>>;
+    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>>;
+
+    /// Zero-copy variant of `get_blob`.
+    fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
+        Ok(self
+            .get_blob(hash)?
+            .map(|blob| bytes::Bytes::from(blob.into_content())))
+    }
+}
+
+impl<S: ObjectStore + ?Sized> ObjectSource for S {
+    #[inline]
+    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        ObjectStore::get_tree(self, hash)
+    }
+
+    #[inline]
+    fn get_state(&self, id: &ChangeId) -> Result<Option<State>> {
+        ObjectStore::get_state(self, id)
+    }
+
+    #[inline]
+    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
+        ObjectStore::get_blob(self, hash)
+    }
+
+    #[inline]
+    fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
+        ObjectStore::get_blob_bytes(self, hash)
+    }
+}
+
+#[cfg(feature = "async-source")]
+#[allow(async_fn_in_trait)]
+pub trait AsyncObjectSource {
+    async fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>>;
+    async fn get_state(&self, id: &ChangeId) -> Result<Option<State>>;
+    async fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>>;
+}

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -73,9 +73,11 @@ tree-sitter-symbols = ["dep:semantic", "semantic/lang-go", "dep:state_review"]
 # declared with the `dep:` prefix, so Cargo does not auto-create an
 # implicit `semantic` feature; this line makes it explicit.
 semantic = ["tree-sitter-symbols"]
+async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
+objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -287,19 +287,10 @@ mod tests {
 
     #[cfg(feature = "async-source")]
     fn block_on<F: std::future::Future>(future: F) -> F::Output {
-        use std::{
-            sync::Arc,
-            task::{Context, Poll, Wake, Waker},
-        };
+        use std::task::{Context, Poll, Waker};
 
-        struct NoopWaker;
-
-        impl Wake for NoopWaker {
-            fn wake(self: Arc<Self>) {}
-        }
-
-        let waker = Waker::from(Arc::new(NoopWaker));
-        let mut context = Context::from_waker(&waker);
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
         let mut future = std::pin::pin!(future);
 
         loop {

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -11,8 +11,11 @@ use objects::{
         Annotation, Blob, ContextTarget, State, Tree,
         annotation_status_for_source_with_symbol_resolver,
     },
-    store::ObjectStore,
+    store::ObjectSource,
 };
+
+#[cfg(feature = "async-source")]
+use objects::store::AsyncObjectSource;
 
 use crate::Repository;
 
@@ -152,7 +155,7 @@ fn resolve_current_symbol_for_repo(
 
 /// Resolve a blob at a file path within a tree by walking the tree hierarchy.
 fn get_blob_at_path(
-    store: &impl ObjectStore,
+    store: &impl ObjectSource,
     tree: &Tree,
     path: &str,
 ) -> Result<Option<Blob>, anyhow::Error> {
@@ -161,7 +164,7 @@ fn get_blob_at_path(
 }
 
 fn get_blob_recursive(
-    store: &impl ObjectStore,
+    store: &impl ObjectSource,
     tree: &Tree,
     parts: &[&str],
 ) -> Result<Option<Blob>, anyhow::Error> {
@@ -188,10 +191,68 @@ fn get_blob_recursive(
     Ok(None)
 }
 
+/// Resolve a blob at a file path within a tree by walking the tree hierarchy.
+#[cfg(feature = "async-source")]
+pub async fn get_blob_at_path_async<S>(
+    store: &S,
+    tree: &Tree,
+    path: &str,
+) -> Result<Option<Blob>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    let parts: Vec<&str> = path.split('/').collect();
+    get_blob_recursive_async(store, tree, &parts).await
+}
+
+#[cfg(feature = "async-source")]
+async fn get_blob_recursive_async<S>(
+    store: &S,
+    tree: &Tree,
+    parts: &[&str],
+) -> Result<Option<Blob>, anyhow::Error>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    if parts.is_empty() {
+        return Ok(None);
+    }
+
+    let name = parts[0];
+    let entry = match tree.get(name) {
+        Some(e) => e,
+        None => return Ok(None),
+    };
+
+    if parts.len() == 1 {
+        if entry.is_blob() {
+            return Ok(store.get_blob(&entry.hash).await?);
+        }
+    } else if entry.is_tree()
+        && let Some(subtree) = store.get_tree(&entry.hash).await?
+    {
+        return Box::pin(get_blob_recursive_async(store, &subtree, &parts[1..])).await;
+    }
+
+    Ok(None)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use objects::object::{AnnotationScope, ContentHash};
+    use objects::{
+        object::{AnnotationScope, ContentHash},
+        store::ObjectStore,
+    };
+
+    #[cfg(feature = "async-source")]
+    use objects::{
+        object::{
+            Blob, ChangeId, DiffKind, EntryType, FileChange, FileMode, TreeEntry,
+            diff_trees_visit, diff_trees_visit_async,
+        },
+        store::{AsyncObjectSource, InMemoryStore},
+    };
 
     fn make_annotation(scope: AnnotationScope, source_hash: Option<ContentHash>) -> Annotation {
         Annotation::new(
@@ -204,6 +265,182 @@ mod tests {
             source_hash,
             None,
         )
+    }
+
+    #[cfg(feature = "async-source")]
+    struct AsyncInMemorySource<'a>(&'a InMemoryStore);
+
+    #[cfg(feature = "async-source")]
+    impl AsyncObjectSource for AsyncInMemorySource<'_> {
+        async fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+            ObjectStore::get_tree(self.0, hash)
+        }
+
+        async fn get_state(&self, id: &ChangeId) -> objects::error::Result<Option<State>> {
+            ObjectStore::get_state(self.0, id)
+        }
+
+        async fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+            ObjectStore::get_blob(self.0, hash)
+        }
+    }
+
+    #[cfg(feature = "async-source")]
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        use std::{
+            sync::Arc,
+            task::{Context, Poll, Wake, Waker},
+        };
+
+        struct NoopWaker;
+
+        impl Wake for NoopWaker {
+            fn wake(self: Arc<Self>) {}
+        }
+
+        let waker = Waker::from(Arc::new(NoopWaker));
+        let mut context = Context::from_waker(&waker);
+        let mut future = std::pin::pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    #[cfg(feature = "async-source")]
+    fn create_blob(store: &InMemoryStore, content: &[u8]) -> ContentHash {
+        ObjectStore::put_blob(store, &Blob::from_slice(content)).unwrap()
+    }
+
+    #[cfg(feature = "async-source")]
+    fn create_tree(
+        store: &InMemoryStore,
+        entries: Vec<(&str, ContentHash, EntryType)>,
+    ) -> ContentHash {
+        let entries = entries
+            .into_iter()
+            .map(|(name, hash, entry_type)| TreeEntry {
+                name: name.to_string(),
+                mode: FileMode::Normal,
+                hash,
+                entry_type,
+            })
+            .collect();
+        ObjectStore::put_tree(store, &Tree::from_entries(entries)).unwrap()
+    }
+
+    #[cfg(feature = "async-source")]
+    fn blob_content(blob: Option<Blob>) -> Option<Vec<u8>> {
+        blob.map(Blob::into_content)
+    }
+
+    #[cfg(feature = "async-source")]
+    #[test]
+    fn async_source_golden_vectors_match_sync_walkers() {
+        let store = InMemoryStore::new();
+        let async_store = AsyncInMemorySource(&store);
+
+        let from_nested = create_blob(&store, b"old nested");
+        let from_nested_tree = create_tree(
+            &store,
+            vec![("c.txt", from_nested, EntryType::Blob)],
+        );
+        let to_nested = create_blob(&store, b"new nested");
+        let to_nested_tree = create_tree(&store, vec![("b.txt", to_nested, EntryType::Blob)]);
+
+        let from_hash = create_tree(
+            &store,
+            vec![
+                (
+                    "a.txt",
+                    create_blob(&store, b"old a"),
+                    EntryType::Blob,
+                ),
+                ("dir", from_nested_tree, EntryType::Tree),
+                (
+                    "same.txt",
+                    create_blob(&store, b"same"),
+                    EntryType::Blob,
+                ),
+                (
+                    "z.txt",
+                    create_blob(&store, b"old z"),
+                    EntryType::Blob,
+                ),
+            ],
+        );
+        let to_hash = create_tree(
+            &store,
+            vec![
+                (
+                    "b.txt",
+                    create_blob(&store, b"new b"),
+                    EntryType::Blob,
+                ),
+                ("dir", to_nested_tree, EntryType::Tree),
+                (
+                    "same.txt",
+                    create_blob(&store, b"same"),
+                    EntryType::Blob,
+                ),
+                (
+                    "z.txt",
+                    create_blob(&store, b"new z"),
+                    EntryType::Blob,
+                ),
+            ],
+        );
+
+        let expected_changes = vec![
+            ("a.txt".to_string(), DiffKind::Deleted),
+            ("b.txt".to_string(), DiffKind::Added),
+            ("dir/b.txt".to_string(), DiffKind::Added),
+            ("dir/c.txt".to_string(), DiffKind::Deleted),
+            ("z.txt".to_string(), DiffKind::Modified),
+        ];
+
+        let mut sync_changes = Vec::new();
+        let _ = diff_trees_visit(&store, &from_hash, &to_hash, |change| {
+            sync_changes.push(FileChange::into_tuple(change));
+            std::ops::ControlFlow::<()>::Continue(())
+        })
+        .unwrap();
+
+        let mut async_changes = Vec::new();
+        let _ = block_on(diff_trees_visit_async(
+            &async_store,
+            &from_hash,
+            &to_hash,
+            |change| {
+                async_changes.push(FileChange::into_tuple(change));
+                std::ops::ControlFlow::<()>::Continue(())
+            },
+        ))
+        .unwrap();
+
+        assert_eq!(sync_changes, expected_changes);
+        assert_eq!(async_changes, expected_changes);
+        assert_eq!(async_changes, sync_changes);
+
+        let to_tree = ObjectStore::get_tree(&store, &to_hash).unwrap().unwrap();
+        let path_vectors = [
+            ("b.txt", Some(b"new b".to_vec())),
+            ("dir/b.txt", Some(b"new nested".to_vec())),
+            ("dir/c.txt", None),
+        ];
+
+        for (path, expected_blob) in path_vectors {
+            let sync_blob = blob_content(get_blob_at_path(&store, &to_tree, path).unwrap());
+            let async_blob = blob_content(
+                block_on(get_blob_at_path_async(&async_store, &to_tree, path)).unwrap(),
+            );
+            assert_eq!(sync_blob, expected_blob, "sync path {path}");
+            assert_eq!(async_blob, expected_blob, "async path {path}");
+            assert_eq!(async_blob, sync_blob, "dual path {path}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Phase 3a of the heddle↔weft storage seam — the **ObjectSource read seam**, the keystone that lets weft drive heddle's object-graph walkers with async backends instead of forking them.

## What this does
- **New `ObjectSource` (sync) + `AsyncObjectSource` (async, AFIT) read traits** in `crates/objects/src/store/source.rs` (get_tree/get_state/get_blob/get_blob_bytes). Blanket `impl<S: ObjectStore> ObjectSource for S` — every existing store satisfies it for free.
- **`tree_diff` retargeted** onto `ObjectSource` (a strictly weaker bound — zero churn, byte-identical sync path) + a new `diff_trees_visit_async`.
- **staleness path-descent** retargeted onto `ObjectSource` + an async twin.
- The async emissions sit behind a **default-OFF `async-source` feature** — confirmed via `cargo tree` that the default build pulls **no** tokio/aws deps (the #529 default-features trap, avoided).

## Behavior-neutral + proven
- Sync side is a pure refactor (weaker bound + move); the existing tree_diff/staleness tests pass untouched.
- The async side earns trust via a **golden-vector dual-emission test** (`async_source_golden_vectors_match_sync_walkers`): a shared corpus run through both the sync emission (InMemoryStore) and the async emission (in-memory AsyncObjectSource), asserting identical output.

## Gates (all green)
default build · `--all-features` build · `-p heddle-objects --features async-source` build · check-no-silent-default-tree-load · `cargo test -p heddle-mount` · clippy (workspace + async-source) · `cargo test --workspace` · the golden-vector test · no-async-deps `cargo tree` check.

## Note
`cargo test --workspace --all-features` surfaces 2 **pre-existing** failures in CLI command-catalog coverage (`auth`/`presence`/`support` rows) — outside this PR's diff (confined to `objects` + `repo/staleness.rs`) and not run by heddle CI (default features). Flagging as a separate follow-up.

## What's next
- **P3b**: decouple `CommitGraphIndex` so `query_history` runs over `ObjectSource` (the local commit-graph as an optional accelerator).
- **P4**: weft impls `AsyncObjectSource` and **deletes its forked async walkers**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/763"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784534676&installation_id=132405951&pr_number=763&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F763&signature=0e95a1f812e7b5fbe094d375a9d86e28863e09f4ec4e685344dce869db6d1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->