### PR TITLE
fix(content): serve symlink entries from the blob walk (#841)

### DIFF
--- a/crates/objects/src/object/tree.rs
+++ b/crates/objects/src/object/tree.rs
@@ -179,6 +179,10 @@ impl TreeEntry {
         self.entry_type == EntryType::Blob
     }
 
+    pub fn is_symlink(&self) -> bool {
+        self.entry_type == EntryType::Symlink
+    }
+
     pub fn is_executable(&self) -> bool {
         self.mode == FileMode::Executable
     }

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -177,7 +177,12 @@ fn get_blob_recursive(
     };
 
     if parts.len() == 1 {
-        if entry.is_blob() {
+        // Serve symlink entries too: a symlink's object is a blob whose bytes
+        // are the target path. We return that target-path content (git
+        // semantics), NOT the content of the file it points at — following the
+        // link is a higher-level fs concern. `is_symlink()` lets such callers
+        // opt into following it themselves.
+        if entry.is_blob() || entry.is_symlink() {
             return Ok(store.get_blob(&entry.hash)?);
         }
     } else if entry.is_tree()
@@ -223,7 +228,9 @@ where
     };
 
     if parts.len() == 1 {
-        if entry.is_blob() {
+        // See `get_blob_recursive`: symlink entries resolve to their blob
+        // (the target-path bytes), git-style; we do not follow the link.
+        if entry.is_blob() || entry.is_symlink() {
             return Ok(store.get_blob(&entry.hash).await?);
         }
     } else if entry.is_tree()
@@ -403,6 +410,54 @@ mod tests {
             assert_eq!(async_blob, expected_blob, "async path {path}");
             assert_eq!(async_blob, sync_blob, "dual path {path}");
         }
+    }
+
+    #[cfg(feature = "async-source")]
+    #[test]
+    fn symlink_entry_resolves_to_target_path_bytes() {
+        let store = InMemoryStore::new();
+        let async_store = AsyncInMemorySource(&store);
+
+        // A symlink's object *is* a blob whose bytes are the target path.
+        let link_target = create_blob(&store, b"AGENTS.md");
+        let real_file = create_blob(&store, b"the real content");
+        let subdir_file = create_blob(&store, b"nested content");
+
+        let subdir = create_tree(&store, vec![("inner.txt", subdir_file, EntryType::Blob)]);
+
+        let root_hash = create_tree(
+            &store,
+            vec![
+                ("AGENTS.md", real_file, EntryType::Blob),
+                ("CLAUDE.md", link_target, EntryType::Symlink),
+                ("dir", subdir, EntryType::Tree),
+            ],
+        );
+        let root = ObjectStore::get_tree(&store, &root_hash).unwrap().unwrap();
+
+        // The symlink resolves to its blob (the target-path bytes), NOT followed
+        // to the target file's content, and NOT dropped as not-found.
+        let sync_symlink = blob_content(get_blob_at_path(&store, &root, "CLAUDE.md").unwrap());
+        let async_symlink = blob_content(
+            block_on(get_blob_at_path_async(&async_store, &root, "CLAUDE.md")).unwrap(),
+        );
+        assert_eq!(sync_symlink, Some(b"AGENTS.md".to_vec()), "sync symlink");
+        assert_eq!(async_symlink, Some(b"AGENTS.md".to_vec()), "async symlink");
+
+        // Regression: a regular blob still resolves to its own content.
+        let sync_blob = blob_content(get_blob_at_path(&store, &root, "AGENTS.md").unwrap());
+        let async_blob = blob_content(
+            block_on(get_blob_at_path_async(&async_store, &root, "AGENTS.md")).unwrap(),
+        );
+        assert_eq!(sync_blob, Some(b"the real content".to_vec()), "sync blob");
+        assert_eq!(async_blob, Some(b"the real content".to_vec()), "async blob");
+
+        // Regression: a directory does not resolve as a blob.
+        let sync_dir = blob_content(get_blob_at_path(&store, &root, "dir").unwrap());
+        let async_dir =
+            blob_content(block_on(get_blob_at_path_async(&async_store, &root, "dir")).unwrap());
+        assert_eq!(sync_dir, None, "sync dir");
+        assert_eq!(async_dir, None, "async dir");
     }
 
     #[test]


### PR DESCRIPTION
Closes #841.

## Root cause
`get_blob_recursive` / `get_blob_recursive_async` (crates/repo/src/staleness.rs) terminal case only served `entry.is_blob()`, returning `Ok(None)` for `EntryType::Symlink`. Every symlink was therefore unreadable through the content path — `get_blob` / `get_blame` / any consumer of `get_blob_at_path_async` reported "file not found" (e.g. ghostty's `CLAUDE.md` -> `AGENTS.md` symlink).

## Fix
- Add an `is_symlink()` predicate on `TreeEntry` alongside `is_blob()`/`is_tree()` (crates/objects/src/object/tree.rs).
- Both terminal cases now serve `entry.is_blob() || entry.is_symlink()` and return `store.get_blob(&entry.hash)`.

## Design choice — RETURN the target, do NOT follow
A symlink's object *is* a blob whose bytes are the target path (git stores symlinks as blobs holding the link target). We return that target-path **content** (git-correct semantics), NOT the content of the file it points at. The new `is_symlink()` predicate lets higher-level callers follow the link themselves if they want; auto-follow (relative targets, repo-escape) is a higher-level fs concern and out of scope.

## Tests
- `symlink_entry_resolves_to_target_path_bytes` (sync + async): a symlink path resolves to `Some(blob)` whose content is the target-path bytes (not None, not the target file's content).
- Regressions retained in the same test: a regular file blob still resolves to its own content; a directory does not resolve as a blob.

## weft note
weft's `GetBlob`/`GetBlame` content read routes through `hosted_repository.rs:611 blob_at_tree_path` -> `repo::staleness::get_blob_at_path_async`, so it inherits this fix for free. weft has other `is_blob()`-only spots (hosted_repository.rs:817/974/1002) but those are separate tree-lookup paths, not the content-read walk; not touched here.

## Gates
`cargo build --locked --workspace` (default + --all-features), `check-no-silent-default-tree-load.sh`, `cargo test -p heddle-repo --all-features`, `cargo test -p heddle-objects`, `cargo test -p heddle-mount`, `cargo clippy --workspace --all-targets -- -D warnings` — all green.

Red-to-green SHA: `85a1c184139ae91d619d33e0d691d71c347a29a4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785510825&installation_id=132405951&pr_number=850&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F850&signature=97b9b338e238c8aff5e2ae9ba589d4ea04639542c5810994e5603d33791d4f70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->