### PR TITLE
chore(panic-free): apply lock helper to cli (safe-class wave 3, final)

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -17,6 +17,7 @@ use objects::{
     error::{HeddleError, Result as HeddleResult},
     object::{Blob, ContentHash, ThreadName},
     store::ObjectStore,
+    sync::LockExt,
 };
 use refs::Head;
 use repo::{BlobHydrator, Repository};
@@ -1487,7 +1488,7 @@ impl GitOverlayBlobHydrator {
     /// Pre-seed the blake3 → git OID mapping. Called by the importer
     /// (or by tests) as missing blobs are discovered.
     pub fn record_blob_oid(&self, hash: ContentHash, oid: ObjectId) {
-        self.blob_oid_map.lock().unwrap().insert(hash, oid);
+        self.blob_oid_map.lock_or_poisoned().insert(hash, oid);
     }
 }
 
@@ -1495,8 +1496,7 @@ impl BlobHydrator for GitOverlayBlobHydrator {
     fn hydrate(&self, repo: &Repository, hash: &ContentHash) -> HeddleResult<()> {
         let oid = self
             .blob_oid_map
-            .lock()
-            .unwrap()
+            .lock_or_poisoned()
             .get(hash)
             .copied()
             .ok_or_else(|| {

--- a/crates/cli/src/cli/commands/daemon/server.rs
+++ b/crates/cli/src/cli/commands/daemon/server.rs
@@ -13,7 +13,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use objects::error::HeddleError;
+use objects::{error::HeddleError, sync::LockExt};
 use repo::daemon::{
     EndpointState, HELPER_HOST, MOUNT_PROTOCOL_VERSION, MountDaemonRequest, MountDaemonResponse,
     MountStatus, mount_daemon_endpoint_path, mount_idle_policy, persist_endpoint, remove_endpoint,
@@ -83,7 +83,7 @@ pub fn run_mount_daemon(repo_root: &Path) -> Result<()> {
     // `daemon stop` may treat mounts.json-gone as a hard
     // post-condition.
     {
-        let mut guard = registry.lock().expect("mount registry lock");
+        let mut guard = registry.lock_or_poisoned();
         guard.shutdown_all();
     }
     remove_endpoint(&endpoint_path);
@@ -117,7 +117,7 @@ impl DaemonHandler for MountDaemonHandler {
         // in `repo::daemon::mount_idle_policy` so the regression
         // tests can exercise it on every host.
         let shutdown = self.shutdown_requested.load(Ordering::Acquire);
-        let live_count = self.registry.lock().expect("mount registry lock").len();
+        let live_count = self.registry.lock_or_poisoned().len();
         mount_idle_policy(shutdown, live_count, idle_for)
     }
 }
@@ -134,7 +134,7 @@ fn dispatch(
             mount_path,
             repo_root: _,
         } => {
-            let mut guard = registry.lock().expect("mount registry lock");
+            let mut guard = registry.lock_or_poisoned();
             match guard.mount(&thread_id, &mount_path) {
                 Ok(MountOutcome::Created) => MountDaemonResponse::Mount {
                     version: MOUNT_PROTOCOL_VERSION,
@@ -156,7 +156,7 @@ fn dispatch(
             }
         }
         MountDaemonRequest::Unmount { thread_id } => {
-            let mut guard = registry.lock().expect("mount registry lock");
+            let mut guard = registry.lock_or_poisoned();
             match guard.unmount(&thread_id) {
                 Ok(was_mounted) => MountDaemonResponse::Unmount {
                     version: MOUNT_PROTOCOL_VERSION,
@@ -171,14 +171,14 @@ fn dispatch(
             }
         }
         MountDaemonRequest::ListMounts {} => {
-            let guard = registry.lock().expect("mount registry lock");
+            let guard = registry.lock_or_poisoned();
             MountDaemonResponse::ListMounts {
                 version: MOUNT_PROTOCOL_VERSION,
                 mounts: guard.snapshot(),
             }
         }
         MountDaemonRequest::Health {} => {
-            let guard = registry.lock().expect("mount registry lock");
+            let guard = registry.lock_or_poisoned();
             MountDaemonResponse::Health {
                 version: MOUNT_PROTOCOL_VERSION,
                 ok: true,

--- a/crates/cli/src/cli/commands/mount_lifecycle.rs
+++ b/crates/cli/src/cli/commands/mount_lifecycle.rs
@@ -132,6 +132,8 @@ mod linux {
     use repo::Repository;
     use tracing::warn;
 
+    use objects::sync::LockExt;
+
     use crate::util::OnceMap;
 
     /// Which backend is actually live behind a [`MountHandle`].
@@ -175,7 +177,7 @@ mod linux {
 
     impl MountHandle {
         pub fn unmount(&self) -> Result<()> {
-            let mut guard = self.session.lock().expect("mount session lock");
+            let mut guard = self.session.lock_or_poisoned();
             if let Some(s) = guard.take() {
                 s.unmount()?;
             }
@@ -293,6 +295,8 @@ mod macos {
     use repo::Repository;
     use tracing::{debug, info, warn};
 
+    use objects::sync::LockExt;
+
     use crate::{cli::commands::mount_lifecycle::FskitReadinessReport, util::OnceMap};
 
     const MIN_FSKIT_MACOS_MAJOR: u64 = 26;
@@ -387,7 +391,7 @@ mod macos {
 
     impl MountHandle {
         pub fn unmount(&self) -> Result<()> {
-            let mut guard = self.session.lock().expect("mount session lock");
+            let mut guard = self.session.lock_or_poisoned();
             if let Some(s) = guard.take() {
                 s.unmount()?;
             }
@@ -790,6 +794,8 @@ mod windows {
     use repo::Repository;
     use tracing::warn;
 
+    use objects::sync::LockExt;
+
     use crate::util::OnceMap;
 
     /// Which backend is actually live behind a [`MountHandle`] on
@@ -817,7 +823,7 @@ mod windows {
 
     impl MountHandle {
         pub fn unmount(&self) -> Result<()> {
-            let mut guard = self.session.lock().expect("mount session lock");
+            let mut guard = self.session.lock_or_poisoned();
             if let Some(s) = guard.take() {
                 s.unmount()?;
             }

--- a/crates/cli/src/util/once_map.rs
+++ b/crates/cli/src/util/once_map.rs
@@ -28,6 +28,8 @@ use std::{
     sync::{Mutex, OnceLock},
 };
 
+use objects::sync::LockExt;
+
 /// A process-lifetime cache that maps `K → V` and computes each entry on
 /// first access. See module docs for semantics.
 pub struct OnceMap<K, V> {
@@ -55,7 +57,7 @@ impl<K: Eq + Hash + Clone, V: Clone> OnceMap<K, V> {
     where
         F: FnOnce() -> V,
     {
-        let mut guard = self.map().lock().expect("OnceMap mutex poisoned");
+        let mut guard = self.map().lock_or_poisoned();
         if let Some(v) = guard.get(key) {
             return v.clone();
         }
@@ -77,8 +79,7 @@ impl<K: Eq + Hash + Clone, V: Clone> OnceMap<K, V> {
         }
         let v = init().await;
         self.map()
-            .lock()
-            .expect("OnceMap mutex poisoned")
+            .lock_or_poisoned()
             .insert(key.clone(), v.clone());
         v
     }
@@ -86,8 +87,7 @@ impl<K: Eq + Hash + Clone, V: Clone> OnceMap<K, V> {
     /// Read without computing. Returns `None` if the key was never inserted.
     pub fn get(&self, key: &K) -> Option<V> {
         self.map()
-            .lock()
-            .expect("OnceMap mutex poisoned")
+            .lock_or_poisoned()
             .get(key)
             .cloned()
     }
@@ -95,8 +95,7 @@ impl<K: Eq + Hash + Clone, V: Clone> OnceMap<K, V> {
     /// Direct insert. Returns the previous value if any.
     pub fn insert(&self, key: K, value: V) -> Option<V> {
         self.map()
-            .lock()
-            .expect("OnceMap mutex poisoned")
+            .lock_or_poisoned()
             .insert(key, value)
     }
 
@@ -105,8 +104,7 @@ impl<K: Eq + Hash + Clone, V: Clone> OnceMap<K, V> {
     /// registry hands the handle back so the caller can unmount it).
     pub fn remove(&self, key: &K) -> Option<V> {
         self.map()
-            .lock()
-            .expect("OnceMap mutex poisoned")
+            .lock_or_poisoned()
             .remove(key)
     }
 }


### PR DESCRIPTION
Final safe-class lock wave (mount #776, objects/refs/oplog/repo #777, now cli). Applies `objects::sync::{LockExt, RwLockExt}` to the mutex-poison lock sites in `crates/cli` (`clone.rs`, `daemon/server.rs`, `mount_lifecycle.rs`, `util/once_map.rs`). Behavior byte-identical.

- `client` was correctly **left untouched** — its lock sites are intentional poison-recovery (`unwrap_or_else(|p| p.into_inner())`, different semantics — must NOT use the panic-preserving helper) or test-only.
- Completes the safe-class lock carve-out across the workspace. No crate-level `deny` (non-lock unwraps remain → later risky-conversion waves).

**Gates:** default + all-features build, clippy `-D warnings`, check-no-silent — all green. `cargo test -p heddle-cli`: 956 passed; the 3 `oss_cli_polish::actor_*` failures are the known **ambient-harness-detection** flake (the test detects the agent running it — `harness:codex, model:claude-opus-4-8[1m]`), which passes in CI's clean environment.

Cross-engine: codex-authored; orchestrator-reviewed (lock-site swaps only; client-skip is correct; behavior-neutral).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784693797&installation_id=132405951&pr_number=778&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F778&signature=da1482b27458a6126eba388e50a4f704347dc4d359902db90c311656f7eeef71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->