### PR TITLE
chore: lib-ify CLI logging + OutputMode into cli-shared

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,12 +1559,19 @@ name = "heddle-cli-shared"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "clap",
  "heddle-objects",
  "heddle-repo",
  "heddle-wire",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "serde",
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,27 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
 wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
 repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true
+tracing.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
+tracing-subscriber.workspace = true
+
+[features]
+observability = [
+    "dep:opentelemetry",
+    "dep:opentelemetry-otlp",
+    "dep:opentelemetry_sdk",
+    "dep:tracing-opentelemetry",
+]
 
 [lib]
 path = "src/lib.rs"

--- a/crates/cli-shared/src/lib.rs
+++ b/crates/cli-shared/src/lib.rs
@@ -10,8 +10,14 @@
 
 pub mod client_config;
 pub mod config;
+pub mod logging;
+pub mod output;
 pub mod remote;
 
 pub use client_config::ClientConfig;
 pub use config::UserConfig;
+pub use logging::{
+    LogFormat, LoggingConfig, LoggingGuard, init_logging, init_logging_default, is_enabled,
+};
+pub use output::OutputMode;
 pub use remote::{Remote, RemoteConfig, RemoteTarget, resolve_remote_with_key};

--- a/crates/cli-shared/src/logging/mod.rs
+++ b/crates/cli-shared/src/logging/mod.rs
@@ -256,7 +256,7 @@ impl OtelConfig {
 /// # Example
 ///
 /// ```rust
-/// use cli::logging::{LoggingConfig, init_logging};
+/// use cli_shared::logging::{LoggingConfig, init_logging};
 ///
 /// fn main() {
 ///     init_logging(LoggingConfig::from_env());

--- a/crates/cli-shared/src/output.rs
+++ b/crates/cli-shared/src/output.rs
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared CLI output mode values.
+
+use clap::ValueEnum;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum OutputMode {
+    Json,
+    // JSON, but only the decision-surface fields (heddle#470). Renders as
+    // `--output json-compact` on the CLI. Deliberately NOT a doc comment:
+    // a per-value help string forces clap's spaced long-help layout onto
+    // every command (the value list is rendered with the global --output
+    // arg), re-bloating all 100+ helps; the format semantics live in
+    // `heddle help output-formats` instead (heddle#652).
+    JsonCompact,
+    Text,
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -155,6 +155,7 @@ ingest = []
 semantic = ["dep:semantic", "repo/tree-sitter-symbols"]
 semantic-extended = ["semantic", "semantic?/extended-languages"]
 observability = [
+    "cli-shared/observability",
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",

--- a/crates/cli/src/cli/cli_args/cli_base.rs
+++ b/crates/cli/src/cli/cli_args/cli_base.rs
@@ -30,7 +30,8 @@
 //! keep working. Add a new short alias only when the letter is already
 //! reserved for that semantic in the table above.
 
-use clap::{Parser, ValueEnum};
+use clap::Parser;
+use cli_shared::OutputMode;
 
 use super::Commands;
 
@@ -99,17 +100,4 @@ impl Cli {
         };
         repo::Repository::open(repo_path).context("open Heddle repository")
     }
-}
-
-#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
-pub enum OutputMode {
-    Json,
-    // JSON, but only the decision-surface fields (heddle#470). Renders as
-    // `--output json-compact` on the CLI. Deliberately NOT a doc comment:
-    // a per-value help string forces clap's spaced long-help layout onto
-    // every command (the value list is rendered with the global --output
-    // arg), re-bloating all 100+ helps; the format semantics live in
-    // `heddle help output-formats` instead (heddle#652).
-    JsonCompact,
-    Text,
 }

--- a/crates/cli/src/cli/cli_args/mod.rs
+++ b/crates/cli/src/cli/cli_args/mod.rs
@@ -24,7 +24,8 @@ mod commands_stash;
 mod commands_thread;
 mod commands_visibility;
 
-pub use cli_base::{Cli, OutputMode};
+pub use cli_base::Cli;
+pub use cli_shared::OutputMode;
 pub use commands_advanced::{
     CheckpointArgs, TransactionAbortArgs, TransactionBeginArgs, TransactionCommands,
     TransactionIdArgs,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -25,7 +25,6 @@ pub mod client;
 pub mod exit;
 pub mod extensions;
 pub mod harness;
-pub mod logging;
 pub mod operation_id;
 pub mod perf;
 #[cfg(feature = "semantic")]
@@ -36,7 +35,10 @@ pub mod util;
 // Shared types now live in cli-shared (so heddle-client can depend on
 // them without a cli ↔ heddle-client cycle). Re-export under the
 // historical paths so internal code keeps working.
-pub use cli_shared::{config, remote};
+pub use cli_shared::{
+    LogFormat, LoggingConfig, LoggingGuard, OutputMode, config, init_logging,
+    init_logging_default, is_enabled, logging, log_operation, log_repo_event, remote,
+};
 pub use objects::{
     error::{HeddleError, HeddleError as StoreError},
     store::ObjectStore,


### PR DESCRIPTION
Moves `logging` and `OutputMode` out of the `heddle-cli` binary crate into the publishable `heddle-cli-shared` library crate, and re-exports them.

**Why:** first brick of the embeddable-facade hardening campaign (see `reviews/heddle-hardening-plan.md`, WU F1 prerequisite). These two pieces of CLI infra are library-shaped (other crates — including weft's server — need them without pulling in the `heddle-cli` binary crate). Lib-ifying them lets downstream consumers depend on `cli-shared` instead of `heddle-cli`.

**Scope (9 files, +55/-18):**
- `crates/cli-shared/src/logging/mod.rs` ← moved from `crates/cli/src/logging/mod.rs`
- `crates/cli-shared/src/output.rs` — new `OutputMode` (moved out of `cli_args/cli_base.rs`)
- re-exports from `cli-shared/src/lib.rs`; `crates/cli` repoints onto the moved symbols
- `cli-shared/Cargo.toml` gains the tracing deps; `cli/Cargo.toml` unchanged dep set otherwise

**Behavior:** none changed — pure relocation + re-export.

**Gates:** default + all-features workspace build, `cargo test -p heddle-cli`, `cargo test -p heddle-cli-shared`, clippy `-D warnings`.

Cross-engine note: codex-authored; reviewed by the orchestrating Claude (mechanical module-move, no logic change).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/770"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784672561&installation_id=132405951&pr_number=770&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F770&signature=d5a8f3e83cabbd866ae23ae18820ddeb410c2c9b08a022d1a70049f655e4bc84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->