### PR TITLE
heddle#767: import gitlinks as submodule blobs

### DIFF
--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -7,6 +7,7 @@ use objects::{
     error::HeddleError,
     object::{ChangeId, ContentHash, FileMode, MarkerName, Principal, State, ThreadName},
     store::ObjectStore,
+    util::SUBMODULE_PREFIX,
 };
 use repo::{AudienceTier, Repository as HeddleRepository, visible};
 use sley::{
@@ -26,8 +27,6 @@ use crate::bridge::{
     git_sync::{sync_marker_to_tag, sync_track_to_branch},
     git_util::{ExportStats, ExportedRef},
 };
-
-const SUBMODULE_PREFIX: &str = "heddle-submodule:";
 
 /// Whether `state` carries a captured original git commit to reconstruct
 /// byte-exactly (the #565 de-lossy fidelity fields). When true, export

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -14,6 +14,7 @@ use objects::{
         TreeEntry,
     },
     store::ObjectStore,
+    util::gitlink_blob_content,
     worktree::should_ignore as should_ignore_path,
 };
 use oplog::{OpBatch, OpLogBackend, OpRecord};
@@ -932,7 +933,7 @@ fn import_index_blob(
 }
 
 fn import_index_gitlink(repo: &Repository, oid: ObjectId) -> Result<ContentHash> {
-    let blob = Blob::new(format!("heddle-submodule: {oid}").into_bytes());
+    let blob = Blob::new(gitlink_blob_content(oid));
     Ok(repo.store().put_blob(&blob)?)
 }
 

--- a/crates/cli/tests/cli_integration/bridge.rs
+++ b/crates/cli/tests/cli_integration/bridge.rs
@@ -61,26 +61,50 @@ fn git_status_porcelain(path: &std::path::Path) -> String {
     String::from_utf8(out.stdout).unwrap()
 }
 
