### PR TITLE
feat(mount): FUSE active inode invalidation, drop FOPEN_DIRECT_IO (#87)

### DIFF
--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -72,8 +72,10 @@ chrono.workspace = true
 criterion = "0.8"
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
-# `fuse_mount_serves_mmap_readers` regression test that locks in
-# `FUSE_DIRECT_IO_ALLOW_MMAP` opt-in (kernel 5.16+).
+# `fuse_mount_serves_mmap_readers` regression test, which locks in
+# that shared mmap works under cached mode (heddle#87) — no
+# `FOPEN_DIRECT_IO`, so the page cache backs the mapping on any
+# FUSE-capable kernel.
 memmap2.workspace = true
 proptest.workspace = true
 tempfile.workspace = true

--- a/crates/mount/README.md
+++ b/crates/mount/README.md
@@ -76,19 +76,28 @@ needs:
 4. **The `fuse` cargo feature**, propagated through
    `heddle-cli`'s `mount` feature.
 
-5. **Linux 5.16+ for shared `mmap` on mounted files.** The shell
-   hands back `FOPEN_DIRECT_IO` on every `open` so kernel page-cache
-   reads don't shadow hot-tier writes (see
-   [`crate::fuse::FuseShell::open`]). Under default kernel semantics
-   that disables `mmap(MAP_SHARED, ...)` on every fd — calls return
-   `ENODEV`. The shell opts out of that restriction by requesting
-   the `FUSE_DIRECT_IO_ALLOW_MMAP` capability in `init`; the kernel
-   bit was added in 5.16. On older kernels the cap is silently
-   dropped and shared mmap fails with `ENODEV` — rust-analyzer,
-   cargo (when reading dep-info files via `mmap`), IDEs, and
-   `grep --mmap` will misbehave on heddle-mounted trees. The mount
-   itself still works; only the mmap path is affected. Upgrade the
-   kernel or use clients that fall back to `read(2)`.
+5. **No kernel-version floor for caching or shared `mmap`.** The
+   shell runs in the kernel's default **cached** mode (heddle#87): it
+   does *not* return `FOPEN_DIRECT_IO`, and instead hands back
+   `FOPEN_KEEP_CACHE` from `open`/`create` so the page cache stays
+   live across opens (see [`crate::fuse::FuseShell::open`]). Repeated
+   reads of unchanged content are served straight from the page cache
+   without a FUSE round-trip, and shared `mmap(MAP_SHARED, ...)` works
+   out of the box — no `FUSE_DIRECT_IO_ALLOW_MMAP` capability, hence
+   no Linux 5.16+ requirement. rust-analyzer, cargo, IDEs, and
+   `grep --mmap` all work on heddle-mounted trees on any FUSE-capable
+   kernel.
+
+   Coherence comes from **active invalidation**, the same model FSKit
+   uses on macOS: every content-changing callback (`write`, `setattr`)
+   pushes a `notify_inval_inode` to the kernel, and every dentry-
+   changing callback (`create`/`mkdir`/`mknod`/`symlink`/`unlink`/
+   `rmdir`/`rename`) pushes a `notify_inval_entry`, so the kernel can
+   never serve stale cached bytes, attrs, or dentries. Those
+   notifications are dispatched from a dedicated invalidator thread
+   (never inline from a callback — that deadlocks on the kernel inode
+   lock); see the `fuse.rs` module docs ("Invalidation contract") for
+   the per-callback mapping.
 
 ### Cleaning up a stale FUSE mount
 

--- a/crates/mount/src/fuse.rs
+++ b/crates/mount/src/fuse.rs
@@ -8,17 +8,81 @@
 //! /`release`, and folded into a real heddle state by
 //! [`ContentAddressedMount::capture`].
 //!
+//! ## Cache coherence — active invalidation (heddle#87)
+//!
+//! The mount lets the kernel cache page data, attrs, and dentries
+//! (no `FOPEN_DIRECT_IO`), and keeps that cache coherent the way
+//! FSKit does on macOS: by *actively pushing invalidations* to the
+//! kernel the instant heddle mutates the backing content. Every
+//! mutation flows through a FUSE callback in *this* shell, so the
+//! invalidation is self-referential — the same callback that mutates
+//! the overlay queues the matching `notify_inval_*` (dispatched off
+//! the worker thread; see below).
+//!
+//! The notifier handle ([`fuser::Notifier`]) only exists *after* the
+//! session is mounted (it wraps the `/dev/fuse` channel). [`FuseShell`]
+//! therefore holds an `Arc<NotifyGate>` that [`Self::mount`] /
+//! [`Self::mount_background`] *start* immediately after spawning the
+//! session. Before the gate is started (and after an unmount), every
+//! invalidate is a best-effort no-op; the un-started window only spans
+//! the mount handshake, during which nothing the kernel has cached can
+//! be stale.
+//!
+//! ### Off-thread dispatch (deadlock avoidance)
+//!
+//! Crucially, callbacks do **not** call the notifier inline. A
+//! whole-inode invalidation makes the kernel acquire `inode->i_rwsem`
+//! — a lock the in-flight `write`/`flush`/`setattr` callback is already
+//! holding — so a synchronous notify from inside the callback
+//! deadlocks the mount. Instead [`NotifyGate`] runs a dedicated
+//! invalidator thread: callbacks `enqueue` the invalidation and return
+//! (releasing the kernel lock), and the thread drains the queue and
+//! issues the actual `notify_inval_*`. This matches how libfuse's own
+//! `notify_inval_*` examples are structured (notify only off the
+//! request loop). Invalidation is therefore *asynchronous* — exactly
+//! like FSKit's `invalidateNode` — so a re-reader sees fresh content
+//! once the queued notify lands, which is effectively immediate but
+//! not synchronously ordered against the mutating syscall's return.
+//!
+//! ### Invalidation contract — which writes trigger which invals
+//!
+//! | callback              | mutation                         | invalidation |
+//! |-----------------------|----------------------------------|--------------|
+//! | `write`               | bytes into the hot tier          | `inval_inode(ino, 0, -1)` — drop cached pages + attrs for the file |
+//! | `setattr`             | chmod / truncate / mtime         | `inval_inode(ino, 0, -1)` — attrs (and, on truncate, data) changed |
+//! | `create` / `mknod`    | new file entry under `parent`    | `inval_entry(parent, name)` — refresh the now-stale negative/positive dentry |
+//! | `mkdir`               | new dir entry under `parent`     | `inval_entry(parent, name)` |
+//! | `symlink`             | new symlink entry under `parent` | `inval_entry(parent, name)` |
+//! | `unlink` / `rmdir`    | remove entry under `parent`      | `inval_entry(parent, name)` — drop the cached dentry so a re-lookup 404s |
+//! | `rename`              | move `src→dst`                   | `inval_entry(src_parent, src_name)` + `inval_entry(dst_parent, dst_name)` |
+//!
+//! `flush` / `release` deliberately do **not** invalidate: they promote
+//! the hot tier into CAS but don't change the bytes the shell serves
+//! (the content-changing `write` / `setattr` callbacks already
+//! invalidated), and `flush` fires on *every* `close(2)` including a
+//! reader's — invalidating there would throw away the cached-read win.
+//!
+//! `inval_inode(ino, 0, -1)` invalidates the *entire* data range plus
+//! the cached attrs; we use the whole-file form because the overlay
+//! re-materialises the blob wholesale on promotion rather than tracking
+//! dirty byte ranges. `inval_entry` is best-effort: the kernel returns
+//! `ENOENT` if it never cached the entry, which `fuser` swallows. All
+//! invalidations are *advisory for performance, mandatory for
+//! correctness* — a dropped notification (channel error) is logged but
+//! cannot corrupt state, only risk a stale read until the attr TTL
+//! lapses, so the callbacks never fail on an invalidation error.
+//!
 //! ## Implemented kernel callbacks
 //!
 //! Read path:
