### PR TITLE
fix(clone): use CredentialFallback auth so clone can prove possession

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1282,7 +1282,14 @@ async fn clone_network(
     // filesystem/repo mutation such as `create_dir_all`, `Repository::init`,
     // state writes, or ref publishes. A rejected security config must leave
     // no partial on-disk artifact.
-    let session = HostedSession::build(&user_config, server_key, HostedAuthMode::ConfigToken)?;
+    // CredentialFallback (not ConfigToken): clone's RepoSync RPC is gated by
+    // the server's proof-of-possession header. ConfigToken sends only the
+    // bearer token (no proof key), so against a PoP-requiring server clone
+    // fails with "missing x-heddle-proof-ts". CredentialFallback resolves the
+    // per-server credential store's proof key when no env token is set —
+    // matching push/pull, which hit the same gated transport.
+    let session =
+        HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?;
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
 
     let mut cleanup = CloneDestinationCleanup::new(local_path);


### PR DESCRIPTION
`heddle clone` built its hosted session with `HostedAuthMode::ConfigToken`, which sends only the bearer token and **no proof key**. Against a weft server that gates the clone/RepoSync RPC behind the proof-of-possession header (`x-heddle-proof` / `x-heddle-proof-ts`), clone fails:
```
authorization failed: missing x-heddle-proof-ts metadata
```
(or `missing authorization metadata` when no env token is set).

`push` and `pull` already use `HostedAuthMode::CredentialFallback`, which falls back to the per-server credential store (and its `private_key_pem` proof key) when no env token is present. `clone` hits the same PoP-gated transport, so it should use the same mode. One-line mode swap + rationale comment.

Verified end-to-end: with a credential-store entry, clone now authenticates against a hosted weft server (previously rejected before any data transfer).

Found while dogfooding the heddle 0.5.0 → weft upload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784784085&installation_id=132405951&pr_number=787&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F787&signature=81e45b32ec7c2170641768c6dc54189e1fb416e2de9c272e165538b41c19fe44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->