### PR TITLE
perf(ingest): batch reflog→oplog emit into one append (O(N²)→O(N))

### DIFF
--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -48,7 +48,7 @@
 //!   that case to keep the log faithful.
 
 use objects::object::{MarkerName, ThreadName};
-use oplog::oplog::{OpLogBackend, OpLogRecorder};
+use oplog::oplog::{OpLogBackend, OpRecord};
 use tracing::warn;
 
 use crate::{IngestError, git_walk::ReflogEntry, sha_map::ShaMap};
@@ -108,35 +108,63 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
         let mut stats = OplogEmitStats::default();
         let scope = self.scope.as_deref();
 
+        // Accumulate one `(records, scope)` group per real event across ALL
+        // reflog entries, then append the whole sequence in a single call.
+        //
+        // The old code called a per-entry `record_*` for every event, and
+        // each call rewrote the entire growing oplog (copy + re-encode +
+        // fsync + rename — `packed_oplog::append_entries`, TODO #423), so N
+        // events cost O(N²). `record_batches_scoped` performs one full-log
+        // rewrite for the whole batch: O(N). Crucially it is NOT a single
+        // mega-batch — each group keeps its own `batch_id` and scope, so the
+        // resulting oplog is byte-for-byte equivalent (ids, batches, scopes,
+        // undo granularity) to what the per-append path produced. Only the
+        // number of disk writes changes.
+        let mut groups: Vec<(Vec<OpRecord>, Option<&str>)> = Vec::new();
+
         for entry in entries {
             match classify(&entry.ref_name) {
-                RefKind::Head => self.emit_head(entry, scope, &mut stats)?,
-                RefKind::Branch(name) => self.emit_branch(entry, &name, scope, &mut stats)?,
-                RefKind::Tag(name) => self.emit_tag(entry, &name, &mut stats)?,
+                RefKind::Head => self.emit_head(entry, scope, &mut groups, &mut stats),
+                RefKind::Branch(name) => {
+                    self.emit_branch(entry, &name, scope, &mut groups, &mut stats)
+                }
+                RefKind::Tag(name) => self.emit_tag(entry, &name, scope, &mut groups, &mut stats),
                 RefKind::Other => {
                     stats.skipped_noop += 1;
                 }
             }
         }
+
+        // Single append for the whole import. `record_batches_scoped` is a
+        // no-op when `groups` is empty, so an emit that classified everything
+        // away (HEAD-only non-checkout, all no-ops, all unmapped) writes
+        // nothing — no empty-batch corruption.
+        if !groups.is_empty() {
+            self.oplog
+                .record_batches_scoped(groups)
+                .map_err(IngestError::from)?;
+        }
+
         Ok(stats)
     }
 
-    fn emit_head(
+    fn emit_head<'g>(
         &self,
         entry: &ReflogEntry,
-        scope: Option<&str>,
+        scope: Option<&'g str>,
+        groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) -> crate::Result<()> {
+    ) {
         // Only `checkout:` is a pure navigation event — everything else
         // (commit, reset, merge, pull, rebase, amend) is mirrored in the
         // per-branch reflog, which already yields the richer thread op.
         if !entry.message.starts_with("checkout:") {
             stats.skipped_noop += 1;
-            return Ok(());
+            return;
         }
         let Some(new_sha) = &entry.new_sha else {
             stats.skipped_noop += 1;
-            return Ok(());
+            return;
         };
         let Some(cid) = self.map.get_commit(new_sha) else {
             warn!(
@@ -145,26 +173,34 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 "dropping HEAD checkout — target commit not in sha map",
             );
             stats.skipped_unmapped += 1;
-            return Ok(());
+            return;
         };
         let prev_cid = entry
             .previous_sha
             .as_deref()
             .and_then(|s| self.map.get_commit(s));
-        self.oplog
-            .record_goto(&cid, prev_cid.as_ref(), scope)
-            .map_err(IngestError::from)?;
+        // Mirrors `OpLogRecorder::record_goto`: the `head` field is the goto
+        // target. Pushed as its own group so it stays an independent undo
+        // unit (one `record_goto` == one batch).
+        groups.push((
+            vec![OpRecord::Goto {
+                target: cid,
+                prev_head: prev_cid,
+                head: cid,
+            }],
+            scope,
+        ));
         stats.gotos += 1;
-        Ok(())
     }
 
