### PR TITLE
feat(distribution): Scoop (Windows) manifest for heddle CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,6 +684,10 @@ jobs:
         shell: bash
         run: scripts/render-homebrew-cask.sh "${{ steps.ver.outputs.tag }}" dist/SHA256SUMS rendered/heddle.rb
 
+      - name: Render Scoop manifest
+        shell: bash
+        run: scripts/render-scoop-manifest.sh "${{ steps.ver.outputs.tag }}" dist/SHA256SUMS rendered/heddle.json
+
       - name: Generate release publisher token
         id: app-token
         uses: actions/create-github-app-token@v2
@@ -691,7 +695,7 @@ jobs:
           app-id: ${{ secrets.HEDDLE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEDDLE_RELEASE_APP_PRIVATE_KEY }}
           owner: HeddleCo
-          repositories: homebrew-heddle
+          repositories: homebrew-heddle,scoop-heddle
 
       - name: Publish Homebrew cask PR
         uses: ./.github/actions/publish-manifest
@@ -701,4 +705,14 @@ jobs:
           rendered-file: rendered/heddle.rb
           token: ${{ steps.app-token.outputs.token }}
           channel: homebrew
+          version: ${{ steps.ver.outputs.version }}
+
+      - name: Publish Scoop manifest PR
+        uses: ./.github/actions/publish-manifest
+        with:
+          target-repo: HeddleCo/scoop-heddle
+          manifest-path: bucket/heddle.json
+          rendered-file: rendered/heddle.json
+          token: ${{ steps.app-token.outputs.token }}
+          channel: scoop
           version: ${{ steps.ver.outputs.version }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -204,8 +204,45 @@ Set these GitHub Actions variables as well:
 | `HEDDLE_DEVELOPER_ID_APPLICATION` | Codesigning identity, e.g. `Developer ID Application: HeddleCo, LLC (33V6242M8S)` |
 
 The release-publisher GitHub App should be installed only on
-`homebrew-heddle` and granted only `Contents: write` and
-`Pull requests: write`.
+`homebrew-heddle` and `scoop-heddle` and granted only `Contents: write`
+and `Pull requests: write`.
+
+## Scoop manifest publication
+
+The Windows install path is:
+
+```bash
+scoop bucket add heddle https://github.com/HeddleCo/scoop-heddle
+scoop install heddle
+```
+
+The bucket repository is `HeddleCo/scoop-heddle`; Scoop reads manifests
+from its `bucket/` directory. Stable releases render `bucket/heddle.json`
+from the Windows zip line(s) in the release `SHA256SUMS` via
+`scripts/render-scoop-manifest.sh`. The manifest declares:
+
+- `architecture.64bit.url` / `.hash` — the `x86_64-pc-windows-msvc.zip`
+  archive and its sha256
+- `bin` / `shortcuts` pointing at `heddle.exe` inside the extracted
+  archive directory
+- `checkver` + `autoupdate` so the bucket can self-update to future
+  stable tags
+- `notes` with the cosign keyless verification command (the `.sig` +
+  `.pem` are published alongside the archive on the GitHub Release)
+
+Only **x64** is shipped today. `aarch64-pc-windows-msvc` is parked
+because `sigstore/cosign-installer@v3` has no Windows-arm64 asset, so the
+release build matrix omits it (see the matrix comment in `release.yml`
+and #347). When that target re-enters the matrix, add an
+`aarch64-pc-windows-msvc` row to `ARCHES` in the renderer and Scoop picks
+up the new architecture block automatically.
+
+Like the Homebrew cask, the manifest is not pushed directly: the
+`publish-manifests` job uses the same release-publisher App token to open
+or refresh a PR against `scoop-heddle`, which a maintainer merges after
+bucket CI passes. The wiring (renderer present, `bucket/heddle.json`
+path, App token, `HeddleCo/scoop-heddle` target) is asserted by
+`scripts/check-release-pipeline.sh`.
 
 ### Linux glibc floor
 

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -228,6 +228,20 @@ else
   err "missing Homebrew cask manifest publication wiring"
 fi
 
+# Scoop (Windows) manifest publication — parallel channel on the same
+# substrate (#233). The renderer emits bucket/heddle.json from the Windows
+# zip line(s) in SHA256SUMS; the publish-manifests job opens a PR against
+# the scoop-heddle bucket with the same App token, gated stable-only by
+# the publish-manifests `if` condition asserted below.
+if [[ -x scripts/render-scoop-manifest.sh ]] \
+   && grep -F "bucket/heddle.json" "$WF" >/dev/null \
+   && grep -F "actions/create-github-app-token" "$WF" >/dev/null \
+   && grep -F "HeddleCo/scoop-heddle" "$WF" >/dev/null; then
+  ok "Scoop manifest publication wired"
+else
+  err "missing Scoop manifest publication wiring"
+fi
+
 if grep -F "if: needs.validate-tag.outputs.kind == 'stable'" "$WF" >/dev/null; then
   ok "manifest publication gated to stable releases"
 else

--- a/scripts/render-scoop-manifest.sh
+++ b/scripts/render-scoop-manifest.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/render-scoop-manifest.sh <tag> <SHA256SUMS> <output>
+
+Renders the Heddle Scoop manifest for a stable GitHub Release.
+
+  tag         Release tag, e.g. v0.3.0
+  SHA256SUMS  Aggregate checksum file containing the Windows zip line(s)
+  output      Destination manifest path (bucket/heddle.json)
+
+The Windows release ships x64 only today (aarch64-pc-windows-msvc is
+parked until cosign publishes a win-arm64 binary; see release.yml and
+the artifact contract in RELEASING.md). When the arm64 leg lands, add an
+aarch64-pc-windows-msvc block to ARCHES below and Scoop picks it up
+automatically.
+USAGE
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 2
+fi
+
+TAG="$1"
+SHA256SUMS="$2"
+OUTPUT="$3"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: Scoop manifest rendering only accepts stable tags (vX.Y.Z): $TAG" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SHA256SUMS" ]]; then
+  echo "error: SHA256SUMS not found: $SHA256SUMS" >&2
+  exit 1
+fi
+
+VERSION="${TAG#v}"
+BASE_URL="https://github.com/HeddleCo/heddle/releases/download/${TAG}"
+
+# Scoop architecture key -> release target triple. Add the arm64 row when
+# aarch64-pc-windows-msvc re-enters the build matrix (release.yml).
+declare -A ARCHES=(
+  ["64bit"]="x86_64-pc-windows-msvc"
+)
+
+# Look up a target's archive sha256 from the aggregate SHA256SUMS. Each
+# line is "<hex>  <filename>"; we match on the exact zip filename so a
+# substring collision (e.g. the .sha256 sidecar) can't be selected.
+sha_for() {
+  local target="$1"
+  local artifact="heddle-${TAG}-${target}.zip"
+  local sha
+  sha="$(awk -v artifact="$artifact" '$2 == artifact { print $1 }' "$SHA256SUMS")"
+  if [[ -z "$sha" ]]; then
+    echo "error: no checksum found for $artifact in $SHA256SUMS" >&2
+    exit 1
+  fi
+  printf '%s' "$sha"
+}
+
+# Build the per-architecture JSON block(s). Each archive extracts to a
+# top-level directory matching the archive stem, so `bin`/`shortcuts`
+# reference heddle.exe inside it.
+ARCH_BLOCKS=""
+for arch in "${!ARCHES[@]}"; do
+  target="${ARCHES[$arch]}"
+  stage="heddle-${TAG}-${target}"
+  sha="$(sha_for "$target")"
+  block=$(cat <<JSON
+        "${arch}": {
+            "url": "${BASE_URL}/${stage}.zip",
+            "hash": "${sha}",
+            "bin": "${stage}\\\\heddle.exe",
+            "shortcuts": [
+                [
+                    "${stage}\\\\heddle.exe",
+                    "heddle"
+                ]
+            ]
+        }
+JSON
+)
+  if [[ -n "$ARCH_BLOCKS" ]]; then
+    ARCH_BLOCKS="${ARCH_BLOCKS},
+${block}"
+  else
+    ARCH_BLOCKS="${block}"
+  fi
+done
+
+mkdir -p "$(dirname "$OUTPUT")"
+
+cat >"$OUTPUT" <<JSON
+{
+    "version": "${VERSION}",
+    "description": "AI-native version control system",
+    "homepage": "https://heddle.sh/",
+    "license": "Apache-2.0",
+    "architecture": {
+${ARCH_BLOCKS}
+    },
+    "checkver": {
+        "github": "https://github.com/HeddleCo/heddle"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "${BASE_URL%/${TAG}}/v\$version/heddle-v\$version-x86_64-pc-windows-msvc.zip",
+                "bin": "heddle-v\$version-x86_64-pc-windows-msvc\\\\heddle.exe",
+                "shortcuts": [
+                    [
+                        "heddle-v\$version-x86_64-pc-windows-msvc\\\\heddle.exe",
+                        "heddle"
+                    ]
+                ]
+            }
+        },
+        "hash": {
+            "url": "\$url.sha256"
+        }
+    },
+    "notes": [
+        "Release archives are signed with cosign (keyless / Sigstore).",
+        "Verify before trusting a binary:",
+        "  cosign verify-blob --certificate-identity-regexp 'https://github.com/HeddleCo/heddle/.+' --certificate-oidc-issuer https://token.actions.githubusercontent.com --signature heddle-v${VERSION}-x86_64-pc-windows-msvc.zip.sig --certificate heddle-v${VERSION}-x86_64-pc-windows-msvc.zip.pem heddle-v${VERSION}-x86_64-pc-windows-msvc.zip",
+        "The .sig and .pem are published alongside the archive on the GitHub Release."
+    ]
+}
+JSON
+
+echo "Rendered $OUTPUT"


