### PR TITLE
docs: add 0.5.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,41 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.5.0 - 2026-06-23
+
+Native-git substrate jumps to sley 0.2.0, the storage seam lands, and the
+embeddable `heddle-core` facade takes shape.
+
+### Added
+
+- **`heddle-core` embeddable facade.** New facade crate with an
+  `ExecutionContext` and observability sinks, a query facade lifted out of
+  the CLI, and a compute→render split exemplar (`fsck` computes a
+  `FsckReport`; the CLI renders it). Groundwork for embedding heddle as a
+  library. (#775, #780, #782)
+- **New published crates `heddle-format` and `heddle-schema`**, extracted as
+  pure (behaviour-neutral) cores from `heddle-objects` and now part of the
+  crates.io publish set. (#761)
+
+### Changed
+
+- **Native-git substrate upgraded to sley `0.2.0`** (~24 parity waves since
+  `0.1.0`: multi-pack-index, reftable basics, fetch, gc, blame, worktree,
+  split-index, mergetool, the diff-format crate extraction, and more). (#784)
+- **Storage seam.** Reads now flow through an `ObjectSource` sync/async seam;
+  `query_history`/`CommitGraphIndex` are decoupled onto it with the cache as
+  an optional accelerator; staleness and context-suggestion pure cores moved
+  into `heddle-objects`. (#762, #763, #764)
+- **`clap` confined to the `heddle-cli` crate.** `heddle-ingest` and the
+  library crates no longer pull `clap`, shrinking the embeddable surface.
+  (#781, #783)
+- Faster status scans: borrow entry names instead of cloning. (#774)
+
+### Removed
+
+- The S3 object backend and its AWS dependency chain (a pre-seam leftover).
+  (#765)
+
 ## 0.4.0 - 2026-06-19
 
 ### Changed


### PR DESCRIPTION
Backfills the `## 0.5.0 - 2026-06-23` section in CHANGELOG.md (the release was cut without it). Covers: sley 0.2.0 substrate bump, the storage seam (P1–P3b), the embeddable `heddle-core` facade, the new `heddle-format`/`heddle-schema` published crates, clap confinement, and S3 backend removal.

Docs-only — no Cargo.toml change, so no publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784774560&installation_id=132405951&pr_number=786&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F786&signature=3451cad7723584d3ea693dab9bc369ca118c084412b5b3c0891b420ae760c03e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->