### PR TITLE
fix(rebase): route content auto-merge through the semantic merge driver (#116)

### DIFF
--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -1116,4 +1116,89 @@ mod tests {
             "two distinct transaction ids must produce two batches"
         );
     }
+
+    /// Regression for heddle#116: a rebase replay's content auto-merge must
+    /// route through the function-level semantic driver (heddle#68), not the
+    /// text-only `text_hunk_merge` path.
+    ///
+    /// This is the load-bearing structural-reshape shape from the heddle#54
+    /// trip report (mirrored from `semantic::merge_driver::tests`): ours
+    /// reorders every function while theirs edits one and appends another.
+    /// Line-level `text_hunk_merge` can't anchor past the reorder and emits a
+    /// wide conflict block — so before the fix `auto_merge_text_lines` returns
+    /// `None` (no clean merge). The semantic driver matches functions by
+    /// identity and resolves cleanly. The `.rs` path is what selects the
+    /// language; an unparseable / unknown-extension file still falls back to
+    /// the text path inside the driver.
+    #[cfg(feature = "semantic")]
+    #[test]
+    fn auto_merge_routes_structural_reshape_through_semantic_driver() {
+        let base = "\
+fn a() { 1 }
+
+fn b() { 2 }
+
+fn c() { 3 }
+
+fn d() { 4 }
+
+fn e() { 5 }
+";
+        // ours reorders to [e, a, c, b, d] — every line moves.
+        let ours = "\
+fn e() { 5 }
+
+fn a() { 1 }
+
+fn c() { 3 }
+
+fn b() { 2 }
+
+fn d() { 4 }
+";
+        // theirs edits c() and appends f().
+        let theirs = "\
+fn a() { 1 }
+
+fn b() { 2 }
+
+fn c() { 333 }
+
+fn d() { 4 }
+
+fn e() { 5 }
+
+fn f() { 6 }
+";
+
+        // Sanity: the plain text path genuinely conflicts on this shape, so a
+        // clean result below can only come from the semantic driver.
+        assert!(
+            matches!(
+                merge::text_hunk_merge(base.as_bytes(), ours.as_bytes(), theirs.as_bytes()),
+                merge::MergeOutcome::Conflicts { .. }
+            ),
+            "fixture must conflict under the text-only path for this test to be meaningful"
+        );
+
+        let merged = auto_merge_text_lines(
+            base.as_bytes(),
+            ours.as_bytes(),
+            theirs.as_bytes(),
+            std::path::Path::new("src/reshape.rs"),
+        )
+        .unwrap()
+        .expect("semantic driver should resolve the structural reshape cleanly");
+        let merged = String::from_utf8(merged).unwrap();
+
+        assert!(
+            !merged.contains("<<<<<<<"),
+            "no conflict markers expected: {merged}"
+        );
+        assert!(merged.contains("fn c() { 333 }"), "theirs c-edit lost: {merged}");
+        assert!(merged.contains("fn f() { 6 }"), "theirs add lost: {merged}");
+        for name in ["fn a", "fn b", "fn c", "fn d", "fn e"] {
+            assert!(merged.contains(name), "missing {name}: {merged}");
+        }
+    }
 }

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -410,6 +410,7 @@ fn apply_commit(
                         &parent.hash,
                         &existing.hash,
                         &new.hash,
+                        &path,
                     )? && let Some(mode) = merge_file_mode(&parent, &existing, &new)
                     {
                         let mut merged = new;
@@ -490,6 +491,7 @@ fn try_auto_merge_textual_change(
     base: &ContentHash,
     current: &ContentHash,
     incoming: &ContentHash,
+    path: &str,
 ) -> Result<Option<ContentHash>> {
     let Some(base_blob) = repo.store().get_blob(base)? else {
         return Ok(None);
@@ -505,6 +507,7 @@ fn try_auto_merge_textual_change(
         base_blob.content(),
         current_blob.content(),
         incoming_blob.content(),
+        std::path::Path::new(path),
     )?
     else {
         return Ok(None);
@@ -519,14 +522,49 @@ fn try_auto_merge_textual_change(
 /// Returns `Some(bytes)` only when the merge resolves *cleanly* — any
 /// conflict (including binary, delete/modify, or overlapping hunks) returns
 /// `None`, leaving the rebase caller to either invoke `blob_contains_both`
-/// or stop with `ApplyResult::Conflict`. Routes through the native
-/// hunk-level merger added in heddle#79 — always available, no feature
-/// gate — so multi-hunk-per-side edits auto-resolve when disjoint even on
-/// `--no-default-features` builds, addressing the heddle#54 trip report's
-/// rebase failure mode.
-fn auto_merge_text_lines(base: &[u8], current: &[u8], incoming: &[u8]) -> Result<Option<Vec<u8>>> {
-    use merge::{MergeOutcome, text_hunk_merge};
-    match text_hunk_merge(base, current, incoming) {
+/// or stop with `ApplyResult::Conflict`.
+///
+/// Routes through the AST-aware function-level merge driver from heddle#68
+/// (`semantic::merge_driver::semantic_three_way_merge`) — the same driver the
+/// `heddle merge` path uses by default (see
+/// `merge::merge_algo::executor::text_hunk_merge_blobs`, `MergeStrategy::Semantic`).
+/// `path` selects the language; parseable source merges per-item by stable
+/// identity, so a structural reshape (function reorder / add / delete) that
+/// would shift every line past the change point — and so collide under the
+/// line-level `text_hunk_merge` — resolves cleanly. Unknown / unparseable
+/// files fall back to `text_hunk_merge` inside the driver itself.
+///
+/// When the `semantic` feature is compiled out (`--no-default-features`), the
+/// call collapses to the historical `text_hunk_merge` path from heddle#79 —
+/// no behavioural change for non-semantic builds.
+fn auto_merge_text_lines(
+    base: &[u8],
+    current: &[u8],
+    incoming: &[u8],
+    path: &std::path::Path,
+) -> Result<Option<Vec<u8>>> {
+    use merge::MergeOutcome;
+
+    // `current` is "ours" (the rebased-onto state) and `incoming` is "theirs"
+    // (the commit being replayed); the markers are only consumed on a conflict,
+    // which this caller maps to `None`, but keep the labelling consistent with
+    // the `heddle merge` path for any future surfacing.
+    let markers = merge::ConflictMarkers {
+        ours: "CURRENT",
+        theirs: "INCOMING",
+    };
+
+    #[cfg(feature = "semantic")]
+    let outcome = semantic::merge_driver::semantic_three_way_merge(
+        base, current, incoming, path, markers,
+    );
+    #[cfg(not(feature = "semantic"))]
+    let outcome = {
+        let _ = path;
+        merge::text_hunk_merge_with_markers(base, current, incoming, markers)
+    };
+
+    match outcome {
         MergeOutcome::Clean(bytes) => Ok(Some(bytes)),
         MergeOutcome::Conflicts { .. } | MergeOutcome::Binary | MergeOutcome::DeleteVsModify => {
             Ok(None)


### PR DESCRIPTION
## Summary

Closes #116.

`heddle rebase`'s replay-time content auto-merge bypassed the function-level semantic merge driver from heddle#68 ([PR #114](https://github.com/HeddleCo/heddle/pull/114), wiring commit `79104f9`). `auto_merge_text_lines` (in `crates/cli/src/cli/commands/rebase/rebase_ops.rs`) called `merge::text_hunk_merge` directly — the line-level path — so a structural reshape (function reorder / add / delete) during rebase produced the whole-file conflict shape the heddle#54 trip report described, even though `heddle merge` resolves the same shape cleanly via the semantic driver. Rebase is the highest-value daily merge surface, so this silently downgraded function-level semantic merges to text merges.

## Fix

Thread the file path through `try_auto_merge_textual_change` → `auto_merge_text_lines` and route through `semantic::merge_driver::semantic_three_way_merge` — the **same entry point** the `heddle merge` path uses by default (`MergeStrategy::Semantic` in `merge::merge_algo::executor::text_hunk_merge_blobs`). The driver:

- matches parseable source per-item by AST identity, so reorders/adds/deletes merge cleanly;
- falls back to `text_hunk_merge` **internally** on unknown / unparseable / non-UTF-8 files — no behavioural regression for those;
- collapses to the historical `text_hunk_merge` path when the `semantic` feature is compiled out (`--no-default-features`) — verified to compile, no behavioural change for non-semantic builds.

The clean-merge-only contract of the rebase path is preserved: any conflict (incl. binary / delete-vs-modify) still returns `None`, leaving the caller to fall through to `ApplyResult::Conflict`.

## Test evidence

Failing-test-first. Regression test `auto_merge_routes_structural_reshape_through_semantic_driver` (in `rebase_ops.rs`, `#[cfg(feature = "semantic")]`) replays the load-bearing structural-reshape fixture from `semantic::merge_driver::tests`: ours reorders every function, theirs edits one and appends another. The test first asserts the fixture genuinely **conflicts** under `merge::text_hunk_merge` (so a clean result can only come from the semantic driver), then asserts `auto_merge_text_lines(.., Path::new("src/reshape.rs"))` resolves cleanly with both sides' edits preserved and no conflict markers.

- **RED**: `3dd06743c51e1e4950d8fce210cc083bb75c36f4` — test added against the unfixed text-only path (`error[E0061]: this function takes 3 arguments but 4 arguments were supplied` — production `auto_merge_text_lines` had no `path` param and routed through `text_hunk_merge`).
- **GREEN**: `e94d3158b524ad2c295cb3ca92eae4b6d0347b0c` — fix lands; test passes (`test result: ok. 1 passed`).

## Gates run (all green)

- `cargo build --locked --workspace` (default features)
- `cargo build --locked --workspace --all-features`
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,semantic,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,zstd` (non-semantic cfg branch)
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-mount`, `cargo test -p heddle-cli`, `cargo test -p heddle-cli --test cli_integration`
- `cargo clippy --workspace --all-targets -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785303247&installation_id=132405951&pr_number=804&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F804&signature=d21ff507ddfa9d2a5de0a8f55596b14e4e484fc19695535bb8e943af3bd8dc02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->