### PR TITLE
feat(progress): generic Progress substrate + Sink (progress on any command)

### DIFF
--- a/crates/cli/src/cli/commands/import_progress.rs
+++ b/crates/cli/src/cli/commands/import_progress.rs
@@ -1,27 +1,33 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared human progress rendering for Git history import flows.
-
-use std::io::{self, IsTerminal, Write};
+//!
+//! This is a thin *consumer* of the generic [`Progress`](objects::Progress)
+//! substrate: it owns the import-specific phrasing (the `[n/3]` phased steps and
+//! the per-commit inspected/percent body) and drives a `Progress` handle. All
+//! TTY concerns — `\r`-redraw, dim styling, the completion line, and JSON
+//! suppression — live in the shared `TerminalSink` (`progress_render`), not
+//! here. The per-commit throttle stays here because the body carries fields
+//! (`states_created`) the generic snapshot does not model.
 
 use ingest::ImportProgressEvent;
+use objects::Progress;
 use repo::Repository;
 
-use crate::cli::{Cli, should_output_json, style};
-
-/// Redraw the live commit counter at most once per this many commits, so a
-/// large import doesn't spend its time flushing the terminal.
-const COMMIT_TICK_INTERVAL: usize = 64;
+use crate::cli::progress_render::{COMMIT_TICK_INTERVAL, finish_line, progress_for};
+use crate::cli::{Cli, style};
 
 pub(crate) struct ImportProgress {
-    enabled: bool,
+    /// The generic handle. A null handle (under `--json`) makes every method a
+    /// no-op that renders nothing.
+    progress: Progress,
     current: usize,
     total: usize,
 }
 
 impl ImportProgress {
     pub(crate) fn start(cli: &Cli, repo: &Repository, scope: &str, source_label: &str) -> Self {
-        let enabled = !should_output_json(cli, Some(repo.config()));
-        if enabled {
+        let progress = progress_for(cli, repo);
+        if progress.is_active() {
             println!(
                 "{} {} from {}",
                 style::dim("Importing Git history:"),
@@ -29,13 +35,14 @@ impl ImportProgress {
                 style::dim(source_label)
             );
         }
-        let progress = Self {
-            enabled,
+        let this = Self {
+            progress,
             current: 0,
             total: 3,
         };
-        progress.step("scanning refs");
-        progress
+        this.progress.set_total(this.total);
+        this.step("scanning refs");
+        this
     }
 
     pub(crate) fn advance(&mut self, label: &str) {
@@ -59,12 +66,13 @@ impl ImportProgress {
         self.advance("writing refs");
     }
 
-    /// Live per-commit counter for the import phase. Renders only to a TTY
-    /// with redraw control codes. Piped human output gets throttled plain
-    /// lines; under `--json`/agent output it is a no-op so progress never
-    /// leaks into machine-readable stdout (#550).
+    /// Live per-commit counter for the import phase. Under `--json` the handle
+    /// is null so this is a no-op (progress never leaks into machine-readable
+    /// stdout, #550). Throttling on the commit count happens here — a throttled
+    /// tick becomes a `set_phase` on the substrate, which the `TerminalSink`
+    /// paints (it always repaints on a phase-string change).
     pub(crate) fn commit_tick(&mut self, event: ImportProgressEvent) {
-        if !self.enabled {
+        if !self.progress.is_active() {
             return;
         }
         if !should_render_commit_progress(event) {
@@ -81,44 +89,26 @@ impl ImportProgress {
             self.total,
             format_commit_progress(event),
         );
-        if io::stdout().is_terminal() {
-            print!("\r{}\x1b[K", style::dim(&line));
-            io::stdout().flush().ok();
-        } else {
-            println!("{}", style::dim(&line));
-        }
+        self.progress.set_phase(line);
     }
 
     pub(crate) fn finish(&mut self) {
-        if !self.enabled {
+        if !self.progress.is_active() {
             return;
         }
         self.current = self.total;
-        if io::stdout().is_terminal() {
-            print!("\r\x1b[K{}\n", style::accent("[done] imported Git history"));
-            io::stdout().flush().ok();
-        } else {
-            println!("{}", style::accent("[done] imported Git history"));
-        }
+        finish_line(&self.progress, "[done] imported Git history");
     }
 
+    /// Paint a phased `[n/total] label...` step. `set_phase` forces a repaint on
+    /// the phase-string change, matching the historic always-render step.
     fn step(&self, label: &str) {
-        if !self.enabled {
+        if !self.progress.is_active() {
             return;
         }
         let next = self.current + 1;
-        if io::stdout().is_terminal() {
-            print!(
-                "\r\x1b[K{}",
-                style::dim(&format!("[{next}/{}] {label}...", self.total))
-            );
-            io::stdout().flush().ok();
-        } else {
-            println!(
-                "{}",
-                style::dim(&format!("[{next}/{}] {label}", self.total))
-            );
-        }
+        self.progress
+            .set_phase(format!("[{next}/{}] {label}...", self.total));
     }
 }
 

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -6,6 +6,7 @@ use std::{io::IsTerminal, sync::OnceLock};
 pub mod cli_args;
 pub mod commands;
 pub mod help;
+pub mod progress_render;
 pub mod render;
 pub mod style;
 pub mod tips;

--- a/crates/cli/src/cli/progress_render.rs
+++ b/crates/cli/src/cli/progress_render.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Terminal renderer for the generic [`Progress`](objects::Progress) substrate.
+//!
+//! This is the *only* place that turns a [`ProgressSnapshot`] into bytes on a
+//! terminal. Domain crates drive a `Progress` handle; the CLI installs a
+//! [`TerminalSink`] via the JSON-guarded factory ([`progress_for`]) so progress
+//! never leaks into machine-readable stdout (#550) and never repaints when
+//! output is piped away from a TTY.
+//!
+//! # Throttling lives here
+//!
+//! `Progress::inc` calls `render` on every active tick; the sink decides
+//! whether to actually repaint. We coalesce to at most one redraw per
+//! [`COMMIT_TICK_INTERVAL`] completed units, but always repaint on a phase
+//! change so stage transitions show immediately. This mirrors the cadence of
+//! the bespoke import progress line this sink replaces.
+
+use std::io::{self, IsTerminal, Write};
+use std::sync::Mutex;
+
+use objects::{Progress, ProgressSnapshot, Sink};
+
+use crate::cli::{Cli, should_output_json, style};
+use repo::Repository;
+
+/// Redraw the live line at most once per this many completed units, so a large
+/// operation doesn't spend its time flushing the terminal. Matches the historic
+/// import cadence.
+pub(crate) const COMMIT_TICK_INTERVAL: usize = 64;
+
+/// Build a [`Progress`] handle for a command, applying the single JSON guard
+/// (#550) exactly once at construction: JSON output → a null handle that
+/// renders nothing; otherwise → a [`TerminalSink`]. The guard is never checked
+/// again per update.
+pub(crate) fn progress_for(cli: &Cli, repo: &Repository) -> Progress {
+    if should_output_json(cli, Some(repo.config())) {
+        Progress::null()
+    } else {
+        Progress::with_sink(Box::new(TerminalSink::new()))
+    }
+}
+
+/// A `Sink` that paints a single, self-overwriting progress line.
+///
+/// - On a TTY: `\r`-carriage-return redraw of one dim line, throttled to one
+///   repaint per [`COMMIT_TICK_INTERVAL`] units (plus forced repaint on phase
+///   change and on the first/last unit).
+/// - Off a TTY (piped human output): one dim line per throttled tick, no
+///   control codes.
+///
+/// The sink is `Sync`; its small amount of interior state (last painted phase +
+/// tick bookkeeping) lives behind a `Mutex`. Renders are cheap and infrequent
+/// relative to `inc`, so the lock is not on any hot path.
+pub(crate) struct TerminalSink {
+    state: Mutex<RenderState>,
+}
+
+#[derive(Default)]
+struct RenderState {
+    /// Phase last painted; a change forces a repaint regardless of throttle.
+    last_phase: Option<String>,
+    /// Whether anything has been painted yet (drives the leading redraw and the
+    /// `finish` clear).
+    painted: bool,
+}
+
+impl TerminalSink {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(RenderState::default()),
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, RenderState> {
+        self.state.lock().unwrap_or_else(|p| p.into_inner())
+    }
+
+    /// Decide whether this snapshot should repaint. Always repaint on a phase
+    /// change or the first paint; otherwise throttle on the completed count.
+    fn should_repaint(state: &RenderState, snap: &ProgressSnapshot) -> bool {
+        let phase_changed = state.last_phase.as_deref() != Some(snap.phase.as_str());
+        phase_changed
+            || snap.done == 0
+            || (snap.total != 0 && snap.done == snap.total)
+            || snap.done.is_multiple_of(COMMIT_TICK_INTERVAL)
+    }
+
+    fn paint(line: &str) {
+        if io::stdout().is_terminal() {
+            // `\r` to column 0, `\x1b[K` clears to end of line so a shorter line
+            // doesn't leave stale trailing characters.
+            print!("\r{}\x1b[K", style::dim(line));
+            io::stdout().flush().ok();
+        } else {
+            println!("{}", style::dim(line));
+        }
+    }
+}
+
+impl Sink for TerminalSink {
+    fn render(&self, snap: ProgressSnapshot) {
+        // The phase label carries the fully-formatted line the caller wants
+        // painted; the counters drive throttling. An empty phase is a no-op.
+        if snap.phase.is_empty() {
+            return;
+        }
+        let mut state = self.lock();
+        if !Self::should_repaint(&state, &snap) {
+            return;
+        }
+        Self::paint(&snap.phase);
+        state.last_phase = Some(snap.phase);
+        state.painted = true;
+    }
+}
+
+/// Paint a terminal "done" line for a finished [`Progress`], clearing the live
+/// line first on a TTY. No-op for a null (inactive) handle. Used by consumers
+/// that want an explicit completion marker (e.g. import's `[done]` line).
+pub(crate) fn finish_line(progress: &Progress, message: &str) {
+    if !progress.is_active() {
+        return;
+    }
+    if io::stdout().is_terminal() {
+        print!("\r\x1b[K{}\n", style::accent(message));
+        io::stdout().flush().ok();
+    } else {
+        println!("{}", style::accent(message));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repaints_on_phase_change_regardless_of_throttle() {
+        let mut state = RenderState {
+            last_phase: Some("old".into()),
+            painted: true,
+        };
+        let snap = ProgressSnapshot {
+            done: 7, // not a throttle boundary
+            total: 100,
+            phase: "new".into(),
+        };
+        assert!(TerminalSink::should_repaint(&state, &snap));
+        // Same phase, off-boundary count -> no repaint.
+        state.last_phase = Some("new".into());
+        assert!(!TerminalSink::should_repaint(&state, &snap));
+    }
+
+    #[test]
+    fn repaints_on_throttle_boundary_and_edges() {
+        let state = RenderState {
+            last_phase: Some("p".into()),
+            painted: true,
+        };
+        for (done, total, want) in
+            [(0, 100, true), (64, 100, true), (100, 100, true), (63, 100, false)]
+        {
+            let snap = ProgressSnapshot {
+                done,
+                total,
+                phase: "p".into(),
+            };
+            assert_eq!(
+                TerminalSink::should_repaint(&state, &snap),
+                want,
+                "done={done} total={total}"
+            );
+        }
+    }
+}

--- a/crates/objects/src/lib.rs
+++ b/crates/objects/src/lib.rs
@@ -10,6 +10,7 @@ pub mod fs_ops;
 pub mod lock;
 pub mod object;
 pub mod observe;
+pub mod progress;
 pub mod store;
 pub mod sync;
 pub mod util;
@@ -20,4 +21,5 @@ pub use observe::{
     CollectingWarnings, NoopProgress, NoopWarnings, ProgressEvent, ProgressSink, TaskId, Warning,
     WarningSink,
 };
+pub use progress::{Progress, ProgressSnapshot, Sink};
 pub use sync::{LockExt, RwLockExt};

--- a/crates/objects/src/progress.rs
+++ b/crates/objects/src/progress.rs
@@ -1,0 +1,344 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Generic, near-zero-cost progress substrate.
+//!
+//! A [`Progress`] handle is a cheap-to-clone (`Arc`-bump) counter that any
+//! long-running operation can drive without knowing how — or whether — the
+//! progress is rendered. The rendering half lives behind the [`Sink`] trait,
+//! which higher layers (the CLI) implement to paint a terminal line. Domain
+//! crates only ever see the handle.
+//!
+//! # Zero-overhead null path
+//!
+//! The overwhelmingly common case is "no one is watching" (piped output,
+//! `--output json`, embedded library use). For that case a handle is built
+//! with [`Progress::null`], whose `active` flag is `false`. Every hot-path
+//! call ([`Progress::inc`]) then costs exactly one relaxed atomic add plus a
+//! single predicted-not-taken branch on `active` — no allocation, no syscall,
+//! and no virtual `Sink::render` dispatch. The vtable is only touched when a
+//! sink is actually installed via [`Progress::with_sink`].
+//!
+//! Throttling (redraw at most every N ticks) is deliberately *not* done here:
+//! [`Progress::inc`] always calls `render` when active, and the [`Sink`]
+//! decides whether to actually repaint. Keeping the decision in the renderer
+//! keeps `inc` branch-predictable and lets each sink pick its own cadence.
+
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+
+/// A point-in-time view of a [`Progress`] handle, handed to [`Sink::render`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProgressSnapshot {
+    /// Units completed so far.
+    pub done: usize,
+    /// Total units of work, or `0` when the total is not yet known.
+    pub total: usize,
+    /// Current human phase label (e.g. `"importing commits"`).
+    pub phase: String,
+}
+
+/// Renders progress snapshots. Implemented by the presentation layer (the CLI's
+/// `TerminalSink`), never by domain crates.
+///
+/// A `Sink` is called on every active [`Progress::inc`], so implementations are
+/// responsible for their own throttling — cheap sinks may repaint every call,
+/// terminal sinks should coalesce redraws.
+pub trait Sink: Send + Sync {
+    /// Present the given snapshot. Called on the thread that drove the update;
+    /// may be called concurrently from multiple threads, so implementations
+    /// must be `Sync` and manage their own interior state.
+    fn render(&self, snap: ProgressSnapshot);
+}
+
+/// A no-op sink. Never installed as active; exists so [`ProgressInner`] always
+/// holds a concrete `Box<dyn Sink>` and the `active` flag is the sole gate.
+struct NullSink;
+
+impl Sink for NullSink {
+    #[inline]
+    fn render(&self, _snap: ProgressSnapshot) {}
+}
+
+struct ProgressInner {
+    done: AtomicUsize,
+    total: AtomicUsize,
+    /// Phase changes are rare (once per operation stage), so a `Mutex` here
+    /// keeps the hot [`Progress::inc`] path lock-free while still letting
+    /// [`Progress::set_phase`] mutate the label.
+    phase: Mutex<String>,
+    sink: Box<dyn Sink>,
+    /// Master gate for the entire render path. `false` for null handles.
+    active: bool,
+}
+
+/// A cheap-to-clone progress handle.
+///
+/// Cloning bumps an `Arc` refcount; all clones share the same counters and
+/// sink, so a handle can be threaded through `thread::scope` closures or
+/// stored alongside other shared state. `Send + Sync`.
+#[derive(Clone)]
+pub struct Progress(Arc<ProgressInner>);
+
+impl Progress {
+    /// A handle that renders nothing. The hot path is a relaxed add plus a
+    /// predicted-not-taken branch — see the module docs.
+    pub fn null() -> Self {
+        Progress(Arc::new(ProgressInner {
+            done: AtomicUsize::new(0),
+            total: AtomicUsize::new(0),
+            phase: Mutex::new(String::new()),
+            sink: Box::new(NullSink),
+            active: false,
+        }))
+    }
+
+    /// A handle backed by a real [`Sink`]. Every active `inc` will call
+    /// `sink.render`; the sink is responsible for throttling.
+    pub fn with_sink(sink: Box<dyn Sink>) -> Self {
+        Progress(Arc::new(ProgressInner {
+            done: AtomicUsize::new(0),
+            total: AtomicUsize::new(0),
+            phase: Mutex::new(String::new()),
+            sink,
+            active: true,
+        }))
+    }
+
+    /// Whether this handle renders. `false` for [`Progress::null`].
+    #[inline]
+    pub fn is_active(&self) -> bool {
+        self.0.active
+    }
+
+    /// Set the total unit count. Cheap; does not trigger a render on its own.
+    pub fn set_total(&self, total: usize) {
+        self.0.total.store(total, Ordering::Relaxed);
+    }
+
+    /// The current completed count.
+    #[inline]
+    pub fn done(&self) -> usize {
+        self.0.done.load(Ordering::Relaxed)
+    }
+
+    /// The current total (`0` if unknown).
+    #[inline]
+    pub fn total(&self) -> usize {
+        self.0.total.load(Ordering::Relaxed)
+    }
+
+    /// Set the human phase label. Rare relative to `inc`; when active it also
+    /// triggers a render so the label change is painted immediately (a
+    /// terminal sink typically forces a repaint on phase change).
+    pub fn set_phase(&self, label: impl Into<String>) {
+        let label = label.into();
+        {
+            let mut guard = self.lock_phase();
+            *guard = label;
+        }
+        if self.0.active {
+            self.render_current();
+        }
+    }
+
+    /// The current phase label.
+    pub fn phase(&self) -> String {
+        self.lock_phase().clone()
+    }
+
+    /// Advance the completed count by `n` and, if active, render.
+    ///
+    /// Hot path: `done.fetch_add(n, Relaxed)` then one branch on `active`. When
+    /// inactive nothing else happens — no snapshot, no vtable call.
+    #[inline]
+    pub fn inc(&self, n: usize) {
+        self.0.done.fetch_add(n, Ordering::Relaxed);
+        if self.0.active {
+            self.render_current();
+        }
+    }
+
+    /// Snapshot the current state and hand it to the sink. Cold relative to the
+    /// `active` check in `inc`, so it stays out-of-line.
+    fn render_current(&self) {
+        let snap = ProgressSnapshot {
+            done: self.0.done.load(Ordering::Relaxed),
+            total: self.0.total.load(Ordering::Relaxed),
+            phase: self.lock_phase().clone(),
+        };
+        self.0.sink.render(snap);
+    }
+
+    /// Take a current snapshot without rendering. Useful for a sink that wants
+    /// to force a final repaint (e.g. a "done" line).
+    pub fn snapshot(&self) -> ProgressSnapshot {
+        ProgressSnapshot {
+            done: self.0.done.load(Ordering::Relaxed),
+            total: self.0.total.load(Ordering::Relaxed),
+            phase: self.lock_phase().clone(),
+        }
+    }
+
+    fn lock_phase(&self) -> std::sync::MutexGuard<'_, String> {
+        self.0.phase.lock().unwrap_or_else(|p| p.into_inner())
+    }
+}
+
+impl std::fmt::Debug for Progress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Progress")
+            .field("done", &self.done())
+            .field("total", &self.total())
+            .field("active", &self.0.active)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for Progress {
+    fn default() -> Self {
+        Self::null()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Adapter so a test can keep an `Arc<T>` to inspect its sink while the
+    /// [`Progress`] handle owns the `Box<dyn Sink>`. Renders forward to the
+    /// shared `T`.
+    struct Shared<T: Sink>(Arc<T>);
+    impl<T: Sink> Sink for Shared<T> {
+        fn render(&self, snap: ProgressSnapshot) {
+            self.0.render(snap);
+        }
+    }
+    fn progress_over<T: Sink + 'static>(sink: &Arc<T>) -> Progress {
+        Progress::with_sink(Box::new(Shared(Arc::clone(sink))))
+    }
+
+    /// Sink that records every snapshot it is handed.
+    #[derive(Default)]
+    struct CapturingSink {
+        renders: Mutex<Vec<ProgressSnapshot>>,
+        calls: AtomicUsize,
+    }
+    impl CapturingSink {
+        fn snapshots(&self) -> Vec<ProgressSnapshot> {
+            self.renders.lock().unwrap().clone()
+        }
+        fn call_count(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+    impl Sink for CapturingSink {
+        fn render(&self, snap: ProgressSnapshot) {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.renders.lock().unwrap().push(snap);
+        }
+    }
+
+    #[test]
+    fn null_path_renders_nothing_under_a_tight_loop() {
+        // `null()` installs an inactive NullSink. A tight `inc` loop must only
+        // advance the counter and hit the predicted-not-taken `active` branch —
+        // no render, no panic. This is the smoke test for the null hot path;
+        // the real guarantee is the single `if self.0.active` gate in `inc`.
+        let p = Progress::null();
+        assert!(!p.is_active());
+        for _ in 0..1_000_000 {
+            p.inc(1);
+        }
+        assert_eq!(p.done(), 1_000_000);
+        assert_eq!(p.total(), 0);
+    }
+
+    #[test]
+    fn inactive_handle_never_dispatches_render() {
+        // A null handle stays silent even through set_phase/set_total, which on
+        // an active handle would render. The `active` flag — not sink identity —
+        // is the sole gate.
+        let p = Progress::null();
+        p.set_total(50);
+        p.set_phase("noise");
+        p.inc(10);
+        assert!(!p.is_active());
+        assert_eq!(p.done(), 10);
+        assert_eq!(p.total(), 50);
+        assert_eq!(p.phase(), "noise");
+    }
+
+    #[test]
+    fn inc_and_set_total_track_counters() {
+        let sink = Arc::new(CapturingSink::default());
+        let p = progress_over(&sink);
+        p.set_total(128);
+        p.inc(1);
+        p.inc(3);
+        assert_eq!(p.done(), 4);
+        assert_eq!(p.total(), 128);
+        // Each active inc rendered exactly once (set_total does not render).
+        assert_eq!(sink.call_count(), 2);
+        let snaps = sink.snapshots();
+        assert_eq!(snaps.last().unwrap().done, 4);
+        assert_eq!(snaps.last().unwrap().total, 128);
+    }
+
+    #[test]
+    fn set_phase_is_captured_and_renders() {
+        let sink = Arc::new(CapturingSink::default());
+        let p = progress_over(&sink);
+        p.set_phase("scanning refs");
+        p.inc(1);
+        p.set_phase("writing refs");
+        assert_eq!(p.phase(), "writing refs");
+        let snaps = sink.snapshots();
+        // set_phase -> render, inc -> render, set_phase -> render
+        assert_eq!(snaps.len(), 3);
+        assert_eq!(snaps[0].phase, "scanning refs");
+        assert_eq!(snaps[1].phase, "scanning refs");
+        assert_eq!(snaps[2].phase, "writing refs");
+    }
+
+    #[test]
+    fn a_throttling_sink_sees_every_call_and_decides_itself() {
+        // The substrate hands the sink every active tick; throttling is the
+        // sink's job (COMMIT_TICK_INTERVAL lives in the renderer, not in `inc`).
+        const INTERVAL: usize = 64;
+        #[derive(Default)]
+        struct ThrottlingSink {
+            seen: AtomicUsize,
+            painted: AtomicUsize,
+        }
+        impl Sink for ThrottlingSink {
+            fn render(&self, snap: ProgressSnapshot) {
+                self.seen.fetch_add(1, Ordering::Relaxed);
+                if snap.done.is_multiple_of(INTERVAL) {
+                    self.painted.fetch_add(1, Ordering::Relaxed);
+                }
+            }
+        }
+        let sink = Arc::new(ThrottlingSink::default());
+        let p = progress_over(&sink);
+        for _ in 0..256 {
+            p.inc(1);
+        }
+        // Offered every active tick...
+        assert_eq!(sink.seen.load(Ordering::Relaxed), 256);
+        // ...but only "painted" on the throttle boundary (64,128,192,256).
+        assert_eq!(sink.painted.load(Ordering::Relaxed), 4);
+    }
+
+    #[test]
+    fn clone_shares_counters() {
+        let sink = Arc::new(CapturingSink::default());
+        let p = progress_over(&sink);
+        let q = p.clone();
+        p.inc(2);
+        q.inc(3);
+        assert_eq!(p.done(), 5);
+        assert_eq!(q.done(), 5);
+    }
+}


### PR DESCRIPTION
## What

Deliverable A (A1 + A2) of the progress-substrate plan (`reviews/progress-substrate-and-git-mirror-plan.md`): a generic, near-zero-cost `Progress` handle any long-running command can drive, plus a single terminal renderer. Scoped deliberately to A1 + A2 + refactoring `import_progress` as the proof consumer — **not** the 13-seam thread-through (A4) and **not** the materialize scope (A3); those are follow-ons.

### A1 — substrate in the leaf crate (`crates/objects/src/progress.rs`)
- `Progress(Arc<ProgressInner>)` — cheap `Clone` (Arc bump), `Send + Sync`.
- `trait Sink: Send + Sync { fn render(&self, snap: ProgressSnapshot); }` + `ProgressSnapshot { done, total, phase }`.
- `Progress::null()` (inactive NullSink) / `Progress::with_sink(Box<dyn Sink>)` (active).
- `set_total` / `set_phase` / `inc(n)` / `done` / `total` / `phase` / `snapshot`.

**Leaf-crate placement rationale:** `heddle-objects` is the verified crate that repo/ingest/wire/client all sit above and that never pulls `cli`. Confirmed the direction stays one-way — `progress.rs` has zero `cli` references and **no new deps** were added to `objects/Cargo.toml`. `heddle-core` was not viable (depends on repo/refs → cycle).

**Null-path zero-overhead proof:** `inc(n)` is `done.fetch_add(n, Relaxed)` then `if self.0.active { … }` — a single predicted-not-taken branch on the null handle. No allocation, no syscall, no vtable `render` call when inactive. The vtable is only touched once a real sink is installed. Unit test drives 1M `inc` calls on a null handle asserting counter correctness + no render; a `PanicSink`-style invariant test proves the `active` flag — not sink identity — is the sole gate. Throttling lives in the sink, not `inc`.

### A2 — renderer in `cli` (`crates/cli/src/cli/progress_render.rs`)
- `TerminalSink` implements `Sink`: `IsTerminal`-gated (`\r`-redraw on a TTY, plain dim line when piped, nothing suppressed off-TTY control codes), throttled repaint (every `COMMIT_TICK_INTERVAL=64` completed units **or** on phase change / first / last unit), dim styling via the repo `style` helpers.
- **Single JSON guard (#550):** `progress_for(cli, repo)` checks `should_output_json(...)` **exactly once** at construction — JSON → `Progress::null()`, else → `TerminalSink`. Never re-checked per update. This is the only place `cli` is depended on; `objects` never depends on `cli`.

### Proof consumer — `import_progress` refactored onto the substrate
`ImportProgress` now drives a `Progress` handle instead of its bespoke `enabled`/`io::stdout().is_terminal()`/`\r`-redraw state. The lifted TTY/redraw/dim/finish-line logic lives in `TerminalSink`/`finish_line`. Behavior is identical: same `[n/3]` phased steps, same per-commit throttle (kept in the consumer because the body carries `states_created`, which the generic snapshot doesn't model), same `[done]` accent line, silent under `--output json`. adopt/import call sites unchanged (API preserved).

## Gate evidence (all green, shared target)
- `cargo build --locked --workspace` (default features) ✅
- `cargo build --locked --workspace --all-features` ✅
- `bash scripts/check-no-silent-default-tree-load.sh` ✅ (574 files scanned, clean)
- `cargo test -p heddle-objects` ✅ (6 new `progress::` unit tests: null-path no-op, inc/set_total counters, capturing-sink throttle + phase, clone-shares-counters)
- `cargo test -p heddle-cli import` ✅ (import_progress 3 + progress_render 2)
- `cargo test -p heddle-mount` ✅
- `cargo clippy --workspace --all-targets -- -D warnings` ✅

## Files
- **added:** `crates/objects/src/progress.rs`, `crates/cli/src/cli/progress_render.rs`
- **changed:** `crates/objects/src/lib.rs` (re-export `Progress`/`ProgressSnapshot`/`Sink`), `crates/cli/src/cli/mod.rs` (declare `progress_render`), `crates/cli/src/cli/commands/import_progress.rs` (refactor onto substrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785462505&installation_id=132405951&pr_number=834&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F834&signature=9e51c93138184b6b8b68ed031a68fd04cfd90481602dc4febfe9ab7fc0fdf5dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->