### PR TITLE
perf(ingest): batch adopt ref writes + skip per-commit notes lookup

### DIFF
--- a/crates/ingest/src/git_walk.rs
+++ b/crates/ingest/src/git_walk.rs
@@ -203,6 +203,12 @@ enum RefResolution {
 /// handle internally; clone-cheap via `&` reference only.
 pub struct GitSource {
     repo: SleyRepository,
+    /// Whether the source repo carries `refs/notes/heddle`, resolved once and
+    /// cached. Most imported repos (e.g. a plain ripgrep clone) have no such
+    /// ref, so `read_heddle_note_bytes` can short-circuit to `None` instead of
+    /// attempting a notes-tree walk per commit (a 4,410-commit import otherwise
+    /// pays 4,410 wasted notes lookups).
+    heddle_notes_present: std::sync::OnceLock<bool>,
 }
 
 impl std::fmt::Debug for GitSource {
@@ -228,7 +234,22 @@ impl GitSource {
             Err(_) => SleyRepository::open(path)
                 .map_err(|e| IngestError::Git(format!("open {}: {e}", path.display())))?,
         };
-        Ok(Self { repo })
+        Ok(Self {
+            repo,
+            heddle_notes_present: std::sync::OnceLock::new(),
+        })
+    }
+
+    /// Whether `refs/notes/heddle` exists in the source repo, resolved once and
+    /// memoized. Absence is the common case (most imports have no heddle notes),
+    /// and lets [`Self::read_heddle_note_bytes`] skip the per-commit notes walk.
+    fn heddle_notes_present(&self) -> bool {
+        *self.heddle_notes_present.get_or_init(|| {
+            matches!(
+                self.repo.find_reference("refs/notes/heddle"),
+                Ok(Some(_))
+            )
+        })
     }
 
     fn resolve_ref_commit(&self, name: &str, target: &SleyRefTarget) -> RefResolution {
@@ -433,6 +454,13 @@ impl GitSource {
     /// Read Heddle's metadata note for `sha`, if the source repository
     /// carries `refs/notes/heddle`.
     pub fn read_heddle_note_bytes(&self, sha: &str) -> crate::Result<Option<Vec<u8>>> {
+        // Short-circuit before touching the object format / notes tree when the
+        // source repo has no `refs/notes/heddle` — the overwhelmingly common
+        // case. This collapses the per-commit notes lookup to a single cached
+        // ref-existence check for the whole import.
+        if !self.heddle_notes_present() {
+            return Ok(None);
+        }
         let oid = parse_oid(self.repo.object_format(), sha)?;
         let notes_ref = sley::notes::NotesRef::expand("refs/notes/heddle");
         self.repo
@@ -975,6 +1003,85 @@ mod tests {
         assert_eq!(commit.author.name, "Test");
         assert_eq!(commit.author.email, "test@example.com");
         assert!(String::from_utf8_lossy(&commit.message).contains("second commit"));
+    }
+
+    #[test]
+    fn heddle_note_absent_repo_short_circuits_to_none() {
+        // The common case (e.g. a plain ripgrep clone): no `refs/notes/heddle`.
+        // `read_heddle_note_bytes` must return `None` without walking a notes
+        // tree, and the presence flag must read `false`.
+        let tmp = TempDir::new().unwrap();
+        let head = seed_repo(tmp.path());
+
+        let src = GitSource::open(tmp.path()).unwrap();
+        assert!(
+            !src.heddle_notes_present(),
+            "repo without refs/notes/heddle must report notes absent"
+        );
+        assert_eq!(
+            src.read_heddle_note_bytes(&head).unwrap(),
+            None,
+            "absent-notes repo must short-circuit to None"
+        );
+        // The walked commit carries no note either.
+        let commit = src.read_commit(&head).unwrap();
+        assert_eq!(commit.heddle_note, None);
+    }
+
+    #[test]
+    fn heddle_note_present_repo_reads_payload() {
+        // The present path must be preserved: a repo WITH refs/notes/heddle
+        // still surfaces the note payload byte-for-byte.
+        let tmp = TempDir::new().unwrap();
+        let head = seed_repo(tmp.path());
+        let path = tmp.path();
+
+        let note_body = "heddle-metadata-payload";
+        let status = Command::new("git")
+            .args(["notes", "--ref=heddle", "add", "-m", note_body, &head])
+            .current_dir(path)
+            .env("GIT_AUTHOR_NAME", "Test")
+            .env("GIT_AUTHOR_EMAIL", "test@example.com")
+            .env("GIT_COMMITTER_NAME", "Test")
+            .env("GIT_COMMITTER_EMAIL", "test@example.com")
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git notes add");
+        assert!(status.success(), "git notes add failed");
+
+        let src = GitSource::open(path).unwrap();
+        assert!(
+            src.heddle_notes_present(),
+            "repo with refs/notes/heddle must report notes present"
+        );
+        let bytes = src
+            .read_heddle_note_bytes(&head)
+            .unwrap()
+            .expect("note should be present");
+        // git notes stores the message with a trailing newline.
+        assert_eq!(String::from_utf8_lossy(&bytes).trim_end(), note_body);
+
+        // A commit WITHOUT a note in a notes-present repo still yields None.
+        let first = src
+            .read_commit(&head)
+            .unwrap()
+            .parents
+            .first()
+            .cloned()
+            .expect("head has a parent");
+        assert_eq!(
+            src.read_heddle_note_bytes(&first).unwrap(),
+            None,
+            "un-annotated commit must yield None even when notes ref exists"
+        );
+
+        // And the head commit's walked entry carries the note bytes.
+        let commit = src.read_commit(&head).unwrap();
+        assert_eq!(
+            commit.heddle_note.map(|b| String::from_utf8_lossy(&b).trim_end().to_string()),
+            Some(note_body.to_string()),
+        );
     }
 
     /// Close-the-class conformance (ingest path): a commit whose extension

--- a/crates/ingest/src/ref_emit.rs
+++ b/crates/ingest/src/ref_emit.rs
@@ -31,7 +31,7 @@ use objects::{
     object::{ChangeId, MarkerName, ThreadName, Tree},
     store::ObjectStore,
 };
-use refs::refs::{RefBackend, RefExpectation};
+use refs::refs::{RefBackend, RefExpectation, RefUpdate};
 use tracing::warn;
 
 use crate::{
@@ -105,6 +105,9 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
                         ))
                     })?;
                     let thread_name = ThreadName::from(head.short_name.as_str());
+                    // The divergence check MUST run before the batch publish:
+                    // a thread import that would move a thread across divergent
+                    // history fails closed here, before any ref is written.
                     if let Some(existing) = self
                         .refs
                         .get_thread(&thread_name)
@@ -122,36 +125,62 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
                     threads.push((thread_name, cid));
                 }
                 RefNamespace::Tag => {
-                    markers.push((MarkerName::from(head.short_name.as_str()), cid));
+                    let marker_name = MarkerName::from(head.short_name.as_str());
+                    // `create_marker` rejects existing names (markers are
+                    // write-once by design), so an idempotent importer has to
+                    // use `RefExpectation::Any`. We still short-circuit when
+                    // the marker already points at the same cid — keeps the
+                    // batch free of no-op churn and matches the prior
+                    // per-marker behavior.
+                    let existing = self
+                        .refs
+                        .get_marker(&marker_name)
+                        .await
+                        .map_err(IngestError::from)?;
+                    markers.push((marker_name, cid, existing));
                 }
             }
         }
 
