### PR TITLE
release: v0.5.0 — storage-seam refactor + S3-backend removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.5.0 - 2026-06-21
+### Changed
+- **Breaking (crate surface):** storage-seam refactor. Extracted pure
+  `heddle-format` + `heddle-schema` crates and decoupled history /
+  commit-graph reads onto an `ObjectSource` seam (sync + async); the
+  commit-graph index is now an optional read accelerator rather than a
+  required backend. Hosted async object storage moves out of heddle into
+  the hosted server. (#761, #762, #763, #764, #766)
+### Removed
+- **Breaking:** removed the in-tree S3 object backend and its `aws-*`
+  dependency chain. Hosted S3 object storage now lives entirely in the
+  hosted server (weft); the OSS CLI no longer carries the S3 backend or
+  the AWS SDK. (#765, #760)
+### Added
+- Async commit-graph ancestry walkers (`is_ancestor` / merge-base) for
+  callers driving heddle over an async `ObjectSource`. (#766)
+### Fixed
+- `adopt` / git-import now represents gitlink (submodule) tree entries
+  losslessly as `heddle-submodule:<oid>` blobs instead of failing with
+  "gitlink/submodule entries have no Heddle tree equivalent". (#768)
+
 ## 0.4.0 - 2026-06-19
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1569,7 +1569,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1706,14 +1706,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "heddle-mount"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1862,14 +1862,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -1880,7 +1880,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5942,7 +5942,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,9 +11,9 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,30 +32,30 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.5" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.4" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.4" }
-heddle-client = { path = "../client", version = "0.4", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.4" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
+heddle-client = { path = "../client", version = "0.5", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.4", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.5", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -104,13 +104,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -29,14 +29,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.4" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.4", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.4" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -16,14 +16,14 @@ name = "heddle-ingest"
 path = "src/bin/main.rs"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.4" }
+heddle-format = { path = "../format", version = "0.5" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+heddle-schema = { path = "../schema", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.4", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+heddle-schema = { path = "../schema", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.4", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.4", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Prep for the **v0.5.0** release (minor bump — crate-surface breaking changes). **Not to be tagged until weft is confirmed building against these internals** (it is — see below) and you give the final GO.

## What's in 0.5.0 (the 9 commits since v0.4.0)
- **Breaking (crate surface):** storage-seam refactor — extracted pure `heddle-format` + `heddle-schema` crates; decoupled history / commit-graph reads onto an `ObjectSource` seam (sync + async); commit-graph index is now an optional accelerator. (#761–#764, #766)
- **Breaking:** removed the in-tree S3 object backend + the `aws-*` dependency chain; hosted S3 object storage now lives entirely in the hosted server. (#760, #765)
- **Added:** async commit-graph ancestry walkers. (#766)
- **Fixed:** `adopt`/git-import represents gitlink (submodule) entries as `heddle-submodule:<oid>` blobs instead of erroring. (#768)

## Mechanics
- Workspace version `0.4.0 → 0.5.0`; internal crate constraints `0.4 → 0.5` (65 pins across 16 crates); `heddle-grpc` stays `0.7.x`.
- `cargo metadata` resolves cleanly at 0.5.0.
- CHANGELOG `0.5.0` section added.

## Downstream confidence
weft (the main consumer) builds **clean against this exact rev** with the full hosted feature set (`postgres,semantic,s3`) — the `S3Store`/`ObjectSource`-seam path compiles, confirming the seam refactor doesn't break consumers.

## Gate
A `branch_dry_run` of the release pipeline is dispatched on this branch. **Do not merge/tag until: dry-run green + your GO.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784666957&installation_id=132405951&pr_number=769&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F769&signature=e83dd0eb1e59ea91f146041440360c4d64995026e069a1bf3252d5c51d484ca4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->