### PR TITLE
chore(lint): unwrap/expect inventory + per-crate deny ratchet

### DIFF
--- a/.github/workflows/unwrap-inventory.yml
+++ b/.github/workflows/unwrap-inventory.yml
@@ -1,0 +1,155 @@
+name: Unwrap Inventory
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  unwrap-inventory:
+    name: unwrap-inventory
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    continue-on-error: true
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: unwrap-inventory-${{ runner.os }}
+          cache-on-failure: true
+
+      - name: Count production unwrap/expect/panic call sites
+        continue-on-error: true
+        run: |
+          set +e
+          cargo metadata --format-version 1 --no-deps > cargo-metadata.json
+          metadata_status=$?
+          cargo clippy --locked --message-format=json --workspace --all-targets -- \
+            -W clippy::unwrap_used \
+            -W clippy::expect_used \
+            -W clippy::panic \
+            > clippy-inventory.json 2> clippy-inventory.stderr
+          clippy_status=$?
+
+          if [ -s clippy-inventory.stderr ]; then
+            echo "::group::cargo clippy stderr"
+            cat clippy-inventory.stderr
+            echo "::endgroup::"
+          fi
+
+          if [ "$metadata_status" -ne 0 ]; then
+            {
+              echo "## unwrap-inventory"
+              echo
+              echo "cargo metadata failed with status $metadata_status; no inventory table was produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          python3 <<'PY'
+          import json
+          import os
+          from collections import defaultdict
+
+          lint_names = {
+              "clippy::unwrap_used": "unwrap_used",
+              "clippy::expect_used": "expect_used",
+              "clippy::panic": "panic",
+          }
+
+          with open("cargo-metadata.json", encoding="utf-8") as handle:
+              metadata = json.load(handle)
+
+          packages = {package["id"]: package for package in metadata["packages"]}
+          workspace_crates = sorted(
+              packages[package_id]["name"] for package_id in metadata["workspace_members"]
+          )
+          counts = defaultdict(set)
+
+          with open("clippy-inventory.json", encoding="utf-8") as handle:
+              for line in handle:
+                  try:
+                      message = json.loads(line)
+                  except json.JSONDecodeError:
+                      continue
+                  if message.get("reason") != "compiler-message":
+                      continue
+                  diagnostic = message.get("message", {})
+                  code = (diagnostic.get("code") or {}).get("code")
+                  if code not in lint_names:
+                      continue
+
+                  package = packages.get(message.get("package_id"))
+                  if package is None:
+                      continue
+                  target_kind = set(message.get("target", {}).get("kind", []))
+                  if target_kind.intersection({"test", "bench"}):
+                      continue
+
+                  primary_spans = [
+                      span for span in diagnostic.get("spans", []) if span.get("is_primary")
+                  ]
+                  if not primary_spans:
+                      primary_spans = diagnostic.get("spans", [])[:1]
+
+                  for span in primary_spans:
+                      path = span.get("file_name", "")
+                      path_parts = set(path.split("/"))
+                      if path_parts.intersection({"tests", "benches"}):
+                          continue
+                      key = (
+                          path,
+                          span.get("line_start"),
+                          span.get("column_start"),
+                          code,
+                      )
+                      counts[(package["name"], lint_names[code])].add(key)
+
+          lines = [
+              "## unwrap-inventory",
+              "",
+              "Unique primary clippy diagnostics in non-test/non-bench targets.",
+              "",
+              "| crate | unwrap_used | expect_used | panic |",
+              "|---|---:|---:|---:|",
+          ]
+          for crate in workspace_crates:
+              lines.append(
+                  "| {crate} | {unwrap} | {expect} | {panic} |".format(
+                      crate=crate,
+                      unwrap=len(counts[(crate, "unwrap_used")]),
+                      expect=len(counts[(crate, "expect_used")]),
+                      panic=len(counts[(crate, "panic")]),
+                  )
+              )
+
+          print("\n".join(lines))
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("\n".join(lines))
+              summary.write("\n")
+          PY
+
+          if [ "$clippy_status" -ne 0 ]; then
+            {
+              echo
+              echo "cargo clippy exited with status $clippy_status; the table above may be partial."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          exit 0

--- a/crates/grpc/src/lib.rs
+++ b/crates/grpc/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
 //! Generated gRPC surface for the hosted transport rewrite.
 
 pub mod heddle {

--- a/crates/weft-client-shim/src/lib.rs
+++ b/crates/weft-client-shim/src/lib.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+
 //! Trait surface separating the OSS Heddle CLI from the closed
 //! heddle-client implementation.
 //!

--- a/docs/unwrap-policy.md
+++ b/docs/unwrap-policy.md
@@ -1,0 +1,43 @@
+# Unwrap and Expect Policy
+
+Heddle should reach zero production `unwrap` and `expect` call sites before 1.0. Until that cleanup is complete, the gate is per-crate: crates that already have no production `clippy::unwrap_used` or `clippy::expect_used` diagnostics deny those lints at the crate root so they cannot regress.
+
+Use this crate-root pattern for already-clean crates:
+
+```rust
+#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]
+```
+
+The `not(test)` carve-out keeps inline `#[cfg(test)]` modules free to use local `unwrap` or `expect` where that keeps tests readable. Do not add these lints as workspace-wide warnings or workspace lints while non-clean crates still contain production call sites, because the main CI clippy gate runs with `-D warnings`.
+
+The SAFE class of intentional panics, including mutex-poison `.lock().expect(...)` and unwraps guarded by an immediate prior check, should converge on a uniform helper plus a local lint allow. The helper itself is tracked separately from this gate scaffolding.
+
+## Current Inventory
+
+Counts below are unique primary clippy diagnostics from `cargo clippy --workspace --all-targets -- -W clippy::unwrap_used -W clippy::expect_used -W clippy::panic`, excluding test and bench targets and paths under `tests/` or `benches/`.
+
+| crate | unwrap_used | expect_used | panic |
+|---|---:|---:|---:|
+| heddle-cli | 1099 | 336 | 58 |
+| heddle-cli-macro-poc | 0 | 2 | 0 |
+| heddle-cli-shared | 0 | 21 | 2 |
+| heddle-client | 23 | 123 | 6 |
+| heddle-crypto | 0 | 78 | 5 |
+| heddle-daemon | 183 | 95 | 8 |
+| heddle-devtools | 32 | 12 | 0 |
+| heddle-format | 25 | 5 | 1 |
+| heddle-grpc | 0 | 0 | 0 |
+| heddle-ingest | 478 | 79 | 3 |
+| heddle-merge | 8 | 2 | 19 |
+| heddle-mount | 373 | 337 | 11 |
+| heddle-objects | 568 | 117 | 13 |
+| heddle-oplog | 303 | 5 | 7 |
+| heddle-refs | 302 | 7 | 1 |
+| heddle-repo | 1993 | 430 | 22 |
+| heddle-review | 57 | 15 | 1 |
+| heddle-runtime-bridge | 0 | 18 | 1 |
+| heddle-schema | 37 | 0 | 2 |
+| heddle-semantic | 189 | 58 | 89 |
+| heddle-state-review | 2 | 0 | 0 |
+| heddle-wire | 96 | 2 | 0 |
+| weft-client-shim | 0 | 0 | 0 |


### PR DESCRIPTION
Gate scaffolding for the panic-free track of the hardening campaign (WU **U-gate**, `reviews/heddle-hardening-plan.md`).

- **`docs/unwrap-policy.md`** — the policy (zero prod `unwrap`/`expect` before 1.0), the per-crate ratchet pattern `#![cfg_attr(not(test), deny(clippy::unwrap_used, clippy::expect_used))]` (denies in prod builds, frees inline `#[cfg(test)]`), and the rule that the SAFE class (mutex-poison `.lock().expect`, post-check unwraps) converges on a uniform helper + local allow rather than rewrite.
- **Ratchet** the two already-clean crates (`grpc`, `weft-client-shim`) to that deny so they can't regress.
- **`unwrap-inventory.yml`** — a **non-blocking** (`continue-on-error: true`) CI job that reports per-crate `unwrap_used`/`expect_used`/`panic` counts to the step summary. Visibility only; never gates a merge.

As each crate is driven to zero by a panic→Result cluster, it gets the same deny attr — which the existing `clippy -D warnings` gate then enforces. The deny is the durable "stays clean" mechanism.

> Follow-up: the inventory job counts with `--all-targets` (includes inline test code), so its numbers over-count and won't reach zero. The per-crate deny is the real done-signal; a prod-only inventory measure is a cheap follow-up.

Cross-engine: codex-authored; orchestrator-reviewed (deny attrs correct; workflow non-blocking).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784675155&installation_id=132405951&pr_number=773&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F773&signature=1c9dcd36f57c871750dd8e5e0519ed7b4203e8ecd1215bbcef211fef65c9fe6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->