### PR TITLE
fix(discuss): carry discussions forward on non-capture state advances + discuss show --state (#836)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_discuss.rs
+++ b/crates/cli/src/cli/cli_args/commands_discuss.rs
@@ -91,4 +91,9 @@ pub struct DiscussListArgs {
 #[derive(Clone, Debug, Args)]
 pub struct DiscussShowArgs {
     pub discussion_id: String,
+    /// Resolve the discussion against this state instead of HEAD. Use when a
+    /// discussion lives on a prior state (found via `discuss list --state <s>`)
+    /// and is no longer on HEAD.
+    #[arg(long)]
+    pub state: Option<String>,
 }

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -334,6 +334,19 @@ pub(crate) fn build_context_state(
     if let Some(provenance) = head_state.provenance {
         new_state = new_state.with_provenance(provenance);
     }
+    // #836: carry discussions forward on a non-capture (annotation/context)
+    // state advance. `context set` does NOT change the tree, so the parent's
+    // discussion anchors are still valid verbatim — no re-anchoring / symbol
+    // analysis needed (that's the capture path's job via
+    // compute_and_persist_discussion_anchor_travel). Without this, HEAD
+    // advances to a discussion-less state and `discuss show <id>` (HEAD-only)
+    // can no longer resolve the discussion. `discussions` is a side-band
+    // pointer NOT part of the state hash (see state_core.rs
+    // `w1_tail_fields_are_not_part_of_state_hash`), so this does NOT change
+    // `change_id`.
+    if let Some(discussions) = head_state.discussions {
+        new_state = new_state.with_discussions(discussions);
+    }
     Ok(new_state)
 }
 
@@ -568,5 +581,71 @@ mod tests {
             } => {}
             other => panic!("expected unchanged scope, got {other:?}"),
         }
+    }
+
+    /// #836 root cause: a non-capture state advance (`context set`) built by
+    /// `build_context_state` MUST carry the parent's `discussions` side-band
+    /// pointer forward. `context set` does not change the tree, so the anchors
+    /// stay valid verbatim — no re-anchoring. Before the fix, `State::new`
+    /// initialised `discussions: None` and nothing copied it, so HEAD advanced
+    /// to a discussion-less state and `discuss show` (HEAD-only) could no
+    /// longer resolve the discussion.
+    #[test]
+    fn build_context_state_carries_discussions_forward() {
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+
+        let tree_hash = repo.store().put_tree(&Tree::new()).expect("put tree");
+        let attribution = Attribution::human(Principal::new("Test", "test@example.com"));
+        let discussions_hash = ContentHash::compute(b"discussions-blob-836");
+        let head_state = State::new(tree_hash, vec![], attribution)
+            .with_change_id(ChangeId::generate())
+            .with_discussions(discussions_hash);
+
+        let advanced =
+            build_context_state(&repo, &head_state, None, "advance".to_string()).expect("build");
+
+        assert_eq!(
+            advanced.discussions,
+            Some(discussions_hash),
+            "discussions side-band pointer must ride forward on a context advance"
+        );
+        assert_eq!(
+            advanced.tree, head_state.tree,
+            "context set does not change the tree, so anchors stay valid verbatim"
+        );
+    }
+
+    /// The change_id-unchanged guarantee that de-risks the carry-forward:
+    /// `discussions` is a side-band pointer NOT part of the state hash
+    /// (state_core.rs `w1_tail_fields_are_not_part_of_state_hash`). Carrying it
+    /// forward must NOT perturb the advanced state's `change_id` — otherwise it
+    /// would diverge the oplog / break "same state?" checks. Proven here by
+    /// clearing the discussions on the built state and confirming the hash is
+    /// byte-identical.
+    #[test]
+    fn carried_discussions_do_not_change_the_state_hash() {
+        let temp = tempfile::TempDir::new().expect("create temp dir");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+
+        let tree_hash = repo.store().put_tree(&Tree::new()).expect("put tree");
+        let attribution = Attribution::human(Principal::new("Test", "test@example.com"));
+        let head_state = State::new(tree_hash, vec![], attribution)
+            .with_change_id(ChangeId::generate())
+            .with_discussions(ContentHash::compute(b"discussions-blob-836"));
+
+        let with_discussions =
+            build_context_state(&repo, &head_state, None, "advance".to_string()).expect("build");
+        assert!(with_discussions.discussions.is_some());
+
+        // The same built state with discussions stripped must hash identically:
+        // the side-band pointer is not part of state identity.
+        let mut without_discussions = with_discussions.clone();
+        without_discussions.discussions = None;
+        assert_eq!(
+            with_discussions.compute_hash(),
+            without_discussions.compute_hash(),
+            "discussions carry-forward must not perturb the state hash / change_id"
+        );
     }
 }

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -251,9 +251,17 @@ async fn run_list(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussListArg
 }
 
 async fn run_show(cli: &Cli, svc: &LocalDiscussionService, args: &DiscussShowArgs) -> Result<()> {
+    // Empty state_id = HEAD (the default). An explicit `--state` resolves the
+    // discussion against a prior state (#836) via the canonical resolver, so
+    // short/full ids and marker names all work.
+    let state_id = match args.state.as_deref() {
+        Some(s) => resolve_state(cli, Some(s))?,
+        None => Vec::new(),
+    };
     let req = GetDiscussionRequest {
         repo_path: String::new(),
         discussion_id: args.discussion_id.clone(),
+        state_id,
     };
     let resp = svc
         .get_discussion(tonic::Request::new(req))

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -276,6 +276,8 @@ mod context_recovery_advice;
 mod current_context_advice;
 #[path = "cli_integration/diff_patch_conformance.rs"]
 mod diff_patch_conformance;
+#[path = "cli_integration/discuss_carry_forward.rs"]
+mod discuss_carry_forward;
 #[path = "cli_integration/doctor_docs.rs"]
 mod doctor_docs;
 #[path = "cli_integration/error_envelope_lint.rs"]

--- a/crates/cli/tests/cli_integration/discuss_carry_forward.rs
+++ b/crates/cli/tests/cli_integration/discuss_carry_forward.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+//! #836: a discussion must remain reachable by `discuss show <id>` after the
+//! state advances via a NON-capture path (`context set` / annotations).
+//!
+//! Root cause: `build_context_state` advanced HEAD via `State::new(...)` which
+//! zeroes `discussions`, and nothing copied the parent's discussions pointer
+//! forward — so HEAD became discussion-less and `discuss show` (HEAD-only)
+//! could no longer resolve the thread. The capture/snapshot path already
+//! carried discussions forward (anchor travel); this closes the gap on the
+//! annotation path. See also the `--state` recoverability safety net.
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::heddle;
+
+/// Set up an initialised repo with one captured state so `discuss open` has a
+/// real HEAD to anchor against.
+fn setup() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("main.rs"), "fn main() {}\n").unwrap();
+    std::fs::write(temp.path().join("other.rs"), "fn f() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+    temp
+}
+
+fn json(out: &str) -> Value {
+    serde_json::from_str(out.trim()).expect("valid JSON output")
+}
+
+/// The core repro from the issue: open a discussion, advance the state with an
+/// unrelated `context set`, then `discuss show <id>` (HEAD default) must still
+/// find it — and `discuss list` (HEAD default) must still surface it.
+#[test]
+fn discussion_survives_context_set_advance() {
+    let temp = setup();
+    let dir = Some(temp.path());
+
+    let opened = json(
+        &heddle(
+            &["--output", "json", "discuss", "open", "main.rs", "main", "review q"],
+            dir,
+        )
+        .unwrap(),
+    );
+    let id = opened["id"].as_str().unwrap().to_string();
+
+    // Advance HEAD via a non-capture (annotation) path, touching a DIFFERENT
+    // file than the discussion anchor — exactly the issue's scenario.
+    heddle(
+        &[
+            "context", "set", "--path", "other.rs", "--scope", "symbol:f", "--kind", "rationale",
+            "-m", "note",
+        ],
+        dir,
+    )
+    .unwrap();
+
+    // Was: "Error: ... discussion <id> not found". Now succeeds against HEAD.
+    let shown = json(
+        &heddle(&["--output", "json", "discuss", "show", &id], dir)
+            .expect("discuss show must resolve the discussion on the advanced HEAD"),
+    );
+    assert_eq!(shown["id"].as_str(), Some(id.as_str()));
+
+    // HEAD-default `discuss list` must still surface the carried-forward thread.
+    let listed = json(&heddle(&["--output", "json", "discuss", "list"], dir).unwrap());
+    let ids: Vec<&str> = listed["discussions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|d| d["id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&id.as_str()),
+        "HEAD-default discuss list must include the carried-forward discussion, got {ids:?}"
+    );
+}
+
+/// `discuss list --state <newHEAD>` must show the discussion attached to the
+/// new HEAD state (proves the carry-forward actually persisted on the advanced
+/// state's blob, not just that `show` fell back somewhere).
+#[test]
+fn advanced_head_state_carries_the_discussion() {
+    let temp = setup();
+    let dir = Some(temp.path());
+
+    let opened = json(
+        &heddle(
+            &["--output", "json", "discuss", "open", "main.rs", "main", "q"],
+            dir,
+        )
+        .unwrap(),
+    );
+    let id = opened["id"].as_str().unwrap().to_string();
+
+    heddle(
+        &[
+            "context", "set", "--path", "other.rs", "--scope", "symbol:f", "--kind", "rationale",
+            "-m", "note",
+        ],
+        dir,
+    )
+    .unwrap();
+
+    // Find the new HEAD anchor from `discuss list` (default = HEAD) and re-query
+    // it explicitly by state — it must resolve there.
+    let head_listed = json(&heddle(&["--output", "json", "discuss", "list"], dir).unwrap());
+    let head_state = head_listed["discussions"][0]["opened_against_state"]
+        .as_str()
+        .expect("discussion carries its (traveled) anchor state")
+        .to_string();
+
+    let by_state = json(
+        &heddle(
+            &["--output", "json", "discuss", "list", "--state", &head_state],
+            dir,
+        )
+        .unwrap(),
+    );
+    let ids: Vec<&str> = by_state["discussions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|d| d["id"].as_str())
+        .collect();
+    assert!(
+        ids.contains(&id.as_str()),
+        "per-state list on the advanced HEAD must include the discussion, got {ids:?}"
+    );
+}
+
+/// Part B safety net: `discuss show <id> --state <priorState>` resolves a
+/// discussion living on a specific prior state, independent of HEAD.
+#[test]
+fn discuss_show_state_flag_resolves_on_prior_state() {
+    let temp = setup();
+    let dir = Some(temp.path());
+
+    let opened = json(
+        &heddle(
+            &["--output", "json", "discuss", "open", "main.rs", "main", "q"],
+            dir,
+        )
+        .unwrap(),
+    );
+    let id = opened["id"].as_str().unwrap().to_string();
+    // The state the discussion was originally opened against.
+    let prior_state = opened["opened_against_state"].as_str().unwrap().to_string();
+
+    heddle(
+        &[
+            "context", "set", "--path", "other.rs", "--scope", "symbol:f", "--kind", "rationale",
+            "-m", "note",
+        ],
+        dir,
+    )
+    .unwrap();
+
+    let shown = json(
+        &heddle(
+            &["--output", "json", "discuss", "show", &id, "--state", &prior_state],
+            dir,
+        )
+        .expect("discuss show --state must resolve a discussion on the named prior state"),
+    );
+    assert_eq!(shown["id"].as_str(), Some(id.as_str()));
+}
+
+/// `discuss append` must still work after a `context set` advance — it shares
+/// the HEAD-blob assumption, so if the drop broke it, Part A fixes it too.
+#[test]
+fn discuss_append_works_after_context_set_advance() {
+    let temp = setup();
+    let dir = Some(temp.path());
+
+    let opened = json(
+        &heddle(
+            &["--output", "json", "discuss", "open", "main.rs", "main", "first"],
+            dir,
+        )
+        .unwrap(),
+    );
+    let id = opened["id"].as_str().unwrap().to_string();
+
+    heddle(
+        &[
+            "context", "set", "--path", "other.rs", "--scope", "symbol:f", "--kind", "rationale",
+            "-m", "note",
+        ],
+        dir,
+    )
+    .unwrap();
+
+    let appended = json(
+        &heddle(
+            &["--output", "json", "discuss", "append", &id, "second"],
+            dir,
+        )
+        .expect("discuss append must find the discussion on HEAD after the advance"),
+    );
+    let turns = appended["turns"].as_array().unwrap();
+    assert_eq!(turns.len(), 2, "append should add a second turn: {appended}");
+    assert_eq!(turns[1]["body"].as_str(), Some("second"));
+}

--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -496,10 +496,18 @@ impl DiscussionService for LocalDiscussionService {
         if req.discussion_id.is_empty() {
             return Err(Status::invalid_argument("discussion_id is required"));
         }
-        // TODO(W2-followup): scan all states / oplog instead of HEAD-only.
+        // Default: HEAD. Optional `state_id` (#836) resolves the discussion
+        // against a specific prior state — the bounded, cheap recoverability
+        // safety net when a discussion no longer lives on HEAD.
+        // TODO(W2-followup): scan all states / oplog instead of HEAD-only when
+        // no explicit state is given.
         let repo = self.inner.repo();
-        let head = head_state(repo)?;
-        let blob = decode_blob_for_state(repo, &head)?;
+        let state = if req.state_id.is_empty() {
+            head_state(repo)?
+        } else {
+            load_state(repo, &req.state_id)?.1
+        };
+        let blob = decode_blob_for_state(repo, &state)?;
         let discussion = blob
             .discussions
             .iter()

--- a/crates/grpc/proto/heddle/v1/discussion.proto
+++ b/crates/grpc/proto/heddle/v1/discussion.proto
@@ -96,4 +96,8 @@ message ListDiscussionsResponse {
 message GetDiscussionRequest {
   string repo_path = 1;
   string discussion_id = 2;
+  // Optional: resolve the discussion against this specific state instead of
+  // HEAD. Empty = HEAD (the default). Lets a discussion living on a prior
+  // state be recovered by id + state (#836) without a full cross-state scan.
+  bytes state_id = 3;
 }


### PR DESCRIPTION
Closes #836.

## Root cause
A discussion opened with `discuss open` became unrecoverable via `discuss show <id>` once HEAD advanced through a **non-capture** path (`context set` / annotations). `build_context_state` (`crates/cli/src/cli/commands/context/mod.rs`) advanced HEAD via `State::new(...)` — which zeroes `discussions` — and copied `context`/`provenance` forward but **never** the `discussions` side-band pointer. So `context set` advanced HEAD to a discussion-less state, and `get_discussion` (HEAD-only) could no longer resolve the thread. The capture/snapshot path already carried discussions forward via anchor travel (`compute_and_persist_discussion_anchor_travel`); this closed the gap only on the snapshot path, not the annotation path — contradicting the help text's "anchors travel on subsequent state mutations".

## Part A — root cause (durable)
In `build_context_state`, copy `head_state.discussions` **verbatim** onto the advanced state via `with_discussions`. `context set` does not change the tree, so the parent's anchors stay valid — no re-anchoring / symbol analysis, works in default features.

`State::new` audit: the only production paths that build a tree-unchanged author state from a parent are the capture path (already handled via anchor travel) and this context/annotation path (`build_context_state`, feeding all four `context_mutate.rs` advances). `rebase`/`collapse` rewrite the **tree**, so a verbatim discussion copy would be wrong there — those belong to the anchor-travel domain and are a distinct, pre-existing concern, deliberately out of scope. `state_writer.rs` reconstructs a State from a git commit (discussions aren't a git concept). No other production advance site drops discussions.

## Part B — safety net (cheap recoverability)
Added `discuss show --state <state>`, mirroring `discuss list --state`, so a discussion living on a prior state is recoverable by id + state (new optional `state_id` field on `GetDiscussionRequest`; empty = HEAD). The pre-existing HEAD-agnostic oplog-scan `// TODO(W2-followup)` is left in place — no scope creep.

## change_id-unchanged guarantee
`discussions` is a side-band `ContentHash` **not part of the state hash** (`state_core.rs` `w1_tail_fields_are_not_part_of_state_hash`; `update_hash_core`/`update_hash_fidelity` never touch it). Copying it forward does **not** change `change_id` — no re-hashing, no oplog divergence, no blob-store format change. Asserted by a unit test.

## Test evidence
Unit (`crates/cli/src/cli/commands/context/mod.rs`):
- `build_context_state_carries_discussions_forward` — advanced state carries the parent's discussions; tree unchanged.
- `carried_discussions_do_not_change_the_state_hash` — the carried pointer does not perturb `compute_hash()`.

Integration (`crates/cli/tests/cli_integration/discuss_carry_forward.rs`):
- `discussion_survives_context_set_advance` — the issue repro: open → `context set` (unrelated file) → `discuss show <id>` now SUCCEEDS + HEAD-default `discuss list` shows it.
- `advanced_head_state_carries_the_discussion` — per-state list on the new HEAD finds it.
- `discuss_show_state_flag_resolves_on_prior_state` — Part B `--state` resolves on a prior state.
- `discuss_append_works_after_context_set_advance` — `append` also works post-advance (shared HEAD-blob assumption).

## Gates (all green)
`cargo build --locked --workspace` (default + `--all-features`), `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-cli discuss`/`context`, `cargo test -p heddle-mount`, `cargo test -p heddle-daemon discussion`, `cargo clippy --workspace --all-targets -- -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)