### PR TITLE
seam P3c: async is_ancestor / find_merge_base emission on AsyncObjectSource

### DIFF
--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -4,6 +4,8 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::Result;
+#[cfg(feature = "async-source")]
+use objects::store::AsyncObjectSource;
 use objects::{
     object::{ChangeId, ContentHash, Tree, diff_trees},
     store::{AnyStore, ObjectSource, ObjectStore},
@@ -28,6 +30,13 @@ struct CommitGraphNode {
     created_at_secs: i64,
     agent_model: Option<String>,
     bloom: Option<[u8; 256]>,
+}
+
+#[cfg(feature = "async-source")]
+#[derive(Clone, Debug)]
+struct AsyncCommitGraphNode {
+    parents: Vec<ChangeId>,
+    generation: usize,
 }
 
 /// Cached metadata for a node — cheap to return by value.
@@ -74,8 +83,7 @@ where
                 let cache_label = cache_label(&cache);
                 warn!(
                     "Failed to load commit graph from {}: {}. Rebuilding in memory.",
-                    cache_label,
-                    error
+                    cache_label, error
                 );
                 (HashMap::new(), true)
             }
@@ -360,6 +368,172 @@ impl LoadedCommitGraphExt for LoadedCommitGraph {
     }
 }
 
+/// Return whether `ancestor_id` is reachable from `descendant_id` using an async object source.
+#[cfg(feature = "async-source")]
+pub async fn is_ancestor_async<S>(
+    source: &S,
+    ancestor_id: &ChangeId,
+    descendant_id: &ChangeId,
+) -> Result<bool>
+where
+    S: AsyncObjectSource + ?Sized,
+{
+    if ancestor_id == descendant_id {
+        return Ok(true);
+    }
+
+    let mut nodes = HashMap::new();
+    ensure_loaded_async(source, &mut nodes, *descendant_id).await?;
+    let Some(ancestor_generation) = generation_async(&nodes, *ancestor_id) else {
+        return Ok(false);
+    };
+
+    let mut stack = vec![*descendant_id];
+    let mut visited = HashSet::new();
+    while let Some(change_id) = stack.pop() {
+        if !visited.insert(change_id) {
+            continue;
+        }
+        if change_id == *ancestor_id {
+            return Ok(true);
+        }
+
+        let Some(node) = nodes.get(&change_id) else {
+            continue;
+        };
+        for parent in &node.parents {
+            if generation_async(&nodes, *parent)
+                .is_some_and(|generation| generation >= ancestor_generation)
+            {
+                stack.push(*parent);
+            }
+        }
+    }
+
+    Ok(false)
+}
+
+/// Find the best common ancestor of two states using an async object source.
+#[cfg(feature = "async-source")]
+pub async fn find_merge_base_async<S>(
+    source: &S,
+    state_a: &ChangeId,
+    state_b: &ChangeId,
+) -> Result<Option<ChangeId>>
+where
+    S: AsyncObjectSource + ?Sized,
+{
+    let mut nodes = HashMap::new();
+    ensure_loaded_async(source, &mut nodes, *state_a).await?;
+    ensure_loaded_async(source, &mut nodes, *state_b).await?;
+
+    let ancestors_a = collect_ancestors_async(source, &mut nodes, *state_a).await?;
+    let ancestors_b = collect_ancestors_async(source, &mut nodes, *state_b).await?;
+    let best = ancestors_a
+        .intersection(&ancestors_b)
+        .copied()
+        .max_by(|left, right| {
+            generation_async(&nodes, *left)
+                .cmp(&generation_async(&nodes, *right))
+                .then_with(|| right.as_bytes().cmp(left.as_bytes()))
+        });
+
+    Ok(best)
+}
+
+#[cfg(feature = "async-source")]
+async fn collect_ancestors_async<S>(
+    source: &S,
+    nodes: &mut HashMap<ChangeId, AsyncCommitGraphNode>,
+    start: ChangeId,
+) -> Result<HashSet<ChangeId>>
+where
+    S: AsyncObjectSource + ?Sized,
+{
+    ensure_loaded_async(source, nodes, start).await?;
+
+    let mut ancestors = HashSet::new();
+    let mut stack = vec![start];
+    while let Some(change_id) = stack.pop() {
+        if !ancestors.insert(change_id) {
+            continue;
+        }
+        if let Some(node) = nodes.get(&change_id) {
+            stack.extend(node.parents.iter().copied());
+        }
+    }
+
+    Ok(ancestors)
+}
+
+#[cfg(feature = "async-source")]
+async fn ensure_loaded_async<S>(
+    source: &S,
+    nodes: &mut HashMap<ChangeId, AsyncCommitGraphNode>,
+    change_id: ChangeId,
+) -> Result<()>
+where
+    S: AsyncObjectSource + ?Sized,
+{
+    if nodes.contains_key(&change_id) {
+        return Ok(());
+    }
+
+    let mut expanded = HashSet::new();
+    let mut stack = vec![change_id];
+    while let Some(current) = stack.pop() {
+        if nodes.contains_key(&current) {
+            continue;
+        }
+
+        if expanded.insert(current) {
+            stack.push(current);
+            let parents = load_state_parents_async(source, current).await?;
+            for parent in &parents {
+                if !nodes.contains_key(parent) {
+                    stack.push(*parent);
+                }
+            }
+            continue;
+        }
+
+        let parents = load_state_parents_async(source, current).await?;
+        let generation = parents
+            .iter()
+            .filter_map(|parent| generation_async(nodes, *parent))
+            .max()
+            .map_or(0, |generation| generation + 1);
+        nodes.insert(
+            current,
+            AsyncCommitGraphNode {
+                parents,
+                generation,
+            },
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "async-source")]
+async fn load_state_parents_async<S>(source: &S, change_id: ChangeId) -> Result<Vec<ChangeId>>
+where
+    S: AsyncObjectSource + ?Sized,
+{
+    Ok(source
+        .get_state(&change_id)
+        .await?
+        .map_or_else(Vec::new, |state| state.parents))
+}
+
+#[cfg(feature = "async-source")]
+fn generation_async(
+    nodes: &HashMap<ChangeId, AsyncCommitGraphNode>,
+    change_id: ChangeId,
+) -> Option<usize> {
+    nodes.get(&change_id).map(|node| node.generation)
+}
+
 pub fn find_merge_base<R, O, S>(
     repo: &Repository<R, O, S>,
     state_a: &ChangeId,
@@ -382,6 +556,11 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{super::Repository, CommitGraphIndex};
+    #[cfg(feature = "async-source")]
+    use objects::{
+        object::{Attribution, Blob, ChangeId, ContentHash, Principal, State, Tree},
+        store::{AsyncObjectSource, InMemoryStore, ObjectStore},
+    };
 
     fn commit_graph_path(repo: &Repository) -> std::path::PathBuf {
         repo.root().join(".heddle/state").join("commit-graph.bin")
@@ -559,5 +738,119 @@ mod tests {
         assert!(bloom_maybe_contains(bloom, "alpha.txt"));
 
         Ok(())
+    }
+
+    #[cfg(feature = "async-source")]
+    #[test]
+    fn async_ancestry_matches_sync_commit_graph_on_fixture() {
+        let store = InMemoryStore::new();
+
+        let root = put_state(&store, vec![]);
+        let left_base = put_state(&store, vec![root.change_id]);
+        let right_base = put_state(&store, vec![root.change_id]);
+        let left_tip = put_state(&store, vec![left_base.change_id]);
+        let right_tip = put_state(&store, vec![right_base.change_id]);
+        let merge_a = put_state(&store, vec![left_base.change_id, right_base.change_id]);
+        let merge_b = put_state(&store, vec![right_base.change_id, left_base.change_id]);
+
+        let async_source = AsyncInMemorySource(&store);
+        for (ancestor, descendant) in [
+            (root.change_id, merge_a.change_id),
+            (left_base.change_id, merge_a.change_id),
+            (merge_a.change_id, merge_a.change_id),
+            (merge_a.change_id, merge_b.change_id),
+            (left_tip.change_id, right_tip.change_id),
+        ] {
+            let mut graph = CommitGraphIndex::with_cache(
+                &store,
+                super::super::commit_graph_persistence::NullCommitGraphCache,
+            );
+            let sync = graph.is_ancestor(&ancestor, &descendant).unwrap();
+            let async_result = block_on(super::is_ancestor_async(
+                &async_source,
+                &ancestor,
+                &descendant,
+            ))
+            .unwrap();
+            assert_eq!(
+                async_result, sync,
+                "is_ancestor mismatch for {ancestor} -> {descendant}"
+            );
+        }
+
+        for (left, right) in [
+            (merge_a.change_id, merge_b.change_id),
+            (left_base.change_id, merge_a.change_id),
+            (left_tip.change_id, right_tip.change_id),
+            (merge_a.change_id, merge_a.change_id),
+        ] {
+            let mut graph = CommitGraphIndex::with_cache(
+                &store,
+                super::super::commit_graph_persistence::NullCommitGraphCache,
+            );
+            let sync = graph.find_merge_base(&left, &right).unwrap();
+            let async_result =
+                block_on(super::find_merge_base_async(&async_source, &left, &right)).unwrap();
+            assert_eq!(
+                async_result, sync,
+                "find_merge_base mismatch for {left} and {right}"
+            );
+        }
+
+        let mut graph = CommitGraphIndex::with_cache(
+            &store,
+            super::super::commit_graph_persistence::NullCommitGraphCache,
+        );
+        let tie_base = graph
+            .find_merge_base(&merge_a.change_id, &merge_b.change_id)
+            .unwrap();
+        assert!(
+            matches!(tie_base, Some(id) if id == left_base.change_id || id == right_base.change_id)
+        );
+    }
+
+    #[cfg(feature = "async-source")]
+    struct AsyncInMemorySource<'a>(&'a InMemoryStore);
+
+    #[cfg(feature = "async-source")]
+    impl AsyncObjectSource for AsyncInMemorySource<'_> {
+        async fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+            ObjectStore::get_tree(self.0, hash)
+        }
+
+        async fn get_state(&self, id: &ChangeId) -> objects::error::Result<Option<State>> {
+            ObjectStore::get_state(self.0, id)
+        }
+
+        async fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+            ObjectStore::get_blob(self.0, hash)
+        }
+    }
+
+    #[cfg(feature = "async-source")]
+    fn put_state(store: &InMemoryStore, parents: Vec<ChangeId>) -> State {
+        let state = State::new(
+            Tree::new().hash(),
+            parents,
+            Attribution::human(Principal::new("Test User", "test@example.com")),
+        );
+        ObjectStore::put_state(store, &state).unwrap();
+        state
+    }
+
+    #[cfg(feature = "async-source")]
+    fn block_on<F: std::future::Future>(future: F) -> F::Output {
+        use std::task::{Context, Poll, Waker};
+
+        let waker = Waker::noop();
+        let mut context = Context::from_waker(waker);
+        let mut future = std::pin::pin!(future);
+
+        loop {
+            match future.as_mut().poll(&mut context) {
+                Poll::Ready(output) => return output,
+                Poll::Pending => std::thread::yield_now(),
+            }
+        }
     }
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -84,6 +84,8 @@ pub use objects::{
         agent_registry::{AgentEntry, AgentRegistry, AgentStatus, generate_agent_id},
     },
 };
