### PR TITLE
perf(status): borrow tree-entry names in the worktree scan instead of cloning

### DIFF
--- a/crates/objects/src/worktree/worktree_compare.rs
+++ b/crates/objects/src/worktree/worktree_compare.rs
@@ -35,18 +35,18 @@ fn compare_worktree_recursive<S: ObjectStore + ?Sized>(
     ignore_patterns: &[String],
     status: &mut WorktreeStatus,
 ) -> Result<()> {
-    let tree_entries: HashMap<String, &TreeEntry> = tree
-        .map(|t| t.entries().iter().map(|e| (e.name.clone(), e)).collect())
+    let tree_entries: HashMap<&str, &TreeEntry> = tree
+        .map(|t| t.entries().iter().map(|e| (e.name.as_str(), e)).collect())
         .unwrap_or_default();
 
-    let mut seen_entries: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_entries: std::collections::HashSet<&str> = std::collections::HashSet::new();
 
     if dir.exists() {
         for entry in fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
             let name = match path.file_name().and_then(|n| n.to_str()) {
-                Some(n) => n.to_string(),
+                Some(n) => n,
                 None => continue,
             };
 
@@ -56,7 +56,9 @@ fn compare_worktree_recursive<S: ObjectStore + ?Sized>(
                 continue;
             }
 
-            seen_entries.insert(name.clone());
+            if let Some((tree_name, _)) = tree_entries.get_key_value(name) {
+                seen_entries.insert(*tree_name);
+            }
 
             if path.is_symlink() {
                 let target = fs::read_link(&path)?;


### PR DESCRIPTION
Removes the per-entry `String` allocations in the worktree-vs-tree status scan (campaign WU **Z4**). Behavior-neutral.

**Change (`worktree_compare.rs`, +7/-5):**
- `tree_entries: HashMap<String, &TreeEntry>` → `HashMap<&str, &TreeEntry>` keyed on `e.name.as_str()` (borrowed from `tree`).
- `seen_entries: HashSet<String>` → `HashSet<&str>`; the worktree filename is kept as a borrowed `&str` (no `to_string()`), and the seen-set inserts the **tree-borrowed** name via `tree_entries.get_key_value(name)` (which outlives the loop) rather than cloning the loop-local worktree name.

**Behavior-neutral:** `seen_entries` is consumed only by the tree-deletion check (`for (name,_) in &tree_entries { if !seen_entries.contains(name) … }`). A tree entry is in `seen` iff it's present in the worktree — identical to before; the untracked worktree names the old code inserted were never queried.

On a large worktree this removes O(files) short-lived `String` allocations per status. **Gates:** default + all-features build, `cargo test -p heddle-objects`, `clippy -p heddle-objects -D warnings`.

Cross-engine: codex-authored; orchestrator-reviewed (verified the seen-set semantics are unchanged).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784675235&installation_id=132405951&pr_number=774&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F774&signature=5a836d1103fa5635ac63bf4ab2c8da93e873b9f9b7f39f8ae458f9d2dc0005a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->