-//! * `init` — opts into `FUSE_DIRECT_IO_ALLOW_MMAP` so mmap works
-//!   alongside `FOPEN_DIRECT_IO`.
+//! * `init` — default page-cache mode; no `FUSE_DIRECT_IO_ALLOW_MMAP`
+//!   opt-in needed now that we don't return `FOPEN_DIRECT_IO`.
 //! * `lookup` / `getattr` / `open` / `read` / `readdir` / `flush` /
 //!   `release` / `opendir` / `releasedir` / `destroy`.
 //!
 //! Write path (heddle#180):
 //! * `create` — `open(O_CREAT[|O_EXCL|O_TRUNC])`. EEXIST on O_EXCL
-//!   clash. Returns `FOPEN_DIRECT_IO`.
+//!   clash. Fires `inval_entry(parent, name)`.
 //! * `mkdir` — empty directory in the overlay.
 //! * `mknod` — regular files only; non-`S_IFREG` returns EPERM.
 //! * `unlink` / `rmdir`.
@@ -132,16 +196,20 @@
 //! platform while sparing the other.
 
 use std::{
-    ffi::OsStr,
+    ffi::{OsStr, OsString},
     panic::AssertUnwindSafe,
     path::Path,
-    sync::Arc,
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+        mpsc::{Sender, channel},
+    },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use fuser::{
     BackgroundSession, BsdFileFlags, Config, Errno, FileAttr, FileHandle, FileType, Filesystem,
-    FopenFlags, Generation, INodeNo, InitFlags, KernelConfig, LockOwner, MountOption, OpenFlags,
+    FopenFlags, Generation, INodeNo, KernelConfig, LockOwner, MountOption, Notifier, OpenFlags,
     RenameFlags, ReplyAttr, ReplyCreate, ReplyData, ReplyDirectory, ReplyEmpty, ReplyEntry,
     ReplyOpen, ReplyWrite, Request, Session, TimeOrNow, WriteFlags,
 };
@@ -165,11 +233,150 @@ const TTL: Duration = Duration::from_secs(1);
 /// remounts, so a constant is fine.
 const GENERATION: Generation = Generation(0);
 
