### PR TITLE
fix(gc): consolidate the object store instead of duplicating it

### DIFF
--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -75,9 +75,8 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
                 trees.len()
             );
 
-            if prune {
-                println!("Would prune loose objects after packing");
-            }
+            let _ = prune;
+            println!("Would prune redundant loose objects after consolidating into a pack");
             if pinned_redactions > 0 {
                 println!(
                     "Pinned {pinned_redactions} redaction tombstone(s) — never collected by GC"
@@ -114,19 +113,28 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
             }
         }
 
-        if prune {
-            let (removed, bytes_freed) = repo.store().prune_loose_objects()?;
-            summary.pruned_loose = removed;
-            summary.bytes_freed = bytes_freed;
-            if !json {
-                if removed > 0 {
-                    println!(
-                        "Pruned {} loose objects (freed {} bytes)",
-                        removed, bytes_freed
-                    );
-                } else {
-                    println!("No loose objects to prune");
-                }
+        // Consolidation prune: drop the loose copies of objects that now
+        // live in the pack we just wrote. This is intrinsic to what a GC
+        // *is* — a GC that packs without pruning leaves every object in
+        // BOTH places, so the object store has strictly more sources to
+        // search and read commands (status/diff/verification) get slower
+        // instead of faster. The prune only removes loose objects whose
+        // canonical copy is now in a pack, so it never loses data
+        // (fsck stays clean). It therefore runs unconditionally, not
+        // behind `--prune`. The `prune`/`aggressive` flags are retained
+        // for callers/scripts but no longer gate this safe step.
+        let _ = prune;
+        let (removed, bytes_freed) = repo.store().prune_loose_objects()?;
+        summary.pruned_loose = removed;
+        summary.bytes_freed = bytes_freed;
+        if !json {
+            if removed > 0 {
+                println!(
+                    "Pruned {} redundant loose objects (freed {} bytes)",
+                    removed, bytes_freed
+                );
+            } else {
+                println!("No loose objects to prune");
             }
         }
 

--- a/crates/cli/tests/production_features/packfiles.rs
+++ b/crates/cli/tests/production_features/packfiles.rs
@@ -2,15 +2,24 @@
 use super::*;
 
 #[test]
-fn test_gc_creates_packfile() {
+fn test_gc_consolidates_into_single_pack() {
     let temp = TempDir::new().unwrap();
     setup_repo_with_file(&temp, "file.txt", "initial content");
 
     // Snapshot batches new blobs straight into a packfile (the
     // perf-hot path), so `packs/` already has at least one entry
-    // before gc runs. We only assert that gc *adds* one (it packs
-    // the loose trees that snapshot still writes loose).
+    // before gc runs, plus loose trees the snapshot writes loose.
+    //
+    // GC's contract is to *consolidate*, not to keep minting packs.
+    // The pre-fix bug added a new pack on every run while leaving the
+    // existing packs and loose copies in place, so the object store
+    // grew more sources to search and read commands slowed down. After
+    // the fix gc folds loose + existing packs into a SINGLE pack and
+    // prunes the redundant loose copies, so the pack count must not
+    // grow and no object is left both loose and packed.
     let packs_dir = temp.path().join(".heddle").join("packs");
+    let blobs_dir = temp.path().join(".heddle").join("objects").join("blobs");
+    let trees_dir = temp.path().join(".heddle").join("objects").join("trees");
     let pack_count_before = pack_count_in(&packs_dir);
 
     let result = heddle(&["maintenance", "gc", "--aggressive"], Some(temp.path()));
@@ -25,11 +34,22 @@ fn test_gc_creates_packfile() {
 
     assert!(packs_dir.exists(), "packs directory should exist after gc");
     let pack_count_after = pack_count_in(&packs_dir);
+    assert_eq!(
+        pack_count_after, 1,
+        "gc must consolidate into exactly one pack: before={}, after={}",
+        pack_count_before, pack_count_after
+    );
     assert!(
-        pack_count_after > pack_count_before,
-        "gc should add a pack: before={}, after={}",
+        pack_count_after <= pack_count_before.max(1),
+        "gc must not grow the pack count: before={}, after={}",
         pack_count_before,
         pack_count_after
+    );
+
+    let loose_after = count_files_recursive(&blobs_dir) + count_files_recursive(&trees_dir);
+    assert_eq!(
+        loose_after, 0,
+        "gc must prune the loose copies of objects it just packed"
     );
 }
 

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -16,6 +16,14 @@ use crate::{
     },
 };
 
+fn remove_file_ignore_missing(path: &std::path::Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(HeddleError::from(e)),
+    }
+}
+
 impl FsStore {
     /// Bulk-install many blobs as a single packfile. Two fsyncs total
     /// (one for `.pack`, one for `.idx`) regardless of blob count —
@@ -75,27 +83,120 @@ impl FsStore {
         Ok(())
     }
 
-    pub(super) fn pack_objects_impl(&self, _aggressive: bool) -> Result<(u64, u64)> {
-        let blobs = list_hashes_from_dir(&blobs_dir(&self.root))?;
-        let trees = list_hashes_from_dir(&trees_dir(&self.root))?;
+    /// Consolidate the object store into a single pack.
+    ///
+    /// GC must *shrink* the set of places a reader has to look, not grow
+    /// it. The naive "pack the loose objects into a fresh pack" strategy
+    /// regressed read performance badly: every `maintenance gc` minted a
+    /// brand-new pack *alongside* the existing pack(s) and (by default)
+    /// left the now-redundant loose copies in place. The result was an
+    /// object store with strictly MORE sources to search — loose objects
+    /// plus an ever-growing fleet of packs — and `PackManager::get_object`
+    /// probes every pack linearly, so each extra pack roughly doubled the
+    /// cost of the object lookups that `status`/`diff`/verification do.
+    ///
+    /// This implementation does a true repack: it folds every object
+    /// already living in a pack *together with* the loose blobs and trees
+    /// into one new consolidated pack, installs it, and then deletes the
+    /// superseded packs. Combined with the caller's
+    /// `prune_loose_objects`, the store ends a GC with exactly one pack
+    /// and no loose duplicates — strictly fewer read sources than it
+    /// started with. Running GC again over an already-consolidated store
+    /// is a no-op (nothing loose, one pack already covers everything).
+    ///
+    /// State objects are addressed by `ChangeId` and may have a stale
+    /// packed body shadowed by a fresher loose copy (#570). We re-pack
+    /// the packed state body verbatim; the loose copy (which `prune`
+    /// never touches) keeps shadowing it on read, so the shadow semantics
+    /// are preserved across the repack.
+    pub(super) fn pack_objects_impl(&self, aggressive: bool) -> Result<(u64, u64)> {
+        let loose_blobs = list_hashes_from_dir(&blobs_dir(&self.root))?;
+        let loose_trees = list_hashes_from_dir(&trees_dir(&self.root))?;
 
-        if blobs.is_empty() && trees.is_empty() {
+        // Snapshot what the existing packs already hold, plus the file
+        // paths we'll retire once the consolidated pack is installed.
+        let (existing_ids, old_pack_files) = {
+            let manager = self.pack_manager().read().map_err(|_| {
+                HeddleError::Config("Failed to acquire pack manager lock".to_string())
+            })?;
+            let ids = manager.list_all_ids()?;
+            let files: Vec<(std::path::PathBuf, std::path::PathBuf)> = manager
+                .pack_file_paths()
+                .into_iter()
+                .map(|(pack, index)| (pack.to_path_buf(), index.to_path_buf()))
+                .collect();
+            (ids, files)
+        };
+
+        // Nothing loose and at most one pack already — the store is
+        // already consolidated; don't churn a fresh identical pack.
+        if loose_blobs.is_empty() && loose_trees.is_empty() && old_pack_files.len() <= 1 {
             return Ok((0, 0));
         }
 
-        let mut builder = PackBuilder::new(self.compression);
+        // Consolidation packs every object that's already packed plus the
+        // loose ones. The default path SKIPS the sliding-window delta
+        // search: it runs across the full payloads of every object and on
+        // a large native store (tens of MB across thousands of objects)
+        // costs minutes for a near-zero size win, because the carried-
+        // forward objects are already zstd-compressed. `--aggressive`
+        // opts back into the full delta search for the rare "shrink the
+        // pack at all costs" case. This mirrors the snapshot hot path
+        // (`put_blobs_packed_impl`), which disables delta for the same
+        // reason.
+        let mut compression = self.compression;
+        if !aggressive {
+            compression.max_delta_size = 0;
+        }
+        let mut builder = PackBuilder::new(compression);
+        let mut seen: std::collections::HashSet<crate::store::pack::PackObjectId> =
+            std::collections::HashSet::new();
 
-        for hash in &blobs {
-            if let Some(blob) = ObjectStore::get_blob(self, hash)? {
-                builder.add(*hash, PackObjectType::Blob, blob.content().to_vec());
+        // 1. Carry forward everything already in a pack so the old packs
+        //    can be retired. `get_object` resolves the body + type for
+        //    any id (blob/tree/state/action), and `add_id` preserves
+        //    ChangeId-keyed state objects.
+        for id in existing_ids {
+            if !seen.insert(id) {
+                continue;
+            }
+            let obj_type = {
+                let manager = self.pack_manager().read().map_err(|_| {
+                    HeddleError::Config("Failed to acquire pack manager lock".to_string())
+                })?;
+                manager.get_object(&id)?
+            };
+            if let Some((obj_type, data)) = obj_type {
+                builder.add_id(id, obj_type, data);
             }
         }
 
-        for hash in &trees {
+        // 2. Fold in the loose blobs and trees. Skip any whose hash is
+        //    already covered by a carried-forward pack entry.
+        for hash in &loose_blobs {
+            let id = crate::store::pack::PackObjectId::Hash(*hash);
+            if seen.contains(&id) {
+                continue;
+            }
+            if let Some(blob) = ObjectStore::get_blob(self, hash)? {
+                seen.insert(id);
+                builder.add(*hash, PackObjectType::Blob, blob.content().to_vec());
+            }
+        }
+        for hash in &loose_trees {
+            let id = crate::store::pack::PackObjectId::Hash(*hash);
+            if seen.contains(&id) {
+                continue;
+            }
             if let Some(tree) = ObjectStore::get_tree(self, hash)? {
                 let data = rmp_serde::to_vec(&tree)?;
+                seen.insert(id);
                 builder.add(*hash, PackObjectType::Tree, data);
             }
+        }
+
+        if seen.is_empty() {
+            return Ok((0, 0));
         }
 
         let (pack_data, index_data, stats) = builder.build()?;
@@ -107,6 +208,29 @@ impl FsStore {
         // path doesn't go through here — it calls
         // `install_pack_files` directly via `put_blobs_packed_impl`,
         // which keeps its caches warm.
+        self.clear_recent_object_caches();
+
+        // Retire the superseded packs now that the consolidated pack is
+        // durably installed and every object they held has been carried
+        // forward. The consolidated pack is content-addressed, so if it
+        // happened to hash-collide with an old pack (a store that was
+        // already a single consolidated pack) that file is excluded here.
+        let new_pack_name = blake3::hash(&pack_data).to_hex();
+        for (pack_path, index_path) in &old_pack_files {
+            let is_new_pack = pack_path
+                .file_stem()
+                .and_then(|stem| stem.to_str())
+                .map(|stem| stem == new_pack_name.as_str())
+                .unwrap_or(false);
+            if is_new_pack {
+                continue;
+            }
+            remove_file_ignore_missing(pack_path)?;
+            remove_file_ignore_missing(index_path)?;
+        }
+        // Disk shrank (packs removed), so `reload_if_disk_grew` would
+        // not pick this up — force a full reload of the pack list.
+        self.reload_packs()?;
         self.clear_recent_object_caches();
 
         let saved = stats.total_uncompressed - stats.total_compressed;

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -522,9 +522,9 @@ fn pack_objects_then_prune_leaves_no_loose_packed_duplicates() {
         let blob = Blob::from(format!("gc-consolidation-blob-{i}"));
         hashes.push(store.put_blob(&blob).unwrap());
     }
-    for i in 0..4 {
+    for (i, hash) in hashes.iter().take(4).enumerate() {
         let tree = Tree::from_entries(vec![
-            TreeEntry::file(format!("file-{i}.txt"), hashes[i], false).unwrap(),
+            TreeEntry::file(format!("file-{i}.txt"), *hash, false).unwrap(),
         ]);
         store.put_tree(&tree).unwrap();
     }

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -465,6 +465,195 @@ fn install_pack_accepts_valid_compressed_blob_pack() {
     );
 }
 
+fn count_packs(store: &FsStore) -> usize {
+    std::fs::read_dir(packs_dir(store.root()))
+        .map(|iter| {
+            iter.flatten()
+                .filter(|entry| {
+                    entry
+                        .path()
+                        .extension()
+                        .and_then(|ext| ext.to_str())
+                        .map(|ext| ext == "pack")
+                        .unwrap_or(false)
+                })
+                .count()
+        })
+        .unwrap_or(0)
+}
+
+fn count_loose_objects(store: &FsStore) -> usize {
+    use super::fs_paths::{blobs_dir, trees_dir};
+    // Loose objects are sharded into 2-char prefix subdirectories
+    // (see `hash_path`), so count files recursively.
+    fn count_files_recursive(dir: &std::path::Path) -> usize {
+        let mut total = 0;
+        if let Ok(iter) = std::fs::read_dir(dir) {
+            for entry in iter.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    total += count_files_recursive(&path);
+                } else if path.is_file() {
+                    total += 1;
+                }
+            }
+        }
+        total
+    }
+    count_files_recursive(&blobs_dir(store.root()))
+        + count_files_recursive(&trees_dir(store.root()))
+}
+
+/// GC's contract is to *consolidate* the object store: pack the loose
+/// objects AND prune the now-redundant loose copies, so the ODB shrinks
+/// rather than gaining a duplicate pack alongside the still-loose
+/// originals. The pre-fix bug (heddle maintenance gc regression) left
+/// every packed object ALSO loose, so the object store had more sources
+/// to search and read commands ran ~2x slower. This test pins the
+/// invariant: after `pack_objects` + `prune_loose_objects` no object is
+/// simultaneously loose and packed.
+#[test]
+fn pack_objects_then_prune_leaves_no_loose_packed_duplicates() {
+    let (_temp, store) = create_test_store();
+
+    // Write a handful of loose blobs + trees.
+    let mut hashes = Vec::new();
+    for i in 0..16 {
+        let blob = Blob::from(format!("gc-consolidation-blob-{i}"));
+        hashes.push(store.put_blob(&blob).unwrap());
+    }
+    for i in 0..4 {
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file(format!("file-{i}.txt"), hashes[i], false).unwrap(),
+        ]);
+        store.put_tree(&tree).unwrap();
+    }
+
+    let loose_before = count_loose_objects(&store);
+    assert!(
+        loose_before >= 20,
+        "expected the test corpus to be written loose, got {loose_before}"
+    );
+
+    let (packed, _saved) = store.pack_objects(false).unwrap();
+    assert!(packed >= 20, "pack_objects should pack the loose corpus");
+    let (pruned, _freed) = store.prune_loose_objects().unwrap();
+    assert!(pruned >= 20, "prune should remove the now-packed loose copies");
+
+    // The consolidation invariant: nothing is left both loose and packed.
+    let loose_after = count_loose_objects(&store);
+    assert_eq!(
+        loose_after, 0,
+        "after gc (pack + prune) the object store must not retain loose copies \
+         of objects that now live in a pack (regression: pack-without-prune)"
+    );
+
+    // Every object is still readable (no data lost to the consolidation).
+    for hash in &hashes {
+        assert!(
+            store.get_blob(hash).unwrap().is_some(),
+            "blob {hash:?} must survive consolidation"
+        );
+    }
+}
+
+/// Running gc twice must not keep growing the pack count. The pre-fix
+/// `pack_objects` always wrote a *new* pack of the loose objects without
+/// consolidating the existing packs, so a repo that is gc'd repeatedly
+/// accumulated packs and got slower on every run. After the fix a
+/// second gc over an already-consolidated store is a no-op: it neither
+/// re-packs already-packed content into yet another pack nor leaves the
+/// pack count climbing.
+#[test]
+fn repeated_gc_does_not_grow_pack_count() {
+    let (_temp, store) = create_test_store();
+
+    for i in 0..16 {
+        let blob = Blob::from(format!("repeated-gc-blob-{i}"));
+        store.put_blob(&blob).unwrap();
+    }
+
+    store.pack_objects(false).unwrap();
+    store.prune_loose_objects().unwrap();
+    let packs_after_first = count_packs(&store);
+    assert_eq!(
+        packs_after_first, 1,
+        "a single gc should consolidate the corpus into exactly one pack"
+    );
+
+    // Second gc with nothing loose: must not mint another pack.
+    let (packed_second, _) = store.pack_objects(false).unwrap();
+    store.prune_loose_objects().unwrap();
+    let packs_after_second = count_packs(&store);
+    assert_eq!(
+        packed_second, 0,
+        "a second gc with no loose objects must not re-pack already-packed content"
+    );
+    assert_eq!(
+        packs_after_second, 1,
+        "repeated gc must not grow the pack count (regression: unbounded pack accumulation)"
+    );
+}
+
+/// The decisive regression: a store that ALREADY has a pack, then
+/// accumulates new loose objects, then is gc'd. The pre-fix
+/// `pack_objects` wrote the new loose objects into a *second* pack and
+/// left the first pack in place, so the pack count grew 1 -> 2. Read
+/// commands probe every pack linearly (`PackManager::get_object`), so on
+/// a real repo each extra pack roughly doubled status time even after
+/// the loose copies were pruned. GC must *consolidate*: fold every
+/// object (loose + already-packed) into a single pack so the pack count
+/// does not grow.
+#[test]
+fn gc_consolidates_into_single_pack_over_existing_pack() {
+    let (_temp, store) = create_test_store();
+
+    // Round 1: write objects and pack them -> one pack.
+    for i in 0..12 {
+        store.put_blob(&Blob::from(format!("round1-{i}"))).unwrap();
+    }
+    store.pack_objects(false).unwrap();
+    store.prune_loose_objects().unwrap();
+    assert_eq!(count_packs(&store), 1, "round 1 produces one pack");
+
+    // Round 2: more loose objects land (a later snapshot), then gc again.
+    let mut round2 = Vec::new();
+    for i in 0..12 {
+        round2.push(store.put_blob(&Blob::from(format!("round2-{i}"))).unwrap());
+    }
+    assert!(count_loose_objects(&store) >= 12);
+
+    store.pack_objects(false).unwrap();
+    store.prune_loose_objects().unwrap();
+
+    assert_eq!(
+        count_packs(&store),
+        1,
+        "gc must consolidate loose + existing pack into a SINGLE pack \
+         (regression: a second gc minted a new pack, growing pack count and \
+         slowing every object lookup)"
+    );
+    assert_eq!(
+        count_loose_objects(&store),
+        0,
+        "gc must prune the loose copies it just packed"
+    );
+
+    // No object lost across the consolidation.
+    for hash in &round2 {
+        assert!(store.get_blob(hash).unwrap().is_some());
+    }
+    // And the round-1 objects, which only ever lived in the first pack,
+    // must survive being folded into the consolidated pack.
+    assert!(
+        store
+            .get_blob(&Blob::from("round1-0").hash())
+            .unwrap()
+            .is_some(),
+        "objects from the pre-existing pack must survive consolidation"
+    );
+}
+
 #[test]
 fn test_blob_deduplication() {
     let (_temp, store) = create_test_store();


### PR DESCRIPTION
## Problem

`heddle maintenance gc` regressed read performance ~2x and **persistently**: on a large repo (ghostty), warm `status` went from ~0.85s to ~1.73s after a single `gc`, and stayed slow across repeated runs (a durable state change, not a cold cache).

## Root cause (proven by HEDDLE_PROFILE + bisect)

`maintenance gc` packed the loose objects into a **new** pack but:
1. left every **existing** pack in place (pack proliferation), and
2. by default (without `--prune`) left the now-redundant **loose** copies on disk.

So every gc ended with strictly **more** places to look — loose objects *plus* an ever-growing fleet of packs. `PackManager::get_object` probes every pack linearly, and the object-reading phases of `status` (`git_overlay_health`, `worktree_status`, verification) walk thousands of objects, so each extra pack roughly doubled their cost.

**Decisive evidence (on a ghostty copy, release build):**
- Dropping **just** the gc-added pack from an otherwise-pristine repo reproduced the full slowdown: 0.80s → 1.67s (refs-packing and journal-removal were innocent — restoring them changed nothing).
- `gc --prune` (which *does* prune loose) was **still slow** (~1.76s): the extra pack — not the loose copies — was the drag.

HEDDLE_PROFILE deltas before→after (buggy) gc:
| phase | before | after (bug) |
|---|---|---|
| `git_overlay_health_ms` | 76 | 529 |
| `worktree_status_ms` | 58 | 488 |
| `compare_ms` (worktree) | 54 | 482 |

## Fix — make gc a true consolidating repack

- `pack_objects` now folds **every object already in a pack** *together with* the loose blobs/trees into **one** new pack, installs it, then **deletes the superseded packs**. A gc over an already-consolidated store is a no-op.
  - State objects (`ChangeId`-addressed) are carried forward verbatim; their loose-shadows-packed semantics (#570) are preserved because prune never touches loose states.
  - The default path **skips the sliding-window delta search** (carried-forward objects are already zstd-compressed; the full search costs minutes on a multi-MB native store for a near-zero size win). `--aggressive` opts back into it. This took gc on ghostty from a would-be **>7 min** down to **1.14s**.
- `cmd_gc` now prunes the redundant loose copies **unconditionally** — a gc that packs without pruning *is* the bug. The prune only removes loose objects whose canonical copy is now in a pack, so it is lossless. `--prune`/`--aggressive` are still accepted.

## Measured before / after (release, ghostty copy)

| | status (warm) | packs | loose |
|---|---|---|---|
| before gc | ~0.85s | 2 | 323 |
| after gc (no flags) | **~0.82s** | **1** | 3 |
| with the bug | ~1.73s | 3 | 323 |

- gc wall time: **1.14s** (no flags); 2nd gc: `No objects to pack`, 0.38s, packs stay 1 (idempotent).
- **fsck clean** after gc: `[ok] repository is valid` — no object loss.

The invariant now holds: **after `maintenance gc`, read commands are at least as fast as before.**

## Tests

- RED commit (`00e923c2`) adds three store-level invariants; the decisive one — `gc_consolidates_into_single_pack_over_existing_pack` — failed pre-fix (pack count grew 1→2) and passes after.
- Updated `test_gc_creates_packfile` → `test_gc_consolidates_into_single_pack` (the old test asserted the buggy "gc adds a pack" behavior).
- RED SHA: `00e923c2` · Fix SHA: `d9c14396`.

## Gates run locally

`cargo build --locked --workspace` (default) + `--all-features` ✓ · `bash scripts/check-no-silent-default-tree-load.sh` ✓ · `cargo clippy --workspace --all-targets -- -D warnings` ✓ · `cargo test -p heddle-objects` (337) ✓ · `cargo test -p heddle-mount` ✓ · `cargo test -p heddle-repo` (544) ✓ · `cargo test -p heddle-cli` comprehensive/production_features/core_functionality (gc, packfiles, maintenance) ✓ · `heddle fsck` clean on a gc'd copy ✓

(Pre-existing, unrelated: 3 `oss_cli_polish` actor/session tests fail on this machine because they assert the harness model identity `gpt-5.3-codex` — an environment artifact, untouched by this change.)

## Out of scope

The git-overlay mirror's ~6011 loose objects in `.heddle/git/objects` are the larger read-path drag but gc never touched them; folding those into `maintenance` is a separate enhancement (worth a follow-up), not part of this regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785284416&installation_id=132405951&pr_number=796&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F796&signature=8f7bf6d2be5bc4e869255ea116b5744b7cb524e6af03011aa6f9e732f26928e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->