### PR TITLE
refactor(objects): typed tree path resolver with leaf policies (#861)

### DIFF
--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -21,8 +21,10 @@ use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use crypto::{Signer, load_signer, verify_payload_signature};
 use objects::{
-    object::{ChangeId, ContentHash, Redaction, RedactionsBlob, StateSignature},
-    store::ObjectStore,
+    object::{
+        ChangeId, ContentHash, LeafPolicy, Redaction, RedactionsBlob, StateSignature,
+        TreePathResolveError, resolve_tree_path,
+    },
     worktree::should_ignore,
 };
 use oplog::OpLogRecorder;
@@ -506,45 +508,24 @@ pub(crate) fn blob_at_path(repo: &Repository, state: &ChangeId, path: &str) -> R
             "heddle redact apply <state> --path <path>",
         )));
     }
-    let hash = walk_path_to_blob(repo, &tree, &parts)?
-        .ok_or_else(|| anyhow!("path '{}' not in state {}", path, state.short()))?;
-    Ok(hash)
-}
-
-/// Walk a slash-split path through nested subtrees to the terminal
-/// blob. Returns `Ok(None)` when any path component is missing or
-/// resolves to the wrong entry type; the caller surfaces the
-/// user-facing error so the message can name the original spec.
-fn walk_path_to_blob(
-    repo: &Repository,
-    tree: &objects::object::Tree,
-    parts: &[&str],
-) -> Result<Option<ContentHash>> {
-    if parts.is_empty() {
-        return Ok(None);
-    }
-    let entry = match tree.get(parts[0]) {
-        Some(e) => e,
-        None => return Ok(None),
-    };
-    if parts.len() == 1 {
-        if let Some(hash) = entry.blob_hash() {
-            return Ok(Some(hash));
+    let hash = match resolve_tree_path(
+        repo.store(),
+        &tree.hash(),
+        std::path::Path::new(path),
+        LeafPolicy::BlobOnly,
+    ) {
+        Ok(Some(target)) => target.content_hash,
+        Ok(None) => None,
+        Err(TreePathResolveError::SubtreeMissing(hash)) => {
+            return Err(anyhow!("subtree {} missing from store", hash.short()));
         }
-        return Ok(None);
+        Err(TreePathResolveError::Store { hash, source }) => {
+            return Err(anyhow::Error::from(*source))
+                .context(format!("load subtree {}", hash.short()));
+        }
     }
-    if !entry.is_tree() {
-        return Ok(None);
-    }
-    let Some(hash) = entry.tree_hash() else {
-        return Ok(None);
-    };
-    let subtree = repo
-        .store()
-        .get_tree(&hash)
-        .with_context(|| format!("load subtree {}", hash.short()))?
-        .ok_or_else(|| anyhow!("subtree {} missing from store", hash.short()))?;
-    walk_path_to_blob(repo, &subtree, &parts[1..])
+    .ok_or_else(|| anyhow!("path '{}' not in state {}", path, state.short()))?;
+    Ok(hash)
 }
 
 /// Resolve a `<redaction-id>` CLI argument (short or full) to its
@@ -890,5 +871,86 @@ fn short_key(hex: &str) -> String {
         hex.to_string()
     } else {
         format!("{}…", &hex[..16])
+    }
+}
+
+#[cfg(test)]
+mod tree_path_tests {
+    use objects::{
+        object::{Attribution, Blob, ContentHash, Principal, State, Tree, TreeEntry},
+        store::ObjectStore,
+    };
+    use repo::Repository;
+    use tempfile::TempDir;
+
+    use super::blob_at_path;
+
+    fn state_with_tree(repo: &Repository, root_hash: ContentHash) -> objects::object::ChangeId {
+        let state = State::new(
+            root_hash,
+            Vec::new(),
+            Attribution::human(Principal::new("tester".to_string(), "tester@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        state.change_id
+    }
+
+    #[test]
+    fn blob_at_path_characterizes_blob_only_policy() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+        let store = repo.store();
+
+        let blob_hash = store.put_blob(&Blob::from_slice(b"blob content")).unwrap();
+        let symlink_hash = store.put_blob(&Blob::from_slice(b"target.txt")).unwrap();
+        let nested_blob_hash = store
+            .put_blob(&Blob::from_slice(b"nested content"))
+            .unwrap();
+        let missing_subtree_hash = ContentHash::compute(b"not-in-store");
+
+        let nested_tree = store
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("inner.txt", nested_blob_hash, false).unwrap(),
+            ]))
+            .unwrap();
+        let missing_parent = store
+            .put_tree(&Tree::from_entries(vec![TreeEntry::directory(
+                "ghost".to_string(),
+                missing_subtree_hash,
+            )
+            .unwrap()]))
+            .unwrap();
+        let root_hash = store
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt", blob_hash, false).unwrap(),
+                TreeEntry::symlink("link".to_string(), symlink_hash).unwrap(),
+                TreeEntry::directory("dir".to_string(), nested_tree).unwrap(),
+                TreeEntry::directory("missing".to_string(), missing_parent).unwrap(),
+            ]))
+            .unwrap();
+        let state = state_with_tree(&repo, root_hash);
+
+        assert_eq!(
+            blob_at_path(&repo, &state, "file.txt").unwrap(),
+            blob_hash
+        );
+        assert_eq!(
+            blob_at_path(&repo, &state, "dir/inner.txt").unwrap(),
+            nested_blob_hash
+        );
+
+        let symlink_err = blob_at_path(&repo, &state, "link").unwrap_err();
+        assert!(symlink_err.to_string().contains("path 'link' not in state"));
+
+        let missing_err = blob_at_path(&repo, &state, "nope.txt").unwrap_err();
+        assert!(missing_err
+            .to_string()
+            .contains("path 'nope.txt' not in state"));
+
+        let subtree_err = blob_at_path(&repo, &state, "missing/ghost/inner.txt").unwrap_err();
+        assert!(subtree_err
+            .to_string()
+            .contains("subtree")
+            && subtree_err.to_string().contains("missing from store"));
     }
 }

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -28,6 +28,7 @@ mod structured_conflict;
 mod suggestion_core;
 mod timeline;
 mod tree;
