### PR TITLE
ci(schemas): gate heddle doctor schemas drift in CI

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -150,15 +150,18 @@ jobs:
           printf '%s\n' "$diff_output" > changed-paths.txt
 
           # docs_only: EVERY changed path is a non-build doc path that the
-          # Rust suite does not validate. The catch: `check-and-test` runs
-          # `doctor docs --all` (which natively walks the repo and scans
-          # EVERY `.md` except those under `docs/spikes/` — see
-          # IGNORE_PATTERNS in crates/cli/src/cli/commands/doctor_docs.rs)
-          # and `doctor schemas` (which parses `docs/json-schemas.md`). So
-          # top-level READMEs and any other `docs/*.md` DO feed those gates
-          # and are NOT doc-only — only `docs/spikes/**` is exempt there,
-          # making it the sole doc-only prefix. Fail-safe: any path outside
-          # it ⇒ not doc-only ⇒ rust=true (run the suite).
+          # Rust suite does not validate. The catch: the `heddle-cli`
+          # integration tests assert `doctor docs --all` (which natively
+          # walks the repo and scans EVERY `.md` except those under
+          # `docs/spikes/` — see IGNORE_PATTERNS in
+          # crates/cli/src/cli/commands/doctor_docs.rs) and `doctor
+          # schemas` (which parses `docs/json-schemas.md`) stay clean, and
+          # `check-and-test`'s `Doctor schemas drift gate` step reruns the
+          # built binary's `doctor schemas` against `docs/json-schemas.md`.
+          # So top-level READMEs and any other `docs/*.md` DO feed those
+          # gates and are NOT doc-only — only `docs/spikes/**` is exempt
+          # there, making it the sole doc-only prefix. Fail-safe: any path
+          # outside it ⇒ not doc-only ⇒ rust=true (run the suite).
           if ! printf '%s\n' "$diff_output" | grep -vE '^(docs/spikes/|[[:space:]]*$)' \
               > /dev/null; then
             docs_only=true
@@ -413,6 +416,17 @@ jobs:
           # install; otherwise Linux mounts silently fall back to NFS
           # (heddle#190 r5 / Codex PR #225 P2).
           bash scripts/check-default-install-ships-worker.sh
+
+      # Assert `heddle doctor schemas` reports no drift between the
+      # generated schema mirrors and the documented `--output json`
+      # samples in `docs/json-schemas.md`. IMPROVEMENT_PLAN §7's DoD
+      # requires this surface stay clean after any Principal/output-
+      # boundary change (heddle#593); the script builds `heddle` from
+      # this checkout, runs `doctor schemas`, and propagates its
+      # non-zero exit on drift (heddle#605).
+      - name: Doctor schemas drift gate
+        if: needs.changes.outputs.cli_checks == 'true'
+        run: bash scripts/check-doctor-schemas-clean.sh
 
       - name: sccache stats
         run: sccache --show-stats

--- a/scripts/check-doctor-schemas-clean.sh
+++ b/scripts/check-doctor-schemas-clean.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Assert `heddle doctor schemas` reports no drift against the committed
+# `docs/json-schemas.md`. IMPROVEMENT_PLAN §7 ("Substrate-specific"
+# gates) carries the DoD that `doctor schemas` must stay clean after any
+# `Principal`/output-boundary change (heddle#593); without a CI gate a
+# schema drift lands silently. heddle#605.
+#
+# `heddle doctor schemas` regenerates every registered schema mirror
+# from the running binary and diffs each documented `--output json`
+# sample in `docs/json-schemas.md` against it. On drift (a sample key
+# the schema doesn't declare, a renamed/dropped field, a coverage gap)
+# the command exits non-zero with a typed recovery envelope; on a clean
+# tree it exits 0. So the gate is simply: build the binary from THIS
+# checkout, run `doctor schemas`, and propagate its exit status. The
+# committed baseline is `docs/json-schemas.md` itself.
+#
+# We build with `--message-format=json` and read the artifact's
+# absolute `executable` path (mirroring
+# `check-default-install-ships-worker.sh`) so the gate enumerates the
+# binary THIS invocation produced — a stale `heddle` in a cached
+# `target/` can't fool it — and so it works under cross-compilation
+# (`--target`, `build.target` in `.cargo/config.toml`) where the binary
+# lands under `${target_dir}/<triple>/debug/`. Writing the build log to
+# disk instead of piping avoids the SIGPIPE+pipefail trap.
+set -euo pipefail
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+build_log=$(mktemp)
+trap 'rm -f "$build_log"' EXIT
+
+cargo build --locked -p heddle-cli --bin heddle --message-format=json >"$build_log"
+
+heddle_bin=$(python3 -c '
+import json, sys
+with open(sys.argv[1]) as f:
+    for line in f:
+        try:
+            m = json.loads(line)
+        except ValueError:
+            continue
+        if (m.get("reason") == "compiler-artifact"
+                and m.get("target", {}).get("name") == "heddle"
+                and m.get("executable")):
+            print(m["executable"])
+            sys.exit(0)
+sys.exit(1)
+' "$build_log") || {
+    echo "ERROR: \`cargo build -p heddle-cli --bin heddle\` did not emit a heddle compiler-artifact with an executable." >&2
+    exit 1
+}
+
+if [ ! -x "$heddle_bin" ]; then
+    echo "ERROR: heddle artifact path is not executable: $heddle_bin" >&2
+    exit 1
+fi
+
+# Run against this checkout. `--repo` pins the source root so the drift
+# check reads THIS tree's `docs/json-schemas.md` rather than discovering
+# some ambient repo. A non-zero exit means the documented samples
+# drifted from the generated schemas (or a coverage gap opened); the
+# command prints the offending verb/field and the recovery command.
+echo "Running \`heddle doctor schemas\` against $repo_root ..."
+if "$heddle_bin" --repo "$repo_root" doctor schemas; then
+    echo "OK: doctor schemas reports no drift against docs/json-schemas.md"
+else
+    status=$?
+    echo "ERROR: \`heddle doctor schemas\` reported schema/doc drift (exit $status)." >&2
+    echo "  Update the schema mirror in crates/cli/src/cli/commands/schemas.rs and/or" >&2
+    echo "  the documented sample in docs/json-schemas.md so they agree, then rerun." >&2
+    echo "  \`heddle doctor schemas --update-docs\` refreshes the machine-contract coverage sample." >&2
+    exit "$status"
+fi


