### PR TITLE
feat(distribution): apt repo + .deb packaging for the heddle CLI

### DIFF
--- a/.github/actions/publish-manifest/action.yml
+++ b/.github/actions/publish-manifest/action.yml
@@ -10,7 +10,11 @@ inputs:
     description: Path inside the target repository to update.
   rendered-file:
     required: true
-    description: Rendered manifest path in the caller workspace.
+    description: >-
+      Rendered manifest path in the caller workspace. A regular file is copied
+      to manifest-path. A directory is synced onto manifest-path as a whole
+      tree (used by the apt channel, whose pool + signed index is a tree, not a
+      single file); manifest-path '.' means the target repository root.
   token:
     required: true
     description: GitHub App installation token with contents and pull-request write access.
@@ -33,10 +37,25 @@ runs:
 
     - name: Copy rendered manifest
       shell: bash
+      env:
+        RENDERED_FILE: ${{ inputs.rendered-file }}
+        MANIFEST_PATH: ${{ inputs.manifest-path }}
       run: |
         set -euo pipefail
-        mkdir -p "package-repo/$(dirname "${{ inputs.manifest-path }}")"
-        cp "${{ inputs.rendered-file }}" "package-repo/${{ inputs.manifest-path }}"
+        if [[ -d "$RENDERED_FILE" ]]; then
+          # Directory source (apt pool + signed index): sync the whole tree.
+          # manifest-path '.' targets the repository root.
+          if [[ "$MANIFEST_PATH" == "." ]]; then
+            dest="package-repo"
+          else
+            dest="package-repo/$MANIFEST_PATH"
+            mkdir -p "$dest"
+          fi
+          cp -a "$RENDERED_FILE/." "$dest/"
+        else
+          mkdir -p "package-repo/$(dirname "$MANIFEST_PATH")"
+          cp "$RENDERED_FILE" "package-repo/$MANIFEST_PATH"
+        fi
 
     - name: Open package update PR
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -688,6 +688,26 @@ jobs:
         shell: bash
         run: scripts/render-scoop-manifest.sh "${{ steps.ver.outputs.tag }}" dist/SHA256SUMS rendered/heddle.json
 
