### PR TITLE
refactor(fsck): single tree-integrity walk for tree and blob checks (#860)

### DIFF
--- a/crates/core/src/fsck/mod.rs
+++ b/crates/core/src/fsck/mod.rs
@@ -68,8 +68,7 @@ pub fn fsck(ctx: &ExecutionContext, opts: FsckOptions) -> Result<FsckReport> {
     state::check_states(repo, &mut errors, &mut objects_checked, opts.thorough)?;
 
     if opts.full {
-        objects::check_trees(repo, &mut errors, &mut warnings, &mut objects_checked)?;
-        objects::check_blobs(repo, &mut errors, &mut warnings, &mut objects_checked)?;
+        objects::check_tree_objects(repo, &mut errors, &mut warnings, &mut objects_checked)?;
     }
 
     refs::check_refs(repo, &mut errors, &mut warnings)?;

--- a/crates/core/src/fsck/objects.rs
+++ b/crates/core/src/fsck/objects.rs
@@ -3,100 +3,65 @@ use std::collections::HashSet;
 
 use objects::{
     error::Result,
-    object::{ContentHash, Tree},
+    object::{ContentHash, TreeIntegrityEvent, walk_tree_integrity},
     store::ObjectStore,
 };
 use repo::Repository;
 
 use super::{FsckError, make_error};
 
-pub(crate) fn check_trees(
+pub(crate) fn check_tree_objects(
     repo: &Repository,
     errors: &mut Vec<FsckError>,
     warnings: &mut Vec<String>,
     objects_checked: &mut usize,
 ) -> Result<()> {
     let states = repo.store().list_states()?;
-    let mut checked_trees: HashSet<ContentHash> = HashSet::new();
+    let roots: Vec<ContentHash> = states
+        .iter()
+        .filter_map(|state_id| {
+            repo.store()
+                .get_state(state_id)
+                .ok()
+                .flatten()
+                .map(|state| state.tree)
+        })
+        .collect();
 
-    for state_id in states {
-        if let Some(state) = repo.store().get_state(&state_id)? {
-            check_tree_recursive(
-                repo,
-                &state.tree,
-                &mut checked_trees,
-                errors,
-                warnings,
-                objects_checked,
-            )?;
-        }
-    }
+    let mut blob_hashes = HashSet::new();
 
-    Ok(())
-}
-
-fn check_tree_recursive(
-    repo: &Repository,
-    tree_hash: &ContentHash,
-    checked: &mut HashSet<ContentHash>,
-    errors: &mut Vec<FsckError>,
-    warnings: &mut Vec<String>,
-    objects_checked: &mut usize,
-) -> Result<()> {
-    if checked.contains(tree_hash) {
-        return Ok(());
-    }
-    checked.insert(*tree_hash);
-
-    let Some(tree) = repo.store().get_tree(tree_hash)? else {
-        return Ok(());
-    };
-
-    *objects_checked += 1;
-
-    for entry in tree.entries() {
-        if let Some(hash) = entry.blob_hash() {
-            if !repo.store().has_blob(&hash)? {
-                if repo.is_missing_blob(&hash)? {
-                    warnings.push(format!(
-                        "Tree entry '{}' references blob {} that is explicitly absent under partial fetch",
-                        entry.name(),
-                        hash.short()
-                    ));
-                } else {
-                    errors.push(make_error(
-                        "missing_blob",
-                        &format!("Tree entry '{}' references missing blob", entry.name()),
-                        Some(hash.short()),
-                    ));
-                }
+    walk_tree_integrity(repo.store(), roots, &mut |event| {
+        match event {
+            TreeIntegrityEvent::EnterTree { .. } => {
+                *objects_checked += 1;
+                Ok(())
             }
-        } else if let Some(hash) = entry.tree_hash() {
-            check_tree_recursive(repo, &hash, checked, errors, warnings, objects_checked)?;
+            TreeIntegrityEvent::BlobLeaf { entry, .. } => {
+                if let Some(hash) = entry.blob_hash() {
+                    if !repo.store().has_blob(&hash)? {
+                        if repo.is_missing_blob(&hash)? {
+                            warnings.push(format!(
+                                "Tree entry '{}' references blob {} that is explicitly absent under partial fetch",
+                                entry.name(),
+                                hash.short()
+                            ));
+                        } else {
+                            errors.push(make_error(
+                                "missing_blob",
+                                &format!("Tree entry '{}' references missing blob", entry.name()),
+                                Some(hash.short()),
+                            ));
+                        }
+                    }
+                    blob_hashes.insert(hash);
+                }
+                Ok(())
+            }
+            TreeIntegrityEvent::TreeRef { .. } => Ok(()),
         }
-    }
+    })?;
 
-    Ok(())
-}
-
-pub(crate) fn check_blobs(
-    repo: &Repository,
-    errors: &mut Vec<FsckError>,
-    _warnings: &mut Vec<String>,
-    objects_checked: &mut usize,
-) -> Result<()> {
-    let states = repo.store().list_states()?;
-    let mut checked_blobs: HashSet<ContentHash> = HashSet::new();
-
-    for state_id in states {
-        if let Some(state) = repo.store().get_state(&state_id)?
-            && let Some(tree) = repo.store().get_tree(&state.tree)?
-        {
-            collect_blobs_from_tree(repo, &tree, &mut checked_blobs)?;
-        }
-    }
-
-    for blob_hash in checked_blobs {
+    for blob_hash in blob_hashes {
         *objects_checked += 1;
         if let Some(blob) = repo.store().get_blob(&blob_hash)? {
             let computed_hash = blob.hash();
@@ -118,22 +83,5 @@ pub(crate) fn check_blobs(
         }
     }
 
-    Ok(())
-}
-
-fn collect_blobs_from_tree(
-    repo: &Repository,
-    tree: &Tree,
-    blobs: &mut HashSet<ContentHash>,
-) -> Result<()> {
-    for entry in tree.entries() {
-        if let Some(hash) = entry.blob_hash() {
-            blobs.insert(hash);
-        } else if let Some(hash) = entry.tree_hash()
-            && let Some(subtree) = repo.store().get_tree(&hash)?
-        {
-            collect_blobs_from_tree(repo, &subtree, blobs)?;
-        }
-    }
     Ok(())
 }

--- a/crates/core/src/fsck/objects.rs
+++ b/crates/core/src/fsck/objects.rs
@@ -17,16 +17,12 @@ pub(crate) fn check_tree_objects(
     objects_checked: &mut usize,
 ) -> Result<()> {
     let states = repo.store().list_states()?;
-    let roots: Vec<ContentHash> = states
-        .iter()
-        .filter_map(|state_id| {
-            repo.store()
-                .get_state(state_id)
-                .ok()
-                .flatten()
-                .map(|state| state.tree)
-        })
-        .collect();
+    let mut roots = Vec::with_capacity(states.len());
+    for state_id in states {
+        if let Some(state) = repo.store().get_state(&state_id)? {
+            roots.push(state.tree);
+        }
+    }
 
     let mut blob_hashes = HashSet::new();
 

--- a/crates/core/src/fsck/objects.rs
+++ b/crates/core/src/fsck/objects.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use objects::{
     error::Result,
-    object::{ContentHash, TreeIntegrityEvent, walk_tree_integrity},
+    object::{TreeIntegrityEvent, walk_tree_integrity},
     store::ObjectStore,
 };
 use repo::Repository;

--- a/crates/core/src/fsck/tests.rs
+++ b/crates/core/src/fsck/tests.rs
@@ -12,7 +12,7 @@ use sley::ObjectId as GitObjectId;
 use tempfile::TempDir;
 
 use super::{
-    objects::{check_blobs, check_trees},
+    objects::check_tree_objects,
     state::check_states,
 };
 
@@ -158,8 +158,8 @@ fn test_fsck_treats_explicitly_missing_partial_fetch_blob_as_warning() {
     let mut warnings = Vec::new();
     let mut objects_checked = 0;
 
-    check_trees(&repo, &mut errors, &mut warnings, &mut objects_checked).expect("check trees");
-    check_blobs(&repo, &mut errors, &mut warnings, &mut objects_checked).expect("check blobs");
+    check_tree_objects(&repo, &mut errors, &mut warnings, &mut objects_checked)
+        .expect("check tree objects");
 
     assert!(
         errors.iter().all(|error| error.kind != "missing_blob"),
@@ -191,14 +191,93 @@ fn test_fsck_does_not_require_gitlink_target_object() {
     let mut warnings = Vec::new();
     let mut objects_checked = 0;
 
-    check_trees(&repo, &mut errors, &mut warnings, &mut objects_checked).expect("check trees");
-    check_blobs(&repo, &mut errors, &mut warnings, &mut objects_checked).expect("check blobs");
+    check_tree_objects(&repo, &mut errors, &mut warnings, &mut objects_checked)
+        .expect("check tree objects");
 
     assert!(
         errors.is_empty(),
         "gitlink target lives outside the Heddle object store: {errors:?}"
     );
     assert!(warnings.is_empty(), "warnings={warnings:?}");
+}
+
+/// Fixture exercising every tree/blob fsck finding class. Expected values were
+/// captured from the pre-refactor `check_trees` + `check_blobs` pair.
+#[test]
+fn test_tree_blob_checks_characterization() {
+    use objects::object::ContentHash;
+
+    let (_temp, repo) = setup_repo();
+
+    // Missing blob (not partial-fetch): referenced but never stored.
+    let missing_hash = ContentHash::compute(b"ghost-blob");
+
+    // Partial-fetch missing blob: referenced and explicitly marked absent.
+    let partial_blob = Blob::from("partial-fetch\n");
+    let partial_hash = partial_blob.hash();
+
+    // Shared subtree reused by two states.
+    let shared_blob = Blob::from("shared-leaf\n");
+    let shared_blob_hash = repo.store().put_blob(&shared_blob).expect("put shared blob");
+    let shared_tree = Tree::from_entries(vec![
+        objects::object::TreeEntry::file("shared.txt", shared_blob_hash, false).unwrap(),
+    ]);
+    let shared_tree_hash = repo.store().put_tree(&shared_tree).expect("put shared tree");
+
+    // Dangling subtree ref (missing child tree — fsck stays silent).
+    let dangling_tree_hash = ContentHash::compute(b"missing-subtree");
+    let dangling_parent = Tree::from_entries(vec![
+        objects::object::TreeEntry::directory("missing", dangling_tree_hash).unwrap(),
+        objects::object::TreeEntry::file("absent.txt", missing_hash, false).unwrap(),
+        objects::object::TreeEntry::file("partial.txt", partial_hash, false).unwrap(),
+    ]);
+    let dangling_parent_hash = repo
+        .store()
+        .put_tree(&dangling_parent)
+        .expect("put dangling parent");
+
+    let state_shared_a = State::new(shared_tree_hash, vec![], sample_attribution());
+    let state_shared_b = State::new(shared_tree_hash, vec![], sample_attribution());
+    let state_dangling = State::new(dangling_parent_hash, vec![], sample_attribution());
+    repo.store().put_state(&state_shared_a).expect("put state a");
+    repo.store().put_state(&state_shared_b).expect("put state b");
+    repo.store().put_state(&state_dangling).expect("put state dangling");
+    repo.record_missing_blob(partial_hash)
+        .expect("record partial-fetch blob");
+
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+    let mut objects_checked = 0;
+
+    check_tree_objects(&repo, &mut errors, &mut warnings, &mut objects_checked)
+        .expect("check tree objects");
+
+    assert_eq!(
+        objects_checked, 6,
+        "three unique trees plus three unique blob checks"
+    );
+
+    let error_kinds: Vec<_> = errors.iter().map(|error| error.kind.as_str()).collect();
+    assert_eq!(
+        error_kinds,
+        vec!["missing_blob", "missing_blob"],
+        "tree-phase then blob-phase ordering must be preserved"
+    );
+
+    assert_eq!(
+        errors[0].message,
+        "Tree entry 'absent.txt' references missing blob"
+    );
+    assert_eq!(errors[1].message, "Tree references missing blob");
+    assert_eq!(errors[0].object, errors[1].object, "same missing blob hash");
+
+    assert_eq!(warnings.len(), 1);
+    assert!(
+        warnings[0].contains("partial.txt")
+            && warnings[0].contains("explicitly absent under partial fetch"),
+        "partial-fetch warning: {}",
+        warnings[0]
+    );
 }
 
 #[test]

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -29,6 +29,7 @@ mod suggestion_core;
 mod timeline;
 mod tree;
 mod tree_diff;
+mod tree_walk;
 mod visibility_tier;
 
 pub use action_id::ActionId;
@@ -96,4 +97,5 @@ pub use tree::{
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;
 pub use tree_diff::{diff_trees, diff_trees_visit};
+pub use tree_walk::{TreeIntegrityEvent, walk_tree_integrity};
 pub use visibility_tier::VisibilityTier;

--- a/crates/objects/src/object/tree_walk.rs
+++ b/crates/objects/src/object/tree_walk.rs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tree integrity walking — single traversal for reference and content checks.
+
+use std::collections::HashSet;
+
+use crate::{
+    error::Result,
+    object::{ContentHash, Tree, TreeEntry},
+    store::ObjectSource,
+};
+
+/// Events emitted while walking reachable trees for integrity checks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TreeIntegrityEvent<'a> {
+    /// A tree was entered for the first time during this walk.
+    EnterTree {
+        hash: ContentHash,
+        tree: &'a Tree,
+    },
+    /// A blob file entry at `path` (symlinks and gitlinks are excluded).
+    BlobLeaf {
+        entry: &'a TreeEntry,
+        path: String,
+    },
+    /// A child tree entry from `parent_hash`.
+    TreeRef {
+        parent_hash: ContentHash,
+        entry: &'a TreeEntry,
+    },
+}
+
+/// Walk all trees reachable from `roots`, deduplicating visited trees.
+///
+/// Missing root or subtree trees are skipped silently. Gitlink entries are not
+/// descended into. Visitation order is depth-first, sorted tree entry order.
+pub fn walk_tree_integrity<S, V>(
+    source: &S,
+    roots: impl IntoIterator<Item = ContentHash>,
+    visitor: &mut V,
+) -> Result<()>
+where
+    S: ObjectSource + ?Sized,
+    V: FnMut(TreeIntegrityEvent<'_>) -> Result<()>,
+{
+    let mut visited = HashSet::new();
+    for root in roots {
+        walk_tree_recursive(source, &root, "", &mut visited, visitor)?;
+    }
+    Ok(())
+}
+
+fn walk_tree_recursive<S, V>(
+    source: &S,
+    tree_hash: &ContentHash,
+    path_prefix: &str,
+    visited: &mut HashSet<ContentHash>,
+    visitor: &mut V,
+) -> Result<()>
+where
+    S: ObjectSource + ?Sized,
+    V: FnMut(TreeIntegrityEvent<'_>) -> Result<()>,
+{
+    if visited.contains(tree_hash) {
+        return Ok(());
+    }
+    visited.insert(*tree_hash);
+
+    let Some(tree) = source.get_tree(tree_hash)? else {
+        return Ok(());
+    };
+
+    visitor(TreeIntegrityEvent::EnterTree {
+        hash: *tree_hash,
+        tree: &tree,
+    })?;
+
+    for entry in tree.entries() {
+        let path = if path_prefix.is_empty() {
+            entry.name().to_string()
+        } else {
+            format!("{path_prefix}/{}", entry.name())
+        };
+
+        if entry.blob_hash().is_some() {
+            visitor(TreeIntegrityEvent::BlobLeaf { entry, path: path.clone() })?;
+        } else if let Some(child_hash) = entry.tree_hash() {
+            visitor(TreeIntegrityEvent::TreeRef {
+                parent_hash: *tree_hash,
+                entry,
+            })?;
+            walk_tree_recursive(source, &child_hash, &path, visited, visitor)?;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        object::{Blob, Tree, TreeEntry},
+        store::{InMemoryStore, ObjectStore},
+    };
+
+    #[test]
+    fn walk_tree_integrity_dedups_shared_subtrees() {
+        let store = InMemoryStore::new();
+        let blob = Blob::from("shared\n");
+        let blob_hash = store.put_blob(&blob).unwrap();
+        let shared = Tree::from_entries(vec![
+            TreeEntry::file("leaf.txt", blob_hash, false).unwrap(),
+        ]);
+        let shared_hash = store.put_tree(&shared).unwrap();
+        let root_a = Tree::from_entries(vec![
+            TreeEntry::directory("shared", shared_hash).unwrap(),
+            TreeEntry::file("a.txt", blob_hash, false).unwrap(),
+        ]);
+        let root_b = Tree::from_entries(vec![TreeEntry::directory("shared", shared_hash).unwrap()]);
+        let root_a_hash = store.put_tree(&root_a).unwrap();
+        let root_b_hash = store.put_tree(&root_b).unwrap();
+
+        let mut enter_count = 0;
+        let mut blob_leaves = Vec::new();
+
+        walk_tree_integrity(&store, [root_a_hash, root_b_hash], &mut |event| {
+            match event {
+                TreeIntegrityEvent::EnterTree { .. } => enter_count += 1,
+                TreeIntegrityEvent::BlobLeaf { path, .. } => blob_leaves.push(path),
+                TreeIntegrityEvent::TreeRef { .. } => {}
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(enter_count, 3, "shared subtree must be visited once");
+        assert_eq!(
+            blob_leaves,
+            vec!["a.txt".to_string(), "shared/leaf.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn walk_tree_integrity_skips_missing_subtree_silently() {
+        let store = InMemoryStore::new();
+        let missing = ContentHash::compute(b"missing-tree");
+        let root = Tree::from_entries(vec![TreeEntry::directory("gone", missing).unwrap()]);
+        let root_hash = store.put_tree(&root).unwrap();
+
+        let mut enter_count = 0;
+        walk_tree_integrity(&store, [root_hash], &mut |event| {
+            if let TreeIntegrityEvent::EnterTree { .. } = event {
+                enter_count += 1;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+        assert_eq!(enter_count, 1);
+    }
+}


### PR DESCRIPTION
Closes #860.

## What changed

- Added `objects::object::tree_walk::walk_tree_integrity`, a pure tree walker emitting `EnterTree`, `BlobLeaf`, and `TreeRef` events with visited-tree dedup.
- Replaced separate `check_trees` + `check_blobs` full traversals in fsck with one `check_tree_objects` pass: reference checks and blob-hash checks are visitors over the same walk.
- Preserved finding kinds, messages, ordering (tree-phase errors/warnings first, then blob-phase errors in HashSet iteration order), partial-fetch exception handling, and shared-subtree dedup.

## Characterization proof

`test_tree_blob_checks_characterization` builds a fixture covering:
- dangling subtree ref (silent skip)
- missing blob (tree-phase + blob-phase duplicate report)
- partial-fetch missing blob (warning only)
- shared subtree across two states (deduped tree visits)

Expected values were captured from the pre-refactor `check_trees` + `check_blobs` pair; the unified walker reproduces them exactly.

## Gates

- `cargo build --locked --workspace` ✓
- `cargo test -p heddle-core -p heddle-objects` ✓
- `cargo clippy -p heddle-core -p heddle-objects --all-targets -- -D warnings` ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785534720&installation_id=132405951&pr_number=867&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F867&signature=ca07827b8e9baa8447fe24f45e390154609499000a38833149312c7834457d62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->