### PR TITLE
perf(capture/commit): single worktree-status walk + instrumentation

### DIFF
--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Git-muscle-memory compatibility shims.
 
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, fs, path::Path, time::Instant};
 
 use anyhow::{Context, Result, anyhow};
 use objects::{
@@ -41,8 +41,9 @@ use super::{
     next_action::{NextActionValidationContext, write_full_command_json},
     snapshot::{
         SnapshotAgentOverrides, create_snapshot, create_snapshot_from_tree,
-        is_placeholder_principal, placeholder_principal_warning,
-        preflight_large_capture_for_compat_commit, resolve_principal,
+        create_snapshot_profiled_with_worktree_status, is_placeholder_principal,
+        placeholder_principal_warning,
+        preflight_large_capture_for_compat_commit_with_worktree_status, resolve_principal,
     },
     thread_cmd::cmd_thread,
 };
@@ -53,6 +54,7 @@ use crate::{
         worktree_status_options,
     },
     config::UserConfig,
+    perf::{ProfileField, emit_profile, profile_enabled},
 };
 
 const GIT_MODE_FILE: u32 = 0o100644;
@@ -148,7 +150,9 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     // exact `Result` from a full worktree walk that re-reads + SHA-1s every
     // tracked file — before this, the clean fast-path paid that walk 3× before
     // the ref ever moved.
+    let preflight_worktree_status_start = Instant::now();
     let worktree_status = repo.git_overlay_worktree_status();
