### PR TITLE
fix(0.5.1-nits): document pull-side unconditional CAS, normalize OID case on parse, single-pass pack build (#791)

### DIFF
--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -21,6 +21,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 sley.workspace = true
+tempfile.workspace = true
 tokio = { workspace = true }
 tokio-stream.workspace = true
 tokio-tungstenite.workspace = true

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -2552,6 +2552,15 @@ fn accept_git_lane_pack(
     Ok(())
 }
 
+/// Apply a server-originated Git ref update on the pull stream.
+///
+/// Pull-side ref application is unconditional: we commit the local Git ref with
+/// [`RefPrecondition::Any`] and do not compare against a prior target oid. That
+/// is deliberate and **not** symmetric with push-side compare-and-set, where the
+/// client transmits `expected_target_oid` / `expected_missing` from `ListRefs`.
+/// The pull stream is single-threaded and server-trusted — the client applies
+/// ref updates in the order the server sends them after installing the
+/// accompanying pack, so there is no concurrent local writer racing this path.
 fn accept_git_lane_ref_update(
     repo: &Repository,
     git_repo: &mut Option<SleyRepository>,

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -2055,9 +2055,17 @@ fn stream_git_pack_messages_blocking(
     pack_file
         .seek(SeekFrom::Start(0))
         .map_err(|err| ProtocolError::InvalidState(format!("rewind Git pack tempfile: {err}")))?;
-    io::copy(&mut pack_file.as_file_mut(), &mut writer).map_err(|err| {
+    let streamed = io::copy(&mut pack_file.as_file_mut(), &mut writer).map_err(|err| {
         ProtocolError::InvalidState(format!("stream Git pack tempfile: {err}"))
     })?;
+    if streamed != pack.pack_size {
+        return Err(ProtocolError::InvalidState(format!(
+            "Git pack stream changed while sending; expected {} bytes/{}, streamed {} bytes",
+            pack.pack_size,
+            hex::encode(&pack.pack_id),
+            streamed
+        )));
+    }
     writer.finish()?;
     Ok(())
 }

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -1,12 +1,14 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
-    io::{self, Write},
+    io::{self, Seek, SeekFrom, Write},
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicUsize, Ordering},
     },
     time::{Duration, Instant},
 };
+
+use tempfile::NamedTempFile;
 
 use grpc::heddle::v1::{
     GetBlobRequest, GitCheckpointTransfer, GitLaneTransfer, GitPackTransfer, GitRefKind,
@@ -82,8 +84,11 @@ struct GitPackPushPlan {
     /// root (the checkpoint commit); the mirror path has one per resolved
     /// ref target. `write_reachable_pack_to_writer` packs the transitive
     /// closure of every root into a single pack.
+    #[cfg_attr(not(test), allow(dead_code))]
     roots: Vec<GitObjectId>,
-    git_repo: SleyRepository,
+    /// Reachable pack bytes written once during planning; streamed on the wire
+    /// without a second ODB traversal. Auto-deleted when the last clone drops.
+    pack_file: Arc<Mutex<NamedTempFile>>,
 }
 
 const PUSH_FULL_DESCRIPTOR_OBJECT_THRESHOLD: usize = 512;
@@ -1977,17 +1982,15 @@ fn build_git_lane_multi_root_pack_plan(
         ));
     }
     let objects = git_repo.objects();
-    let mut sink = io::sink();
-    // TODO: Replace this metadata-only reachable-pack walk and the later
-    // streaming walk with the Sley reachable-pack facade gate once it can expose
-    // stable size/checksum plus streaming. Do not grow a second planner in
-    // Heddle.
+    let mut pack_file = NamedTempFile::new().map_err(|err| {
+        ProtocolError::InvalidState(format!("create Git pack tempfile: {err}"))
+    })?;
     let pack = sley::plumbing::sley_odb::write_reachable_pack_to_writer(
         objects.as_ref(),
         git_repo.object_format(),
         roots.iter().copied(),
         &HashSet::new(),
-        &mut sink,
+        &mut pack_file,
     )
     .map_err(|err| ProtocolError::InvalidState(format!("plan reachable Git pack stream: {err}")))?
     .ok_or_else(|| {
@@ -2012,7 +2015,7 @@ fn build_git_lane_multi_root_pack_plan(
         pack_id: pack.checksum.as_bytes().to_vec(),
         pack_size: pack.pack_size,
         roots,
-        git_repo: git_repo.clone(),
+        pack_file: Arc::new(Mutex::new(pack_file)),
     })
 }
 
