### PR TITLE
fix(release): strip CR when aggregating SHA256SUMS (Windows CRLF breaks Scoop render)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -516,7 +516,7 @@ jobs:
           mkdir -p dist
           find staging -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name '*.sig' -o -name '*.pem' -o -name '*.sha256' \) \
             -exec cp -t dist {} +
-          ( cd dist && cat *.sha256 | sort > SHA256SUMS )
+          ( cd dist && cat *.sha256 | tr -d '\r' | sort > SHA256SUMS )
           echo "--- artifacts ---"
           ls -la dist
 
@@ -668,7 +668,7 @@ jobs:
           mkdir -p dist rendered
           find staging -type f \( -name '*.tar.gz' -o -name '*.zip' -o -name '*.dmg' -o -name '*.sha256' \) \
             -exec cp -t dist {} +
-          ( cd dist && cat *.sha256 | sort > SHA256SUMS )
+          ( cd dist && cat *.sha256 | tr -d '\r' | sort > SHA256SUMS )
 
       - name: Compute manifest inputs
         id: ver


### PR DESCRIPTION
## Root cause
v0.6.0's `publish package manifests` job failed at *Render Scoop manifest*: `no checksum found for heddle-v0.6.0-x86_64-pc-windows-msvc.zip in dist/SHA256SUMS`.

The Windows build writes its `.sha256` via PowerShell `Out-File -Encoding ascii` (**CRLF**). The job aggregates with `cat *.sha256 | sort > SHA256SUMS`, so the Windows line carries a trailing `\r`. The Scoop render's anchored filename lookup can't match the CR-terminated line. Homebrew rendered first and passed (darwin entries are LF); Scoop hit the Windows gap and `set -e` halted the job before any manifest published.

The checksum was actually correct and present — purely a line-ending artifact.

## Fix
`cat *.sha256 | tr -d '\r' | sort` in both aggregation sites (release job + manifests job). Harmless for LF inputs; also yields a clean-LF published SHA256SUMS for checksum verification.

## Scope
- **Future releases**: brew/scoop/apt manifests publish correctly.
- **v0.6.0**: NOT retroactively fixed (its run uses the tagged workflow). Per maintainer decision, 0.6.0's manifests ride the next tagged release. The core 0.6.0 artifacts (crates.io, binaries + GitHub Release, `@heddleco/grpc@0.7.3` npm) are already live.

Codex-offline interim gate — Claude-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785375547&installation_id=132405951&pr_number=824&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F824&signature=99993f7f0978935aeb5e85c506d4103819bb9e1b6dc0e9c4306c3e11baf75bc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->