### PR TITLE
chore(refs): delete pre-v0.2.0 legacy ref layout + migration + dead import wrapper

### DIFF
--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -772,21 +772,12 @@ pub fn import_git_into_with_options(
     heddle_path: impl AsRef<Path>,
     options: ImportOptions,
 ) -> crate::Result<(ImportStats, ShaMap)> {
-    import_git_into_with_options_and_progress(git_path, heddle_path, options, None)
-}
-
-pub fn import_git_into_with_options_and_progress(
-    git_path: impl AsRef<Path>,
-    heddle_path: impl AsRef<Path>,
-    options: ImportOptions,
-    progress: Option<&mut dyn FnMut(ImportProgressEvent)>,
-) -> crate::Result<(ImportStats, ShaMap)> {
     import_git_into_scoped_with_options_and_progress(
         git_path,
         heddle_path,
         options,
         ImportScope::all(),
-        progress,
+        None,
     )
 }
 

--- a/crates/ingest/src/lib.rs
+++ b/crates/ingest/src/lib.rs
@@ -51,7 +51,7 @@ pub use import_options::{ImportOptions, LossyImportAction, LossyImportEntry};
 pub use importer::{
     ImportProgressEvent, ImportScope, ImportStats, Importer, import_git_into,
     import_git_into_scoped_with_options, import_git_into_scoped_with_options_and_progress,
-    import_git_into_with_options, import_git_into_with_options_and_progress,
+    import_git_into_with_options,
 };
 pub use oplog_emit::{OplogEmitStats, OplogEmitter};
 pub use reasoning::{ReasoningEvidence, ReasoningPoint, ReasoningTarget};

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -11,7 +11,6 @@ use std::{
 
 use objects::{
     error::{HeddleError, Result},
-    fs_ops::remove_path_recursively,
     object::{ChangeId, MarkerName, ThreadName},
 };
 
@@ -653,41 +652,6 @@ impl RefManager {
         std::fs::create_dir_all(self.threads_dir())?;
         std::fs::create_dir_all(self.markers_dir())?;
         std::fs::create_dir_all(self.remotes_dir())?;
-        Ok(())
-    }
-
-    pub fn migrate_legacy_tracks(&self) -> Result<()> {
-        let legacy_dir = self.legacy_tracks_dir();
-        if !legacy_dir.exists() {
-            return Ok(());
-        }
-
-        let threads_dir = self.threads_dir();
-        if !threads_dir.exists() {
-            std::fs::create_dir_all(self.refs_dir())?;
-            std::fs::rename(&legacy_dir, &threads_dir)?;
-            return Ok(());
-        }
-
-        let legacy_threads = self.list_refs_recursive(&legacy_dir, "")?;
-        for name in legacy_threads {
-            let legacy_path = self.legacy_track_path(&name)?;
-            let thread_path = self.thread_path(&name)?;
-            if thread_path.exists() {
-                continue;
-            }
-
-            let parent = thread_path
-                .parent()
-                .ok_or_else(|| HeddleError::Config(format!("invalid thread path for {}", name)))?;
-            std::fs::create_dir_all(parent)?;
-            std::fs::rename(&legacy_path, &thread_path)?;
-        }
-
-        if legacy_dir.exists() {
-            remove_path_recursively(&legacy_dir)?;
-        }
-
         Ok(())
     }
 

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -52,13 +52,6 @@ impl RefManager {
     pub(super) fn flat_threads_dir(&self) -> PathBuf {
         self.threads_dir().join(FLAT_THREADS_DIR_NAME)
     }
-    pub(super) fn legacy_tracks_dir(&self) -> PathBuf {
-        self.refs_dir().join("tracks")
-    }
-    pub(super) fn legacy_track_path(&self, name: &str) -> Result<PathBuf> {
-        validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
-        Ok(self.legacy_tracks_dir().join(name))
-    }
     pub(super) fn markers_dir(&self) -> PathBuf {
         self.refs_dir().join("markers")
     }
@@ -97,23 +90,24 @@ impl RefManager {
     pub(crate) fn ref_summary_index_path(&self) -> PathBuf {
         self.refs_dir().join("ref-summary-index")
     }
+    /// On-disk path for a thread ref.
+    ///
+    /// Slashed names are stored in the flat layout (`threads/__heddle_flat/<hex>`),
+    /// which has been the only write target since v0.2.0 — no per-ref `statx`
+    /// fallback to a nested legacy layout is performed. Top-level (non-slashed)
+    /// names never needed nesting and are stored plainly at `threads/<name>`.
     pub(super) fn thread_path(&self, name: &ThreadName) -> Result<PathBuf> {
         validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
         if name.contains('/') {
-            let flat = self.flat_thread_path(name)?;
-            if flat.exists() {
-                return Ok(flat);
-            }
-            let legacy = self.legacy_thread_path(name)?;
-            if legacy.exists() {
-                return Ok(legacy);
-            }
-            Ok(flat)
+            self.flat_thread_path(name)
         } else {
-            self.legacy_thread_path(name)
+            self.plain_thread_path(name)
         }
     }
-    pub(super) fn legacy_thread_path(&self, name: &str) -> Result<PathBuf> {
+    /// Plain (non-flat-encoded) path under `threads/` for a top-level thread
+    /// name. Only valid for non-slashed names; slashed names use the flat
+    /// layout via [`flat_thread_path`](Self::flat_thread_path).
+    pub(super) fn plain_thread_path(&self, name: &str) -> Result<PathBuf> {
         validate_ref_name(name).map_err(|error| HeddleError::InvalidRefName(error.name))?;
         Ok(self.threads_dir().join(name))
     }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -87,24 +87,6 @@ impl RefManager {
                 }
             }
         }
-        if name.contains('/') {
-            let legacy_path = self.legacy_thread_path(name)?;
-            if legacy_path != path {
-                let legacy_raw = self.read_optional_string(&legacy_path)?;
-                if let Some(ref contents) = legacy_raw {
-                    match parse_change_id_text(contents) {
-                        Ok(id) => return Ok((legacy_path, Some(id), legacy_raw)),
-                        Err(_) => {
-                            return Err(HeddleError::InvalidObject(format!(
-                                "invalid thread {}: {}",
-                                name,
-                                contents.trim()
-                            )));
-                        }
-                    }
-                }
-            }
-        }
         let packed_id = PackedRefs::load(&self.packed_refs_path())?.get_thread(name);
         let effective_prev = packed_id.map(|id| format_change_id_text(&id));
         Ok((path, packed_id, effective_prev))

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Declarative repository migrations.
 //!
-//! Replaces the ad-hoc `migrate_legacy_tracks()` callsites that used to live
-//! in `Repository::open_raw`/`open` with a single registered, ordered list.
-//! Each migration is forward-only; `apply_pending` walks the list and runs
-//! anything missing from `.heddle/state/schema_versions.toml`.
+//! A single registered, ordered list of forward-only migrations applied on
+//! repo open. `apply_pending` walks the list and runs anything missing from
+//! `.heddle/state/schema_versions.toml`. The list is currently empty (a clean
+//! no-op); the framework stays so future schema changes have a place to land
+//! without tangling `Repository::open_raw`/`open`.
 //!
 //! # Adding a migration
 //!
@@ -155,17 +156,12 @@ fn ledger_path(repo: &Repository) -> PathBuf {
 /// Registered migrations, run in this order. New migrations append at the
 /// tail; never reorder existing ids.
 ///
-/// `0001_legacy_tracks` formalises the long-standing track-shape fix-up
-/// that used to live inline in `Repository::open` as
-/// `RefManager::migrate_legacy_tracks`. It's the only registered migration
-/// today — the framework exists so future schema changes have a place to
-/// land without tangling `Repository::open_raw`.
-pub static MIGRATIONS: &[Migration] = &[Migration {
-    id: "0001_legacy_tracks",
-    description: "Rewrite legacy thread/track refs into the post-2024 layout",
-    applies_to: SchemaTarget::RefSummary,
-    run: run_legacy_tracks,
-}];
+/// Currently empty: the framework exists so future schema changes have a
+/// place to land without tangling `Repository::open_raw`. The former
+/// `0001_legacy_tracks` migration (which renamed a pre-v0.2.0 `tracks/`
+/// layout that was never publicly produced) was removed — `apply_pending`
+/// over an empty list is a clean no-op.
+pub static MIGRATIONS: &[Migration] = &[];
 
 /// Apply any registered migration not yet present in
 /// `<repo>/.heddle/state/schema_versions.toml`. Idempotent: a second
@@ -199,17 +195,6 @@ pub fn apply_pending(repo: &Repository) -> Result<MigrationReport> {
     }
 
     Ok(MigrationReport { outcomes })
-}
-
-fn run_legacy_tracks(ctx: &mut MigrationCtx<'_>) -> Result<()> {
-    // `RefManager::migrate_legacy_tracks` lives on the manager type, not on
-    // the `RefBackend` trait that `Repository::refs()` exposes — so we
-    // construct a manager pointed at the same `.heddle/` directory rather
-    // than reaching through the repo. The manager is a thin wrapper, no
-    // heavy state to share.
-    let refs = refs::RefManager::new(ctx.repo.heddle_dir());
-    refs.migrate_legacy_tracks()?;
-    Ok(())
 }
 
 #[cfg(test)]
@@ -259,14 +244,18 @@ mod tests {
         if ledger_file.exists() {
             std::fs::remove_file(&ledger_file).unwrap();
         }
-        apply_pending(&repo).unwrap();
-        let raw = std::fs::read_to_string(&ledger_file).unwrap();
-        for migration in MIGRATIONS {
-            assert!(
-                raw.contains(migration.id),
-                "missing {} in ledger",
-                migration.id
-            );
+        let report = apply_pending(&repo).unwrap();
+        let applied: Vec<&str> = report.applied().collect();
+        // Every id that `apply_pending` reports as Applied must be durable in
+        // the ledger. When the registry is empty nothing is applied and no
+        // ledger is written — that is the correct no-op.
+        if applied.is_empty() {
+            assert!(!ledger_file.exists());
+        } else {
+            let raw = std::fs::read_to_string(&ledger_file).unwrap();
+            for id in applied {
+                assert!(raw.contains(id), "missing {id} in ledger");
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Pre-1.0, strict no-backcompat cleanup. Deletes three confirmed-dead pieces. The flat layout (`__heddle_flat`) has been the **only** write target since v0.2.0 (first public release, 2026-05-13); the nested/`tracks/` legacy layout was only ever *read* as a fallback, never written, and `tracks/` was never publicly produced.

## Dead-code proof (per item)

### 1. Legacy nested/`tracks/` ref-layout reader (`crates/refs/`)
- **No writer:** `git grep` for `legacy_*` found only readers. The sole write path is `thread_path` → `flat_thread_path` (slashed names) / `plain_thread_path` (top-level names). Nothing writes the nested legacy layout.
- Deleted `legacy_tracks_dir`, `legacy_track_path`, and the legacy fallback branch of `thread_path` (the `legacy.exists()` check was a **per-ref `statx` on the hot read path** — gone now).
- Deleted the legacy fallback branch in `read_track_with_packed_fallback` (`refs_transactions.rs`).
- **Load-bearing subtlety (kept):** `legacy_thread_path` was misnamed — for non-slashed top-level names (`main`, `topic`, `branch-00001`) it is the *live* storage path `threads/<name>`, not a legacy fallback. Renamed to `plain_thread_path` and kept. Likewise the `.or_else` branch in `scan_loose_threads` (`ref_summary_index.rs`) is load-bearing for top-level plain names, so it stays — its incidental handling of legacy nested entries is now naturally inert because `thread_path` no longer resolves them.

### 2. `0001_legacy_tracks` migration (`crates/repo/`, `crates/refs/`)
- Migrated a `tracks/` layout **never publicly produced** → dead. It was the *only* registered migration.
- Removed `migrate_legacy_tracks` (refs), `run_legacy_tracks` + the `MIGRATIONS` entry (repo). `MIGRATIONS` is now `&[]`.
- **Zero-migration repo-open proof:** `apply_pending` over an empty list runs no loop body, writes no ledger, returns an empty report — a clean no-op (no panic/error). Verified by the full `heddle-repo` suite (**544 tests green**), every fresh repo of which opens via `init_default` → `apply_pending` then exercises `set_thread`/`get_thread` on slashed and non-slashed names. The `migration::tests` trio (`first_apply_runs_every_registered_migration`, `second_apply_is_a_no_op`, `ledger_persists_applied_ids`) was generalized to the empty-registry case and passes. The migration framework is kept intact per scope.

### 3. Dead import wrapper (`crates/ingest/`)
- `import_git_into_with_options_and_progress` had **zero external callers** (`git grep`: only the internal chain link + the export). Adopt + bridge call `import_git_into_scoped_with_options_and_progress` directly.
- Deleted it; rewired `import_git_into_with_options` to call the scoped variant with `ImportScope::all()`. `import_git_into` and `import_git_into_with_options` (both have many external callers) are unchanged.

## LOC

~117 deletions / ~37 insertions across 6 files (net **-80**).

## Gates (all green)

- `cargo build --locked --workspace` (default) ✅ and `--all-features` ✅
- `bash scripts/check-no-silent-default-tree-load.sh` ✅ (572 files scanned, clean)
- `cargo test -p heddle-refs` (191) ✅, `-p heddle-repo` (544) ✅, `-p heddle-ingest` (80) ✅, `-p heddle-cli` ✅ (only the 3 pre-authorized `oss_cli_polish::actor_*` env-leak failures)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

Codex offline — interim gate is strict Claude review.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785441222&installation_id=132405951&pr_number=828&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F828&signature=834b7c0b7bfc81da282d26f774b6992467fba63b80ee44b2f9c436315d78b5db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->