### PR TITLE
fix(fetch): route hosted heddle:// remotes through the hosted-sync path (#839)

### DIFF
--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -48,6 +48,14 @@ struct FetchOutput {
 
 pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<()> {
     let repo = cli.open_repo()?;
+
+    // A git-overlay repo (not a hosted-native repo) fetches through the
+    // git-overlay exporter *except* for remotes that resolve to a hosted
+    // `heddle://` network endpoint. Those must route through the native
+    // hosted-sync path (`fetch_network`), the same way `pull`/`clone` do —
+    // the overlay exporter cannot speak the `heddle://` scheme and hard-errors
+    // on it. `--all` may mix git and hosted remotes, so classify each remote
+    // by its own scheme rather than gating the whole batch on one guard.
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let remotes = if all {
             let configured = repo.refs().list_remotes()?;
@@ -67,43 +75,60 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
             vec![selected]
         };
 
-        for remote_name in &remotes {
+        // Peel off hosted-network remotes; the rest fetch via the overlay
+        // exporter. A repo with a mixed set gets each remote routed by scheme.
+        let (hosted_remotes, overlay_remotes): (Vec<String>, Vec<String>) = remotes
+            .into_iter()
+            .partition(|name| {
+                super::remote::push_target_is_hosted_network(&repo, Some(name.as_str()))
+            });
+
+        for remote_name in &overlay_remotes {
             let mut bridge = GitBridge::new(&repo);
             bridge.fetch(remote_name)?;
         }
 
-        if should_output_json(cli, Some(repo.config())) {
-            println!(
-                "{}",
-                serde_json::to_string(&FetchOutput {
-                    output_kind: "fetch",
-                    remote: if all {
-                        "all".to_string()
+        // If every remote was hosted (or a mix), the hosted ones fall through
+        // to the shared network path below. Only short-circuit here when there
+        // is nothing hosted left to fetch.
+        if hosted_remotes.is_empty() {
+            if should_output_json(cli, Some(repo.config())) {
+                println!(
+                    "{}",
+                    serde_json::to_string(&FetchOutput {
+                        output_kind: "fetch",
+                        remote: if all {
+                            "all".to_string()
+                        } else {
+                            overlay_remotes
+                                .first()
+                                .cloned()
+                                .unwrap_or_else(|| "origin".to_string())
+                        },
+                        ref_scope: Some("branches_and_heddle_notes"),
+                        tags_included: Some(false),
+                        refs_fetched: overlay_remotes.len(),
+                        objects_fetched: 0,
+                        trust: build_repository_verification_state(&repo),
+                    })?
+                );
+            } else {
+                println!(
+                    "{} fetched branches + refs/notes/heddle from {} (tags skipped)",
+                    style::ok_marker(),
+                    if all {
+                        style::bold("all remotes")
                     } else {
-                        remotes
-                            .first()
-                            .cloned()
-                            .unwrap_or_else(|| "origin".to_string())
-                    },
-                    ref_scope: Some("branches_and_heddle_notes"),
-                    tags_included: Some(false),
-                    refs_fetched: remotes.len(),
-                    objects_fetched: 0,
-                    trust: build_repository_verification_state(&repo),
-                })?
-            );
-        } else {
-            println!(
-                "{} fetched branches + refs/notes/heddle from {} (tags skipped)",
-                style::ok_marker(),
-                if all {
-                    style::bold("all remotes")
-                } else {
-                    style::bold(&remotes.join(", "))
-                }
-            );
+                        style::bold(&overlay_remotes.join(", "))
+                    }
+                );
+            }
+            return Ok(());
         }
-        return Ok(());
+
+        // Hosted remotes remain: route them through the network path below.
+        // (Any overlay remotes were already fetched above.)
+        return fetch_via_network(cli, &repo, hosted_remotes, all).await;
     }
 
     let remotes = if all {
@@ -116,6 +141,19 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
         return Err(RecoveryAdvice::remote_name_required_for_fetch().into());
     };
 
+    fetch_via_network(cli, &repo, remotes, all).await
+}
+
+/// Fetch each remote through the resolve → `RemoteTarget` routing (local heddle
+/// sync or hosted `fetch_network`). This is the shared tail for hosted-native
+/// repos and for git-overlay repos whose remote(s) are hosted `heddle://`
+/// endpoints.
+async fn fetch_via_network(
+    cli: &Cli,
+    repo: &Repository,
+    remotes: Vec<String>,
+    all: bool,
+) -> Result<()> {
     let mut total_refs = 0;
     let mut total_objects = 0;
     #[cfg(feature = "client")]
@@ -123,15 +161,15 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
 
     for remote_name in &remotes {
         #[cfg(feature = "client")]
-        let (target, server_key) = resolve_remote_with_key(&repo, Some(remote_name.as_str()))
+        let (target, server_key) = resolve_remote_with_key(repo, Some(remote_name.as_str()))
             .map_err(anyhow::Error::msg)?;
         #[cfg(not(feature = "client"))]
-        let (target, _server_key) = resolve_remote_with_key(&repo, Some(remote_name.as_str()))
+        let (target, _server_key) = resolve_remote_with_key(repo, Some(remote_name.as_str()))
             .map_err(anyhow::Error::msg)?;
 
         match target {
             RemoteTarget::Local(path) => {
-                let (refs, objects) = fetch_local(&repo, &path, remote_name, cli).await?;
+                let (refs, objects) = fetch_local(repo, &path, remote_name, cli).await?;
                 total_refs += refs;
                 total_objects += objects;
             }
@@ -139,7 +177,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
                 #[cfg(feature = "client")]
                 {
                     let (refs, objects) = match fetch_network(
-                        &repo,
+                        repo,
                         FetchNetworkOptions {
                             addr,
                             repo_path: repo_path.as_deref(),
@@ -153,7 +191,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
                     {
                         Ok(result) => result,
                         Err(err) => {
-                            return Err(augment_missing_blob_error(&repo, err));
+                            return Err(augment_missing_blob_error(repo, err));
                         }
                     };
                     total_refs += refs;
@@ -185,7 +223,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
                 tags_included: None,
                 refs_fetched: total_refs,
                 objects_fetched: total_objects,
-                trust: build_repository_verification_state(&repo),
+                trust: build_repository_verification_state(repo),
             })?
         );
     } else {

--- a/crates/cli/src/cli/commands/fetch.rs
+++ b/crates/cli/src/cli/commands/fetch.rs
@@ -27,7 +27,7 @@ use crate::{
     bridge::GitBridge,
     cli::{Cli, should_output_json, style},
     client::LocalSync,
-    remote::{RemoteTarget, resolve_remote_with_key},
+    remote::{RemoteConfig, RemoteTarget, resolve_remote_with_key},
 };
 
 #[derive(Serialize)]
@@ -58,7 +58,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
     // by its own scheme rather than gating the whole batch on one guard.
     if repo.capability() == RepositoryCapability::GitOverlay && !repo.hosted_enabled() {
         let remotes = if all {
-            let configured = repo.refs().list_remotes()?;
+            let configured = all_configured_remotes(&repo)?;
             if configured.is_empty() {
                 vec!["origin".to_string()]
             } else {
@@ -132,7 +132,7 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
     }
 
     let remotes = if all {
-        repo.refs().list_remotes()?
+        all_configured_remotes(&repo)?
     } else if let Some(remote) = remote.as_ref() {
         vec![remote.clone()]
     } else if let Some(default) = resolved_default_remote_name(&repo)? {
@@ -142,6 +142,34 @@ pub async fn cmd_fetch(cli: &Cli, remote: Option<String>, all: bool) -> Result<(
     };
 
     fetch_via_network(cli, &repo, remotes, all).await
+}
+
+/// Enumerate every configured remote for `fetch --all`, unioning the Heddle
+/// remote aliases (`.heddle/remotes.toml`) with the refs backend's
+/// remote-tracking namespaces. `refs().list_remotes()` alone only surfaces
+/// remotes that already have tracking refs, so a freshly-added remote that has
+/// never been fetched — e.g. a hosted `heddle://` remote — was silently dropped
+/// from `--all` (#839). Ordering is deterministic: Heddle-config remotes first
+/// (in config order), then any tracking-only remotes not already listed.
+fn all_configured_remotes(repo: &Repository) -> Result<Vec<String>> {
+    let mut names = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    if let Ok(cfg) = RemoteConfig::open(repo) {
+        for (name, _) in cfg.list() {
+            if seen.insert(name.clone()) {
+                names.push(name);
+            }
+        }
+    }
+
+    for name in repo.refs().list_remotes()? {
+        if seen.insert(name.clone()) {
+            names.push(name);
+        }
+    }
+
+    Ok(names)
 }
 
 /// Fetch each remote through the resolve → `RemoteTarget` routing (local heddle

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -365,6 +365,136 @@ fn git_overlay_push_to_heddle_scheme_routes_to_hosted_not_git_exporter() {
     }
 }
 
+/// Regression (#839): `heddle fetch` on a git-overlay repo whose remote is a
+/// hosted `heddle://` endpoint (with an EMPTY `[hosted]` config block, so
+/// `hosted_enabled() == false`) must route through the native hosted-sync path
+/// (`fetch_network`), NOT the git-overlay exporter. The bug: the entry-gate
+/// guard in `cmd_fetch` lacked pull's `!fetch_uses_hosted_network` term, so a
+/// hosted remote entered the overlay branch and hit `local_path_from_url`,
+/// which HARD-ERRORS on any `heddle://` URL with "...cannot be pushed via the
+/// git-overlay exporter" — a push-flavoured error during a *fetch*.
+///
+/// No live server runs in CI, so we assert on the ROUTING DECISION: a correctly
+/// routed hosted fetch fails on the CONNECTION to the (absent) server, while the
+/// bug fails on the exporter's scheme rejection. We reject that specific
+/// scheme-rejection signature and accept any connection-flavoured failure.
+#[test]
+fn git_overlay_fetch_heddle_scheme_routes_to_hosted_not_git_exporter() {
+    let source = TempDir::new().unwrap();
+
+    // Real git-overlay repo (git init + heddle adopt): capability() is
+    // GitOverlay and `[hosted]` is empty — exactly the buggy predicate's input.
+    git_ok(&["init", "-b", "main"], source.path());
+    git_ok(&["config", "user.name", "Heddle Test"], source.path());
+    git_ok(
+        &["config", "user.email", "heddle@example.com"],
+        source.path(),
+    );
+    std::fs::write(source.path().join("README.md"), "seed\n").unwrap();
+    git_ok(&["add", "README.md"], source.path());
+    git_ok(&["commit", "-m", "seed"], source.path());
+    heddle(&["adopt", "--ref", "main"], Some(source.path())).expect("adopt source Git repo");
+
+    // A hosted heddle:// remote pointing at a port nothing is listening on,
+    // exercised through both invocation forms that resolve to it (inline URL
+    // and named remote), each of which must route identically.
+    let hosted_url = "heddle://127.0.0.1:1/org/repo";
+    heddle(
+        &["remote", "add", "origin", hosted_url],
+        Some(source.path()),
+    )
+    .expect("add hosted origin remote");
+
+    for fetch_arg in [hosted_url, "origin"] {
+        let output = heddle_output(&["fetch", fetch_arg], Some(source.path()))
+            .expect("spawn heddle fetch");
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let combined = format!("{stdout}{stderr}");
+
+        // The exact bug signature: the git-overlay exporter rejecting the
+        // heddle:// scheme. That message must never appear for a fetch — a
+        // fetch that reaches the git-overlay exporter is mis-routed.
+        assert!(
+            !combined.contains("cannot be pushed via the git-overlay exporter"),
+            "`heddle fetch {fetch_arg}` was mis-routed to the git-overlay exporter \
+             (scheme-rejection error) instead of the hosted-sync path.\n\
+             stdout: {stdout}\nstderr: {stderr}"
+        );
+
+        // A hosted fetch that cannot reach a server must fail loudly (the dead
+        // port yields a connection error, or a `client`-feature-less build's
+        // `network_feature_unavailable`) — proving it reached the hosted
+        // transport rather than the overlay exporter's local reconcile.
+        assert!(
+            !output.status.success(),
+            "`heddle fetch {fetch_arg}` to an unreachable hosted remote must fail \
+             loudly (connection error), not succeed.\nstdout: {stdout}\nstderr: {stderr}"
+        );
+    }
+}
+
+/// Regression (#839, `--all` mixed set): `heddle fetch --all` on a git-overlay
+/// repo that has BOTH a local-git remote and a hosted `heddle://` remote must
+/// route each remote by its own scheme — overlay-fetch the git remote, hosted
+/// `fetch_network` the heddle:// remote — not gate the whole batch on a single
+/// classification. The git remote is reachable (a real bare repo) so the batch
+/// gets as far as the hosted remote, which then fails on its dead-port
+/// connection — NOT on the overlay exporter's scheme rejection.
+#[test]
+fn git_overlay_fetch_all_routes_mixed_remotes_per_scheme() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source.git");
+    let work = temp.path().join("work");
+    let src = SleyRepository::init_bare(&source).expect("init bare source");
+
+    let tree = git_tree_with_file(&src, "tracked.txt", b"one\n");
+    git_commit_with_tree(&src, Some("refs/heads/main"), tree, "one", &[]);
+    std::fs::write(source.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+    let source_arg = source.to_str().expect("source path utf8");
+    let work_arg = work.to_str().expect("work path utf8");
+    // Clone from the local git remote — `origin` now points at the bare repo.
+    heddle(&["clone", source_arg, work_arg], Some(temp.path())).expect("clone succeeds");
+
+    // Add a SECOND, hosted heddle:// remote alongside the git `origin`.
+    let hosted_url = "heddle://127.0.0.1:1/org/repo";
+    heddle(&["remote", "add", "hosted", hosted_url], Some(&work))
+        .expect("add hosted remote");
+
+    let output = heddle_output(&["fetch", "--all"], Some(&work)).expect("spawn heddle fetch --all");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    // The hosted remote in the batch must never be routed to the git-overlay
+    // exporter — that scheme-rejection error is the mis-route signature.
+    assert!(
+        !combined.contains("cannot be pushed via the git-overlay exporter"),
+        "`heddle fetch --all` mis-routed the hosted remote to the git-overlay \
+         exporter instead of the hosted-sync path.\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // The git remote is reachable but the hosted one is not, so the overall
+    // command must fail loudly on the hosted connection rather than silently
+    // succeed or reject the whole batch on the exporter scheme error.
+    assert!(
+        !output.status.success(),
+        "`heddle fetch --all` with an unreachable hosted remote in the set must \
+         fail loudly (hosted connection error).\nstdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Regression guard: the reachable git remote was still fetched — its
+    // remote-tracking ref exists — proving the hosted failure did not skip the
+    // git remote's overlay fetch.
+    assert_eq!(
+        git_stdout_trimmed(&["rev-parse", "refs/remotes/origin/main"], &work),
+        git_stdout_trimmed(&["rev-parse", "refs/heads/main"], &source),
+        "the git remote in a mixed --all set must still be overlay-fetched"
+    );
+}
+
 #[test]
 fn test_cli_remote_show_missing_uses_typed_advice() {
     let temp = TempDir::new().unwrap();


### PR DESCRIPTION
Closes #839. `cmd_fetch`'s entry guard was missing the hosted-network bypass that `cmd_pull` has, so a git-overlay-from-hosted repo routed fetch into the git-overlay exporter which hard-errors on `heddle://`. Adds the `push_target_is_hosted_network` bypass (per-remote for `--all`), routing hosted fetches through the existing `fetch_network` path. PR opened by orchestrator (builder completed the fix + push but exited in monitor-wait without creating the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785466608&installation_id=132405951&pr_number=840&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F840&signature=dca39eb7c64599eeafa3d04b25b1780a4fb9a8417993e6659c0af3ba8133a295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->