### PR TITLE
chore(release): draft 0.6.0 CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,95 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.6.0 - Unreleased
+
+### Added
+
+- **Debian/Ubuntu apt distribution.** The `heddle` CLI now ships as a signed
+  apt channel (`.deb` for amd64 and arm64) alongside the existing Homebrew
+  cask, built on the shared publish-manifest substrate. Includes a
+  `heddle-archive-keyring` trust anchor and a GPG-signed pool. (#234, #806)
+- **Scoop (Windows) distribution.** A Scoop manifest (`bucket/heddle.json`,
+  x64) rides the same publish-manifest substrate as Homebrew and apt, so
+  Windows users can install and upgrade `heddle` from a Scoop bucket.
+  (#233, #802)
+- **FUSE mount uses the kernel page cache.** The Linux FUSE shell switched
+  from cache-bypass (`FOPEN_DIRECT_IO`) to active inode invalidation: mounts
+  run in the kernel's cached mode and push invalidations when heddle mutates
+  backing content. Shared `mmap` now works on any FUSE-capable kernel (no
+  Linux 5.16+ floor) and reads can use the page cache while staying coherent.
+  (#87, #810)
+
+### Changed
+
+- **Dependency refresh.** Upgraded `rusqlite` (0.32 → 0.39), `sqlx`
+  (0.8 → 0.9), and `reqwest` (0.13.2 → 0.13.4), plus syntax-indexing
+  improvements in the semantic parser (a dedicated parser pool and syntax
+  index). (#820)
+- **Merge preview matches apply.** The content-merge strategy is now decided
+  exactly once per merge attempt and read back by both the preview report and
+  the apply path, so `merge`'s preview can no longer diverge from what apply
+  actually does. (#503)
+- **Worktree checkout reconstructs from heddle state.** `bridge git checkout`
+  now rebuilds each byte-faithful commit's git objects directly from heddle
+  state instead of copying them out of the eager `.heddle/git` mirror, with a
+  loud OID-equality gate that hard-errors rather than materializing a
+  wrong-SHA checkout. The mirror now backstops only the lossy residual
+  (`--lossy` imports, non-UTF8 identities). First step of the mirror
+  demotion. (#568)
+
+### Fixed
+
+- **Rebase auto-merge uses the semantic driver.** `heddle rebase`'s content
+  auto-merge now routes through the function-level semantic merge driver
+  instead of the line-level text path, so structural reshapes (function
+  reorder/add/delete) resolve cleanly instead of emitting a wide conflict
+  block. (#116)
+- **Semantic merge matches the text engine on trailing newlines.** The
+  semantic merge driver now carries the trailing-newline state of the side
+  that authored the final line (a 3-way one-bit merge) instead of a
+  context-free majority vote, matching the text engine's EOF-newline
+  behavior. (#123)
+- **`heddle://` hosted push on git-overlay repos.** A `heddle://` hosted
+  remote on a git-overlay repo with an empty `[hosted]` config block no
+  longer silently routes through the generic git pusher and no-ops; hosted
+  push routing is hardened to take the hosted lane. (#794)
+- **`maintenance gc` consolidates the object store.** `heddle maintenance gc`
+  previously packed loose objects into a new pack without pruning the
+  now-redundant loose copies or consolidating pre-existing packs, leaving the
+  object store with *more* sources to search and regressing read
+  performance. It now consolidates instead of duplicating. (#796)
+- **Malformed credentials surface a real error.** A malformed
+  `credentials.toml` (e.g. a missing `subject` field) now reports the actual
+  parse error instead of falling through to an unauthenticated request that
+  the server rejects with an opaque "missing authorization metadata". `fetch`
+  and thread-approval now use the same proof-of-possession-capable auth path
+  as push/pull/clone. (#788)
+
+### Performance
+
+- **Pull is sub-second on the common path.** A bare `heddle pull` now
+  advertises its locally-held head so the hosted server prunes to the delta
+  and fires the zero-delta short-circuit; a warm pull of a ~6000-object repo
+  that previously paid the full-closure cost to transfer ~4 objects now
+  transfers only the delta. The advertise is gated on local-closure
+  completeness — both the bare-pull and explicit `--local-thread` paths
+  refuse to over-advertise against an incomplete (partial/interrupted) local
+  repo and fall back to a correct full pull, so the optimization can never
+  corrupt a repo with missing objects. (#821, #822)
+- **Read-only commands compute worktree status once.** `status`, `verify`,
+  `diff`, `thread-list`, `capture`, `commit`, `ready`, and `checkpoint`
+  previously re-walked and re-hashed every tracked file two or three times
+  per invocation. They now compute the git-overlay worktree status once and
+  share it (the second full walk on a 5.7k-file worktree cost ~340ms), plus
+  incremental object copy that skips re-copying objects already present in
+  the mirror. (#793, #795)
+
+### Security
+
+- Bumped `anyhow` 1.0.102 → 1.0.103 to clear RUSTSEC-2026-0190 (an
+  `Error::downcast_mut()` unsoundness advisory). (#817)
+
 ## 0.5.1 - 2026-06-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1514,7 +1514,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1598,7 +1598,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "heddle-cli-shared",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1665,7 +1665,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1695,7 +1695,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1755,14 +1755,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "similar",
 ]
 
 [[package]]
 name = "heddle-mount"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1911,14 +1911,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -1929,7 +1929,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1950,7 +1950,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5972,7 +5972,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.5.1",
+  "schemaVersion": "0.6.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.5.1" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.6.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,31 +32,31 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.6" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.6" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
-heddle-core = { path = "../core", version = "0.5" }
-heddle-client = { path = "../client", version = "0.5", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
+heddle-core = { path = "../core", version = "0.6" }
+heddle-client = { path = "../client", version = "0.6", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.6" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.5", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.6", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -105,13 +105,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.5", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -31,14 +31,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.5" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6" }
 rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.5", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.6" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.5" }
+heddle-format = { path = "../format", version = "0.6" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.5" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+heddle-schema = { path = "../schema", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.6", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.5" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+heddle-schema = { path = "../schema", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.5", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.6", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.5" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.5" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.5", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.5", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.6", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.5" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.5", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.5", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.5" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
<!-- REVIEW: hosted-vs-OSS judgment calls -->
**These commits touch hosted-product surface and I EXCLUDED them from the OSS changelog — please confirm.** The CHANGELOG header scopes this file to "changes that affect the OSS CLI and its supporting crates"; hosted-product work lives in weft/tapestry. My recommendation for each:

| Commit | What | Recommendation |
|---|---|---|
| #819 (`486fd66d`) | gRPC proto cut: E2 recovery RPCs (DeclareRecoveryMethod / BeginRecovery / …), cross-device attestation fields on RegisterPublicKey, `SetNamespaceVisibility` + `SpoolVisibility`, `ResolveSubjects` → heddle-grpc 0.7.3 | **EXCLUDE.** Pure hosted-auth / hosted-namespace surface (auth.proto + hosted.proto), consumed by weft#119/#120/#182-186. Belongs in weft's changelog. The heddle-grpc *crate* is published, but it's independently versioned (0.7.3) and not part of the OSS-CLI release — these RPCs don't change `heddle` binary behavior. |
| #809 (`6fef90f9`) | Read-side tree-edit RPCs for hosted threads (`StatusForThread` / `DiffForThread` / `LogForThread` on a new `TreeEditService`) + hosted-client wrappers | **EXCLUDE.** Hosted-thread RPC surface (spike #267 / refs #409). The new RPCs and `HostedGrpcClient` wrappers serve the hosted product; no OSS-CLI command exposes them. Borderline because it lands in the published `heddle-client` crate — surfacing for your call. |
| #788 (`4c639b6f`) | Hosted-auth robustness: malformed `credentials.toml` surfaces a real error; `fetch`/thread-approval unified onto the proof-of-possession auth path | **INCLUDE (as Fixed).** Although it's hosted-*auth*, the user-visible effect is a CLI-facing error-message + auth-mode fix on `heddle fetch` and thread-approval (clone/push/pull already on this path). A CLI user hitting a malformed credentials file or a PoP server sees the improvement directly. Included it; flag if you'd rather it live in weft. |
| #803 (`5c89f5d3`) | `bridge git checkout` reconstructs the worktree from heddle state instead of the eager `.heddle/git` mirror (mirror-demotion P1) | **INCLUDE (as Changed).** This is native git-overlay / bridge behavior in the OSS CLI (`crates/cli/src/bridge`), with a user-visible correctness gate. Included. |
| #821 / #822 (`8031a834` / `dd9f6172`) | Bare-pull delta sync advertises local head + closure-completeness gate (weft#215 follow-up) | **INCLUDE (as Performance).** The code lives in `heddle-client` sync and is a big user-facing `heddle pull` speedup ("sub-second on the common path"); the weft#215 reference is just the server-side counterpart. Included. |

Also **EXCLUDED as internal-only** (no changelog entry, not user-visible): #609 phases 1-3 (`9c0fb453`/`fd4f92ef`/`30b129d7`) god-module test/source splits; CI-only commits #813 schemas-drift gate (`41923296`), #811 dep-count guard (`2f0f2922`); spike docs #545 FIDO2 (`e0e0e110`) and #578 checkpoint UX (`7557a1cb`).

---

## Summary

Release-prep **DRAFT** for `0.6.0`, covering everything merged since `v0.5.1` (29 commits).

**Version bump:**
- `[workspace.package] version` `0.5.1` → `0.6.0` and the inter-crate caret pins (`version = "0.5"` → `"0.6"`) across all heddle crates (same pattern as the v0.5.0 release commit `ebc02ad6`). Third-party `base32`/`tower` 0.5 deps untouched.
- `Cargo.lock` re-synced (`cargo build --locked --workspace` green; `heddle --version` → `heddle 0.6.0`).
- **`heddle-grpc` left at `0.7.3`** (independent versioning) — verified unchanged.

**CHANGELOG `## 0.6.0 - Unreleased`** sections:
- **Added** — apt/.deb distribution (#234), Scoop/Windows manifest (#233), FUSE page-cache via active inode invalidation (#87).
- **Changed** — dependency refresh rusqlite/sqlx/reqwest + syntax indexing (#820), merge preview==apply (#503), worktree checkout reconstructs from heddle state (#568 P1).
- **Fixed** — rebase auto-merge routes through semantic driver (#116), semantic merge EOF-newline parity (#123), `heddle://` hosted-push routing (#794), `maintenance gc` consolidation (#796), malformed-credentials error surfacing (#788).
- **Performance** — pull delta-sync sub-second common path (#821/#822), compute-worktree-status-once across read commands (#793/#795).
- **Security** — anyhow 1.0.103 / RUSTSEC-2026-0190 (#817).

Related commits consolidated into coherent entries (the read-path perf arc spans several commits incl. the bottom-of-log checkpoint perf trio; the pull-perf arc spans #821+#822). Entries written as user-facing prose matching the 0.5.1/0.5.0 tone.

**Does NOT tag or trigger release — held for maintainer GO.** heddle-grpc left at 0.7.3 (independent versioning).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785361720&installation_id=132405951&pr_number=823&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F823&signature=0d357f2c48c2afdbc3dcef7240a1c082134a6a99a3299f1059d11e300e601e27"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->