### PR DESCRIPTION
Closes #233

Adds the **Scoop** packaging channel for Windows users (`scoop install heddle`), riding the shared publish-manifest substrate shipped in #547. This is the residual Scoop-specific work: a renderer + a publish step, parallel to the existing Homebrew cask channel on the same channel-agnostic substrate.

## What's added

- **`scripts/render-scoop-manifest.sh`** — renders `bucket/heddle.json` from `(tag, SHA256SUMS)`, mirroring `render-homebrew-cask.sh`. Stable-tag-gated (`vX.Y.Z`), exact-filename sha lookup out of `SHA256SUMS`, emits `architecture.64bit` with `url`/`hash`/`bin`/`shortcuts`, plus `checkver` + `autoupdate` (with `$version` templating) and `notes` carrying the cosign keyless verification command. The arch table is structured so re-adding `aarch64-pc-windows-msvc` is a one-row change.
- **`publish-manifests` job (`.github/workflows/release.yml`)** — a *Render Scoop manifest* step + a *Publish Scoop manifest PR* step targeting `HeddleCo/scoop-heddle` (`bucket/heddle.json`), reusing the same stable-only `create-github-app-token` App token (scope widened to `homebrew-heddle,scoop-heddle`). Inherits the job's `if: needs.validate-tag.outputs.kind == 'stable'` gate.
- **`scripts/check-release-pipeline.sh`** — new assertion `Scoop manifest publication wired` (renderer executable + `bucket/heddle.json` + App token + `HeddleCo/scoop-heddle`), parallel to the Homebrew assertion.
- **`RELEASING.md`** — a *Scoop manifest publication* section parallel to Homebrew: bucket add/install path, manifest shape, cosign verification, the parked-arm64 caveat; App-install note updated to include `scoop-heddle`.

