### PR TITLE
ci(deps): guard heddle-cli transitive dep count vs post-gix baseline

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -56,6 +56,24 @@ jobs:
           # this, cargo-deny errors out before policy checks run.
           rust-version: stable
 
+  cli-dep-count:
+    name: cli transitive dep count (heddle#604)
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Guards the heddle-cli transitive-dependency closure against silent
+      # regrowth after the gix removal (IMPROVEMENT_PLAN section 8 / P4 cut a
+      # ~277-dep subtree). Pure `cargo metadata` — no crate build — so it
+      # stays cheap on the PR path. Fails if the live count exceeds the
+      # committed baseline + slack; raise the baseline JSON in the same PR for
+      # an intentional addition.
+      - name: Assert CLI transitive dep count within baseline
+        run: bash scripts/check-cli-dep-count.sh
+
   cargo-audit:
     name: cargo-audit
     if: github.event_name != 'pull_request'

--- a/scripts/check-cli-dep-count.sh
+++ b/scripts/check-cli-dep-count.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Guard for the CLI transitive-dependency count (heddle#604).
+#
+# IMPROVEMENT_PLAN section 8 (P4) removed gix, a ~277-transitive-dep git
+# library subtree, taking the `heddle-cli` crate from 485 transitive deps
+# (docs/CLI_DEP_AUDIT_2026-05-12.md) down to the baseline recorded in
+# scripts/cli-dep-count-baseline.json. Without a guard that number silently
+# regrows: a careless `cargo add`, a feature flip that unifies a heavy
+# subtree, or a gix-style library sneaking back in all add transitive deps
+# that nobody notices until a cold build is slow again.
+#
+# This script counts the `heddle-cli` crate's transitive dependency closure
+# (default features, normal edges only — the same method the audit doc uses)
+# and FAILS if the live count exceeds baseline + slack. We persist only the
+# count, not the full dep set, so on a regression the failure message points
+# the author at `cargo tree` to find the new subtree.
+#
+# It uses `cargo metadata` only — no crate build — so it is cheap enough to
+# run on every PR.
+#
+# Knobs:
+#   HEDDLE_CLI_DEP_BASELINE_FILE — path to the baseline JSON
+#                                  (default: scripts/cli-dep-count-baseline.json)
+#
+# To intentionally raise the ceiling (a deliberate dep addition): bump
+# `baseline` in the JSON in the same PR, with a one-line justification in the
+# PR body. Lowering it after a reduction is encouraged — it tightens the gate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+WORKSPACE_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BASELINE_FILE="${HEDDLE_CLI_DEP_BASELINE_FILE:-$SCRIPT_DIR/cli-dep-count-baseline.json}"
+
+if [[ ! -f "$BASELINE_FILE" ]]; then
+  echo "error: baseline file not found: $BASELINE_FILE" >&2
+  exit 1
+fi
+
+# Resolve the dependency graph from the workspace root so the active
+# Cargo.lock is used. Write to a temp file (not a pipe) because the python
+# below is itself fed on stdin via a heredoc — stdin is not available for the
+# metadata payload.
+META_FILE="$(mktemp)"
+trap 'rm -f "$META_FILE"' EXIT
+(cd "$WORKSPACE_ROOT" && cargo metadata --format-version 1 --quiet) >"$META_FILE"
+
+# Single python pass: read the baseline JSON, walk the cli closure over normal
+# edges (default features), compare against baseline + slack. Exit non-zero on
+# regression. Keeps the graph-walk identical to docs/CLI_DEP_AUDIT_2026-05-12.md.
+BASELINE_FILE="$BASELINE_FILE" META_FILE="$META_FILE" python3 - <<'PY'
+import json
+import os
+import sys
+
+with open(os.environ["META_FILE"]) as f:
+    meta = json.load(f)
+
+with open(os.environ["BASELINE_FILE"]) as f:
+    base = json.load(f)
+
+pkg_name = base.get("package", "heddle-cli")
+baseline = int(base["baseline"])
+slack = int(base.get("slack", 0))
+ceiling = baseline + slack
+
+# Workspace members (source is None) are not counted as external deps.
+ws = {p["name"] for p in meta["packages"] if p["source"] is None}
+node_by_id = {n["id"]: n for n in meta["resolve"]["nodes"]}
+pkg_by_id = {p["id"]: p for p in meta["packages"]}
+
+try:
+    cli_id = next(
+        p["id"]
+        for p in meta["packages"]
+        if p["name"] == pkg_name and p["source"] is None
+    )
+except StopIteration:
+    print(f"error: workspace package {pkg_name!r} not found in cargo metadata", file=sys.stderr)
+    sys.exit(1)
+
+# Reachable closure over normal (non-dev, non-build) edges only.
+seen, stack = set(), [cli_id]
+while stack:
+    nid = stack.pop()
+    if nid in seen:
+        continue
+    seen.add(nid)
+    for d in node_by_id[nid]["deps"]:
+        # dep_kinds entry with kind == None is a normal (runtime) edge.
+        if not any(k.get("kind") is None for k in d.get("dep_kinds", [])):
+            continue
+        stack.append(d["pkg"])
+
+external = {pkg_by_id[i]["name"] for i in seen if pkg_by_id[i]["name"] not in ws}
+count = len(external)
+
+print(f"{pkg_name} transitive deps (default features): {count}")
+print(f"baseline: {baseline}  slack: {slack}  ceiling: {ceiling}")
+
+if count > ceiling:
+    over = count - baseline
+    print("", file=sys.stderr)
+    print(
+        f"FAIL: {pkg_name} transitive dep count {count} exceeds "
+        f"baseline {baseline} + slack {slack} = {ceiling} (over by {over}).",
+        file=sys.stderr,
+    )
+    print(
+        "      A dependency subtree grew. Find the new crate(s) with:",
+        file=sys.stderr,
+    )
+    print(f"        cargo tree -p {pkg_name} --edges normal", file=sys.stderr)
+    print(
+        "      If the addition is intentional, raise `baseline` in "
+        f"{os.path.basename(os.environ['BASELINE_FILE'])} in this PR with a "
+        "justification.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if count < baseline:
+    print(
+        f"note: count {count} is below baseline {baseline}; consider lowering "
+        "the baseline to keep the gate tight.",
+    )
+
+print("OK: within ceiling.")
+PY

--- a/scripts/cli-dep-count-baseline.json
+++ b/scripts/cli-dep-count-baseline.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "Post-gix-removal transitive-dependency baseline for the heddle-cli crate (default features). Tracked by scripts/check-cli-dep-count.sh, wired into .github/workflows/audit.yml. See docs/CLI_DEP_AUDIT_2026-05-12.md for the audit method and the dep-reduction plan (IMPROVEMENT_PLAN section 8, P4: gix removal cut a ~277-dep subtree). The gate FAILS if the live count exceeds baseline + slack; raise the baseline (with justification) only when a dep addition is deliberate.",
+  "package": "heddle-cli",
+  "features": "default",
+  "baseline": 350,
+  "slack": 10,
+  "measured_at": "2026-06-29",
+  "measured_against": "main post-#598 (sley-substrate) merge; pre-gix-removal count was 485 (docs/CLI_DEP_AUDIT_2026-05-12.md)"
+}


### PR DESCRIPTION
Closes #604

## What

Adds a CI guard that records the post-gix-removal transitive dependency count of the `heddle-cli` crate as a committed baseline and **fails CI if the count regresses upward beyond a tolerance**, so a careless `cargo add`, a feature flip that unifies a heavy subtree, or a gix-style library sneaking back in gets caught before it silently bloats the CLI.

IMPROVEMENT_PLAN section 8 / P4 removed gix (a ~277-transitive-dep git library subtree), taking `heddle-cli` from **485** transitive deps (`docs/CLI_DEP_AUDIT_2026-05-12.md`) down to the current count.

## Baseline count

**350** transitive deps (default features), measured on this branch (off `main`, post-#598 sley-substrate merge). Committed in `scripts/cli-dep-count-baseline.json` with **slack 10** (ceiling 360). Counting method is identical to the audit doc's reproduction recipe: walk the `heddle-cli` closure over normal (runtime) edges via `cargo metadata`, excluding workspace members.

## Where it's wired

New `cli-dep-count` job in `.github/workflows/audit.yml`, running on **every PR** (alongside `cargo-deny`, which already runs unconditionally on PRs per that file's own note). Pure `cargo metadata` — no crate build — so it's cheap on the PR path.

## Gate-bites proof (run locally)

- **At baseline** (350 ≤ ceiling 360) → `OK: within ceiling.`, exit 0.
- **Simulated regression** (baseline lowered to 339, slack 10, ceiling 349 < live 350):
  ```
  FAIL: heddle-cli transitive dep count 350 exceeds baseline 339 + slack 10 = 349 (over by 11).
        A dependency subtree grew. Find the new crate(s) with:
          cargo tree -p heddle-cli --edges normal
  ```
  exit 1 — the gate bites.
- **Below baseline** (baseline 400) → emits a `note:` suggesting the baseline be lowered, exit 0.

Count verified deterministic across repeated runs. `audit.yml` re-parses as valid YAML; baseline JSON re-parses. Script uses `set -euo pipefail`, quoted expansions, `mktemp` + `trap` cleanup.

## Scope

CI/scripts only — `.github/workflows/audit.yml`, `scripts/check-cli-dep-count.sh`, `scripts/cli-dep-count-baseline.json`. No Rust crates touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785307355&installation_id=132405951&pr_number=811&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F811&signature=c71bdf0acbde3f74168357cea39f838c1fc91bdd4002d7df345c3e842c5a98ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->