### PR TITLE
chore(release): move Homebrew tap to HeddleCo/homebrew-tap (brew install HeddleCo/tap/heddle)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,12 +715,12 @@ jobs:
           app-id: ${{ secrets.HEDDLE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEDDLE_RELEASE_APP_PRIVATE_KEY }}
           owner: HeddleCo
-          repositories: homebrew-heddle,scoop-heddle,apt-heddle
+          repositories: homebrew-tap,scoop-heddle,apt-heddle
 
       - name: Publish Homebrew cask PR
         uses: ./.github/actions/publish-manifest
         with:
-          target-repo: HeddleCo/homebrew-heddle
+          target-repo: HeddleCo/homebrew-tap
           manifest-path: Casks/heddle.rb
           rendered-file: rendered/heddle.rb
           token: ${{ steps.app-token.outputs.token }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -72,7 +72,7 @@ release-plz → push-to-main flow documented in
      artifacts, signatures, certificates, and an aggregated
      `SHA256SUMS`
    - for stable releases only, render `Casks/heddle.rb` and open a PR
-     against `HeddleCo/homebrew-heddle`
+     against `HeddleCo/homebrew-tap`
 
 4. Verify the Release page lists the expected asset set (see
    [Artifact contract](#artifact-contract) below). If anything is
@@ -164,8 +164,8 @@ The primary macOS install path is:
 brew install --cask heddleco/heddle/heddle
 ```
 
-The tap repository is `HeddleCo/homebrew-heddle`, which maps to
-`heddleco/heddle` by Homebrew's tap naming convention. Stable releases
+The tap repository is `HeddleCo/homebrew-tap`, which maps to
+`heddleco/tap` by Homebrew's tap naming convention. Stable releases
 render `Casks/heddle.rb` with:
 
 - `app "Heddle.app"` so Homebrew installs the host app into
@@ -204,7 +204,7 @@ Set these GitHub Actions variables as well:
 | `HEDDLE_DEVELOPER_ID_APPLICATION` | Codesigning identity, e.g. `Developer ID Application: HeddleCo, LLC (33V6242M8S)` |
 
 The release-publisher GitHub App should be installed only on
-`homebrew-heddle`, `scoop-heddle`, and `apt-heddle` and granted only
+`homebrew-tap`, `scoop-heddle`, and `apt-heddle` and granted only
 `Contents: write` and `Pull requests: write`. The token minted in the
 `publish-manifests` job lists all three in its `repositories:` scope.
 

--- a/crates/mount/swift/HeddleHost/README.md
+++ b/crates/mount/swift/HeddleHost/README.md
@@ -287,7 +287,7 @@ The eventual `brew install --cask heddleco/heddle/heddle` should:
 A Homebrew **cask** is the right shape because it ships a `.app`:
 
 ```ruby
-# Pseudo-cask in heddleco/homebrew-heddle:
+# Pseudo-cask in heddleco/homebrew-tap:
 cask "heddle" do
   version "0.3.0"
   sha256 "..."

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -222,7 +222,7 @@ fi
 if [[ -x scripts/render-homebrew-cask.sh ]] \
    && grep -F "Casks/heddle.rb" "$WF" >/dev/null \
    && grep -F "actions/create-github-app-token" "$WF" >/dev/null \
-   && grep -F "HeddleCo/homebrew-heddle" "$WF" >/dev/null; then
+   && grep -F "HeddleCo/homebrew-tap" "$WF" >/dev/null; then
   ok "Homebrew cask manifest publication wired"
 else
   err "missing Homebrew cask manifest publication wiring"


### PR DESCRIPTION
Renames the Homebrew tap so installs are `brew install HeddleCo/tap/heddle` instead of the redundant `HeddleCo/heddle/heddle`.

- **Repo rename already done** on GitHub: `HeddleCo/homebrew-heddle` → `HeddleCo/homebrew-tap` (old name redirects; the GitHub App installation follows by repo-id so its access is preserved).
- This PR updates the references: `release.yml` publish-manifests (app-token `repositories:` scope + cask `target-repo`), `check-release-pipeline.sh` assertion (would otherwise fail CI on the new workflow), `RELEASING.md` + swift README docs.
- The tap repo's own README (`heddleco/heddle` → `heddleco/tap` install text) is updated separately in HeddleCo/homebrew-tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785454529&installation_id=132405951&pr_number=831&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F831&signature=8b2e715a9fcae9732dc19bddf75f7ae6c8eb39a3c26e4806437dc0168ebb60a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->