### PR TITLE
chore(panic-free): apply lock helper to objects/refs/oplog/repo (safe-class wave 2)

### DIFF
--- a/crates/objects/benches/tree_diff.rs
+++ b/crates/objects/benches/tree_diff.rs
@@ -12,6 +12,7 @@ use objects::{
         diff_trees,
     },
     store::{ObjectStore, Result},
+    sync::RwLockExt,
 };
 
 const SIZES: &[usize] = &[1_000, 10_000, 100_000];
@@ -41,31 +42,31 @@ struct BenchStore {
 
 impl ObjectStore for BenchStore {
     fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
-        Ok(self.blobs.read().unwrap().get(hash).cloned())
+        Ok(self.blobs.read_or_poisoned().get(hash).cloned())
     }
 
     fn put_blob(&self, blob: &Blob) -> Result<ContentHash> {
         let hash = blob.hash();
-        self.blobs.write().unwrap().insert(hash, blob.clone());
+        self.blobs.write_or_poisoned().insert(hash, blob.clone());
         Ok(hash)
     }
 
     fn has_blob(&self, hash: &ContentHash) -> Result<bool> {
-        Ok(self.blobs.read().unwrap().contains_key(hash))
+        Ok(self.blobs.read_or_poisoned().contains_key(hash))
     }
 
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        Ok(self.trees.read().unwrap().get(hash).cloned())
+        Ok(self.trees.read_or_poisoned().get(hash).cloned())
     }
 
     fn put_tree(&self, tree: &Tree) -> Result<ContentHash> {
         let hash = tree.hash();
-        self.trees.write().unwrap().insert(hash, tree.clone());
+        self.trees.write_or_poisoned().insert(hash, tree.clone());
         Ok(hash)
     }
 
     fn has_tree(&self, hash: &ContentHash) -> Result<bool> {
-        Ok(self.trees.read().unwrap().contains_key(hash))
+        Ok(self.trees.read_or_poisoned().contains_key(hash))
     }
 
     fn get_state(&self, _id: &ChangeId) -> Result<Option<State>> {
@@ -97,11 +98,11 @@ impl ObjectStore for BenchStore {
     }
 
     fn list_blobs(&self) -> Result<Vec<ContentHash>> {
-        Ok(self.blobs.read().unwrap().keys().copied().collect())
+        Ok(self.blobs.read_or_poisoned().keys().copied().collect())
     }
 
     fn list_trees(&self) -> Result<Vec<ContentHash>> {
-        Ok(self.trees.read().unwrap().keys().copied().collect())
+        Ok(self.trees.read_or_poisoned().keys().copied().collect())
     }
 }
 

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -17,6 +17,7 @@ use crate::{
         compression::CompressionConfig,
         pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
     },
