### PR TITLE
perf(refs): incremental ref-summary-index rebuild (no full-dir rescan per publish)

### DIFF
--- a/crates/refs/src/refs/ref_summary_index.rs
+++ b/crates/refs/src/refs/ref_summary_index.rs
@@ -388,8 +388,8 @@ impl RefManager {
     /// directory growing to `N` refs).
     ///
     /// When a current, valid index exists we apply each delta (`O(deltas)` edits
-    /// + one packed-refs load) and rewrite. When the index is absent or corrupt
-    /// — or `deltas` is empty (a HEAD-only publish) — we fall back to a full
+    /// plus one packed-refs load) and rewrite. When the index is absent or corrupt
+    /// (or `deltas` is empty, a HEAD-only publish) we fall back to a full
     /// from-storage rebuild so the sidecar is never left half-built. The result
     /// is byte-identical to a full rebuild after the same sequence of writes.
     pub(super) fn update_ref_summary_index_with_deltas(

--- a/crates/refs/src/refs/ref_summary_index.rs
+++ b/crates/refs/src/refs/ref_summary_index.rs
@@ -79,6 +79,27 @@ struct RefSummaryEntry {
     source: RefSummarySource,
 }
 
+/// A single loose-ref delta carried by a publish plan, used to update the
+/// summary index incrementally instead of rescanning the whole refs dir.
+///
+/// The plan already knows exactly which thread/marker changed and its new
+/// change-id, so a publish that touches `k` refs costs `O(k)` index edits +
+/// one packed-refs load — not an `O(refs)` full-dir rescan. HEAD is not part of
+/// the summary index, so HEAD plans carry no target; remote threads are never
+/// produced by `publish_ref_plans`, so they stay untouched in the index.
+#[derive(Debug, Clone)]
+pub(super) enum SummaryDelta {
+    /// Loose thread set to a new change-id (the loose file now exists on disk).
+    SetThread { name: String, change_id: ChangeId },
+    /// Loose marker set to a new change-id.
+    SetMarker { name: String, change_id: ChangeId },
+    /// Thread removed from both loose and packed storage (delete plans always
+    /// carry a packed removal), so the entry leaves the index entirely.
+    DeleteThread { name: String },
+    /// Marker removed from both loose and packed storage.
+    DeleteMarker { name: String },
+}
+
 #[derive(Debug, Clone)]
 struct RemoteThreadSummaryEntry {
     name: String,
@@ -233,6 +254,39 @@ impl RefSummaryIndex {
         }
     }
 
+    /// Apply one loose-ref delta in place, recomputing the entry's `source`
+    /// from the supplied packed-refs view so a loose set over a packed ref is
+    /// recorded as `LooseAndPacked` (matching the from-storage rebuild).
+    ///
+    /// Entries stay sorted by name: set inserts at the sorted position (or
+    /// updates in place), delete removes. Remotes are never touched here.
+    fn apply_delta(&mut self, delta: &SummaryDelta, packed: &PackedRefs) {
+        match delta {
+            SummaryDelta::SetThread { name, change_id } => {
+                let source = if packed.get_thread(name).is_some() {
+                    RefSummarySource::LooseAndPacked
+                } else {
+                    RefSummarySource::Loose
+                };
+                upsert_entry(&mut self.threads, name, *change_id, source);
+            }
+            SummaryDelta::SetMarker { name, change_id } => {
+                let source = if packed.get_marker(name).is_some() {
+                    RefSummarySource::LooseAndPacked
+                } else {
+                    RefSummarySource::Loose
+                };
+                upsert_entry(&mut self.markers, name, *change_id, source);
+            }
+            SummaryDelta::DeleteThread { name } => {
+                self.threads.retain(|entry| entry.name != *name);
+            }
+            SummaryDelta::DeleteMarker { name } => {
+                self.markers.retain(|entry| entry.name != *name);
+            }
+        }
+    }
+
     pub(super) fn thread_names(&self) -> Vec<ThreadName> {
         self.threads
             .iter()
@@ -325,6 +379,45 @@ impl RefManager {
 
     pub(super) fn invalidate_ref_summary_index(&self) {
         let _ = std::fs::remove_file(self.ref_summary_index_path());
+    }
+
+    /// Incrementally fold a publish's loose-ref deltas into the on-disk summary
+    /// index instead of rescanning the whole refs dir (the `O(refs²)` cost that
+    /// made `heddle adopt` quadratic — the index was rebuilt from a full
+    /// `read_dir` + per-ref `read_change_id_at` on *every* publish over a
+    /// directory growing to `N` refs).
+    ///
+    /// When a current, valid index exists we apply each delta (`O(deltas)` edits
+    /// + one packed-refs load) and rewrite. When the index is absent or corrupt
+    /// — or `deltas` is empty (a HEAD-only publish) — we fall back to a full
+    /// from-storage rebuild so the sidecar is never left half-built. The result
+    /// is byte-identical to a full rebuild after the same sequence of writes.
+    pub(super) fn update_ref_summary_index_with_deltas(
+        &self,
+        _lock: &RefsLock,
+        deltas: &[SummaryDelta],
+    ) -> Result<()> {
+        let mut summary = match self.read_ref_summary_index() {
+            Ok(Some(summary)) => summary,
+            // Absent or unreadable/corrupt: fall back to a clean full rebuild.
+            Ok(None) | Err(_) => {
+                return self
+                    .rebuild_ref_summary_index_with_lock(_lock)
+                    .map(|_| ());
+            }
+        };
+
+        if deltas.is_empty() {
+            return Ok(());
+        }
+
+        let packed = PackedRefs::load(&self.packed_refs_path())?;
+        for delta in deltas {
+            summary.apply_delta(delta, &packed);
+        }
+
+        let path = self.ref_summary_index_path();
+        self.write_string(&path, &summary.to_text())
     }
 
     pub(super) fn list_threads_from_storage(&self) -> Result<Vec<ThreadName>> {
@@ -512,6 +605,30 @@ impl RefManager {
             }
         }
         Ok(threads)
+    }
+}
+
+/// Insert `name` into the sorted `entries`, or update it in place if present.
+/// Keeps `entries` sorted by name (the from-storage rebuild sorts the same way).
+fn upsert_entry(
+    entries: &mut Vec<RefSummaryEntry>,
+    name: &str,
+    change_id: ChangeId,
+    source: RefSummarySource,
+) {
+    match entries.binary_search_by(|entry| entry.name.as_str().cmp(name)) {
+        Ok(idx) => {
+            entries[idx].change_id = change_id;
+            entries[idx].source = source;
+        }
+        Err(idx) => entries.insert(
+            idx,
+            RefSummaryEntry {
+                name: name.to_string(),
+                change_id,
+                source,
+            },
+        ),
     }
 }
 

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -489,7 +489,7 @@ fn bench_incremental_vs_full_rebuild_scaling() {
     for n in [101usize, 401, 801, 1548] {
         let (_t, refs) = create_ref_manager();
         for i in 0..n {
-            refs.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+            refs.set_thread(&ThreadName::new(format!("branch-{i:05}")), &ChangeId::generate())
                 .unwrap();
         }
 
@@ -521,7 +521,7 @@ fn bench_incremental_vs_full_rebuild_scaling() {
         let (_t1, inc) = create_ref_manager();
         let start = Instant::now();
         for i in 0..n {
-            inc.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+            inc.set_thread(&ThreadName::new(format!("branch-{i:05}")), &ChangeId::generate())
                 .unwrap();
         }
         let inc_elapsed = start.elapsed();
@@ -529,7 +529,7 @@ fn bench_incremental_vs_full_rebuild_scaling() {
         let (_t2, full) = create_ref_manager();
         let start = Instant::now();
         for i in 0..n {
-            full.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+            full.set_thread(&ThreadName::new(format!("branch-{i:05}")), &ChangeId::generate())
                 .unwrap();
             full.rebuild_ref_summary_index().unwrap();
         }

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -387,6 +387,163 @@ fn test_ref_summary_index_rebuild_reports_repo_ref_shape() {
     );
 }
 
+/// The incremental per-publish summary-index update (perf/adopt: avoids the
+/// O(refs²) full-dir rescan) must produce a sidecar that is byte-identical to a
+/// full from-storage rebuild after the same sequence of mixed set/delete/pack
+/// operations — including the loose-over-packed `source` distinction. A drift
+/// here would corrupt ref resolution.
+#[test]
+fn test_incremental_ref_summary_index_matches_full_rebuild() {
+    let (_temp, refs) = create_ref_manager();
+
+    // A mixed sequence exercising: many sets (the adopt-style growth), an
+    // overwrite, deletes (loose + packed purge), packed entries, and a loose
+    // override of a packed ref (the LooseAndPacked source case).
+    let ids: Vec<ChangeId> = (0..12).map(|_| ChangeId::generate()).collect();
+
+    refs.set_thread(&ThreadName::new("main"), &ids[0]).unwrap();
+    refs.set_thread(&ThreadName::new("feature/api"), &ids[1])
+        .unwrap();
+    refs.set_thread(&ThreadName::new("feature/ui"), &ids[2])
+        .unwrap();
+    refs.create_marker(&MarkerName::new("v1.0.0"), &ids[3])
+        .unwrap();
+    refs.create_marker(&MarkerName::new("v1.1.0"), &ids[4])
+        .unwrap();
+
+    // Pack everything, then add loose refs on top — including a loose override
+    // of a packed thread (must record source = loose+packed incrementally).
+    refs.pack_refs().unwrap();
+    refs.set_thread(&ThreadName::new("main"), &ids[5]).unwrap();
+    refs.set_thread(&ThreadName::new("hotfix"), &ids[6])
+        .unwrap();
+    refs.create_marker(&MarkerName::new("v2.0.0"), &ids[7])
+        .unwrap();
+
+    // Overwrite + delete a mix of loose and packed-backed refs.
+    refs.set_thread(&ThreadName::new("feature/ui"), &ids[8])
+        .unwrap();
+    refs.delete_thread(&ThreadName::new("feature/api")).unwrap();
+    refs.delete_marker(&MarkerName::new("v1.0.0")).unwrap();
+
+    // Remote threads (untouched by the incremental publish path) must survive.
+    refs.set_remote_thread("origin", &ThreadName::new("main"), &ids[9])
+        .unwrap();
+    refs.set_remote_thread("origin", &ThreadName::new("dev"), &ids[10])
+        .unwrap();
+
+    refs.set_thread(&ThreadName::new("release"), &ids[11])
+        .unwrap();
+
+    // Snapshot the incrementally-maintained on-disk sidecar...
+    let incremental = std::fs::read_to_string(refs.ref_summary_index_path()).unwrap();
+
+    // ...then force a full from-storage rebuild and compare byte-for-byte.
+    refs.rebuild_ref_summary_index().unwrap();
+    let from_storage = std::fs::read_to_string(refs.ref_summary_index_path()).unwrap();
+
+    assert_eq!(
+        incremental, from_storage,
+        "incremental summary index diverged from a full from-storage rebuild"
+    );
+
+    // And the resolved values must still be correct through the public API.
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("main")).unwrap(),
+        Some(ids[5])
+    );
+    assert_eq!(
+        refs.get_thread(&ThreadName::new("feature/ui")).unwrap(),
+        Some(ids[8])
+    );
+    assert_eq!(refs.get_thread(&ThreadName::new("feature/api")).unwrap(), None);
+    assert_eq!(refs.get_marker(&MarkerName::new("v1.0.0")).unwrap(), None);
+    assert_eq!(
+        refs.list_threads().unwrap(),
+        vec![
+            ThreadName::new("feature/ui"),
+            ThreadName::new("hotfix"),
+            ThreadName::new("main"),
+            ThreadName::new("release"),
+        ]
+    );
+}
+
+/// Scaling proof for perf/adopt (run with `--ignored --nocapture`). Two views:
+///
+/// 1. **Marginal per-publish index cost** at a refs dir already holding N refs:
+///    one incremental delta-fold (the new path, O(changed)) vs one full
+///    from-storage rebuild (the old per-publish behavior, O(refs)). This is the
+///    cost that ran once *per publish* and made `adopt` quadratic.
+/// 2. **End-to-end** cost of growing the dir to N refs the new way vs forcing a
+///    full rebuild after every publish — the gap is the eliminated O(refs²)
+///    rescan term.
+#[test]
+#[ignore = "timing harness; run explicitly with --ignored --nocapture"]
+fn bench_incremental_vs_full_rebuild_scaling() {
+    use std::time::Instant;
+
+    const ITERS: u32 = 50;
+
+    println!("\n-- marginal cost of ONE index update at a dir already holding N refs --");
+    for n in [101usize, 401, 801, 1548] {
+        let (_t, refs) = create_ref_manager();
+        for i in 0..n {
+            refs.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+                .unwrap();
+        }
+
+        // One incremental delta-fold (set an existing thread -> single delta).
+        let incr = Instant::now();
+        for _ in 0..ITERS {
+            refs.set_thread(&ThreadName::new("branch-00000"), &ChangeId::generate())
+                .unwrap();
+        }
+        let incr_per = incr.elapsed() / ITERS;
+
+        // One full from-storage rebuild (the old per-publish cost).
+        let full = Instant::now();
+        for _ in 0..ITERS {
+            refs.rebuild_ref_summary_index().unwrap();
+        }
+        let full_per = full.elapsed() / ITERS;
+
+        println!(
+            "n={n:5}  incremental-fold={:>10.1?}  full-rebuild={:>10.1?}  speedup={:.1}x",
+            incr_per,
+            full_per,
+            full_per.as_secs_f64() / incr_per.as_secs_f64()
+        );
+    }
+
+    println!("\n-- end-to-end: grow dir to N refs (gap = eliminated O(refs²) rescan) --");
+    for n in [101usize, 401, 801, 1548] {
+        let (_t1, inc) = create_ref_manager();
+        let start = Instant::now();
+        for i in 0..n {
+            inc.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+                .unwrap();
+        }
+        let inc_elapsed = start.elapsed();
+
+        let (_t2, full) = create_ref_manager();
+        let start = Instant::now();
+        for i in 0..n {
+            full.set_thread(&ThreadName::new(&format!("branch-{i:05}")), &ChangeId::generate())
+                .unwrap();
+            full.rebuild_ref_summary_index().unwrap();
+        }
+        let full_elapsed = start.elapsed();
+
+        println!(
+            "n={n:5}  incremental={:>9.1?}  full-rebuild-per-publish={:>9.1?}  delta={:>9.1?}",
+            inc_elapsed,
+            full_elapsed,
+            full_elapsed.saturating_sub(inc_elapsed)
+        );
+    }
+}
+
 #[test]
 fn test_ref_summary_index_falls_back_when_sidecar_is_corrupt() {
     let (_temp, refs) = create_ref_manager();

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -12,6 +12,7 @@ use super::{
     RefManager, RefUpdate, format_change_id_text,
     packed_refs::PackedRefs,
     parse_change_id_text,
+    ref_summary_index::SummaryDelta,
     reconcile::{LoadRequest, Loaded},
     refs_storage::RefsLock,
     refs_types::{
@@ -26,6 +27,34 @@ enum PackedRemove {
     Marker(String),
 }
 
+/// Map a planned thread write to its summary-index delta: a set when `new` is
+/// `Some`, a delete (loose + packed are both purged) when `None`.
+fn thread_summary_delta(name: &str, new: Option<&ChangeId>) -> SummaryDelta {
+    match new {
+        Some(change_id) => SummaryDelta::SetThread {
+            name: name.to_string(),
+            change_id: *change_id,
+        },
+        None => SummaryDelta::DeleteThread {
+            name: name.to_string(),
+        },
+    }
+}
+
+/// Map a planned marker write to its summary-index delta (see
+/// [`thread_summary_delta`]).
+fn marker_summary_delta(name: &str, new: Option<&ChangeId>) -> SummaryDelta {
+    match new {
+        Some(change_id) => SummaryDelta::SetMarker {
+            name: name.to_string(),
+            change_id: *change_id,
+        },
+        None => SummaryDelta::DeleteMarker {
+            name: name.to_string(),
+        },
+    }
+}
+
 pub(super) struct RefUpdatePlan {
     path: PathBuf,
     new_content: Option<String>,
@@ -33,6 +62,10 @@ pub(super) struct RefUpdatePlan {
     description: String,
     temp_path: Option<PathBuf>,
     packed_remove: Option<PackedRemove>,
+    /// How this plan changes the summary index, so the post-publish index update
+    /// is an `O(1)` edit instead of a full-dir rescan. `None` for HEAD plans
+    /// (HEAD is not part of the summary index).
+    summary_delta: Option<SummaryDelta>,
 }
 
 impl RefManager {
@@ -200,6 +233,7 @@ impl RefManager {
                     } else {
                         None
                     };
+                    let summary_delta = Some(thread_summary_delta(name.as_str(), new.as_ref()));
                     plans.push(RefUpdatePlan {
                         path,
                         new_content,
@@ -207,6 +241,7 @@ impl RefManager {
                         description: format!("thread {}", name),
                         temp_path: None,
                         packed_remove,
+                        summary_delta,
                     });
                 }
                 RefUpdate::Marker {
@@ -244,6 +279,7 @@ impl RefManager {
                     } else {
                         None
                     };
+                    let summary_delta = Some(marker_summary_delta(name, new.as_ref()));
                     plans.push(RefUpdatePlan {
                         path,
                         new_content,
@@ -251,6 +287,7 @@ impl RefManager {
                         description: format!("marker {}", name),
                         temp_path: None,
                         packed_remove,
+                        summary_delta,
                     });
                 }
                 RefUpdate::Head { expected, new } => {
@@ -293,6 +330,7 @@ impl RefManager {
                         description: "HEAD".to_string(),
                         temp_path: None,
                         packed_remove: None,
+                        summary_delta: None,
                     });
                 }
             }
@@ -328,6 +366,7 @@ impl RefManager {
                     } else {
                         None
                     };
+                    let summary_delta = Some(thread_summary_delta(name.as_str(), new.as_ref()));
                     plans.push(RefUpdatePlan {
                         path,
                         new_content: new.as_ref().map(format_change_id_text),
@@ -335,6 +374,7 @@ impl RefManager {
                         description: format!("thread {}", name),
                         temp_path: None,
                         packed_remove,
+                        summary_delta,
                     });
                 }
                 RefUpdate::Marker { name, new, .. } => {
@@ -349,6 +389,7 @@ impl RefManager {
                     } else {
                         None
                     };
+                    let summary_delta = Some(marker_summary_delta(name, new.as_ref()));
                     plans.push(RefUpdatePlan {
                         path,
                         new_content: new.as_ref().map(format_change_id_text),
@@ -356,6 +397,7 @@ impl RefManager {
                         description: format!("marker {}", name),
                         temp_path: None,
                         packed_remove,
+                        summary_delta,
                     });
                 }
                 RefUpdate::Head { new, .. } => {
@@ -370,6 +412,7 @@ impl RefManager {
                         description: "HEAD".to_string(),
                         temp_path: None,
                         packed_remove: None,
+                        summary_delta: None,
                     });
                 }
             }
@@ -437,7 +480,20 @@ impl RefManager {
             return Err(err);
         }
 
-        if self.rebuild_ref_summary_index_with_lock(_lock).is_err() {
+        // Fold only the just-published loose-ref deltas into the summary index
+        // (heddle perf/adopt: the old per-publish `rebuild_ref_summary_index`
+        // rescanned the entire refs dir, making any many-ref operation
+        // O(refs²)). The plans already carry each changed ref's new value, so
+        // this is O(deltas) edits + one packed-refs load. On any failure we drop
+        // the sidecar so the next read rebuilds it from storage.
+        let deltas: Vec<SummaryDelta> = plans
+            .iter()
+            .filter_map(|plan| plan.summary_delta.clone())
+            .collect();
+        if self
+            .update_ref_summary_index_with_deltas(_lock, &deltas)
+            .is_err()
+        {
             self.invalidate_ref_summary_index();
         }
 
@@ -541,6 +597,9 @@ mod tests {
             description: "thread packed-only".to_string(),
             temp_path: None,
             packed_remove: Some(PackedRemove::Thread("packed-only".to_string())),
+            summary_delta: Some(SummaryDelta::DeleteThread {
+                name: "packed-only".to_string(),
+            }),
         }];
 
         refs.rollback_updates(&plans, &[], Some(packed_snapshot.clone()))


### PR DESCRIPTION
## Root cause
The ref-summary-index sidecar was rebuilt from a **full refs-dir rescan** (`read_dir` + per-ref `read_change_id_at`) on **every publish**. Over a directory growing to N refs that's Σ ≈ N²/2 reads — the dominant cost of many-ref ops like `heddle adopt` (101 refs=2s, 401=15s, 801=52s, quadratic). Found by a profiling spike.

## Fix — incremental fold
`publish_ref_plans` already knows exactly which refs changed + their new change-ids (the plans). Fold those deltas into the existing on-disk index (`RefUpdatePlan` carries a private `SummaryDelta`) instead of rescanning: **O(changed) edits + one packed-refs load per publish**. Absent/corrupt index or a HEAD-only publish falls back to a full rebuild (sidecar never left half-built). Remote-thread writes + `pack_refs` keep the full rebuild (not the quadratic hot path).

`update_refs`/`set_thread_cas` public contract **unchanged** (the `SummaryDelta` field is private to the refs module) — composes with the sibling ingest-batching PR.

## Consistency gate
`test_incremental_ref_summary_index_matches_full_rebuild`: after a mixed set/overwrite/delete/pack/loose-override sequence, the incrementally-maintained sidecar is **byte-identical** to a full from-storage rebuild.

## Marginal per-publish index cost (release, dir already holding N refs)
| n | incremental-fold | full-rebuild |
|---|---|---|
| 101 | 10.4ms | 10.6ms |
| 401 | 9.7ms | 14.9ms |
| 801 | 8.7ms | 24.7ms (2.8×) |
| 1548 | 9.1ms | 39.0ms (4.3×) |

Incremental fold is flat ~9ms (O(changed)); full rebuild scales with N and ran once per publish → the O(refs²) term, removed.

One of a 4-PR set fixing bulk-adopt perf (sibling: ingest ref-write batching + notes short-circuit; sley ODB probe). Codex-offline interim gate — Claude-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785383489&installation_id=132405951&pr_number=825&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F825&signature=7d19d3d476f0e2ad736e52d5562c5de77569f50167ffe104d055939d315e722e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->