### PR TITLE
seam P3b: decouple query_history/CommitGraphIndex onto ObjectSource (cache = optional accelerator)

### DIFF
--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! In-memory commit graph index with persistence and Bloom filter support.
 
-use std::{
-    collections::{HashMap, HashSet},
-    path::PathBuf,
-};
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
 use objects::{
@@ -17,7 +14,7 @@ use super::{
     Repository,
     bloom_filter::bloom_insert,
     commit_graph_persistence::{
-        PersistedCommitGraphNode, commit_graph_path, load_commit_graph, save_commit_graph,
+        CommitGraphCache, FsCommitGraphCache, LoadedCommitGraph, PersistedCommitGraphNode,
     },
 };
 
@@ -42,33 +39,16 @@ pub struct CachedNodeMetadata {
 pub struct CommitGraphIndex<'repo> {
     repo: &'repo Repository,
     nodes: HashMap<ChangeId, CommitGraphNode>,
-    graph_path: PathBuf,
+    cache: FsCommitGraphCache,
     persistence_dirty: bool,
 }
 
 impl<'repo> CommitGraphIndex<'repo> {
     pub fn new(repo: &'repo Repository) -> Self {
-        let graph_path = commit_graph_path(repo.root());
-        let (nodes, persistence_dirty) = match load_commit_graph(&graph_path) {
-            Ok(Some(nodes)) => (
-                nodes
-                    .into_iter()
-                    .map(|(change_id, node)| {
-                        (
-                            change_id,
-                            CommitGraphNode {
-                                parents: node.parents,
-                                generation: node.generation,
-                                tree_hash: node.tree_hash,
-                                created_at_secs: node.created_at_secs,
-                                agent_model: node.agent_model,
-                                bloom: node.bloom,
-                            },
-                        )
-                    })
-                    .collect(),
-                false,
-            ),
+        let cache = FsCommitGraphCache::new(repo.root());
+        let graph_path = cache.path().expect("fs commit graph cache has a path");
+        let (nodes, persistence_dirty) = match cache.load() {
+            Ok(Some(nodes)) => (nodes.into_memory_nodes(), false),
             Ok(None) => (HashMap::new(), false),
             Err(error) => {
                 warn!(
@@ -83,7 +63,7 @@ impl<'repo> CommitGraphIndex<'repo> {
         Self {
             repo,
             nodes,
-            graph_path,
+            cache,
             persistence_dirty,
         }
     }
@@ -315,14 +295,39 @@ impl<'repo> CommitGraphIndex<'repo> {
             })
             .collect();
 
-        match save_commit_graph(&self.graph_path, &persisted_nodes) {
+        let graph_path = self.cache.path().expect("fs commit graph cache has a path");
+        match self.cache.save(&persisted_nodes) {
             Ok(()) => self.persistence_dirty = false,
             Err(error) => warn!(
                 "Failed to persist commit graph to {}: {}",
-                self.graph_path.display(),
+                graph_path.display(),
                 error
             ),
         }
+    }
+}
+
+trait LoadedCommitGraphExt {
+    fn into_memory_nodes(self) -> HashMap<ChangeId, CommitGraphNode>;
+}
+
+impl LoadedCommitGraphExt for LoadedCommitGraph {
+    fn into_memory_nodes(self) -> HashMap<ChangeId, CommitGraphNode> {
+        self.into_iter()
+            .map(|(change_id, node)| {
+                (
+                    change_id,
+                    CommitGraphNode {
+                        parents: node.parents,
+                        generation: node.generation,
+                        tree_hash: node.tree_hash,
+                        created_at_secs: node.created_at_secs,
+                        agent_model: node.agent_model,
+                        bloom: node.bloom,
+                    },
+                )
+            })
+            .collect()
     }
 }
 

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -6,7 +6,7 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use objects::{
     object::{ChangeId, ContentHash, Tree, diff_trees},
-    store::{ObjectSource, ObjectStore},
+    store::{AnyStore, ObjectSource, ObjectStore},
 };
 use oplog::OpLogBackend;
 use refs::RefBackend;
@@ -38,7 +38,7 @@ pub struct CachedNodeMetadata {
     pub created_at_secs: i64,
 }
 
-pub struct CommitGraphIndex<'source, S: ObjectSource + ?Sized> {
+pub struct CommitGraphIndex<'source, S: ObjectSource + ?Sized = AnyStore> {
     source: &'source S,
     nodes: HashMap<ChangeId, CommitGraphNode>,
     cache: Box<dyn CommitGraphCache + 'source>,

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -6,8 +6,10 @@ use std::collections::{HashMap, HashSet};
 use anyhow::Result;
 use objects::{
     object::{ChangeId, ContentHash, Tree, diff_trees},
-    store::ObjectStore,
+    store::{ObjectSource, ObjectStore},
 };
+use oplog::OpLogBackend;
+use refs::RefBackend;
 use tracing::warn;
 
 use super::{
@@ -36,24 +38,43 @@ pub struct CachedNodeMetadata {
     pub created_at_secs: i64,
 }
 
-pub struct CommitGraphIndex<'repo> {
-    repo: &'repo Repository,
+pub struct CommitGraphIndex<'source, S: ObjectSource + ?Sized> {
+    source: &'source S,
     nodes: HashMap<ChangeId, CommitGraphNode>,
-    cache: FsCommitGraphCache,
+    cache: Box<dyn CommitGraphCache + 'source>,
     persistence_dirty: bool,
 }
 
-impl<'repo> CommitGraphIndex<'repo> {
-    pub fn new(repo: &'repo Repository) -> Self {
-        let cache = FsCommitGraphCache::new(repo.root());
-        let graph_path = cache.path().expect("fs commit graph cache has a path");
+impl<'source, S> CommitGraphIndex<'source, S>
+where
+    S: ObjectStore,
+{
+    pub fn new<R, O>(repo: &'source Repository<R, O, S>) -> Self
+    where
+        R: RefBackend,
+        O: OpLogBackend,
+    {
+        let cache = FsCommitGraphCache::new(&repo.root);
+        Self::with_cache(repo.store(), cache)
+    }
+}
+
+impl<'source, S> CommitGraphIndex<'source, S>
+where
+    S: ObjectSource + ?Sized,
+{
+    pub(crate) fn with_cache<C>(source: &'source S, cache: C) -> Self
+    where
+        C: CommitGraphCache + 'source,
+    {
         let (nodes, persistence_dirty) = match cache.load() {
             Ok(Some(nodes)) => (nodes.into_memory_nodes(), false),
             Ok(None) => (HashMap::new(), false),
             Err(error) => {
+                let cache_label = cache_label(&cache);
                 warn!(
                     "Failed to load commit graph from {}: {}. Rebuilding in memory.",
-                    graph_path.display(),
+                    cache_label,
                     error
                 );
                 (HashMap::new(), true)
@@ -61,9 +82,9 @@ impl<'repo> CommitGraphIndex<'repo> {
         };
 
         Self {
-            repo,
+            source,
             nodes,
-            cache,
+            cache: Box::new(cache),
             persistence_dirty,
         }
     }
@@ -237,7 +258,7 @@ impl<'repo> CommitGraphIndex<'repo> {
             Tree::new().hash()
         };
 
-        let changes = diff_trees(self.repo.store(), &parent_tree, &state_tree)?;
+        let changes = diff_trees(self.source, &parent_tree, &state_tree)?;
         let mut bloom = [0u8; 256];
         for change in changes.iter() {
             bloom_insert(&mut bloom, &change.path);
@@ -257,7 +278,7 @@ impl<'repo> CommitGraphIndex<'repo> {
         &self,
         change_id: ChangeId,
     ) -> Result<(Vec<ChangeId>, ContentHash, i64, Option<String>)> {
-        match self.repo.store().get_state(&change_id)? {
+        match self.source.get_state(&change_id)? {
             Some(state) => Ok((
                 state.parents,
                 state.tree,
@@ -295,16 +316,24 @@ impl<'repo> CommitGraphIndex<'repo> {
             })
             .collect();
 
-        let graph_path = self.cache.path().expect("fs commit graph cache has a path");
         match self.cache.save(&persisted_nodes) {
             Ok(()) => self.persistence_dirty = false,
-            Err(error) => warn!(
-                "Failed to persist commit graph to {}: {}",
-                graph_path.display(),
-                error
-            ),
+            Err(error) => {
+                let cache_label = cache_label(self.cache.as_ref());
+                warn!(
+                    "Failed to persist commit graph to {}: {}",
+                    cache_label, error
+                );
+            }
         }
     }
+}
+
+fn cache_label(cache: &(impl CommitGraphCache + ?Sized)) -> String {
+    cache
+        .path()
+        .map(|path| path.display().to_string())
+        .unwrap_or_else(|| "commit graph cache".to_string())
 }
 
 trait LoadedCommitGraphExt {
@@ -331,11 +360,16 @@ impl LoadedCommitGraphExt for LoadedCommitGraph {
     }
 }
 
-pub fn find_merge_base(
-    repo: &Repository,
+pub fn find_merge_base<R, O, S>(
+    repo: &Repository<R, O, S>,
     state_a: &ChangeId,
     state_b: &ChangeId,
-) -> Result<Option<ChangeId>> {
+) -> Result<Option<ChangeId>>
+where
+    R: RefBackend,
+    O: OpLogBackend,
+    S: ObjectStore,
+{
     let mut graph = CommitGraphIndex::new(repo);
     graph.find_merge_base(state_a, state_b)
 }

--- a/crates/repo/src/commit_graph_persistence.rs
+++ b/crates/repo/src/commit_graph_persistence.rs
@@ -55,6 +55,7 @@ impl CommitGraphCache for FsCommitGraphCache {
     }
 }
 
+#[cfg_attr(not(feature = "async-source"), allow(dead_code))]
 pub(crate) struct NullCommitGraphCache;
 
 impl CommitGraphCache for NullCommitGraphCache {

--- a/crates/repo/src/commit_graph_persistence.rs
+++ b/crates/repo/src/commit_graph_persistence.rs
@@ -19,6 +19,54 @@ const GRAPH_VERSION: u32 = 1;
 const CHANGE_ID_BYTES: usize = 16;
 const CONTENT_HASH_BYTES: usize = 32;
 
+pub(crate) type LoadedCommitGraph = HashMap<ChangeId, PersistedCommitGraphNode>;
+
+pub(crate) trait CommitGraphCache {
+    fn load(&self) -> Result<Option<LoadedCommitGraph>>;
+    fn save(&self, nodes: &LoadedCommitGraph) -> Result<()>;
+    fn path(&self) -> Option<&Path> {
+        None
+    }
+}
+
+pub(crate) struct FsCommitGraphCache {
+    path: PathBuf,
+}
+
+impl FsCommitGraphCache {
+    pub(crate) fn new(repo_root: &Path) -> Self {
+        Self {
+            path: commit_graph_path(repo_root),
+        }
+    }
+}
+
+impl CommitGraphCache for FsCommitGraphCache {
+    fn load(&self) -> Result<Option<LoadedCommitGraph>> {
+        load_commit_graph(&self.path)
+    }
+
+    fn save(&self, nodes: &LoadedCommitGraph) -> Result<()> {
+        save_commit_graph(&self.path, nodes)
+    }
+
+    fn path(&self) -> Option<&Path> {
+        Some(&self.path)
+    }
+}
+
+pub(crate) struct NullCommitGraphCache;
+
+impl CommitGraphCache for NullCommitGraphCache {
+    fn load(&self) -> Result<Option<LoadedCommitGraph>> {
+        Ok(None)
+    }
+
+    fn save(&self, _nodes: &LoadedCommitGraph) -> Result<()> {
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct PersistedCommitGraphNode {
     pub(crate) parents: Vec<ChangeId>,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -101,6 +101,8 @@ pub use repository::{
     is_synthetic_root,
 };
 pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
+#[cfg(feature = "async-source")]
+pub use repository::query_history_async;
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -86,6 +86,8 @@ pub use repo_config::{
     SignalModuleToml, TestReachabilityToml,
 };
 pub use repository_history::{ChangedPathFilter, ChangedPathFilters, HistoryQuery};
+#[cfg(feature = "async-source")]
+pub use repository_history::query_history_async;
 pub use repository_maintenance::{
     ChangeMonitorInspection, CommitGraphInspection, PackFilesInspection, PartialFetchInspection,
     PullPlannerCacheInspection, RefCountsInspection, RepositoryMaintenanceRunReport,

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -10,12 +10,19 @@ use objects::{
     object::{ChangeId, ContentHash, State, Tree, diff_trees_visit},
     store::ObjectSource,
 };
+#[cfg(feature = "async-source")]
+use objects::{
+    object::diff_trees_visit_async,
+    store::AsyncObjectSource,
+};
 use tracing::{instrument, trace};
 
 use crate::{
     HeddleError, Repository, Result,
     repository::commit_graph_persistence::{CommitGraphCache, FsCommitGraphCache},
 };
+#[cfg(feature = "async-source")]
+use crate::repository::commit_graph_persistence::NullCommitGraphCache;
 
 /// A normalized changed-path filter for history traversal.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -281,6 +288,106 @@ where
     }
 }
 
+/// Walk first-parent history against an async read-only object source.
+#[cfg(feature = "async-source")]
+pub async fn query_history_async<S>(source: &S, query: &HistoryQuery) -> Result<Vec<State>>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    query_history_async_with_cache(source, query, NullCommitGraphCache).await
+}
+
+#[cfg(feature = "async-source")]
+async fn query_history_async_with_cache<S>(
+    source: &S,
+    query: &HistoryQuery,
+    _cache: NullCommitGraphCache,
+) -> Result<Vec<State>>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    let mut candidate_ids = Vec::new();
+    let mut current = query.start;
+
+    while let Some(state_id) = current {
+        if candidate_ids.len() >= query.limit {
+            break;
+        }
+
+        if let Some(stop) = query.stop_at
+            && state_id == stop
+        {
+            break;
+        }
+
+        let Some(state) = source.get_state(&state_id).await? else {
+            break;
+        };
+        current = state.parents.first().copied();
+
+        if let Some(ref filter) = query.agent_model_substring {
+            match state.attribution.agent.as_ref().map(|agent| &agent.model) {
+                Some(model) if model.contains(filter.as_str()) => {}
+                _ => continue,
+            }
+        }
+
+        if query.changed_paths.is_empty()
+            || state_matches_changed_paths_async(source, &state, &query.changed_paths).await?
+        {
+            trace!(state = %state_id, "async history query matched state");
+            candidate_ids.push(state_id);
+        }
+    }
+
+    let mut result = Vec::with_capacity(candidate_ids.len());
+    for id in candidate_ids {
+        if let Some(state) = source.get_state(&id).await? {
+            result.push(state);
+        }
+    }
+    Ok(result)
+}
+
+#[cfg(feature = "async-source")]
+async fn state_matches_changed_paths_async<S>(
+    source: &S,
+    state: &State,
+    changed_paths: &ChangedPathFilters,
+) -> Result<bool>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    let base_tree = parent_tree_hash_async(source, state).await?;
+    let flow = diff_trees_visit_async(source, &base_tree, &state.tree, |change| {
+        if changed_paths.matches(&change.path) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .await
+    .map_err(|error| HeddleError::InvalidObject(format!("tree diff failed: {error}")))?;
+    Ok(flow.is_break())
+}
+
+#[cfg(feature = "async-source")]
+async fn parent_tree_hash_async<S>(source: &S, state: &State) -> Result<ContentHash>
+where
+    S: AsyncObjectSource + Sync + ?Sized,
+{
+    match state.first_parent() {
+        Some(parent_id) => {
+            let parent = source
+                .get_state(parent_id)
+                .await?
+                .ok_or(HeddleError::StateNotFound(*parent_id))?;
+            Ok(parent.tree)
+        }
+        None => Ok(Tree::new().hash()),
+    }
+}
+
 fn normalize_repo_relative_path(path: &str) -> Result<String> {
     let input = Path::new(path);
     if input.is_absolute() {
@@ -335,6 +442,15 @@ mod tests {
     };
     use crate::Repository;
     use crate::repository::commit_graph_persistence::NullCommitGraphCache;
+
+    #[cfg(feature = "async-source")]
+    use objects::{
+        object::{
+            Attribution, Blob, ChangeId, ContentHash, EntryType, FileMode, Principal, State, Tree,
+            TreeEntry,
+        },
+        store::{AsyncObjectSource, InMemoryStore, ObjectStore},
+    };
 
     #[test]
     fn changed_path_filter_matches_exact_paths_and_children() {
@@ -399,6 +515,125 @@ mod tests {
                 .collect::<Vec<_>>(),
             expected
         );
+    }
+
+    #[cfg(feature = "async-source")]
+    #[test]
+    fn query_history_async_matches_sync_null_cache_for_path_filtered_first_parent_walk() {
+        let store = InMemoryStore::new();
+
+        let base_tree = root_tree(&store, "one\n", None);
+        let base = put_state(&store, base_tree, vec![]);
+
+        let docs_tree = root_tree(&store, "one\n", Some("docs\n"));
+        let docs = put_state(&store, docs_tree, vec![base.change_id]);
+
+        let src_tree = root_tree(&store, "two\n", Some("docs\n"));
+        let src = put_state(&store, src_tree, vec![docs.change_id]);
+
+        let side_tree = root_tree(&store, "side\n", None);
+        let side = put_state(&store, side_tree, vec![base.change_id]);
+
+        let head_tree = root_tree(&store, "two\n", Some("more docs\n"));
+        let head = put_state(&store, head_tree, vec![src.change_id, side.change_id]);
+
+        let query = HistoryQuery::new(Some(head.change_id))
+            .with_limit(10)
+            .with_changed_paths(ChangedPathFilters::try_from_paths(["src"]).unwrap());
+
+        let sync = query_history_with_cache(&store, &query, NullCommitGraphCache).unwrap();
+        let async_source = AsyncInMemorySource(&store);
+        let async_result = block_on(super::query_history_async(&async_source, &query)).unwrap();
+
+        assert_eq!(sync, async_result);
+        assert_eq!(
+            async_result
+                .iter()
+                .map(|state| state.change_id)
+                .collect::<Vec<_>>(),
+            vec![src.change_id, base.change_id]
+        );
+    }
+
+    #[cfg(feature = "async-source")]
+    struct AsyncInMemorySource<'a>(&'a InMemoryStore);
+
+    #[cfg(feature = "async-source")]
+    impl AsyncObjectSource for AsyncInMemorySource<'_> {
+        async fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+            ObjectStore::get_tree(self.0, hash)
+        }
+
+        async fn get_state(
+            &self,
+            id: &objects::object::ChangeId,
+        ) -> objects::error::Result<Option<State>> {
+            ObjectStore::get_state(self.0, id)
+        }
+
+        async fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+            ObjectStore::get_blob(self.0, hash)
+        }
+    }
+
+    #[cfg(feature = "async-source")]
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        use std::task::{Context, Poll, Waker};
+
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        let mut future = std::pin::pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
+    }
+
+    #[cfg(feature = "async-source")]
+    fn root_tree(store: &InMemoryStore, src_content: &str, readme: Option<&str>) -> ContentHash {
+        let lib = ObjectStore::put_blob(store, &Blob::from_slice(src_content.as_bytes())).unwrap();
+        let src = tree(
+            store,
+            vec![("lib.rs", lib, EntryType::Blob)],
+        );
+        let mut entries = vec![("src", src, EntryType::Tree)];
+        if let Some(readme) = readme {
+            let readme =
+                ObjectStore::put_blob(store, &Blob::from_slice(readme.as_bytes())).unwrap();
+            entries.push(("README.md", readme, EntryType::Blob));
+        }
+        tree(store, entries)
+    }
+
+    #[cfg(feature = "async-source")]
+    fn tree(
+        store: &InMemoryStore,
+        entries: Vec<(&str, ContentHash, EntryType)>,
+    ) -> ContentHash {
+        let entries = entries
+            .into_iter()
+            .map(|(name, hash, entry_type)| TreeEntry {
+                name: name.to_string(),
+                mode: FileMode::Normal,
+                hash,
+                entry_type,
+            })
+            .collect();
+        ObjectStore::put_tree(store, &Tree::from_entries(entries)).unwrap()
+    }
+
+    #[cfg(feature = "async-source")]
+    fn put_state(store: &InMemoryStore, tree: ContentHash, parents: Vec<ChangeId>) -> State {
+        let state = State::new(
+            tree,
+            parents,
+            Attribution::human(Principal::new("Test User", "test@example.com")),
+        );
+        ObjectStore::put_state(store, &state).unwrap();
+        state
     }
 
     #[test]

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -7,12 +7,15 @@ use std::{
 };
 
 use objects::{
-    object::{ChangeId, State, Tree},
-    store::ObjectStore,
+    object::{ChangeId, ContentHash, State, Tree, diff_trees_visit},
+    store::ObjectSource,
 };
 use tracing::{instrument, trace};
 
-use crate::{HeddleError, Repository, Result};
+use crate::{
+    HeddleError, Repository, Result,
+    repository::commit_graph_persistence::{CommitGraphCache, FsCommitGraphCache},
+};
 
 /// A normalized changed-path filter for history traversal.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -138,120 +141,143 @@ impl Repository {
     /// Walk first-parent history and return states matching the query.
     #[instrument(skip(self, query), fields(limit = query.limit, changed_path_filters = query.changed_paths.len()))]
     pub fn query_history(&self, query: &HistoryQuery) -> Result<Vec<State>> {
-        use super::commit_graph::CommitGraphIndex;
+        query_history_with_cache(
+            self.store(),
+            query,
+            FsCommitGraphCache::new(self.root()),
+        )
+    }
+}
 
-        let mut graph = CommitGraphIndex::new(self);
-        let mut candidate_ids = Vec::new();
-        let mut current = query.start;
+/// Walk first-parent history against any read-only object source.
+pub(crate) fn query_history_with_cache<S, C>(
+    source: &S,
+    query: &HistoryQuery,
+    cache: C,
+) -> Result<Vec<State>>
+where
+    S: ObjectSource + ?Sized,
+    C: CommitGraphCache,
+{
+    use super::commit_graph::CommitGraphIndex;
 
-        while let Some(state_id) = current {
-            if candidate_ids.len() >= query.limit {
-                break;
+    let mut graph = CommitGraphIndex::with_cache(source, cache);
+    let mut candidate_ids = Vec::new();
+    let mut current = query.start;
+
+    while let Some(state_id) = current {
+        if candidate_ids.len() >= query.limit {
+            break;
+        }
+
+        // `stop_at` (the exclusive `--since` bound) is checked
+        // BEFORE filters so the walk terminates at the bound even
+        // when the bound state itself is filtered out by `--agent`
+        // or `--path`. Without this, a `--since` whose resolved
+        // state doesn't match the active filter would silently
+        // degrade and matches older than the bound would leak.
+        if let Some(stop) = query.stop_at
+            && state_id == stop
+        {
+            break;
+        }
+
+        graph
+            .ensure_loaded(state_id)
+            .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
+        let Some(meta) = graph.node_metadata(&state_id) else {
+            break;
+        };
+        current = meta.first_parent;
+
+        // Fast agent filter from cached metadata — no state load needed
+        if let Some(ref filter) = query.agent_model_substring {
+            match &meta.agent_model {
+                Some(model) if model.contains(filter.as_str()) => {}
+                _ => continue,
             }
+        }
 
-            // `stop_at` (the exclusive `--since` bound) is checked
-            // BEFORE filters so the walk terminates at the bound even
-            // when the bound state itself is filtered out by `--agent`
-            // or `--path`. Without this, a `--since` whose resolved
-            // state doesn't match the active filter would silently
-            // degrade and matches older than the bound would leak.
-            if let Some(stop) = query.stop_at
-                && state_id == stop
-            {
-                break;
-            }
-
-            graph
-                .ensure_loaded(state_id)
-                .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
-            let Some(meta) = graph.node_metadata(&state_id) else {
-                break;
-            };
-            current = meta.first_parent;
-
-            // Fast agent filter from cached metadata — no state load needed
-            if let Some(ref filter) = query.agent_model_substring {
-                match &meta.agent_model {
-                    Some(model) if model.contains(filter.as_str()) => {}
-                    _ => continue,
-                }
-            }
-
-            if query.changed_paths.is_empty() {
-                // No path filter — this is a match
-                candidate_ids.push(state_id);
-                trace!(state = %state_id, "history query matched state (no path filter)");
-                continue;
-            }
-
-            // Use bloom filter to skip expensive tree diffs
-            graph
-                .ensure_bloom_populated(state_id)
-                .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
-            if graph
-                .node_bloom(&state_id)
-                .is_some_and(|bloom| !query.changed_paths.bloom_maybe_matches(bloom))
-            {
-                // Bloom says "definitely not changed" — skip
-                continue;
-            }
-
-            // Bloom says "maybe" (or no bloom) — confirm with full tree diff
-            let Some(state) = self.store().get_state(&state_id)? else {
-                break;
-            };
-            if !self.state_matches_changed_paths(&state, &query.changed_paths)? {
-                continue;
-            }
-            trace!(state = %state_id, "history query matched state");
+        if query.changed_paths.is_empty() {
+            // No path filter — this is a match
             candidate_ids.push(state_id);
+            trace!(state = %state_id, "history query matched state (no path filter)");
+            continue;
         }
 
-        // Load full State objects only for final matches
-        let mut result = Vec::with_capacity(candidate_ids.len());
-        for id in candidate_ids {
-            if let Some(state) = self.store().get_state(&id)? {
-                result.push(state);
-            }
+        // Use bloom filter to skip expensive tree diffs
+        graph
+            .ensure_bloom_populated(state_id)
+            .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
+        if graph
+            .node_bloom(&state_id)
+            .is_some_and(|bloom| !query.changed_paths.bloom_maybe_matches(bloom))
+        {
+            // Bloom says "definitely not changed" — skip
+            continue;
         }
-        Ok(result)
+
+        // Bloom says "maybe" (or no bloom) — confirm with full tree diff
+        let Some(state) = source.get_state(&state_id)? else {
+            break;
+        };
+        if !state_matches_changed_paths(source, &state, &query.changed_paths)? {
+            continue;
+        }
+        trace!(state = %state_id, "history query matched state");
+        candidate_ids.push(state_id);
     }
 
-    pub(crate) fn state_matches_changed_paths(
-        &self,
-        state: &State,
-        changed_paths: &ChangedPathFilters,
-    ) -> Result<bool> {
-        let base_tree = self.parent_tree_hash(state)?;
-        // Early-exit: stop diffing the moment the first change matches the
-        // filter, rather than materializing the whole change list to scan it.
-        let flow = self.diff_trees_visit(&base_tree, &state.tree, |change| {
-            if changed_paths.matches(&change.path) {
-                ControlFlow::Break(())
-            } else {
-                ControlFlow::Continue(())
-            }
-        })?;
-        let matched = flow.is_break();
-        trace!(
-            state = %state.change_id,
-            matched,
-            "evaluated changed-path filters"
-        );
-        Ok(matched)
-    }
-
-    fn parent_tree_hash(&self, state: &State) -> Result<objects::object::ContentHash> {
-        match state.first_parent() {
-            Some(parent_id) => {
-                let parent = self
-                    .store()
-                    .get_state(parent_id)?
-                    .ok_or(HeddleError::StateNotFound(*parent_id))?;
-                Ok(parent.tree)
-            }
-            None => Ok(Tree::new().hash()),
+    // Load full State objects only for final matches
+    let mut result = Vec::with_capacity(candidate_ids.len());
+    for id in candidate_ids {
+        if let Some(state) = source.get_state(&id)? {
+            result.push(state);
         }
+    }
+    Ok(result)
+}
+
+pub(crate) fn state_matches_changed_paths<S>(
+    source: &S,
+    state: &State,
+    changed_paths: &ChangedPathFilters,
+) -> Result<bool>
+where
+    S: ObjectSource + ?Sized,
+{
+    let base_tree = parent_tree_hash(source, state)?;
+    // Early-exit: stop diffing the moment the first change matches the
+    // filter, rather than materializing the whole change list to scan it.
+    let flow = diff_trees_visit(source, &base_tree, &state.tree, |change| {
+        if changed_paths.matches(&change.path) {
+            ControlFlow::Break(())
+        } else {
+            ControlFlow::Continue(())
+        }
+    })
+    .map_err(|error| HeddleError::InvalidObject(format!("tree diff failed: {error}")))?;
+    let matched = flow.is_break();
+    trace!(
+        state = %state.change_id,
+        matched,
+        "evaluated changed-path filters"
+    );
+    Ok(matched)
+}
+
+fn parent_tree_hash<S>(source: &S, state: &State) -> Result<ContentHash>
+where
+    S: ObjectSource + ?Sized,
+{
+    match state.first_parent() {
+        Some(parent_id) => {
+            let parent = source
+                .get_state(parent_id)?
+                .ok_or(HeddleError::StateNotFound(*parent_id))?;
+            Ok(parent.tree)
+        }
+        None => Ok(Tree::new().hash()),
     }
 }
 
@@ -299,7 +325,16 @@ fn normalize_repo_relative_path(path: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::{ChangedPathFilter, ChangedPathFilters, normalize_repo_relative_path};
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::{
+        ChangedPathFilter, ChangedPathFilters, HistoryQuery, normalize_repo_relative_path,
+        query_history_with_cache,
+    };
+    use crate::Repository;
+    use crate::repository::commit_graph_persistence::NullCommitGraphCache;
 
     #[test]
     fn changed_path_filter_matches_exact_paths_and_children() {
@@ -315,6 +350,55 @@ mod tests {
         let filters = ChangedPathFilters::try_from_paths(["./src/lib.rs"]).unwrap();
 
         assert!(filters.matches("src/lib.rs"));
+    }
+
+    #[test]
+    fn query_history_path_filter_matches_with_and_without_fs_commit_graph_cache() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+
+        let src_dir = temp_dir.path().join("src");
+        fs::create_dir(&src_dir).unwrap();
+        fs::write(src_dir.join("lib.rs"), "one\n").unwrap();
+        let base = repo.snapshot(Some("base".to_string()), None).unwrap();
+
+        fs::write(temp_dir.path().join("README.md"), "docs\n").unwrap();
+        let _docs = repo.snapshot(Some("docs".to_string()), None).unwrap();
+
+        fs::write(src_dir.join("lib.rs"), "two\n").unwrap();
+        let src = repo.snapshot(Some("src".to_string()), None).unwrap();
+
+        fs::write(temp_dir.path().join("README.md"), "more docs\n").unwrap();
+        let head = repo.snapshot(Some("head".to_string()), None).unwrap();
+
+        let query = HistoryQuery::new(Some(head.change_id))
+            .with_limit(10)
+            .with_changed_paths(ChangedPathFilters::try_from_paths(["src"]).unwrap());
+        let expected = vec![src.change_id, base.change_id];
+
+        let warmed = repo.query_history(&query).unwrap();
+        assert_eq!(
+            warmed.iter().map(|state| state.change_id).collect::<Vec<_>>(),
+            expected
+        );
+
+        let graph_path = super::super::commit_graph_persistence::commit_graph_path(repo.root());
+        assert!(graph_path.exists());
+
+        let with_cache = repo.query_history(&query).unwrap();
+        let null_cache = query_history_with_cache(repo.store(), &query, NullCommitGraphCache).unwrap();
+        fs::remove_file(&graph_path).unwrap();
+        let without_cache = repo.query_history(&query).unwrap();
+
+        assert_eq!(with_cache, without_cache);
+        assert_eq!(with_cache, null_cache);
+        assert_eq!(
+            without_cache
+                .iter()
+                .map(|state| state.change_id)
+                .collect::<Vec<_>>(),
+            expected
+        );
     }
 
     #[test]


### PR DESCRIPTION
Phase 3b — the last streaming walker. `query_history`/`CommitGraphIndex` now run over the `ObjectSource` read seam instead of a concrete `&Repository`, with the on-disk commit-graph demoted to an **optional accelerator**.

## What this does
- **`CommitGraphIndex` generic over the source** + an injected cache (`commit_graph_persistence.rs`: `FsCommitGraphCache` = the existing `.bin` behavior; `NullCommitGraphCache` = no-op for backends with no cache file). The graph walk's correctness uses only `get_state` (first-parent chain) + `diff_trees` (bloom) — both on `ObjectSource`; the bloom/generation cache is a pure speedup.
- **`query_history` async emission** (`#[cfg(feature="async-source")]`) over `AsyncObjectSource` + `NullCommitGraphCache`. This is the last walker weft re-forks; after this weft can delete its history fork.
- A default source-type param keeps existing `CommitGraphIndex<'_>` annotations compiling.

## Behavior-neutral + proven
- **Sync neutrality:** `query_history_path_filter_matches_with_and_without_fs_commit_graph_cache` — identical `Vec<State>` WITH and WITHOUT the fs cache present (proves the bloom is a pure prefilter, not correctness).
- **Dual-emission:** `query_history_async_matches_sync_null_cache_for_path_filtered_first_parent_walk` — async == sync over the same data.

## Gates (all green)
default + `--all-features` builds · objects/repo `--features async-source` builds · check-no-silent-default-tree-load · `cargo test -p heddle-mount` · clippy (workspace + async-source) · `cargo test --workspace` · no-async-deps `cargo tree` check.

## What's next
P3b completes heddle's side of the seam. **P4** (next): weft impls `AsyncObjectSource` + deletes its ~225-line forked walkers (diff/blob/summary/suggestion now; history after this). heddle's leftover S3 backend is being removed in parallel (codex/heddle-rm-s3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784562510&installation_id=132405951&pr_number=764&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F764&signature=b2ec3d9fed201c7edf5423c06a5f55c6910ae79af82ea2530f75e3934b546be6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->