### PR TITLE
feat(bridge): materialize worktree checkout from heddle state, not the mirror (#568 P1)

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -27,8 +27,9 @@ use sley::{
 };
 
 use super::{
-    git_export::{export_all, export_current_thread},
+    git_export::{commit_is_byte_faithful, export_all, export_current_thread},
     git_ingest::import_git_history,
+    git_reconstruct::{commit_object_id, reconstruct_commit_bytes, write_commit_object},
     git_util::ImportStats,
 };
 
@@ -594,6 +595,14 @@ impl SyncMapping {
     /// Iterate over mappings.
     pub(crate) fn iter(&self) -> impl Iterator<Item = (&ChangeId, &ObjectId)> {
         self.heddle_to_git.iter()
+    }
+
+    /// Whether the in-memory mapping holds no `ChangeId → git OID` entries. The
+    /// checkout-materialization path (#568 P1) uses this to decide whether it must
+    /// hydrate the mapping from disk (a standalone `bridge git checkout`) or trust
+    /// the mapping export just built in memory (a checkpoint/push).
+    pub(crate) fn is_empty(&self) -> bool {
+        self.heddle_to_git.is_empty()
     }
 
     pub(crate) fn retain_git_objects(&mut self, repo: &SleyRepository) {
@@ -1665,6 +1674,18 @@ impl<'a> GitBridge<'a> {
         state_id: &ChangeId,
     ) -> GitResult<WriteThroughOutcome> {
         let mirror_repo = self.open_git_repo()?;
+        // Reconstructing a faithful commit from state (#568 P1) resolves each
+        // parent's git OID through the bridge mapping. A checkpoint/push runs
+        // export first, which leaves the in-memory mapping populated for the
+        // served set — trust it, and do NOT re-read from disk (notes vs sidecar
+        // can legitimately disagree mid-operation, e.g. a `--git-commit` merge
+        // checkpoint that has not yet flushed; clobbering the freshly-built
+        // mapping with a disk read trips the conflict guard). Only a STANDALONE
+        // checkout (`bridge git checkout`, no preceding export) starts with an
+        // empty mapping; hydrate it from disk in that case alone.
+        if self.mapping.is_empty() {
+            self.build_existing_mapping(None)?;
+        }
         let git_oid = if let Some(git_oid) = self.mapping.get_git(state_id) {
             git_oid
         } else if let Some(git_commit) = self
@@ -1707,22 +1728,23 @@ impl<'a> GitBridge<'a> {
             .flatten()
             .and_then(|reference| reference.peeled_oid(&object_repo).ok().flatten());
 
+        let heddle_repo = self.heddle_repo;
+        let mapping = &self.mapping;
         let write_result = (|| -> GitResult<()> {
-            // Incremental object copy (perf): copying the new commit's full
-            // reachable closure from the mirror into the checkout re-walks +
-            // delta-compresses the ENTIRE tree every checkpoint — ~115s of the
-            // ~140s on the ~6k-object ghostty tree, scaling with total history
-            // rather than the change. But the checkout already holds the prior
-            // HEAD (`previous_branch`) and its whole closure. So exclude that
-            // closure from the copy: only objects genuinely new since the parent
-            // are walked + packed. Excluding the parent COMMIT alone is not enough
-            // — the new commit's tree re-reaches the parent's unchanged
-            // trees/blobs, so they would not be pruned. Compute the parent's FULL
-            // closure from the DESTINATION (cheap: those objects are local and
-            // already packed) and exclude all of it. Byte-identical result — every
-            // pruned object was already present in the checkout; only the transfer
-            // is smaller (O(changed) not O(history)). First checkpoint on a thread
-            // has no previous branch, so the exclude set is empty (full copy).
+            // Incremental object materialization (perf): bringing the new commit's
+            // full reachable closure into the checkout re-walks the ENTIRE tree
+            // every checkpoint — ~115s of the ~140s on the ~6k-object ghostty tree,
+            // scaling with total history rather than the change. But the checkout
+            // already holds the prior HEAD (`previous_branch`) and its whole
+            // closure. So exclude that closure: only objects genuinely new since
+            // the parent are reconstructed/copied. Excluding the parent COMMIT
+            // alone is not enough — the new commit's tree re-reaches the parent's
+            // unchanged trees/blobs, so they would not be pruned. Compute the
+            // parent's FULL closure from the DESTINATION (cheap: those objects are
+            // local and already packed) and exclude all of it. Byte-identical
+            // result — every pruned object was already present in the checkout.
+            // First checkpoint on a thread has no previous branch, so the exclude
+            // set is empty (full materialization).
             let excluded: HashSet<ObjectId> = match previous_branch {
                 Some(parent) => sley::plumbing::sley_odb::collect_reachable_object_ids(
                     object_repo.objects().as_ref(),
@@ -1732,7 +1754,22 @@ impl<'a> GitBridge<'a> {
                 .map_err(|error| GitBridgeError::Git(error.to_string()))?,
                 None => HashSet::new(),
             };
-            copy_reachable_objects_excluding(&mirror_repo, &object_repo, [git_oid], &excluded)?;
+            // #568 P1: materialize the checkout from heddle state, NOT by copying
+            // the eager `.heddle/git` mirror's verbatim objects. Each byte-faithful
+            // commit's object closure is reconstructed directly into the checkout
+            // `object_repo`; the mirror is consulted only for the lossy residual
+            // (commits whose original bytes can't be re-derived). This is the
+            // strategic flip — heddle-native store feeds the worktree, git is a
+            // derived projection — with a per-commit fallback so nothing is lost.
+            materialize_checkout_closure_from_state(
+                heddle_repo,
+                mapping,
+                &mirror_repo,
+                &object_repo,
+                state_id,
+                git_oid,
+                &excluded,
+            )?;
             // Atomic temp+rename so a torn write can't leave HEAD in a
             // self-inconsistent state mid-write-through (the rollback
             // path below restores previous_head on any later failure).
@@ -3795,6 +3832,138 @@ fn clone_url_to_bare_via_sley(
     Ok(outcome
         .head_symref
         .and_then(|target| target.strip_prefix("refs/heads/").map(str::to_string)))
+}
+
+/// Materialize the checkout `.git` object closure for the commit mapped to
+/// `tip_state_id` (`tip_oid`) — reconstructing every byte-faithful commit from
+/// heddle state, and copying only the lossy residual from the eager `.heddle/git`
+/// mirror (#568 P1).
+///
+/// Walks the heddle state DAG from `tip_state_id`. For each visited state:
+///   * its mapped git OID is already in `excluded` (the prior checkout HEAD's full
+///     closure, already on disk) ⇒ skip it AND its ancestors — that subgraph is
+///     present;
+///   * [`commit_is_byte_faithful`] ⇒ reconstruct the commit object (and, via
+///     [`reconstruct_commit_bytes`]'s [`export_tree`], its whole tree/blob closure)
+///     directly into `object_repo`, then recurse into its parents;
+///   * otherwise (lossy: `--lossy` import or non-UTF8 identity — the residual the
+///     mirror exclusively holds) ⇒ copy that commit's full reachable closure from
+///     `mirror_repo` and DO NOT recurse (the copy already brought its ancestry).
+///
+/// CRITICAL safety gate: every reconstructed commit's git OID MUST equal the
+/// mapped `git_oid`. A mismatch means reconstruction diverged from the imported
+/// bytes (an unmodeled fidelity gap), which would silently materialize a
+/// wrong-OID checkout — so this HARD-ERRORS instead. This assertion is what lets
+/// the reconstruction path be trusted as a mirror replacement.
+///
+/// Output is byte-identical to the prior `copy_reachable_objects_excluding(mirror
+/// → checkout)`: git objects are content-addressed, so a faithful reconstruction
+/// lands the exact same OID the mirror copy would have, and the lossy path copies
+/// verbatim. The exclude set keeps it O(objects new since the parent).
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_checkout_closure_from_state(
+    heddle_repo: &HeddleRepository,
+    mapping: &SyncMapping,
+    mirror_repo: &SleyRepository,
+    object_repo: &SleyRepository,
+    tip_state_id: &ChangeId,
+    tip_oid: ObjectId,
+    excluded: &HashSet<ObjectId>,
+) -> GitResult<()> {
+    // Lossy commits whose closure is copied verbatim from the mirror. Their roots
+    // are batched and copied once at the end (a single excluding pack install,
+    // matching the prior single-copy perf shape) rather than per-commit.
+    let mut lossy_roots: Vec<ObjectId> = Vec::new();
+    let mut stack: Vec<ChangeId> = vec![*tip_state_id];
+    let mut seen: HashSet<ChangeId> = HashSet::new();
+
+    while let Some(state_id) = stack.pop() {
+        if !seen.insert(state_id) {
+            continue;
+        }
+        let Some(git_oid) = resolve_mapped_git_oid(heddle_repo, mapping, &state_id, object_repo)?
+        else {
+            // No mapping for this state: it was never exported (e.g. an embargoed
+            // ancestor withheld from the served frontier). The tip itself always
+            // resolves (`tip_oid`), and a withheld ancestor's git object is, by
+            // construction, absent from both store-reconstruction and the served
+            // mirror — so there is nothing to materialize. Skip without recursing.
+            continue;
+        };
+
+        // Already on disk (this state's object is in the parent's excluded closure,
+        // or a sibling branch already materialized it): the whole subgraph beneath
+        // it is present too, so prune here.
+        if excluded.contains(&git_oid) || object_repo.read_object(&git_oid).is_ok() {
+            continue;
+        }
+
+        let state = heddle_repo
+            .store()
+            .get_state(&state_id)?
+            .ok_or(GitBridgeError::StateNotFound(state_id))?;
+
+        if commit_is_byte_faithful(&state) {
+            let content = reconstruct_commit_bytes(heddle_repo, object_repo, mapping, &state)?;
+            // The byte-exact gate (#568 P1): a faithful reconstruction MUST hash to
+            // the mapped OID. If it does not, refuse — never write a wrong-SHA
+            // object into the worktree.
+            let reconstructed = commit_object_id(&content);
+            if reconstructed != git_oid {
+                return Err(GitBridgeError::Git(format!(
+                    "checkout reconstruction OID mismatch for state {state_id}: reconstructed {reconstructed}, expected mapped {git_oid}; \
+                     refusing to materialize a wrong-OID checkout (unmodeled fidelity gap)"
+                )));
+            }
+            let written = write_commit_object(object_repo, &content)?;
+            debug_assert_eq!(written, git_oid);
+            stack.extend(state.parents.iter().copied());
+        } else {
+            // Lossy residual: the verbatim bytes live only in the mirror. Copy this
+            // commit's full closure from there and stop — the copy carries its
+            // ancestry, so we don't reconstruct (or re-copy) beneath it.
+            lossy_roots.push(git_oid);
+        }
+    }
+
+    // Ensure the requested tip is materialized even in the degenerate case where
+    // the walk skipped it (e.g. an unmapped store state that nonetheless has a
+    // mirror object): fall back to the mirror copy for it. The faithful path above
+    // already wrote it when reconstructable, and a redundant root here is pruned
+    // by the exclude set / idempotent install.
+    if object_repo.read_object(&tip_oid).is_err() && !lossy_roots.contains(&tip_oid) {
+        lossy_roots.push(tip_oid);
+    }
+
+    if !lossy_roots.is_empty() {
+        copy_reachable_objects_excluding(mirror_repo, object_repo, lossy_roots, excluded)?;
+    }
+
+    Ok(())
+}
+
+/// Resolve the git OID a heddle state maps to, preferring the in-memory bridge
+/// mapping and falling back to the git-overlay checkpoint mapping (the same
+/// resolution the checkout tip uses). Returns `None` when the state has no mapped
+/// git object at all.
+fn resolve_mapped_git_oid(
+    heddle_repo: &HeddleRepository,
+    mapping: &SyncMapping,
+    state_id: &ChangeId,
+    object_repo: &SleyRepository,
+) -> GitResult<Option<ObjectId>> {
+    if let Some(git_oid) = mapping.get_git(state_id) {
+        return Ok(Some(git_oid));
+    }
+    if let Some(git_commit) = heddle_repo
+        .git_overlay_mapped_git_commit_for_change(state_id)
+        .map_err(|error| GitBridgeError::Git(error.to_string()))?
+    {
+        let oid = ObjectId::from_hex(object_repo.object_format(), &git_commit)
+            .map_err(|error| GitBridgeError::InvalidMapping(error.to_string()))?;
+        return Ok(Some(oid));
+    }
+    Ok(None)
 }
 
 pub(crate) fn copy_reachable_objects(

--- a/crates/cli/src/bridge/git_export.rs
+++ b/crates/cli/src/bridge/git_export.rs
@@ -70,7 +70,14 @@ fn identity_is_byte_faithful(who: &Principal) -> bool {
 /// When false the caller MUST keep the verbatim mirror bytes / preserved mapped
 /// OID (or fall through to the native mint) rather than mint a wrong-SHA
 /// reconstructed object.
-fn commit_is_byte_faithful(state: &State) -> bool {
+///
+/// `pub(crate)` so the checkout write-through path (#568 P1,
+/// `git_core::write_thread_state_checkout_from_existing_mirror`) reads the SAME
+/// single faithful-or-lossy discriminator the export path does — reconstruct
+/// faithful commits from state, mirror-backstop the lossy residual. Keeping ONE
+/// chokepoint for the decision means a new consumer cannot drift to a different
+/// (wrong-SHA) rule.
+pub(crate) fn commit_is_byte_faithful(state: &State) -> bool {
     has_git_fidelity(state)
         && !state.git_lossy
         && identity_is_byte_faithful(&state.attribution.principal)

--- a/crates/cli/src/bridge/test_support.rs
+++ b/crates/cli/src/bridge/test_support.rs
@@ -249,3 +249,27 @@ pub fn heddle_repo<'a>(bridge: &'a GitBridge<'a>) -> &'a HeddleRepository {
 pub fn open_repo(path: &Path) -> GitResult<SleyRepository> {
     git_core::open_repo(path)
 }
+
+/// Drive the #568 P1 checkout-materialization closure walk directly: reconstruct
+/// faithful commits from heddle state into `object_repo`, mirror-backstop the
+/// lossy residual. Used by the bridge integration tests to prove a faithful
+/// commit materializes WITHOUT the mirror holding its objects (and that the OID
+/// safety gate fires on a divergence).
+pub fn materialize_checkout_closure_from_state(
+    bridge: &GitBridge<'_>,
+    mirror_repo: &SleyRepository,
+    object_repo: &SleyRepository,
+    tip_state_id: &ChangeId,
+    tip_oid: ObjectId,
+    excluded: &HashSet<ObjectId>,
+) -> GitResult<()> {
+    git_core::materialize_checkout_closure_from_state(
+        bridge.heddle_repo,
+        &bridge.mapping,
+        mirror_repo,
+        object_repo,
+        tip_state_id,
+        tip_oid,
+        excluded,
+    )
+}

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -1200,6 +1200,233 @@ fn both_engines_fail_hard_on_default_rerun_after_lossy() {
     }
 }
 
+/// #568 P1: the checkout-materialization closure walk reconstructs a
+/// byte-faithful commit's objects DIRECTLY from heddle state into the worktree
+/// `.git`, instead of copying the verbatim objects out of the eager `.heddle/git`
+/// mirror. Proven by handing the walk an EMPTY mirror: if it still leaned on the
+/// mirror copy the commit could not materialize, but reconstruction-from-state
+/// lands the byte-identical OID with nothing in the mirror to copy.
+#[test]
+fn checkout_materialization_reconstructs_faithful_commit_from_empty_mirror() {
+    use cli::bridge::git_reconstruct::commit_object_id;
+    use objects::object::{Attribution, Principal, State};
+    use std::collections::HashSet;
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+
+    // A faithful root state: git-fidelity (`raw_message`), valid UTF-8 identity,
+    // not lossy → `commit_is_byte_faithful` is true, so it routes to reconstruct.
+    let blob_hash = repo
+        .store()
+        .put_blob(&Blob::from_slice(b"hello\n"))
+        .expect("put blob");
+    let tree_hash = repo
+        .store()
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+        ]))
+        .expect("put tree");
+    let state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    )
+    .with_raw_message("an imported commit\n");
+    repo.store().put_state(&state).expect("put state");
+    let state_id = state.change_id;
+
+    let mut bridge = GitBridge::new(&repo);
+
+    // Learn the expected git OID the SAME way export does — reconstruct the
+    // commit's bytes from state and hash them — and seed the bridge mapping so
+    // the walk's OID-equality gate has an expected target.
+    let scratch_temp = TempDir::new().expect("scratch temp");
+    let scratch = SleyRepository::init_bare(scratch_temp.path()).expect("scratch repo");
+    let expected_oid = bridge
+        .reconstruct_and_write_commit(&scratch, &state)
+        .expect("reconstruct expected oid");
+    test_support::mapping_mut(&mut bridge).insert(state_id, expected_oid);
+
+    // The mirror is EMPTY — a copy-from-mirror path could not materialize the
+    // commit. The checkout object db is empty too (fresh worktree).
+    let mirror_temp = TempDir::new().expect("mirror temp");
+    let mirror_repo = SleyRepository::init_bare(mirror_temp.path()).expect("empty mirror");
+    let checkout_temp = TempDir::new().expect("checkout temp");
+    let object_repo = SleyRepository::init_bare(checkout_temp.path()).expect("checkout odb");
+
+    assert!(
+        mirror_repo.read_object(&expected_oid).is_err(),
+        "test invariant: the mirror must NOT hold the commit — reconstruction is the only way it can appear"
+    );
+    assert!(
+        object_repo.read_object(&expected_oid).is_err(),
+        "test invariant: the checkout starts without the commit"
+    );
+
+    test_support::materialize_checkout_closure_from_state(
+        &bridge,
+        &mirror_repo,
+        &object_repo,
+        &state_id,
+        expected_oid,
+        &HashSet::new(),
+    )
+    .expect("materialize faithful commit from state");
+
+    // The checkout now carries the byte-identical commit object AND its tree/blob
+    // closure — all reconstructed from state, none copied from the empty mirror.
+    let commit = object_repo
+        .read_commit(&expected_oid)
+        .expect("checkout must hold the reconstructed commit");
+    assert_eq!(
+        commit_object_id(
+            &bridge
+                .reconstruct_commit_bytes(&object_repo, &state)
+                .expect("re-reconstruct")
+        ),
+        expected_oid,
+        "reconstructed OID is byte-identical to the mapped expected OID",
+    );
+    assert!(
+        object_repo.read_object(&commit.tree).is_ok(),
+        "the commit's tree must be materialized into the checkout too",
+    );
+}
+
+/// #568 P1 safety gate: when a commit is classified faithful but reconstructs to
+/// a DIFFERENT OID than the mapping expects (an unmodeled fidelity gap), the walk
+/// MUST hard-error rather than silently materialize a wrong-OID checkout.
+#[test]
+fn checkout_materialization_hard_errors_on_oid_mismatch() {
+    use objects::object::{Attribution, Principal, State};
+    use std::collections::HashSet;
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+
+    let blob_hash = repo
+        .store()
+        .put_blob(&Blob::from_slice(b"hello\n"))
+        .expect("put blob");
+    let tree_hash = repo
+        .store()
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+        ]))
+        .expect("put tree");
+    let state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    )
+    .with_raw_message("an imported commit\n");
+    repo.store().put_state(&state).expect("put state");
+    let state_id = state.change_id;
+
+    let mut bridge = GitBridge::new(&repo);
+    // Deliberately map the state to a WRONG OID — reconstruction will produce a
+    // different id, which must trip the gate.
+    let wrong_oid: ObjectId = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        .parse()
+        .expect("oid");
+    test_support::mapping_mut(&mut bridge).insert(state_id, wrong_oid);
+
+    let mirror_temp = TempDir::new().expect("mirror temp");
+    let mirror_repo = SleyRepository::init_bare(mirror_temp.path()).expect("mirror");
+    let checkout_temp = TempDir::new().expect("checkout temp");
+    let object_repo = SleyRepository::init_bare(checkout_temp.path()).expect("checkout odb");
+
+    let err = test_support::materialize_checkout_closure_from_state(
+        &bridge,
+        &mirror_repo,
+        &object_repo,
+        &state_id,
+        wrong_oid,
+        &HashSet::new(),
+    )
+    .expect_err("OID mismatch must hard-error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("OID mismatch") && msg.contains("refusing to materialize"),
+        "error must name the OID-mismatch safety gate; got: {msg}"
+    );
+    assert!(
+        object_repo.read_object(&wrong_oid).is_err(),
+        "no wrong-OID object may be written to the checkout on the failure path",
+    );
+}
+
+/// #568 P1: a LOSSY commit (verbatim bytes live ONLY in the mirror — `--lossy`
+/// import or non-UTF8 identity) is NOT reconstructed; the walk backstops to the
+/// mirror copy. Proven by reconstructing-then-stashing the object only in the
+/// mirror (not the checkout) and confirming the lossy state still materializes.
+#[test]
+fn checkout_materialization_backstops_lossy_commit_from_mirror() {
+    use objects::object::{Attribution, Principal, State};
+    use std::collections::HashSet;
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+
+    let blob_hash = repo
+        .store()
+        .put_blob(&Blob::from_slice(b"hello\n"))
+        .expect("put blob");
+    let tree_hash = repo
+        .store()
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+        ]))
+        .expect("put tree");
+    // `git_lossy` → NOT byte-faithful → mirror backstop, even though raw_message
+    // is present.
+    let state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    )
+    .with_raw_message("a lossy imported commit\n")
+    .with_git_lossy(true);
+    repo.store().put_state(&state).expect("put state");
+    let state_id = state.change_id;
+
+    let mut bridge = GitBridge::new(&repo);
+
+    // The mirror is the ONLY home of the lossy commit's bytes. Stage the object
+    // there (the verbatim bytes); use the reconstructed bytes as a stand-in for
+    // the verbatim ones (the tree/identity here happen to round-trip; the point is
+    // the walk must NOT reconstruct-into-checkout and must copy from the mirror).
+    let mirror_temp = TempDir::new().expect("mirror temp");
+    let mirror_repo = SleyRepository::init_bare(mirror_temp.path()).expect("mirror");
+    let lossy_oid = bridge
+        .reconstruct_and_write_commit(&mirror_repo, &state)
+        .expect("stage lossy bytes in the mirror");
+    test_support::mapping_mut(&mut bridge).insert(state_id, lossy_oid);
+
+    let checkout_temp = TempDir::new().expect("checkout temp");
+    let object_repo = SleyRepository::init_bare(checkout_temp.path()).expect("checkout odb");
+    assert!(
+        object_repo.read_object(&lossy_oid).is_err(),
+        "test invariant: the checkout starts without the lossy commit",
+    );
+
+    test_support::materialize_checkout_closure_from_state(
+        &bridge,
+        &mirror_repo,
+        &object_repo,
+        &state_id,
+        lossy_oid,
+        &HashSet::new(),
+    )
+    .expect("lossy commit materializes via the mirror backstop");
+
+    assert!(
+        object_repo.read_object(&lossy_oid).is_ok(),
+        "the lossy commit must be copied from the mirror into the checkout",
+    );
+}
+
 #[test]
 fn import_all_lossy_clean_repo_reports_no_lossy_entries() {
     let heddle_temp = TempDir::new().expect("heddle temp");


### PR DESCRIPTION
First step of the mirror demotion (**#568**): make the worktree `.git` checkout materialize git commits by **reconstructing them from heddle state**, instead of copying objects out of the eager `.heddle/git` mirror — with the mirror backstopping only the lossy (non-byte-faithful) residual.

## VERIFY findings (pre-implementation)

P1 was **NOT** already done. On `origin/main` (f6cdcd63), `write_thread_state_checkout_from_existing_mirror` (`crates/cli/src/bridge/git_core.rs`) still copied the tip's full reachable closure unconditionally:

```rust
copy_reachable_objects_excluding(&mirror_repo, &object_repo, [git_oid], &excluded)?;
```

The substrate the brief referenced **does** exist and is live (closed #596/#597): `reconstruct_commit_bytes` / `build_commit_content` / `write_commit_object` (`git_reconstruct.rs`), `export_tree` onto the sley sink (`git_export.rs`), and the `commit_is_byte_faithful` gate (`git_export.rs`, including the #593 identity check). So P1 is purely heddle-side re-plumbing of which sink the existing reconstruction writes into — no new sley work.

## What changed

- **`write_thread_state_checkout_from_existing_mirror`** now calls a new `materialize_checkout_closure_from_state` helper that walks the thread's state closure:
  - **faithful** commit (`commit_is_byte_faithful`): reconstruct its objects directly into the checkout ODB (`export_tree` writes the tree/blob closure, `write_commit_object` writes the commit); recurse into parents.
  - **lossy** commit (`!commit_is_byte_faithful` — `--lossy` import or non-UTF8 identity): copy that commit's closure from the mirror and stop (the verbatim bytes live only there — `git_export.rs`).
  - already-on-disk subgraphs (the prior HEAD's `excluded` closure, or a sibling branch's objects) are pruned — the incremental O(objects-new-since-parent) perf invariant is preserved.
- **`commit_is_byte_faithful`** lifted to `pub(crate)` so the checkout path reads the **same single discriminator** the export path does (one chokepoint, no drift to a wrong-SHA rule).
- The standalone `bridge git checkout` path (no preceding export) hydrates the mapping from disk **only when empty**, so a checkpoint/push keeps its freshly-built in-memory mapping and never re-trips the notes-vs-sidecar conflict guard.

## Correctness gate (loud)

For every reconstructed commit, the reconstructed git OID **MUST equal** the mapped `git_oid`. On mismatch it hard-errors:

> `checkout reconstruction OID mismatch for state <id>: reconstructed <a>, expected mapped <b>; refusing to materialize a wrong-OID checkout (unmodeled fidelity gap)`

— never silently materializes a wrong-OID checkout. This is the safety net that lets the reconstruction path be trusted.

## Before/after byte-identical proof

Same `.heddle` store + mirror, materializing the worktree `.git` via the **OLD** (origin/main, copy-from-mirror) and **NEW** (reconstruct-from-state) binaries, then diffing HEAD / refs / full object set / index tree / clean status:

```
=== DIFF (old vs new) ===
>>> BYTE-IDENTICAL worktree .git after re-materialization
```

Identical: `HEAD`, both branch refs, all 16 objects (commits/trees/blobs), `INDEX_TREE`, and `STATUS_LINES=0`. (A naive "two independent heddle runs" diff would differ only because ChangeIds/native-commit identities are minted fresh per run — so the proof fixes one store and varies only the materialization binary.)

## fsck-clean proof

```
[ok] repository is valid (5 objects checked)
```

(`heddle fsck` on the NEW-materialized worktree.)

## Lossy backstop

`!commit_is_byte_faithful` commits keep the mirror-copy path verbatim — their bytes exist nowhere else. Exercised by `checkout_materialization_backstops_lossy_commit_from_mirror` (a `git_lossy` state materializes only because the mirror holds it).

## Tests (regression, `git_bridge_integration.rs`)

- `checkout_materialization_reconstructs_faithful_commit_from_empty_mirror` — faithful commit materializes into the checkout from an **EMPTY** mirror (reconstruction is the only path that can make it appear; asserts byte-identical OID + tree present).
- `checkout_materialization_hard_errors_on_oid_mismatch` — a faithful-but-wrong-mapped commit hard-errors on the OID gate and writes **nothing**.
- `checkout_materialization_backstops_lossy_commit_from_mirror` — lossy commit backstops from the mirror.

**RED verified:** with the faithful branch disabled (copy-only, the pre-P1 behavior), the faithful + OID-gate tests fail with `not found: object 0cebcf...` / `not found: object deadbeef...`; restoring reconstruction turns them green.

## Gates run (all green, locally)

- `cargo build --locked --workspace` (default) **and** `--all-features`
- `bash scripts/check-no-silent-default-tree-load.sh` (567 files clean)
- `cargo test -p heddle-mount`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p heddle-cli --lib` (662), `--test git_bridge_integration` (93), `--test commit_conformance` + `--test roundtrip_fidelity` (14), `--test cli_integration` git_overlay/replacement matrices (all green), `output_kind_invariant` (12, incl. `doc_samples_match_runtime...`). No `--output json` surface changed.

Linked issue: #568 (this is its first step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785303204&installation_id=132405951&pr_number=803&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F803&signature=986d8cf7c0e7a2c52b56284e00f784e063da0bfa618c45e4210ae2ec6f7f2138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->