+        // Batch every thread + marker write into ONE `update_refs` call so the
+        // whole import publishes under a single lock with a single ref-summary
+        // rebuild. The previous one-ref-at-a-time loop made N publishes, each
+        // rescanning the entire refs dir — Σ ≈ N²/2 file reads (101 refs=2s,
+        // 401=15s, 801=52s). `update_refs` validates the whole batch atomically
+        // and rejects duplicate paths, so the batch must carry at most one
+        // update per distinct path. Git ref names live in disjoint namespaces
+        // (`refs/heads`/`refs/remotes` → threads, `refs/tags` → markers) and a
+        // ref list never repeats a full name, so each (kind, short_name) pair
+        // is already unique across the batch.
+        let mut updates: Vec<RefUpdate> = Vec::with_capacity(threads.len() + markers.len());
+
         for (thread_name, cid) in threads {
-            self.refs
-                .set_thread(&thread_name, &cid)
-                .map_err(IngestError::from)?;
+            updates.push(RefUpdate::Thread {
+                name: thread_name,
+                // The divergence check above already validated the move; there
+                // is no concurrent writer during import, so `Any` mirrors the
+                // single-ref `set_thread` it replaces.
+                expected: RefExpectation::Any,
+                new: Some(cid),
+            });
             stats.threads_written += 1;
         }
 
