### PR TITLE
refactor(merge): merge planning owns strategy consistency (preview == apply) (#503)

### DIFF
--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -411,7 +411,13 @@ pub(crate) fn merge_thread_into_current(
     no_semantic: bool,
     git_commit: bool,
 ) -> Result<MergeOutput> {
-    let use_semantic = semantic_merge_enabled(no_semantic);
+    // Strategy + diff-semantics decided ONCE per merge attempt
+    // (HeddleCo/heddle#503). Preview, refresh, apply, and diff all read
+    // their strategy back off this single plan instead of re-deriving it
+    // — so the preview can't pick a different content-merge strategy than
+    // the apply path, which is the documented Codex r13 divergence class.
+    let attempt = MergeAttemptPlan::decide(no_semantic);
+    let use_semantic = attempt.use_semantic();
     let registry = AgentRegistry::new(repo.heddle_dir());
     let thread_manager = ThreadManager::new(repo.heddle_dir());
     let mut thread = thread_manager.find_by_thread(track_name)?;
@@ -467,8 +473,8 @@ pub(crate) fn merge_thread_into_current(
     // match the strategy the actual merge plan (below) will use, so
     // the `preview_summary` lines don't contradict the real outcome
     // (e.g. reporting `conflicts: 1 path conflict(s)` on a structural
-    // reshape that semantic resolves cleanly).
-    let preview_strategy = merge_strategy_for(use_semantic);
+    // reshape that semantic resolves cleanly). Both now read the SAME
+    // decision off `attempt` (#503), so they cannot diverge.
     let current_thread = repo
         .current_lane()?
         .unwrap_or_else(|| "detached".to_string());
@@ -485,7 +491,7 @@ pub(crate) fn merge_thread_into_current(
             &mut graph,
             thread,
             preview,
-            preview_strategy,
+            attempt.strategy(),
             Some(PreviewTarget {
                 label: &current_thread,
                 change_id: current_state.change_id,
@@ -516,7 +522,7 @@ pub(crate) fn merge_thread_into_current(
         ConflictLabels {
             current: &current_label,
             incoming: &incoming_label,
-            strategy: merge_strategy_for(use_semantic),
+            strategy: attempt.strategy(),
         },
     )?;
 

--- a/crates/cli/src/cli/commands/merge/mod.rs
+++ b/crates/cli/src/cli/commands/merge/mod.rs
@@ -335,6 +335,54 @@ fn merge_strategy_for(use_semantic: bool) -> MergeStrategy {
     }
 }
 
+/// Strategy + target decided **once per merge attempt** and reused by
+/// preview, refresh, apply, and diff (HeddleCo/heddle#503).
+///
+/// Before this seam existed, `merge_thread_into_current` computed the
+/// content-merge strategy independently for the preview report and for
+/// the apply `MergePlan` (two separate `merge_strategy_for(use_semantic)`
+/// calls). They agreed only by construction — and a Codex r13 P2 finding
+/// documented a real preview-vs-actual divergence regression caused by
+/// exactly that kind of duplicated, drift-prone strategy state. Routing
+/// every consumer through one decision makes "preview == apply" an
+/// invariant the type system enforces rather than a discipline each call
+/// site must remember.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct MergeAttemptPlan {
+    strategy: MergeStrategy,
+    /// Whether semantic analysis feeds the `--with-diff` / symbol-delta
+    /// payload. Derived from the same `use_semantic` decision as
+    /// `strategy`, so the diff path can't drift from the content-merge
+    /// path either.
+    use_semantic: bool,
+}
+
+impl MergeAttemptPlan {
+    /// Decide the strategy for one `heddle merge` invocation. This is the
+    /// single point where `no_semantic` becomes a `MergeStrategy`; every
+    /// downstream consumer reads it back off the plan.
+    pub(crate) fn decide(no_semantic: bool) -> Self {
+        let use_semantic = semantic_merge_enabled(no_semantic);
+        Self {
+            strategy: merge_strategy_for(use_semantic),
+            use_semantic,
+        }
+    }
+
+    /// The content-merge strategy for this attempt. Consumed identically
+    /// by the preview report's 3-way merge and the apply `MergePlan`, so
+    /// the two cannot select different strategies.
+    pub(crate) fn strategy(&self) -> MergeStrategy {
+        self.strategy
+    }
+
+    /// Whether semantic analysis is active for this attempt's diff
+    /// payload. Mirrors `strategy() == Semantic`.
+    pub(crate) fn use_semantic(&self) -> bool {
+        self.use_semantic
+    }
+}
+
 fn merge_already_in_progress_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "merge_already_in_progress",
@@ -2739,6 +2787,70 @@ fn merge_relation_summary(result: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression-lock for HeddleCo/heddle#503 (guards the documented
+    /// Codex r13 preview-vs-actual divergence class).
+    ///
+    /// Strategy is decided **once per merge attempt** via
+    /// `MergeAttemptPlan::decide`; preview and apply both read the
+    /// strategy back off that single plan. This test pins two things:
+    ///
+    /// 1. The decision is internally consistent — `strategy()` and
+    ///    `use_semantic()` never disagree (a `Semantic` strategy with
+    ///    `use_semantic == false`, or vice versa, would let the diff
+    ///    payload contradict the content merge).
+    /// 2. `merge_thread_into_current` no longer recomputes the strategy
+    ///    independently for preview and apply. We enforce this at the
+    ///    source level: the body must contain exactly ONE
+    ///    `MergeAttemptPlan::decide(` call and ZERO bare
+    ///    `merge_strategy_for(use_semantic)` call sites — the old
+    ///    duplicated form the issue flagged. If a future edit
+    ///    reintroduces a second, drift-prone strategy decision, this
+    ///    assertion fails.
+    #[test]
+    fn merge_strategy_is_decided_once_preview_equals_apply() {
+        // (1) The decision object is self-consistent for both flags.
+        for no_semantic in [false, true] {
+            let plan = MergeAttemptPlan::decide(no_semantic);
+            let semantic_active = plan.strategy() == MergeStrategy::Semantic;
+            assert_eq!(
+                semantic_active,
+                plan.use_semantic(),
+                "MergeAttemptPlan strategy and use_semantic must agree (no_semantic={no_semantic})"
+            );
+            assert_eq!(
+                plan.strategy(),
+                merge_strategy_for(semantic_merge_enabled(no_semantic)),
+                "decide() must select the same strategy the legacy derivation would"
+            );
+        }
+
+        // (2) Source-level invariant: the merge-attempt flow decides the
+        // strategy exactly once and never re-derives it independently for
+        // preview vs apply. The preview report and the apply MergePlan
+        // must consume the SAME plan, so there is one `decide(` call and
+        // no surviving `merge_strategy_for(use_semantic)` call sites in
+        // `merge_thread_into_current`.
+        let source = include_str!("mod.rs");
+        let body = source
+            .split_once("pub(crate) fn merge_thread_into_current(")
+            .expect("merge_thread_into_current must exist")
+            .1
+            .split_once("\nfn mark_merge_previewed(")
+            .expect("merge_thread_into_current must be delimited by mark_merge_previewed")
+            .0;
+        let decide_calls = body.matches("MergeAttemptPlan::decide(").count();
+        assert_eq!(
+            decide_calls, 1,
+            "merge_thread_into_current must decide the merge strategy exactly once \
+             (found {decide_calls} MergeAttemptPlan::decide call sites)"
+        );
+        assert!(
+            !body.contains("merge_strategy_for(use_semantic)"),
+            "preview and apply must consume the single MergeAttemptPlan, not re-derive \
+             the strategy via merge_strategy_for(use_semantic)"
+        );
+    }
 
     #[test]
     fn merge_in_progress_refusal_uses_typed_recovery_advice() {


### PR DESCRIPTION
Closes #503.

## Divergence found
The content-merge strategy was **recomputed independently** for the merge preview and for the apply path in `merge_thread_into_current` (`crates/cli/src/cli/commands/merge/mod.rs`):

- the preview report's 3-way merge got `merge_strategy_for(use_semantic)` (old line 471), and
- the apply `MergePlan` got a *separate* `merge_strategy_for(use_semantic)` (old line 519).

They agreed only **by construction** — and an in-code `Codex r13 P2` comment in that region documents a prior preview-vs-actual divergence regression caused by exactly this kind of duplicated, drift-prone strategy state. Any future edit to one call site (e.g. a strategy override) would silently let the preview render one outcome while the apply produced another. So this is a latent correctness seam, not just a locality nit.

## Fix
Decide strategy + diff-semantics **once per merge attempt** in a new `MergeAttemptPlan::decide(no_semantic)`, computed at the top of `merge_thread_into_current`. The preview report, the apply `MergePlan`, and the `--with-diff`/symbol-delta payload all read their strategy back off this single plan (`attempt.strategy()` / `attempt.use_semantic()`) instead of independently calling `merge_strategy_for(use_semantic)`. "preview == apply" becomes structural rather than a discipline each call site must remember. CLI rendering is unchanged — it remains an adapter over the resulting plan. Diff confined to `crates/cli/src/cli/commands/merge/mod.rs` (123 insertions, 5 deletions).

## Test (failing-test-first)
Added `merge_strategy_is_decided_once_preview_equals_apply` (regression-lock guarding the documented r13 class). It pins two things:
1. `MergeAttemptPlan::decide` is internally consistent — `strategy()` and `use_semantic()` never disagree, for both `no_semantic` values.
2. Source-level invariant: `merge_thread_into_current` contains **exactly one** `MergeAttemptPlan::decide(` call and **zero** `merge_strategy_for(use_semantic)` call sites — so a future edit can't reintroduce a second, drift-prone strategy decision without reddening CI.

- **RED:** `c8f77fc27890abe512104d73a9b27127360d9393` — fails with `found 0 MergeAttemptPlan::decide call sites` (apply/preview still re-derive independently).
- **Fix (GREEN):** `96ea9805949bc4bfcc3be3bc56064766b99e4b46`.

## Gates
- `bash scripts/check-no-silent-default-tree-load.sh` — clean (567 files)
- `cargo build --locked --workspace` (default features) — OK
- `cargo build --locked --workspace --all-features` — OK
- `cargo build --locked -p heddle-cli --no-default-features --features git-overlay,semantic` — OK. (Note: bare `--no-default-features --features semantic` is **not a buildable config** — `heddle-cli` has a `compile_error!` requiring at least one repo mode; this is pre-existing on main, not introduced here. Used the minimal valid `git-overlay,semantic` slim build instead.)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p heddle-semantic -p heddle-mount -p heddle-cli` — green (925/928 cli; the 3 failures are the pre-existing `oss_cli_polish::actor_*` env-leak tests — they assert harness/model detection driven by leaked `CLAUDE_CODE_*`/`CODEX_*` env in the runner, unrelated to merge; persist when re-run in isolation, not in my diff scope)
- `cargo test -p heddle-cli --test cli_integration` — same 3 pre-existing `actor_*` leaks; output_kind invariant + all other integration tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785307902&installation_id=132405951&pr_number=812&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F812&signature=5cc3c8cef3cdc941010f19c010328bcdfda1c403d60c3c17b58b02e17813ace6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->