-fn seed_gitlink_repo(path: &std::path::Path) {
-    init_colocated_git_repo(path);
-    std::fs::write(path.join("README.md"), "root\n").unwrap();
-    git_commit_all_in(path, "initial");
-
-    let submodule_oid = "0606060606060606060606060606060606060606";
-    let status = Command::new("git")
-        .args(["update-index", "--add", "--cacheinfo"])
-        .arg(format!("160000,{submodule_oid},vendor"))
+fn git_output_in(path: &std::path::Path, args: &[&str], stdin: Option<&[u8]>) -> String {
+    let mut command = Command::new("git");
+    command
+        .args(args)
         .current_dir(path)
-        .status()
-        .expect("git update-index should run");
-    assert!(status.success(), "git update-index should succeed");
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .env("GIT_AUTHOR_NAME", "Heddle Test")
+        .env("GIT_AUTHOR_EMAIL", "heddle@example.com")
+        .env("GIT_COMMITTER_NAME", "Heddle Test")
+        .env("GIT_COMMITTER_EMAIL", "heddle@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    if stdin.is_some() {
+        command.stdin(std::process::Stdio::piped());
+    }
+    let mut child = command.spawn().expect("git command should run");
+    if let Some(stdin) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin should be piped")
+            .write_all(stdin)
+            .expect("write git stdin");
+    }
+    let output = child.wait_with_output().expect("git command output");
+    assert!(
+        output.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
 
-    let status = Command::new("git")
-        .args(["commit", "-m", "add gitlink"])
-        .current_dir(path)
-        .status()
-        .expect("git commit should run");
-    assert!(status.success(), "git commit should succeed");
+fn seed_unrepresentable_tree_name_repo(path: &std::path::Path) {
+    git_output_in(path, &["init", "-q", "--initial-branch=main"], None);
+
+    let blob = git_output_in(path, &["hash-object", "-w", "--stdin"], Some(b"hello\n"));
+    let mut tree_input = Vec::new();
+    write!(&mut tree_input, "100644 blob {blob}\t").expect("tree record");
+    tree_input.extend_from_slice(b"bad\\\xffname\0");
+    let tree = git_output_in(path, &["mktree", "-z"], Some(&tree_input));
+    let commit = git_output_in(path, &["commit-tree", &tree, "-m", "invalid name"], None);
+    git_output_in(path, &["update-ref", "refs/heads/main", &commit], None);
 }
 
 /// The empty-blob object id (SHA-1). An intent-to-add index entry points
@@ -89,9 +113,9 @@ fn seed_gitlink_repo(path: &std::path::Path) {
 const EMPTY_BLOB_OID: &str = "e69de29bb2d1d6434b8b29ae775ad8c2e48c5391";
 
 #[test]
-fn bridge_git_import_refuses_gitlink_by_default_and_lossy_summarizes() {
+fn bridge_git_import_refuses_unrepresentable_tree_name_by_default_and_lossy_summarizes() {
     let source = TempDir::new().unwrap();
-    seed_gitlink_repo(source.path());
+    seed_unrepresentable_tree_name_repo(source.path());
 
     let default_target = TempDir::new().unwrap();
     heddle(&["init"], Some(default_target.path())).expect("init default target");
@@ -108,11 +132,11 @@ fn bridge_git_import_refuses_gitlink_by_default_and_lossy_summarizes() {
     .expect("run default import");
     assert!(
         !default_output.status.success(),
-        "default git import must fail on gitlink"
+        "default git import must fail on unrepresentable tree name"
     );
     let default_stderr = String::from_utf8_lossy(&default_output.stderr);
     assert!(
-        default_stderr.contains("vendor"),
+        default_stderr.contains("bad") && default_stderr.contains("name"),
         "error should name the offending entry: {default_stderr}"
     );
     assert!(
@@ -139,7 +163,10 @@ fn bridge_git_import_refuses_gitlink_by_default_and_lossy_summarizes() {
         lossy.contains("lossy import accepted"),
         "lossy import should emit an end-of-run summary: {lossy}"
     );
-    assert!(lossy.contains("vendor"), "summary names entry: {lossy}");
+    assert!(
+        lossy.contains("bad") && lossy.contains("name"),
+        "summary names entry: {lossy}"
+    );
     assert!(lossy.contains("dropped"), "summary names action: {lossy}");
 }
 

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -35,6 +35,7 @@ use objects::{
         Blob, ChangeId, ContentHash, EntryType, FileMode, MarkerName, ThreadName, Tree, TreeEntry,
     },
     store::ObjectStore,
+    util::gitlink_blob_content,
 };
 use repo::Repository;
 use sley::{
@@ -434,6 +435,56 @@ fn init_gitlink_repo() -> (TempDir, SleyRepository) {
     (git_temp, git_repo)
 }
 
+fn git_output(path: &std::path::Path, args: &[&str], stdin: Option<&[u8]>) -> String {
+    let mut command = Command::new("git");
+    command
+        .args(args)
+        .current_dir(path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("GIT_AUTHOR_NAME", "Test")
+        .env("GIT_AUTHOR_EMAIL", "test@example.com")
+        .env("GIT_COMMITTER_NAME", "Test")
+        .env("GIT_COMMITTER_EMAIL", "test@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null");
+    if stdin.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    let mut child = command.spawn().expect("git cmd");
+    if let Some(stdin) = stdin {
+        child
+            .stdin
+            .as_mut()
+            .expect("stdin")
+            .write_all(stdin)
+            .expect("write stdin");
+    }
+    let output = child.wait_with_output().expect("git output");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap().trim().to_string()
+}
+
+fn init_invalid_utf8_name_repo() -> TempDir {
+    let temp = TempDir::new().expect("temp dir");
+    git_output(temp.path(), &["init", "-q", "--initial-branch=main"], None);
+
+    let blob = git_output(temp.path(), &["hash-object", "-w", "--stdin"], Some(b"hello\n"));
+    let mut tree_input = Vec::new();
+    write!(&mut tree_input, "100644 blob {blob}\t").expect("tree record");
+    tree_input.extend_from_slice(b"bad\xffname\0");
+    let tree = git_output(temp.path(), &["mktree", "-z"], Some(&tree_input));
+    let commit = git_output(temp.path(), &["commit-tree", &tree, "-m", "invalid name"], None);
+    git_output(temp.path(), &["update-ref", "refs/heads/main", &commit], None);
+
+    temp
+}
+
 struct GitDaemon {
     child: Child,
     port: u16,
@@ -795,7 +846,7 @@ fn export_tree_writes_submodule_entries() {
     let submodule_oid: ObjectId = "0303030303030303030303030303030303030303"
         .parse()
         .expect("oid");
-    let blob = Blob::new(format!("heddle-submodule: {}", submodule_oid).into_bytes());
+    let blob = Blob::new(gitlink_blob_content(submodule_oid));
     let blob_hash = repo.store().put_blob(&blob).expect("blob");
 
     let tree = Tree::from_entries(vec![TreeEntry {
@@ -916,39 +967,45 @@ fn export_tree_substitutes_stub_for_redacted_blob() {
 }
 
 #[test]
-fn import_all_rejects_gitlink_by_default_and_lossy_reports_drop() {
+fn import_all_imports_gitlink_losslessly_and_exports_gitlink() {
     let (_git_temp, git_repo) = init_gitlink_repo();
 
-    let default_heddle = TempDir::new().expect("heddle temp");
-    let default_repo = Repository::init(default_heddle.path()).expect("init heddle");
-    let mut default_bridge = GitBridge::new(&default_repo);
-    let err = import_all(
-        &mut default_bridge,
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut bridge = GitBridge::new(&repo);
+    let stats = import_all(
+        &mut bridge,
         Some(git_repo.workdir().expect("workdir").as_path()),
     )
-    .expect_err("default import must fail on gitlink");
-    let message = err.to_string();
-    assert!(message.contains("vendor"), "error names entry: {message}");
-    assert!(message.contains("--lossy"), "error names opt-in: {message}");
-
-    let lossy_heddle = TempDir::new().expect("heddle temp");
-    let lossy_repo = Repository::init(lossy_heddle.path()).expect("init heddle");
-    let mut lossy_bridge = GitBridge::new(&lossy_repo);
-    let stats = import_all_with_options(
-        &mut lossy_bridge,
-        Some(git_repo.workdir().expect("workdir").as_path()),
-        ingest::ImportOptions { lossy: true },
-    )
-    .expect("lossy import accepts gitlink drop");
+    .expect("default import accepts gitlink");
 
     assert_eq!(stats.states_created, 1);
-    assert_eq!(stats.lossy_entries.len(), 1);
-    assert_eq!(stats.lossy_entries[0].path, "vendor");
-    assert!(stats.lossy_entries[0].summary_line().contains("dropped"));
+    assert!(stats.lossy_entries.is_empty());
+
+    let state_id = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .expect("main thread lookup")
+        .expect("main thread");
+    let state = repo
+        .store()
+        .get_state(&state_id)
+        .expect("get state")
+        .expect("state present");
+    assert!(!state.git_lossy, "gitlink import must not set git_lossy");
+
+    let exported_tree = export_tree(&repo, &git_repo, &state.tree).expect("export tree");
+    let git_tree = git_repo.find_tree(exported_tree).expect("exported tree");
+    let entry = git_tree.find_entry("vendor").expect("vendor entry");
+    let expected_oid: ObjectId = "0505050505050505050505050505050505050505"
+        .parse()
+        .expect("oid");
+    assert_eq!(entry.mode().kind(), EntryKind::Commit);
+    assert_eq!(entry.object_id(), expected_oid);
 }
 
 #[test]
-fn import_all_lossy_reports_cached_shared_subtree_entries_without_mapping_sidecar() {
+fn import_all_reuses_shared_gitlink_subtree_without_lossy_entries() {
     let (_git_temp, git_repo) = init_git_repo();
     let shared_tree = gitlink_tree(&git_repo, "vendor");
 
@@ -979,39 +1036,32 @@ fn import_all_lossy_reports_cached_shared_subtree_entries_without_mapping_sideca
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let mut bridge = GitBridge::new(&repo);
-    let stats = import_all_with_options(
+    let stats = import_all(
         &mut bridge,
         Some(&git_repo.workdir().expect("workdir")),
-        ingest::ImportOptions { lossy: true },
     )
-    .expect("lossy import accepts shared gitlink subtree");
+    .expect("default import accepts shared gitlink subtree");
 
     assert_eq!(stats.states_created, 2);
-    assert_eq!(
-        stats.lossy_entries.len(),
-        2,
-        "runtime stats should include both the original and cached ingest lossy entries"
-    );
-    assert_eq!(stats.lossy_entries[0].path, "shared/vendor");
-    assert_eq!(stats.lossy_entries[1].path, "shared/vendor");
+    assert!(stats.lossy_entries.is_empty());
 
     assert!(
         !test_support::mapping_path(&bridge).exists(),
-        "bridge import must not publish lossy entries through the served mapping cache"
+        "bridge import must not publish ingest-only mappings through the served mapping cache"
     );
 }
 
 #[test]
 fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
-    let (_git_temp, git_repo) = init_gitlink_repo();
-    let git_path = git_repo.workdir().expect("workdir");
+    let git_temp = init_invalid_utf8_name_repo();
+    let git_path = git_temp.path();
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
 
     let mut first_bridge = GitBridge::new(&repo);
     let first = import_all_with_options(
         &mut first_bridge,
-        Some(git_path.as_path()),
+        Some(git_path),
         ingest::ImportOptions { lossy: true },
     )
     .expect("initial lossy bridge import succeeds");
@@ -1023,22 +1073,22 @@ fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
     );
 
     let mut rerun_bridge = GitBridge::new(&repo);
-    let err = import_all(&mut rerun_bridge, Some(git_path.as_path()))
+    let err = import_all(&mut rerun_bridge, Some(git_path))
         .expect_err("default bridge import must not reuse cached lossy state silently");
     assert_lossy_default_rerun_error("bridge", &err.to_string());
 }
 
 #[test]
 fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
-    let (_git_temp, git_repo) = init_gitlink_repo();
-    let git_path = git_repo.workdir().expect("workdir");
+    let git_temp = init_invalid_utf8_name_repo();
+    let git_path = git_temp.path();
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
 
     let mut first_bridge = GitBridge::new(&repo);
     import_all_with_options(
         &mut first_bridge,
-        Some(git_path.as_path()),
+        Some(git_path),
         ingest::ImportOptions { lossy: true },
     )
     .expect("initial lossy bridge import succeeds");
@@ -1046,15 +1096,15 @@ fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
     let mut rerun_bridge = GitBridge::new(&repo);
     let second = import_all_with_options(
         &mut rerun_bridge,
-        Some(git_path.as_path()),
+        Some(git_path),
         ingest::ImportOptions { lossy: true },
     )
     .expect("lossy bridge rerun reports ingest-cached lossy entries");
 
     assert_eq!(second.states_created, 0);
     assert_eq!(second.lossy_entries.len(), 1);
-    assert_eq!(second.lossy_entries[0].path, "vendor");
-    assert!(second.lossy_entries[0].summary_line().contains("dropped"));
+    assert_eq!(second.lossy_entries[0].path, "bad\u{fffd}name");
+    assert!(second.lossy_entries[0].summary_line().contains("converted"));
 }
 
 #[cfg(feature = "ingest")]
@@ -1076,11 +1126,11 @@ impl ImportEngine {
 
 fn assert_lossy_default_rerun_error(engine: &str, message: &str) {
     assert!(
-        message.contains("vendor"),
+        message.contains("bad"),
         "{engine} error names entry: {message}"
     );
     assert!(
-        message.contains("losslessly"),
+        message.contains("not valid UTF-8"),
         "{engine} error explains policy: {message}"
     );
     assert!(
@@ -1091,15 +1141,15 @@ fn assert_lossy_default_rerun_error(engine: &str, message: &str) {
 
 #[cfg(feature = "ingest")]
 fn run_lossy_then_default_rerun(engine: ImportEngine) {
-    let (_git_temp, git_repo) = init_gitlink_repo();
-    let git_path = git_repo.workdir().expect("workdir");
+    let git_temp = init_invalid_utf8_name_repo();
+    let git_path = git_temp.path();
     let message = match engine {
         ImportEngine::Ingest => {
             use ingest::{ImportOptions, import_git_into, import_git_into_with_options};
 
             let heddle_temp = TempDir::new().expect("heddle temp");
             let (first, map) = import_git_into_with_options(
-                &git_path,
+                git_path,
                 heddle_temp.path(),
                 ImportOptions { lossy: true },
             )
@@ -1117,14 +1167,14 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
             let mut first_bridge = GitBridge::new(&repo);
             let first = import_all_with_options(
                 &mut first_bridge,
-                Some(git_path.as_path()),
+                Some(git_path),
                 ingest::ImportOptions { lossy: true },
             )
             .expect("initial lossy bridge import succeeds");
             assert_eq!(first.lossy_entries.len(), 1);
 
             let mut rerun_bridge = GitBridge::new(&repo);
-            import_all(&mut rerun_bridge, Some(git_path.as_path()))
+            import_all(&mut rerun_bridge, Some(git_path))
                 .expect_err("default bridge import must fail on cached lossy commit")
                 .to_string()
         }
@@ -1161,7 +1211,7 @@ fn import_all_lossy_clean_repo_reports_no_lossy_entries() {
     assert!(stats.lossy_entries.is_empty());
 }
 
-/// The single imported gitlink state must carry git-fidelity (`raw_message`) —
+/// The single imported lossy state must carry git-fidelity (`raw_message`) —
 /// the signal that opts a commit INTO reconstruct-from-state — yet be flagged
 /// `git_lossy`, so the #567 export guard keeps it OFF that path. Asserted for
 /// both lossy population surfaces so they converge on ONE canonical marker.
@@ -1173,7 +1223,7 @@ fn assert_only_state_is_lossy_with_fidelity(repo: &Repository, surface: &str) {
         .iter()
         .filter_map(|id| repo.store().get_state(id).expect("get state"))
         .collect();
-    assert_eq!(states.len(), 1, "{surface}: single gitlink commit imported");
+    assert_eq!(states.len(), 1, "{surface}: single lossy commit imported");
     let state = &states[0];
     assert!(
         state.raw_message.is_some(),
@@ -1187,25 +1237,22 @@ fn assert_only_state_is_lossy_with_fidelity(repo: &Repository, surface: &str) {
     );
 }
 
-/// `bridge git import --lossy` records the canonical `git_lossy` marker.
+/// `bridge git import --lossy` records the canonical `git_lossy` marker for
+/// genuinely unrepresentable tree entries.
 #[test]
 fn bridge_import_lossy_state_carries_canonical_git_lossy_marker() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
-    let (_git_temp, git_repo) = init_gitlink_repo();
+    let git_temp = init_invalid_utf8_name_repo();
 
     let mut bridge = GitBridge::new(&repo);
     let stats = import_all_with_options(
         &mut bridge,
-        Some(git_repo.workdir().expect("workdir").as_path()),
+        Some(git_temp.path()),
         ingest::ImportOptions { lossy: true },
     )
     .expect("lossy bridge import succeeds");
-    assert_eq!(
-        stats.lossy_entries.len(),
-        1,
-        "gitlink is the one lossy entry"
-    );
+    assert_eq!(stats.lossy_entries.len(), 1);
 
     assert_only_state_is_lossy_with_fidelity(&repo, "bridge import --lossy");
 }
@@ -1221,19 +1268,15 @@ fn bridge_import_lossy_state_carries_canonical_git_lossy_marker() {
 fn ingest_lossy_state_carries_canonical_git_lossy_marker() {
     use ingest::{ImportOptions, import_git_into_with_options};
 
-    let (_git_temp, git_repo) = init_gitlink_repo();
-    let git_path = git_repo.workdir().expect("workdir");
+    let git_temp = init_invalid_utf8_name_repo();
+    let git_path = git_temp.path();
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let (stats, map) =
         import_git_into_with_options(git_path, heddle_temp.path(), ImportOptions { lossy: true })
             .expect("lossy ingest succeeds");
     drop(map);
-    assert_eq!(
-        stats.lossy_entries.len(),
-        1,
-        "gitlink is the one lossy entry"
-    );
+    assert_eq!(stats.lossy_entries.len(), 1);
 
     let repo = Repository::open(heddle_temp.path()).expect("open heddle repo");
     assert_only_state_is_lossy_with_fidelity(&repo, "ingest-backed lossy import");
@@ -1253,19 +1296,15 @@ fn ingest_lossy_state_carries_canonical_git_lossy_marker() {
 fn export_mints_lossy_ingest_state_from_raw_metadata() {
     use ingest::{ImportOptions, import_git_into_with_options};
 
-    let (_git_temp, git_repo) = init_gitlink_repo();
-    let git_path = git_repo.workdir().expect("workdir");
+    let git_temp = init_invalid_utf8_name_repo();
+    let git_path = git_temp.path();
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let (stats, map) =
         import_git_into_with_options(git_path, heddle_temp.path(), ImportOptions { lossy: true })
             .expect("lossy ingest succeeds");
     drop(map);
-    assert_eq!(
-        stats.lossy_entries.len(),
-        1,
-        "gitlink is the one lossy entry"
-    );
+    assert_eq!(stats.lossy_entries.len(), 1);
 
     let repo = Repository::open(heddle_temp.path()).expect("open heddle repo");
     let state = {

--- a/crates/cli/tests/roundtrip_fidelity.rs
+++ b/crates/cli/tests/roundtrip_fidelity.rs
@@ -130,11 +130,9 @@ fn assert_roundtrip_fidelity(case: &str, source: &Path) {
 }
 
 /// As [`assert_roundtrip_fidelity`], but `lossy` opts into the explicit
-/// `--lossy` import surface. Gitlinks (submodules) are the one tree-entry
-/// kind heddle refuses to import silently — it converts them to a
-/// `heddle-submodule` blob only under the opt-in, then export reconstitutes
-/// the gitlink. The fidelity bar is unchanged: the round-trip must still be
-/// byte-identical.
+/// `--lossy` import surface for fixtures that intentionally exercise
+/// unrepresentable git tree data. The fidelity bar is unchanged: the
+/// round-trip must still be byte-identical whenever the source is representable.
 fn assert_roundtrip_fidelity_opts(case: &str, source: &Path, lossy: bool) {
     // git fsck the source first: a corrupt fixture would make the whole
     // comparison meaningless.
@@ -385,9 +383,9 @@ fn roundtrip_submodule_gitlink() {
         ls.contains("160000 commit"),
         "expected a 160000 gitlink tree entry, got: {ls}"
     );
-    // Gitlinks are heddle's one opt-in lossy tree-entry kind; the round-trip
-    // must still reproduce the gitlink (and thus the tree/commit SHA) exactly.
-    assert_roundtrip_fidelity_opts("submodule-gitlink", dir, true);
+    // Gitlinks import losslessly via the heddle-submodule blob convention and
+    // export back to mode 160000, so no --lossy opt-in is required.
+    assert_roundtrip_fidelity("submodule-gitlink", dir);
 }
 
 #[test]

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -27,7 +27,10 @@ use objects::{
         CompressionConfig, ObjectStore,
         pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder},
     },
-    util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name},
+    util::{
+        GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name,
+        gitlink_blob_content,
+    },
 };
 use oplog::oplog::{OpLog, OpLogBackend};
 use refs::refs::RefBackend;
@@ -642,13 +645,11 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
                 ))
             }
             TreeChildKind::Gitlink => {
-                let entry = LossyImportEntry::dropped(
-                    join_tree_path(path_prefix, &name),
-                    Some(child.sha.clone()),
-                    "gitlink/submodule entries have no Heddle tree equivalent",
-                );
-                self.record_lossy(entry)?;
-                Ok(None)
+                let hash = self.write_synthetic_blob(gitlink_blob_content(&child.sha))?;
+                Ok(Some(
+                    TreeEntry::file(name, hash, false)
+                        .map_err(|e| IngestError::Heddle(e.into()))?,
+                ))
             }
         }
     }
@@ -677,6 +678,15 @@ impl<'a, W: std::io::Write + std::io::Read + std::io::Seek> PackedImport<'a, W> 
         self.map
             .insert_blob(git_blob_sha, hash)
             .map_err(IngestError::from)?;
+        Ok(hash)
+    }
+
+    fn write_synthetic_blob(&mut self, bytes: Vec<u8>) -> crate::Result<ContentHash> {
+        let blob = Blob::new(bytes.clone());
+        let hash = blob.hash();
+        self.builder.add(hash, PackObjectType::Blob, bytes)?;
+        self.stats.object_count += 1;
+        self.stats.blobs += 1;
         Ok(hash)
     }
 
@@ -840,7 +850,10 @@ pub fn import_git_into_scoped_with_options_and_progress(
 mod tests {
     use std::{io::Write, path::Path, process::Command};
 
-    use objects::{object::ThreadName, store::InMemoryStore};
+    use objects::{
+        object::{EntryType, FileMode, ThreadName},
+        store::InMemoryStore,
+    };
     use refs::refs::RefManager;
     use tempfile::TempDir;
 
@@ -1086,36 +1099,47 @@ mod tests {
     }
 
     #[test]
-    fn import_git_into_rejects_gitlink_by_default() {
+    fn import_git_into_represents_gitlink_as_submodule_blob() {
         let gitdir = TempDir::new().unwrap();
         let heddledir = TempDir::new().unwrap();
         seed_gitlink_repo(gitdir.path());
 
-        let err = import_git_into(gitdir.path(), heddledir.path())
-            .expect_err("gitlink import must fail without --lossy");
-        let message = err.to_string();
-
-        assert!(message.contains("vendor"), "error names entry: {message}");
-        assert!(message.contains("--lossy"), "error names opt-in: {message}");
-    }
-
-    #[test]
-    fn import_git_into_lossy_drops_gitlink_and_summarizes() {
-        let gitdir = TempDir::new().unwrap();
-        let heddledir = TempDir::new().unwrap();
-        seed_gitlink_repo(gitdir.path());
-
-        let (stats, _map) = import_git_into_with_options(
-            gitdir.path(),
-            heddledir.path(),
-            ImportOptions { lossy: true },
-        )
-        .expect("lossy import succeeds");
+        let (stats, _map) =
+            import_git_into(gitdir.path(), heddledir.path()).expect("gitlink import succeeds");
 
         assert!(stats.commits_imported >= 2);
-        assert_eq!(stats.lossy_entries.len(), 1);
-        assert_eq!(stats.lossy_entries[0].path, "vendor");
-        assert!(stats.lossy_entries[0].summary_line().contains("dropped"));
+        assert!(stats.lossy_entries.is_empty());
+
+        let repo = repo::Repository::open(heddledir.path()).unwrap();
+        let main_cid = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("main thread");
+        let state = repo
+            .store()
+            .get_state(&main_cid)
+            .unwrap()
+            .expect("main state");
+        assert!(!state.git_lossy, "gitlink import must remain byte-faithful");
+        let tree = repo
+            .store()
+            .get_tree(&state.tree)
+            .unwrap()
+            .expect("root tree");
+        let entry = tree.get("vendor").expect("vendor gitlink entry");
+
+        assert_eq!(entry.entry_type, EntryType::Blob);
+        assert_eq!(entry.mode, FileMode::Normal);
+        let blob = repo
+            .store()
+            .get_blob(&entry.hash)
+            .unwrap()
+            .expect("submodule blob");
+        assert_eq!(
+            blob.content(),
+            gitlink_blob_content("0808080808080808080808080808080808080808")
+        );
     }
 
     #[test]

--- a/crates/objects/src/util/git_submodule.rs
+++ b/crates/objects/src/util/git_submodule.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared in-band representation for Git gitlinks/submodules.
+
+use std::fmt::Display;
+
+pub const SUBMODULE_PREFIX: &str = "heddle-submodule:";
+
+pub fn gitlink_blob_content(oid: impl Display) -> Vec<u8> {
+    format!("{SUBMODULE_PREFIX} {oid}").into_bytes()
+}

--- a/crates/objects/src/util/mod.rs
+++ b/crates/objects/src/util/mod.rs
@@ -2,8 +2,10 @@
 //! Shared utilities used across the objects crate.
 
 pub mod git_tree_name;
+pub mod git_submodule;
 pub mod symlink;
 
+pub use git_submodule::{SUBMODULE_PREFIX, gitlink_blob_content};
 pub use git_tree_name::{
     GitTreeNameClassification, GitTreeNameLossy, GitTreeNameLossyAction, classify_git_tree_name,
 };


### PR DESCRIPTION
Fixes #767.

## What changed
- `heddle-ingest` now represents Git gitlink tree entries as normal Heddle blobs using the existing `heddle-submodule: {oid}` convention instead of treating them as lossy drops.
- The git index importer and git exporter now share the submodule prefix/byte constructor from `objects::util`, so the importer bytes match the exporter parser.
- Gitlink imports no longer add lossy entries or set `State::git_lossy`; genuinely lossy entries such as invalid UTF-8 names remain on the existing `--lossy` path.

## Round-trip proof
- Added ingest coverage asserting a gitlink imports without `--lossy`, stores a `FileMode::Normal` / `EntryType::Blob` entry, and the blob bytes are exactly `heddle-submodule: {oid}`.
- Updated bridge/export coverage asserting imported gitlinks export back as mode `160000` commit entries with the same target OID.
- Updated `roundtrip_submodule_gitlink` to run without `--lossy` and preserve byte-identical Git object IDs.

## Gates
- `cargo build --locked --workspace`
- `cargo build --locked --workspace --all-features`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-ingest`
- `cargo test -p heddle-cli --test git_bridge_integration`
- `cargo test -p heddle-cli --test roundtrip_fidelity`
- `cargo test -p heddle-mount`
- `cargo clippy --workspace --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784607734&installation_id=132405951&pr_number=768&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F768&signature=e13138a78d37e55f3a2157001af1081ec7e7f0fe9f941ce0eb3149a693f4e102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->