### PR TITLE
perf(adopt): batch ref-publish fsyncs (residual per-ref cost)

### DIFF
--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -12,10 +12,14 @@ use super::{
     action_line::print_next,
     advice::RecoveryAdvice,
     command_catalog::ActionTemplate,
-    git_overlay_health::{RepositoryVerificationState, build_repository_verification_state},
+    git_overlay_health::{
+        RepositoryVerificationState, build_repository_verification_state,
+        build_repository_verification_state_profiled,
+    },
     import_progress::ImportProgress,
 };
 use crate::cli::{AdoptArgs, Cli, should_output_json, style};
+use crate::perf::{ProfileField, emit_profile, profile_enabled};
 
 #[derive(Debug, Serialize)]
 struct AdoptOutput {
@@ -78,10 +82,34 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
     let source_label = repo.root().display().to_string();
     let mut progress = ImportProgress::start(cli, &repo, &scope, &source_label);
     progress.begin_commit_import();
+    let import_start = std::time::Instant::now();
     let stats = import_git_history_for_adopt(&repo, &args.refs, &mut progress)?;
+    let import_ms = import_start.elapsed().as_millis();
     progress.begin_ref_write();
     progress.finish();
-    let trust = build_repository_verification_state(&repo);
+    let verification_start = std::time::Instant::now();
+    let (trust, verification_profile) = if profile_enabled() {
+        let (trust, profile) = build_repository_verification_state_profiled(&repo);
+        (trust, Some(profile))
+    } else {
+        (build_repository_verification_state(&repo), None)
+    };
+    let verification_ms = verification_start.elapsed().as_millis();
+    if let Some(profile) = verification_profile {
+        emit_profile(
+            "adopt",
+            &[
+                ProfileField::millis("import_ms", import_ms),
+                ProfileField::millis("verification_ms", verification_ms),
+                ProfileField::millis(
+                    "verification_worktree_status_ms",
+                    profile.worktree_status_ms,
+                ),
+                ProfileField::millis("verification_health_ms", profile.health_ms),
+                ProfileField::millis("verification_from_health_ms", profile.from_health_ms),
+            ],
+        );
+    }
     let already_in_sync = stats.states_created == 0 && stats.commits_imported > 0;
     let recommended_action = action_value(&trust);
     // The .heddle data dir lives inside the repo; render it relative to the

--- a/crates/cli/src/cli/commands/git_overlay_health/mod.rs
+++ b/crates/cli/src/cli/commands/git_overlay_health/mod.rs
@@ -1175,6 +1175,49 @@ pub(crate) fn build_repository_verification_state(
     RepositoryVerificationState::from_health_with_worktree_status(repo, health, &worktree_status)
 }
 
+/// Sub-phase timings for [`build_repository_verification_state_profiled`], in
+/// milliseconds. Used by `adopt`'s `HEDDLE_PROFILE=1` instrumentation to attribute
+/// the post-import verification cost across its three phases.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct VerificationProfile {
+    pub worktree_status_ms: u128,
+    pub health_ms: u128,
+    pub from_health_ms: u128,
+}
+
+/// [`build_repository_verification_state`] that additionally reports per-phase
+/// timings. Classification is identical; the only difference is the elapsed
+/// clocks around each phase.
+pub(crate) fn build_repository_verification_state_profiled(
+    repo: &Repository,
+) -> (RepositoryVerificationState, VerificationProfile) {
+    let worktree_status_start = std::time::Instant::now();
+    let worktree_status = if repo.capability() == repo::RepositoryCapability::GitOverlay {
+        repo.git_overlay_worktree_status()
+    } else {
+        Ok(None)
+    };
+    let worktree_status_ms = worktree_status_start.elapsed().as_millis();
+
+    let health_start = std::time::Instant::now();
+    let health = build_git_overlay_health_with_worktree_status(repo, &worktree_status);
+    let health_ms = health_start.elapsed().as_millis();
+
+    let from_health_start = std::time::Instant::now();
+    let state =
+        RepositoryVerificationState::from_health_with_worktree_status(repo, health, &worktree_status);
+    let from_health_ms = from_health_start.elapsed().as_millis();
+
+    (
+        state,
+        VerificationProfile {
+            worktree_status_ms,
+            health_ms,
+            from_health_ms,
+        },
+    )
+}
+
 /// Verification-state build that reuses an already-computed git-overlay worktree
 /// status instead of re-walking + re-SHA-1ing every tracked file. Used by the
 /// `checkpoint` hot path, where the same status would otherwise be recomputed