## Verification

- `bash scripts/check-release-pipeline.sh` → **release-pipeline check passed** (includes `ok: Scoop manifest publication wired`).
- `python3 -m json.tool` on a sample render → valid JSON; `release.yml` parses as YAML.

## Sample rendered `bucket/heddle.json` (from a v0.3.0 sample SHA256SUMS)

```json
{
    "version": "0.3.0",
    "description": "AI-native version control system",
    "homepage": "https://heddle.sh/",
    "license": "Apache-2.0",
    "architecture": {
        "64bit": {
            "url": "https://github.com/HeddleCo/heddle/releases/download/v0.3.0/heddle-v0.3.0-x86_64-pc-windows-msvc.zip",
            "hash": "aaaa1111...8888",
            "bin": "heddle-v0.3.0-x86_64-pc-windows-msvc\\heddle.exe",
            "shortcuts": [["heddle-v0.3.0-x86_64-pc-windows-msvc\\heddle.exe", "heddle"]]
        }
    },
    "checkver": { "github": "https://github.com/HeddleCo/heddle" },
    "autoupdate": {
        "architecture": {
            "64bit": {
                "url": "https://github.com/HeddleCo/heddle/releases/download/v$version/heddle-v$version-x86_64-pc-windows-msvc.zip",
                "bin": "heddle-v$version-x86_64-pc-windows-msvc\\heddle.exe",
                ...
            }
        },
        "hash": { "url": "$url.sha256" }
    },
    "notes": ["Release archives are signed with cosign ...", "..."]
}
```

## Notes / gaps

- **x64 only.** `aarch64-pc-windows-msvc` is parked in the release build matrix (cosign-installer@v3 ships no win-arm64 asset; #347). The Win-arm64 manifest entry from #233's AC cannot land until that target is built — flagged, not blocked: the renderer is arm64-ready (add one `ARCHES` row). The Win-arm64 `scoop install` AC is deferred with the build-matrix target.
- The `scoop-heddle` bucket repo + the release-publisher App install are org-infra owned (per #547 / out-of-scope in the issue); this PR only supplies the renderer + matrix wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/802"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785302473&installation_id=132405951&pr_number=802&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F802&signature=6010881a9ebe36e1e923c8a3dd5f6efa1d616c3a9951ec5b4bc2faa2c4494906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->