### PR TITLE
perf(read-only): compute git-overlay worktree status once across status/verify/diff/thread-list

### DIFF
--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -226,6 +226,29 @@ impl GitOverlayHealth {
 
 impl RepositoryVerificationState {
     pub(crate) fn from_health(repo: &Repository, health: GitOverlayHealth) -> Self {
+        Self::from_health_inner(repo, health, None)
+    }
+
+    /// Verification-state build that reuses an already-computed git-overlay
+    /// worktree status instead of re-walking + re-SHA-1ing every tracked file.
+    /// `worktree_status` must be the exact `Result` from
+    /// `git_overlay_worktree_status()` so the dirty/clean classification stays
+    /// byte-identical to [`from_health`]. Callers that already hold the status
+    /// (e.g. the `status`/`verify`/`thread list` read paths, which compute it to
+    /// build `health`) thread it through here to avoid a second full walk.
+    pub(crate) fn from_health_with_worktree_status(
+        repo: &Repository,
+        health: GitOverlayHealth,
+        worktree_status: &repo::Result<Option<WorktreeStatus>>,
+    ) -> Self {
+        Self::from_health_inner(repo, health, Some(worktree_status))
+    }
+
+    fn from_health_inner(
+        repo: &Repository,
+        health: GitOverlayHealth,
+        precomputed_worktree_status: Option<&repo::Result<Option<WorktreeStatus>>>,
+    ) -> Self {
         let git_branch = repo.git_overlay_current_branch().ok().flatten();
         let heddle_thread = repo.current_lane().ok().flatten();
         let active_operation = repo.operation_status().ok().flatten().map(|operation| {
@@ -267,10 +290,25 @@ impl RepositoryVerificationState {
         let health_worktree_dirty = health.checks.iter().any(|check| {
             matches!(check.name.as_str(), "worktree" | "heddle_worktree") && check.status != "clean"
         });
-        let git_worktree_status = repo.git_overlay_worktree_status().ok().flatten();
-        let git_worktree_dirty = git_worktree_status
-            .as_ref()
-            .is_some_and(|status| !status.is_clean());
+        // Reuse the caller's already-computed status when threaded; otherwise
+        // fall back to a fresh walk. `.ok().flatten()` preserves the original
+        // dirty/clean classification exactly.
+        // Reuse the caller's already-computed status when threaded; otherwise
+        // fall back to a fresh walk. Hold a borrow (`WorktreeStatus` is not
+        // `Clone`) so the dirty/clean classification stays byte-identical.
+        let computed_worktree_status;
+        let worktree_status_ref: &repo::Result<Option<WorktreeStatus>> =
+            match precomputed_worktree_status {
+                Some(result) => result,
+                None => {
+                    computed_worktree_status = repo.git_overlay_worktree_status();
+                    &computed_worktree_status
+                }
+            };
+        let git_worktree_dirty = matches!(
+            worktree_status_ref,
+            Ok(Some(status)) if !status.is_clean()
+        );
         let worktree_dirty = health_worktree_dirty || git_worktree_dirty;
         let ready_threads = ready_thread_actions(repo);
         let actionable_ready_threads = ready_threads
@@ -1125,8 +1163,19 @@ fn verification_check(
 pub(crate) fn build_repository_verification_state(
     repo: &Repository,
 ) -> RepositoryVerificationState {
-    let health = build_git_overlay_health(repo);
-    RepositoryVerificationState::from_health(repo, health)
+    // Compute the git-overlay worktree status ONCE and thread it through both
+    // consumers (the health build + the `from_health` dirty classification).
+    // `git_overlay_worktree_status` re-reads + SHA-1s every tracked file
+    // (~340ms on the ghostty 5.7k-file worktree); previously the verification
+    // state paid that twice (here and again inside `from_health`). For
+    // non-git-overlay repos the status is `Ok(None)`, so the walk is skipped.
+    let worktree_status = if repo.capability() == repo::RepositoryCapability::GitOverlay {
+        repo.git_overlay_worktree_status()
+    } else {
+        Ok(None)
+    };
+    let health = build_git_overlay_health_with_worktree_status(repo, &worktree_status);
+    RepositoryVerificationState::from_health_with_worktree_status(repo, health, &worktree_status)
 }
 
 /// Verification-state build that reuses an already-computed git-overlay worktree
@@ -1140,7 +1189,7 @@ pub(crate) fn build_repository_verification_state_with_worktree_status(
     worktree_status: &repo::Result<Option<WorktreeStatus>>,
 ) -> RepositoryVerificationState {
     let health = build_git_overlay_health_with_worktree_status(repo, worktree_status);
-    RepositoryVerificationState::from_health(repo, health)
+    RepositoryVerificationState::from_health_with_worktree_status(repo, health, worktree_status)
 }
 
 pub(crate) fn unimported_git_history_advice(

--- a/crates/cli/src/cli/commands/git_overlay_health.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health.rs
@@ -291,9 +291,6 @@ impl RepositoryVerificationState {
             matches!(check.name.as_str(), "worktree" | "heddle_worktree") && check.status != "clean"
         });
         // Reuse the caller's already-computed status when threaded; otherwise
-        // fall back to a fresh walk. `.ok().flatten()` preserves the original
-        // dirty/clean classification exactly.
-        // Reuse the caller's already-computed status when threaded; otherwise
         // fall back to a fresh walk. Hold a borrow (`WorktreeStatus` is not
         // `Clone`) so the dirty/clean classification stays byte-identical.
         let computed_worktree_status;

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -771,7 +771,13 @@ pub(crate) fn build_status_output(cli: &Cli, short: bool) -> Result<StatusOutput
         build_git_overlay_health_with_worktree_status(&repo, &git_worktree_status_result);
     let git_overlay_health_ms = git_overlay_health_start.elapsed().as_millis();
     let verification_start = Instant::now();
-    let trust = RepositoryVerificationState::from_health(&repo, git_overlay_health.clone());
+    // Reuse the worktree status already computed above (line ~767) instead of
+    // re-walking inside `from_health`. Behaviour-identical; just one fewer pass.
+    let trust = RepositoryVerificationState::from_health_with_worktree_status(
+        &repo,
+        git_overlay_health.clone(),
+        &git_worktree_status_result,
+    );
     let verification_ms = verification_start.elapsed().as_millis();
     let remote_tracking =
         remote_tracking.map(|remote| remote_tracking_with_verification_action(remote, &trust));

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -57,7 +57,9 @@ use crate::{
         worktree_status_options,
     },
     config::{UserConfig, UserThreadWorkspaceMode},
+    perf::{ProfileField, emit_profile, profile_enabled},
 };
+use std::time::Instant;
 
 pub(crate) const DEFAULT_AVAILABLE_GIT_REF_LIMIT: usize = 5;
 
@@ -1282,10 +1284,15 @@ fn available_git_ref_from_summary(summary: &ThreadSummary) -> AvailableGitRef {
 }
 
 pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs) -> Result<()> {
+    let body_start = Instant::now();
     let as_json = should_output_json(cli, Some(repo.config()));
     let current = repo.current_lane()?;
+    let collect_start = Instant::now();
     let mut summaries = collect_thread_summaries(repo)?;
+    let collect_summaries_ms = collect_start.elapsed().as_millis();
+    let verification_start = Instant::now();
     let mut trust = build_repository_verification_state(repo);
+    let verification_ms = verification_start.elapsed().as_millis();
     if !args.include_auto {
         // Always keep the current thread visible even if it's auto:
         // hiding it from the user who is *standing in it* would be
@@ -1402,6 +1409,17 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
         }
         render_thread_sections(&output.threads, cli.verbose > 0);
         render_available_git_refs(&output.available_git_refs, cli.verbose > 0);
+    }
+
+    if profile_enabled() {
+        emit_profile(
+            "thread list phases",
+            &[
+                ProfileField::millis("collect_summaries_ms", collect_summaries_ms),
+                ProfileField::millis("verification_ms", verification_ms),
+                ProfileField::duration("command_body_ms", body_start.elapsed()),
+            ],
+        );
     }
 
     Ok(())

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -13,7 +13,11 @@ use super::{
         build_repository_verification_state, repository_setup_guidance,
     },
 };
-use crate::cli::{Cli, should_output_json, style};
+use crate::{
+    cli::{Cli, should_output_json, style},
+    perf::{ProfileField, emit_profile, profile_enabled},
+};
+use std::time::Instant;
 
 #[derive(Debug, Serialize)]
 struct VerifyOutput {
@@ -27,10 +31,16 @@ struct VerifyOutput {
 }
 
 pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
+    let body_start = Instant::now();
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
+    let probe_start = Instant::now();
+    let plain_git_probe = build_plain_git_verification_probe(start)?;
+    let plain_git_probe_ms = probe_start.elapsed().as_millis();
+    let mut repo_open_ms = 0u128;
+    let mut verification_ms = 0u128;
     let (trust, presentation, repo_config) =
-        if let Some(probe) = build_plain_git_verification_probe(start)? {
+        if let Some(probe) = plain_git_probe {
             (
                 probe.trust,
                 crate::cli::render::RepositoryPresentation {
@@ -40,12 +50,27 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
                 None,
             )
         } else {
+            let repo_open_start = Instant::now();
             let repo = Repository::open(start)?;
+            repo_open_ms = repo_open_start.elapsed().as_millis();
+            let verification_start = Instant::now();
             let trust = build_repository_verification_state(&repo);
+            verification_ms = verification_start.elapsed().as_millis();
             let presentation = crate::cli::render::repository_presentation(&repo, None, None);
             let config = repo.config().clone();
             (trust, presentation, Some(config))
         };
+    if profile_enabled() {
+        emit_profile(
+            "verify phases",
+            &[
+                ProfileField::millis("plain_git_probe_ms", plain_git_probe_ms),
+                ProfileField::millis("repo_open_ms", repo_open_ms),
+                ProfileField::millis("verification_ms", verification_ms),
+                ProfileField::duration("command_body_ms", body_start.elapsed()),
+            ],
+        );
+    }
     let output = VerifyOutput {
         output_kind: "verify",
         clean: trust.verified,


### PR DESCRIPTION
## What

Read-only commands on a large git-overlay repo were paying for the same full worktree walk twice. `RepositoryVerificationState::from_health` re-walked + re-SHA-1'd every tracked file via `git_overlay_worktree_status()` (line ~270) even though every caller had *already* computed that exact status to build the health report it was handed. The existing `build_git_overlay_health_with_worktree_status` seam threaded the status into the health build but stopped there — `from_health` re-walked anyway.

This PR threads the already-computed worktree status through `from_health` too:
- new `RepositoryVerificationState::from_health_with_worktree_status` variant + private `from_health_inner` (mirrors the existing health seam)
- `build_repository_verification_state` now walks once and threads the result into both consumers
- `status`'s short path passes the `git_worktree_status_result` it already holds (line ~767)
- `build_repository_verification_state_with_worktree_status` now also threads into `from_health` (it previously still re-walked)

Every read-only command that builds verification state benefits: `status`, `verify`, `diff`, `thread list`.

## Before/after (RELEASE, best-of-3, ghostty-work: 5742 tracked files, 6011 loose objects)

| command | before | after | delta |
|---|---|---|---|
| `status` | 1.16s | 0.84s | -28% |
| `diff` | 0.76s | 0.54s | -29% |
| `verify` | 0.77s | 0.45s | -42% |
| `thread list` | 0.81s | 0.49s | -40% |

`HEDDLE_PROFILE` confirms the mechanism — status's `verification_ms` dropped from 339ms to 5ms (it's now a pure classification over the threaded status instead of a second full sley scan).

## What was redundant vs inherent

**Avoidable (fixed here):** the second `git_overlay_worktree_status()` walk inside `from_health`. ~340ms per command, pure duplication of the walk the caller already did. This was the single largest avoidable cost on every one of these commands.

**Inherent (left as-is, documented):**
- `git_overlay_status_ms` ~335ms — the *first* worktree walk via sley's status engine. Status genuinely needs it. ~200ms of it is loose-object reads on the 6011 loose objects; a mirror repack would shrink it, but a maintenance step the user must run is a worse fix than this, so not pursued here.
- `git_index_ms` ~297ms (status only) — `git_index_plan_for_repo` runs a *third* sley `stream_short_status` scan to populate the git-index section of `heddle status` (staged / unstaged / untracked). It can't reuse `WorktreeStatus`: that type collapses the index/worktree byte distinction that the index plan needs (staged-vs-unstaged), and the two scans apply different ignore semantics (`.heddle/` filtering + directory-prune for worktree status vs `build_worktree_ignore` for the index intent). Merging them into one shared scan is feasible but crosses the repo/cli crate boundary and risks subtle output changes; out of scope for this behaviour-preserving pass. Flagged for a follow-up.

## Instrumentation (HEDDLE_PROFILE)

`verify` and `thread list` previously emitted only `command_body_ms`. Added env-gated sub-phase timers matching `status`'s granularity:
- `verify`: `plain_git_probe_ms`, `repo_open_ms`, `verification_ms`, `command_body_ms`
- `thread list`: `collect_summaries_ms`, `verification_ms`, `command_body_ms`

(This also surfaced that `thread list`'s per-thread fields are cheap — they come from persisted records — and the enrich-current-thread compare is only ~82ms; the dominant cost was the verification walk this PR halves.)

## Same-output proof

`--output json` diffed before (origin/main 60e7b9cf, separately built baseline binary) vs after on ghostty-work:
- `status`: byte-identical
- `verify`: byte-identical
- `thread list`: identical modulo `last_activity_at`/`updated_at` timestamps
- text output (`status`, `verify`, `verify --verbose`, `thread list`): identical

The only intended surface change is the new env-gated profiling sub-timers.

## Gates run (locally, this worktree)

- `cargo build --locked --workspace` (default features) — pass
- `cargo build --locked --workspace --all-features` — pass
- `bash scripts/check-no-silent-default-tree-load.sh` — pass (567 files)
- `cargo test -p heddle-mount` — pass (4)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p heddle-cli` — 925 pass; 3 pre-existing failures (`oss_cli_polish::actor_*`) that reproduce identically on a clean origin/main build — they assert a harness model id (`gpt-5.3-codex` vs the env's `claude-opus-4-8`), unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785277655&installation_id=132405951&pr_number=795&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F795&signature=3bddb1f163dc1a671f5b5546f9cee997e25bb1f13a199510ebec713a04a7ed4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->