### PR TITLE
deps: bump rusqlite 0.32→0.39, sqlx 0.8→0.9 + pooled semantic parser/syntax-index refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayref"
@@ -153,9 +153,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
 
 [[package]]
 name = "async-trait"
@@ -165,7 +165,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -402,6 +402,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,12 +421,12 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.12.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
 dependencies = [
  "memchr",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -440,9 +449,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cast"
@@ -472,16 +481,16 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -503,9 +512,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -559,7 +568,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -603,7 +612,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -611,6 +620,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -691,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -811,6 +826,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -834,7 +867,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -906,8 +939,19 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid 0.9.6",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -918,7 +962,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -994,7 +1038,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -1021,7 +1065,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1042,13 +1086,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1143,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1285,7 +1328,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1353,16 +1396,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1427,22 +1468,22 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1458,20 +1499,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1670,7 +1702,7 @@ dependencies = [
  "proc-macro2",
  "protoc-bin-vendored",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "toml 1.1.2+spec-1.1.0",
  "walkdir",
@@ -1956,7 +1988,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1969,12 +2010,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2024,9 +2065,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
  "typenum",
 ]
@@ -2211,12 +2252,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2261,8 +2296,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -2396,7 +2429,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2415,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2430,9 +2463,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2448,7 +2481,7 @@ dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -2493,12 +2526,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2511,22 +2538,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
-name = "libredox"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
-dependencies = [
- "bitflags 2.13.0",
- "libc",
- "plain",
- "redox_syscall 0.8.1",
-]
-
-[[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2556,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -2586,12 +2601,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2817,7 +2832,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2879,7 +2894,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3054,7 +3069,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3066,7 +3081,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3131,7 +3146,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3193,12 +3208,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"
@@ -3293,7 +3302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3333,7 +3342,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3401,7 +3410,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -3428,7 +3437,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3551,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3598,7 +3607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -3685,15 +3694,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
-dependencies = [
- "bitflags 2.13.0",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3710,7 +3710,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3792,7 +3792,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3859,17 +3859,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "rusqlite"
-version = "0.32.1"
+name = "rsqlite-vfs"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.13.0",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink 0.9.1",
+ "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3902,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "log",
  "once_cell",
@@ -3993,12 +4004,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "salsa20"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4048,7 +4053,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4151,7 +4156,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4162,7 +4167,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4186,18 +4191,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
 ]
 
 [[package]]
@@ -4232,7 +4225,7 @@ checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4244,6 +4237,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4268,6 +4272,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4393,7 +4408,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8d5abdf501a882e81922a432c34a411b45ac01e5638ce25e46e8eb2824516dd"
 dependencies = [
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -4736,10 +4751,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlx"
-version = "0.8.6"
+name = "sqlite-wasm-rs"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4750,12 +4777,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -4765,12 +4793,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
- "hashlink 0.10.0",
+ "hashbrown 0.16.1",
+ "hashlink",
  "indexmap",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
@@ -4783,33 +4810,33 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -4819,60 +4846,44 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
  "uuid",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -4886,18 +4897,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4909,13 +4918,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4925,7 +4935,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -5009,9 +5018,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5035,7 +5044,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5045,7 +5054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5077,7 +5086,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5088,7 +5097,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5102,9 +5111,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5122,9 +5131,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5189,7 +5198,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5346,7 +5355,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5358,7 +5367,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5396,7 +5405,7 @@ dependencies = [
  "prost-build",
  "prost-types 0.14.4",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build",
 ]
@@ -5481,7 +5490,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5554,9 +5563,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
 dependencies = [
  "cc",
  "regex",
@@ -5672,7 +5681,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
 ]
 
@@ -5722,12 +5731,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5747,7 +5750,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5794,11 +5797,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -5862,29 +5865,14 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
+ "wit-bindgen",
 ]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5895,9 +5883,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.75"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5905,9 +5893,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5915,65 +5903,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.125"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.102"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5991,9 +5945,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6004,14 +5958,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6027,13 +5981,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -6119,7 +6069,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6130,7 +6080,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6169,15 +6119,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -6201,21 +6142,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -6262,12 +6188,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6280,12 +6200,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6295,12 +6209,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6328,12 +6236,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6343,12 +6245,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6364,12 +6260,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6379,12 +6269,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6415,97 +6299,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -6532,7 +6328,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6553,7 +6349,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6573,7 +6369,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -6594,7 +6390,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6627,14 +6423,14 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,9 +73,9 @@ opentelemetry-otlp = { version = "0.32", features = ["grpc-tonic", "trace", "met
 opentelemetry_sdk = "0.32"
 rand = "0.10"
 regex-lite = "0.1"
-reqwest = { version = "0.13.2", default-features = false, features = ["json", "rustls-no-provider"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-no-provider"] }
 rmp-serde = "1"
-rusqlite = { version = "0.32", features = ["bundled"] }
+rusqlite = { version = "0.39", features = ["bundled"] }
 rsa = { version = "0.9", features = ["pem"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }
 schemars = { version = "1.2", features = ["chrono04"] }
@@ -85,7 +85,7 @@ serde_json = "1"
 serial_test = "3"
 sha2 = { version = "0.10", features = ["oid"] }
 similar = "3"
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "uuid", "json"] }
+sqlx = { version = "0.9", default-features = false, features = ["runtime-tokio", "tls-rustls-ring", "postgres", "chrono", "uuid", "json"] }
 syn = { version = "2", features = ["full", "visit", "extra-traits"] }
 tempfile = "3"
 thiserror = "2"

--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -25,7 +25,8 @@ use super::{
     command_catalog::ActionTemplate,
     git_overlay_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState,
-        build_repository_verification_state, build_repository_verification_state_with_worktree_status,
+        build_repository_verification_state,
+        build_repository_verification_state_with_worktree_status,
         git_overlay_mutation_preflight_advice_with_worktree_status,
         plain_git_mutation_preflight_advice, repository_verification_blocked_advice,
     },

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -44,8 +44,7 @@ use crate::{
     bridge::{
         GitBridge,
         git_core::{
-            clone_url_to_bare, copy_local_repo_to_bare, open_repo, set_reference,
-            write_head_symref,
+            clone_url_to_bare, copy_local_repo_to_bare, open_repo, set_reference, write_head_symref,
         },
         git_ingest::import_git_history,
     },

--- a/crates/cli/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli/src/cli/commands/command_catalog/mod.rs
@@ -1232,10 +1232,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["agent", "list"],
         surface(documented_schemas(READ_JSON, &["agent list"]), "automation"),
     ),
-    entry(
-        &["auth"],
-        category(feature_gated(GROUP, "client"), "repo"),
-    ),
+    entry(&["auth"], category(feature_gated(GROUP, "client"), "repo")),
     entry(&["auth", "login"], feature_gated(MUTATING_TEXT, "client")),
     entry(
         &["auth", "logout"],
@@ -3118,7 +3115,11 @@ fn append_feature_gated_command_entries(
         if clap_command_path_exists(root, entry.path) {
             continue;
         }
-        out.push(feature_gated_catalog_entry(&owned_path, entry.contract, op_id_option));
+        out.push(feature_gated_catalog_entry(
+            &owned_path,
+            entry.contract,
+            op_id_option,
+        ));
     }
 }
 
@@ -3149,7 +3150,9 @@ fn feature_gated_catalog_entry(
             .canonical_command
             .map(std::string::ToString::to_string),
         canonical_action: canonical_action(contract),
-        command_action: contract.advertised_action.map(command_action_from_advertised),
+        command_action: contract
+            .advertised_action
+            .map(command_action_from_advertised),
         summary: String::new(),
         has_subcommands: false,
         supports_json: contract.supports_json,

--- a/crates/cli/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli/src/cli/commands/command_catalog/tests.rs
@@ -564,10 +564,9 @@ fn recommended_action_templates_describe_display_only_placeholders() {
     assert_eq!(dynamic_clone.required_inputs, vec!["path"]);
     assert!(!dynamic_clone.agent_may_fill);
 
-    let import = recommended_action_template(
-        "heddle bridge git import --path <full-git-repo> --ref <ref>",
-    )
-    .expect("shallow import recovery placeholder should resolve");
+    let import =
+        recommended_action_template("heddle bridge git import --path <full-git-repo> --ref <ref>")
+            .expect("shallow import recovery placeholder should resolve");
     assert_eq!(
         import.argv_template,
         vec![
@@ -718,9 +717,8 @@ fn recommended_action_parser_supports_shell_quoted_arguments() {
         ["merge", "feature with spaces", "--preview"]
     );
 
-    let template =
-        recommended_action_template("heddle merge 'feature '\\''quoted'\\''' --preview")
-            .expect("shell-quoted apostrophe should resolve to a template");
+    let template = recommended_action_template("heddle merge 'feature '\\''quoted'\\''' --preview")
+        .expect("shell-quoted apostrophe should resolve to a template");
     assert_eq!(
         template.argv_template[1..],
         ["merge", "feature 'quoted'", "--preview"]
@@ -731,8 +729,8 @@ fn recommended_action_parser_supports_shell_quoted_arguments() {
 fn checked_action_builder_quotes_and_validates_from_argv() {
     let action = heddle_action(["merge", "feature with spaces", "--preview"]);
     assert_eq!(action, "heddle merge 'feature with spaces' --preview");
-    let template = recommended_action_template(&action)
-        .expect("built action should resolve to a template");
+    let template =
+        recommended_action_template(&action).expect("built action should resolve to a template");
     assert_eq!(
         template.argv_template[1..],
         ["merge", "feature with spaces", "--preview"]
@@ -933,8 +931,7 @@ fn contract_paths_with_children(
         .iter()
         .filter(|candidate| {
             entries.iter().any(|entry| {
-                entry.path.len() > candidate.path.len()
-                    && entry.path.starts_with(candidate.path)
+                entry.path.len() > candidate.path.len() && entry.path.starts_with(candidate.path)
             })
         })
         .map(|entry| entry.path.to_vec())
@@ -1225,8 +1222,7 @@ fn hidden_clap_flags_are_present_in_machine_catalog() {
     let mut failures = Vec::new();
     for (display, id) in hidden_flags {
         if display.is_empty() {
-            let Some(option) = catalog.global_options.iter().find(|option| option.id == id)
-            else {
+            let Some(option) = catalog.global_options.iter().find(|option| option.id == id) else {
                 failures.push(format!("global hidden flag `{id}` missing from catalog"));
                 continue;
             };
@@ -1239,9 +1235,8 @@ fn hidden_clap_flags_are_present_in_machine_catalog() {
         }
 
         let Some(entry) = catalog.command_by_display(&display) else {
-            if command_contract_removed_alias_root(
-                display.split_whitespace().next().unwrap_or(""),
-            ) {
+            if command_contract_removed_alias_root(display.split_whitespace().next().unwrap_or(""))
+            {
                 continue;
             }
             failures.push(format!(
@@ -1997,5 +1992,8 @@ fn op_id_persistence_reads_contract_table() {
 
 #[test]
 fn feature_gated_command_roots_are_catalog_owned() {
-    assert_eq!(feature_gated_command_roots(), &["auth", "presence", "support"]);
+    assert_eq!(
+        feature_gated_command_roots(),
+        &["auth", "presence", "support"]
+    );
 }

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -18,7 +18,8 @@ use super::{
     advice::RecoveryAdvice,
     git_overlay_health::{
         RepositoryVerificationState, build_plain_git_verification_probe,
-        build_repository_verification_state, build_repository_verification_state_with_worktree_status,
+        build_repository_verification_state,
+        build_repository_verification_state_with_worktree_status,
         override_trust_recommended_action,
     },
     merge::{ThreadPreviewReport, build_thread_preview_report},

--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -555,9 +555,8 @@ fn auto_merge_text_lines(
     };
 
     #[cfg(feature = "semantic")]
-    let outcome = semantic::merge_driver::semantic_three_way_merge(
-        base, current, incoming, path, markers,
-    );
+    let outcome =
+        semantic::merge_driver::semantic_three_way_merge(base, current, incoming, path, markers);
     #[cfg(not(feature = "semantic"))]
     let outcome = {
         let _ = path;
@@ -1233,7 +1232,10 @@ fn f() { 6 }
             !merged.contains("<<<<<<<"),
             "no conflict markers expected: {merged}"
         );
-        assert!(merged.contains("fn c() { 333 }"), "theirs c-edit lost: {merged}");
+        assert!(
+            merged.contains("fn c() { 333 }"),
+            "theirs c-edit lost: {merged}"
+        );
         assert!(merged.contains("fn f() { 6 }"), "theirs add lost: {merged}");
         for name in ["fn a", "fn b", "fn c", "fn d", "fn e"] {
             assert!(merged.contains(name), "missing {name}: {merged}");

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -4,8 +4,10 @@
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
-use objects::object::{Agent, Attribution, ChangeId, Principal, Tree};
-use objects::worktree::WorktreeStatus;
+use objects::{
+    object::{Agent, Attribution, ChangeId, Principal, Tree},
+    worktree::WorktreeStatus,
+};
 use repo::{
     Hook, HookContext, HookManager, Repository, SessionManager, SnapshotProfile, format_confidence,
     refresh_active_thread_metadata,

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -2804,10 +2804,10 @@ mod tests {
 
     use super::{
         ActorInfo, ChangesInfo, CoordinationStatus, GitOverlayHealth, MaterializedThreadInfo,
-        PlainGitStatusOutput, RepositoryVerificationState, ShortStatusRow,
-        append_fast_status_row, assess_materialized_threads, build_status_output,
-        combined_verdict_axes, coordination_axis_clean, coordination_label,
-        render_status_materialized, resolve_coordination_with_trust,
+        PlainGitStatusOutput, RepositoryVerificationState, ShortStatusRow, append_fast_status_row,
+        assess_materialized_threads, build_status_output, combined_verdict_axes,
+        coordination_axis_clean, coordination_label, render_status_materialized,
+        resolve_coordination_with_trust,
     };
 
     const AGENT_CONTEXT_STATUS_KEYS: &[&str] = &[
@@ -3395,7 +3395,12 @@ mod tests {
         }
     }
 
-    fn status_row<'a>(index: u8, worktree: u8, path: &'a [u8], in_head: bool) -> ShortStatusRow<'a> {
+    fn status_row<'a>(
+        index: u8,
+        worktree: u8,
+        path: &'a [u8],
+        in_head: bool,
+    ) -> ShortStatusRow<'a> {
         ShortStatusRow {
             index,
             worktree,

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -5,6 +5,7 @@ use std::{
     collections::{BTreeSet, HashMap},
     path::{Path, PathBuf},
     process,
+    time::Instant,
 };
 
 use anyhow::{Context, Result, anyhow};
@@ -59,7 +60,6 @@ use crate::{
     config::{UserConfig, UserThreadWorkspaceMode},
     perf::{ProfileField, emit_profile, profile_enabled},
 };
-use std::time::Instant;
 
 pub(crate) const DEFAULT_AVAILABLE_GIT_REF_LIMIT: usize = 5;
 

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Repository verification proof surface.
 
+use std::time::Instant;
+
 use anyhow::{Result, anyhow};
 use repo::Repository;
 use serde::Serialize;
@@ -17,7 +19,6 @@ use crate::{
     cli::{Cli, should_output_json, style},
     perf::{ProfileField, emit_profile, profile_enabled},
 };
-use std::time::Instant;
 
 #[derive(Debug, Serialize)]
 struct VerifyOutput {
@@ -39,27 +40,26 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
     let plain_git_probe_ms = probe_start.elapsed().as_millis();
     let mut repo_open_ms = 0u128;
     let mut verification_ms = 0u128;
-    let (trust, presentation, repo_config) =
-        if let Some(probe) = plain_git_probe {
-            (
-                probe.trust,
-                crate::cli::render::RepositoryPresentation {
-                    label: crate::cli::render::repository_mode_label("plain-git", "git-only"),
-                    context: None,
-                },
-                None,
-            )
-        } else {
-            let repo_open_start = Instant::now();
-            let repo = Repository::open(start)?;
-            repo_open_ms = repo_open_start.elapsed().as_millis();
-            let verification_start = Instant::now();
-            let trust = build_repository_verification_state(&repo);
-            verification_ms = verification_start.elapsed().as_millis();
-            let presentation = crate::cli::render::repository_presentation(&repo, None, None);
-            let config = repo.config().clone();
-            (trust, presentation, Some(config))
-        };
+    let (trust, presentation, repo_config) = if let Some(probe) = plain_git_probe {
+        (
+            probe.trust,
+            crate::cli::render::RepositoryPresentation {
+                label: crate::cli::render::repository_mode_label("plain-git", "git-only"),
+                context: None,
+            },
+            None,
+        )
+    } else {
+        let repo_open_start = Instant::now();
+        let repo = Repository::open(start)?;
+        repo_open_ms = repo_open_start.elapsed().as_millis();
+        let verification_start = Instant::now();
+        let trust = build_repository_verification_state(&repo);
+        verification_ms = verification_start.elapsed().as_millis();
+        let presentation = crate::cli::render::repository_presentation(&repo, None, None);
+        let config = repo.config().clone();
+        (trust, presentation, Some(config))
+    };
     if profile_enabled() {
         emit_profile(
             "verify phases",

--- a/crates/cli/tests/cli_integration/placeholder_identity.rs
+++ b/crates/cli/tests/cli_integration/placeholder_identity.rs
@@ -94,7 +94,11 @@ fn capture_fails_closed_on_corrupt_user_config() {
         &[("HEDDLE_CONFIG", good_config.to_str().unwrap())],
     )
     .expect("run init");
-    assert!(init.status.success(), "init should succeed: {}", stderr(&init));
+    assert!(
+        init.status.success(),
+        "init should succeed: {}",
+        stderr(&init)
+    );
 
     // Now corrupt the user config and capture: the identity load must
     // error instead of attributing the snapshot to the Unknown default.

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -331,11 +331,8 @@ fn git_overlay_push_to_heddle_scheme_routes_to_hosted_not_git_exporter() {
     .expect("add hosted origin remote");
 
     for push_arg in [hosted_url, "origin"] {
-        let output = heddle_output(
-            &["--output", "json", "push", push_arg],
-            Some(source.path()),
-        )
-        .expect("spawn heddle push");
+        let output = heddle_output(&["--output", "json", "push", push_arg], Some(source.path()))
+            .expect("spawn heddle push");
 
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/crates/cli/tests/cli_integration/try_cmd.rs
+++ b/crates/cli/tests/cli_integration/try_cmd.rs
@@ -370,10 +370,7 @@ fn try_does_not_leak_parent_env_into_child() {
     let script_path = probe_dir.path().join("dump-env.sh");
     fs::write(
         &script_path,
-        format!(
-            "#!/bin/sh\nenv > '{}'\n",
-            env_dump.to_str().unwrap()
-        ),
+        format!("#!/bin/sh\nenv > '{}'\n", env_dump.to_str().unwrap()),
     )
     .unwrap();
     #[cfg(unix)]

--- a/crates/cli/tests/core_functionality/log_and_errors.rs
+++ b/crates/cli/tests/core_functionality/log_and_errors.rs
@@ -60,7 +60,10 @@ fn test_snapshot_fresh_repo_with_change() {
     heddle_must_succeed(&["init"], temp.path());
     std::fs::write(temp.path().join("first.txt"), "first change").unwrap();
     let result = heddle(&["capture", "-m", "First snapshot"], Some(temp.path()));
-    assert!(result.is_ok(), "capture with eligible changes must succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "capture with eligible changes must succeed: {result:?}"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/git_bridge_integration.rs
+++ b/crates/cli/tests/git_bridge_integration.rs
@@ -1208,9 +1208,10 @@ fn both_engines_fail_hard_on_default_rerun_after_lossy() {
 /// lands the byte-identical OID with nothing in the mirror to copy.
 #[test]
 fn checkout_materialization_reconstructs_faithful_commit_from_empty_mirror() {
+    use std::collections::HashSet;
+
     use cli::bridge::git_reconstruct::commit_object_id;
     use objects::object::{Attribution, Principal, State};
-    use std::collections::HashSet;
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
@@ -1299,8 +1300,9 @@ fn checkout_materialization_reconstructs_faithful_commit_from_empty_mirror() {
 /// MUST hard-error rather than silently materialize a wrong-OID checkout.
 #[test]
 fn checkout_materialization_hard_errors_on_oid_mismatch() {
-    use objects::object::{Attribution, Principal, State};
     use std::collections::HashSet;
+
+    use objects::object::{Attribution, Principal, State};
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
@@ -1363,8 +1365,9 @@ fn checkout_materialization_hard_errors_on_oid_mismatch() {
 /// mirror (not the checkout) and confirming the lossy state still materializes.
 #[test]
 fn checkout_materialization_backstops_lossy_commit_from_mirror() {
-    use objects::object::{Attribution, Principal, State};
     use std::collections::HashSet;
+
+    use objects::object::{Attribution, Principal, State};
 
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");

--- a/crates/client/src/grpc_hosted/tree_edit.rs
+++ b/crates/client/src/grpc_hosted/tree_edit.rs
@@ -99,8 +99,9 @@ mod tests {
     use grpc::heddle::v1::{
         CompareSummary, DiffForThreadRequest, DiffForThreadResponse, FileDiff, LogForThreadRequest,
         LogForThreadResponse, StateSummary, StatusForThreadRequest, StatusForThreadResponse,
-        ThreadPathSet, Treeish, treeish,
+        ThreadPathSet, Treeish,
         tree_edit_service_server::{TreeEditService, TreeEditServiceServer},
+        treeish,
     };
     use tonic::{Request, Response, Status, transport::Server};
 

--- a/crates/mount/tests/fuse_mount.rs
+++ b/crates/mount/tests/fuse_mount.rs
@@ -107,7 +107,11 @@ fn mount_fixture(repo: Repository) -> (BackgroundSession, TempDir) {
 /// serving repeated reads (cached mode, heddle#87).
 fn mount_fixture_with_read_counter(
     repo: Repository,
-) -> (BackgroundSession, TempDir, std::sync::Arc<std::sync::atomic::AtomicU64>) {
+) -> (
+    BackgroundSession,
+    TempDir,
+    std::sync::Arc<std::sync::atomic::AtomicU64>,
+) {
     let mount = ContentAddressedMount::new(repo, "main").expect("open mount");
     let mountpoint = TempDir::new().expect("tempdir for mountpoint");
     let shell = FuseShell::new(mount);

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -538,7 +538,10 @@ fn pack_objects_then_prune_leaves_no_loose_packed_duplicates() {
     let (packed, _saved) = store.pack_objects(false).unwrap();
     assert!(packed >= 20, "pack_objects should pack the loose corpus");
     let (pruned, _freed) = store.prune_loose_objects().unwrap();
-    assert!(pruned >= 20, "prune should remove the now-packed loose copies");
+    assert!(
+        pruned >= 20,
+        "prune should remove the now-packed loose copies"
+    );
 
     // The consolidation invariant: nothing is left both loose and packed.
     let loose_after = count_loose_objects(&store);

--- a/crates/oplog/src/oplog/pg_oplog.rs
+++ b/crates/oplog/src/oplog/pg_oplog.rs
@@ -17,7 +17,7 @@ use objects::{
     object::{OperationId, Principal},
 };
 use runtime_bridge::RuntimeBridge;
-use sqlx::{PgPool, Row};
+use sqlx::{AssertSqlSafe, PgPool, Row};
 use uuid::Uuid;
 
 use super::{
@@ -189,7 +189,7 @@ impl PgOpLogBackend {
              FROM oplog WHERE repo_id = $1 AND batch_id = ANY($2)
              ORDER BY batch_id {order}, batch_index ASC"
         );
-        let rows = sqlx::query(&sql)
+        let rows = sqlx::query(AssertSqlSafe(sql))
             .bind(repo_id)
             .bind(batch_ids)
             .fetch_all(pool)
@@ -235,7 +235,7 @@ impl PgOpLogBackend {
                  WHERE repo_id = $1 {extra_where} AND scope = $2
                  ORDER BY batch_id {order} LIMIT $3"
             );
-            sqlx::query_scalar::<_, i64>(&sql)
+            sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
                 .bind(repo_id)
                 .bind(scope)
                 .bind(count as i64)
@@ -248,7 +248,7 @@ impl PgOpLogBackend {
                  WHERE repo_id = $1 {extra_where}
                  ORDER BY batch_id {order} LIMIT $2"
             );
-            sqlx::query_scalar::<_, i64>(&sql)
+            sqlx::query_scalar::<_, i64>(AssertSqlSafe(sql))
                 .bind(repo_id)
                 .bind(count as i64)
                 .fetch_all(pool)
@@ -589,7 +589,7 @@ mod current_thread_runtime_tests {
             .connect(database_url)
             .await
             .expect("connect to postgres for pg oplog fixture");
-        sqlx::query(&format!("CREATE SCHEMA {quoted_schema}"))
+        sqlx::query(AssertSqlSafe(format!("CREATE SCHEMA {quoted_schema}")))
             .execute(&admin)
             .await
             .expect("create pg oplog fixture schema");
@@ -600,7 +600,7 @@ mod current_thread_runtime_tests {
             .after_connect(move |conn, _meta| {
                 let search_path_sql = search_path_sql.clone();
                 Box::pin(async move {
-                    conn.execute(search_path_sql.as_str()).await?;
+                    conn.execute(AssertSqlSafe(search_path_sql)).await?;
                     Ok(())
                 })
             })
@@ -648,10 +648,12 @@ mod current_thread_runtime_tests {
             .connect(database_url)
             .await
             .expect("connect to postgres for pg oplog fixture cleanup");
-        sqlx::query(&format!("DROP SCHEMA {quoted_schema} CASCADE"))
-            .execute(&admin)
-            .await
-            .expect("drop pg oplog fixture schema");
+        sqlx::query(AssertSqlSafe(format!(
+            "DROP SCHEMA {quoted_schema} CASCADE"
+        )))
+        .execute(&admin)
+        .await
+        .expect("drop pg oplog fixture schema");
     }
 
     /// Issue #62: `PgOpLogBackend`'s sync methods must not panic when the

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -93,7 +93,9 @@ fn scan_directory(
     // changed path falls under `dir_key`, and returns false when the monitor is not
     // usable). Without fsmonitor we must descend so nested additions are seen; the
     // descent is cheap because tracked-file hashing stays cached by stat-freshness.
-    if ctx.monitor.can_skip_directory(rel_path, Some(tree), ctx.index)
+    if ctx
+        .monitor
+        .can_skip_directory(rel_path, Some(tree), ctx.index)
         && !ctx.tracked_dirty_directories.contains(dir_key)
         && ctx.index.get_directory(dir_key).is_some_and(|cached| {
             cached.child_names_match(

--- a/crates/semantic/src/cache.rs
+++ b/crates/semantic/src/cache.rs
@@ -69,7 +69,9 @@ impl SemanticParseCache {
             return parsed;
         }
 
-        let parsed = ParsedFile::parse(source, language).map(Arc::new);
+        let parsed =
+            ParsedFile::parse_with_hash(Arc::<str>::from(source), language, key.content_hash)
+                .map(Arc::new);
         self.store(key, parsed.clone());
         parsed
     }

--- a/crates/semantic/src/merge_driver/items.rs
+++ b/crates/semantic/src/merge_driver/items.rs
@@ -22,10 +22,12 @@
 //! See HeddleCo/heddle#133 for the audit motivation.
 
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     rc::Rc,
+    sync::{Arc, Mutex, OnceLock},
 };
 
+use objects::object::ContentHash;
 use tree_sitter::Node;
 
 use super::language_rules::{Classified, MetadataBinding, USE_POISON_KEY, rules_for};
@@ -112,6 +114,20 @@ pub(crate) struct FileSegments {
     pub source_len: usize,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct SegmentCacheKey {
+    content_hash: ContentHash,
+    language: Language,
+}
+
+#[derive(Default)]
+struct SegmentCacheInner {
+    entries: HashMap<SegmentCacheKey, Arc<FileSegments>>,
+    order: VecDeque<SegmentCacheKey>,
+}
+
+const SEGMENT_CACHE_MAX_ENTRIES: usize = 256;
+
 /// Inter-item slices for a list of sibling items occupying the byte region
 /// `[region_start, region_end)`. Length is `items.len() + 1`: the first slice
 /// is the preamble (region_start → first item), the last is the postamble
@@ -186,9 +202,53 @@ pub(crate) fn extract_items(parsed: &ParsedFile) -> Vec<Item> {
 /// Top-level entry: segment a parsed file into items + record the source
 /// length so reconstruction can recover inter-item content.
 pub(crate) fn segment_file(parsed: &ParsedFile) -> FileSegments {
-    FileSegments {
+    cached_file_segments(parsed).as_ref().clone()
+}
+
+fn cached_file_segments(parsed: &ParsedFile) -> Arc<FileSegments> {
+    let key = SegmentCacheKey {
+        content_hash: parsed.content_hash(),
+        language: parsed.language,
+    };
+
+    {
+        let mut cache = lock_segment_cache();
+        if let Some(segments) = cache.entries.get(&key).cloned() {
+            if let Some(position) = cache.order.iter().position(|existing| *existing == key) {
+                cache.order.remove(position);
+            }
+            cache.order.push_back(key);
+            return segments;
+        }
+    }
+
+    let segments = Arc::new(FileSegments {
         items: extract_items(parsed),
         source_len: parsed.source.len(),
+    });
+
+    let mut cache = lock_segment_cache();
+    if cache.entries.len() >= SEGMENT_CACHE_MAX_ENTRIES {
+        while cache.entries.len() >= SEGMENT_CACHE_MAX_ENTRIES {
+            let Some(evicted) = cache.order.pop_front() else {
+                break;
+            };
+            cache.entries.remove(&evicted);
+        }
+    }
+    cache.entries.insert(key, segments.clone());
+    cache.order.push_back(key);
+    segments
+}
+
+fn lock_segment_cache() -> std::sync::MutexGuard<'static, SegmentCacheInner> {
+    static CACHE: OnceLock<Mutex<SegmentCacheInner>> = OnceLock::new();
+    match CACHE
+        .get_or_init(|| Mutex::new(SegmentCacheInner::default()))
+        .lock()
+    {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
     }
 }
 

--- a/crates/semantic/src/merge_driver/reconstruct.rs
+++ b/crates/semantic/src/merge_driver/reconstruct.rs
@@ -45,6 +45,129 @@ const N_SIDES: usize = 3;
 /// (heddle#468 r5: the duplicate-import class the positional path produced).
 type MatchKey = (ItemKey, usize);
 
+/// Cross-region item moves that should still be resolved as one semantic item.
+///
+/// C++ is the motivating shape: an inline class method lives inside the class
+/// body region, while the out-of-class definition (`void A::foo()`) lives in
+/// the enclosing region. The normal per-region matcher cannot see across that
+/// boundary, so it treats the inline method as deleted and the out-of-class
+/// definition as added. This table promotes the unique out-of-region item to
+/// merge against its unique in-scope counterparts, and marks those in-scope
+/// counterparts as consumed so the class body keeps only the declaration/trivia.
+#[derive(Default)]
+struct CrossRegionMoves<'a> {
+    promoted: BTreeMap<ItemKey, [Option<&'a Item>; N_SIDES]>,
+    consumed_in_scope: BTreeSet<ItemKey>,
+}
+
+#[derive(Default)]
+struct MoveCandidates<'a> {
+    direct: BTreeMap<ItemKey, Vec<&'a Item>>,
+    in_scope: BTreeMap<ItemKey, Vec<&'a Item>>,
+}
+
+impl<'a> CrossRegionMoves<'a> {
+    fn new(base: &'a [Item], ours: &'a [Item], theirs: &'a [Item]) -> Self {
+        let mut candidates = [
+            MoveCandidates::default(),
+            MoveCandidates::default(),
+            MoveCandidates::default(),
+        ];
+        for (items, candidate) in [base, ours, theirs].into_iter().zip(candidates.iter_mut()) {
+            collect_move_candidates(items, &[], candidate);
+        }
+
+        let mut keys = BTreeSet::new();
+        for candidate in &candidates {
+            keys.extend(candidate.direct.keys().cloned());
+            keys.extend(candidate.in_scope.keys().cloned());
+        }
+
+        let mut promoted = BTreeMap::new();
+        let mut consumed_in_scope = BTreeSet::new();
+        for key in keys {
+            let mut refs: [Option<&Item>; N_SIDES] = [None; N_SIDES];
+            let mut has_direct = false;
+            let mut has_in_scope = false;
+            let mut valid = true;
+
+            for side in 0..N_SIDES {
+                let direct = unique_item(candidates[side].direct.get(&key).map(Vec::as_slice));
+                let in_scope = unique_item(candidates[side].in_scope.get(&key).map(Vec::as_slice));
+                if direct.is_some() && in_scope.is_some() {
+                    valid = false;
+                    break;
+                }
+                has_direct |= direct.is_some();
+                has_in_scope |= in_scope.is_some();
+                refs[side] = direct.or(in_scope);
+            }
+
+            if valid && has_direct && has_in_scope && refs[0].is_some() {
+                consumed_in_scope.insert(key.clone());
+                promoted.insert(key, refs);
+            }
+        }
+
+        Self {
+            promoted,
+            consumed_in_scope,
+        }
+    }
+}
+
+fn unique_item<'a>(items: Option<&[&'a Item]>) -> Option<&'a Item> {
+    match items {
+        Some(items) if items.len() == 1 => Some(items[0]),
+        _ => None,
+    }
+}
+
+fn collect_move_candidates<'a>(
+    items: &'a [Item],
+    region_scope: &[String],
+    candidates: &mut MoveCandidates<'a>,
+) {
+    for item in items {
+        if matches!(item.key.kind, ItemKind::Function) {
+            if is_out_of_region_scoped_item(item, region_scope) {
+                candidates
+                    .direct
+                    .entry(item.key.clone())
+                    .or_default()
+                    .push(item);
+            } else if item.key.scope == region_scope {
+                candidates
+                    .in_scope
+                    .entry(item.key.clone())
+                    .or_default()
+                    .push(item);
+            }
+        }
+
+        if let Some(body) = &item.body {
+            let child_scope = child_region_scope(item);
+            collect_move_candidates(&body.items, &child_scope, candidates);
+        }
+    }
+}
+
+fn child_region_scope(item: &Item) -> Vec<String> {
+    let mut scope = item.key.scope.clone();
+    scope.push(item.key.name.clone());
+    scope
+}
+
+fn is_out_of_region_scoped_item(item: &Item, region_scope: &[String]) -> bool {
+    item.key.scope.len() > region_scope.len()
+        && item
+            .key
+            .scope
+            .iter()
+            .zip(region_scope.iter())
+            .all(|(a, b)| a == b)
+}
+
 /// Stitch three sides together via recursive per-region tree merge.
 ///
 /// The whole file is the outermost region; each matched container body is a
@@ -65,9 +188,17 @@ pub(crate) fn reconstruct_merged_file(
     // (`emit_addadd_conflict`) when the conflicting item bodies carry zero
     // EOL observations (Codex r8, cid 3256283857).
     let sides = SideSources::new(base, ours, theirs);
+    let cross_region_moves = CrossRegionMoves::new(
+        &base_segments.items,
+        &ours_segments.items,
+        &theirs_segments.items,
+    );
+    let root_scope = Vec::new();
 
     let (mut output, total_conflicts) = merge_region(
         sides,
+        &cross_region_moves,
+        &root_scope,
         &base_segments.items,
         &ours_segments.items,
         &theirs_segments.items,
@@ -102,6 +233,8 @@ pub(crate) fn reconstruct_merged_file(
 #[allow(clippy::too_many_arguments)]
 fn merge_region(
     sides: SideSources<'_>,
+    cross_region_moves: &CrossRegionMoves<'_>,
+    region_scope: &[String],
     base_items: &[Item],
     ours_items: &[Item],
     theirs_items: &[Item],
@@ -153,13 +286,31 @@ fn merge_region(
         if key.0.kind == ItemKind::Use {
             continue;
         }
-        let resolution = resolve_node(
-            sides,
-            base_map.get(*key).copied(),
-            ours_map.get(*key).copied(),
-            theirs_map.get(*key).copied(),
-            markers,
-        );
+        let base_item = base_map.get(*key).copied();
+        let ours_item = ours_map.get(*key).copied();
+        let theirs_item = theirs_map.get(*key).copied();
+        let has_direct_item = [base_item, ours_item, theirs_item]
+            .into_iter()
+            .flatten()
+            .any(|item| is_out_of_region_scoped_item(item, region_scope));
+        let resolution = if key.1 == 0
+            && cross_region_moves.consumed_in_scope.contains(&key.0)
+            && !has_direct_item
+        {
+            (None, 0)
+        } else {
+            let promoted = (key.1 == 0)
+                .then(|| cross_region_moves.promoted.get(&key.0))
+                .flatten();
+            resolve_node(
+                sides,
+                cross_region_moves,
+                base_item.or_else(|| promoted.and_then(|items| items[0])),
+                ours_item.or_else(|| promoted.and_then(|items| items[1])),
+                theirs_item.or_else(|| promoted.and_then(|items| items[2])),
+                markers,
+            )
+        };
         total_conflicts += resolution.1;
         resolved.insert((*key).clone(), resolution);
     }
@@ -219,29 +370,37 @@ fn merge_region(
     let mut output: Vec<u8> = Vec::new();
 
     for key in &item_emit_order {
+        // A clean-deleted item emits no bytes, so its leading gap should not be
+        // emitted in that now-empty slot. The side that deleted the item carries
+        // any surviving standalone trivia into the next sibling gap or the
+        // postamble; emitting the deleted item's old gap as well duplicates it.
+        let clean_deleted =
+            matches!(resolved.get(key), Some((None, 0))) && key.0.kind != ItemKind::Use;
         let mut segs: [Option<&str>; N_SIDES] = [None, None, None];
-        for s in 0..N_SIDES {
-            // A side contributes the gap PRECEDING `key` only if it actually
-            // has `key`. A side that lacks `key` (an item added on another
-            // side, or one this side deleted) contributes nothing for this
-            // slot — its surrounding content flows with its own items and its
-            // trailing content stays in the postamble. Bridging a lacking
-            // side to "the gap after its nearest prior item" used to pull the
-            // postamble (or a mid-sequence gap) in early, duplicating it —
-            // the heddle#484 Bug 1 (`// MARK` woven twice) / Bug 2 (module
-            // duplicated) class.
-            if let Some(&r) = side_idx_maps[s].get(key)
-                && emitted[s].insert(r)
-            {
-                segs[s] = Some(inter_slice(side_sources[s], &side_ranges[s], r));
+        if !clean_deleted {
+            for s in 0..N_SIDES {
+                // A side contributes the gap PRECEDING `key` only if it actually
+                // has `key`. A side that lacks `key` (an item added on another
+                // side, or one this side deleted) contributes nothing for this
+                // slot — its surrounding content flows with its own items and its
+                // trailing content stays in the postamble. Bridging a lacking
+                // side to "the gap after its nearest prior item" used to pull the
+                // postamble (or a mid-sequence gap) in early, duplicating it —
+                // the heddle#484 Bug 1 (`// MARK` woven twice) / Bug 2 (module
+                // duplicated) class.
+                if let Some(&r) = side_idx_maps[s].get(key)
+                    && emitted[s].insert(r)
+                {
+                    segs[s] = Some(inter_slice(side_sources[s], &side_ranges[s], r));
+                }
             }
-        }
-        let (seg_bytes, seg_conflicts) = merge_segment(segs[0], segs[1], segs[2], markers);
-        output.extend_from_slice(&seg_bytes);
-        total_conflicts += seg_conflicts;
+            let (seg_bytes, seg_conflicts) = merge_segment(segs[0], segs[1], segs[2], markers);
+            output.extend_from_slice(&seg_bytes);
+            total_conflicts += seg_conflicts;
 
-        if let Some((Some(item_bytes), _)) = resolved.get(key) {
-            output.extend_from_slice(item_bytes);
+            if let Some((Some(item_bytes), _)) = resolved.get(key) {
+                output.extend_from_slice(item_bytes);
+            }
         }
     }
 
@@ -688,6 +847,7 @@ fn footer_bytes<'a>(item: &Item, src: &'a str) -> &'a [u8] {
 /// P2).
 fn resolve_node(
     sides: SideSources<'_>,
+    cross_region_moves: &CrossRegionMoves<'_>,
     base_item: Option<&Item>,
     ours_item: Option<&Item>,
     theirs_item: Option<&Item>,
@@ -699,7 +859,14 @@ fn resolve_node(
         .peekable();
     let all_containers = present.peek().is_some() && present.all(|i| i.body.is_some());
     if all_containers {
-        resolve_container(sides, base_item, ours_item, theirs_item, markers)
+        resolve_container(
+            sides,
+            cross_region_moves,
+            base_item,
+            ours_item,
+            theirs_item,
+            markers,
+        )
     } else {
         resolve_item(sides, base_item, ours_item, theirs_item, markers)
     }
@@ -715,6 +882,7 @@ fn resolve_node(
 /// by construction.
 fn resolve_container(
     sides: SideSources<'_>,
+    cross_region_moves: &CrossRegionMoves<'_>,
     base_item: Option<&Item>,
     ours_item: Option<&Item>,
     theirs_item: Option<&Item>,
@@ -780,7 +948,7 @@ fn resolve_container(
             } else if tw == bw || ow == tw {
                 (Some(ow.to_vec()), 0)
             } else {
-                merge_container_3way(sides, b, o, t, markers)
+                merge_container_3way(sides, cross_region_moves, b, o, t, markers)
             }
         }
     }
@@ -796,6 +964,7 @@ fn resolve_container(
 /// recursion without an anchor — heddle#490 r5).
 fn merge_container_3way(
     sides: SideSources<'_>,
+    cross_region_moves: &CrossRegionMoves<'_>,
     base: &Item,
     ours: &Item,
     theirs: &Item,
@@ -819,6 +988,7 @@ fn merge_container_3way(
     let bb = base.body.as_ref().expect("container");
     let ob = ours.body.as_ref().expect("container");
     let tb = theirs.body.as_ref().expect("container");
+    let child_scope = child_region_scope(base);
 
     // The body's STRUCTURAL opening/closing delimiters (`{` / `}` for brace
     // languages; empty for delimiter-less Python `block`s) are merged ONCE
@@ -838,6 +1008,8 @@ fn merge_container_3way(
     );
     let (body, bc) = merge_region(
         sides,
+        cross_region_moves,
+        &child_scope,
         &bb.items,
         &ob.items,
         &tb.items,

--- a/crates/semantic/src/merge_driver/tests.rs
+++ b/crates/semantic/src/merge_driver/tests.rs
@@ -6775,12 +6775,7 @@ fn semantic_eof_byte(base: &str, ours: &str, theirs: &str) -> Option<u8> {
 }
 
 fn text_outcome(base: &str, ours: &str, theirs: &str) -> MergeOutcome {
-    text_hunk_merge_with_markers(
-        base.as_bytes(),
-        ours.as_bytes(),
-        theirs.as_bytes(),
-        MARKERS,
-    )
+    text_hunk_merge_with_markers(base.as_bytes(), ours.as_bytes(), theirs.as_bytes(), MARKERS)
 }
 
 #[test]

--- a/crates/semantic/src/parser/mod.rs
+++ b/crates/semantic/src/parser/mod.rs
@@ -4,7 +4,9 @@
 mod parser_core;
 mod parser_deps;
 mod parser_language;
+mod parser_pool;
 mod parser_types;
+mod syntax_index;
 
 #[cfg(test)]
 mod parser_tests;
@@ -13,3 +15,4 @@ pub use parser_core::ParsedFile;
 pub use parser_deps::extract_dependencies;
 pub use parser_language::Language;
 pub use parser_types::{FunctionDef, Import, ImportKind};
+pub use syntax_index::{FunctionRef, ImportRef, SyntaxIndex};

--- a/crates/semantic/src/parser/parser_core.rs
+++ b/crates/semantic/src/parser/parser_core.rs
@@ -1,31 +1,48 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Core parsing implementation.
 
-use tree_sitter::{Node, Parser, Tree as TSTree};
+use std::sync::{Arc, OnceLock};
+
+use objects::object::ContentHash;
+use tree_sitter::{Node, Tree as TSTree};
 
 use super::{
     parser_language::Language,
-    parser_types::{FunctionDef, Import, ImportKind},
+    parser_pool::parse_fresh,
+    parser_types::{FunctionDef, Import},
+    syntax_index::{FunctionRef, ImportRef, SyntaxIndex},
 };
 
-/// A parsed file with its AST.
+/// A parsed file with its tree-sitter AST and Heddle-owned syntax index.
 #[derive(Debug)]
 pub struct ParsedFile {
     pub language: Language,
-    pub source: String,
+    pub source: Arc<str>,
+    content_hash: ContentHash,
     tree: TSTree,
+    index: OnceLock<SyntaxIndex>,
 }
 
 impl ParsedFile {
     /// Parse a file's contents.
-    pub fn parse(source: impl Into<String>, language: Language) -> Option<Self> {
-        let source = source.into();
-        let lang = language.parser()?;
+    pub fn parse(source: impl AsRef<str>, language: Language) -> Option<Self> {
+        let source = Arc::<str>::from(source.as_ref());
+        let content_hash = ContentHash::compute(source.as_bytes());
+        Self::parse_with_hash(source, language, content_hash)
+    }
 
-        let mut parser = Parser::new();
-        parser.set_language(&lang).ok()?;
-        let tree = parser.parse(&source, None)?;
+    /// Parse already-owned contents without copying the source string.
+    pub fn parse_owned(source: String, language: Language) -> Option<Self> {
+        let content_hash = ContentHash::compute(source.as_bytes());
+        Self::parse_with_hash(Arc::<str>::from(source), language, content_hash)
+    }
 
+    pub(crate) fn parse_with_hash(
+        source: Arc<str>,
+        language: Language,
+        content_hash: ContentHash,
+    ) -> Option<Self> {
+        let tree = parse_fresh(source.as_bytes(), language)?;
         if tree.root_node().has_error() {
             return None;
         }
@@ -33,8 +50,20 @@ impl ParsedFile {
         Some(Self {
             language,
             source,
+            content_hash,
             tree,
+            index: OnceLock::new(),
         })
+    }
+
+    /// Stable content identity for caches and sidecars.
+    pub fn content_hash(&self) -> ContentHash {
+        self.content_hash
+    }
+
+    /// Borrow the source text without cloning.
+    pub fn source(&self) -> &str {
+        &self.source
     }
 
     /// Get the root node of the AST.
@@ -42,300 +71,35 @@ impl ParsedFile {
         self.tree.root_node()
     }
 
+    /// Compact Heddle-owned syntax data derived from the AST.
+    pub fn syntax_index(&self) -> &SyntaxIndex {
+        self.index.get_or_init(|| {
+            SyntaxIndex::build(self.language, self.source.as_ref(), self.root_node())
+        })
+    }
+
+    /// Borrow indexed function definitions.
+    pub fn functions(&self) -> impl Iterator<Item = FunctionRef<'_>> + '_ {
+        self.syntax_index().functions(self.source.as_ref())
+    }
+
+    /// Borrow indexed imports.
+    pub fn imports(&self) -> impl Iterator<Item = ImportRef<'_>> + '_ {
+        self.syntax_index().imports(self.source.as_ref())
+    }
+
     /// Extract function definitions from the file.
     pub fn extract_functions(&self) -> Vec<FunctionDef> {
-        let mut functions = Vec::new();
-        let mut stack = vec![self.root_node()];
-
-        while let Some(node) = stack.pop() {
-            if Self::is_function_node(&node, self.language)
-                && let Some(name) = self.get_function_name(&node)
-            {
-                functions.push(FunctionDef {
-                    name: name.to_string(),
-                    signature: self.get_function_signature(&node),
-                    start_line: node.start_position().row,
-                    end_line: node.end_position().row,
-                    content: self.source[node.byte_range()].to_string(),
-                });
-            }
-
-            push_children_reverse(node, &mut stack);
-        }
-
-        functions
+        self.functions().map(FunctionRef::to_owned).collect()
     }
 
     /// Extract imports from the file.
     pub fn extract_imports(&self) -> Vec<Import> {
-        match self.language {
-            Language::Rust => self.extract_rust_imports(),
-            Language::Python => self.extract_imports_by_kind(
-                &["import_statement", "import_from_statement"],
-                ImportKind::Import,
-            ),
-            Language::JavaScript | Language::TypeScript => {
-                self.extract_imports_by_kind(&["import_statement"], ImportKind::Import)
-            }
-            Language::Go | Language::Java => {
-                self.extract_imports_by_kind(&["import_declaration"], ImportKind::Import)
-            }
-            _ => Vec::new(),
-        }
+        self.imports().map(ImportRef::to_owned).collect()
     }
 
     /// Check if a node kind string represents a function definition in the given language.
     pub fn is_function_kind(kind: &str, language: Language) -> bool {
-        match language {
-            Language::Rust => {
-                kind == "function_item"
-                    || kind == "method_declaration"
-                    || kind == "closure_expression"
-            }
-            Language::Python => kind == "function_definition",
-            Language::JavaScript | Language::TypeScript => {
-                kind == "function_declaration"
-                    || kind == "method_definition"
-                    || kind == "generator_function_declaration"
-                    || kind == "variable_declarator"
-            }
-            Language::Go => kind == "function_declaration" || kind == "method_declaration",
-            Language::C | Language::Cpp => kind == "function_definition",
-            Language::Java => kind == "method_declaration" || kind == "constructor_declaration",
-            _ => false,
-        }
-    }
-
-    fn is_function_node(node: &Node<'_>, language: Language) -> bool {
-        match language {
-            Language::Rust => {
-                node.kind() == "function_item"
-                    || node.kind() == "method_declaration"
-                    || node.kind() == "closure_expression"
-            }
-            Language::Python => node.kind() == "function_definition",
-            Language::JavaScript | Language::TypeScript => {
-                node.kind() == "function_declaration"
-                    || node.kind() == "method_definition"
-                    || node.kind() == "generator_function_declaration"
-                    || (node.kind() == "variable_declarator"
-                        && node
-                            .child_by_field_name("value")
-                            .is_some_and(|value| is_javascript_function_value(value.kind())))
-            }
-            Language::Go => {
-                node.kind() == "function_declaration" || node.kind() == "method_declaration"
-            }
-            Language::C | Language::Cpp => node.kind() == "function_definition",
-            Language::Java => {
-                node.kind() == "method_declaration" || node.kind() == "constructor_declaration"
-            }
-            _ => false,
-        }
-    }
-
-    fn get_function_name(&self, node: &Node<'_>) -> Option<&str> {
-        if let Some(name) = node.child_by_field_name("name") {
-            return Some(&self.source[name.byte_range()]);
-        }
-        if let Some(declarator) = node.child_by_field_name("declarator") {
-            if let Some(name) = self.c_function_name(declarator) {
-                return Some(name);
-            }
-            if let Some(name) = self.find_identifier_in_subtree(declarator) {
-                return Some(name);
-            }
-        }
-
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i as u32)
-                && matches!(
-                    child.kind(),
-                    "identifier" | "field_identifier" | "type_identifier" | "property_identifier"
-                )
-            {
-                return Some(&self.source[child.byte_range()]);
-            }
-        }
-        None
-    }
-
-    /// Resolve the actual function name from a C/C++ declarator.
-    ///
-    /// Mirrors `merge_driver::items::c_function_name` (heddle#114
-    /// commit `dc37af8`, Codex r5 P1 #2). A plain DFS over the
-    /// declarator subtree returns the FIRST identifier-ish leaf — for
-    /// a templated qualified name like `void Foo<U>::bar()` the
-    /// scope's inner `type_identifier` ("Foo") wins, so every method
-    /// on the same scope collapses to name="Foo". Instead, walk the
-    /// declarator's `declarator` field, peel wrapper layers, and
-    /// recurse into `qualified_identifier` / `template_function`'s
-    /// `name` field so the scope's identifier never wins.
-    ///
-    /// Duplicated rather than lifted to a shared module: the function
-    /// is short, and `parser_core` vs `merge_driver` are different
-    /// concerns. Lift if a third caller appears.
-    fn c_function_name(&self, function_declarator: Node<'_>) -> Option<&str> {
-        let mut current = function_declarator.child_by_field_name("declarator")?;
-        // Cap traversal so a pathological wrapper chain doesn't loop.
-        for _ in 0..32 {
-            match current.kind() {
-                "identifier"
-                | "field_identifier"
-                | "type_identifier"
-                | "property_identifier"
-                | "operator_name"
-                | "destructor_name" => {
-                    return Some(&self.source[current.byte_range()]);
-                }
-                "qualified_identifier" | "template_function" => {
-                    current = current.child_by_field_name("name")?;
-                }
-                "pointer_declarator"
-                | "reference_declarator"
-                | "function_declarator"
-                | "parenthesized_declarator" => {
-                    current = current.child_by_field_name("declarator")?;
-                }
-                _ => return None,
-            }
-        }
-        None
-    }
-
-    fn find_identifier_in_subtree(&self, node: Node<'_>) -> Option<&str> {
-        let mut stack = vec![node];
-        while let Some(current) = stack.pop() {
-            if matches!(
-                current.kind(),
-                "identifier" | "field_identifier" | "type_identifier" | "property_identifier"
-            ) {
-                return Some(&self.source[current.byte_range()]);
-            }
-            push_children_reverse(current, &mut stack);
-        }
-        None
-    }
-
-    fn get_function_signature(&self, node: &Node<'_>) -> String {
-        if node.kind() == "variable_declarator" {
-            return self.get_variable_function_signature(node);
-        }
-
-        let mut signature_parts = Vec::new();
-
-        for i in 0..node.child_count() {
-            if let Some(child) = node.child(i as u32) {
-                let kind = child.kind();
-                if matches!(
-                    kind,
-                    "identifier"
-                        | "field_identifier"
-                        | "type_identifier"
-                        | "property_identifier"
-                        | "parameters"
-                        | "formal_parameters"
-                        | "parameter_list"
-                        | "function_declarator"
-                        | "type_parameters"
-                        | "type_arguments"
-                        | "return_type"
-                        | "type_annotation"
-                        | "result"
-                ) {
-                    signature_parts.push(&self.source[child.byte_range()]);
-                }
-                if matches!(
-                    kind,
-                    "block" | "compound_statement" | "statement_block" | "suite"
-                ) {
-                    break;
-                }
-            }
-        }
-
-        signature_parts.join(" ")
-    }
-
-    fn get_variable_function_signature(&self, node: &Node<'_>) -> String {
-        let Some(name) = node.child_by_field_name("name") else {
-            return String::new();
-        };
-        let Some(value) = node.child_by_field_name("value") else {
-            return self.source[name.byte_range()].to_string();
-        };
-
-        let mut signature_parts = vec![&self.source[name.byte_range()]];
-        for i in 0..value.child_count() {
-            if let Some(child) = value.child(i as u32) {
-                if matches!(child.kind(), "formal_parameters" | "parameters") {
-                    signature_parts.push(&self.source[child.byte_range()]);
-                }
-                if matches!(child.kind(), "statement_block" | "body") {
-                    break;
-                }
-            }
-        }
-        signature_parts.join(" ")
-    }
-
-    fn extract_rust_imports(&self) -> Vec<Import> {
-        let mut imports = Vec::new();
-        let root = self.root_node();
-
-        for i in 0..root.child_count() {
-            if let Some(child) = root.child(i as u32) {
-                if child.kind() == "use_declaration" {
-                    let text = &self.source[child.byte_range()];
-                    imports.push(Import {
-                        raw: text.to_string(),
-                        kind: ImportKind::Use,
-                    });
-                } else if child.kind() == "extern_crate_declaration" {
-                    let text = &self.source[child.byte_range()];
-                    imports.push(Import {
-                        raw: text.to_string(),
-                        kind: ImportKind::ExternCrate,
-                    });
-                }
-            }
-        }
-
-        imports
-    }
-
-    fn extract_imports_by_kind(&self, kinds: &[&str], kind: ImportKind) -> Vec<Import> {
-        let mut imports = Vec::new();
-        let root = self.root_node();
-
-        for i in 0..root.child_count() {
-            if let Some(child) = root.child(i as u32)
-                && kinds.contains(&child.kind())
-            {
-                let text = &self.source[child.byte_range()];
-                imports.push(Import {
-                    raw: text.to_string(),
-                    kind: kind.clone(),
-                });
-            }
-        }
-
-        imports
-    }
-}
-
-fn is_javascript_function_value(kind: &str) -> bool {
-    matches!(
-        kind,
-        "arrow_function" | "function_expression" | "generator_function"
-    )
-}
-
-fn push_children_reverse<'tree>(node: Node<'tree>, stack: &mut Vec<Node<'tree>>) {
-    let child_count = node.child_count();
-    for index in (0..child_count).rev() {
-        if let Some(child) = node.child(index as u32) {
-            stack.push(child);
-        }
+        super::syntax_index::is_function_kind(kind, language)
     }
 }

--- a/crates/semantic/src/parser/parser_pool.rs
+++ b/crates/semantic/src/parser/parser_pool.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Thread-local tree-sitter parser reuse.
+
+use std::{
+    cell::RefCell,
+    collections::{HashMap, hash_map::Entry},
+};
+
+use tree_sitter::{Parser, Tree as TSTree};
+
+use super::parser_language::Language;
+
+thread_local! {
+    static PARSERS: RefCell<HashMap<Language, Parser>> = RefCell::new(HashMap::new());
+}
+
+/// Parse a complete document with the pooled parser for `language`.
+///
+/// Tree-sitter parsers are stateful. We reset before each unrelated document
+/// parse and pass `None` for the old tree because callers do not currently
+/// retain an edited old tree that corresponds to `source`.
+pub(super) fn parse_fresh(source: &[u8], language: Language) -> Option<TSTree> {
+    let ts_language = language.parser()?;
+    PARSERS.with(|parsers| {
+        let mut parsers = parsers.borrow_mut();
+        let parser = match parsers.entry(language) {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(entry) => {
+                let mut parser = Parser::new();
+                parser.set_language(&ts_language).ok()?;
+                entry.insert(parser)
+            }
+        };
+        parser.reset();
+        parser.parse(source, None)
+    })
+}

--- a/crates/semantic/src/parser/parser_types.rs
+++ b/crates/semantic/src/parser/parser_types.rs
@@ -19,7 +19,7 @@ pub struct Import {
 }
 
 /// Type of import.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ImportKind {
     Use,
     ExternCrate,

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Compact syntax index derived from a tree-sitter parse tree.
+
+use std::ops::Range;
+
+use tree_sitter::Node;
+
+use super::{
+    parser_language::Language,
+    parser_types::{FunctionDef, Import, ImportKind},
+};
+
+/// Compact Heddle-owned syntax data for one parsed source file.
+#[derive(Debug)]
+pub struct SyntaxIndex {
+    functions: Vec<IndexedFunction>,
+    imports: Vec<IndexedImport>,
+    line_offsets: Vec<usize>,
+}
+
+/// Borrowed view of a function indexed in a [`SyntaxIndex`].
+#[derive(Clone, Copy, Debug)]
+pub struct FunctionRef<'a> {
+    inner: &'a IndexedFunction,
+    source: &'a str,
+}
+
+/// Borrowed view of an import indexed in a [`SyntaxIndex`].
+#[derive(Clone, Copy, Debug)]
+pub struct ImportRef<'a> {
+    inner: &'a IndexedImport,
+    source: &'a str,
+}
+
+#[derive(Debug)]
+struct IndexedFunction {
+    name: String,
+    signature: String,
+    start_line: usize,
+    end_line: usize,
+    content: Range<usize>,
+}
+
+#[derive(Debug)]
+struct IndexedImport {
+    raw: Range<usize>,
+    kind: ImportKind,
+}
+
+impl SyntaxIndex {
+    pub(super) fn build(language: Language, source: &str, root: Node<'_>) -> Self {
+        let mut index = Self {
+            functions: Vec::new(),
+            imports: Vec::new(),
+            line_offsets: line_offsets(source),
+        };
+
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if is_function_node(&node, language)
+                && let Some(name) = function_name(&node, source)
+            {
+                index.functions.push(IndexedFunction {
+                    name: name.to_string(),
+                    signature: function_signature(&node, source),
+                    start_line: node.start_position().row,
+                    end_line: node.end_position().row,
+                    content: node.byte_range(),
+                });
+            }
+
+            push_children_reverse(node, &mut stack);
+        }
+
+        let mut cursor = root.walk();
+        for child in root.children(&mut cursor) {
+            match language {
+                Language::Rust => match child.kind() {
+                    "use_declaration" => index.imports.push(IndexedImport {
+                        raw: child.byte_range(),
+                        kind: ImportKind::Use,
+                    }),
+                    "extern_crate_declaration" => index.imports.push(IndexedImport {
+                        raw: child.byte_range(),
+                        kind: ImportKind::ExternCrate,
+                    }),
+                    _ => {}
+                },
+                Language::Python => {
+                    if matches!(child.kind(), "import_statement" | "import_from_statement") {
+                        index.imports.push(IndexedImport {
+                            raw: child.byte_range(),
+                            kind: ImportKind::Import,
+                        });
+                    }
+                }
+                Language::JavaScript | Language::TypeScript => {
+                    if child.kind() == "import_statement" {
+                        index.imports.push(IndexedImport {
+                            raw: child.byte_range(),
+                            kind: ImportKind::Import,
+                        });
+                    }
+                }
+                Language::Go | Language::Java => {
+                    if child.kind() == "import_declaration" {
+                        index.imports.push(IndexedImport {
+                            raw: child.byte_range(),
+                            kind: ImportKind::Import,
+                        });
+                    }
+                }
+                Language::C | Language::Cpp | Language::Unknown => {}
+            }
+        }
+
+        index
+    }
+
+    pub fn functions<'a>(&'a self, source: &'a str) -> impl Iterator<Item = FunctionRef<'a>> + 'a {
+        self.functions
+            .iter()
+            .map(move |inner| FunctionRef { inner, source })
+    }
+
+    pub fn imports<'a>(&'a self, source: &'a str) -> impl Iterator<Item = ImportRef<'a>> + 'a {
+        self.imports
+            .iter()
+            .map(move |inner| ImportRef { inner, source })
+    }
+
+    /// Byte offsets where each line starts. The first entry is always `0`.
+    pub fn line_offsets(&self) -> &[usize] {
+        &self.line_offsets
+    }
+}
+
+impl FunctionRef<'_> {
+    pub fn name(&self) -> &str {
+        &self.inner.name
+    }
+
+    pub fn signature(&self) -> &str {
+        &self.inner.signature
+    }
+
+    pub fn start_line(&self) -> usize {
+        self.inner.start_line
+    }
+
+    pub fn end_line(&self) -> usize {
+        self.inner.end_line
+    }
+
+    pub fn content(&self) -> &str {
+        &self.source[self.inner.content.clone()]
+    }
+
+    pub fn to_owned(self) -> FunctionDef {
+        FunctionDef {
+            name: self.name().to_string(),
+            signature: self.signature().to_string(),
+            start_line: self.start_line(),
+            end_line: self.end_line(),
+            content: self.content().to_string(),
+        }
+    }
+}
+
+impl ImportRef<'_> {
+    pub fn raw(&self) -> &str {
+        &self.source[self.inner.raw.clone()]
+    }
+
+    pub fn kind(&self) -> ImportKind {
+        self.inner.kind
+    }
+
+    pub fn to_owned(self) -> Import {
+        Import {
+            raw: self.raw().to_string(),
+            kind: self.kind(),
+        }
+    }
+}
+
+pub(super) fn is_function_kind(kind: &str, language: Language) -> bool {
+    match language {
+        Language::Rust => {
+            kind == "function_item" || kind == "method_declaration" || kind == "closure_expression"
+        }
+        Language::Python => kind == "function_definition",
+        Language::JavaScript | Language::TypeScript => {
+            kind == "function_declaration"
+                || kind == "method_definition"
+                || kind == "generator_function_declaration"
+                || kind == "variable_declarator"
+        }
+        Language::Go => kind == "function_declaration" || kind == "method_declaration",
+        Language::C | Language::Cpp => kind == "function_definition",
+        Language::Java => kind == "method_declaration" || kind == "constructor_declaration",
+        Language::Unknown => false,
+    }
+}
+
+fn is_function_node(node: &Node<'_>, language: Language) -> bool {
+    match language {
+        Language::JavaScript | Language::TypeScript => {
+            matches!(
+                node.kind(),
+                "function_declaration" | "method_definition" | "generator_function_declaration"
+            ) || (node.kind() == "variable_declarator"
+                && node
+                    .child_by_field_name("value")
+                    .is_some_and(|value| is_javascript_function_value(value.kind())))
+        }
+        _ => is_function_kind(node.kind(), language),
+    }
+}
+
+fn function_name<'a>(node: &Node<'_>, source: &'a str) -> Option<&'a str> {
+    if let Some(name) = node.child_by_field_name("name") {
+        return Some(&source[name.byte_range()]);
+    }
+    if let Some(declarator) = node.child_by_field_name("declarator") {
+        if let Some(name) = c_function_name(declarator, source) {
+            return Some(name);
+        }
+        if let Some(name) = first_identifier_in_subtree(declarator, source) {
+            return Some(name);
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "identifier" | "field_identifier" | "type_identifier" | "property_identifier"
+        ) {
+            return Some(&source[child.byte_range()]);
+        }
+    }
+    None
+}
+
+fn c_function_name<'a>(function_declarator: Node<'_>, source: &'a str) -> Option<&'a str> {
+    let mut current = function_declarator.child_by_field_name("declarator")?;
+    for _ in 0..32 {
+        match current.kind() {
+            "identifier"
+            | "field_identifier"
+            | "type_identifier"
+            | "property_identifier"
+            | "operator_name"
+            | "destructor_name" => return Some(&source[current.byte_range()]),
+            "qualified_identifier" | "template_function" => {
+                current = current.child_by_field_name("name")?;
+            }
+            "pointer_declarator"
+            | "reference_declarator"
+            | "function_declarator"
+            | "parenthesized_declarator" => {
+                current = current.child_by_field_name("declarator")?;
+            }
+            _ => return None,
+        }
+    }
+    None
+}
+
+fn first_identifier_in_subtree<'a>(node: Node<'_>, source: &'a str) -> Option<&'a str> {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if matches!(
+            current.kind(),
+            "identifier" | "field_identifier" | "type_identifier" | "property_identifier"
+        ) {
+            return Some(&source[current.byte_range()]);
+        }
+        push_children_reverse(current, &mut stack);
+    }
+    None
+}
+
+fn function_signature(node: &Node<'_>, source: &str) -> String {
+    if node.kind() == "variable_declarator" {
+        return variable_function_signature(node, source);
+    }
+
+    let mut signature_parts = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        let kind = child.kind();
+        if matches!(
+            kind,
+            "identifier"
+                | "field_identifier"
+                | "type_identifier"
+                | "property_identifier"
+                | "parameters"
+                | "formal_parameters"
+                | "parameter_list"
+                | "function_declarator"
+                | "type_parameters"
+                | "type_arguments"
+                | "return_type"
+                | "type_annotation"
+                | "result"
+        ) {
+            signature_parts.push(&source[child.byte_range()]);
+        }
+        if matches!(
+            kind,
+            "block" | "compound_statement" | "statement_block" | "suite"
+        ) {
+            break;
+        }
+    }
+
+    signature_parts.join(" ")
+}
+
+fn variable_function_signature(node: &Node<'_>, source: &str) -> String {
+    let Some(name) = node.child_by_field_name("name") else {
+        return String::new();
+    };
+    let Some(value) = node.child_by_field_name("value") else {
+        return source[name.byte_range()].to_string();
+    };
+
+    let mut signature_parts = vec![&source[name.byte_range()]];
+    let mut cursor = value.walk();
+    for child in value.children(&mut cursor) {
+        if matches!(child.kind(), "formal_parameters" | "parameters") {
+            signature_parts.push(&source[child.byte_range()]);
+        }
+        if matches!(child.kind(), "statement_block" | "body") {
+            break;
+        }
+    }
+    signature_parts.join(" ")
+}
+
+fn line_offsets(source: &str) -> Vec<usize> {
+    let mut offsets =
+        Vec::with_capacity(source.as_bytes().iter().filter(|&&b| b == b'\n').count() + 1);
+    offsets.push(0);
+    for (index, byte) in source.bytes().enumerate() {
+        if byte == b'\n' && index + 1 < source.len() {
+            offsets.push(index + 1);
+        }
+    }
+    offsets
+}
+
+fn is_javascript_function_value(kind: &str) -> bool {
+    matches!(
+        kind,
+        "arrow_function" | "function_expression" | "generator_function"
+    )
+}
+
+fn push_children_reverse<'tree>(node: Node<'tree>, stack: &mut Vec<Node<'tree>>) {
+    let child_count = node.child_count();
+    for index in (0..child_count).rev() {
+        if let Some(child) = node.child(index as u32) {
+            stack.push(child);
+        }
+    }
+}

--- a/crates/semantic/src/symbol_resolver.rs
+++ b/crates/semantic/src/symbol_resolver.rs
@@ -10,7 +10,10 @@
 
 use std::path::Path;
 
-use crate::{parser::Language, symbol_extraction::find_definitions};
+use crate::{
+    parser::{Language, ParsedFile},
+    symbol_extraction::find_definitions,
+};
 
 /// Result of resolving a symbol to lines in a source file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -92,28 +95,19 @@ pub fn extract_definitions(
     source: &[u8],
     path: &Path,
 ) -> Result<Vec<Definition>, SymbolResolveError> {
-    let language = Language::from_path(path).parser_handle().ok_or_else(|| {
+    let language = Language::from_path(path);
+    language.parser_handle().ok_or_else(|| {
         SymbolResolveError::UnsupportedLanguage(
             path.extension()
                 .map(|e| e.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "<none>".to_string()),
         )
     })?;
-
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&language)
-        .map_err(|_| SymbolResolveError::ParseFailed)?;
-
-    let tree = parser
-        .parse(source, None)
-        .ok_or(SymbolResolveError::ParseFailed)?;
-    if tree.root_node().has_error() {
-        return Err(SymbolResolveError::ParseFailed);
-    }
+    let source_text = std::str::from_utf8(source).map_err(|_| SymbolResolveError::ParseFailed)?;
+    let parsed = ParsedFile::parse(source_text, language).ok_or(SymbolResolveError::ParseFailed)?;
 
     let mut out = Vec::new();
-    walk_definitions(&tree.root_node(), source, None, &mut out);
+    walk_definitions(&parsed.root_node(), source, None, &mut out);
     Ok(out)
 }
 
@@ -400,22 +394,16 @@ pub fn resolve_symbol_lines(
     path: &Path,
     symbol: &str,
 ) -> Result<(u32, u32), SymbolResolveError> {
-    let language = Language::from_path(path).parser_handle().ok_or_else(|| {
+    let language = Language::from_path(path);
+    language.parser_handle().ok_or_else(|| {
         SymbolResolveError::UnsupportedLanguage(
             path.extension()
                 .map(|e| e.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "<none>".to_string()),
         )
     })?;
-
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&language)
-        .map_err(|_| SymbolResolveError::ParseFailed)?;
-
-    let tree = parser
-        .parse(source, None)
-        .ok_or(SymbolResolveError::ParseFailed)?;
+    let source_text = std::str::from_utf8(source).map_err(|_| SymbolResolveError::ParseFailed)?;
+    let parsed = ParsedFile::parse(source_text, language).ok_or(SymbolResolveError::ParseFailed)?;
 
     // Split qualified name: "Repository::open" -> parent="Repository", target="open"
     let (parent_filter, target_name) = if let Some(pos) = symbol.rfind("::") {
@@ -424,7 +412,7 @@ pub fn resolve_symbol_lines(
         (None, symbol)
     };
 
-    let definitions = find_definitions(&tree.root_node(), source, target_name);
+    let definitions = find_definitions(&parsed.root_node(), source, target_name);
 
     // If a parent filter is specified, prefer matches where the parent matches.
     let matched = if let Some(parent) = parent_filter {
@@ -456,22 +444,16 @@ pub fn resolve_all_symbols(
     path: &Path,
     symbol: &str,
 ) -> Result<Vec<ResolvedSymbol>, SymbolResolveError> {
-    let language = Language::from_path(path).parser_handle().ok_or_else(|| {
+    let language = Language::from_path(path);
+    language.parser_handle().ok_or_else(|| {
         SymbolResolveError::UnsupportedLanguage(
             path.extension()
                 .map(|e| e.to_string_lossy().into_owned())
                 .unwrap_or_else(|| "<none>".to_string()),
         )
     })?;
-
-    let mut parser = tree_sitter::Parser::new();
-    parser
-        .set_language(&language)
-        .map_err(|_| SymbolResolveError::ParseFailed)?;
-
-    let tree = parser
-        .parse(source, None)
-        .ok_or(SymbolResolveError::ParseFailed)?;
+    let source_text = std::str::from_utf8(source).map_err(|_| SymbolResolveError::ParseFailed)?;
+    let parsed = ParsedFile::parse(source_text, language).ok_or(SymbolResolveError::ParseFailed)?;
 
     let (parent_filter, target_name) = if let Some(pos) = symbol.rfind("::") {
         (Some(&symbol[..pos]), &symbol[pos + 2..])
@@ -479,7 +461,7 @@ pub fn resolve_all_symbols(
         (None, symbol)
     };
 
-    let definitions = find_definitions(&tree.root_node(), source, target_name);
+    let definitions = find_definitions(&parsed.root_node(), source, target_name);
 
     if let Some(parent) = parent_filter {
         let filtered: Vec<_> = definitions


### PR DESCRIPTION
Codex-authored branch `codex/deps-tree-sitter-bb1b1f0e`. Semantic syntax-indexing refactor (new `syntax_index.rs`, `parser_pool.rs`; `parser_core.rs` slimmed) + merge_driver/reconstruct changes + assorted CLI call-site updates.

**Gate:** cross-engine Claude adversarial review (codex-authored ⇒ a @codex :+1: would be self-review) + green CI. Integrating per maintainer request once sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/820"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785349792&installation_id=132405951&pr_number=820&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F820&signature=6655e3686c4b9906efa1b51b6097fe2711e76094461a6a3a45e33b3f615509b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->