--- a/crates/objects/src/fs_atomic.rs
+++ b/crates/objects/src/fs_atomic.rs
@@ -197,6 +197,67 @@ pub fn temp_path(path: &Path) -> PathBuf {
     parent.join(format!(".{file_name}.tmp-{pid}-{unique}-{counter}"))
 }
 
+/// Kick a file's dirty page cache into background writeback WITHOUT waiting
+/// for it or issuing a device flush. Best-effort: any error is ignored, since
+/// the caller's subsequent `fsync` is what actually guarantees durability —
+/// this only *starts* the I/O early so many files' writeback overlaps instead
+/// of each `fsync` flushing its file synchronously from scratch.
+///
+/// Linux-only (`sync_file_range`); a no-op elsewhere, where the batched-fsync
+/// pass in [`stage_temp_files_durable`] simply runs without the overlap.
+#[cfg(target_os = "linux")]
+fn kick_writeback(file: &File) {
+    use std::os::unix::io::AsRawFd;
+    // SYNC_FILE_RANGE_WRITE = 2: initiate writeback of dirty pages in the
+    // given range (0..0 = whole file) without blocking. No barrier, no error
+    // path — a failure just means the later `sync_all` does the work.
+    const SYNC_FILE_RANGE_WRITE: libc::c_uint = 2;
+    unsafe {
+        libc::sync_file_range(file.as_raw_fd(), 0, 0, SYNC_FILE_RANGE_WRITE);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn kick_writeback(_file: &File) {}
+
+/// Write many temp files with a single overlapped-writeback durability pass.
+///
+/// For each `(temp_path, bytes)`: create the temp file and write its contents,
+/// then start its page-cache writeback in the background ([`kick_writeback`]).
+/// After every file is written, `fsync` each one. On return, every temp file's
+/// data is on stable storage — the SAME guarantee as writing + `fsync`-ing each
+/// file individually — but the writeback I/O overlaps instead of serializing
+/// one synchronous `fsync` barrier per file.
+///
+/// This is the bulk-ref hot path (`heddle adopt` of N branches publishes N ref
+/// files in one batch): the per-file `write → fsync` loop paid ~N serial fsync
+/// barriers (~2.3s for 800 refs on a local SSD); overlapping the writeback
+/// collapses that to ~0.1s with no change to the durability contract. Callers
+/// still `rename` each temp into place and `fsync` the parent directory to make
+/// the renames durable.
+///
+/// The temp files' parent directories must already exist. On the first write
+/// error the partial temp files are left for the caller's rollback/cleanup to
+/// remove (they are uniquely named and never renamed into place).
+pub fn stage_temp_files_durable(files: &[(PathBuf, Vec<u8>)]) -> io::Result<()> {
+    let mut handles: Vec<File> = Vec::with_capacity(files.len());
+    for (temp_path, bytes) in files {
+        let mut file =
+            File::create(temp_path).map_err(|err| enrich_write_error(temp_path, err))?;
+        file.write_all(bytes)
+            .map_err(|err| enrich_write_error(temp_path, err))?;
+        kick_writeback(&file);
+        handles.push(file);
+    }
+    // Barrier pass: by now most files' writeback is already in flight (or done),
+    // so each `sync_all` blocks only on the tail, not a cold synchronous flush.
+    for (file, (temp_path, _)) in handles.iter().zip(files) {
+        file.sync_all()
+            .map_err(|err| enrich_write_error(temp_path, err))?;
+    }
+    Ok(())
+}
+
 /// fsync the directory inode so a preceding `rename` is durable across
 /// crashes. POSIX-only — on Windows this is a no-op.
 ///
@@ -673,6 +734,48 @@ mod tests {
         let target = dir.path().join("nested/under/here/file.bin");
         write_file_atomic(&target, b"hello").unwrap();
         assert_eq!(fs::read(&target).unwrap(), b"hello");
+    }
+
+    #[test]
+    fn stage_temp_files_durable_writes_every_file_verbatim() {
+        // The bulk-ref hot path stages N temp files in one overlapped-writeback
+        // pass. Every file must land with its exact bytes — the batching is a
+        // durability/perf optimization, never a content one.
+        let dir = tempfile::TempDir::new().unwrap();
+        let files: Vec<(PathBuf, Vec<u8>)> = (0..50)
+            .map(|i| {
+                (
+                    dir.path().join(format!("ref-{i}.tmp")),
+                    format!("change-id-{i}\n").into_bytes(),
+                )
+            })
+            .collect();
+
+        stage_temp_files_durable(&files).unwrap();
+
+        for (path, bytes) in &files {
+            assert_eq!(&fs::read(path).unwrap(), bytes, "mismatch at {path:?}");
+        }
+    }
+
+    #[test]
+    fn stage_temp_files_durable_empty_batch_is_ok() {
+        // A publish with no new-content plans (e.g. a pure delete batch) hands
+        // an empty slice; it must be a clean no-op, not an error.
+        stage_temp_files_durable(&[]).unwrap();
+    }
+
+    #[test]
+    fn stage_temp_files_durable_errors_when_parent_missing() {
+        // The helper does NOT create parent directories (callers pre-create
+        // them via `alloc_temp_path`); a missing parent surfaces as an error
+        // rather than silently dropping the write.
+        let dir = tempfile::TempDir::new().unwrap();
+        let files = vec![(
+            dir.path().join("does/not/exist/ref.tmp"),
+            b"x".to_vec(),
+        )];
+        assert!(stage_temp_files_durable(&files).is_err());
     }
 
     #[cfg(unix)]

--- a/crates/refs/src/fs_atomic.rs
+++ b/crates/refs/src/fs_atomic.rs
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: Apache-2.0
-pub(crate) use objects::fs_atomic::{sync_directory, write_file_atomic};
+pub(crate) use objects::fs_atomic::{stage_temp_files_durable, sync_directory, write_file_atomic};

--- a/crates/refs/src/refs/refs_storage.rs
+++ b/crates/refs/src/refs/refs_storage.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::{self, File, OpenOptions},
-    io::{self, Read, Write},
+    io::{self, Read},
     path::{Path, PathBuf},
     thread::{self},
     time::{Duration, Instant},
@@ -197,18 +197,22 @@ impl RefManager {
     pub(super) fn write_string(&self, path: &Path, contents: &str) -> Result<()> {
         Ok(write_file_atomic(path, contents.as_bytes())?)
     }
-    pub(super) fn write_string_temp(&self, path: &Path, contents: &str) -> Result<PathBuf> {
+
+    /// Allocate the temp path a canonical ref file will be staged into
+    /// (ensuring its parent directory exists), WITHOUT writing anything.
+    ///
+    /// Staging + fsync is done in one overlapped-writeback batch by
+    /// [`stage_temp_files_durable`](objects::fs_atomic::stage_temp_files_durable)
+    /// so publishing N refs pays ~1 fsync barrier's worth of latency instead of
+    /// N serial ones (the `heddle adopt` bulk-ref hot path).
+    pub(super) fn alloc_temp_path(&self, path: &Path) -> Result<PathBuf> {
         let parent = path
             .parent()
             .ok_or_else(|| std::io::Error::other("invalid ref path"))?;
         std::fs::create_dir_all(parent)?;
 
         let suffix: u64 = rand::random();
-        let temp_path = path.with_extension(format!("tmp-{}", suffix));
-        let mut file = File::create(&temp_path)?;
-        file.write_all(contents.as_bytes())?;
-        file.sync_all()?;
-        Ok(temp_path)
+        Ok(path.with_extension(format!("tmp-{}", suffix)))
     }
     pub(super) fn list_refs_recursive(&self, dir: &Path, prefix: &str) -> Result<Vec<ThreadName>> {
         let mut refs = Vec::new();

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Transactional ref update logic for RefManager.
 
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::HashSet,
+    path::{Path, PathBuf},
+};
 
 use objects::{
     error::{HeddleError, Result},
@@ -20,7 +23,7 @@ use super::{
         describe_head, matches_expectation,
     },
 };
-use crate::fs_atomic::sync_directory;
+use crate::fs_atomic::{stage_temp_files_durable, sync_directory};
 
 enum PackedRemove {
     Thread(String),
@@ -412,25 +415,46 @@ impl RefManager {
         mut plans: Vec<RefUpdatePlan>,
         _lock: &RefsLock,
     ) -> Result<()> {
+        // Stage every new-content plan into a temp file, then make them all
+        // durable in ONE overlapped-writeback pass. The previous per-plan
+        // `write → fsync` loop paid one serial fsync barrier per ref, so a batch
+        // publishing N refs (the `heddle adopt` hot path: N branches → one
+        // `update_refs`) sat ~N fsyncs deep (~2.3s for 800 refs). Kicking every
+        // temp file's writeback up front and fsyncing them as a batch keeps the
+        // identical per-file durability guarantee — each temp is fsync'd before
+        // its rename — while overlapping the writeback I/O.
+        let mut temp_writes: Vec<(PathBuf, Vec<u8>)> = Vec::new();
         for plan in &mut plans {
             if let Some(ref content) = plan.new_content {
-                let temp_path = self.write_string_temp(&plan.path, content)?;
-                plan.temp_path = Some(temp_path.clone());
+                let temp_path = self.alloc_temp_path(&plan.path)?;
+                temp_writes.push((temp_path.clone(), content.clone().into_bytes()));
+                plan.temp_path = Some(temp_path);
             }
         }
+        stage_temp_files_durable(&temp_writes)?;
 
         let packed_snapshot = self.read_optional_string(&self.packed_refs_path())?;
         let mut applied = Vec::new();
+        // Directories whose entries changed via rename. Their fsync is hoisted
+        // out of the per-plan loop: a batch that publishes N refs into the same
+        // `refs/threads/` directory (the adopt hot path — N branches → one
+        // `update_refs`) shares one parent, so the old per-rename `sync_directory`
+        // fsync'd that directory N times (2 fsyncs/ref on adopt: the temp file +
+        // its parent dir). We instead fsync each *distinct* parent once, after
+        // every rename lands. The post-batch durability is identical — on success
+        // every rename's directory entry is durable — and the batch was never
+        // crash-atomic across refs in either version (there is no journal spanning
+        // all N renames; `rollback_updates` handles in-process errors, not power
+        // loss mid-loop).
+        let mut dirty_parents: Vec<PathBuf> = Vec::new();
         for (index, plan) in plans.iter().enumerate() {
             let result = if let Some(ref temp_path) = plan.temp_path {
-                std::fs::rename(temp_path, &plan.path).map_err(HeddleError::from)?;
-                let parent = plan
-                    .path
-                    .parent()
-                    .ok_or_else(|| HeddleError::Config("invalid ref path".to_string()))?;
-                sync_directory(parent)?;
-                Ok(())
+                std::fs::rename(temp_path, &plan.path)
+                    .map_err(HeddleError::from)
+                    .and_then(|()| note_dirty_parent(&mut dirty_parents, &plan.path))
             } else if plan.path.exists() {
+                // Matches the pre-hoist behavior: only renames drove a directory
+                // fsync (a loose-ref delete published via `remove_file` did not).
                 std::fs::remove_file(&plan.path).map_err(HeddleError::from)
             } else {
                 Ok(())
@@ -449,6 +473,12 @@ impl RefManager {
             }
 
             applied.push(index);
+        }
+
+        // One directory fsync per distinct parent, making every rename in this
+        // batch durable. On adopt this collapses ~N dir fsyncs into 1.
+        for parent in &dirty_parents {
+            sync_directory(parent)?;
         }
 
         if let Err(err) = self.apply_packed_removals(&plans) {
@@ -530,6 +560,18 @@ impl RefManager {
 
         Ok(())
     }
+}
+
+/// Record `path`'s parent as a directory whose entries changed, so the batch can
+/// fsync each distinct parent exactly once after every rename/remove lands.
+fn note_dirty_parent(dirty_parents: &mut Vec<PathBuf>, path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| HeddleError::Config("invalid ref path".to_string()))?;
+    if !dirty_parents.iter().any(|p| p == parent) {
+        dirty_parents.push(parent.to_path_buf());
+    }
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- **Root cause (found via `HEDDLE_PROFILE=1`, release):** post-#830, native `heddle adopt` of N branches was dominated by ref publishing. At N=800, `ref_emit` was 2344ms of the 2504ms import (83% of wall clock), and the single batched `update_refs` publish was ~2324ms of that. The residual is **fsync-per-ref**: publishing N loose ref files paid two serial fsync barriers per ref — the temp file's data (`write_string_temp`'s `sync_all`) and the parent directory after each rename. For 800 branches in one dir that's ~1600 serial fsyncs (~2.3s on a local SSD).
- **Fix 1 — `objects::fs_atomic::stage_temp_files_durable`:** write all temp files, kick each into background writeback up front (Linux `sync_file_range`; no-op elsewhere), then fsync them as a batch so the writeback I/O overlaps instead of each fsync flushing cold. Measured 1989ms → 115ms for 800 files.
- **Fix 2 — hoist the per-rename directory fsync** out of the publish loop: fsync each *distinct* parent once after all renames land (adopt: N → 1).
- **No behavior change** — classification, output, idempotency, and exact change-id targets are unchanged; every temp is still fsync'd before its rename and every rename's dir entry is fsync'd before publish returns.
- Also lands the `HEDDLE_PROFILE=1` adopt instrumentation (import vs verification phase split) used to find this, per the profiling AC.

Closes HeddleCo/heddle#845

## Red commit
N/A — perf refactor, no behavior change (DoD Type ≠ TDD-Rust). Correctness is guarded by the existing `batched_emit_writes_every_thread_and_marker_exactly_once` test + the refs suite, plus new `stage_temp_files_durable` unit tests.

## Before / after (release, `HEDDLE_PROFILE=1`)

Pure-ref adopt (N branches → 1 base commit), wall clock:

| N | before total | after total | import before → after |
|---|---|---|---|
| 100 | 0.42s | 0.19s | 329 → 98 ms |
| 400 | 1.46s | 0.36s | 1260 → 188 ms |
| 800 | 2.64s | 0.63s | 2338 → 343 ms |
| 1600 | 4.89s | 1.21s | 4386 → 661 ms |

`ripgrep` (276 refs, real history): **9.50s → 8.72s** — ref publishing is ~0.8s there; the remaining ~8.5s is inherent commit/tree/blob translation (prior-wave territory, #825–#830). Post-import verification (`compare_worktree`/health) measured ~0.1–0.25s on a clean adopt — not the ~1s #829 saw on a large *dirty* worktree, so it is not a residual on the adopt path.

## Test evidence
```
# crates touched by the change
cargo test -p heddle-refs -p heddle-objects -p heddle-ingest
    refs:    test result: ok. 191 passed; 0 failed; 1 ignored
    objects: test result: ok. 350 passed; 0 failed; 1 ignored  (incl. new stage_temp_files_durable_* )
    ingest:  test result: ok.  80 passed; 0 failed; 1 ignored

# DoD gates
cargo build --locked --workspace                       # ok (1m18s)
cargo build --locked --workspace --all-features        # ok (1m29s)
cargo clippy --workspace --all-targets -- -D warnings  # ok, 0 warnings
cargo test -p heddle-mount                             # ok. 152 passed; 0 failed
bash scripts/check-no-silent-default-tree-load.sh      # clean: 574 files scanned
```

Functional check: `adopt` of the 100-branch fixture lands exactly 101 threads (100 branches + `main`), exit 0.

## Manual verification
N/A — covered by tests + before/after profiling above.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785484201&installation_id=132405951&pr_number=849&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F849&signature=46d7f41fb484a448d960a899c346228ea6e6848e4eae4c73f1cde447a3a0b33e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->