+      - name: Build apt pool + signed index
+        shell: bash
+        env:
+          # Ed25519 signing subkey exported offline from the primary (#328
+          # Decision 2). Imported into an ephemeral GNUPGHOME that lives only
+          # for this step; apt-heddle never sees a secret.
+          HEDDLE_APT_GPG_PRIVATE_KEY: ${{ secrets.HEDDLE_APT_GPG_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          GNUPGHOME="$(mktemp -d)"
+          export GNUPGHOME
+          chmod 700 "$GNUPGHOME"
+          printf '%s' "$HEDDLE_APT_GPG_PRIVATE_KEY" | gpg --batch --import
+          # Sign with the first secret subkey/key id imported above.
+          key_id="$(gpg --list-secret-keys --with-colons | awk -F: '/^fpr:/{print $10; exit}')"
+          HEDDLE_APT_GPG_KEY_ID="$key_id" \
+            scripts/build-apt-pool.sh "${{ steps.ver.outputs.tag }}" \
+              dist/SHA256SUMS dist rendered/apt
+          rm -rf "$GNUPGHOME"
+
       - name: Generate release publisher token
         id: app-token
         uses: actions/create-github-app-token@v2
@@ -695,7 +715,7 @@ jobs:
           app-id: ${{ secrets.HEDDLE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEDDLE_RELEASE_APP_PRIVATE_KEY }}
           owner: HeddleCo
-          repositories: homebrew-heddle,scoop-heddle
+          repositories: homebrew-heddle,scoop-heddle,apt-heddle
 
       - name: Publish Homebrew cask PR
         uses: ./.github/actions/publish-manifest
@@ -715,4 +735,16 @@ jobs:
           rendered-file: rendered/heddle.json
           token: ${{ steps.app-token.outputs.token }}
           channel: scoop
+          version: ${{ steps.ver.outputs.version }}
+
+      - name: Publish apt pool PR
+        uses: ./.github/actions/publish-manifest
+        with:
+          target-repo: HeddleCo/apt-heddle
+          # Whole pool + signed index tree, not a single file. manifest-path
+          # '.' syncs onto the apt-heddle repository root (Pages serves it).
+          manifest-path: .
+          rendered-file: rendered/apt
+          token: ${{ steps.app-token.outputs.token }}
+          channel: apt
           version: ${{ steps.ver.outputs.version }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -204,8 +204,9 @@ Set these GitHub Actions variables as well:
 | `HEDDLE_DEVELOPER_ID_APPLICATION` | Codesigning identity, e.g. `Developer ID Application: HeddleCo, LLC (33V6242M8S)` |
 
 The release-publisher GitHub App should be installed only on
-`homebrew-heddle` and `scoop-heddle` and granted only `Contents: write`
-and `Pull requests: write`.
+`homebrew-heddle`, `scoop-heddle`, and `apt-heddle` and granted only
+`Contents: write` and `Pull requests: write`. The token minted in the
+`publish-manifests` job lists all three in its `repositories:` scope.
 
 ## Scoop manifest publication
 
@@ -243,6 +244,94 @@ or refresh a PR against `scoop-heddle`, which a maintainer merges after
 bucket CI passes. The wiring (renderer present, `bucket/heddle.json`
 path, App token, `HeddleCo/scoop-heddle` target) is asserted by
 `scripts/check-release-pipeline.sh`.
+
+## apt repository publication
+
+The Debian/Ubuntu install path pins Heddle's signing key to its own
+keyring and scopes trust to Heddle's source with `signed-by=` (never
+`apt-key add`, which is removed on modern apt):
+
+```bash
+# 1. Install Heddle's signing key into its own keyring.
+curl -fsSL https://apt.heddle.sh/heddle-archive-keyring.gpg \
+  | sudo tee /usr/share/keyrings/heddle-archive-keyring.gpg > /dev/null
+
+# 2. Register the source, pinned to that keyring + this machine's arch.
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/heddle-archive-keyring.gpg] https://apt.heddle.sh stable main" \
+  | sudo tee /etc/apt/sources.list.d/heddle.list > /dev/null
+
+# 3. Install. The heddle-archive-keyring package keeps the key current
+#    across future `apt upgrade`s.
+sudo apt update && sudo apt install heddle
+```
+
+The modern deb822 form (`/etc/apt/sources.list.d/heddle.sources`) is
+equivalent:
+
+```
+Types: deb
+URIs: https://apt.heddle.sh
+Suites: stable
+Components: main
+Architectures: amd64 arm64
+Signed-By: /usr/share/keyrings/heddle-archive-keyring.gpg
+```
+
+The repository is `HeddleCo/apt-heddle` (git-backed pool + signed index,
+served as static files via GitHub Pages at `apt.heddle.sh`). Stable
+releases run `scripts/build-apt-pool.sh`, which:
+
+- verifies the two `*-unknown-linux-gnu.tar.gz` archives against the
+  release `SHA256SUMS`, then builds `heddle_<version>_amd64.deb` and
+  `heddle_<version>_arm64.deb` into `pool/main/h/heddle/`
+- builds the `heddle-archive-keyring_<n>_all.deb` self-updating trust
+  anchor (it ships the dearmored public key into
+  `/usr/share/keyrings/`), and writes the same key to
+  `heddle-archive-keyring.gpg` at the repo root for manual installers
+- generates the `dists/stable/main/binary-<arch>/Packages{,.gz}` indices
+  and the suite `dists/stable/Release` (single rolling `stable main`
+  suite carrying both arches — the binaries are glibc-dynamic, not
+  codename-specific)
+- GPG-signs `Release` (detached `Release.gpg` + inline `InRelease`) with
+  the Ed25519 signing subkey imported into an ephemeral `GNUPGHOME`. The
+  subkey comes from the `HEDDLE_APT_GPG_PRIVATE_KEY` secret; `apt-heddle`
+  holds no secrets.
+
+Like the Homebrew cask and Scoop manifest, the signed tree is not pushed
+directly: the `publish-manifests` job uses the same release-publisher App
+token (scoped to include `apt-heddle`) and the shared
+`./.github/actions/publish-manifest` composite action to open a PR
+against `apt-heddle` carrying the whole pool + signed index
+(`manifest-path: .`). A maintainer merges it; GitHub Pages then serves
+the merged tree. The wiring (`scripts/build-apt-pool.sh` present, the
+GPG secret imported into an ephemeral `GNUPGHOME`, the `apt-heddle`
+target, and the widened App-token scope) is asserted by
+`scripts/check-release-pipeline.sh`.
+
+The design rationale — hosting platform, GPG key strategy, key rotation,
+and install UX — lives in
+`docs/design/apt-hosting-gpg-spike.md`.
+
+### Required GitHub Actions secrets (apt)
+
+- `HEDDLE_APT_GPG_PRIVATE_KEY` — the armored Ed25519 **signing subkey**
+  exported offline from the primary. The primary stays offline; only the
+  subkey reaches CI, so a leak is revocable without re-minting subscriber
+  trust. Rotate by updating this one secret (no workflow change).
+
+### apt human-infra prerequisites (org-admin)
+
+These are one-time setup steps tracked in
+`docs/design/apt-hosting-gpg-spike.md`. Until they land, the apt leg
+opens its PR but the published repo is not yet reachable at the branded
+URL:
+
+1. Create `HeddleCo/apt-heddle`; install the "Heddle Release Publisher"
+   GitHub App on it (`Contents: write` + `Pull requests: write`).
+2. `apt.heddle.sh` DNS (CNAME → `heddleco.github.io`) + Pages
+   custom-domain + TLS.
+3. Offline-generate the Ed25519 primary + signing subkey; export the
+   subkey to the `HEDDLE_APT_GPG_PRIVATE_KEY` secret.
 
 ### Linux glibc floor
 

--- a/scripts/build-apt-pool.sh
+++ b/scripts/build-apt-pool.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/build-apt-pool.sh <tag> <SHA256SUMS> <staging-dir> <output-dir>
+
+Builds the Heddle apt pool + signed index from the Linux release archives.
+
+  tag          Release tag, e.g. v0.3.0
+  SHA256SUMS   Aggregate checksum file (used to verify the linux tarballs)
+  staging-dir  Directory holding the downloaded release artifacts (the
+               *-unknown-linux-gnu.tar.gz archives live somewhere under it)
+  output-dir   Destination apt tree (mirrors HeddleCo/apt-heddle root):
+                 pool/main/h/heddle/heddle_<ver>_<arch>.deb
+                 pool/main/h/heddle/heddle-archive-keyring_<ver>_all.deb
+                 dists/stable/main/binary-<arch>/Packages{,.gz}
+                 dists/stable/Release   (+ Release.gpg / InRelease when signing)
+                 heddle-archive-keyring.gpg   (dearmored public key, repo root)
+
+Channel: apt. Parallel to scripts/render-scoop-manifest.sh (Scoop) and
+scripts/render-homebrew-cask.sh (Homebrew) on the shared publish-manifest
+substrate. Consumes the git-backed apt-heddle composition branch
+(docs/design/apt-hosting-gpg-spike.md). Stable tags only.
+
+GPG signing is opt-in via the environment, so the script runs in CI (where
+the Ed25519 signing subkey is imported into an ephemeral GNUPGHOME) and
+locally (unsigned dry-run for shape validation):
+
+  HEDDLE_APT_GPG_KEY_ID    key/subkey id or fingerprint to sign Release with.
+                           When set, the script writes Release.gpg + InRelease
+                           and exports the dearmored public key to the repo
+                           root. When unset, the index is built unsigned and a
+                           warning is printed (local dry-run only — CI must set
+                           it; the publish-manifests apt leg asserts this).
+  GNUPGHOME                honoured as-is (ephemeral GNUPGHOME per #328
+                           Decision 2); the caller imports the subkey into it.
+
+Architectures: amd64 (x86_64-unknown-linux-gnu) + arm64
+(aarch64-unknown-linux-gnu). Suite: a single rolling `stable main`
+(#328 Decision 3).
+USAGE
+}
+
+if [[ $# -ne 4 ]]; then
+  usage
+  exit 2
+fi
+
+TAG="$1"
+SHA256SUMS="$2"
+STAGING="$3"
+OUTPUT="$4"
+
+if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "error: apt pool build only accepts stable tags (vX.Y.Z): $TAG" >&2
+  exit 1
+fi
+
+if [[ ! -f "$SHA256SUMS" ]]; then
+  echo "error: SHA256SUMS not found: $SHA256SUMS" >&2
+  exit 1
+fi
+
+if [[ ! -d "$STAGING" ]]; then
+  echo "error: staging dir not found: $STAGING" >&2
+  exit 1
+fi
+
+for tool in dpkg-deb ar apt-ftparchive gzip; do
+  if ! command -v "$tool" >/dev/null 2>&1; then
+    echo "error: required tool not found on PATH: $tool" >&2
+    exit 1
+  fi
+done
+
+VERSION="${TAG#v}"
+MAINTAINER="Heddle <release@heddle.sh>"
+HOMEPAGE="https://heddle.sh/"
+DESC_SHORT="AI-native version control system"
+DESC_LONG="Heddle is an AI-native version control system that overlays git."
+# Keyring package version is independent of the CLI version; bump when the
+# embedded trust anchor changes. Held at 1 until the first primary rotation.
+KEYRING_VERSION="1"
+
+# apt arch -> release target triple. Both linux-gnu legs are glibc-dynamic
+# (glibc floor 2.35, #549), so a single rolling suite carries both.
+declare -A ARCHES=(
+  ["amd64"]="x86_64-unknown-linux-gnu"
+  ["arm64"]="aarch64-unknown-linux-gnu"
+)
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+POOLDIR="$OUTPUT/pool/main/h/heddle"
+mkdir -p "$POOLDIR"
+
+# Verify a target's archive sha256 against the aggregate SHA256SUMS. Each
+# line is "<hex>  <filename>"; match the exact tarball filename so a
+# substring collision (e.g. the .sha256 sidecar) can't be selected.
+sha_for() {
+  local target="$1"
+  local artifact="heddle-${TAG}-${target}.tar.gz"
+  local sha
+  sha="$(awk -v artifact="$artifact" '$2 == artifact { print $1 }' "$SHA256SUMS")"
+  if [[ -z "$sha" ]]; then
+    echo "error: no checksum found for $artifact in $SHA256SUMS" >&2
+    exit 1
+  fi
+  printf '%s' "$sha"
+}
+
+# Locate the staged tarball (download-artifact nests it under per-artifact
+# subdirs; find the exact basename anywhere under staging).
+find_archive() {
+  local artifact="$1"
+  local found
+  found="$(find "$STAGING" -type f -name "$artifact" -print -quit)"
+  if [[ -z "$found" ]]; then
+    echo "error: release archive not found under $STAGING: $artifact" >&2
+    exit 1
+  fi
+  printf '%s' "$found"
+}
+
+# Build one architecture .deb from its release tarball. The tarball extracts
+# to a top-level heddle-<tag>-<target>/ dir containing the `heddle` binary
+# plus README/LICENSE/NOTICE (release.yml stage step).
+build_cli_deb() {
+  local arch="$1" target="$2"
+  local artifact="heddle-${TAG}-${target}.tar.gz"
+  local archive expected_sha actual_sha
+  archive="$(find_archive "$artifact")"
+  expected_sha="$(sha_for "$target")"
+  actual_sha="$(sha256sum "$archive" | awk '{ print $1 }')"
+  if [[ "$actual_sha" != "$expected_sha" ]]; then
+    echo "error: sha256 mismatch for $artifact" >&2
+    echo "  expected $expected_sha (SHA256SUMS)" >&2
+    echo "  actual   $actual_sha ($archive)" >&2
+    exit 1
+  fi
+
+  local root="$WORK/cli-$arch"
+  local stage="heddle-${TAG}-${target}"
+  rm -rf "$root"
+  mkdir -p "$root/usr/bin" "$root/usr/share/doc/heddle" "$root/DEBIAN"
+  tar -xzf "$archive" -C "$WORK"
+  install -m 0755 "$WORK/$stage/heddle" "$root/usr/bin/heddle"
+  install -m 0644 "$WORK/$stage/README.md" "$root/usr/share/doc/heddle/README.md"
+  install -m 0644 "$WORK/$stage/LICENSE" "$root/usr/share/doc/heddle/copyright"
+  install -m 0644 "$WORK/$stage/NOTICE" "$root/usr/share/doc/heddle/NOTICE"
+
+  cat >"$root/DEBIAN/control" <<CONTROL
+Package: heddle
+Version: ${VERSION}
+Architecture: ${arch}
+Maintainer: ${MAINTAINER}
+Section: vcs
+Priority: optional
+Homepage: ${HOMEPAGE}
+Description: ${DESC_SHORT}
+ ${DESC_LONG}
+CONTROL
+
+  local deb="$POOLDIR/heddle_${VERSION}_${arch}.deb"
+  # Deterministic, reproducible-ish: pin the package mtime to the source
+  # epoch when CI provides one (apt diffs the pool by content).
+  dpkg-deb --root-owner-group --build "$root" "$deb" >/dev/null
+  echo "Built $deb"
+}
+
+# Build the heddle-archive-keyring package (arch: all). It ships the
+# dearmored public key into /usr/share/keyrings so the trust anchor
+# self-updates on `apt upgrade` (#328 Decision 3). When no key is configured
+# (local dry-run) a placeholder marker is shipped so the package shape is
+# still validated; CI always supplies the real key.
+build_keyring_deb() {
+  local root="$WORK/keyring"
+  rm -rf "$root"
+  mkdir -p "$root/usr/share/keyrings" "$root/usr/share/doc/heddle-archive-keyring" "$root/DEBIAN"
+
+  if [[ -s "$OUTPUT/heddle-archive-keyring.gpg" ]]; then
+    install -m 0644 "$OUTPUT/heddle-archive-keyring.gpg" \
+      "$root/usr/share/keyrings/heddle-archive-keyring.gpg"
+  else
+    echo "warning: no dearmored public key available; shipping placeholder keyring (dry-run)" >&2
+    printf 'PLACEHOLDER heddle-archive-keyring (unsigned dry-run build)\n' \
+      >"$root/usr/share/keyrings/heddle-archive-keyring.gpg"
+  fi
+
+  cat >"$root/usr/share/doc/heddle-archive-keyring/copyright" <<'COPY'
+The Heddle apt archive signing key, distributed under Apache-2.0 alongside
+the heddle project. See https://heddle.sh/ for details.
+COPY
+
+  cat >"$root/DEBIAN/control" <<CONTROL
+Package: heddle-archive-keyring
+Version: ${KEYRING_VERSION}
+Architecture: all
+Maintainer: ${MAINTAINER}
+Section: utils
+Priority: optional
+Homepage: ${HOMEPAGE}
+Description: GnuPG archive key for the Heddle apt repository
+ This package contains the GnuPG archive key used to verify packages in the
+ Heddle apt repository at https://apt.heddle.sh. Installing it keeps the
+ signing key current across future apt upgrades.
+CONTROL
+
+  local deb="$POOLDIR/heddle-archive-keyring_${KEYRING_VERSION}_all.deb"
+  dpkg-deb --root-owner-group --build "$root" "$deb" >/dev/null
+  echo "Built $deb"
+}
+
+# Export the dearmored public key to the repo root for manual installers.
+# Done before the keyring .deb so the package embeds the same bytes.
+export_public_key() {
+  if [[ -z "${HEDDLE_APT_GPG_KEY_ID:-}" ]]; then
+    return 0
+  fi
+  gpg --export "$HEDDLE_APT_GPG_KEY_ID" >"$OUTPUT/heddle-archive-keyring.gpg"
+  echo "Exported dearmored public key -> $OUTPUT/heddle-archive-keyring.gpg"
+}
+
+# Generate the Packages index per arch and the suite Release file.
+build_index() {
+  local dists="$OUTPUT/dists/stable"
+  for arch in "${!ARCHES[@]}"; do
+    mkdir -p "$dists/main/binary-${arch}"
+  done
+
+  # apt-ftparchive scans the pool relative to OUTPUT so Filename: paths are
+  # repo-root-relative (pool/main/...), which is what apt expects.
+  for arch in "${!ARCHES[@]}"; do
+    ( cd "$OUTPUT" && apt-ftparchive --arch "$arch" packages pool/main ) \
+      >"$dists/main/binary-${arch}/Packages"
+    gzip -9 -c "$dists/main/binary-${arch}/Packages" \
+      >"$dists/main/binary-${arch}/Packages.gz"
+  done
+
+  local arch_list
+  arch_list="$(printf '%s ' "${!ARCHES[@]}" | sed 's/ $//')"
+
+  ( cd "$OUTPUT" && apt-ftparchive \
+      -o "APT::FTPArchive::Release::Origin=Heddle" \
+      -o "APT::FTPArchive::Release::Label=Heddle" \
+      -o "APT::FTPArchive::Release::Suite=stable" \
+      -o "APT::FTPArchive::Release::Codename=stable" \
+      -o "APT::FTPArchive::Release::Components=main" \
+      -o "APT::FTPArchive::Release::Architectures=${arch_list}" \
+      release dists/stable ) >"$dists/Release"
+  echo "Generated dists/stable/Release"
+}
+
+# Sign Release: detached Release.gpg + inline InRelease. Skipped (with a
+# loud warning) when no key id is configured — the CI apt leg always sets it.
+sign_release() {
+  local dists="$OUTPUT/dists/stable"
+  if [[ -z "${HEDDLE_APT_GPG_KEY_ID:-}" ]]; then
+    echo "warning: HEDDLE_APT_GPG_KEY_ID unset — Release is UNSIGNED (dry-run only)" >&2
+    return 0
+  fi
+  gpg --batch --yes --local-user "$HEDDLE_APT_GPG_KEY_ID" \
+    --armor --detach-sign --output "$dists/Release.gpg" "$dists/Release"
+  gpg --batch --yes --local-user "$HEDDLE_APT_GPG_KEY_ID" \
+    --clearsign --output "$dists/InRelease" "$dists/Release"
+  echo "Signed dists/stable/Release (Release.gpg + InRelease)"
+}
+
+mkdir -p "$OUTPUT"
+export_public_key
+for arch in "${!ARCHES[@]}"; do
+  build_cli_deb "$arch" "${ARCHES[$arch]}"
+done
+build_keyring_deb
+build_index
+sign_release
+
+echo "Built apt pool at $OUTPUT"

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -242,6 +242,25 @@ else
   err "missing Scoop manifest publication wiring"
 fi
 
+# apt (Debian/Ubuntu) pool publication — parallel channel on the same
+# substrate (#234). scripts/build-apt-pool.sh builds the amd64 + arm64 .deb
+# (and the heddle-archive-keyring .deb) from the linux-gnu tarballs in
+# SHA256SUMS, then generates + GPG-signs the pool/Packages/Release index in
+# an ephemeral GNUPGHOME (Ed25519 subkey, #328 Decision 2). The
+# publish-manifests job PRs the whole signed tree to apt-heddle via the same
+# composite action + App token, gated stable-only. The App token scope must
+# include apt-heddle alongside the homebrew/scoop taps.
+if [[ -x scripts/build-apt-pool.sh ]] \
+   && grep -F "scripts/build-apt-pool.sh" "$WF" >/dev/null \
+   && grep -F "HeddleCo/apt-heddle" "$WF" >/dev/null \
+   && grep -F "HEDDLE_APT_GPG_PRIVATE_KEY" "$WF" >/dev/null \
+   && grep -F "actions/create-github-app-token" "$WF" >/dev/null \
+   && grep -E "repositories: .*apt-heddle" "$WF" >/dev/null; then
+  ok "apt pool publication wired"
+else
+  err "missing apt pool publication wiring"
+fi
+
 if grep -F "if: needs.validate-tag.outputs.kind == 'stable'" "$WF" >/dev/null; then
   ok "manifest publication gated to stable releases"
 else


### PR DESCRIPTION
Closes #234

Adds the Debian/Ubuntu **apt** distribution channel on the shared publish-manifest substrate, mirroring the just-merged **Scoop** (#233) and **Homebrew** channels. Takes the git-backed composition branch decided in `docs/design/apt-hosting-gpg-spike.md` (#328).

## What's here

- **`scripts/build-apt-pool.sh`** (new) — channel renderer for apt:
  - Verifies the two `*-unknown-linux-gnu.tar.gz` archives against the release `SHA256SUMS`, then builds `heddle_<version>_amd64.deb` + `heddle_<version>_arm64.deb` into `pool/main/h/heddle/`.
  - Builds the `heddle-archive-keyring_<n>_all.deb` self-updating trust anchor and exports the dearmored public key to `heddle-archive-keyring.gpg` at the repo root.
  - Generates `dists/stable/main/binary-<arch>/Packages{,.gz}` + the suite `dists/stable/Release` (single rolling `stable main`, both arches).
  - GPG-signs `Release` (detached `Release.gpg` + inline `InRelease`) with the Ed25519 signing subkey imported into an ephemeral `GNUPGHOME` (#328 Decision 2). Signing is opt-in via `HEDDLE_APT_GPG_KEY_ID` so the script runs as an unsigned local dry-run too.
- **`release.yml` `publish-manifests`** — apt leg: imports `HEDDLE_APT_GPG_PRIVATE_KEY` into an ephemeral `GNUPGHOME`, renders the pool, widens the App-token `repositories:` scope to include `apt-heddle`, and PRs the whole signed tree to `HeddleCo/apt-heddle` via the shared composite action. Same stable-only gate.
- **`.github/actions/publish-manifest`** — extended to sync a *directory* `rendered-file` onto `manifest-path` (`.` = repo root); single-file copy path unchanged. Keeps the composite shared across all three channels.
- **`check-release-pipeline.sh`** — asserts the apt wiring (renderer present, `apt-heddle` target, GPG secret imported, widened token scope).
- **`RELEASING.md`** — `signed-by=` keyring install recipe (+ deb822), pipeline docs, the required `HEDDLE_APT_GPG_PRIVATE_KEY` secret, and the org-admin infra prerequisites.

## Verification

- `bash scripts/check-release-pipeline.sh` → **PASS** (exit 0; new `ok: apt pool publication wired`).
- End-to-end dry-run build with synthetic tarballs: both `.deb`s + keyring `.deb` build; `dpkg-deb --info`/`--contents` well-formed; `Packages` indices carry repo-root-relative `Filename:` + all checksums; `Release` declares both arches.
- Signing path exercised with a throwaway Ed25519 key: `Release.gpg` **and** `InRelease` both verify as *Good signature*; the keyring `.deb` embeds the real public key bytes.
- `release.yml` + `action.yml` re-parse as valid YAML.

## Gaps to flag (not blocking the code)

These are tracked org-admin / human-infra prerequisites from the #328 design doc; the apt leg will open its PR regardless, but the published repo isn't reachable at the branded URL until they land:

1. **`HeddleCo/apt-heddle` doesn't exist yet** + the "Heddle Release Publisher" App must be installed on it.
2. **`apt.heddle.sh` DNS / Pages custom-domain / TLS** not yet set up.
3. **`HEDDLE_APT_GPG_PRIVATE_KEY` secret** (offline-generated Ed25519 primary + signing subkey) must be added to the heddle repo.
4. **glibc floor (#549)** — the apt `install` only *works* once the linux-gnu binaries clear the glibc floor; the build already pins `ubuntu-22.04`/`-arm` (glibc 2.35), so this is satisfied on `main` today, but `apt install` on the oldest supported target should be smoke-tested at the first stable cut.

Note: `aptly`/`reprepro` are not on the runner; the renderer uses `dpkg-deb` + `apt-ftparchive` (both present on `ubuntu-24.04`), which produce an equivalent signed pool/index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785304416&installation_id=132405951&pr_number=806&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F806&signature=52ede97321dfadcb434b72d7123707c6a25edd7531f29c7592e40ed2ac248e5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->