### PR TITLE
feat(progress): thread Progress through the parallel materialization seam (#844)

### DIFF
--- a/crates/cli/src/cli/commands/goto.rs
+++ b/crates/cli/src/cli/commands/goto.rs
@@ -14,6 +14,7 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::{
+    cli::progress_render::{clear_line, progress_for},
     cli::{Cli, should_output_json},
     config::UserConfig,
 };
@@ -65,6 +66,14 @@ pub fn cmd_switch_state_checkout(cli: &Cli, target: String, force: bool) -> Resu
 
     let target_state = require_resolved_state(&repo, &target_id)?;
 
+    // Install a live progress line for the checkout's tree materialization. The
+    // JSON guard (#550) is applied once here: under `--output json` / non-TTY
+    // this is a null handle that renders nothing, so machine output is
+    // byte-unchanged. The materialize seam drives `inc` per written file.
+    let progress = progress_for(cli, &repo);
+    progress.set_phase("checking out files");
+    repo.set_progress(progress.clone());
+
     if current_worktree_verified_clean {
         repo.goto_verified_clean(&target_id)?;
     } else if force {
@@ -72,6 +81,7 @@ pub fn cmd_switch_state_checkout(cli: &Cli, target: String, force: bool) -> Resu
     } else {
         repo.goto(&target_id)?;
     }
+    clear_line(&progress);
 
     let output = SwitchOutput {
         output_kind: "thread_switch",

--- a/crates/cli/src/cli/progress_render.rs
+++ b/crates/cli/src/cli/progress_render.rs
@@ -85,6 +85,24 @@ impl TerminalSink {
             || snap.done.is_multiple_of(COMMIT_TICK_INTERVAL)
     }
 
+    /// Format the line to paint: the phase label, plus a live `(done/total,
+    /// pct%)` suffix when the snapshot carries a real count.
+    ///
+    /// A consumer that pre-formats its own counts into the phase string (the
+    /// import flow) never advances `done`, so `done == 0` and no suffix is
+    /// appended — its lines paint verbatim. A count-driven seam (tree
+    /// materialization) leaves the phase a bare label and increments `done`, so
+    /// the suffix supplies the live count. This is the single rule that lets one
+    /// renderer serve both styles without double-counting.
+    fn format_line(snap: &ProgressSnapshot) -> String {
+        if snap.done > 0 && snap.total > 0 {
+            let pct = snap.done.saturating_mul(100) / snap.total;
+            format!("{} ({}/{}, {}%)", snap.phase, snap.done, snap.total, pct)
+        } else {
+            snap.phase.clone()
+        }
+    }
+
     fn paint(line: &str) {
         if io::stdout().is_terminal() {
             // `\r` to column 0, `\x1b[K` clears to end of line so a shorter line
@@ -99,8 +117,9 @@ impl TerminalSink {
 
 impl Sink for TerminalSink {
     fn render(&self, snap: ProgressSnapshot) {
-        // The phase label carries the fully-formatted line the caller wants
-        // painted; the counters drive throttling. An empty phase is a no-op.
+        // The phase label is the human line; the counters drive throttling and
+        // (for count-driven seams) the live `(done/total)` suffix. An empty
+        // phase is a no-op.
         if snap.phase.is_empty() {
             return;
         }
@@ -108,9 +127,24 @@ impl Sink for TerminalSink {
         if !Self::should_repaint(&state, &snap) {
             return;
         }
-        Self::paint(&snap.phase);
+        Self::paint(&Self::format_line(&snap));
         state.last_phase = Some(snap.phase);
         state.painted = true;
+    }
+}
+
+/// Clear the live progress line without printing a completion message. No-op
+/// for a null (inactive) handle or off a TTY (where each tick was already a
+/// standalone line, not a `\r`-overwritten one). Used by consumers that print
+/// their own final output right after the operation (e.g. `switch` printing
+/// `Now at: …`) and just need the transient line erased first.
+pub(crate) fn clear_line(progress: &Progress) {
+    if !progress.is_active() {
+        return;
+    }
+    if io::stdout().is_terminal() {
+        print!("\r\x1b[K");
+        io::stdout().flush().ok();
     }
 }
 
@@ -148,6 +182,44 @@ mod tests {
         // Same phase, off-boundary count -> no repaint.
         state.last_phase = Some("new".into());
         assert!(!TerminalSink::should_repaint(&state, &snap));
+    }
+
+    #[test]
+    fn count_driven_snapshot_gets_a_live_suffix() {
+        // A materialize-style seam leaves the phase a bare label and advances
+        // `done`; the renderer supplies the live `(done/total, pct%)` suffix.
+        let snap = ProgressSnapshot {
+            done: 32,
+            total: 128,
+            phase: "checking out files".into(),
+        };
+        assert_eq!(
+            TerminalSink::format_line(&snap),
+            "checking out files (32/128, 25%)"
+        );
+    }
+
+    #[test]
+    fn preformatted_line_without_a_count_paints_verbatim() {
+        // The import flow pre-formats its own counts into the phase and never
+        // advances `done` (stays 0), so no suffix is appended and the line is
+        // painted exactly as given — no double-counting.
+        let snap = ProgressSnapshot {
+            done: 0,
+            total: 3,
+            phase: "[2/3] importing commits... 64/128 inspected (50%)".into(),
+        };
+        assert_eq!(
+            TerminalSink::format_line(&snap),
+            "[2/3] importing commits... 64/128 inspected (50%)"
+        );
+        // A count with an unknown total (total == 0) also gets no suffix.
+        let counting = ProgressSnapshot {
+            done: 500,
+            total: 0,
+            phase: "scanning".into(),
+        };
+        assert_eq!(TerminalSink::format_line(&counting), "scanning");
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -1017,3 +1017,32 @@ fn purge_list_envelope_includes_recent_apply() {
         "purge list after purge apply must show at least one entry: {value}"
     );
 }
+
+/// #844 suppression proof: `switch` installs a live tree-materialization
+/// progress line, but the JSON guard (#550) makes that handle null under
+/// `--output json`, so stdout is byte-clean — exactly the one `thread_switch`
+/// envelope with no progress lines leaked. The test harness pipes stdout (no
+/// TTY); had the guard regressed to an active sink, the non-TTY renderer would
+/// `println!` extra dim lines onto stdout and the single-line assertion below
+/// would fail. This is the "`--output json` byte output is UNCHANGED" DoD test.
+#[test]
+fn switch_output_json_is_byte_clean_of_progress() {
+    let temp = init_and_capture();
+    capture_second(&temp);
+
+    // Switch back to the first state: the worktree really changes, so
+    // materialization has files to write and would drive the progress line if
+    // it were active.
+    let stdout = heddle(&["--output", "json", "switch", "HEAD~1"], Some(temp.path()))
+        .expect("switch --output json");
+
+    let non_empty: Vec<&str> = stdout.lines().filter(|line| !line.trim().is_empty()).collect();
+    assert_eq!(
+        non_empty.len(),
+        1,
+        "json stdout must be exactly one line (no progress leak), got: {stdout:?}"
+    );
+    let value: Value = serde_json::from_str(non_empty[0])
+        .unwrap_or_else(|err| panic!("switch json stdout not JSON: {err}\n  line: {}", non_empty[0]));
+    assert_output_kind(&value, "thread_switch");
+}

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -68,6 +68,7 @@ pub use context_suggestions::{
 };
 pub use objects::object::DiffKind;
 use objects::{
+    Progress,
     error::{HeddleError, Result},
     fs_atomic::write_file_atomic,
     lock::{RepoLock, RepositoryLockExt},
@@ -307,6 +308,14 @@ where
     shallow: RwLock<ShallowInfo>,
     blob_hydrator: RwLock<Option<Arc<dyn BlobHydrator>>>,
     git_overlay_repo: RwLock<Option<SleyRepository>>,
+    /// Live progress handle driven by long-running operations (tree
+    /// materialization, and future streaming seams). Defaults to
+    /// [`Progress::null`] — a no-op that costs one relaxed atomic add per
+    /// update — so the common "no one is watching" path (piped output,
+    /// `--output json`, library use) pays nothing. A CLI command installs a
+    /// real, TTY-rendering handle via [`Repository::set_progress`] before
+    /// driving an operation. Set-after-construction like `blob_hydrator`.
+    progress: RwLock<Progress>,
 }
 
 impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repository<R, O, S> {
@@ -348,6 +357,7 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
             shallow: RwLock::new(shallow),
             blob_hydrator: RwLock::new(None),
             git_overlay_repo: RwLock::new(None),
+            progress: RwLock::new(Progress::null()),
         }
     }
 
@@ -569,6 +579,7 @@ impl Repository {
             shallow: RwLock::new(ShallowInfo::load(&heddle_dir)?),
             blob_hydrator: RwLock::new(None),
             git_overlay_repo: RwLock::new(None),
+            progress: RwLock::new(Progress::null()),
         })
     }
 
@@ -2398,6 +2409,22 @@ impl Repository {
     /// The currently registered hydrator, if any.
     pub fn blob_hydrator(&self) -> Option<Arc<dyn BlobHydrator>> {
         self.blob_hydrator.read_or_poisoned().clone()
+    }
+
+    /// Install a live [`Progress`] handle. Long-running operations on this
+    /// repository (tree materialization today) drive it; the caller — the CLI —
+    /// installs a TTY-rendering handle here before the operation and reads the
+    /// same handle back to paint a completion line. Passing [`Progress::null`]
+    /// (the default) disables rendering. The handle is a cheap `Arc` clone, so
+    /// it can be shared across the parallel-materialization worker threads.
+    pub fn set_progress(&self, progress: Progress) {
+        *self.progress.write_or_poisoned() = progress;
+    }
+
+    /// The currently installed progress handle (a cheap clone). Defaults to
+    /// [`Progress::null`] until [`Repository::set_progress`] is called.
+    pub fn progress(&self) -> Progress {
+        self.progress.read_or_poisoned().clone()
     }
 
     fn partial_fetch_metadata(&self) -> repository_partial_fetch::PartialFetchMetadataManager {

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -472,6 +472,7 @@ impl Repository {
             let mut seeded = Vec::with_capacity(writes.len());
             for write in writes {
                 seeded.push(self.materialize_write_op(write, &context)?);
+                progress.inc(1);
             }
             Ok((worker_count, seeded))
         } else {
@@ -480,10 +481,12 @@ impl Repository {
                 let mut workers = Vec::new();
                 let context = &context;
                 for chunk in writes.chunks(chunk_size) {
+                    let progress = progress.clone();
                     workers.push(scope.spawn(move || -> Result<Vec<SeededWorktreeEntry>> {
                         let mut seeded = Vec::with_capacity(chunk.len());
                         for write in chunk {
                             seeded.push(self.materialize_write_op(write, context)?);
+                            progress.inc(1);
                         }
                         Ok(seeded)
                     }));

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -458,6 +458,16 @@ impl Repository {
         // dedicated probe.
         let context = MaterializationContext::new();
 
+        // Drive the repository's live progress handle: one `inc` per
+        // materialized write op. On the common null handle this is a relaxed
+        // atomic add plus a predicted-not-taken branch (no render). When a CLI
+        // command has installed a real sink, this paints a live "checking out
+        // files (n/total)" line. The handle is a cheap `Arc` clone, so it
+        // survives the `thread::scope` seam below — each worker gets its own
+        // clone and increments the shared atomic counter.
+        let progress = self.progress();
+        progress.set_total(writes.len());
+
         let result = if worker_count <= 1 {
             let mut seeded = Vec::with_capacity(writes.len());
             for write in writes {
@@ -941,6 +951,67 @@ mod tests {
         MaterializationContext, Repository, WorktreeWriteOp, classify_clone_failure,
         materialization_worker_count, remove_materialized_leaf,
     };
+
+    /// The generic [`Progress`](objects::Progress) handle installed on a
+    /// repository must survive the `thread::scope` parallel-materialization seam:
+    /// a single shared `Arc` handle, cloned into each worker, whose atomic
+    /// counter ends at exactly the file count no matter how the work was split
+    /// across threads. This is the load-bearing acceptance criterion for #844.
+    #[test]
+    fn progress_handle_survives_parallel_materialization_seam() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use objects::{Progress, ProgressSnapshot, Sink};
+
+        /// Active sink that just counts render calls, proving the active path
+        /// ran concurrently across workers without panicking.
+        struct CountingSink(Arc<AtomicUsize>);
+        impl Sink for CountingSink {
+            fn render(&self, _snap: ProgressSnapshot) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+
+        // Well over MATERIALIZE_PARALLEL_THRESHOLD (32): on any multi-core host
+        // this exercises the `thread::scope` branch; on a single core it
+        // degrades to the serial branch and the counter assertion still holds.
+        let file_count = 256usize;
+        for i in 0..file_count {
+            std::fs::write(
+                temp_dir.path().join(format!("seam-{i:04}.txt")),
+                format!("seam payload {i} {}", "y".repeat(48)),
+            )
+            .unwrap();
+        }
+        let state = repo.snapshot(Some("seam".to_string()), None).unwrap();
+        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
+
+        let render_count = Arc::new(AtomicUsize::new(0));
+        let progress = Progress::with_sink(Box::new(CountingSink(render_count.clone())));
+        repo.set_progress(progress.clone());
+
+        let dest = temp_dir.path().join("materialized");
+        repo.materialize_tree(&tree, &dest).unwrap();
+
+        // Every write op incremented the shared counter exactly once, across
+        // however many worker threads split the batch.
+        assert_eq!(
+            progress.done(),
+            file_count,
+            "shared progress counter must equal the file count after the parallel seam"
+        );
+        assert_eq!(progress.total(), file_count, "total set from the write batch");
+        // The active handle rendered at least once through the seam (throttled,
+        // so not once-per-file) — proving the sink is driven across threads.
+        assert!(
+            render_count.load(Ordering::Relaxed) > 0,
+            "active sink should have rendered during materialization"
+        );
+    }
 
     /// heddle#571 (round 2, finding 2): a clone syscall that raises ENOENT
     /// because the loose source vanished AFTER the pre-check (TOCTOU) must


### PR DESCRIPTION
## Summary

- Threads the generic `Progress` substrate (shipped in #834 as A1+A2) through the one acceptance criterion #834 deferred: the `thread::scope` **parallel-materialization seam**. `Repository` now carries a set-after-construction `Progress` handle (mirrors the existing `blob_hydrator` idiom); `materialize_write_ops_seeded` sets the total and `inc`s the shared `Arc` counter once per written file, cloning the cheap handle into each worker so it survives the seam. This one chokepoint covers checkout/switch, adopt, clone, merge, rebase, and cherry-pick materialization at once (plan §A.6).
- Null handle (the default, and every `--output json` / non-TTY / library path) stays near-zero-cost: one relaxed atomic add plus a predicted-not-taken branch, no render.
- `TerminalSink` now appends a live `(done/total, pct%)` suffix when a snapshot carries a real count, so count-driven seams (materialization) show progress while pre-formatted consumers (import, which never advances `done`) still paint verbatim — one renderer, no double-counting. Adds `clear_line` for callers that print their own final output.
- `heddle switch` installs a JSON-guarded (`should_output_json`, #550 single guard) progress handle and clears the line before printing its result — the live-line demo of the new seam.

### Scope note
#844's substrate ACs (`Progress` Arc handle, `Sink` trait in the leaf `heddle-objects` crate, single JSON guard, `\r` TTY renderer) all landed in **#834**. This PR completes the remaining, specifically-named AC — *"must survive the `thread::scope` parallel-materialization seam (handle shared across worker threads)"* — and drives one demo command. The full A4 seam-out of the non-materialize streaming paths (push/pull/gc) remains a follow-on, consistent with how #834 split this issue.

Closes HeddleCo/heddle#844

## Red commit
`bdcd2f55` — seam counter unwired, so `progress.done()` is 0 where the test expects 256.

## Test evidence
```
test repository::repository_materialization::tests::progress_handle_survives_parallel_materialization_seam ... ok
test result: ok. 29 passed; 0 failed (heddle-repo materialization suite)

test cli::progress_render::tests::count_driven_snapshot_gets_a_live_suffix ... ok
test cli::progress_render::tests::preformatted_line_without_a_count_paints_verbatim ... ok
test result: ok. 4 passed; 0 failed (progress_render unit tests)

test output_kind_runtime::switch_output_json_is_byte_clean_of_progress ... ok
test result: ok (--output json stdout is byte-clean — suppression proven)
```

Gates run locally, all green: `cargo build --locked --workspace` (default features) AND `--all-features`; `cargo clippy --workspace --all-targets -- -D warnings`; `cargo test -p heddle-mount`; `bash scripts/check-no-silent-default-tree-load.sh`.

## Manual verification
N/A — covered by tests. The `--output json` byte-clean test (`switch_output_json_is_byte_clean_of_progress`) is the automated proof that progress never leaks into machine-readable stdout; the seam test proves the live counter across the parallel worker threads.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785479607&installation_id=132405951&pr_number=847&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F847&signature=88680158b585e0278637e20fe8ec780972dee6a7765eb2a8810229bb6937e415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->