### PR TITLE
release: heddle v0.5.0

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -74,27 +74,29 @@ env:
   # `publish = true` in Cargo.toml is invisible at PR review time, and
   # accidentally flipping it would silently expand the public surface.
   PUBLISHABLE_CRATES: |
-    heddle-devtools
-    heddle-grpc
-    heddle-merge
-    heddle-review
-    heddle-runtime-bridge
+    heddle-format
     heddle-objects
     heddle-crypto
+    heddle-runtime-bridge
+    heddle-schema
     heddle-oplog
-    heddle-wire
     heddle-refs
+    heddle-merge
     heddle-semantic
     heddle-state-review
+    heddle-wire
     heddle-repo
     heddle-cli-shared
+    heddle-grpc
+    weft-client-shim
+    heddle-client
     heddle-core
     heddle-daemon
     heddle-ingest
     heddle-mount
-    weft-client-shim
-    heddle-client
     heddle-cli
+    heddle-devtools
+    heddle-review
 
 jobs:
   validate-publish:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.7.2"
+version = "0.7.1"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,7 +1482,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1547,7 +1547,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1595,7 +1595,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "heddle-cli-shared",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1675,7 +1675,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1683,7 +1683,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "prost 0.14.4",
  "prost-types 0.14.4",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1719,14 +1719,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "heddle-mount"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1875,14 +1875,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5989,7 +5989,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.4.0",
+  "schemaVersion": "0.5.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.4.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.5.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,31 +32,31 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.5" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.4" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.4" }
-heddle-core = { path = "../core", version = "0.4" }
-heddle-client = { path = "../client", version = "0.4", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.4" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
+heddle-core = { path = "../core", version = "0.5" }
+heddle-client = { path = "../client", version = "0.5", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.4", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.5", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -105,13 +105,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.4", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,14 +28,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.4" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.4" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.4", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.4" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.7.2"
+version = "0.7.1"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.4" }
+heddle-format = { path = "../format", version = "0.5" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+heddle-schema = { path = "../schema", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.4", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+heddle-schema = { path = "../schema", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.4", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.4" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.4" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.4", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.4", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.4" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.4", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.4", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.4" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,7 +12,15 @@ publish_allow_dirty = false
 
 # Publishable OSS crates — all release = true.
 [[package]]
+name = "heddle-format"
+release = true
+
+[[package]]
 name = "heddle-objects"
+release = true
+
+[[package]]
+name = "heddle-schema"
 release = true
 
 [[package]]


### PR DESCRIPTION
Cuts the **0.5.0** release (off current main, which now uses sley 0.2.0 via #784).

## Version bumps
- Workspace `version` 0.4.0 → **0.5.0** (all workspace-versioned crates).
- `heddle-grpc` 0.7.1 → **0.7.2** (independently versioned; ships its one post-0.7.1 change, #773).
- All inter-crate path-dep version reqs `0.4` → `0.5` so `cargo publish` resolves them on crates.io. (`chrono = "0.4"` left alone.)

## Publish-set fix
`heddle-format` and `heddle-schema` are leaf deps of publishable crates (objects/refs/oplog) but were **never in PUBLISHABLE_CRATES nor on crates.io** — a 0.5.0 publish would fail resolving them (same bug class as sley's missing-closure crates). Added both to `PUBLISHABLE_CRATES` and `release-plz.toml`, and rewrote PUBLISHABLE_CRATES to a full **23-crate topological order**.

## On merge
`publish-crates.yml` auto-publishes the 0.5.0 crates to crates.io. After that I'll tag `v0.5.0` (→ binary release) and repoint weft off its git rev to the crates.io versions.

## Verification
- `scripts/check-publish-pipeline.sh` passes (the contract check; independently re-derives the closure and validates every consumer version req).
- `cargo check` clean at 0.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784768143&installation_id=132405951&pr_number=785&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F785&signature=f9ae0a13eb4c857c284c7400be39ab5979a6abd70d80696be09d2748c8dc07d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->