+/// A single kernel-invalidation request, enqueued by a FUSE callback
+/// and drained by the background invalidator thread.
+enum InvalMsg {
+    /// Drop cached pages + attrs for the whole inode.
+    Inode(u64),
+    /// Drop the cached dentry for `(parent, name)`.
+    Entry(u64, OsString),
+}
+
+/// Dispatcher that pushes active cache invalidations to the kernel for
+/// a live mount, **off the FUSE worker thread**.
+///
+/// ## Why a separate thread (the deadlock this avoids)
+///
+/// `fuse_lowlevel_notify_inval_inode` makes the kernel walk the inode's
+/// page cache and acquire `inode->i_rwsem`. An in-flight `write` /
+/// `flush` / `setattr` callback is *already holding* that lock when it
+/// runs — so calling the notifier **synchronously from inside the
+/// callback** is a classic AB-BA deadlock: the callback waits for the
+/// notify ack, the kernel waits for the callback's lock. (Empirically:
+/// the first cut of heddle#87 did exactly this and wedged the mount
+/// hard, leaving zombie worker threads.) libfuse's own
+/// `notify_inval_*` examples sidestep it by only ever notifying from a
+/// thread that is *not* the request loop. We do the same: callbacks
+/// `enqueue` a message and return immediately (releasing the kernel
+/// lock); a dedicated thread drains the queue and issues the notifier
+/// calls once the originating op has completed.
+///
+/// The [`Notifier`] only exists after the session mounts, so the gate
+/// starts empty (a [`OnceLock`] of the sender half) and
+/// [`NotifyGate::start`] fills it — spawning the thread — the moment
+/// the session is live. Before that, and after the session drops (the
+/// `Notifier`'s channel dies, the thread exits, the receiver is gone),
+/// every `enqueue` is a best-effort no-op.
+#[derive(Default)]
+struct NotifyGate {
+    /// Sender half of the invalidation queue, installed by [`Self::start`].
+    tx: OnceLock<Sender<InvalMsg>>,
+    /// Join handle for the invalidator thread, kept so the gate can be
+    /// dropped cleanly. Behind a `Mutex<Option<…>>` because `Drop`
+    /// needs `&mut`-style access through the shared `Arc`.
+    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+impl NotifyGate {
+    /// Install the live notifier and spawn the invalidator thread.
+    /// Called once, right after the session mounts. A second call (it
+    /// can't happen with the current flow) is ignored — the first
+    /// notifier wins and the second thread never starts.
+    fn start(&self, notifier: Notifier) {
+        let (tx, rx) = channel::<InvalMsg>();
+        if self.tx.set(tx).is_err() {
+            // Already started; drop the freshly-built channel.
+            return;
+        }
+        let handle = std::thread::Builder::new()
+            .name("heddle-fuse-inval".to_string())
+            .spawn(move || {
+                // Drains until every sender is dropped (i.e. the gate /
+                // mount is torn down), then exits.
+                for msg in rx {
+                    match msg {
+                        InvalMsg::Inode(ino) => {
+                            // offset 0, len -1 == the entire data range
+                            // plus the cached attrs.
+                            if let Err(err) = notifier.inval_inode(INodeNo(ino), 0, -1) {
+                                debug!(
+                                    ?err,
+                                    ino, "inval_inode failed; stale read possible until TTL"
+                                );
+                            }
+                        }
+                        InvalMsg::Entry(parent, name) => {
+                            if let Err(err) = notifier.inval_entry(INodeNo(parent), &name) {
+                                debug!(
+                                    ?err,
+                                    parent,
+                                    ?name,
+                                    "inval_entry failed; stale dentry possible until TTL"
+                                );
+                            }
+                        }
+                    }
+                }
+            })
+            .expect("spawn heddle-fuse-inval thread");
+        *self.worker.lock().expect("notify worker mutex") = Some(handle);
+    }
+
+    /// Enqueue a whole-inode invalidation. Best-effort: a no-op before
+    /// the gate is started or after the worker has exited. Never blocks
+    /// the FUSE callback on the kernel — that's the whole point.
+    fn inval_inode(&self, ino: u64) {
+        if let Some(tx) = self.tx.get() {
+            let _ = tx.send(InvalMsg::Inode(ino));
+        }
+    }
+
+    /// Enqueue a dentry invalidation for `(parent, name)`. Best-effort,
+    /// same rationale as [`Self::inval_inode`].
+    fn inval_entry(&self, parent: u64, name: &OsStr) {
+        if let Some(tx) = self.tx.get() {
+            let _ = tx.send(InvalMsg::Entry(parent, name.to_os_string()));
+        }
+    }
+}
+
+impl Drop for NotifyGate {
+    fn drop(&mut self) {
+        // Field drop order would already close the channel (dropping
+        // the `Sender` in `tx`) and let the thread exit, but be explicit
+        // and deterministic: take the sender out first so the thread's
+        // `for msg in rx` loop ends, then join it. Joining keeps the
+        // invalidator from outliving the mount it serves.
+        //
+        // We can't move the `Sender` out of the `OnceLock` behind `&mut
+        // self` without `OnceLock::take` (stable), so use it to drop the
+        // sender, then join.
+        let _ = self.tx.take();
+        if let Some(handle) = self.worker.lock().ok().and_then(|mut g| g.take()) {
+            let _ = handle.join();
+        }
+    }
+}
+
 /// Adapter that exposes a [`ContentAddressedMount`] to the kernel
 /// via FUSE. Owns the mount in an `Arc` so the FUSE worker thread(s)
 /// share the same registry.
 pub struct FuseShell {
     inner: Arc<ContentAddressedMount>,
+    /// Kernel-notification handle, populated at mount time. Shared with
+    /// nothing else; the `Arc` is only so [`Self::mount`] can hand a
+    /// clone to the spawned session while keeping one for the shell
+    /// that's been moved into the session. See [`NotifyGate`].
+    notify: Arc<NotifyGate>,
+    /// Count of `read` callbacks served since mount. Lets a test prove
+    /// the kernel page cache is live (cached mode, heddle#87): in
+    /// cached mode a re-read of unchanged content is served from the
+    /// page cache and never reaches this callback, so the counter
+    /// stays flat across the second read; in the old `FOPEN_DIRECT_IO`
+    /// mode every userspace `read(2)` would bump it. Shared via `Arc`
+    /// so a caller can hold a handle ([`Self::read_calls_handle`])
+    /// after the shell is consumed by `mount_background`.
+    read_calls: Arc<AtomicU64>,
 }
 
 impl FuseShell {
@@ -177,7 +384,18 @@ impl FuseShell {
     pub fn new(mount: ContentAddressedMount) -> Self {
         Self {
             inner: Arc::new(mount),
+            notify: Arc::new(NotifyGate::default()),
+            read_calls: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Shared handle to the FUSE `read`-callback counter. Grab this
+    /// *before* mounting (the shell is consumed by `mount` /
+    /// `mount_background`) to observe how many reads actually reach
+    /// userspace — used by the cache-mode-active test to confirm the
+    /// kernel page cache is serving repeated reads (heddle#87).
+    pub fn read_calls_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.read_calls)
     }
 
     /// Best-effort mtime to attach to entry replies for newly
@@ -208,19 +426,51 @@ impl FuseShell {
 
     /// Mount synchronously. Blocks the calling thread for the lifetime
     /// of the mount (returns when unmounted or on error).
+    ///
+    /// We build the [`Session`] explicitly (rather than the
+    /// `fuser::mount2` convenience) so we can install the kernel
+    /// [`Notifier`] into the shell's [`NotifyGate`] *before* the event
+    /// loop starts serving callbacks — that's what lets the write-side
+    /// callbacks push active cache invalidations (heddle#87). The gate
+    /// is shared via `self.notify`, which gets moved into the session
+    /// along with `self`; we kept a clone of the `Arc` before the move.
+    ///
+    /// `Session::run` is crate-private in fuser, so to keep blocking
+    /// semantics we spawn the worker thread and `join()` it — the join
+    /// returns when the mount is torn down, exactly as the old
+    /// `mount2` call did.
     pub fn mount(self, mountpoint: impl AsRef<Path>) -> Result<()> {
         let config = default_config();
-        fuser::mount2(self, mountpoint.as_ref(), &config)
+        let gate = Arc::clone(&self.notify);
+        let session = Session::new(self, mountpoint.as_ref(), &config)
+            .map_err(|e| crate::error::MountError::Store(objects::error::HeddleError::Io(e)))?;
+        gate.start(session.notifier());
+        let bg = session
+            .spawn()
+            .map_err(|e| crate::error::MountError::Store(objects::error::HeddleError::Io(e)))?;
+        bg.join()
             .map_err(|e| crate::error::MountError::Store(objects::error::HeddleError::Io(e)))?;
         Ok(())
     }
 
     /// Mount in a background session. Caller holds the returned
     /// [`BackgroundSession`]; dropping it triggers an unmount.
+    ///
+    /// As with [`Self::mount`], the kernel [`Notifier`] is installed
+    /// into the shell's [`NotifyGate`] right after the session mounts
+    /// so the write-side callbacks can invalidate the kernel cache.
     pub fn mount_background(self, mountpoint: impl AsRef<Path>) -> Result<BackgroundSession> {
         let config = default_config();
+        let gate = Arc::clone(&self.notify);
         let session = Session::new(self, mountpoint.as_ref(), &config)
             .map_err(|e| crate::error::MountError::Store(objects::error::HeddleError::Io(e)))?;
+        // Install the notifier before spawning the worker thread: once
+        // the thread is live the kernel can issue callbacks, and we
+        // want the gate filled before the first mutation arrives. The
+        // `Session`'s notifier and the `BackgroundSession`'s notifier
+        // wrap clones of the same channel sender, so a notifier taken
+        // here stays valid for the whole session lifetime.
+        gate.start(session.notifier());
         session
             .spawn()
             .map_err(|e| crate::error::MountError::Store(objects::error::HeddleError::Io(e)))
@@ -396,29 +646,16 @@ fn guard_call<T>(label: &'static str, f: impl FnOnce() -> Result<T>) -> Result<T
 }
 
 impl Filesystem for FuseShell {
-    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> std::io::Result<()> {
-        // Opt into `FUSE_DIRECT_IO_ALLOW_MMAP`. We hand back
-        // `FOPEN_DIRECT_IO` from `open` (see the comment there), and
-        // under default kernel semantics that disables shared `mmap`
-        // on every fd — calls to `mmap(MAP_SHARED, ...)` return
-        // `ENODEV`. The kernel cap added in 5.16 keeps direct-IO
-        // bypass for `read(2)`/`write(2)` but re-enables shared mmap,
-        // which is the daily-use path for rust-analyzer, cargo, IDEs,
-        // and `grep --mmap` on heddle-mounted trees.
-        //
-        // `add_capabilities` errors when the kernel is < 5.16 (the
-        // bit wasn't defined). That's not fatal — older kernels just
-        // get the pre-cap behaviour (no shared mmap), which is the
-        // same shape r1 of this fix shipped with. Log it once at
-        // mount time so operators on old kernels can correlate
-        // `ENODEV` from a mapping syscall with the missing cap.
-        if let Err(unsupported) = config.add_capabilities(InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP) {
-            debug!(
-                ?unsupported,
-                "kernel does not support FUSE_DIRECT_IO_ALLOW_MMAP (requires 5.16+); \
-                 shared mmap on mounted files will fail with ENODEV"
-            );
-        }
+    fn init(&mut self, _req: &Request, _config: &mut KernelConfig) -> std::io::Result<()> {
+        // Nothing to opt into. The mount runs in the kernel's default
+        // caching mode: `open` no longer returns `FOPEN_DIRECT_IO`, so
+        // the page cache is live and shared `mmap(MAP_SHARED, ...)`
+        // works out of the box without the `FUSE_DIRECT_IO_ALLOW_MMAP`
+        // capability (and therefore without the Linux 5.16+ floor that
+        // cap required). Coherence comes from active invalidation: see
+        // the module-level "Invalidation contract" — every write-side
+        // callback pushes the matching `notify_inval_*` so the kernel
+        // can never serve stale cached bytes, attrs, or dentries.
         Ok(())
     }
 
@@ -437,38 +674,35 @@ impl Filesystem for FuseShell {
                 "on_open bookkeeping failed; orphan cleanup may misfire"
             );
         }
-        // Open every file in `direct_io` mode so the kernel never
-        // serves bytes from its page cache. The content-addressed
-        // mount maintains its own blob cache ([`BlobCachePool`]),
-        // which already deduplicates repeated reads against the
-        // captured tree — so the kernel-side page cache wins us
-        // nothing, and *costs* correctness on the write-then-read
-        // path:
+        // Cached mode (heddle#87). Two flags, no `FOPEN_DIRECT_IO`:
         //
-        // Without `direct_io`, after a captured file is opened-for-
-        // write, mutated, closed (→ `flush` promotes the hot tier
-        // into the warm tier), and reopened, the kernel happily
-        // serves the *pre-write* bytes from its page cache. The
-        // dentry/inode caching at our 1-second TTL doesn't help —
-        // the page cache is keyed off the kernel-side inode, and
-        // the kernel has no way to know we replaced the blob behind
-        // it. `direct_io` short-circuits the page cache entirely;
-        // every kernel `read(2)` becomes a FUSE `read` callback,
-        // which we serve from the hot-tier-then-warm-tier-then-
-        // captured-blob priority chain.
+        // * (absence of `FOPEN_DIRECT_IO`) — reads flow through the
+        //   kernel page cache instead of bypassing it, so repeated
+        //   reads of unchanged content are served without a FUSE
+        //   round-trip (the throughput win), and shared `mmap` works
+        //   without the `FUSE_DIRECT_IO_ALLOW_MMAP` cap (no Linux 5.16+
+        //   floor).
+        // * `FOPEN_KEEP_CACHE` — tells the kernel *not* to drop the
+        //   page cache on `open`. FUSE's default is to invalidate the
+        //   data cache on every open, which would defeat cross-open
+        //   caching entirely (each fresh `open`+`read` would re-hit the
+        //   shell). With KEEP_CACHE the cache persists across opens and
+        //   we own coherence explicitly via active invalidation.
         //
-        // The kernel's default rule for direct-IO files is "no shared
-        // mmap" (the page cache is the mapping substrate; bypass it
-        // and `mmap(MAP_SHARED, ...)` returns `ENODEV`). We opt out
-        // of that rule by requesting `FUSE_DIRECT_IO_ALLOW_MMAP` in
-        // [`Self::init`] — on Linux 5.16+ the kernel keeps the
-        // direct-IO bypass for `read`/`write` but lets shared mmap
-        // through, which is the daily-use path for rust-analyzer,
-        // cargo, IDEs, and `grep --mmap` on heddle-mounted trees.
+        // Coherence is maintained actively: the content-changing
+        // callbacks (`write`, `setattr`) push a `notify_inval_*` after
+        // they mutate the overlay (see the module-level invalidation
+        // contract). The classic stale-read hazard — write a captured
+        // file, close, reopen, and have the kernel serve the *pre-write*
+        // bytes from its page cache — is closed because `write` /
+        // `setattr` enqueue `inval_inode(ino, 0, -1)`, dropping those
+        // cached pages so a re-reader misses cache and re-asks us. This
+        // is the same invalidate-on-change model FSKit uses on macOS,
+        // giving both platforms identical caching semantics.
         //
         // FH=0 mirrors the fuser default (we don't track per-handle
         // state — open files identify by inode in [`PlatformShell`]).
-        reply.opened(FileHandle(0), FopenFlags::FOPEN_DIRECT_IO);
+        reply.opened(FileHandle(0), FopenFlags::FOPEN_KEEP_CACHE);
     }
 
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
@@ -513,6 +747,13 @@ impl Filesystem for FuseShell {
         _lock_owner: Option<LockOwner>,
         reply: ReplyData,
     ) {
+        // Bump the read-callback counter. In cached mode (heddle#87)
+        // the kernel serves repeated reads of unchanged content from
+        // its page cache, so this fires far less often than userspace
+        // issues `read(2)` — the cache-mode-active test asserts on the
+        // gap. `Relaxed` is fine: the test reads the counter only after
+        // the relevant filesystem ops have completed and been observed.
+        self.read_calls.fetch_add(1, Ordering::Relaxed);
         let result = guard_call("read", || {
             let mut buf = vec![0u8; size as usize];
             let n = self.inner.read(NodeId(ino.0), offset, &mut buf)?;
@@ -584,7 +825,14 @@ impl Filesystem for FuseShell {
         reply: ReplyWrite,
     ) {
         match guard_call("write", || self.inner.write(NodeId(ino.0), offset, data)) {
-            Ok(n) => reply.written(n as u32),
+            Ok(n) => {
+                // The hot tier now holds bytes the kernel's page cache
+                // doesn't know about. Drop the cached pages + attrs for
+                // this inode so any concurrent/subsequent reader re-asks
+                // us. (heddle#87 invalidation contract.)
+                self.notify.inval_inode(ino.0);
+                reply.written(n as u32);
+            }
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
@@ -599,6 +847,15 @@ impl Filesystem for FuseShell {
     ) {
         // Flush fires on `close(2)` from userspace. This is the
         // natural place to promote the hot buffer to CAS.
+        //
+        // We deliberately do *not* invalidate here. Promotion moves the
+        // bytes between tiers but doesn't change the *content* the shell
+        // serves — and the `write` (and `setattr`) callbacks already
+        // invalidated the kernel's cache for every byte they changed. A
+        // blanket invalidate on every `flush` would also drop the cache
+        // on a *read-only* close (flush fires on every `close(2)`, not
+        // just writers), defeating the cached-read win this whole change
+        // exists to deliver. (heddle#87 invalidation contract.)
         match guard_call("flush", || self.inner.flush(NodeId(ino.0))) {
             Ok(()) => reply.ok(),
             Err(err) => reply.error(errno_from_mount_error(err)),
@@ -618,6 +875,11 @@ impl Filesystem for FuseShell {
         // Belt-and-braces: a process that exits without an explicit
         // close still gets a release on the inode. Promote any
         // surviving buffer.
+        //
+        // As with `flush`: no invalidation here. The content-changing
+        // callbacks (`write` / `setattr`) already invalidated, and an
+        // unconditional release-time invalidate would drop the cache on
+        // every reader's close. (heddle#87 invalidation contract.)
         match guard_call("release", || self.inner.release(NodeId(ino.0))) {
             Ok(()) => reply.ok(),
             Err(err) => reply.error(errno_from_mount_error(err)),
@@ -654,10 +916,16 @@ impl Filesystem for FuseShell {
                         "on_open bookkeeping failed; orphan cleanup may misfire"
                     );
                 }
-                // Mirror the `open` callback: opt the new fd into
-                // FOPEN_DIRECT_IO so kernel page-cache reads don't
-                // shadow hot-tier writes (see `Self::open` for the
-                // full reasoning).
+                // A new entry now exists under `parent`. The kernel may
+                // have cached a *negative* dentry for this name (e.g.
+                // from an `O_CREAT` open that first `stat`ed and got
+                // ENOENT); invalidate it so the entry becomes visible.
+                // (heddle#87 invalidation contract.)
+                self.notify.inval_entry(parent.0, name);
+                // Mirror the `open` callback: cached mode with
+                // `FOPEN_KEEP_CACHE`, no `FOPEN_DIRECT_IO` (see
+                // `Self::open` for the full reasoning + the
+                // invalidation contract).
                 let attr = match guard_call("create", || self.inner.attrs(entry.node)) {
                     Ok(attrs) => file_attr_from(attrs),
                     Err(err) => {
@@ -670,7 +938,7 @@ impl Filesystem for FuseShell {
                     &attr,
                     GENERATION,
                     FileHandle(0),
-                    FopenFlags::FOPEN_DIRECT_IO,
+                    FopenFlags::FOPEN_KEEP_CACHE,
                 );
             }
             Err(err) => reply.error(errno_from_mount_error(err)),
@@ -689,6 +957,9 @@ impl Filesystem for FuseShell {
         let result = guard_call("mkdir", || self.inner.make_dir(NodeId(parent.0), name));
         match result {
             Ok(entry) => {
+                // New dir entry under `parent`; refresh any cached
+                // (likely negative) dentry. (heddle#87.)
+                self.notify.inval_entry(parent.0, name);
                 let attr = entry_attr_from(&entry, self.inner_mtime());
                 reply.entry(&TTL, &attr, GENERATION);
             }
@@ -725,6 +996,9 @@ impl Filesystem for FuseShell {
         });
         match result {
             Ok(entry) => {
+                // New file entry under `parent`; refresh the dentry.
+                // (heddle#87.)
+                self.notify.inval_entry(parent.0, name);
                 let attr = entry_attr_from(&entry, self.inner_mtime());
                 reply.entry(&TTL, &attr, GENERATION);
             }
@@ -734,14 +1008,25 @@ impl Filesystem for FuseShell {
 
     fn unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         match guard_call("unlink", || self.inner.unlink_entry(NodeId(parent.0), name)) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                // Drop the now-removed entry's cached dentry so a
+                // re-lookup 404s instead of resurrecting it from cache.
+                // (heddle#87.)
+                self.notify.inval_entry(parent.0, name);
+                reply.ok();
+            }
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
 
     fn rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         match guard_call("rmdir", || self.inner.rmdir_entry(NodeId(parent.0), name)) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                // Same as `unlink`: drop the removed dir's dentry.
+                // (heddle#87.)
+                self.notify.inval_entry(parent.0, name);
+                reply.ok();
+            }
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
@@ -785,7 +1070,14 @@ impl Filesystem for FuseShell {
                 options,
             )
         }) {
-            Ok(()) => reply.ok(),
+            Ok(()) => {
+                // Both the source (now gone) and destination (now
+                // present, possibly replacing a cached entry) dentries
+                // are stale. Invalidate each. (heddle#87.)
+                self.notify.inval_entry(parent.0, name);
+                self.notify.inval_entry(newparent.0, newname);
+                reply.ok();
+            }
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
@@ -827,7 +1119,13 @@ impl Filesystem for FuseShell {
             mtime_sec,
         };
         match guard_call("setattr", || self.inner.set_attrs(NodeId(ino.0), update)) {
-            Ok(attrs) => reply.attr(&TTL, &file_attr_from(attrs)),
+            Ok(attrs) => {
+                // chmod / truncate / mtime all change cached attrs, and
+                // a truncate changes the cached data too. Whole-inode
+                // invalidate covers both. (heddle#87.)
+                self.notify.inval_inode(ino.0);
+                reply.attr(&TTL, &file_attr_from(attrs));
+            }
             Err(err) => reply.error(errno_from_mount_error(err)),
         }
     }
@@ -846,6 +1144,9 @@ impl Filesystem for FuseShell {
         });
         match result {
             Ok(entry) => {
+                // New symlink entry under `parent`; refresh the dentry.
+                // (heddle#87.)
+                self.notify.inval_entry(parent.0, link_name);
                 let attr = entry_attr_from(&entry, self.inner_mtime());
                 reply.entry(&TTL, &attr, GENERATION);
             }

--- a/crates/mount/tests/fuse_mount.rs
+++ b/crates/mount/tests/fuse_mount.rs
@@ -32,12 +32,19 @@
 //!   parallelism (a build of any non-trivial project will issue tens
 //!   of these per second).
 //! * [`fuse_mount_serves_mmap_readers`] — `mmap(MAP_SHARED, ...)` on a
-//!   mounted file. Locks in the [`InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP`]
-//!   opt-in: without it, every `open` reply carrying
-//!   `FOPEN_DIRECT_IO` forces `mmap(MAP_SHARED, ...)` to fail with
-//!   `ENODEV`, which breaks rust-analyzer, cargo, IDEs, and
-//!   `grep --mmap` on heddle-mounted trees. Requires Linux 5.16+;
-//!   skips itself on older kernels (the cap is silently dropped).
+//!   mounted file. Locks in cached mode (heddle#87): with no
+//!   `FOPEN_DIRECT_IO`, the page cache is the mapping substrate and
+//!   shared mmap works on any FUSE-capable kernel — the path
+//!   rust-analyzer, cargo, IDEs, and `grep --mmap` rely on. (No longer
+//!   needs the `FUSE_DIRECT_IO_ALLOW_MMAP` cap or Linux 5.16+.)
+//! * [`fuse_mount_cache_stays_coherent_after_write`] — heddle#87
+//!   coherence red-commit. Write→close→reopen serves *fresh* content
+//!   under cached mode, proving active inode invalidation closes the
+//!   stale-read hazard that `FOPEN_DIRECT_IO` used to paper over.
+//! * [`fuse_mount_serves_repeat_reads_from_cache`] — heddle#87
+//!   cache-mode-active red-commit. A repeat read of unchanged content
+//!   is served from the kernel page cache (the FUSE `read`-callback
+//!   counter stays flat), proving the mount isn't bypassing the cache.
 //! * [`fuse_mount_unmounts_cleanly_on_session_drop`] — drop semantics.
 //!   After the session is dropped the mountpoint must no longer
 //!   serve the captured file; reading should fail with `NotFound` and
@@ -93,6 +100,25 @@ fn mount_fixture(repo: Repository) -> (BackgroundSession, TempDir) {
     let target = mountpoint.path().join("hello.txt");
     wait_for(&target, true, Duration::from_secs(5));
     (session, mountpoint)
+}
+
+/// Like [`mount_fixture`], but also hands back the FUSE `read`-callback
+/// counter so a test can observe whether the kernel page cache is
+/// serving repeated reads (cached mode, heddle#87).
+fn mount_fixture_with_read_counter(
+    repo: Repository,
+) -> (BackgroundSession, TempDir, std::sync::Arc<std::sync::atomic::AtomicU64>) {
+    let mount = ContentAddressedMount::new(repo, "main").expect("open mount");
+    let mountpoint = TempDir::new().expect("tempdir for mountpoint");
+    let shell = FuseShell::new(mount);
+    let read_calls = shell.read_calls_handle();
+    let session = shell
+        .mount_background(mountpoint.path())
+        .expect("mount session");
+
+    let target = mountpoint.path().join("hello.txt");
+    wait_for(&target, true, Duration::from_secs(5));
+    (session, mountpoint, read_calls)
 }
 
 /// Poll up to `deadline` for `target` to exist (`expect_present=true`)
@@ -155,6 +181,134 @@ fn fuse_mount_round_trips_writes_to_existing_file() {
     drop(session);
 }
 
+/// **heddle#87 red-commit (coherence).** The write→close→reopen
+/// stale-read hazard that heddle#74 r1 originally papered over with
+/// `FOPEN_DIRECT_IO` must stay closed *under cached mode* — i.e. with
+/// the page cache live and coherence maintained by active inode
+/// invalidation instead.
+///
+/// The scenario is deliberately the worst case for a page cache:
+///   1. Read the file through a fresh fd → kernel caches the bytes.
+///   2. Truncate-and-rewrite with *different-length* content through a
+///      *separate* fd, then close (→ `flush`/`release` promote the hot
+///      tier and fire `inval_inode`).
+///   3. Open a brand-new fd and read again.
+///
+/// Without invalidation, step 3 would hand back the bytes cached in
+/// step 1 (the page cache is keyed off the kernel-side inode, which is
+/// unchanged). With the heddle#87 invalidation contract, step 2's
+/// `inval_inode(ino, 0, -1)` drops those pages, so step 3 re-asks the
+/// shell and observes the fresh content. A regression that drops the
+/// invalidation (or re-introduces a caching mode the inval can't reach)
+/// fails here with the stale bytes.
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_cache_stays_coherent_after_write() {
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint) = mount_fixture(repo);
+
+    let target = mountpoint.path().join("hello.txt");
+
+    // 1. Prime the kernel page cache with the captured content.
+    assert_eq!(
+        fs::read_to_string(&target).expect("prime read"),
+        "world",
+        "captured content visible before write"
+    );
+
+    // 2. Rewrite with longer, different content through a separate fd.
+    //    `truncate(true)` exercises the `setattr(size=0)` → invalidation
+    //    path as well as the `write` + `flush`/`release` path.
+    {
+        let mut f = fs::OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .open(&target)
+            .expect("open for truncate+write");
+        f.write_all(b"FRESH-AND-LONGER-CONTENT")
+            .expect("write new content");
+        // drop → close → flush + release → promote + inval_inode.
+    }
+
+    // 3. Fresh open + read. Must observe the new bytes, not the cached
+    //    "world" from step 1.
+    //
+    //    Invalidation is dispatched off the FUSE worker thread (it has
+    //    to be — a synchronous notify from inside the mutating callback
+    //    deadlocks on the kernel inode lock), so it lands a beat after
+    //    `close(2)` returns rather than synchronously with it. Poll a
+    //    bounded window — deliberately *shorter than the 1 s attr TTL*
+    //    (`fuse::TTL`) — for the fresh content. The short window is what
+    //    makes this a real test of *active* invalidation rather than
+    //    passive TTL expiry: a coherent mount drops the page cache and
+    //    converges within single-digit ms, but a broken mount (no
+    //    invalidation) can only self-heal once the kernel re-validates
+    //    attrs at the TTL boundary — which is outside this window, so it
+    //    would still be serving the stale "world" when we assert.
+    let deadline = Instant::now() + Duration::from_millis(700);
+    let mut after = fs::read_to_string(&target).expect("read after rewrite");
+    while after != "FRESH-AND-LONGER-CONTENT" && Instant::now() < deadline {
+        thread::sleep(Duration::from_millis(10));
+        after = fs::read_to_string(&target).expect("re-read after rewrite");
+    }
+    assert_eq!(
+        after, "FRESH-AND-LONGER-CONTENT",
+        "active invalidation must drop the stale page cache so the \
+         reopened fd sees fresh content (heddle#87 coherence)"
+    );
+
+    drop(session);
+}
+
+/// **heddle#87 red-commit (cache-mode-active).** Proves the kernel
+/// page cache is actually serving repeated reads — i.e. the mount runs
+/// in cached mode, not the old `FOPEN_DIRECT_IO` bypass.
+///
+/// We read the same unchanged file twice through fresh fds and watch
+/// the FUSE `read`-callback counter. In cached mode the *second* whole
+/// read is served entirely from the kernel page cache, so the counter
+/// must not advance for it. In the old direct-IO mode every userspace
+/// `read(2)` becomes a FUSE `read` callback, so the counter would climb
+/// on the second read too — which is exactly the throughput cost
+/// heddle#87 removes. A regression that re-introduces `FOPEN_DIRECT_IO`
+/// fails here: the counter advances on the second read.
+#[test]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
+fn fuse_mount_serves_repeat_reads_from_cache() {
+    use std::sync::atomic::Ordering;
+
+    let (_repo_dir, repo) = build_fixture();
+    let (session, mountpoint, read_calls) = mount_fixture_with_read_counter(repo);
+
+    let target = mountpoint.path().join("hello.txt");
+
+    // First read: populates the page cache. This *does* go through the
+    // FUSE `read` callback (cold cache).
+    assert_eq!(fs::read_to_string(&target).expect("first read"), "world");
+    let after_first = read_calls.load(Ordering::Relaxed);
+    assert!(
+        after_first >= 1,
+        "the cold first read must reach the FUSE read callback at least once \
+         (got {after_first})"
+    );
+
+    // Second read of the same unchanged file through a fresh fd. In
+    // cached mode the kernel serves it from the page cache and never
+    // calls us; the counter stays flat.
+    assert_eq!(fs::read_to_string(&target).expect("second read"), "world");
+    let after_second = read_calls.load(Ordering::Relaxed);
+
+    assert_eq!(
+        after_second, after_first,
+        "cached mode must serve the second read from the kernel page cache \
+         without a FUSE round-trip — counter went {after_first} → {after_second}; \
+         a nonzero delta means the mount is still bypassing the cache \
+         (FOPEN_DIRECT_IO regression, heddle#87)"
+    );
+
+    drop(session);
+}
+
 #[test]
 #[ignore = "requires FUSE on host; opt-in via --ignored"]
 fn fuse_mount_serves_concurrent_readers() {
@@ -192,34 +346,20 @@ fn fuse_mount_serves_concurrent_readers() {
 /// `mmap(MAP_SHARED, ...)` against a mounted file must succeed and
 /// must return the captured bytes when the mapping is read.
 ///
-/// This locks in `FUSE_DIRECT_IO_ALLOW_MMAP`: the shell unconditionally
-/// returns `FOPEN_DIRECT_IO` from `open` so kernel page-cache reads
-/// don't shadow hot-tier writes, and under default kernel semantics
-/// that disables shared `mmap` on every fd (the page cache is the
-/// mapping substrate; bypass it and the kernel refuses to map the
-/// file, returning `ENODEV` from the `mmap` syscall). The shell opts
-/// out of that restriction via `InitFlags::FUSE_DIRECT_IO_ALLOW_MMAP`
-/// in its `init` callback — without that opt-in, this test fails
-/// with `Errno::NODEV` at the `Mmap::map(&file)` call, which is the
-/// exact failure mode rust-analyzer, cargo, and IDEs hit on
-/// heddle-mounted repos.
+/// Post-heddle#87 the shell runs in the kernel's default *cached*
+/// mode — `open` no longer returns `FOPEN_DIRECT_IO` — so shared
+/// `mmap` works out of the box: the page cache is the mapping
+/// substrate, and we keep it live. This is what makes rust-analyzer,
+/// cargo, IDEs, and `grep --mmap` work on heddle-mounted repos.
 ///
-/// The cap requires Linux 5.16+ (when the kernel-side flag was
-/// added). Older kernels silently drop the request — fuser logs it at
-/// debug — and this test will fail there. We probe the kernel version
-/// up front and skip rather than fail on older kernels so the
-/// `fuse-smoke` CI matrix stays portable.
+/// (Before heddle#87 this test had to opt the kernel into
+/// `FUSE_DIRECT_IO_ALLOW_MMAP` to map a `FOPEN_DIRECT_IO` fd, which
+/// required Linux 5.16+. Active invalidation removed both the
+/// direct-IO flag and that kernel-version floor, so the test no
+/// longer probes the kernel version.)
 #[test]
-#[ignore = "requires FUSE on host (Linux 5.16+); opt-in via --ignored"]
+#[ignore = "requires FUSE on host; opt-in via --ignored"]
 fn fuse_mount_serves_mmap_readers() {
-    if !kernel_at_least(5, 16) {
-        eprintln!(
-            "skipping fuse_mount_serves_mmap_readers: \
-             FUSE_DIRECT_IO_ALLOW_MMAP requires Linux 5.16+"
-        );
-        return;
-    }
-
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
 
@@ -229,11 +369,10 @@ fn fuse_mount_serves_mmap_readers() {
     // SAFETY: `Mmap::map` is unsafe because the kernel may revoke the
     // mapping out from under us if another process truncates the
     // backing file. In this test we hold the only handle to the
-    // mounted file for the lifetime of `mapping`, and the FUSE shell
-    // doesn't expose `setattr(size)` (so truncation is impossible
-    // through the mount). Soundness is on us; we accept the contract.
+    // mounted file for the lifetime of `mapping`, and we don't mutate
+    // it through the mount. Soundness is on us; we accept the contract.
     let mapping = unsafe { memmap2::Mmap::map(&file) }
-        .expect("mmap(MAP_SHARED) on mounted file (FUSE_DIRECT_IO_ALLOW_MMAP must be enabled)");
+        .expect("mmap(MAP_SHARED) on mounted file (cached mode must be in effect)");
 
     assert_eq!(
         &mapping[..],
@@ -244,22 +383,6 @@ fn fuse_mount_serves_mmap_readers() {
     drop(mapping);
     drop(file);
     drop(session);
-}
-
-/// Parse `/proc/sys/kernel/osrelease` to skip the mmap test on
-/// kernels older than `(major, minor)`. The cap was added in 5.16; a
-/// `mount.fuse.kernel-old.smoke` CI runner on an older kernel should
-/// skip rather than fail.
-fn kernel_at_least(major: u32, minor: u32) -> bool {
-    let raw = match fs::read_to_string("/proc/sys/kernel/osrelease") {
-        Ok(s) => s,
-        Err(_) => return true, // not Linux-shaped — let the test attempt and report
-    };
-    let version_str = raw.trim().split('-').next().unwrap_or("");
-    let mut parts = version_str.split('.').filter_map(|s| s.parse::<u32>().ok());
-    let host_major = parts.next().unwrap_or(0);
-    let host_minor = parts.next().unwrap_or(0);
-    (host_major, host_minor) >= (major, minor)
 }
 
 /// End-to-end verification of the write-side overlay ops added in


### PR DESCRIPTION
Closes #87

## What & why

Switches the Linux FUSE shell from cache-bypass (`FOPEN_DIRECT_IO` + the `FUSE_DIRECT_IO_ALLOW_MMAP` 5.16+ kernel cap) to the **FSKit-style active-invalidation** model: the mount runs in the kernel's *cached* mode and actively pushes `notify_inval_*` to the kernel the moment heddle mutates the backing content. Reads now use the page cache (throughput + zero-cap shared mmap) while staying coherent.

## Coherence guarantee

The stale-read hazard heddle#74 papered over with `FOPEN_DIRECT_IO` — write a captured file, close, reopen, kernel serves the pre-write page cache — is closed by **active invalidation, not cache bypass**:

| callback | invalidation |
|---|---|
| `write`, `setattr` | `inval_inode(ino, 0, -1)` (drops cached pages + attrs) |
| `create`/`mknod`/`mkdir`/`symlink` | `inval_entry(parent, name)` |
| `unlink`/`rmdir` | `inval_entry(parent, name)` |
| `rename` | `inval_entry` on both src and dst |

`flush`/`release` deliberately do **not** invalidate — promotion (hot→CAS) doesn't change the bytes served, and `flush` fires on every `close(2)` including a reader's, so invalidating there would throw away the cached-read win.

`open`/`create` now return `FOPEN_KEEP_CACHE` (no `FOPEN_DIRECT_IO`) so the page cache persists across opens; `init` drops the `FUSE_DIRECT_IO_ALLOW_MMAP` opt-in (and with it the **Linux 5.16+ floor** — shared mmap now works on any FUSE-capable kernel).

### The deadlock this avoids (notifier-thread architecture)

A whole-inode invalidation makes the kernel acquire `inode->i_rwsem` — a lock the in-flight `write`/`setattr` callback is *already holding*. Calling the notifier **inline from the callback deadlocks the mount** (the first cut did exactly this and wedged it, leaving zombie worker threads). So invalidations are enqueued onto a dedicated **invalidator thread** (`NotifyGate` = mpsc + worker, started right after the session mounts); callbacks enqueue and return immediately, the thread drains and issues the actual `notify_inval_*`. This mirrors how libfuse's own `notify_inval_*` examples are structured, and matches FSKit's asynchronous `invalidateNode`.

## Test evidence (red-commit)

Linux + FUSE, `#[ignore]`-gated (opt-in via `--ignored`):

- **`fuse_mount_cache_stays_coherent_after_write`** (coherence) — write→close→reopen serves fresh content within a window *shorter than the 1 s attr TTL*, so it proves *active* invalidation rather than passive TTL expiry.
- **`fuse_mount_serves_repeat_reads_from_cache`** (cache-mode-active) — a FUSE `read`-callback counter stays flat across a repeat read, proving cached mode is in effect; a `FOPEN_DIRECT_IO` regression bumps the counter and fails.
- existing heddle#74 write-roundtrip, concurrent-reader, and mmap tests still pass (mmap no longer needs the 5.16 cap); worker-crash/SIGKILL-auto-unmount tests pass; **a real `cargo build` through the mount (`cargo_build_smoke`) succeeds**.

## Gates run locally (all green)

- `cargo build --locked --workspace` (default) + `--all-features`
- `bash scripts/check-no-silent-default-tree-load.sh`
- `cargo test -p heddle-mount` (default) + `--features fuse --lib` (162 tests)
- `cargo test -p heddle-mount --features fuse --test fuse_mount -- --ignored` (8/8), `fuse_worker_crash`, `fuse_worker_resource_cleanup`, `cargo_build_smoke` (all run live against `/dev/fuse` on this Linux host)
- `cargo clippy --workspace --all-targets -- -D warnings` (default) + `clippy -p heddle-mount --features fuse --all-targets`

## Could not exercise locally

- **macOS/FSKit path** — this change is Linux-FUSE-only (`crates/mount/src/fskit/`). The FSKit shell already uses the invalidate-on-change model (`invalidateNode`); no FSKit code was touched. The structural parity (cached mode + active invalidation) is the goal, but the macOS adapter itself couldn't be compiled or run on this Linux host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785307122&installation_id=132405951&pr_number=810&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F810&signature=a3df2dc35d97f11eed75558a802572aa2e0b346d578365dc4d705d316ae397c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->