+    sync::RwLockExt,
 };
 
 fn create_test_store() -> (TempDir, FsStore) {
@@ -738,7 +739,7 @@ fn loose_blob_path_rejects_torn_cache_mirror() {
     // Drop the in-process verified cache and corrupt the file. This
     // is the post-crash state we're guarding against: cache empty,
     // file's bytes don't match the hash any more.
-    *store.verified_loose_blobs.write().unwrap() =
+    *store.verified_loose_blobs.write_or_poisoned() =
         super::fs_store::RecentObjectCache::with_capacity(65_536);
     std::fs::write(&path, b"torn-write garbage").unwrap();
 

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, sync::RwLock};
 use crate::{
     object::{Action, ActionId, Blob, ChangeId, ContentHash, State, Tree},
     store::{HeddleError, ObjectStore, Result},
+    sync::RwLockExt,
 };
 
 /// A non-persistent, in-memory implementation of [`ObjectStore`].
@@ -49,8 +50,7 @@ impl ObjectStore for InMemoryStore {
     fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
         Ok(self
             .blobs
-            .read()
-            .unwrap()
+            .read_or_poisoned()
             .get(hash)
             .map(|v| Blob::new(v.clone())))
     }
@@ -58,28 +58,31 @@ impl ObjectStore for InMemoryStore {
     fn put_blob(&self, blob: &Blob) -> Result<ContentHash> {
         let hash = blob.hash();
         self.blobs
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(hash, blob.content().to_vec());
         Ok(hash)
     }
 
     fn has_blob(&self, hash: &ContentHash) -> Result<bool> {
-        Ok(self.blobs.read().unwrap().contains_key(hash))
+        Ok(self.blobs.read_or_poisoned().contains_key(hash))
     }
 
     fn blob_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
         // InMemoryStore keeps raw uncompressed bytes — the length of
         // the stored buffer is the blob size, no header parsing needed.
-        Ok(self.blobs.read().unwrap().get(hash).map(|v| v.len() as u64))
+        Ok(self
+            .blobs
+            .read_or_poisoned()
+            .get(hash)
+            .map(|v| v.len() as u64))
     }
 
     fn list_blobs(&self) -> Result<Vec<ContentHash>> {
-        Ok(self.blobs.read().unwrap().keys().copied().collect())
+        Ok(self.blobs.read_or_poisoned().keys().copied().collect())
     }
 
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        match self.trees.read().unwrap().get(hash) {
+        match self.trees.read_or_poisoned().get(hash) {
             Some(bytes) => Ok(Some(rmp_serde::from_slice(bytes)?)),
             None => Ok(None),
         }
@@ -88,22 +91,21 @@ impl ObjectStore for InMemoryStore {
     fn put_tree(&self, tree: &Tree) -> Result<ContentHash> {
         let hash = tree.hash();
         self.trees
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(hash, rmp_serde::to_vec(tree)?);
         Ok(hash)
     }
 
     fn has_tree(&self, hash: &ContentHash) -> Result<bool> {
-        Ok(self.trees.read().unwrap().contains_key(hash))
+        Ok(self.trees.read_or_poisoned().contains_key(hash))
     }
 
     fn list_trees(&self) -> Result<Vec<ContentHash>> {
-        Ok(self.trees.read().unwrap().keys().copied().collect())
+        Ok(self.trees.read_or_poisoned().keys().copied().collect())
     }
 
     fn get_state(&self, id: &ChangeId) -> Result<Option<State>> {
-        match self.states.read().unwrap().get(id) {
+        match self.states.read_or_poisoned().get(id) {
             Some(bytes) => Ok(Some(rmp_serde::from_slice(bytes)?)),
             None => Ok(None),
         }
@@ -111,22 +113,21 @@ impl ObjectStore for InMemoryStore {
 
     fn put_state(&self, state: &State) -> Result<()> {
         self.states
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(state.change_id, rmp_serde::to_vec(state)?);
         Ok(())
     }
 
     fn has_state(&self, id: &ChangeId) -> Result<bool> {
-        Ok(self.states.read().unwrap().contains_key(id))
+        Ok(self.states.read_or_poisoned().contains_key(id))
     }
 
     fn list_states(&self) -> Result<Vec<ChangeId>> {
-        Ok(self.states.read().unwrap().keys().copied().collect())
+        Ok(self.states.read_or_poisoned().keys().copied().collect())
     }
 
     fn get_action(&self, id: &ActionId) -> Result<Option<Action>> {
-        match self.actions.read().unwrap().get(id) {
+        match self.actions.read_or_poisoned().get(id) {
             Some(bytes) => {
                 let action: Action = rmp_serde::from_slice(bytes)?;
                 let found_id = action.compute_id();
@@ -145,48 +146,45 @@ impl ObjectStore for InMemoryStore {
     fn put_action(&self, action: &mut Action) -> Result<ActionId> {
         let id = action.id();
         self.actions
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(id, rmp_serde::to_vec(action)?);
         Ok(id)
     }
 
     fn list_actions(&self) -> Result<Vec<ActionId>> {
-        Ok(self.actions.read().unwrap().keys().copied().collect())
+        Ok(self.actions.read_or_poisoned().keys().copied().collect())
     }
 
     fn has_redactions_for_blob(&self, blob: &ContentHash) -> Result<bool> {
-        Ok(self.redactions.read().unwrap().contains_key(blob))
+        Ok(self.redactions.read_or_poisoned().contains_key(blob))
     }
 
     fn get_redactions_bytes_for_blob(&self, blob: &ContentHash) -> Result<Option<Vec<u8>>> {
-        Ok(self.redactions.read().unwrap().get(blob).cloned())
+        Ok(self.redactions.read_or_poisoned().get(blob).cloned())
     }
 
     fn put_redactions_bytes_for_blob(&self, blob: &ContentHash, bytes: &[u8]) -> Result<()> {
         self.redactions
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(*blob, bytes.to_vec());
         Ok(())
     }
 
     fn list_blobs_with_redactions(&self) -> Result<Vec<ContentHash>> {
-        Ok(self.redactions.read().unwrap().keys().copied().collect())
+        Ok(self.redactions.read_or_poisoned().keys().copied().collect())
     }
 
     fn has_state_visibility_for_state(&self, state: &ChangeId) -> Result<bool> {
-        Ok(self.state_visibility.read().unwrap().contains_key(state))
+        Ok(self.state_visibility.read_or_poisoned().contains_key(state))
     }
 
     fn get_state_visibility_bytes_for_state(&self, state: &ChangeId) -> Result<Option<Vec<u8>>> {
-        Ok(self.state_visibility.read().unwrap().get(state).cloned())
+        Ok(self.state_visibility.read_or_poisoned().get(state).cloned())
     }
 
     fn put_state_visibility_bytes_for_state(&self, state: &ChangeId, bytes: &[u8]) -> Result<()> {
         self.state_visibility
-            .write()
-            .unwrap()
+            .write_or_poisoned()
             .insert(*state, bytes.to_vec());
         Ok(())
     }
@@ -194,8 +192,7 @@ impl ObjectStore for InMemoryStore {
     fn list_states_with_visibility(&self) -> Result<Vec<ChangeId>> {
         Ok(self
             .state_visibility
-            .read()
-            .unwrap()
+            .read_or_poisoned()
             .keys()
             .copied()
             .collect())

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -11,6 +11,7 @@ use objects::{
     error::{HeddleError, Result},
     lock::{RepoLock, WriteLockGuard},
     object::Principal,
+    sync::LockExt,
 };
 
 use super::{
@@ -133,14 +134,14 @@ impl OpLog {
 
     /// Load from cache or disk (for read operations).
     fn load_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLogIndex>>> {
-        let guard = self.cached.lock().unwrap();
+        let guard = self.cached.lock_or_poisoned();
         if guard.is_some() {
             return Ok(guard);
         }
         drop(guard);
 
         self.ensure_current_format()?;
-        let mut guard = self.cached.lock().unwrap();
+        let mut guard = self.cached.lock_or_poisoned();
         if guard.is_none() {
             let path = self.oplog_path();
             *guard = Some(if path.exists() {
@@ -159,7 +160,7 @@ impl OpLog {
     /// 3329711888).
     fn refresh_cached(&self) -> Result<std::sync::MutexGuard<'_, Option<PackedOpLogIndex>>> {
         self.ensure_current_format()?;
-        let mut guard = self.cached.lock().unwrap();
+        let mut guard = self.cached.lock_or_poisoned();
         let path = self.oplog_path();
         *guard = Some(if path.exists() {
             PackedOpLogIndex::open(&path)?
@@ -204,7 +205,7 @@ impl OpLog {
         let report = recover_oplog_at(&path)?;
         // Drop any cached (now-stale) index view so subsequent reads see the
         // rebuilt oplog.
-        *self.cached.lock().unwrap() = None;
+        *self.cached.lock_or_poisoned() = None;
         Ok(report)
     }
 
@@ -334,7 +335,7 @@ impl OpLog {
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
         let updated = index.append_entries(&new_entries)?;
-        *self.cached.lock().unwrap() = Some(updated);
+        *self.cached.lock_or_poisoned() = Some(updated);
 
         Ok(Some(ids))
     }
@@ -382,7 +383,7 @@ impl OpLog {
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
         let updated = index.append_entries(&new_entries)?;
-        *self.cached.lock().unwrap() = Some(updated);
+        *self.cached.lock_or_poisoned() = Some(updated);
 
         Ok(Some(ids))
     }
@@ -430,7 +431,7 @@ impl OpLog {
         packed.entries = entries;
         packed.head_id = head_id;
         packed.save()?;
-        *self.cached.lock().unwrap() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
+        *self.cached.lock_or_poisoned() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
         Ok(())
     }
 
@@ -470,7 +471,7 @@ impl OpLog {
             e.undone = undone;
         }
 
-        *self.cached.lock().unwrap() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
+        *self.cached.lock_or_poisoned() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
 
         Ok(OpBatch {
             id: batch.id,
@@ -517,7 +518,7 @@ impl OpLogBackend for OpLog {
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
         let updated = index.append_entries(&new_entries)?;
-        *self.cached.lock().unwrap() = Some(updated);
+        *self.cached.lock_or_poisoned() = Some(updated);
 
         Ok(ids)
     }
@@ -578,7 +579,7 @@ impl OpLogBackend for OpLog {
         let ids: Vec<u64> = new_entries.iter().map(|e| e.id).collect();
 
         let updated = index.append_entries(&new_entries)?;
-        *self.cached.lock().unwrap() = Some(updated);
+        *self.cached.lock_or_poisoned() = Some(updated);
 
         Ok(ConditionalCommitOutcome::Committed(ids))
     }
@@ -665,7 +666,7 @@ impl OpLogBackend for OpLog {
             .into_iter()
             .map(|idx| packed.entries[idx].clone())
             .collect::<Vec<_>>();
-        *self.cached.lock().unwrap() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
+        *self.cached.lock_or_poisoned() = Some(PackedOpLogIndex::open(&self.oplog_path())?);
 
         Ok(OpBatch {
             id: primary_batch_id,

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -889,7 +889,7 @@ mod default_backend {
     use std::sync::{Arc, Mutex};
 
     use chrono::Utc;
-    use objects::{error::Result, object::Principal};
+    use objects::{error::Result, object::Principal, sync::LockExt};
 
     use super::{
         super::oplog_types::{OpBatch, OpEntry, OpRecord},
@@ -908,7 +908,7 @@ mod default_backend {
             operations: Vec<OpRecord>,
             scope: Option<&str>,
         ) -> Result<Vec<u64>> {
-            let mut next = self.next_id.lock().unwrap();
+            let mut next = self.next_id.lock_or_poisoned();
             let batch_id = *next + 1;
             let mut ids = Vec::new();
             let mut entries = Vec::new();
@@ -927,7 +927,7 @@ mod default_backend {
                     operation_id: None,
                 });
             }
-            self.batches.lock().unwrap().push(OpBatch {
+            self.batches.lock_or_poisoned().push(OpBatch {
                 id: batch_id,
                 entries,
             });

--- a/crates/refs/src/refs/backend.rs
+++ b/crates/refs/src/refs/backend.rs
@@ -110,6 +110,7 @@ mod tests {
     use objects::{
         error::HeddleError,
         object::{ChangeId, MarkerName, ThreadName},
+        sync::LockExt,
     };
 
     use super::CoreRefBackend;
@@ -130,13 +131,12 @@ mod tests {
 
         fn read_head(&self) -> Result<Head, HeddleError> {
             self.head
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .clone()
                 .ok_or_else(|| HeddleError::Config("no head".to_string()))
         }
         fn write_head(&self, head: &Head) -> Result<(), HeddleError> {
-            *self.head.lock().unwrap() = Some(head.clone());
+            *self.head.lock_or_poisoned() = Some(head.clone());
             Ok(())
         }
         fn write_head_cas(
@@ -147,12 +147,15 @@ mod tests {
             self.write_head(head)
         }
         async fn get_thread(&self, name: &ThreadName) -> Result<Option<ChangeId>, HeddleError> {
-            Ok(self.threads.lock().unwrap().get(name.as_str()).copied())
+            Ok(self
+                .threads
+                .lock_or_poisoned()
+                .get(name.as_str())
+                .copied())
         }
         fn set_thread(&self, name: &ThreadName, state: &ChangeId) -> Result<(), HeddleError> {
             self.threads
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
             Ok(())
         }
@@ -165,7 +168,7 @@ mod tests {
             self.set_thread(name, state)
         }
         fn delete_thread(&self, name: &ThreadName) -> Result<Option<ChangeId>, HeddleError> {
-            Ok(self.threads.lock().unwrap().remove(name.as_str()))
+            Ok(self.threads.lock_or_poisoned().remove(name.as_str()))
         }
         fn delete_thread_cas(
             &self,
@@ -177,14 +180,17 @@ mod tests {
         fn list_threads(&self) -> Result<Vec<ThreadName>, HeddleError> {
             Ok(self
                 .threads
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .keys()
                 .map(|k| ThreadName::new(k.as_str()))
                 .collect())
         }
         async fn get_marker(&self, name: &MarkerName) -> Result<Option<ChangeId>, HeddleError> {
-            Ok(self.markers.lock().unwrap().get(name.as_str()).copied())
+            Ok(self
+                .markers
+                .lock_or_poisoned()
+                .get(name.as_str())
+                .copied())
         }
         async fn create_marker(
             &self,
@@ -192,8 +198,7 @@ mod tests {
             state: &ChangeId,
         ) -> Result<(), HeddleError> {
             self.markers
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
             Ok(())
         }
@@ -204,13 +209,12 @@ mod tests {
             state: &ChangeId,
         ) -> Result<(), HeddleError> {
             self.markers
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .insert(name.as_str().to_string(), *state);
             Ok(())
         }
         fn delete_marker(&self, name: &MarkerName) -> Result<Option<ChangeId>, HeddleError> {
-            Ok(self.markers.lock().unwrap().remove(name.as_str()))
+            Ok(self.markers.lock_or_poisoned().remove(name.as_str()))
         }
         fn delete_marker_cas(
             &self,
@@ -222,8 +226,7 @@ mod tests {
         fn list_markers(&self) -> Result<Vec<MarkerName>, HeddleError> {
             Ok(self
                 .markers
-                .lock()
-                .unwrap()
+                .lock_or_poisoned()
                 .keys()
                 .map(|k| MarkerName::new(k.as_str()))
                 .collect())

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -542,6 +542,7 @@ mod chokepoint {
     use objects::{
         error::Result,
         object::{ChangeId, MarkerName, ThreadName},
+        sync::LockExt,
     };
     use tempfile::TempDir;
 
@@ -834,7 +835,7 @@ mod chokepoint {
             .unwrap();
 
         // The committer saw the records (phase 4) and the ref published (phase 5).
-        let seen = committer.seen.lock().unwrap();
+        let seen = committer.seen.lock_or_poisoned();
         assert_eq!(seen.len(), 1);
         assert_eq!(seen[0].0, records);
         assert_eq!(seen[0].1.as_deref(), Some("lane"));

--- a/crates/repo/src/lazy_hydrator.rs
+++ b/crates/repo/src/lazy_hydrator.rs
@@ -33,6 +33,7 @@ use std::{
 use objects::{
     error::{HeddleError, Result},
     fs_atomic::write_file_atomic,
+    sync::RwLockExt,
 };
 use serde::{Deserialize, Serialize};
 
@@ -201,7 +202,7 @@ fn registry() -> &'static RwLock<HashMap<String, BlobHydratorFactory>> {
 /// registrations of the same factory pointer; new calls override an
 /// existing registration for that kind.
 pub fn register_factory(kind: impl Into<String>, factory: BlobHydratorFactory) {
-    let mut map = registry().write().unwrap();
+    let mut map = registry().write_or_poisoned();
     map.insert(kind.into(), factory);
 }
 
@@ -211,7 +212,7 @@ pub fn register_factory(kind: impl Into<String>, factory: BlobHydratorFactory) {
 /// (e.g. a one-off script that uses `heddle-repo` directly) may
 /// legitimately not need hydration.
 pub fn lookup_factory(kind: &str) -> Option<BlobHydratorFactory> {
-    registry().read().unwrap().get(kind).cloned()
+    registry().read_or_poisoned().get(kind).cloned()
 }
 
 /// Convenience: load the persisted config (if any), look up the
@@ -250,6 +251,7 @@ mod tests {
     use objects::{
         object::{Blob, ContentHash},
         store::ObjectStore,
+        sync::LockExt,
     };
     use tempfile::TempDir;
 
@@ -342,7 +344,7 @@ mod tests {
                         bytes: payload_for_factory.clone(),
                         calls: AtomicUsize::new(0),
                     });
-                    *made_for_factory.lock().unwrap() = Some(Arc::clone(&h));
+                    *made_for_factory.lock_or_poisoned() = Some(Arc::clone(&h));
                     Ok(h)
                 },
             ),
@@ -360,9 +362,9 @@ mod tests {
 
         let hydrator = try_reconstruct(temp.path(), &heddle).unwrap();
         assert!(hydrator.is_some());
-        assert!(made.lock().unwrap().is_some());
+        assert!(made.lock_or_poisoned().is_some());
         // The held reference should match the one the factory built.
-        let kept = made.lock().unwrap().as_ref().map(Arc::clone).unwrap();
+        let kept = made.lock_or_poisoned().as_ref().map(Arc::clone).unwrap();
         assert!(Arc::strong_count(&kept) >= 1);
     }
 

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -31,6 +31,7 @@ use objects::{
     fs_atomic::write_file_atomic,
     lock::{RepoLock, WriteLockGuard},
     object::OperationId,
+    sync::LockExt,
 };
 use oplog::IsolationKey;
 use serde::{Deserialize, Serialize};
@@ -139,13 +140,12 @@ impl ReserveOpIdClaim {
     }
 
     fn set(&self, outcome: DedupOutcome) {
-        *self.outcome.lock().expect("reserve op-id outcome poisoned") = Some(outcome);
+        *self.outcome.lock_or_poisoned() = Some(outcome);
     }
 
     fn into_outcome(self) -> Result<DedupOutcome> {
         self.outcome
-            .lock()
-            .expect("reserve op-id outcome poisoned")
+            .lock_or_poisoned()
             .take()
             .ok_or_else(|| HeddleError::Conflict("eager op-id reserve produced no outcome".into()))
     }
@@ -377,7 +377,7 @@ impl OperationDedupStore {
         request_hash: [u8; 32],
     ) -> Result<DedupOutcome> {
         let key = key_for(verb, operation_id);
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         let _file_guard = self.acquire_file_lock()?;
         self.reload_under_lock(&mut inner)?;
         match inner.entries.get(&key) {
@@ -431,7 +431,7 @@ impl OperationDedupStore {
             created_at_secs: now_secs(),
             pending: false,
         };
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         let _file_guard = self.acquire_file_lock()?;
         self.reload_under_lock(&mut inner)?;
         inner.entries.insert(key, entry);
@@ -444,7 +444,7 @@ impl OperationDedupStore {
     /// has already been finalised by [`Self::record`].
     pub fn cancel(&self, operation_id: OperationId, verb: &str) -> Result<()> {
         let key = key_for(verb, operation_id);
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         let _file_guard = self.acquire_file_lock()?;
         self.reload_under_lock(&mut inner)?;
         if let Some(existing) = inner.entries.get(&key)
@@ -460,7 +460,7 @@ impl OperationDedupStore {
     /// pruned entries.
     pub fn compact(&self, retention_secs: i64) -> Result<usize> {
         let cutoff = now_secs() - retention_secs;
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         let _file_guard = self.acquire_file_lock()?;
         self.reload_under_lock(&mut inner)?;
         let before = inner.entries.len();
@@ -476,7 +476,7 @@ impl OperationDedupStore {
     /// from disk under the file lock so writes from sibling processes are
     /// reflected.
     pub fn len(&self) -> usize {
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         let _file_guard = match self.acquire_file_lock() {
             Ok(guard) => guard,
             Err(_) => return inner.entries.len(),
@@ -498,7 +498,7 @@ impl OperationDedupStore {
         verb: &str,
     ) -> Option<DedupConflictMetadata> {
         let key = key_for(verb, operation_id);
-        let mut inner = self.inner.lock().expect("dedup mutex poisoned");
+        let mut inner = self.inner.lock_or_poisoned();
         if let Ok(_file_guard) = self.acquire_file_lock() {
             let _ = self.reload_under_lock(&mut inner);
         }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -73,6 +73,7 @@ use objects::{
     lock::{RepoLock, RepositoryLockExt},
     object::{Attribution, ChangeId, ContentHash, MarkerName, Principal, State, ThreadName, Tree},
     store::{AnyStore, FsStore, ObjectStore, ShallowInfo},
+    sync::RwLockExt,
     worktree::{WorktreeStatus, should_ignore as should_ignore_path},
 };
 use oplog::{OpLog, OpLogBackend, OpRecord};
@@ -2369,11 +2370,11 @@ impl Repository {
     }
 
     pub fn is_shallow(&self, id: &ChangeId) -> bool {
-        self.shallow.read().unwrap().is_shallow(id)
+        self.shallow.read_or_poisoned().is_shallow(id)
     }
 
     pub fn set_shallow(&self, state_id: &ChangeId, _parents: &[ChangeId]) -> Result<()> {
-        self.shallow.write().unwrap().add_shallow(*state_id)?;
+        self.shallow.write_or_poisoned().add_shallow(*state_id)?;
         Ok(())
     }
 
@@ -2507,12 +2508,12 @@ impl Repository {
     /// [`crate::lazy_hydrator::try_reconstruct`] to look up the
     /// registered factory and re-install the hydrator automatically.
     pub fn set_blob_hydrator(&self, hydrator: Arc<dyn BlobHydrator>) {
-        *self.blob_hydrator.write().unwrap() = Some(hydrator);
+        *self.blob_hydrator.write_or_poisoned() = Some(hydrator);
     }
 
     /// The currently registered hydrator, if any.
     pub fn blob_hydrator(&self) -> Option<Arc<dyn BlobHydrator>> {
-        self.blob_hydrator.read().unwrap().clone()
+        self.blob_hydrator.read_or_poisoned().clone()
     }
 
     fn partial_fetch_metadata(&self) -> repository_partial_fetch::PartialFetchMetadataManager {
@@ -2520,7 +2521,7 @@ impl Repository {
     }
 
     pub fn shallow(&self) -> std::sync::RwLockReadGuard<'_, ShallowInfo> {
-        self.shallow.read().unwrap()
+        self.shallow.read_or_poisoned()
     }
 }
 

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1479,6 +1479,7 @@ mod blob_hydrator_callback {
         error::Result,
         object::{Blob, ContentHash},
         store::ObjectStore,
+        sync::LockExt,
     };
 
     use super::create_test_repo;
@@ -1515,14 +1516,14 @@ mod blob_hydrator_callback {
         }
 
         fn hashes_seen(&self) -> Vec<ContentHash> {
-            self.seen.lock().unwrap().clone()
+            self.seen.lock_or_poisoned().clone()
         }
     }
 
     impl BlobHydrator for ScriptedHydrator {
         fn hydrate(&self, repo: &Repository, hash: &ContentHash) -> Result<()> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            self.seen.lock().unwrap().push(*hash);
+            self.seen.lock_or_poisoned().push(*hash);
             match &self.mode {
                 HydratorMode::WritePayload(payload) => {
                     repo.store().put_blob(&Blob::new(payload.clone()))?;


### PR DESCRIPTION
Panic-free safe-class wave 2 (after #776's mount wave). Applies the existing `objects::sync::{LockExt, RwLockExt}` helper (`lock_or_poisoned`/`read_or_poisoned`/`write_or_poisoned`) to the mutex-poison lock sites in `objects`, `refs`, `oplog`, `repo`. Behavior byte-identical (panic-on-poison preserved).

- **refs / oplog: fully converted** (0 raw lock-unwraps left); **objects / repo: prod sites converted** (~25 + ~20 helper calls).
- Remaining raw `.lock().unwrap()` are **test-only** (`objects/src/lock.rs` test module, `repo`'s `TEST_REGISTRY_LOCK`, an `identity.rs` test) — correctly left (clippy carves out tests).
- No crate-level `deny` added (these crates still have non-lock unwraps — later risky-conversion waves).

**Gates:** default + all-features build, `cargo test -p heddle-objects -p heddle-refs -p heddle-oplog -p heddle-repo -p heddle-mount` (all green), `clippy -D warnings`, check-no-silent-default. Behavior-neutral.

Cross-engine: codex-authored; orchestrator-reviewed (scope = lock-site swaps only; behavior-neutral; remaining raw sites confirmed test-only).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784691529&installation_id=132405951&pr_number=777&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F777&signature=177b86cc85e64f669c547d1e31dfdad2e4202ea1a244a804724efb05e9c37146"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->