+#[cfg(feature = "async-source")]
+pub use repository::query_history_async;
 pub use repository::{
     BlobHydrator, ChangeMonitorInspection, ChangedPathFilter, ChangedPathFilters,
     CheckoutMaterialization, CommitGraphIndex, CommitGraphInspection, ContextSuggestion,
@@ -100,9 +102,9 @@ pub use repository::{
     WorktreeStatusDetailed, compute_rewrite_pct, find_merge_base, is_major_rewrite,
     is_synthetic_root,
 };
-pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 #[cfg(feature = "async-source")]
-pub use repository::query_history_async;
+pub use repository::{find_merge_base_async, is_ancestor_async};
+pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 pub use session_storage::SessionManager;
 pub use snapshot_metadata::{
     ABSENT_CONFIDENCE_DISPLAY, ThreadMetadataRefresh, classify_impact_categories,

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -59,6 +59,8 @@ use std::{
 
 use chrono::Utc;
 pub use commit_graph::{CommitGraphIndex, find_merge_base};
+#[cfg(feature = "async-source")]
+pub use commit_graph::{find_merge_base_async, is_ancestor_async};
 pub use context_suggestions::{
     ContextSuggestion, ContextSuggestionTier, HIGH_SUGGESTION_THRESHOLD,
     MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD, SUGGESTION_WINDOW,
@@ -85,9 +87,9 @@ pub use repo_config::{
     PatternDeviationToml, ReviewConfig, ReviewSignalsToml, SelfFlaggedToml, SignalEnableToml,
     SignalModuleToml, TestReachabilityToml,
 };
-pub use repository_history::{ChangedPathFilter, ChangedPathFilters, HistoryQuery};
 #[cfg(feature = "async-source")]
 pub use repository_history::query_history_async;
+pub use repository_history::{ChangedPathFilter, ChangedPathFilters, HistoryQuery};
 pub use repository_maintenance::{
     ChangeMonitorInspection, CommitGraphInspection, PackFilesInspection, PartialFetchInspection,
     PullPlannerCacheInspection, RefCountsInspection, RepositoryMaintenanceRunReport,


### PR DESCRIPTION
Adds async twins of the sync commit-graph ancestry walkers, gated `#[cfg(feature = "async-source")]`, so consumers driving the seam async (weft) can do ancestry checks without forking heddle's walker.

## What
- `is_ancestor_async` (commit_graph.rs:373) + `find_merge_base_async` (:418) — read `State` via `AsyncObjectSource`, **behavior-identical** to the sync `CommitGraphIndex::is_ancestor`/`find_merge_base` (same generation-pruning, same `(generation, reverse change-id)` tiebreak).
- Feature-gated re-exports (repository.rs, lib.rs).
- Dual-emission proof test (commit_graph.rs:745): asserts async == sync across ancestor / non-ancestor / self / nearest-base / root-base / criss-cross-two-equal-generation-base (locks the tiebreak).

## Behavior preservation
Adversarial cross-engine review: **SHIP** — all risk areas confirmed-equivalent (generation computation traced identical line-by-line, tiebreak direction verified, no DAG shape diverges). Default build stays sync-only — `cargo tree -p heddle-repo --edges normal` shows no tokio/aws.

## Gates (local)
default build ✓ · `--all-features` ✓ · `-p heddle-repo --features async-source` build+test ✓ · clippy (workspace + async-source) ✓ · `check-no-silent-default-tree-load.sh` ✓ · `cargo test -p heddle-mount` ✓ · `cargo test --workspace` ✓ · default-tree purity ✓

Unblocks weft deleting its last `is_ancestor` fork (calls `is_ancestor_async`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784572717&installation_id=132405951&pr_number=766&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F766&signature=5e59fd589a57875c2b17adb8eaff0350cff7d8b26d65a4664af868d6bf4ce9ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->