### PR DESCRIPTION
Closes #605

## What

IMPROVEMENT_PLAN §7's DoD requires `heddle doctor schemas` stay clean after any `Principal`/output-boundary change (#593), but **no CI step actually ran the binary** against the committed docs — a schema drift could land silently. The only enforcement was the in-process `heddle-cli` integration test `doctor_schemas_reports_runtime_and_documented_coverage`; meanwhile the `changes`-job comment *claimed* `check-and-test` ran `doctor schemas` while nothing invoked it.

This adds an explicit binary-level gate.

## Gate mechanism

`scripts/check-doctor-schemas-clean.sh`:
1. Builds `heddle` from this checkout via `cargo build -p heddle-cli --bin heddle --message-format=json`, reading the artifact's absolute `executable` path (mirrors `check-default-install-ships-worker.sh`, so a stale cached binary in `target/` can't fool it, and it works under cross-compilation).
2. Runs `heddle --repo <root> doctor schemas`. That command regenerates every registered schema mirror from the running binary and diffs each documented `--output json` sample in `docs/json-schemas.md` against it. On drift (an undeclared sample key, a renamed/dropped field, a coverage gap) it exits **74** with a typed recovery envelope; clean exits 0.
3. Propagates the exit status, printing the offending verb/field and the fix commands on failure.

The committed baseline is `docs/json-schemas.md` itself (already in tree, clean today).

## Where it's wired

A `Doctor schemas drift gate` step in the `check-and-test` job of `.github/workflows/rust-tests.yml`, gated on `cli_checks` (the schema surface lives in `heddle-cli`). Doc-only changes to `docs/json-schemas.md` are already non-doc-only → `rust=true`, so the existing `cli_integration` test covers that path; this step is the built-binary belt-and-suspenders for source changes. The stale `changes`-job comment is corrected to describe the real gates.

## What schemas it covers

Every `--output json`-emitting verb registered in `crates/cli/src/cli/commands/schemas.rs` (173 documented runtime schema verbs) plus catalog-wide schema-coverage assertions — the same surface `doctor schemas` validates.

## Gate-bites proof

```
# baseline
$ bash scripts/check-doctor-schemas-clean.sh
OK: doctor schemas reports no drift against docs/json-schemas.md   # exit 0

# perturb: insert one bogus top-level field into the `status` sample in docs/json-schemas.md
$ bash scripts/check-doctor-schemas-clean.sh
Error: 1 schema drift issue(s) found
ERROR: `heddle doctor schemas` reported schema/doc drift (exit 74).
  Update the schema mirror in crates/cli/src/cli/commands/schemas.rs and/or
  the documented sample in docs/json-schemas.md so they agree, then rerun.
# script exit 74
```

Restoring the doc returns the gate to exit 0.

## Notes

- YAML parse-validated; bash syntax-checked (`bash -n`). shellcheck not installed on the box, but the script reuses the vetted shape of `check-default-install-ships-worker.sh`.
- Scope: CI workflow + new check script only. No source crates touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785307923&installation_id=132405951&pr_number=813&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F813&signature=e0d9df562e7b9fc7cd6b0e8b613240f4899977d70d089c0ff1fa3a464e657c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->