@@ -2038,7 +2041,6 @@ fn stream_git_pack_messages_blocking(
     chunk_size: usize,
     progress: Progress,
 ) -> Result<(), ProtocolError> {
-    let objects = pack.git_repo.objects();
     let mut writer = GitPackPushMessageWriter::new(
         tx,
         pack.transfer_id.clone(),
@@ -2047,31 +2049,16 @@ fn stream_git_pack_messages_blocking(
         chunk_size,
         progress,
     );
-    // TODO: This is the second walk of the same reachable Git closure planned
-    // in build_git_lane_pack_plan. Collapse both walks behind Sley's
-    // reachable-pack facade when available, without changing the protobuf lane.
-    let summary = sley::plumbing::sley_odb::write_reachable_pack_to_writer(
-        objects.as_ref(),
-        pack.git_repo.object_format(),
-        pack.roots.iter().copied(),
-        &HashSet::new(),
-        &mut writer,
-    )
-    .map_err(|err| ProtocolError::InvalidState(format!("stream reachable Git pack: {err}")))?
-    .ok_or_else(|| {
-        ProtocolError::InvalidState("roots did not produce a reachable Git pack".to_string())
+    let mut pack_file = pack.pack_file.lock().map_err(|err| {
+        ProtocolError::InvalidState(format!("lock Git pack tempfile: {err}"))
+    })?;
+    pack_file
+        .seek(SeekFrom::Start(0))
+        .map_err(|err| ProtocolError::InvalidState(format!("rewind Git pack tempfile: {err}")))?;
+    io::copy(&mut pack_file.as_file_mut(), &mut writer).map_err(|err| {
+        ProtocolError::InvalidState(format!("stream Git pack tempfile: {err}"))
     })?;
     writer.finish()?;
-    if summary.pack_size != pack.pack_size || summary.checksum.as_bytes() != pack.pack_id.as_slice()
-    {
-        return Err(ProtocolError::InvalidState(format!(
-            "Git pack stream changed while sending; expected {} bytes/{}, got {} bytes/{}",
-            pack.pack_size,
-            hex::encode(&pack.pack_id),
-            summary.pack_size,
-            summary.checksum.to_hex()
-        )));
-    }
     Ok(())
 }
 
@@ -3199,6 +3186,11 @@ mod tests {
                 pack_bytes.extend_from_slice(&pack.pack_chunk);
             }
         }
+        assert_eq!(
+            pack_bytes.len() as u64,
+            plan.pack.pack_size,
+            "streamed pack size must match plan",
+        );
         let indexed = sley::plumbing::sley_odb::index_raw_pack(&pack_bytes, git.object_format())
             .expect("mirror pack indexes");
         let packed: HashSet<Vec<u8>> = indexed

--- a/crates/repo/src/revision_address.rs
+++ b/crates/repo/src/revision_address.rs
@@ -64,7 +64,7 @@ impl FromStr for RevisionAddress {
                 return Err(RevisionAddressParseError::EmptyGitCommit);
             }
             validate_git_commit_oid(oid)?;
-            return Ok(Self::GitCommit(oid.to_string()));
+            return Ok(Self::GitCommit(oid.to_ascii_lowercase()));
         }
         Err(RevisionAddressParseError::UnknownPrefix)
     }
@@ -123,6 +123,33 @@ mod tests {
             address
         );
         assert_eq!(address.storage_prefix(), "git");
+    }
+
+    #[cfg(feature = "git-overlay")]
+    #[test]
+    fn git_revision_address_normalizes_oid_case_on_parse() {
+        let lowercase_sha1 = "0123456789abcdef0123456789abcdef01234567";
+        let uppercase_sha1 = "0123456789ABCDEF0123456789ABCDEF01234567";
+        let lowercase_sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let uppercase_sha256 = "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF";
+
+        let from_lower_sha1 = format!("git:{lowercase_sha1}")
+            .parse::<RevisionAddress>()
+            .expect("parse lowercase sha1");
+        let from_upper_sha1 = format!("git:{uppercase_sha1}")
+            .parse::<RevisionAddress>()
+            .expect("parse uppercase sha1");
+        let from_lower_sha256 = format!("git:{lowercase_sha256}")
+            .parse::<RevisionAddress>()
+            .expect("parse lowercase sha256");
+        let from_upper_sha256 = format!("git:{uppercase_sha256}")
+            .parse::<RevisionAddress>()
+            .expect("parse uppercase sha256");
+
+        assert_eq!(from_upper_sha1, from_lower_sha1);
+        assert_eq!(from_upper_sha256, from_lower_sha256);
+        assert_eq!(from_upper_sha1.to_string(), format!("git:{lowercase_sha1}"));
+        assert_eq!(from_upper_sha256.to_string(), format!("git:{lowercase_sha256}"));
     }
 
     #[cfg(feature = "git-overlay")]


### PR DESCRIPTION
Closes #791.

**NIT 1 — pull-side ref application docs:** Added a doc comment on `accept_git_lane_ref_update` explaining that pull-side ref updates use `RefPrecondition::Any` unconditionally by design, unlike push-side CAS (`expected_target_oid` / `expected_missing`), and why that is safe on the single-threaded server-trusted pull stream. Docs-only; no behavior change.

**NIT 2 — OID case normalization:** `RevisionAddress::from_str` now lowercases `git:<oid>` at parse time so stored/compared addresses always match lowercase wire emission. Proven by new unit test `git_revision_address_normalizes_oid_case_on_parse` covering uppercase 40- and 64-char hex inputs.

**NIT 3 — single-pass pack build:** `build_git_lane_multi_root_pack_plan` writes the reachable pack once to a `NamedTempFile` (auto-deleted on drop), captures `pack_size`/`checksum` from that write, and `stream_git_pack_messages_blocking` streams from the tempfile instead of regenerating the pack. Proven by existing `git_lane_messages_pack_reachable_commit_graph_and_attach_checkpoint` test plus new `pack_size` assertion in `git_mirror_plan_builds_one_pack_and_checkpointless_updates_for_all_refs`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785529872&installation_id=132405951&pr_number=851&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F851&signature=0fe3be583b44ec843c4e296d0f39eed2c7de7b9b60db36ebdae0249188012a95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->