-    fn emit_branch(
+    fn emit_branch<'g>(
         &self,
         entry: &ReflogEntry,
         short_name: &str,
-        scope: Option<&str>,
+        scope: Option<&'g str>,
+        groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) -> crate::Result<()> {
+    ) {
         match (&entry.previous_sha, &entry.new_sha) {
             (None, None) => {
                 stats.skipped_noop += 1;
@@ -172,28 +208,36 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
             (None, Some(new_sha)) => {
                 let Some(cid) = self.map.get_commit(new_sha) else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
                 // Git-history ingest does not write a ThreadManager
                 // record — those exist for native heddle threads. Pass
                 // `None` for the snapshot; the recorded
                 // `ThreadCreate` carries no record body to restore
-                // on redo. heddle#23 r2.
-                let thread_name = ThreadName::from(short_name);
-                self.oplog
-                    .record_thread_create(&thread_name, &cid, None, scope)
-                    .map_err(IngestError::from)?;
+                // on redo. heddle#23 r2. Mirrors `record_thread_create`.
+                groups.push((
+                    vec![OpRecord::ThreadCreate {
+                        name: ThreadName::from(short_name).to_string(),
+                        state: cid,
+                        manager_snapshot: None,
+                    }],
+                    scope,
+                ));
                 stats.thread_creates += 1;
             }
             (Some(prev_sha), None) => {
                 let Some(cid) = self.map.get_commit(prev_sha) else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
-                let thread_name = ThreadName::from(short_name);
-                self.oplog
-                    .record_thread_delete(&thread_name, &cid, scope)
-                    .map_err(IngestError::from)?;
+                // Mirrors `record_thread_delete`.
+                groups.push((
+                    vec![OpRecord::ThreadDelete {
+                        name: ThreadName::from(short_name).to_string(),
+                        state: cid,
+                    }],
+                    scope,
+                ));
                 stats.thread_deletes += 1;
             }
             (Some(prev), Some(new)) if prev == new => {
@@ -206,51 +250,61 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                     (self.map.get_commit(prev), self.map.get_commit(new))
                 else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
-                self.oplog
-                    .record_batch_scoped(
-                        vec![oplog::oplog::OpRecord::ThreadUpdate {
-                            name: short_name.to_string(),
-                            old_state: old_cid,
-                            new_state: new_cid,
-                            manager_snapshots: None,
-                        }],
-                        scope,
-                    )
-                    .map_err(IngestError::from)?;
+                groups.push((
+                    vec![OpRecord::ThreadUpdate {
+                        name: short_name.to_string(),
+                        old_state: old_cid,
+                        new_state: new_cid,
+                        manager_snapshots: None,
+                    }],
+                    scope,
+                ));
                 stats.thread_updates += 1;
             }
         }
-        Ok(())
     }
 
-    fn emit_tag(
+    fn emit_tag<'g>(
         &self,
         entry: &ReflogEntry,
         short_name: &str,
+        scope: Option<&'g str>,
+        groups: &mut Vec<(Vec<OpRecord>, Option<&'g str>)>,
         stats: &mut OplogEmitStats,
-    ) -> crate::Result<()> {
-        let marker_name = MarkerName::from(short_name);
+    ) {
         match (&entry.previous_sha, &entry.new_sha) {
             (None, Some(new)) => {
                 let Some(cid) = self.map.get_commit(new) else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
-                self.oplog
-                    .record_marker_create(&marker_name, &cid)
-                    .map_err(IngestError::from)?;
+                // Mirrors `record_marker_create`, which records with scope
+                // `None` (it goes through `record_batch`, not the scoped
+                // variant). Preserved here to keep replay equivalence.
+                groups.push((
+                    vec![OpRecord::MarkerCreate {
+                        name: MarkerName::from(short_name).to_string(),
+                        state: cid,
+                    }],
+                    None,
+                ));
                 stats.marker_creates += 1;
             }
             (Some(prev), None) => {
                 let Some(cid) = self.map.get_commit(prev) else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
-                self.oplog
-                    .record_marker_delete(&marker_name, &cid)
-                    .map_err(IngestError::from)?;
+                // Mirrors `record_marker_delete` — scope `None`.
+                groups.push((
+                    vec![OpRecord::MarkerDelete {
+                        name: MarkerName::from(short_name).to_string(),
+                        state: cid,
+                    }],
+                    None,
+                ));
                 stats.marker_deletes += 1;
             }
             (Some(prev), Some(new)) if prev == new => {
@@ -258,31 +312,30 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
             }
             (Some(prev), Some(new)) => {
                 // Tag moved. Markers are write-once; emit delete+create so
-                // replay lands in the same state as git. We route both
-                // through `record_batch_scoped` so a single undo reverses
-                // the whole move — matches user intent better than two
-                // independently undoable ops.
+                // replay lands in the same state as git. Both ops go in ONE
+                // group so a single undo reverses the whole move — matches
+                // user intent better than two independently undoable ops.
+                // This arm uses the emitter scope (it always did, via the
+                // earlier inline `record_batch_scoped(_, self.scope)`).
                 let (Some(old_cid), Some(new_cid)) =
                     (self.map.get_commit(prev), self.map.get_commit(new))
                 else {
                     stats.skipped_unmapped += 1;
-                    return Ok(());
+                    return;
                 };
-                self.oplog
-                    .record_batch_scoped(
-                        vec![
-                            oplog::oplog::OpRecord::MarkerDelete {
-                                name: short_name.to_string(),
-                                state: old_cid,
-                            },
-                            oplog::oplog::OpRecord::MarkerCreate {
-                                name: short_name.to_string(),
-                                state: new_cid,
-                            },
-                        ],
-                        self.scope.as_deref(),
-                    )
-                    .map_err(IngestError::from)?;
+                groups.push((
+                    vec![
+                        OpRecord::MarkerDelete {
+                            name: short_name.to_string(),
+                            state: old_cid,
+                        },
+                        OpRecord::MarkerCreate {
+                            name: short_name.to_string(),
+                            state: new_cid,
+                        },
+                    ],
+                    scope,
+                ));
                 stats.marker_deletes += 1;
                 stats.marker_creates += 1;
             }
@@ -290,7 +343,6 @@ impl<'a, O: OpLogBackend> OplogEmitter<'a, O> {
                 stats.skipped_noop += 1;
             }
         }
-        Ok(())
     }
 }
 
@@ -321,7 +373,7 @@ fn classify(ref_name: &str) -> RefKind {
 mod tests {
     use chrono::Utc;
     use objects::object::ChangeId;
-    use oplog::oplog::{OpLog, OpRecord};
+    use oplog::oplog::{OpLog, OpLogRecorder};
     use tempfile::TempDir;
 
     use super::*;
@@ -556,5 +608,179 @@ mod tests {
 
         let last = log.last().unwrap().unwrap();
         assert_eq!(last.scope.as_deref(), Some("import"));
+    }
+
+    /// Read every entry back in chronological order, projecting the fields
+    /// that define replay: operation, scope, and per-batch grouping
+    /// (`batch_id` relative to the first id, plus `batch_index`).
+    fn entry_fingerprints(log: &OpLog) -> Vec<(String, Option<String>, u64, u32)> {
+        let mut entries = log.recent(1024).unwrap();
+        entries.reverse(); // newest-first -> chronological
+        let base = entries.first().map(|e| e.batch_id).unwrap_or(0);
+        entries
+            .into_iter()
+            .map(|e| {
+                (
+                    // OpRecord doesn't derive PartialEq; its Debug rendering is
+                    // a faithful, deterministic projection of every field.
+                    format!("{:?}", e.operation),
+                    e.scope.clone(),
+                    e.batch_id - base, // batch_id normalized to the first batch
+                    e.batch_index,
+                )
+            })
+            .collect()
+    }
+
+    /// The load-bearing correctness gate: the batched single-append emit must
+    /// produce a byte-for-byte equivalent oplog to the old per-event
+    /// `record_*` path — same ops, same order, same scopes, and same
+    /// *per-event* batch boundaries (so `heddle undo` still steps one ref
+    /// event at a time, not one mega-undo of the whole import).
+    ///
+    /// We reproduce the OLD behavior by driving the public `record_*`
+    /// recorder helpers in the exact sequence/scopes the pre-refactor emit
+    /// used, into a reference oplog, then assert the fingerprints match the
+    /// batched emit's.
+    #[test]
+    fn batched_emit_matches_per_append_replay() {
+        let mut map = ShaMap::new();
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        let sha_c = "c".repeat(40);
+        let cid_a = ChangeId::generate();
+        let cid_b = ChangeId::generate();
+        let cid_c = ChangeId::generate();
+        map.insert_commit(&sha_a, cid_a).unwrap();
+        map.insert_commit(&sha_b, cid_b).unwrap();
+        map.insert_commit(&sha_c, cid_c).unwrap();
+
+        // A representative multi-ref reflog touching every emit arm:
+        // branch create/update/delete, tag create, tag move, HEAD checkout.
+        let entries = vec![
+            mk_entry("refs/heads/main", None, Some(&sha_a), "branch: Created"),
+            mk_entry("refs/heads/main", Some(&sha_a), Some(&sha_b), "commit: x"),
+            mk_entry("refs/tags/v1", None, Some(&sha_a), "tag: created"),
+            mk_entry("refs/tags/v1", Some(&sha_a), Some(&sha_b), "tag: moved"),
+            mk_entry(
+                "HEAD",
+                Some(&sha_b),
+                Some(&sha_a),
+                "checkout: moving from main to topic",
+            ),
+            mk_entry("refs/heads/main", Some(&sha_b), None, "branch: deleted"),
+        ];
+
+        // ---- batched path (the new code) ----
+        let (_tmp_batched, batched) = fresh_oplog();
+        let stats = OplogEmitter::new(&batched, &map)
+            .with_scope("ingest")
+            .emit(&entries)
+            .unwrap();
+
+        // ---- reference path (old per-append behavior, replayed via the
+        //      public recorder helpers in identical order/scope) ----
+        let (_tmp_ref, reference) = fresh_oplog();
+        let scope = Some("ingest");
+        // branch: Created
+        reference
+            .record_thread_create(&ThreadName::from("main"), &cid_a, None, scope)
+            .unwrap();
+        // commit: x  (branch update)
+        reference
+            .record_thread_update(&ThreadName::from("main"), &cid_a, &cid_b, None, scope)
+            .unwrap();
+        // tag: created  (marker create — scope None, via record_marker_create)
+        reference
+            .record_marker_create(&MarkerName::from("v1"), &cid_a)
+            .unwrap();
+        // tag: moved  (delete+create in ONE batch, emitter scope)
+        reference
+            .record_batch_scoped(
+                vec![
+                    OpRecord::MarkerDelete {
+                        name: "v1".to_string(),
+                        state: cid_a,
+                    },
+                    OpRecord::MarkerCreate {
+                        name: "v1".to_string(),
+                        state: cid_b,
+                    },
+                ],
+                scope,
+            )
+            .unwrap();
+        // HEAD checkout -> goto
+        reference
+            .record_goto(&cid_a, Some(&cid_b), scope)
+            .unwrap();
+        // branch: deleted
+        reference
+            .record_thread_delete(&ThreadName::from("main"), &cid_b, scope)
+            .unwrap();
+
+        // Same ops, same scopes, same per-event batch boundaries, same ids.
+        assert_eq!(
+            entry_fingerprints(&batched),
+            entry_fingerprints(&reference),
+            "batched emit must replay identically to the per-append path"
+        );
+
+        // And the stat tally is unchanged by the batching.
+        assert_eq!(stats.thread_creates, 1);
+        assert_eq!(stats.thread_updates, 1);
+        assert_eq!(stats.thread_deletes, 1);
+        assert_eq!(stats.marker_creates, 2); // create + the create half of the move
+        assert_eq!(stats.marker_deletes, 1);
+        assert_eq!(stats.gotos, 1);
+    }
+
+    /// Each real event stays its OWN batch (distinct `batch_id`) — the
+    /// batching collapses disk writes, not undo granularity.
+    #[test]
+    fn each_event_is_an_independent_batch() {
+        let (_tmp, log) = fresh_oplog();
+        let mut map = ShaMap::new();
+        let sha_a = "a".repeat(40);
+        let sha_b = "b".repeat(40);
+        map.insert_commit(&sha_a, ChangeId::generate()).unwrap();
+        map.insert_commit(&sha_b, ChangeId::generate()).unwrap();
+
+        let entries = vec![
+            mk_entry("refs/heads/main", None, Some(&sha_a), "branch: Created"),
+            mk_entry("refs/heads/main", Some(&sha_a), Some(&sha_b), "commit: x"),
+            mk_entry("refs/heads/main", Some(&sha_b), None, "branch: deleted"),
+        ];
+        OplogEmitter::new(&log, &map).emit(&entries).unwrap();
+
+        let mut all = log.recent(1024).unwrap();
+        all.reverse();
+        let distinct: std::collections::BTreeSet<u64> =
+            all.iter().map(|e| e.batch_id).collect();
+        assert_eq!(all.len(), 3);
+        assert_eq!(distinct.len(), 3, "three events => three distinct batches");
+        // ids are globally sequential across the batches.
+        let ids: Vec<u64> = all.iter().map(|e| e.id).collect();
+        assert_eq!(ids, vec![ids[0], ids[0] + 1, ids[0] + 2]);
+    }
+
+    /// An emit that classifies everything away appends nothing — no
+    /// empty-batch corruption.
+    #[test]
+    fn empty_emit_writes_nothing() {
+        let (_tmp, log) = fresh_oplog();
+        let map = ShaMap::new();
+        // HEAD commit (not a checkout) -> skipped; nothing else.
+        let entries = vec![mk_entry(
+            "HEAD",
+            None,
+            Some(&"a".repeat(40)),
+            "commit (initial): first",
+        )];
+        let before = log.last().unwrap();
+        let stats = OplogEmitter::new(&log, &map).emit(&entries).unwrap();
+        assert_eq!(stats.skipped_noop, 1);
+        assert!(all_ops(&log).is_empty());
+        assert!(before.is_none() && log.last().unwrap().is_none());
     }
 }

--- a/crates/ingest/src/oplog_emit.rs
+++ b/crates/ingest/src/oplog_emit.rs
@@ -764,6 +764,41 @@ mod tests {
         assert_eq!(ids, vec![ids[0], ids[0] + 1, ids[0] + 2]);
     }
 
+    /// Scaling proof (run with `cargo test -p heddle-ingest --release
+    /// -- --ignored --nocapture oplog_emit_scaling`). Times
+    /// `OplogEmitter::emit` — the phase the profiling spike pinned as the
+    /// O(N²) term — at N=100/200/400/800. Pre-fix it grows ~4× per doubling
+    /// (one full-log rewrite per reflog entry); post-fix it is ~linear (one
+    /// rewrite for the whole import).
+    #[test]
+    #[ignore = "timing benchmark; run explicitly with --ignored --nocapture in release"]
+    fn oplog_emit_scaling_curve() {
+        use std::time::Instant;
+        for &n in &[100usize, 200, 400, 800] {
+            let (_tmp, log) = fresh_oplog();
+            let mut map = ShaMap::new();
+            let mut entries = Vec::with_capacity(n);
+            for i in 0..n {
+                let sha = format!("{:040x}", i + 1);
+                map.insert_commit(&sha, ChangeId::generate()).unwrap();
+                entries.push(mk_entry(
+                    &format!("refs/heads/b{i}"),
+                    None,
+                    Some(&sha),
+                    "branch: Created",
+                ));
+            }
+            let start = Instant::now();
+            let stats = OplogEmitter::new(&log, &map)
+                .with_scope("ingest")
+                .emit(&entries)
+                .unwrap();
+            let dt = start.elapsed();
+            assert_eq!(stats.thread_creates, n);
+            println!("oplog_emit N={n:<5} emit={:.3}s", dt.as_secs_f64());
+        }
+    }
+
     /// An emit that classifies everything away appends nothing — no
     /// empty-batch corruption.
     #[test]

--- a/crates/oplog/src/oplog/oplog_backend.rs
+++ b/crates/oplog/src/oplog/oplog_backend.rs
@@ -36,6 +36,34 @@ pub trait OpLogBackend: Send + Sync {
         scope: Option<&str>,
     ) -> Result<Vec<u64>>;
 
+    /// Append many independent batches in a single write.
+    ///
+    /// Each element of `groups` becomes its own logical batch — its own
+    /// `batch_id`, its own scope, its own undo/redo granularity — exactly as
+    /// if it had been passed to [`record_batch_scoped`] on its own. The only
+    /// difference is durability cost: the file-backed `OpLog` rewrites the
+    /// whole log once per *call* (see TODO #423 write-amplification in
+    /// `packed_oplog::append_entries`), so N separate `record_batch_scoped`
+    /// calls are O(N²) total while one `record_batches_scoped` of N groups is
+    /// O(N). This is the importer's path: a reflog with N entries emits N
+    /// per-event batches that must stay independently undoable but must not
+    /// pay N full-log rewrites.
+    ///
+    /// Returns one id-vector per input group, in order; empty groups yield an
+    /// empty id-vector and consume no batch id. The default implementation is
+    /// the naive loop (correct, but pays the per-call cost) — backends with no
+    /// per-append amplification (e.g. the Postgres table) keep it; `OpLog`
+    /// overrides it to coalesce into one `append_entries`.
+    fn record_batches_scoped(
+        &self,
+        groups: Vec<(Vec<OpRecord>, Option<&str>)>,
+    ) -> Result<Vec<Vec<u64>>> {
+        groups
+            .into_iter()
+            .map(|(ops, scope)| self.record_batch_scoped(ops, scope))
+            .collect()
+    }
+
     /// Atomic dedup+append for transaction-scoped batches: scan the
     /// most recent `recent_window` batches under the same write lock
     /// used by [`OpLogBackend::record_batch_scoped`] for an

--- a/crates/oplog/src/oplog/oplog_core.rs
+++ b/crates/oplog/src/oplog/oplog_core.rs
@@ -523,6 +523,53 @@ impl OpLogBackend for OpLog {
         Ok(ids)
     }
 
+    fn record_batches_scoped(
+        &self,
+        groups: Vec<(Vec<OpRecord>, Option<&str>)>,
+    ) -> Result<Vec<Vec<u64>>> {
+        // Drop empty groups but remember their slot so the returned shape
+        // matches the input 1:1 (an empty group consumes no id and no
+        // batch).
+        if groups.iter().all(|(ops, _)| ops.is_empty()) {
+            return Ok(groups.iter().map(|_| Vec::new()).collect());
+        }
+
+        let _lock = self.write_lock()?;
+        // Reload from disk to catch any writes from other processes — same
+        // freshness contract as the single-batch path.
+        let index = self.open_index_for_write()?;
+
+        let timestamp = Utc::now();
+        // One id space across the whole call: ids stay globally monotonic and
+        // sequential across all groups (so replay order == emit order), while
+        // each group keeps a distinct `batch_id` (= the id of its first
+        // entry) so it remains an independent undo/redo unit.
+        let mut next_id = index.head_id() + 1;
+        let mut all_entries: Vec<OpEntry> = Vec::new();
+        let mut result: Vec<Vec<u64>> = Vec::with_capacity(groups.len());
+
+        for (operations, scope) in groups {
+            if operations.is_empty() {
+                result.push(Vec::new());
+                continue;
+            }
+            let scope_owned = scope.map(str::to_string);
+            let entries =
+                Self::build_entries(&self.actor, operations, next_id, timestamp, &scope_owned);
+            let ids: Vec<u64> = entries.iter().map(|e| e.id).collect();
+            next_id += entries.len() as u64;
+            all_entries.extend(entries);
+            result.push(ids);
+        }
+
+        // Single full-log rewrite for every batch in the call — this is the
+        // O(N²)→O(N) win for the importer's reflog→oplog emit.
+        let updated = index.append_entries(&all_entries)?;
+        *self.cached.lock_or_poisoned() = Some(updated);
+
+        Ok(result)
+    }
+
     async fn record_batch_scoped_if_no_transaction(
         &self,
         operations: Vec<OpRecord>,


### PR DESCRIPTION
## Root cause — per-append write-amplification

`heddle adopt` / `bridge git import` translate the git reflog into the Heddle oplog via `OplogEmitter::emit`, which looped over the ~N reflog entries and called a per-entry `record_*` for each event. Every `record_*` → `OpLogBackend::record_batch_scoped` → `PackedOpLogIndex::append_entries`, which is **O(current log size)**: it reads + clones the whole index, `std::io::copy`s the entire old entry stream into a temp file, re-encodes all index sections, fsyncs, and renames (the code flags it: `TODO(#423) ... write-amplification` in `packed_oplog.rs`). N appends, the k-th costing O(k), sum to **O(N²)**.

A profiling spike isolated `oplog_emit` as the dominant quadratic phase (every other adopt phase is linear): **2.07s / 7.21s / 23.4s at N=200/400/800** — clean quadratic.

## Fix — accumulate all ops, append once

`OplogEmitter::emit` now accumulates one `(records, scope)` group per real reflog event across **all** entries, then flushes via a new `OpLogBackend::record_batches_scoped`, which builds every batch's entries and performs **one** `append_entries` — a single full-log rewrite for the whole import: **O(N)**.

- The per-entry helpers (`emit_head`/`emit_branch`/`emit_tag`) now push their `OpRecord`(s) into a shared accumulator (and still tally `stats`) instead of each calling `record_*`. Flushed once after the loop.
- `record_batches_scoped` assigns globally-sequential ids across the whole call while giving each group its **own `batch_id` and scope**, so each event stays an independent undo/redo unit. The local `OpLog` overrides it to coalesce into one `append_entries`; the default impl is the naive loop (kept by the Postgres backend, which has no per-append amplification).

## Correctness — replay equivalence is the gate

The resulting oplog is equivalent to the per-append path in **ops, ids, batch boundaries, scopes, and undo granularity** — only the number of disk writes changes. Notably preserved: the per-event batch split (so `heddle undo` still steps one ref event at a time, not one mega-undo of the whole import), and the marker create/delete arms' `scope: None` (they go through `record_marker_create`/`record_marker_delete` = `record_batch`, not the scoped variant).

New tests in `oplog_emit.rs`:
- **`batched_emit_matches_per_append_replay`** — drives the public `record_*` recorder helpers in the old sequence/scopes into a reference oplog and asserts identical entry fingerprints (operation, scope, normalized batch_id, batch_index) against the batched emit. Also asserts the `OplogEmitStats` tally is unchanged.
- **`each_event_is_an_independent_batch`** — three events ⇒ three distinct `batch_id`s, ids globally sequential.
- **`empty_emit_writes_nothing`** — an emit that classifies everything away appends nothing (no empty-batch corruption).

## Scaling proof

Isolated `oplog_emit` micro-benchmark (`oplog_emit_scaling_curve`, `#[ignore]`), same box / same fixture, release:

| N | before (per-append) | after (one batch) | speedup |
|---|---|---|---|
| 100 | 0.805s | 0.009s | 89× |
| 200 | 2.161s | 0.018s | 120× |
| 400 | 7.351s | 0.024s | 306× |
| 800 | 25.114s | 0.039s | 644× |

Before matches the spike (2.16/7.35/25.1 at 200/400/800) and is clean quadratic (~4× per doubling); after is clean linear (~2× per doubling). End-to-end `heddle adopt` on the pure-ref fixture drops correspondingly (e.g. N=800: 388s → 69s; the residual super-linear growth is a *separate* adopt phase, out of scope for this issue).

## Gates

- `cargo build --locked --workspace` (default) ✅ and `--all-features` ✅
- `scripts/check-no-silent-default-tree-load.sh` ✅
- `cargo test -p heddle-ingest` ✅ · `-p heddle-oplog` ✅ · `-p heddle-devtools` (OpRecord exhaustiveness) ✅
- `cargo test -p heddle-cli` ✅ (only the 3 pre-authorized `oss_cli_polish::actor_*` env-leak failures)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785438001&installation_id=132405951&pr_number=827&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F827&signature=6c37ab32ac704b40b430f56cdb21b21648483ad16059f1ec6588e91337f3872e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->