### PR TITLE
fix(push): harden heddle:// hosted-push routing on git-overlay repos

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -2710,6 +2710,20 @@ fn repo_relative_base(repo: &SleyRepository) -> PathBuf {
 }
 
 fn local_path_from_url(url: &str) -> GitResult<Option<PathBuf>> {
+    // Defense in depth (push-routing no-op): the git-overlay exporter speaks
+    // only the local/git network transports. A `heddle://` hosted URL must
+    // NEVER reach this classifier — the hosted-sync path
+    // (`GrpcHostedClient`) is the only thing that can push to it. If routing
+    // upstream is correct this is unreachable; making it a hard error here
+    // means a `heddle://` slipping into the git exporter can never again be a
+    // silent success (it would otherwise fall through as a generic network
+    // URL, "reconcile" locally, and report success without contacting the
+    // server).
+    if url.starts_with("heddle://") {
+        return Err(GitBridgeError::Git(format!(
+            "remote '{url}' uses the hosted heddle:// scheme, which cannot be pushed via the git-overlay exporter; hosted pushes must go through the native hosted-sync path"
+        )));
+    }
     let Some(raw_path) = url.strip_prefix("file://") else {
         return Ok(None);
     };

--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -4054,6 +4054,49 @@ mod tests {
     }
 
     #[test]
+    fn local_path_from_url_rejects_hosted_heddle_scheme() {
+        // Regression (push-routing no-op): a `heddle://` hosted remote that
+        // reaches the git-overlay exporter must be a HARD ERROR, never a
+        // silent no-op success. The git network pusher cannot speak the
+        // hosted protocol, so classifying a `heddle://` URL here must fail
+        // loudly rather than fall through to `ResolvedRemote::Url` (which
+        // would "reconcile" locally and report success without ever
+        // contacting the server).
+        let err = local_path_from_url("heddle://weft.local:8421/org/repo")
+            .expect_err("heddle:// must be rejected by the git exporter classifier");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("heddle://") && msg.contains("hosted"),
+            "error should explain the hosted scheme cannot be pushed via the git-overlay exporter, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn local_path_from_url_still_accepts_file_and_git_urls() {
+        // The guard must not regress legitimate transports: `file://` still
+        // resolves to a local path, and ordinary git URLs (https/ssh) still
+        // pass through as "not local" (Ok(None)) for the network git pusher.
+        assert!(
+            local_path_from_url("file:///tmp/repo.git")
+                .expect("file url ok")
+                .is_some(),
+            "file:// must still resolve to a local path"
+        );
+        assert!(
+            local_path_from_url("https://example.com/org/repo.git")
+                .expect("https url ok")
+                .is_none(),
+            "https git url must pass through as a network URL"
+        );
+        assert!(
+            local_path_from_url("git@github.com:org/repo.git")
+                .expect("ssh url ok")
+                .is_none(),
+            "ssh git url must pass through as a network URL"
+        );
+    }
+
+    #[test]
     fn refspec_forced_round_trips_git_format() {
         let spec =
             RefSpec::forced("refs/heads/main", "refs/heads/main").expect("valid forced refspec");

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -287,6 +287,87 @@ fn native_push_and_pull_reject_direct_git_remote_before_native_sync() {
     }
 }
 
+/// Regression (push-routing silent no-op): a `heddle://` HOSTED remote on a
+/// git-overlay repo whose `[hosted]` config block is EMPTY must route to the
+/// native hosted-sync path, NOT the local git-overlay refs exporter. The bug:
+/// the exporter treats `heddle://` as a generic git network URL, "reconciles"
+/// refs locally, and returns `{"transport":"git","success":true,"refs_written":[]}`
+/// without ever contacting the server — a silent no-op reported as success.
+///
+/// No live server runs in CI, so we assert on the ROUTING DECISION, not an
+/// end-to-end push: a correctly-routed hosted push fails LOUDLY trying to reach
+/// the (absent) server; the bug-signature is a `transport:"git"` SUCCESS
+/// envelope. We accept any loud failure (or a non-git transport) and reject the
+/// silent-git-success signature specifically.
+#[test]
+fn git_overlay_push_to_heddle_scheme_routes_to_hosted_not_git_exporter() {
+    let source = TempDir::new().unwrap();
+
+    // Build a real git-overlay repo (git init + heddle adopt) — `capability()`
+    // is GitOverlay and `[hosted]` is empty (hosted_enabled() == false), which
+    // is exactly the buggy predicate's input.
+    git_ok(&["init", "-b", "main"], source.path());
+    git_ok(&["config", "user.name", "Heddle Test"], source.path());
+    git_ok(
+        &["config", "user.email", "heddle@example.com"],
+        source.path(),
+    );
+    std::fs::write(source.path().join("README.md"), "seed\n").unwrap();
+    git_ok(&["add", "README.md"], source.path());
+    git_ok(&["commit", "-m", "seed"], source.path());
+    heddle(&["adopt", "--ref", "main"], Some(source.path())).expect("adopt source Git repo");
+
+    // A hosted heddle:// remote pointing at a port nothing is listening on,
+    // exercised through BOTH invocation forms that resolve to it:
+    //   1. inline URL:        `heddle push heddle://...`
+    //   2. named remote:      `heddle push origin`  (origin -> heddle://)
+    // The named-remote form is the common real-world repro and resolves the
+    // URL via RemoteConfig, so it must route identically.
+    let hosted_url = "heddle://127.0.0.1:1/org/repo";
+    heddle(
+        &["remote", "add", "origin", hosted_url],
+        Some(source.path()),
+    )
+    .expect("add hosted origin remote");
+
+    for push_arg in [hosted_url, "origin"] {
+        let output = heddle_output(
+            &["--output", "json", "push", push_arg],
+            Some(source.path()),
+        )
+        .expect("spawn heddle push");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        // The exact bug signature: a SUCCESS via the git exporter. If the push
+        // routed to the git-overlay exporter, stdout carries
+        // {"transport":"git","success":true,...}. That must never happen for a
+        // heddle:// remote regardless of how it was named.
+        if let Ok(envelope) = serde_json::from_str::<Value>(stdout.trim()) {
+            let transport = envelope["transport"].as_str().unwrap_or_default();
+            let success = envelope["success"].as_bool().unwrap_or(false);
+            assert!(
+                !(transport == "git" && success),
+                "`heddle push {push_arg}` silently no-opped via the git-overlay \
+                 exporter (transport=git, success=true) instead of routing to the \
+                 hosted path: {envelope}"
+            );
+        }
+
+        // Positively, a hosted push that cannot reach a server must FAIL loudly
+        // (non-zero exit) rather than report success of any kind — proving it
+        // reached the hosted transport (dead-port connect error, or a
+        // `client`-feature-less build's `network_feature_unavailable`) instead
+        // of the git-overlay exporter's silent local reconcile.
+        assert!(
+            !output.status.success(),
+            "`heddle push {push_arg}` to an unreachable hosted remote must fail \
+             loudly, not succeed (silent no-op). stdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+}
+
 #[test]
 fn test_cli_remote_show_missing_uses_typed_advice() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
## The bug class

A `heddle://` hosted push on a **git-overlay repo** can silently no-op while reporting success. `cmd_push` historically branched on `repo.capability() == GitOverlay && !repo.hosted_enabled()`. When a git-overlay repo's `origin` resolves to a `heddle://` hosted remote but the repo's `[hosted]` config block is empty (so `repo.hosted_enabled()` returns false), the push would take the git-overlay refs branch → `push_git_overlay_refs` → `push_network_remote` (`crates/cli/src/bridge/git_core.rs`), which treats the `heddle://` URL as a generic git network remote, "reconciles" refs locally, writes a sidecar, and returns `{"transport":"git","success":true,"refs_written":[]}` — **without ever constructing a `GrpcHostedClient` or contacting the server**.

## What I found (important — verified against `origin/main` 9d9cf3cf)

**Part A (the routing fix) is ALREADY present on main** and demonstrably works. The gate at `crates/cli/src/cli/commands/remote/mod.rs` reads:

```rust
let push_uses_hosted_network = push_target_is_hosted_network(&repo, remote.as_deref());
if repo.capability() == RepositoryCapability::GitOverlay
    && !repo.hosted_enabled()
    && !push_uses_hosted_network
{
    // ... git-overlay refs exporter ...
}
```

`push_target_is_hosted_network` → `classify_remote_spec` resolves the named/inline remote's URL and returns `NetworkHeddle` for any `heddle://` target **independent of `hosted_enabled()`**, so a `heddle://` remote falls through to the native hosted-sync path (`RemoteTarget::Network` → `push_network` → `GrpcHostedClient::push`). I verified this is the live behavior, not just the source:

```
$ heddle --output json push heddle://127.0.0.1:1/org/repo   # inline URL
$ heddle --output json push origin                          # origin -> heddle://
$ heddle --output json push                                 # default remote
# all three -> the NATIVE Network branch (errors loudly trying to reach the
# server / network_feature_unavailable on a no-client build), NEVER
# {"transport":"git","success":true}
```

So this PR does **not** re-implement Part A — duplicating a correct, in-place gate would be wrong. Instead it (1) **locks** that routing with an end-to-end regression test, and (2) adds the **Part B** defense-in-depth guard that was genuinely missing.

## What this PR changes

**Part B — defense in depth (`crates/cli/src/bridge/git_core.rs`).** Even with correct routing, the git exporter's URL classifier `local_path_from_url` accepted a `heddle://` scheme and let it fall through as a generic network URL. I lifted a hard-error guard to that primitive — the single chokepoint on the push (`resolve_remote`), note-hydration, and clone-to-bare paths — so a `heddle://` URL reaching the git-overlay exporter now fails loudly ("hosted heddle:// scheme cannot be pushed via the git-overlay exporter") instead of silently no-op-succeeding. One guard at the primitive covers every caller. This makes the silent-success class structurally impossible to recur even if routing upstream were ever broken.

**Routing regression test (`crates/cli/tests/cli_integration/remotes.rs`).** End-to-end CLI test: a git-overlay repo (real `git init` + `heddle adopt`) with a `heddle://` remote and empty `[hosted]` must NOT produce the `transport:"git", success:true` silent-no-op signature, and must fail loudly reaching the hosted transport — asserted across both the inline-URL and named-remote (`origin`) forms. Locks Part A's behavior so it cannot silently regress.

## Commits / SHAs

- `15118eca` — RED: `local_path_from_url_rejects_hosted_heddle_scheme` (Part B regression at the classifier; failed because `heddle://` returned `Ok(None)`).
- `edf69788` — Part B fix: `local_path_from_url` hard-errors on `heddle://`; the RED test goes green. Also adds a no-regression test (`file://` → local path; https/ssh → network pass-through).
- `97665d98` — end-to-end routing guard locking the (verified-correct) Part A behavior for both invocation forms.

Note on RED-first for the routing test: it is a guard, not a fix-driver — it **passes on current main** because Part A's gate is already correct, so it could not be expressed RED against this tree. It is committed as a behavior lock, honestly labeled.

## CI gates run locally (all green)

- `cargo build --locked --workspace` (default features) ✅
- `cargo build --locked --workspace --all-features` ✅
- `bash scripts/check-no-silent-default-tree-load.sh` ✅ (567 files, clean)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo test -p heddle-mount` ✅
- `cargo test -p heddle-cli --lib` ✅ (662 passed, incl. the 2 Part-B unit tests)
- `cargo test -p heddle-cli --test cli_integration push` ✅ (52 push/remote integration tests, incl. the new routing guard; no regression to local-path / git-URL routing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)