+mod tree_path;
 mod tree_diff;
 mod visibility_tier;
 
@@ -93,6 +94,11 @@ pub use tree::{
     EntryType, FileMode, Tree, TreeEntry, TreeEntryTarget, TreeError,
     validate_name as validate_tree_entry_name,
 };
+pub use tree_path::{
+    LeafPolicy, ResolvedTreeTarget, TreePathResolveError, resolve_tree_path, split_path,
+};
+#[cfg(feature = "async-source")]
+pub use tree_path::resolve_tree_path_async;
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;
 pub use tree_diff::{diff_trees, diff_trees_visit};

--- a/crates/objects/src/object/tree_path.rs
+++ b/crates/objects/src/object/tree_path.rs
@@ -1,0 +1,599 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed tree path resolution with per-caller leaf policies.
+
+use std::path::{Component, Path};
+
+use super::{Blob, ContentHash, Tree, TreeEntry};
+use crate::error::HeddleError;
+use crate::store::ObjectSource;
+
+/// How a tree-path walk classifies and materializes the terminal entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeafPolicy {
+    /// Return the terminal [`TreeEntry`] regardless of entry type (provenance).
+    Entry,
+    /// Return the blob content hash at the terminal path; symlinks are excluded (redact).
+    BlobOnly,
+    /// Load the terminal blob via [`TreeEntry::leaf_content_hash`], including symlinks
+    /// (staleness).
+    LeafContentBlob,
+}
+
+/// Successful resolution of a path within a tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTreeTarget {
+    pub entry: TreeEntry,
+    pub content_hash: Option<ContentHash>,
+    pub blob: Option<Blob>,
+}
+
+/// Errors surfaced by [`resolve_tree_path`] that callers map to their own messages.
+#[derive(Debug)]
+pub enum TreePathResolveError {
+    Store {
+        hash: ContentHash,
+        source: Box<HeddleError>,
+    },
+    SubtreeMissing(ContentHash),
+}
+
+impl std::error::Error for TreePathResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TreePathResolveError::Store { source, .. } => Some(source.as_ref()),
+            TreePathResolveError::SubtreeMissing(_) => None,
+        }
+    }
+}
+
+impl From<TreePathResolveError> for HeddleError {
+    fn from(value: TreePathResolveError) -> Self {
+        match value {
+            TreePathResolveError::Store { source, .. } => *source,
+            TreePathResolveError::SubtreeMissing(hash) => {
+                HeddleError::InvalidObject(format!("subtree {} missing from store", hash.short()))
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for TreePathResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TreePathResolveError::Store { hash, .. } => {
+                write!(f, "failed to load tree {}", hash.short())
+            }
+            TreePathResolveError::SubtreeMissing(hash) => {
+                write!(f, "subtree {} missing from store", hash.short())
+            }
+        }
+    }
+}
+
+/// Split a repository-relative path into its first component and the remainder.
+pub fn split_path(path: &Path) -> Option<(&str, &Path)> {
+    let mut components = path.components();
+    let first = components.next()?;
+    let Component::Normal(name) = first else {
+        return None;
+    };
+    Some((name.to_str()?, components.as_path()))
+}
+
+/// Walk `path` from `root` through nested subtrees and resolve the terminal entry
+/// according to `policy`.
+///
+/// `Ok(None)` means the path is absent or terminates at the wrong entry type for the
+/// policy. Store failures and missing subtrees are policy-dependent; see
+/// [`TreePathResolveError`].
+pub fn resolve_tree_path<S: ObjectSource>(
+    store: &S,
+    root: &ContentHash,
+    path: &Path,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    let Some(segments) = segments_for_policy(path, policy) else {
+        return Ok(None);
+    };
+    if segments.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(tree) = load_subtree(store, root, policy)? else {
+        return Ok(None);
+    };
+    resolve_from_tree(store, &tree, &segments, policy)
+}
+
+#[cfg(feature = "async-source")]
+pub async fn resolve_tree_path_async<S: crate::store::AsyncObjectSource + ?Sized>(
+    store: &S,
+    root: &ContentHash,
+    path: &Path,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    let Some(segments) = segments_for_policy(path, policy) else {
+        return Ok(None);
+    };
+    if segments.is_empty() {
+        return Ok(None);
+    }
+
+    let Some(tree) = load_subtree_async(store, root, policy).await? else {
+        return Ok(None);
+    };
+    resolve_from_tree_async(store, &tree, &segments, policy).await
+}
+
+fn segments_for_policy(path: &Path, policy: LeafPolicy) -> Option<Vec<String>> {
+    match policy {
+        LeafPolicy::Entry => path_segments(path),
+        LeafPolicy::BlobOnly => {
+            let path_str = path.to_str()?;
+            Some(
+                path_str
+                    .split('/')
+                    .filter(|part| !part.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+            )
+        }
+        LeafPolicy::LeafContentBlob => Some(
+            path.to_string_lossy()
+                .split('/')
+                .map(str::to_string)
+                .collect(),
+        ),
+    }
+}
+
+fn path_segments(path: &Path) -> Option<Vec<String>> {
+    if path.as_os_str().is_empty() {
+        return None;
+    }
+    let mut segments = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::Normal(name) => segments.push(name.to_str()?.to_string()),
+            _ => return None,
+        }
+    }
+    if segments.is_empty() {
+        return None;
+    }
+    Some(segments)
+}
+
+fn resolve_from_tree<S: ObjectSource>(
+    store: &S,
+    tree: &Tree,
+    segments: &[String],
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    let name = segments[0].as_str();
+    let Some(entry) = tree.get(name) else {
+        return Ok(None);
+    };
+
+    if segments.len() == 1 {
+        return resolve_leaf(store, entry.clone(), policy);
+    }
+
+    if !entry.is_tree() {
+        return Ok(None);
+    }
+    let Some(tree_hash) = entry.tree_hash() else {
+        return Ok(None);
+    };
+    let Some(subtree) = load_subtree(store, &tree_hash, policy)? else {
+        return Ok(None);
+    };
+    resolve_from_tree(store, &subtree, &segments[1..], policy)
+}
+
+#[cfg(feature = "async-source")]
+async fn resolve_from_tree_async<S: crate::store::AsyncObjectSource + ?Sized>(
+    store: &S,
+    tree: &Tree,
+    segments: &[String],
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    let name = segments[0].as_str();
+    let Some(entry) = tree.get(name) else {
+        return Ok(None);
+    };
+
+    if segments.len() == 1 {
+        return resolve_leaf_async(store, entry.clone(), policy).await;
+    }
+
+    if !entry.is_tree() {
+        return Ok(None);
+    }
+    let Some(tree_hash) = entry.tree_hash() else {
+        return Ok(None);
+    };
+    let Some(subtree) = load_subtree_async(store, &tree_hash, policy).await? else {
+        return Ok(None);
+    };
+    Box::pin(resolve_from_tree_async(store, &subtree, &segments[1..], policy)).await
+}
+
+fn resolve_leaf<S: ObjectSource>(
+    store: &S,
+    entry: TreeEntry,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    match policy {
+        LeafPolicy::Entry => {
+            let content_hash = entry_content_hash(&entry);
+            Ok(Some(ResolvedTreeTarget {
+                entry,
+                content_hash,
+                blob: None,
+            }))
+        }
+        LeafPolicy::BlobOnly => {
+            let Some(content_hash) = entry.blob_hash() else {
+                return Ok(None);
+            };
+            Ok(Some(ResolvedTreeTarget {
+                entry,
+                content_hash: Some(content_hash),
+                blob: None,
+            }))
+        }
+        LeafPolicy::LeafContentBlob => {
+            let Some(content_hash) = entry.leaf_content_hash() else {
+                return Ok(None);
+            };
+            let blob = match store.get_blob(&content_hash) {
+                Ok(Some(blob)) => Some(blob),
+                Ok(None) => None,
+                Err(source) => {
+                    return Err(TreePathResolveError::Store {
+                        hash: content_hash,
+                        source: Box::new(source),
+                    });
+                }
+            };
+            Ok(blob.map(|blob| ResolvedTreeTarget {
+                entry,
+                content_hash: Some(content_hash),
+                blob: Some(blob),
+            }))
+        }
+    }
+}
+
+#[cfg(feature = "async-source")]
+async fn resolve_leaf_async<S: crate::store::AsyncObjectSource + ?Sized>(
+    store: &S,
+    entry: TreeEntry,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<ResolvedTreeTarget>, TreePathResolveError> {
+    match policy {
+        LeafPolicy::Entry => {
+            let content_hash = entry_content_hash(&entry);
+            Ok(Some(ResolvedTreeTarget {
+                entry,
+                content_hash,
+                blob: None,
+            }))
+        }
+        LeafPolicy::BlobOnly => {
+            let Some(content_hash) = entry.blob_hash() else {
+                return Ok(None);
+            };
+            Ok(Some(ResolvedTreeTarget {
+                entry,
+                content_hash: Some(content_hash),
+                blob: None,
+            }))
+        }
+        LeafPolicy::LeafContentBlob => {
+            let Some(content_hash) = entry.leaf_content_hash() else {
+                return Ok(None);
+            };
+            let blob = match store.get_blob(&content_hash).await {
+                Ok(Some(blob)) => Some(blob),
+                Ok(None) => None,
+                Err(source) => {
+                    return Err(TreePathResolveError::Store {
+                        hash: content_hash,
+                        source: Box::new(source),
+                    });
+                }
+            };
+            Ok(blob.map(|blob| ResolvedTreeTarget {
+                entry,
+                content_hash: Some(content_hash),
+                blob: Some(blob),
+            }))
+        }
+    }
+}
+
+fn entry_content_hash(entry: &TreeEntry) -> Option<ContentHash> {
+    entry
+        .content_hash()
+        .or_else(|| entry.tree_hash())
+        .or_else(|| entry.leaf_content_hash())
+}
+
+fn load_subtree<S: ObjectSource>(
+    store: &S,
+    hash: &ContentHash,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<Tree>, TreePathResolveError> {
+    match policy {
+        LeafPolicy::Entry => Ok(store.get_tree(hash).ok().flatten()),
+        LeafPolicy::LeafContentBlob => match store.get_tree(hash) {
+            Ok(tree) => Ok(tree),
+            Err(source) => Err(TreePathResolveError::Store {
+                hash: *hash,
+                source: Box::new(source),
+            }),
+        },
+        LeafPolicy::BlobOnly => match store.get_tree(hash) {
+            Ok(Some(tree)) => Ok(Some(tree)),
+            Ok(None) => Err(TreePathResolveError::SubtreeMissing(*hash)),
+            Err(source) => Err(TreePathResolveError::Store {
+                hash: *hash,
+                source: Box::new(source),
+            }),
+        },
+    }
+}
+
+#[cfg(feature = "async-source")]
+async fn load_subtree_async<S: crate::store::AsyncObjectSource + ?Sized>(
+    store: &S,
+    hash: &ContentHash,
+    policy: LeafPolicy,
+) -> std::result::Result<Option<Tree>, TreePathResolveError> {
+    match policy {
+        LeafPolicy::Entry => Ok(store.get_tree(hash).await.ok().flatten()),
+        LeafPolicy::LeafContentBlob => match store.get_tree(hash).await {
+            Ok(tree) => Ok(tree),
+            Err(source) => Err(TreePathResolveError::Store {
+                hash: *hash,
+                source: Box::new(source),
+            }),
+        },
+        LeafPolicy::BlobOnly => match store.get_tree(hash).await {
+            Ok(Some(tree)) => Ok(Some(tree)),
+            Ok(None) => Err(TreePathResolveError::SubtreeMissing(*hash)),
+            Err(source) => Err(TreePathResolveError::Store {
+                hash: *hash,
+                source: Box::new(source),
+            }),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::{EntryType, TreeEntry};
+    use crate::store::{InMemoryStore, ObjectStore};
+
+    fn create_blob(store: &InMemoryStore, content: &[u8]) -> ContentHash {
+        ObjectStore::put_blob(store, &Blob::from_slice(content)).unwrap()
+    }
+
+    fn create_tree(
+        store: &InMemoryStore,
+        entries: Vec<(&str, ContentHash, EntryType)>,
+    ) -> ContentHash {
+        let entries = entries
+            .into_iter()
+            .map(|(name, hash, entry_type)| match entry_type {
+                EntryType::Blob => TreeEntry::file(name.to_string(), hash, false),
+                EntryType::Tree => TreeEntry::directory(name.to_string(), hash),
+                EntryType::Symlink => TreeEntry::symlink(name.to_string(), hash),
+                EntryType::Gitlink => unreachable!("tree path tests do not build gitlinks"),
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        ObjectStore::put_tree(store, &Tree::from_entries(entries)).unwrap()
+    }
+
+    struct Fixture {
+        store: InMemoryStore,
+        root: ContentHash,
+        blob_hash: ContentHash,
+        symlink_hash: ContentHash,
+        nested_blob_hash: ContentHash,
+        missing_subtree_hash: ContentHash,
+    }
+
+    fn fixture() -> Fixture {
+        let store = InMemoryStore::new();
+        let blob_hash = create_blob(&store, b"blob content");
+        let symlink_hash = create_blob(&store, b"target.txt");
+        let nested_blob_hash = create_blob(&store, b"nested content");
+
+        let nested_tree = create_tree(
+            &store,
+            vec![("inner.txt", nested_blob_hash, EntryType::Blob)],
+        );
+        let missing_subtree_hash = ContentHash::compute(b"not-in-store");
+        let missing_subtree_parent = create_tree(
+            &store,
+            vec![("ghost", missing_subtree_hash, EntryType::Tree)],
+        );
+        let root = create_tree(
+            &store,
+            vec![
+                ("file.txt", blob_hash, EntryType::Blob),
+                ("link", symlink_hash, EntryType::Symlink),
+                ("dir", nested_tree, EntryType::Tree),
+                ("missing", missing_subtree_parent, EntryType::Tree),
+            ],
+        );
+
+        Fixture {
+            store,
+            root,
+            blob_hash,
+            symlink_hash,
+            nested_blob_hash,
+            missing_subtree_hash,
+        }
+    }
+
+    #[test]
+    fn leaf_content_blob_resolves_symlinks_and_nested_paths() {
+        let fx = fixture();
+
+        let file = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("file.txt"),
+            LeafPolicy::LeafContentBlob,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(file.content_hash, Some(fx.blob_hash));
+        assert_eq!(file.blob.as_ref().unwrap().content(), b"blob content");
+
+        let link = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("link"),
+            LeafPolicy::LeafContentBlob,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(link.content_hash, Some(fx.symlink_hash));
+        assert_eq!(link.blob.as_ref().unwrap().content(), b"target.txt");
+
+        let nested = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("dir/inner.txt"),
+            LeafPolicy::LeafContentBlob,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(nested.content_hash, Some(fx.nested_blob_hash));
+
+        assert!(
+            resolve_tree_path(
+                &fx.store,
+                &fx.root,
+                Path::new("dir"),
+                LeafPolicy::LeafContentBlob,
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            resolve_tree_path(
+                &fx.store,
+                &fx.root,
+                Path::new("nope.txt"),
+                LeafPolicy::LeafContentBlob,
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            resolve_tree_path(
+                &fx.store,
+                &fx.root,
+                Path::new("missing/ghost/inner.txt"),
+                LeafPolicy::LeafContentBlob,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn entry_policy_returns_terminal_entry_for_any_leaf_type() {
+        let fx = fixture();
+
+        let file = resolve_tree_path(&fx.store, &fx.root, Path::new("file.txt"), LeafPolicy::Entry)
+            .unwrap()
+            .unwrap();
+        assert_eq!(file.entry.blob_hash(), Some(fx.blob_hash));
+
+        let link = resolve_tree_path(&fx.store, &fx.root, Path::new("link"), LeafPolicy::Entry)
+            .unwrap()
+            .unwrap();
+        assert!(link.entry.is_symlink());
+        assert_eq!(link.entry.leaf_content_hash(), Some(fx.symlink_hash));
+
+        let dir = resolve_tree_path(&fx.store, &fx.root, Path::new("dir"), LeafPolicy::Entry)
+            .unwrap()
+            .unwrap();
+        assert!(dir.entry.is_tree());
+
+        assert!(
+            resolve_tree_path(&fx.store, &fx.root, Path::new("dir/missing"), LeafPolicy::Entry)
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            resolve_tree_path(
+                &fx.store,
+                &fx.root,
+                Path::new("missing/ghost/inner.txt"),
+                LeafPolicy::Entry,
+            )
+            .unwrap()
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn blob_only_excludes_symlinks_and_errors_on_missing_subtree() {
+        let fx = fixture();
+
+        let file = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("file.txt"),
+            LeafPolicy::BlobOnly,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(file.content_hash, Some(fx.blob_hash));
+
+        assert!(
+            resolve_tree_path(&fx.store, &fx.root, Path::new("link"), LeafPolicy::BlobOnly)
+                .unwrap()
+                .is_none()
+        );
+
+        let nested = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("dir/inner.txt"),
+            LeafPolicy::BlobOnly,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(nested.content_hash, Some(fx.nested_blob_hash));
+
+        assert!(
+            resolve_tree_path(&fx.store, &fx.root, Path::new("dir"), LeafPolicy::BlobOnly)
+                .unwrap()
+                .is_none()
+        );
+
+        let err = resolve_tree_path(
+            &fx.store,
+            &fx.root,
+            Path::new("missing/ghost/inner.txt"),
+            LeafPolicy::BlobOnly,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            TreePathResolveError::SubtreeMissing(hash) if hash == fx.missing_subtree_hash
+        ));
+    }
+}

--- a/crates/repo/src/repository_provenance/helpers.rs
+++ b/crates/repo/src/repository_provenance/helpers.rs
@@ -3,8 +3,8 @@ use std::{collections::HashMap, path::Path};
 
 use objects::{
     object::{
-        Blob, ContentHash, FileProvenance, LineSpan, Origin, ProvenanceError, State, Tree,
-        TreeEntry,
+        Blob, ContentHash, FileProvenance, LeafPolicy, LineSpan, Origin, ProvenanceError, State,
+        Tree, TreeEntry, resolve_tree_path,
     },
     store::ObjectStore,
 };
@@ -142,25 +142,13 @@ pub(super) fn coalesce_line_spans(line_origin_sets: &[u32]) -> Vec<LineSpan> {
     spans
 }
 
+pub(super) use objects::object::split_path;
+
 pub(super) fn lookup_tree_entry(repo: &Repository, tree: &Tree, path: &Path) -> Option<TreeEntry> {
-    let (name, rest) = split_path(path)?;
-    let entry = tree.get(name)?.clone();
-    if rest.as_os_str().is_empty() {
-        return Some(entry);
-    }
-    if !entry.is_tree() {
-        return None;
-    }
-    let subtree_hash = entry.tree_hash()?;
-    let subtree = repo.store().get_tree(&subtree_hash).ok().flatten()?;
-    lookup_tree_entry(repo, &subtree, rest)
+    resolve_tree_path(repo.store(), &tree.hash(), path, LeafPolicy::Entry)
+        .ok()
+        .flatten()
+        .map(|target| target.entry)
 }
 
-pub(super) fn split_path(path: &Path) -> Option<(&str, &Path)> {
-    let mut components = path.components();
-    let first = components.next()?;
-    let std::path::Component::Normal(name) = first else {
-        return None;
-    };
-    Some((name.to_str()?, components.as_path()))
-}
+

--- a/crates/repo/src/repository_provenance/tests.rs
+++ b/crates/repo/src/repository_provenance/tests.rs
@@ -3,14 +3,14 @@ use std::path::Path;
 
 use objects::{
     object::{
-        Attribution, Blob, ChangeId, ContentHash, FileProvenance, LineSpan, Origin, OriginSet,
-        Principal, State, Tree, TreeEntry,
+        Attribution, Blob, ChangeId, ContentHash, FileProvenance, LineSpan, Origin,
+        OriginSet, Principal, State, Tree, TreeEntry,
     },
     store::ObjectStore,
 };
 use tempfile::TempDir;
 
-use super::helpers::{build_single_origin_provenance, lcs_line_matches};
+use super::helpers::{build_single_origin_provenance, lcs_line_matches, lookup_tree_entry};
 use crate::Repository;
 
 #[test]
@@ -418,4 +418,56 @@ fn provenance_merge_unions_origin_sets_not_set_indexes() {
     let line_sets = provenance.line_origin_set_indexes().unwrap();
     let first_line_origins = &provenance.origin_sets[line_sets[0] as usize].origin_indexes;
     assert_eq!(first_line_origins, &[0]);
+}
+
+#[test]
+fn lookup_tree_entry_characterizes_entry_policy_paths() {
+    let temp_dir = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp_dir.path()).unwrap();
+    let store = repo.store();
+
+    let blob_hash = store.put_blob(&Blob::from_slice(b"blob content")).unwrap();
+    let symlink_hash = store.put_blob(&Blob::from_slice(b"target.txt")).unwrap();
+    let nested_blob_hash = store
+        .put_blob(&Blob::from_slice(b"nested content"))
+        .unwrap();
+    let missing_subtree_hash = ContentHash::compute(b"not-in-store");
+
+    let nested_tree = store
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("inner.txt", nested_blob_hash, false).unwrap(),
+        ]))
+        .unwrap();
+    let missing_parent = store
+        .put_tree(&Tree::from_entries(vec![TreeEntry::directory(
+            "ghost".to_string(),
+            missing_subtree_hash,
+        )
+        .unwrap()]))
+        .unwrap();
+    let root_hash = store
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("file.txt", blob_hash, false).unwrap(),
+            TreeEntry::symlink("link".to_string(), symlink_hash).unwrap(),
+            TreeEntry::directory("dir".to_string(), nested_tree).unwrap(),
+            TreeEntry::directory("missing".to_string(), missing_parent).unwrap(),
+        ]))
+        .unwrap();
+    let tree = store.get_tree(&root_hash).unwrap().unwrap();
+
+    let file = lookup_tree_entry(&repo, &tree, Path::new("file.txt")).unwrap();
+    assert_eq!(file.blob_hash(), Some(blob_hash));
+
+    let link = lookup_tree_entry(&repo, &tree, Path::new("link")).unwrap();
+    assert!(link.is_symlink());
+
+    let dir = lookup_tree_entry(&repo, &tree, Path::new("dir")).unwrap();
+    assert!(dir.is_tree());
+
+    let nested = lookup_tree_entry(&repo, &tree, Path::new("dir/inner.txt")).unwrap();
+    assert_eq!(nested.blob_hash(), Some(nested_blob_hash));
+
+    assert!(lookup_tree_entry(&repo, &tree, Path::new("nope.txt")).is_none());
+    assert!(lookup_tree_entry(&repo, &tree, Path::new("dir/missing.txt")).is_none());
+    assert!(lookup_tree_entry(&repo, &tree, Path::new("missing/ghost/inner.txt")).is_none());
 }

--- a/crates/repo/src/staleness.rs
+++ b/crates/repo/src/staleness.rs
@@ -13,11 +13,13 @@ pub use objects::object::{
 use objects::store::AsyncObjectSource;
 use objects::{
     object::{
-        Annotation, Blob, ContextTarget, State, Tree,
-        annotation_status_for_source_with_symbol_resolver,
+        Annotation, Blob, ContextTarget, LeafPolicy, State, Tree,
+        annotation_status_for_source_with_symbol_resolver, resolve_tree_path,
     },
     store::ObjectSource,
 };
+#[cfg(feature = "async-source")]
+use objects::object::resolve_tree_path_async;
 
 use crate::Repository;
 
@@ -157,41 +159,14 @@ fn get_blob_at_path(
     tree: &Tree,
     path: &str,
 ) -> Result<Option<Blob>, anyhow::Error> {
-    let parts: Vec<&str> = path.split('/').collect();
-    get_blob_recursive(store, tree, &parts)
-}
-
-fn get_blob_recursive(
-    store: &impl ObjectSource,
-    tree: &Tree,
-    parts: &[&str],
-) -> Result<Option<Blob>, anyhow::Error> {
-    if parts.is_empty() {
-        return Ok(None);
-    }
-
-    let name = parts[0];
-    let entry = match tree.get(name) {
-        Some(e) => e,
-        None => return Ok(None),
-    };
-
-    if parts.len() == 1 {
-        // Serve symlink entries too: a symlink's object is a blob whose bytes
-        // are the target path. We return that target-path content (git
-        // semantics), NOT the content of the file it points at — following the
-        // link is a higher-level fs concern. `is_symlink()` lets such callers
-        // opt into following it themselves.
-        if let Some(blob_hash) = entry.leaf_content_hash() {
-            return Ok(store.get_blob(&blob_hash)?);
-        }
-    } else if let Some(tree_hash) = entry.tree_hash()
-        && let Some(subtree) = store.get_tree(&tree_hash)?
-    {
-        return get_blob_recursive(store, &subtree, &parts[1..]);
-    }
-
-    Ok(None)
+    let resolved = resolve_tree_path(
+        store,
+        &tree.hash(),
+        Path::new(path),
+        LeafPolicy::LeafContentBlob,
+    )
+    .map_err(anyhow::Error::from)?;
+    Ok(resolved.and_then(|target| target.blob))
 }
 
 /// Resolve a blob at a file path within a tree by walking the tree hierarchy.
@@ -204,42 +179,15 @@ pub async fn get_blob_at_path_async<S>(
 where
     S: AsyncObjectSource + Sync + ?Sized,
 {
-    let parts: Vec<&str> = path.split('/').collect();
-    get_blob_recursive_async(store, tree, &parts).await
-}
-
-#[cfg(feature = "async-source")]
-async fn get_blob_recursive_async<S>(
-    store: &S,
-    tree: &Tree,
-    parts: &[&str],
-) -> Result<Option<Blob>, anyhow::Error>
-where
-    S: AsyncObjectSource + Sync + ?Sized,
-{
-    if parts.is_empty() {
-        return Ok(None);
-    }
-
-    let name = parts[0];
-    let entry = match tree.get(name) {
-        Some(e) => e,
-        None => return Ok(None),
-    };
-
-    if parts.len() == 1 {
-        // See `get_blob_recursive`: symlink entries resolve to their blob
-        // (the target-path bytes), git-style; we do not follow the link.
-        if let Some(blob_hash) = entry.leaf_content_hash() {
-            return Ok(store.get_blob(&blob_hash).await?);
-        }
-    } else if let Some(tree_hash) = entry.tree_hash()
-        && let Some(subtree) = store.get_tree(&tree_hash).await?
-    {
-        return Box::pin(get_blob_recursive_async(store, &subtree, &parts[1..])).await;
-    }
-
-    Ok(None)
+    let resolved = resolve_tree_path_async(
+        store,
+        &tree.hash(),
+        Path::new(path),
+        LeafPolicy::LeafContentBlob,
+    )
+    .await
+    .map_err(anyhow::Error::from)?;
+    Ok(resolved.and_then(|target| target.blob))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #861.

## What changed

- Added `objects::resolve_tree_path` in `crates/objects/src/object/tree_path.rs` with three `LeafPolicy` variants that encode the intentional per-caller differences:
  - **`Entry`** — return terminal `TreeEntry` (any type); lenient subtree loads (provenance)
  - **`BlobOnly`** — blob hash only, symlinks excluded; strict subtree loads with `SubtreeMissing` error (redact)
  - **`LeafContentBlob`** — load blob via `leaf_content_hash` including symlinks; propagate store errors, missing subtree → not found (staleness)
- Re-pointed staleness (`get_blob_at_path` / async), provenance (`lookup_tree_entry`), and redact (`blob_at_path`); deleted the three private recursive walkers.
- Moved `split_path` into `objects` for shared path splitting.

## Characterization proof

Shared fixture tree: nested dir, symlink, missing subtree.

| Call site | Tests |
|-----------|-------|
| objects core | `leaf_content_blob_*`, `entry_policy_*`, `blob_only_*` |
| staleness | existing `symlink_entry_resolves_to_target_path_bytes` + async golden vectors |
| provenance | `lookup_tree_entry_characterizes_entry_policy_paths` |
| redact | `blob_at_path_characterizes_blob_only_policy` |

## Gates

- `cargo build --locked --workspace` ✓
- `cargo build --locked --workspace --all-features` ✓
- `cargo test -p heddle-objects -p heddle-repo -p heddle-cli --lib` ✓
- `cargo clippy -p heddle-objects -p heddle-repo --all-targets -- -D warnings` ✓

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/868"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785534931&installation_id=132405951&pr_number=868&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F868&signature=6df9df04357c5206c15ad1177ea1fdd313125fb503a8645d2190e2c9ac541f7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->