-        for (marker_name, cid) in markers {
-            // `create_marker` rejects existing names (markers are
-            // write-once by design), so an idempotent importer has to
-            // use `set_marker_cas(Any, …)`. We still short-circuit when
-            // the marker already points at the same cid — saves a lock
-            // cycle.
-            let existing = self
-                .refs
-                .get_marker(&marker_name)
-                .await
-                .map_err(IngestError::from)?;
+        for (marker_name, cid, existing) in markers {
             if existing != Some(cid) {
-                self.refs
-                    .set_marker_cas(&marker_name, RefExpectation::Any, &cid)
-                    .map_err(IngestError::from)?;
+                updates.push(RefUpdate::Marker {
+                    name: marker_name,
+                    expected: RefExpectation::Any,
+                    new: Some(cid),
+                });
             }
+            // `markers_written` counts every tag we adopted (including no-op
+            // re-points), preserving the prior stat semantics.
             stats.markers_written += 1;
         }
+
+        self.refs.update_refs(&updates).map_err(IngestError::from)?;
+
         Ok(stats)
     }
 
@@ -368,6 +397,109 @@ mod tests {
 
         assert_eq!(first, second);
         assert_eq!(mgr.get_thread(&ThreadName::new("main")).unwrap(), Some(cid));
+    }
+
+    #[test]
+    fn batched_emit_writes_every_thread_and_marker_exactly_once() {
+        // Regression guard for the O(refs²) → single-batch rewrite: a many-ref
+        // import must land EVERY branch + tag at its exact change-id, with
+        // nothing dropped, duplicated, or mis-targeted. A batched
+        // `update_refs` that loses or mis-routes a ref is the cardinal bug.
+        let (_tmp, mgr) = fresh_ref_manager();
+        let store = InMemoryStore::new();
+        let mut map = ShaMap::new();
+
+        const N_BRANCHES: usize = 30;
+        const N_REMOTES: usize = 10;
+        const N_TAGS: usize = 20;
+
+        let mut heads = Vec::new();
+        // Each ref gets its OWN distinct commit/change-id so a mis-target
+        // (ref A ending up pointing at ref B's cid) is detectable.
+        let mut expected_threads = Vec::new();
+        let mut expected_markers = Vec::new();
+
+        let mut next_sha = 0u64;
+        let fresh = |store: &InMemoryStore, map: &mut ShaMap, n: &mut u64| {
+            let cid = test_state(store, vec![]);
+            let sha = format!("{:040x}", *n);
+            *n += 1;
+            map.insert_commit(&sha, cid).unwrap();
+            (sha, cid)
+        };
+
+        for i in 0..N_BRANCHES {
+            let (sha, cid) = fresh(&store, &mut map, &mut next_sha);
+            // Mix flat and slashed names to exercise nested path writes.
+            let name = if i % 3 == 0 {
+                format!("feature/branch-{i}")
+            } else {
+                format!("branch-{i}")
+            };
+            heads.push(sample_head(&name, RefNamespace::Branch, &sha));
+            expected_threads.push((name, cid));
+        }
+        for i in 0..N_REMOTES {
+            let (sha, cid) = fresh(&store, &mut map, &mut next_sha);
+            let name = format!("origin/remote-{i}");
+            heads.push(sample_head(&name, RefNamespace::RemoteBranch, &sha));
+            expected_threads.push((name, cid));
+        }
+        for i in 0..N_TAGS {
+            let (sha, cid) = fresh(&store, &mut map, &mut next_sha);
+            let name = format!("v{i}.0");
+            heads.push(sample_head(&name, RefNamespace::Tag, &sha));
+            expected_markers.push((name, cid));
+        }
+
+        let stats =
+            pollster::block_on(RefEmitter::new(&mgr, &store, &map).emit(&heads)).unwrap();
+
+        assert_eq!(stats.threads_written, N_BRANCHES + N_REMOTES);
+        assert_eq!(stats.markers_written, N_TAGS);
+        assert_eq!(stats.skipped_unmapped, 0);
+
+        // Every thread present at its EXACT change-id.
+        for (name, cid) in &expected_threads {
+            assert_eq!(
+                mgr.get_thread(&ThreadName::new(name)).unwrap(),
+                Some(*cid),
+                "thread {name} missing or mis-targeted after batched emit",
+            );
+        }
+        // Exactly the threads we asked for — none extra, none dropped.
+        let listed_threads = mgr.list_threads().unwrap();
+        assert_eq!(
+            listed_threads.len(),
+            expected_threads.len(),
+            "thread count drift: {listed_threads:?}",
+        );
+
+        // Every marker present at its EXACT change-id.
+        for (name, cid) in &expected_markers {
+            assert_eq!(
+                mgr.get_marker(&MarkerName::new(name)).unwrap(),
+                Some(*cid),
+                "marker {name} missing or mis-targeted after batched emit",
+            );
+        }
+        let listed_markers = mgr.list_markers().unwrap();
+        assert_eq!(
+            listed_markers.len(),
+            expected_markers.len(),
+            "marker count drift: {listed_markers:?}",
+        );
+
+        // Idempotent: a second identical emit is a no-op for final state.
+        let again =
+            pollster::block_on(RefEmitter::new(&mgr, &store, &map).emit(&heads)).unwrap();
+        assert_eq!(again.threads_written, N_BRANCHES + N_REMOTES);
+        for (name, cid) in &expected_threads {
+            assert_eq!(mgr.get_thread(&ThreadName::new(name)).unwrap(), Some(*cid));
+        }
+        for (name, cid) in &expected_markers {
+            assert_eq!(mgr.get_marker(&MarkerName::new(name)).unwrap(), Some(*cid));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Root cause
`heddle adopt` / `bridge git import` of a many-branch repo was O(refs²). Two issues (found by a profiling spike):

**Fix 1 (the quadratic killer):** `RefEmitter::emit` looped one ref at a time (`set_thread`/`set_marker_cas`), each call publishing via `update_refs(&[single])`. Every publish rebuilt the whole ref-summary-index by rescanning the refs dir, so N refs cost Σ ≈ N²/2 file reads (101 refs=2s, 401=15s, 801=52s). Now `emit` assembles ONE `Vec<RefUpdate>` covering all threads + markers and makes a single `update_refs(&all)` call → one lock, one summary rebuild. CAS semantics preserved (`RefExpectation::Any` per ref, matching the single-ref calls it replaces); the divergence check still runs BEFORE the batch; marker no-op short-circuit preserved so the batch carries no duplicate/redundant paths.

**Fix 3 (per-commit floor):** `read_heddle_note_bytes` attempted a `refs/notes/heddle` notes-tree resolution **per commit** even when the source repo has no such ref (the common case). `GitSource` now resolves the ref's presence ONCE (cached `OnceLock<bool>`) and short-circuits to `None` when absent — a 4,410-commit import drops from 4,410 notes walks to one check.

## Correctness gate
`batched_emit_writes_every_thread_and_marker_exactly_once` (30 branches + 10 remotes + 20 tags in one emit): asserts each lands at its exact change-id, none dropped/duplicated. Notes path preserved both ways (present → imported, absent → short-circuit).

Composes with #825 (incremental summary-index): Fix 1 collapses N publishes → 1, and #825 makes each rebuild O(changed) — together they kill the quadratic. `update_refs`/`set_thread_cas` public contract untouched.

Part of the 4-PR bulk-adopt-perf set (sley #117 ✅, refs #825). Codex-offline interim gate — Claude-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785418809&installation_id=132405951&pr_number=826&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F826&signature=0ce0cc9d757c44857f9f58dad6a3089a66cfedcac80f31da9163fbbec85a4c35"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->