### PR TITLE
fix(test): make oplog-recover doc-sample check deterministic (repo-open salvage race)

### DIFF
--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -1093,11 +1093,31 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
         // full `daemon_stop` payload, so a bare init fixture suffices.
         "daemon_stop" => (init_fixture(), sv(&["daemon", "stop"])),
         "oplog_recover" => {
-            // Seed three captures, then truncate the packed oplog mid-record so
-            // the footer is destroyed and the salvage takes the forward-greedy
-            // path. The CLI's repo open auto-recovers before the handler runs,
-            // so `oplog recover` reports the prior recovery from the sidecar —
-            // the realistic operator key set (no `quarantine_path`).
+            // Seed three captures, then truncate the packed oplog so the index
+            // trailer is destroyed and any read takes the forward-greedy salvage
+            // path.
+            //
+            // DETERMINISM (heddle#272 flake fix): the `oplog recover` payload has
+            // TWO shapes depending on WHO performs the salvage:
+            //   * the everyday read path's silent auto-fallback salvaged first →
+            //     handler reports `prior_recovery: true` from the durable
+            //     `.oplog.recovery` sidecar, `quarantine_path` OMITTED; or
+            //   * the `recover` handler itself is the first to touch the damaged
+            //     body → `prior_recovery: false`, `quarantine_path` PRESENT.
+            // Which one fires is a race between the recover command's own
+            // repo-open reads (reconciler / status hooks call
+            // `PackedOpLogIndex::open`, which auto-salvages) and the handler's
+            // explicit `recover()`. That race resolved differently across
+            // environments — green locally (auto-fallback won) but red on CI
+            // (handler won, emitting the extra `quarantine_path` key), so the
+            // documented sample's key set drifted from runtime non-deterministically.
+            //
+            // Pin the auto-fallback variant by running a benign read FIRST: it
+            // forces the silent salvage to complete (heals `oplog.bin`, quarantines
+            // the damaged original, writes the sidecar) BEFORE `oplog recover`
+            // opens the repo. From that point the handler ALWAYS sees a healthy
+            // oplog plus the sidecar and reports `prior_recovery: true` with no
+            // `quarantine_path` — the stable operator key set the doc documents.
             let t = init_fixture();
             for i in 1..=3 {
                 std::fs::write(t.path().join("f.txt"), format!("v{i}")).unwrap();
@@ -1108,6 +1128,9 @@ fn runtime_doc_case(output_kind: &str) -> Option<(TempDir, Vec<String>)> {
             let bytes = std::fs::read(&oplog).expect("read fixture oplog");
             let cut = bytes.len() * 6 / 10;
             std::fs::write(&oplog, &bytes[..cut]).expect("truncate fixture oplog");
+            // Benign read: deterministically drive the silent auto-fallback to
+            // salvage the oplog before the recover handler ever opens the repo.
+            heddle(&["status"], Some(t.path())).expect("status triggers oplog auto-recovery");
             (t, sv(&["oplog", "recover"]))
         }
         "timeline_log" => (init_fixture(), sv(&["log", "--timeline"])),


### PR DESCRIPTION
## Problem
`output_kind_invariant::doc_samples_match_runtime_for_every_catalog_discriminator` is **flaky** on the `oplog recover` discriminator — it passes locally but **fails in CI** with `oplog_recover: in runtime only: ["quarantine_path"]` (confirmed in #830's CI log; pre-existing on main).

## Root cause — a salvage race
For a freshly-truncated oplog, the `oplog recover` payload has two valid shapes depending on WHO salvages first:
- the command's own repo-open reads (reconciler / status open-hooks → `PackedOpLogIndex::open`, which auto-salvages) win → `prior_recovery: true`, `quarantine_path` **omitted**
- the explicit recover handler is first to touch the damaged body → `prior_recovery: false`, `quarantine_path` **present**

Locally the auto-fallback always won (green); in CI the handler won (extra `quarantine_path` key → exact-key-set mismatch → red).

## Fix (test-only)
Add a benign `heddle status` before `oplog recover` in the fixture (`crates/cli/tests/cli_integration/output_kind_invariant.rs`), forcing the silent salvage to fully complete (heal, quarantine, sidecar) before the recover handler opens the repo — so the handler deterministically sees a healthy oplog + sidecar → `prior_recovery: true`, no `quarantine_path`. **No doc change needed** — `docs/json-schemas.md` already documents exactly this prior-recovery shape; only the runtime was non-deterministic.

## Verification
- Invariant test: **6/6 consecutive green**
- Fixture at binary level: **20/20 iterations identical** (always the 9-key prior-recovery set, never `quarantine_path`)
- `cargo clippy -p heddle-cli --tests` clean

Un-reds main (the pre-existing failure) independently; #830 picks it up on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785456105&installation_id=132405951&pr_number=833&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F833&signature=db00e3e70ed5b42b201afa46058607f673f224e2c5f6fcde94bb7abd17b86195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->