### PR TITLE
perf(capture/commit/ready): extend compute-worktree-status-once seam

### DIFF
--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -115,7 +115,30 @@ pub(crate) fn create_git_checkpoint(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, true, None)
+    create_git_checkpoint_inner(repo, message, status_options, true, None, None)
+}
+
+/// Variant of [`create_git_checkpoint`] that reuses an already-computed
+/// git-overlay worktree status for checkpoint's two PRE-mutation preflights
+/// instead of re-walking the worktree. Used by `commit`, which has already
+/// computed the same pre-mutation status for its own preflights — no Git
+/// mutation happens between commit's walk and checkpoint's preflights, so they
+/// observe the same git state and the gating decision is byte-identical to
+/// [`create_git_checkpoint`].
+pub(crate) fn create_git_checkpoint_with_worktree_status(
+    repo: &Repository,
+    message: Option<&str>,
+    status_options: repo::WorktreeStatusOptions,
+    worktree_status: &repo::Result<Option<objects::worktree::WorktreeStatus>>,
+) -> Result<GitCheckpointRecord> {
+    create_git_checkpoint_inner(
+        repo,
+        message,
+        status_options,
+        true,
+        None,
+        Some(worktree_status),
+    )
 }
 
 pub(crate) fn create_git_checkpoint_from_index_snapshot(
@@ -123,7 +146,7 @@ pub(crate) fn create_git_checkpoint_from_index_snapshot(
     message: Option<&str>,
     status_options: repo::WorktreeStatusOptions,
 ) -> Result<GitCheckpointRecord> {
-    create_git_checkpoint_inner(repo, message, status_options, false, None)
+    create_git_checkpoint_inner(repo, message, status_options, false, None, None)
 }
 
 fn create_git_checkpoint_inner(
@@ -132,6 +155,7 @@ fn create_git_checkpoint_inner(
     status_options: repo::WorktreeStatusOptions,
     require_clean_worktree: bool,
     git_parent_override: Option<Vec<ObjectId>>,
+    precomputed_worktree_status: Option<&repo::Result<Option<objects::worktree::WorktreeStatus>>>,
 ) -> Result<GitCheckpointRecord> {
     if repo.capability() != RepositoryCapability::GitOverlay {
         return Err(anyhow!(native_checkpoint_unavailable_advice(repo)));
@@ -145,13 +169,22 @@ fn create_git_checkpoint_inner(
     // the checkpoint advances the Git ref — see `run`). Threading the exact
     // `Result` keeps the clean/dirty classification byte-identical, and both
     // consumers observe the SAME pre-mutation git state, so reuse is sound.
-    let worktree_status = repo.git_overlay_worktree_status();
-    preflight_git_checkpoint_ref_update_with_worktree_status(repo, "checkpoint", &worktree_status)?;
+    // A caller that has already computed this pre-mutation status (e.g. `commit`)
+    // passes it in so checkpoint does not re-walk the worktree.
+    let computed_worktree_status;
+    let worktree_status = match precomputed_worktree_status {
+        Some(status) => status,
+        None => {
+            computed_worktree_status = repo.git_overlay_worktree_status();
+            &computed_worktree_status
+        }
+    };
+    preflight_git_checkpoint_ref_update_with_worktree_status(repo, "checkpoint", worktree_status)?;
     if let Some(advice) = git_overlay_mutation_preflight_advice_with_worktree_status(
         repo,
         "checkpoint",
         GitOverlayMutationPreflight::checkpoint_like(),
-        &worktree_status,
+        worktree_status,
     )? {
         return Err(anyhow!(advice));
     }

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -27,12 +27,14 @@ use super::{
     advice::RecoveryAdvice,
     checkpoint::{
         create_git_checkpoint, create_git_checkpoint_from_index_snapshot,
-        preflight_git_checkpoint_ref_update,
+        create_git_checkpoint_with_worktree_status, preflight_git_checkpoint_ref_update,
     },
     command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState,
-        build_repository_verification_state, git_overlay_mutation_preflight_advice,
+        build_repository_verification_state,
+        build_repository_verification_state_with_worktree_status,
+        git_overlay_mutation_preflight_advice_with_worktree_status,
         override_trust_recommended_action, plain_git_mutation_preflight_advice,
         repository_verification_blocked_advice,
     },
@@ -138,10 +140,20 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     }
 
     let repo = Repository::open(start)?;
-    if let Some(advice) = git_overlay_mutation_preflight_advice(
+    // Compute the git-overlay worktree status ONCE up front. The commit mutation
+    // preflight here is PRE-mutation and shared by every commit path; the clean
+    // fast-path below reuses the same status for its verification preflight and
+    // for the checkpoint it triggers, all of which observe the same pre-mutation
+    // git state (no Git ref moves until `create_git_checkpoint`). This is the
+    // exact `Result` from a full worktree walk that re-reads + SHA-1s every
+    // tracked file — before this, the clean fast-path paid that walk 3× before
+    // the ref ever moved.
+    let worktree_status = repo.git_overlay_worktree_status();
+    if let Some(advice) = git_overlay_mutation_preflight_advice_with_worktree_status(
         &repo,
         "commit",
         GitOverlayMutationPreflight::commit_like(),
+        &worktree_status,
     )? {
         return Err(anyhow!(advice));
     }
@@ -164,7 +176,11 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             && repo.capability() == RepositoryCapability::GitOverlay
             && !git_index_intent_for_repo(&repo)?.staged_paths.is_empty();
         if status.is_clean() && !has_staged_index_intent {
-            let trust = build_repository_verification_state(&repo);
+            // Reuse the pre-mutation git-overlay worktree status computed at the
+            // top: no Git ref has moved on this fast-path, so the verification
+            // state is byte-identical to a fresh walk here.
+            let trust =
+                build_repository_verification_state_with_worktree_status(&repo, &worktree_status);
             // `--no-all` forces an index-only commit and must never auto-commit
             // the captured worktree state. On this fast-path the worktree is
             // clean and the index has no staged intent, so an index-only commit
@@ -176,10 +192,15 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             if trust.status == "needs_checkpoint" {
                 preflight_git_checkpoint_identity(&repo, &user_config, "commit")?;
                 let git_previous_commit = git_head_oid(repo.root());
-                let record = create_git_checkpoint(
+                // Thread the same pre-mutation status into the checkpoint so it
+                // does not re-run its own pre-mutation worktree walk. The
+                // checkpoint then advances the Git ref, so the post-checkpoint
+                // `build_repository_verification_state` below stays a FRESH walk.
+                let record = create_git_checkpoint_with_worktree_status(
                     &repo,
                     Some(message.as_str()),
                     worktree_status_options(Some(repo.config())),
+                    &worktree_status,
                 )?;
                 let trust = commit_safe_trust(build_repository_verification_state(&repo));
                 let output = CommitCompatOutput {

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -18,7 +18,8 @@ use super::{
     advice::RecoveryAdvice,
     git_overlay_health::{
         RepositoryVerificationState, build_plain_git_verification_probe,
-        build_repository_verification_state, override_trust_recommended_action,
+        build_repository_verification_state, build_repository_verification_state_with_worktree_status,
+        override_trust_recommended_action,
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},
     next_action::{
@@ -153,7 +154,16 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
 
     let repo = Repository::open(start)?;
     let user_config = UserConfig::load_default().unwrap_or_default();
-    let initial_trust = build_repository_verification_state(&repo);
+    // Compute the git-overlay worktree status ONCE up front. It feeds the initial
+    // verification preflight here and the second preflight further down, which
+    // `ready` previously recomputed from scratch — a full worktree walk that
+    // re-reads + SHA-1s every tracked file. The second preflight can reuse this
+    // status ONLY when no bootstrap capture intervened (see below): a bootstrap
+    // capture advances the Heddle state and flips the git-overlay health
+    // classification, so after one the second preflight must take a FRESH walk.
+    let worktree_status = repo.git_overlay_worktree_status();
+    let initial_trust =
+        build_repository_verification_state_with_worktree_status(&repo, &worktree_status);
     if ready_verification_preflight_blocks(&initial_trust) {
         let output = trust_blocked_ready_output(args.thread.as_deref(), initial_trust);
         write_ready_output(cli, &repo, &output)?;
@@ -202,7 +212,16 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         })?,
     };
 
-    let preflight_trust = build_repository_verification_state(&repo);
+    // Reuse the status computed at the top only when no bootstrap capture ran
+    // (`had_current_state`): between the initial preflight and here, the only
+    // mutation is `ensure_current_state`'s bootstrap capture, which fires iff
+    // `!had_current_state`. After a bootstrap capture the git-overlay health
+    // classification flips, so that case must take a FRESH walk.
+    let preflight_trust = if had_current_state {
+        build_repository_verification_state_with_worktree_status(&repo, &worktree_status)
+    } else {
+        build_repository_verification_state(&repo)
+    };
     if ready_verification_preflight_blocks(&preflight_trust) {
         let mut report = build_thread_preview_report(&repo, &mut thread, true)?;
         report.thread_state = "blocked".to_string();

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use anyhow::{Result, anyhow};
 use objects::object::{Agent, Attribution, ChangeId, Principal, Tree};
+use objects::worktree::WorktreeStatus;
 use repo::{
     Hook, HookContext, HookManager, Repository, SessionManager, SnapshotProfile, format_confidence,
     refresh_active_thread_metadata,
@@ -26,6 +27,7 @@ use super::{
     git_overlay_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState, action_template,
         build_repository_verification_state, git_overlay_mutation_preflight_advice,
+        git_overlay_mutation_preflight_advice_with_worktree_status,
         plain_git_mutation_preflight_advice, unimported_git_history_advice,
     },
     next_action::{NextActionValidationContext, write_command_json},
@@ -202,8 +204,26 @@ pub async fn cmd_snapshot(
     if !complete_thread_resolution && !capture_has_worktree_changes(&repo)? {
         return Err(anyhow!(nothing_to_capture_advice()));
     }
-    preflight_large_capture(&repo, force)?;
-    let mut output = match create_snapshot(&repo, &user_config, Some(intent), confidence, agent) {
+    // Compute the git-overlay worktree status ONCE and thread it through both
+    // PRE-mutation consumers: the large-capture safety preflight and the
+    // capture mutation preflight inside `create_snapshot`. Both build from a
+    // full worktree walk that re-reads + SHA-1s every tracked file; before this
+    // the non-`--force` git-overlay capture path paid that walk twice here
+    // (plus a third, post-capture verification walk that must stay FRESH — the
+    // capture advances the Heddle state and flips the git-overlay health
+    // classification, so it is NOT threaded). Both pre-mutation consumers
+    // observe the same pre-capture git state, so reuse is sound and the
+    // classification stays byte-identical.
+    let worktree_status = repo.git_overlay_worktree_status();
+    preflight_large_capture_with_status(force, &worktree_status)?;
+    let mut output = match create_snapshot_with_worktree_status(
+        &repo,
+        &user_config,
+        Some(intent),
+        confidence,
+        agent,
+        &worktree_status,
+    ) {
         Ok(output) => output,
         Err(err) => {
             // ENOSPC is the only mid-capture failure where the user's
@@ -425,8 +445,22 @@ fn preflight_large_capture(repo: &Repository, force: bool) -> Result<()> {
     if force {
         return Ok(());
     }
+    preflight_large_capture_with_status(force, &repo.git_overlay_worktree_status())
+}
 
-    let Ok(Some(status)) = repo.git_overlay_worktree_status() else {
+/// Variant of [`preflight_large_capture`] that reuses an already-computed
+/// git-overlay worktree status instead of re-walking the worktree. The
+/// large-capture classification is byte-identical because it reads the same
+/// `WorktreeStatus`; only the redundant walk is removed.
+fn preflight_large_capture_with_status(
+    force: bool,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> Result<()> {
+    if force {
+        return Ok(());
+    }
+
+    let Ok(Some(status)) = worktree_status else {
         return Ok(());
     };
 
@@ -503,6 +537,31 @@ pub(crate) fn create_snapshot(
     create_snapshot_profiled(repo, user_config, intent, confidence, agent).map(|(output, _)| output)
 }
 
+/// Variant of [`create_snapshot`] that reuses an already-computed git-overlay
+/// worktree status for the PRE-mutation capture preflight instead of re-walking
+/// the worktree. The snapshot result is byte-identical; only the redundant
+/// pre-mutation status walk is removed. The post-mutation verification state
+/// built after the capture is still computed FRESH (the capture advances the
+/// Heddle state, which flips the git-overlay health classification).
+pub(crate) fn create_snapshot_with_worktree_status(
+    repo: &Repository,
+    user_config: &UserConfig,
+    intent: Option<String>,
+    confidence: Option<f32>,
+    agent: SnapshotAgentOverrides,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> Result<SnapshotOutput> {
+    create_snapshot_profiled_inner(
+        repo,
+        user_config,
+        intent,
+        confidence,
+        agent,
+        Some(worktree_status),
+    )
+    .map(|(output, _)| output)
+}
+
 pub(crate) fn create_snapshot_from_tree(
     repo: &Repository,
     user_config: &UserConfig,
@@ -551,13 +610,33 @@ pub(crate) fn create_snapshot_profiled(
     confidence: Option<f32>,
     agent: SnapshotAgentOverrides,
 ) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
+    create_snapshot_profiled_inner(repo, user_config, intent, confidence, agent, None)
+}
+
+fn create_snapshot_profiled_inner(
+    repo: &Repository,
+    user_config: &UserConfig,
+    intent: Option<String>,
+    confidence: Option<f32>,
+    agent: SnapshotAgentOverrides,
+    worktree_status: Option<&repo::Result<Option<WorktreeStatus>>>,
+) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
     info!("Creating snapshot");
 
-    if let Some(advice) = git_overlay_mutation_preflight_advice(
-        repo,
-        "capture",
-        GitOverlayMutationPreflight::capture_like(),
-    )? {
+    let preflight_advice = match worktree_status {
+        Some(status) => git_overlay_mutation_preflight_advice_with_worktree_status(
+            repo,
+            "capture",
+            GitOverlayMutationPreflight::capture_like(),
+            status,
+        )?,
+        None => git_overlay_mutation_preflight_advice(
+            repo,
+            "capture",
+            GitOverlayMutationPreflight::capture_like(),
+        )?,
+    };
+    if let Some(advice) = preflight_advice {
         return Err(anyhow!(advice));
     }
 


### PR DESCRIPTION
## What

Extends the "compute git-overlay worktree status once" seam (landed for `checkpoint` in #792) to the other three commands that walked the worktree redundantly: **capture**, **commit**, and **ready**.

Reuses the existing `_with_worktree_status` seam (`git_overlay_health.rs`) rather than duplicating it — the only new entry point is `create_git_checkpoint_with_worktree_status`, which lets `commit` thread its pre-mutation status into the bundled checkpoint.

## The three fixes

- **capture** (`snapshot.rs`, `cf70a446`) — compute status once before `preflight_large_capture`, thread into `create_snapshot_with_worktree_status`. Eliminates 2 redundant pre-mutation passes. **Post-capture verification walk kept FRESH** (capture advances Heddle state + flips git-overlay health).
- **commit** (`git_compat.rs` + `checkpoint.rs`, `99639795`) — compute once, thread through all 3 pre-mutation fast-path consumers (mutation preflight, fast-path verification, bundled checkpoint). **Post-checkpoint trust kept FRESH** (verified it reads `clean`, not stale `needs_checkpoint`).
- **ready** (`ready_cmd.rs`, `f7d226db`) — threads the once-computed status into the first preflight; the second preflight reuses it **only when `had_current_state`**. When the conditional bootstrap capture (`ensure_current_state`) intervenes, the second preflight stays a **fresh walk** (health classification flips).

## Same-output proofs (old baseline binary vs new)

- **capture**: identical captured **tree** `08a7efeef4ac` (content_hash differs only by per-run timestamp in the state envelope).
- **commit**: identical committed git **tree** `e69cc9747574` + identical verdict (`status=committed`, `trust.status=clean`, `recommended_action=None`). Commit OID differs only by the nondeterministic Heddle change_id in metadata.
- **ready**: identical output on **both** paths (reuse + bootstrap fresh-walk).

## Timing (ghostty git-overlay, 5742 tracked files)

- **capture**: ~7.77s → ~6.99s (~0.78s/pass saved; value = per-pass × capture frequency).
- **commit**: ~47.4s → ~45.9s (~1.5s, ≈2 passes; commit total dominated by checkpoint object-write).

## Gates — all green

`cargo build --locked --workspace` (default + `--all-features`) · `check-no-silent-default-tree-load.sh` (567 files) · `clippy --workspace --all-targets -D warnings` (0) · `heddle-repo` 544 · `heddle-mount` 152+ · `heddle-cli` full: 924+57 pass, only the 5 known LOCAL-only harness-identity failures (identical on baseline, zero added) · `git_overlay_matrix` 128.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785257089&installation_id=132405951&pr_number=793&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F793&signature=e5668a3a02ebc7d35e7bc58fe930ba8512d266cf85483aa3665b143188eb5aa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->