+    let preflight_worktree_status_ms = preflight_worktree_status_start.elapsed().as_millis();
     if let Some(advice) = git_overlay_mutation_preflight_advice_with_worktree_status(
         &repo,
         "commit",
@@ -160,12 +164,23 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     let user_config = UserConfig::load_default().unwrap_or_default();
     let placeholder_principal_warning =
         placeholder_principal_first_commit_warning(&repo, &user_config)?;
+    // Heddle-side clean-check: walks the worktree against the current Heddle tree
+    // (load index + read + SHA-1 every tracked file + save index). This is a
+    // SEPARATE walk from the git-overlay `worktree_status` above (different
+    // representation/semantics), so it cannot be threaded from it. It is only
+    // needed to distinguish "nothing to commit" / index-only-intent from a real
+    // change; the dirty path discards the result. Profiled below so the cost is
+    // attributed. Cutting it (cheap is-dirty probe for the dirty path) is a
+    // noted L-effort follow-up.
+    let mut clean_check_status_ms = 0u128;
     if let Some(state) = repo.current_state()? {
         let tree = repo.require_tree(&state.tree)?;
+        let clean_check_start = Instant::now();
         let status = repo.compare_worktree_cached_with_options(
             &tree,
             &worktree_status_options(Some(repo.config())),
         )?;
+        clean_check_status_ms = clean_check_start.elapsed().as_millis();
         // A clean worktree (matches Heddle's current tree) can still
         // hide real index-only intent on a Git-overlay checkout — e.g.
         // `git rm --cached path` stages a deletion without touching
@@ -323,8 +338,23 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
     }
     let git_index = GitIndexPlan::from_intent(&index_intent, args.all);
 
-    preflight_large_capture_for_compat_commit(&repo, args.force)?;
-    let snapshot = create_snapshot(
+    // Reuse the pre-mutation git-overlay worktree status computed at the top of
+    // this command (`worktree_status`) for the dirty-commit path's three
+    // PRE-mutation consumers: the large-capture safety preflight, the capture
+    // mutation preflight inside the snapshot, and the checkpoint's two
+    // preflights. None of these moves a Git ref, so they all observe the same
+    // pre-mutation git state and reuse is byte-identical to a fresh walk. Before
+    // this, the dirty path re-walked the worktree (re-reading + SHA-1ing every
+    // tracked file) four-plus times here — the large-capture preflight, the
+    // snapshot preflight, and both checkpoint preflights each ran their own
+    // walk. The post-checkpoint verification (`build_repository_verification_state`
+    // below) is left FRESH: the checkpoint advances the Git ref, which flips the
+    // git-overlay health classification.
+    let large_capture_start = Instant::now();
+    preflight_large_capture_for_compat_commit_with_worktree_status(args.force, &worktree_status)?;
+    let large_capture_preflight_ms = large_capture_start.elapsed().as_millis();
+    let snapshot_start = Instant::now();
+    let (snapshot, _snapshot_profile) = create_snapshot_profiled_with_worktree_status(
         &repo,
         &user_config,
         Some(message.clone()),
@@ -338,15 +368,19 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             no_policy: false,
             no_agent: false,
         },
+        &worktree_status,
     )?;
+    let snapshot_ms = snapshot_start.elapsed().as_millis();
     let captured_state = repo
         .current_state()?
         .ok_or_else(|| anyhow!("capture succeeded but no current state was recorded"))?;
     let snapshot_batch = find_recent_snapshot_batch(&repo, &captured_state.change_id)?;
-    let record = create_git_checkpoint(
+    let checkpoint_start = Instant::now();
+    let record = create_git_checkpoint_with_worktree_status(
         &repo,
         Some(message.as_str()),
         worktree_status_options(Some(repo.config())),
+        &worktree_status,
     )
     .map_err(|err| {
         anyhow!(commit_checkpoint_failed_advice(
@@ -356,6 +390,7 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             false,
         ))
     })?;
+    let checkpoint_ms = checkpoint_start.elapsed().as_millis();
     let checkpoint_batch = find_recent_git_checkpoint_batch(&repo, &record.git_commit)?;
     repo.oplog()
         .coalesce_batches(snapshot_batch.id, checkpoint_batch.id)
@@ -363,7 +398,22 @@ pub async fn cmd_commit_compat(cli: &Cli, args: CommitArgs) -> Result<()> {
             "commit completed but failed to record capture and Git checkpoint as one undo batch",
         )?;
 
+    let verify_start = Instant::now();
     let trust = commit_safe_trust(build_repository_verification_state(&repo));
+    let verify_ms = verify_start.elapsed().as_millis();
+    if profile_enabled() {
+        emit_profile(
+            "commit phases",
+            &[
+                ProfileField::millis("preflight_worktree_status_ms", preflight_worktree_status_ms),
+                ProfileField::millis("clean_check_status_ms", clean_check_status_ms),
+                ProfileField::millis("large_capture_preflight_ms", large_capture_preflight_ms),
+                ProfileField::millis("snapshot_ms", snapshot_ms),
+                ProfileField::millis("checkpoint_ms", checkpoint_ms),
+                ProfileField::millis("verify_ms", verify_ms),
+            ],
+        );
+    }
     let output = CommitCompatOutput {
         output_kind: "commit",
         status: "committed",

--- a/crates/cli/src/cli/commands/git_compat.rs
+++ b/crates/cli/src/cli/commands/git_compat.rs
@@ -26,8 +26,8 @@ use super::{
     action_line::print_next,
     advice::RecoveryAdvice,
     checkpoint::{
-        create_git_checkpoint, create_git_checkpoint_from_index_snapshot,
-        create_git_checkpoint_with_worktree_status, preflight_git_checkpoint_ref_update,
+        create_git_checkpoint_from_index_snapshot, create_git_checkpoint_with_worktree_status,
+        preflight_git_checkpoint_ref_update,
     },
     command_catalog::{ActionFields, ActionTemplate},
     git_overlay_health::{

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -42,6 +42,7 @@ use crate::{
     bridge::GitBridge,
     cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
     config::UserConfig,
+    perf::{ProfileField, emit_profile, profile_enabled},
 };
 
 #[derive(Serialize)]
@@ -216,17 +217,22 @@ pub async fn cmd_snapshot(
     // classification, so it is NOT threaded). Both pre-mutation consumers
     // observe the same pre-capture git state, so reuse is sound and the
     // classification stays byte-identical.
+    let worktree_status_start = Instant::now();
     let worktree_status = repo.git_overlay_worktree_status();
+    let worktree_status_ms = worktree_status_start.elapsed().as_millis();
     preflight_large_capture_with_status(force, &worktree_status)?;
-    let mut output = match create_snapshot_with_worktree_status(
+    let snapshot_start = Instant::now();
+    let snapshot_result = create_snapshot_profiled_with_worktree_status(
         &repo,
         &user_config,
         Some(intent),
         confidence,
         agent,
         &worktree_status,
-    ) {
-        Ok(output) => output,
+    );
+    let snapshot_ms = snapshot_start.elapsed().as_millis();
+    let (mut output, snapshot_profile) = match snapshot_result {
+        Ok((output, profile)) => (output, profile),
         Err(err) => {
             // ENOSPC is the only mid-capture failure where the user's
             // working tree is guaranteed safe (we never touched it) and
@@ -356,6 +362,33 @@ pub async fn cmd_snapshot(
         );
     }
 
+    if profile_enabled() {
+        emit_profile(
+            "capture phases",
+            &[
+                // Pre-mutation git-overlay worktree status walk (threaded into
+                // both the large-capture preflight and the snapshot mutation
+                // preflight — a single walk for both).
+                ProfileField::millis("worktree_status_ms", worktree_status_ms),
+                // The snapshot itself (preflight + tree build + blob/tree write
+                // + state/ref/oplog), broken down below.
+                ProfileField::millis("snapshot_ms", snapshot_ms),
+                ProfileField::millis("snapshot_tree_walk_ms", snapshot_profile.tree_walk_ms),
+                ProfileField::millis("snapshot_blob_prep_ms", snapshot_profile.blob_prep_ms),
+                ProfileField::millis("snapshot_blob_write_ms", snapshot_profile.blob_write_ms),
+                ProfileField::millis("snapshot_tree_write_ms", snapshot_profile.tree_write_ms),
+                ProfileField::millis(
+                    "snapshot_state_ref_oplog_ms",
+                    snapshot_profile.state_ref_oplog_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_thread_metadata_ms",
+                    snapshot_profile.thread_metadata_ms,
+                ),
+            ],
+        );
+    }
+
     Ok(())
 }
 
@@ -436,24 +469,23 @@ fn current_thread_name(repo: &Repository) -> String {
     }
 }
 
-pub(crate) fn preflight_large_capture_for_compat_commit(
-    repo: &Repository,
+/// Large-capture safety preflight for `commit`'s dirty path, reusing an
+/// already-computed git-overlay worktree status instead of re-walking the
+/// worktree. `commit` has already computed the same pre-mutation status for its
+/// own preflights and the (unchanged) clean classification, so threading it here
+/// removes a redundant full walk. The large-capture gating decision is
+/// byte-identical because it reads the same `WorktreeStatus`.
+pub(crate) fn preflight_large_capture_for_compat_commit_with_worktree_status(
     force: bool,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
 ) -> Result<()> {
-    preflight_large_capture(repo, force)
+    preflight_large_capture_with_status(force, worktree_status)
 }
 
-fn preflight_large_capture(repo: &Repository, force: bool) -> Result<()> {
-    if force {
-        return Ok(());
-    }
-    preflight_large_capture_with_status(force, &repo.git_overlay_worktree_status())
-}
-
-/// Variant of [`preflight_large_capture`] that reuses an already-computed
-/// git-overlay worktree status instead of re-walking the worktree. The
-/// large-capture classification is byte-identical because it reads the same
-/// `WorktreeStatus`; only the redundant walk is removed.
+/// Large-capture safety preflight built from an already-computed git-overlay
+/// worktree status instead of re-walking the worktree. The large-capture
+/// classification is byte-identical because it reads the same `WorktreeStatus`;
+/// only the redundant walk is removed.
 fn preflight_large_capture_with_status(
     force: bool,
     worktree_status: &repo::Result<Option<WorktreeStatus>>,
@@ -539,31 +571,6 @@ pub(crate) fn create_snapshot(
     create_snapshot_profiled(repo, user_config, intent, confidence, agent).map(|(output, _)| output)
 }
 
-/// Variant of [`create_snapshot`] that reuses an already-computed git-overlay
-/// worktree status for the PRE-mutation capture preflight instead of re-walking
-/// the worktree. The snapshot result is byte-identical; only the redundant
-/// pre-mutation status walk is removed. The post-mutation verification state
-/// built after the capture is still computed FRESH (the capture advances the
-/// Heddle state, which flips the git-overlay health classification).
-pub(crate) fn create_snapshot_with_worktree_status(
-    repo: &Repository,
-    user_config: &UserConfig,
-    intent: Option<String>,
-    confidence: Option<f32>,
-    agent: SnapshotAgentOverrides,
-    worktree_status: &repo::Result<Option<WorktreeStatus>>,
-) -> Result<SnapshotOutput> {
-    create_snapshot_profiled_inner(
-        repo,
-        user_config,
-        intent,
-        confidence,
-        agent,
-        Some(worktree_status),
-    )
-    .map(|(output, _)| output)
-}
-
 pub(crate) fn create_snapshot_from_tree(
     repo: &Repository,
     user_config: &UserConfig,
@@ -613,6 +620,28 @@ pub(crate) fn create_snapshot_profiled(
     agent: SnapshotAgentOverrides,
 ) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
     create_snapshot_profiled_inner(repo, user_config, intent, confidence, agent, None)
+}
+
+/// Profiled variant of [`create_snapshot_with_worktree_status`]. Reuses an
+/// already-computed pre-mutation git-overlay worktree status for capture's
+/// mutation preflight (no extra worktree walk) and returns the inner snapshot
+/// profile so the caller can attribute sub-phase timings.
+pub(crate) fn create_snapshot_profiled_with_worktree_status(
+    repo: &Repository,
+    user_config: &UserConfig,
+    intent: Option<String>,
+    confidence: Option<f32>,
+    agent: SnapshotAgentOverrides,
+    worktree_status: &repo::Result<Option<WorktreeStatus>>,
+) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
+    create_snapshot_profiled_inner(
+        repo,
+        user_config,
+        intent,
+        confidence,
+        agent,
+        Some(worktree_status),
+    )
 }
 
 fn create_snapshot_profiled_inner(


### PR DESCRIPTION
## Root cause

On a real warm-cache repo (ghostty, ~5,700 files) `heddle commit` was ~5.5s and `heddle capture` ~1.7-2.1s. Both are statx-bound; the cost is the worktree-status walk (read + SHA-1 every tracked file), not git object lookups (packing the mirror left statx unchanged).

**Why so many statx/file:** the worktree-status walk stats each tracked file plus probes ignore/marker paths that usually miss — hence the large ENOENT statx fraction (~20K of 77K on capture). That per-walk cost is in the status engine (sley + the heddle-side index compare); this PR does not change the per-walk cost. It cuts the **number of walks**.

**The real bug — commit walks the worktree ~3-4× before any Git ref moves.** Measured statx (load-independent, ghostty, warm):

| Command | statx (before) | /file | statx (after) | /file |
|---|---|---|---|---|
| capture | 77,074 | 13.4 | 77,095 | 13.4 (instrumentation only) |
| **commit** | **247,585** | **43** | **184,796** | **32** |

Capture was already single-walk-threaded (#792/793/795 thread the pre-mutation status through the large-capture preflight + the snapshot mutation preflight; the post-mutation verification stays fresh). The **clean** commit fast-path was threaded too. But the **dirty** commit path — the common case (edit a file, `heddle commit`) — recomputed the pre-mutation `git_overlay_worktree_status` independently in:

1. `preflight_large_capture_for_compat_commit` (a full walk),
2. the snapshot's own capture mutation preflight (`create_snapshot` was called un-threaded), and
3. both checkpoint preflights (`create_git_checkpoint` un-threaded).

None of these moves a Git ref, so they all observe the same pre-mutation state the command already computed at the top.

## Fix

Thread the single pre-mutation `worktree_status` (already computed for commit's own mutation preflight) through all three dirty-path consumers, mirroring the clean fast-path:

- `preflight_large_capture_for_compat_commit_with_worktree_status` (new)
- `create_snapshot_profiled_with_worktree_status` (new) instead of `create_snapshot`
- `create_git_checkpoint_with_worktree_status` (existing) instead of `create_git_checkpoint`

**Result:** commit statx **247,585 → 184,796 (−25%)**, ENOENT probes **63,707 → 36,931 (−42%)**. Quiet-box wall time: commit **5,347ms → 4,093ms (~23%)**, capture unchanged (1.7-2.1s, instrumentation-only).

## Instrumentation (worth landing on its own)

capture/commit previously emitted only `command_body_ms` under `HEDDLE_PROFILE=1`. They now emit sub-phases (matching the `status` pattern):

- **capture phases:** `worktree_status_ms`, `snapshot_ms` + `snapshot_tree_walk_ms` / `snapshot_blob_*` / `snapshot_tree_write_ms` / `snapshot_state_ref_oplog_ms` / `snapshot_thread_metadata_ms`
- **commit phases:** `preflight_worktree_status_ms`, `clean_check_status_ms`, `large_capture_preflight_ms`, `snapshot_ms`, `checkpoint_ms`, `verify_ms`

Example (after, ghostty): commit `preflight_worktree_status_ms: 340, large_capture_preflight_ms: 0 (eliminated), snapshot_ms: 1202, checkpoint_ms: 990, verify_ms: 395`.

## Noted follow-up (L-effort, not in this PR)

The new `clean_check_status_ms` surfaces a remaining heddle-side walk: commit's "nothing to commit / index-only intent" check (`compare_worktree_cached`, ~1s on ghostty) is a separate walk against the current Heddle tree, distinct in representation from the git-overlay status, so it can't be threaded from it. Replacing it with a cheap is-dirty probe for the dirty path (which already knows the worktree is dirty) would remove most of the remaining commit cost, but needs care around the `git rm --cached` index-only-intent edge case.

## Correctness

Capture/commit produce byte-identical captured state and Git checkpoint: each threaded consumer receives the exact same pre-mutation `Result<Option<WorktreeStatus>>` it would otherwise have re-walked, and no Git ref moves between the walk and these preflights — identical to the clean-path precedent (#792/793/795). The post-checkpoint verification is left as a fresh walk (the checkpoint advances the Git ref, flipping the health classification).

Gates: default + `--all-features` build, `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-cli -p heddle-repo -p heddle-mount`, clippy `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785448553&installation_id=132405951&pr_number=829&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F829&signature=12a597075807de7697ff04e1dc32fe8a17e81c540d5ee50150890bcef1c1c9a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->