### PR TITLE
perf(checkpoint): 142s→30s on ghostty — incremental object copy + single status pass

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -1708,7 +1708,31 @@ impl<'a> GitBridge<'a> {
             .and_then(|reference| reference.peeled_oid(&object_repo).ok().flatten());
 
         let write_result = (|| -> GitResult<()> {
-            copy_reachable_objects(&mirror_repo, &object_repo, [git_oid])?;
+            // Incremental object copy (perf): copying the new commit's full
+            // reachable closure from the mirror into the checkout re-walks +
+            // delta-compresses the ENTIRE tree every checkpoint — ~115s of the
+            // ~140s on the ~6k-object ghostty tree, scaling with total history
+            // rather than the change. But the checkout already holds the prior
+            // HEAD (`previous_branch`) and its whole closure. So exclude that
+            // closure from the copy: only objects genuinely new since the parent
+            // are walked + packed. Excluding the parent COMMIT alone is not enough
+            // — the new commit's tree re-reaches the parent's unchanged
+            // trees/blobs, so they would not be pruned. Compute the parent's FULL
+            // closure from the DESTINATION (cheap: those objects are local and
+            // already packed) and exclude all of it. Byte-identical result — every
+            // pruned object was already present in the checkout; only the transfer
+            // is smaller (O(changed) not O(history)). First checkpoint on a thread
+            // has no previous branch, so the exclude set is empty (full copy).
+            let excluded: HashSet<ObjectId> = match previous_branch {
+                Some(parent) => sley::plumbing::sley_odb::collect_reachable_object_ids(
+                    object_repo.objects().as_ref(),
+                    object_repo.object_format(),
+                    [parent],
+                )
+                .map_err(|error| GitBridgeError::Git(error.to_string()))?,
+                None => HashSet::new(),
+            };
+            copy_reachable_objects_excluding(&mirror_repo, &object_repo, [git_oid], &excluded)?;
             // Atomic temp+rename so a torn write can't leave HEAD in a
             // self-inconsistent state mid-write-through (the rollback
             // path below restores previous_head on any later failure).
@@ -3766,6 +3790,48 @@ pub(crate) fn copy_reachable_objects(
 ) -> GitResult<()> {
     let roots = roots.into_iter().collect::<Vec<_>>();
     target.copy_reachable_from(source, &roots).map_err(git_err)
+}
+
+/// Incremental variant of [`copy_reachable_objects`]: copy the closure
+/// reachable from `roots`, skipping every object in `excluded`.
+///
+/// INVARIANT: every OID in `excluded` MUST already be present in `target` — the
+/// walk neither visits nor copies an excluded object (nor anything reachable only
+/// through it), so excluding an object the target is missing would silently drop
+/// it. Callers satisfy this by computing `excluded` as the reachable closure of
+/// something already in `target`. Used by checkpoint write-through, which passes
+/// the prior checkout HEAD's full closure (already entirely in the checkout's
+/// object DB): the new commit's tree re-reaches the parent's unchanged
+/// trees/blobs, so excluding the whole closure — not just the parent commit —
+/// prunes them all, turning per-checkpoint object transfer from O(total history)
+/// into O(objects new since the parent). Output is byte-identical — the same
+/// objects end up in `target`; the pruned ones were already there.
+pub(crate) fn copy_reachable_objects_excluding(
+    source: &SleyRepository,
+    target: &SleyRepository,
+    roots: impl IntoIterator<Item = ObjectId>,
+    excluded: &HashSet<ObjectId>,
+) -> GitResult<()> {
+    if excluded.is_empty() {
+        return copy_reachable_objects(source, target, roots);
+    }
+    if source.object_format() != target.object_format() {
+        // Mismatched formats can't share objects; fall back to the plain copy so
+        // its existing format-mismatch error surfaces unchanged.
+        return copy_reachable_objects(source, target, roots);
+    }
+    sley::plumbing::sley_odb::install_reachable_pack_excluding(
+        source.objects().as_ref(),
+        target.objects().as_ref(),
+        target.object_format(),
+        roots,
+        excluded,
+    )
+    .map_err(|error| GitBridgeError::Git(error.to_string()))?;
+    // Make the freshly-installed pack visible to subsequent reads on `target`,
+    // mirroring what `copy_reachable_from` does internally.
+    target.refresh_objects();
+    Ok(())
 }
 
 fn fetch_network_remote(

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -450,6 +450,24 @@ fn export_scoped(bridge: &mut GitBridge, thread: Option<&str>) -> GitResult<Expo
                 && has_git_fidelity(&state)
             {
                 let mapped = bridge.mapping.get_git(&state_id);
+                // Incremental-export fast path (perf, latent O(history) fix): the
+                // regenerate-from-state step below is purely a #567 idempotent
+                // re-write — it rebuilds the commit object from state and writes it
+                // so a correct export no longer DEPENDS on the mirror's verbatim
+                // bytes. But when the mapped commit object is ALREADY in the mirror,
+                // that re-write is a no-op (sley hashes-then-skips), preceded by
+                // `reconstruct_commit_bytes`'s FULL recursive tree re-walk + re-hash.
+                // On a deep imported history every already-mapped commit hits this
+                // branch on every export, so that re-walk is paid once per historical
+                // commit per export — O(total history). Skipping when the object is
+                // present makes it O(commits whose object is missing), with
+                // byte-identical output: the served object, its OID, and the mapping
+                // are all unchanged. The reconstruct still runs (and the safety net
+                // still guards the write) for any mapped commit whose object is NOT
+                // yet in the mirror — the case #567/#568 actually need it for.
+                if mapped.is_some_and(|oid| repo.read_object(&oid).is_ok()) {
+                    continue;
+                }
                 // mirror still required for non-byte-faithful commits (non-UTF8
                 // identities, --lossy); #568 mirror elimination must account for
                 // these, and full de-lossy needs byte-preserving identities (#564

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -25,7 +25,8 @@ use super::{
     command_catalog::ActionTemplate,
     git_overlay_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState,
-        build_repository_verification_state, git_overlay_mutation_preflight_advice,
+        build_repository_verification_state, build_repository_verification_state_with_worktree_status,
+        git_overlay_mutation_preflight_advice_with_worktree_status,
         plain_git_mutation_preflight_advice, repository_verification_blocked_advice,
     },
     snapshot::ensure_current_state,
@@ -74,15 +75,31 @@ pub async fn run(cli: &Cli, args: &CheckpointArgs) -> Result<()> {
 
     let repo = Repository::open(start)?;
     let status_options = worktree_status_options(Some(repo.config()));
+    // Compute the git-overlay worktree status ONCE for the whole command and
+    // thread it through the checkpoint creation AND the output build. Checkpoint
+    // mutates Git refs/objects, not tracked worktree files, so the status taken
+    // here is still valid for `build_output` after the write.
+    let worktree_status = repo.git_overlay_worktree_status();
     let record = if args.from_index_snapshot {
-        create_git_checkpoint_from_index_snapshot(&repo, args.message.as_deref(), status_options)?
+        create_git_checkpoint_from_index_snapshot_with_worktree_status(
+            &repo,
+            args.message.as_deref(),
+            status_options,
+            &worktree_status,
+        )?
     } else {
-        create_git_checkpoint(&repo, args.message.as_deref(), status_options)?
+        create_git_checkpoint_with_worktree_status(
+            &repo,
+            args.message.as_deref(),
+            status_options,
+            &worktree_status,
+        )?
     };
     let state = repo
         .current_state()?
         .ok_or_else(|| anyhow!("no captured state found after checkpoint"))?;
-    let output = build_output(&repo, &state.change_id.short(), &record);
+    let output =
+        build_output_with_worktree_status(&repo, &state.change_id.short(), &record, &worktree_status);
 
     if should_output_json(cli, Some(repo.config())) {
         println!("{}", serde_json::to_string(&output)?);
@@ -107,7 +124,17 @@ pub(crate) fn create_git_checkpoint(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, true, None)
+    let worktree_status = repo.git_overlay_worktree_status();
+    create_git_checkpoint_inner(repo, message, status_options, true, None, &worktree_status)
+}
+
+pub(crate) fn create_git_checkpoint_with_worktree_status(
+    repo: &Repository,
+    message: Option<&str>,
+    status_options: repo::WorktreeStatusOptions,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
+) -> Result<GitCheckpointRecord> {
+    create_git_checkpoint_inner(repo, message, status_options, true, None, worktree_status)
 }
 
 pub(crate) fn create_git_checkpoint_from_index_snapshot(
@@ -115,7 +142,17 @@ pub(crate) fn create_git_checkpoint_from_index_snapshot(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, false, None)
+    let worktree_status = repo.git_overlay_worktree_status();
+    create_git_checkpoint_inner(repo, message, status_options, false, None, &worktree_status)
+}
+
+pub(crate) fn create_git_checkpoint_from_index_snapshot_with_worktree_status(
+    repo: &Repository,
+    message: Option<&str>,
+    status_options: repo::WorktreeStatusOptions,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
+) -> Result<GitCheckpointRecord> {
+    create_git_checkpoint_inner(repo, message, status_options, false, None, worktree_status)
 }
 
 fn create_git_checkpoint_inner(
@@ -124,15 +161,22 @@ fn create_git_checkpoint_inner(
     status_options: repo::WorktreeStatusOptions,
     require_clean_worktree: bool,
     git_parent_override: Option<Vec<ObjectId>>,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
 ) -> Result<GitCheckpointRecord> {
     if repo.capability() != RepositoryCapability::GitOverlay {
         return Err(anyhow!(native_checkpoint_unavailable_advice(repo)));
     }
-    preflight_git_checkpoint_ref_update(repo, "checkpoint")?;
-    if let Some(advice) = git_overlay_mutation_preflight_advice(
+    // The git-overlay worktree status is computed ONCE by the caller and threaded
+    // through every consumer below. `git_overlay_worktree_status` re-reads +
+    // SHA-1s every tracked file; checkpoint otherwise paid that ~3× (preflight
+    // ref-update, the verification preflight, and the output build). Threading
+    // the exact `Result` keeps the clean/dirty classification byte-identical.
+    preflight_git_checkpoint_ref_update_with_worktree_status(repo, "checkpoint", worktree_status)?;
+    if let Some(advice) = git_overlay_mutation_preflight_advice_with_worktree_status(
         repo,
         "checkpoint",
         GitOverlayMutationPreflight::checkpoint_like(),
+        worktree_status,
     )? {
         return Err(anyhow!(advice));
     }
@@ -207,6 +251,30 @@ pub(crate) fn preflight_git_checkpoint_ref_update(repo: &Repository, action: &st
         return Ok(());
     }
     let trust = build_repository_verification_state(repo);
+    preflight_git_checkpoint_ref_update_with_trust(repo, action, trust)
+}
+
+/// `checkpoint` hot-path variant that reuses an already-computed git-overlay
+/// worktree status instead of re-walking the worktree to build the verification
+/// state. The gating decision is identical to
+/// [`preflight_git_checkpoint_ref_update`].
+pub(crate) fn preflight_git_checkpoint_ref_update_with_worktree_status(
+    repo: &Repository,
+    action: &str,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
+) -> Result<()> {
+    if repo.capability() != RepositoryCapability::GitOverlay {
+        return Ok(());
+    }
+    let trust = build_repository_verification_state_with_worktree_status(repo, worktree_status);
+    preflight_git_checkpoint_ref_update_with_trust(repo, action, trust)
+}
+
+fn preflight_git_checkpoint_ref_update_with_trust(
+    repo: &Repository,
+    action: &str,
+    trust: RepositoryVerificationState,
+) -> Result<()> {
     if git_checkpoint_trust_allows_ref_update(&trust)
         || git_checkpoint_can_close_integrated_remote_gap(repo, &trust)
     {
@@ -341,12 +409,22 @@ fn git_rev_parse_head(root: &std::path::Path) -> Option<String> {
     git.head().ok()?.oid.map(|id| id.to_string())
 }
 
-fn build_output(
+fn build_output_with_worktree_status(
     repo: &Repository,
     change_id: &str,
     record: &GitCheckpointRecord,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
 ) -> CheckpointOutput {
-    let trust = build_repository_verification_state(repo);
+    let trust = build_repository_verification_state_with_worktree_status(repo, worktree_status);
+    build_output_with_trust(repo, change_id, record, trust)
+}
+
+fn build_output_with_trust(
+    repo: &Repository,
+    change_id: &str,
+    record: &GitCheckpointRecord,
+    trust: RepositoryVerificationState,
+) -> CheckpointOutput {
     let recommended_action = action_value(&trust);
     CheckpointOutput {
         output_kind: "checkpoint",

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -75,31 +75,22 @@ pub async fn run(cli: &Cli, args: &CheckpointArgs) -> Result<()> {
 
     let repo = Repository::open(start)?;
     let status_options = worktree_status_options(Some(repo.config()));
-    // Compute the git-overlay worktree status ONCE for the whole command and
-    // thread it through the checkpoint creation AND the output build. Checkpoint
-    // mutates Git refs/objects, not tracked worktree files, so the status taken
-    // here is still valid for `build_output` after the write.
-    let worktree_status = repo.git_overlay_worktree_status();
     let record = if args.from_index_snapshot {
-        create_git_checkpoint_from_index_snapshot_with_worktree_status(
-            &repo,
-            args.message.as_deref(),
-            status_options,
-            &worktree_status,
-        )?
+        create_git_checkpoint_from_index_snapshot(&repo, args.message.as_deref(), status_options)?
     } else {
-        create_git_checkpoint_with_worktree_status(
-            &repo,
-            args.message.as_deref(),
-            status_options,
-            &worktree_status,
-        )?
+        create_git_checkpoint(&repo, args.message.as_deref(), status_options)?
     };
     let state = repo
         .current_state()?
         .ok_or_else(|| anyhow!("no captured state found after checkpoint"))?;
-    let output =
-        build_output_with_worktree_status(&repo, &state.change_id.short(), &record, &worktree_status);
+    // NOTE: `build_output` recomputes the verification state from scratch — it
+    // must NOT reuse the pre-checkpoint worktree status. The checkpoint just
+    // advanced the Git ref, which flips the git-overlay health from
+    // `needs_checkpoint` to `clean` (and remote drift from diverged to ahead);
+    // the post-mutation output reflects the NEW git state, so the status walk
+    // here is a different, necessary one. The redundant-walk elimination is
+    // scoped to the PRE-mutation consumers inside `create_git_checkpoint_inner`.
+    let output = build_output(&repo, &state.change_id.short(), &record);
 
     if should_output_json(cli, Some(repo.config())) {
         println!("{}", serde_json::to_string(&output)?);
@@ -124,17 +115,7 @@ pub(crate) fn create_git_checkpoint(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    let worktree_status = repo.git_overlay_worktree_status();
-    create_git_checkpoint_inner(repo, message, status_options, true, None, &worktree_status)
-}
-
-pub(crate) fn create_git_checkpoint_with_worktree_status(
-    repo: &Repository,
-    message: Option<&str>,
-    status_options: repo::WorktreeStatusOptions,
-    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
-) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, true, None, worktree_status)
+    create_git_checkpoint_inner(repo, message, status_options, true, None)
 }
 
 pub(crate) fn create_git_checkpoint_from_index_snapshot(
@@ -142,17 +123,7 @@ pub(crate) fn create_git_checkpoint_from_index_snapshot(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    let worktree_status = repo.git_overlay_worktree_status();
-    create_git_checkpoint_inner(repo, message, status_options, false, None, &worktree_status)
-}
-
-pub(crate) fn create_git_checkpoint_from_index_snapshot_with_worktree_status(
-    repo: &Repository,
-    message: Option<&str>,
-    status_options: repo::WorktreeStatusOptions,
-    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
-) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, false, None, worktree_status)
+    create_git_checkpoint_inner(repo, message, status_options, false, None)
 }
 
 fn create_git_checkpoint_inner(
@@ -161,22 +132,26 @@ fn create_git_checkpoint_inner(
     status_options: repo::WorktreeStatusOptions,
     require_clean_worktree: bool,
     git_parent_override: Option<Vec<ObjectId>>,
-    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
 ) -> Result<GitCheckpointRecord> {
     if repo.capability() != RepositoryCapability::GitOverlay {
         return Err(anyhow!(native_checkpoint_unavailable_advice(repo)));
     }
-    // The git-overlay worktree status is computed ONCE by the caller and threaded
-    // through every consumer below. `git_overlay_worktree_status` re-reads +
-    // SHA-1s every tracked file; checkpoint otherwise paid that ~3× (preflight
-    // ref-update, the verification preflight, and the output build). Threading
-    // the exact `Result` keeps the clean/dirty classification byte-identical.
-    preflight_git_checkpoint_ref_update_with_worktree_status(repo, "checkpoint", worktree_status)?;
+    // Compute the git-overlay worktree status ONCE up front and thread it through
+    // the two PRE-mutation consumers below: the ref-update preflight and the
+    // verification preflight. Both build the repository verification state, which
+    // runs `git_overlay_worktree_status` — a walk that re-reads + SHA-1s every
+    // tracked file. Before this, checkpoint paid that walk twice here (plus a
+    // third in `build_output`, which must stay a FRESH walk because it runs AFTER
+    // the checkpoint advances the Git ref — see `run`). Threading the exact
+    // `Result` keeps the clean/dirty classification byte-identical, and both
+    // consumers observe the SAME pre-mutation git state, so reuse is sound.
+    let worktree_status = repo.git_overlay_worktree_status();
+    preflight_git_checkpoint_ref_update_with_worktree_status(repo, "checkpoint", &worktree_status)?;
     if let Some(advice) = git_overlay_mutation_preflight_advice_with_worktree_status(
         repo,
         "checkpoint",
         GitOverlayMutationPreflight::checkpoint_like(),
-        worktree_status,
+        &worktree_status,
     )? {
         return Err(anyhow!(advice));
     }
@@ -409,22 +384,15 @@ fn git_rev_parse_head(root: &std::path::Path) -> Option<String> {
     git.head().ok()?.oid.map(|id| id.to_string())
 }
 
-fn build_output_with_worktree_status(
+fn build_output(
     repo: &Repository,
     change_id: &str,
     record: &GitCheckpointRecord,
-    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
 ) -> CheckpointOutput {
-    let trust = build_repository_verification_state_with_worktree_status(repo, worktree_status);
-    build_output_with_trust(repo, change_id, record, trust)
-}
-
-fn build_output_with_trust(
-    repo: &Repository,
-    change_id: &str,
-    record: &GitCheckpointRecord,
-    trust: RepositoryVerificationState,
-) -> CheckpointOutput {
+    // Fresh verification state: this runs AFTER the checkpoint advanced the Git
+    // ref, so it must re-read the new git-overlay state (do NOT reuse the
+    // pre-checkpoint worktree status threaded into the preflights above).
+    let trust = build_repository_verification_state(repo);
     let recommended_action = action_value(&trust);
     CheckpointOutput {
         output_kind: "checkpoint",

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -1129,6 +1129,20 @@ pub(crate) fn build_repository_verification_state(
     RepositoryVerificationState::from_health(repo, health)
 }
 
+/// Verification-state build that reuses an already-computed git-overlay worktree
+/// status instead of re-walking + re-SHA-1ing every tracked file. Used by the
+/// `checkpoint` hot path, where the same status would otherwise be recomputed
+/// across the preflight, the verification preflight, and the output build. The
+/// classification is byte-identical to [`build_repository_verification_state`]
+/// because it threads the exact `Result` from `git_overlay_worktree_status()`.
+pub(crate) fn build_repository_verification_state_with_worktree_status(
+    repo: &Repository,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> RepositoryVerificationState {
+    let health = build_git_overlay_health_with_worktree_status(repo, worktree_status);
+    RepositoryVerificationState::from_health(repo, health)
+}
+
 pub(crate) fn unimported_git_history_advice(
     repo: &Repository,
     action: &str,
@@ -1206,7 +1220,18 @@ pub(crate) fn verification_blocking_mutation_advice(
     repo: &Repository,
     action: &str,
 ) -> anyhow::Result<Option<RecoveryAdvice>> {
-    let trust = build_repository_verification_state(repo);
+    verification_blocking_mutation_advice_with_trust(
+        repo,
+        action,
+        build_repository_verification_state(repo),
+    )
+}
+
+fn verification_blocking_mutation_advice_with_trust(
+    repo: &Repository,
+    action: &str,
+    trust: RepositoryVerificationState,
+) -> anyhow::Result<Option<RecoveryAdvice>> {
     if trust.status != "needs_reconcile" {
         return Ok(None);
     }
@@ -1360,6 +1385,28 @@ pub(crate) fn git_overlay_mutation_preflight_advice(
     action: &str,
     preflight: GitOverlayMutationPreflight,
 ) -> anyhow::Result<Option<RecoveryAdvice>> {
+    git_overlay_mutation_preflight_advice_inner(repo, action, preflight, None)
+}
+
+/// `checkpoint` hot-path variant of [`git_overlay_mutation_preflight_advice`]
+/// that reuses an already-computed git-overlay worktree status for the
+/// `check_verification` branch instead of re-walking the worktree. All other
+/// branches and the resulting advice are identical.
+pub(crate) fn git_overlay_mutation_preflight_advice_with_worktree_status(
+    repo: &Repository,
+    action: &str,
+    preflight: GitOverlayMutationPreflight,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> anyhow::Result<Option<RecoveryAdvice>> {
+    git_overlay_mutation_preflight_advice_inner(repo, action, preflight, Some(worktree_status))
+}
+
+fn git_overlay_mutation_preflight_advice_inner(
+    repo: &Repository,
+    action: &str,
+    preflight: GitOverlayMutationPreflight,
+    worktree_status: Option<&repo::Result<Option<WorktreeStatus>>>,
+) -> anyhow::Result<Option<RecoveryAdvice>> {
     if repo.capability() != repo::RepositoryCapability::GitOverlay {
         return Ok(None);
     }
@@ -1376,10 +1423,18 @@ pub(crate) fn git_overlay_mutation_preflight_advice(
     {
         return Ok(Some(advice));
     }
-    if preflight.check_verification
-        && let Some(advice) = verification_blocking_mutation_advice(repo, action)?
-    {
-        return Ok(Some(advice));
+    if preflight.check_verification {
+        let advice = match worktree_status {
+            Some(status) => verification_blocking_mutation_advice_with_trust(
+                repo,
+                action,
+                build_repository_verification_state_with_worktree_status(repo, status),
+            )?,
+            None => verification_blocking_mutation_advice(repo, action)?,
+        };
+        if let Some(advice) = advice {
+            return Ok(Some(advice));
+        }
     }
     Ok(None)
 }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1287,6 +1287,19 @@ impl Repository {
         graph.is_ancestor(ancestor, descendant).unwrap_or(false)
     }
 
+    /// Git-overlay worktree status, compared against the **Git index** (distinct
+    /// from `compare_worktree_cached*`, which compares against heddle's own index).
+    ///
+    /// The expensive part — deciding whether each tracked file changed since it
+    /// was staged — is handled by sley's `stream_short_status_with_options`, which
+    /// honors git's racy-clean stat cache: when a file's mode + size + mtime match
+    /// its Git index entry (and the entry is not racily clean), sley reuses the
+    /// staged OID and SKIPS re-reading + SHA-1ing the file (`reuse_tracked_entry`),
+    /// falling back to a full content hash whenever the stat is ambiguous. On a
+    /// warm worktree this turns the walk from "hash every file" into "stat every
+    /// file" (~0.35s vs minutes on the ~6k-file ghostty tree). This stat-cache
+    /// MUST be preserved across sley bumps — a sley that re-hashes unconditionally
+    /// would silently reintroduce the pathological checkpoint cost.
     pub fn git_overlay_worktree_status(&self) -> Result<Option<WorktreeStatus>> {
         if self.capability() != RepositoryCapability::GitOverlay {
             return Ok(None);


### PR DESCRIPTION
`heddle checkpoint` was pathologically slow — **2:22 on ghostty** (~6000 objects), where the git/sley write itself is 0.03s. Profiling found the cost was redundant per-checkpoint work, not the substrate. **142s → ~30s (~4.5×)**, behavior-identical (same commit + tree OID).

## Root cause (profiler, not the original hypothesis)
The 2-minute hotspot was **`copy_reachable_objects` in checkpoint write-through (115s of 142s)** — every checkpoint re-copied the new commit's *entire* reachable object closure from the mirror into the user's checkout, re-walking + delta-compressing all ~6k objects (O(total history)). The redundant worktree-status passes were real but only ~12s.

## Fixes
1. **Single worktree-status pass** (`3489c31c` + `8a1047c1`) — compute `git_overlay_worktree_status()` once and thread it through the two **pre-mutation** consumers (ref-update + verification preflight) via `_with_worktree_status` variants. Correctness catch: `build_output` runs *after* the ref advances (which flips health `needs_checkpoint`→`clean`), so it keeps a **fresh** walk — reusing the stale status regressed `git_overlay_matrix_checkpoint_closes_imported_remote_divergence_after_merge`; `8a1047c1` scopes reuse to pre-mutation only.
2. **Stat-cache** (`a69e1645`) — already correct in sley 0.3.1 (`reuse_tracked_entry`: skip read+hash when mode/size/mtime match the index, racy-clean fallback); heddle already routes through it (warm status walk 0.35s). Added a doc-comment **invariant** pinning the contract rather than duplicating sley's racy-git rule.
3. **Incremental object copy** (`687dd1ee`) — compute the destination's existing closure and **exclude** it from the copy, so only objects new since the parent are walked + packed. Every excluded OID is provably already in the destination → cannot drop a needed object. Plus skip re-export of commits already in the mirror.

## Correctness proof
Two pristine copies of the identical captured state checkpointed old-binary vs new → **identical commit `b5c5c2e861f2` + tree `9a6f0ca9e856`**; `git fsck --full` clean; dirty-worktree detection unchanged (the heddle-index compare is untouched). The previously-regressing matrix test passes.

## Gates
`cargo build --locked --workspace` + `--all-features` ✅ · `check-no-silent-default-tree-load.sh` ✅ · `clippy --workspace --all-targets -D warnings` ✅ · `heddle-repo` 544 ✅ · `heddle-mount` 152 ✅ · `heddle-cli --no-fail-fast` — only the 5 documented local-only harness-detect failures, **zero added**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785253955&installation_id=132405951&pr_number=792&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F792&signature=1db34c3e2a3acafbfe2a81c92bf3d78da2cc3985b8fafc38b5e9e59878c23294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->