### PR TITLE
fix(clone): materialize the working tree on native network clones

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1340,6 +1340,16 @@ async fn clone_network(
             let cfg = LazyHydratorConfig::hosted(endpoint_spec, repo_path, track_name, track_name);
             cfg.save(local_repo.heddle_dir())
                 .context("failed to persist lazy-hydrator.toml")?;
+        } else if let Some(final_state) = result.final_state.as_ref() {
+            // Full clone: write the working tree from the cloned state.
+            // `clone_local` and the Git-overlay path already materialize their
+            // checkout; the native network path fetched every object into the
+            // local store but never wrote any files to disk, leaving the
+            // worktree empty (`heddle status` reported "checkout health needs
+            // attention"). Materialize it here so a clone yields a usable tree.
+            local_repo
+                .goto_from_materialized_state(final_state, None)
+                .context("clone fetched all objects but failed to materialize the working tree")?;
         }
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(


### PR DESCRIPTION
## The bug
A `heddle clone` of a hosted (`heddle://`) repo completed and fetched all objects, but **left the working tree empty** — no files on disk, and `heddle status` reported "checkout health needs attention". The data was all there (`heddle diff` showed the cloned state's content); it just never got written.

## Cause
`clone_network` does a Full `pull_with_depth_and_materialization` (fetches every object into the local store) but — unlike `clone_local` and the Git-overlay path, which both call `goto_from_materialized_state` — never materializes the worktree from the pulled state.

## Fix
After a successful non-lazy clone, call `local_repo.goto_from_materialized_state(final_state, None)` to write the working tree. Lazy clones are untouched (they hydrate on read).

## Verification
`heddle clone` of a hosted repo now writes the files (content matches the source) and `heddle status` reports `Verdict: clean, worktree clean` — completing the push → clone round-trip.

Found while dogfooding heddle 0.5.0 → weft. (To reach the clone against a PoP server you also need the clone-auth fixes in #787/#788.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784813543&installation_id=132405951&pr_number=789&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F789&signature=eeacf34d85dec4e3211f30934d45909fda7dd60ebd740e0e061b6c3801e4c90e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->