### PR TITLE
refactor(repo): one state-resolution API with explicit policy; delete per-command resolvers (#863)

### DIFF
--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -267,6 +267,11 @@ pub(crate) fn resolve_target(
 /// disambiguation that `heddle show` and `heddle context list --ref` already do.
 pub(crate) fn resolve_state_id(repo: &Repository, spec: &str) -> Result<objects::object::ChangeId> {
     let user_config = UserConfig::load_default().unwrap_or_default();
+    // The bootstrap hook must return a HeddleError, but ensure_current_state's
+    // failure carries CLI-level context (IO/snapshot causes) that must reach
+    // the user unrecategorized. Stash the original error and swap it back in
+    // below; the HeddleError is only a carrier across the typed boundary.
+    let bootstrap_failure = std::cell::RefCell::new(None);
     let bootstrap = |repo: &Repository| {
         ensure_current_state(
             repo,
@@ -274,13 +279,18 @@ pub(crate) fn resolve_state_id(repo: &Repository, spec: &str) -> Result<objects:
             Some("Bootstrap git-overlay before resolving HEAD context".to_string()),
         )
         .map(|_| ())
-        .map_err(|err| HeddleError::Conflict(err.to_string()))
+        .map_err(|err| {
+            let carrier = HeddleError::Conflict(err.to_string());
+            *bootstrap_failure.borrow_mut() = Some(err);
+            carrier
+        })
     };
     let policy = ResolvePolicy {
         git_overlay_import_hints: true,
         bootstrap_on_empty_head: Some(&bootstrap),
     };
     resolve_state_id_with_policy(repo, spec, policy)
+        .map_err(|err| bootstrap_failure.borrow_mut().take().unwrap_or(err))
 }
 
 pub(crate) fn target_label(target: &ContextTarget) -> (String, String) {

--- a/crates/cli/src/cli/commands/context/mod.rs
+++ b/crates/cli/src/cli/commands/context/mod.rs
@@ -18,8 +18,12 @@ use refs::Head;
 use repo::Repository;
 use serde::Serialize;
 
+use objects::error::HeddleError;
+use repo::ResolvePolicy;
+
 use super::{
-    advice::RecoveryAdvice, history_target::resolve_state_id as resolve_state_id_impl,
+    advice::RecoveryAdvice,
+    history_target::resolve_state_id_with_policy,
     snapshot::ensure_current_state,
 };
 use crate::{
@@ -262,14 +266,21 @@ pub(crate) fn resolve_target(
 /// (e.g. `hd-q99fkjzgjmjv`), full IDs, or ref-manager names — matching the
 /// disambiguation that `heddle show` and `heddle context list --ref` already do.
 pub(crate) fn resolve_state_id(repo: &Repository, spec: &str) -> Result<objects::object::ChangeId> {
-    if matches!(spec, "HEAD" | "@") && repo.current_state()?.is_none() {
+    let user_config = UserConfig::load_default().unwrap_or_default();
+    let bootstrap = |repo: &Repository| {
         ensure_current_state(
             repo,
-            &UserConfig::load_default().unwrap_or_default(),
+            &user_config,
             Some("Bootstrap git-overlay before resolving HEAD context".to_string()),
-        )?;
-    }
-    resolve_state_id_impl(repo, spec)
+        )
+        .map(|_| ())
+        .map_err(|err| HeddleError::Conflict(err.to_string()))
+    };
+    let policy = ResolvePolicy {
+        git_overlay_import_hints: true,
+        bootstrap_on_empty_head: Some(&bootstrap),
+    };
+    resolve_state_id_with_policy(repo, spec, policy)
 }
 
 pub(crate) fn target_label(target: &ContextTarget) -> (String, String) {

--- a/crates/cli/src/cli/commands/history_target.rs
+++ b/crates/cli/src/cli/commands/history_target.rs
@@ -12,12 +12,8 @@
 //! * `HEAD`, `@`, `HEAD~N`, `@~N`
 //! * a thread name
 //!
-//! The hard work happens in [`Repository::resolve_state`]; this layer
-//! adds two pieces of CLI-friendly polish:
-//!
-//! 1. A precise "not found" error message instead of `Ok(None)`.
-//! 2. A targeted hint when the spec matches a tip-only Git overlay
-//!    branch/tag whose history hasn't been imported yet.
+//! Resolution policy and lookup live in [`repo::resolve_state_for_command`];
+//! this layer maps structured failures to CLI [`RecoveryAdvice`] envelopes.
 //!
 //! Use [`resolve_state_id`] for the typed [`ChangeId`]. Use
 //! [`resolve_state_id_bytes`] when you need the wire-form 16-byte
@@ -29,9 +25,23 @@ use objects::{
     object::{ChangeId, State},
     store::ObjectStore,
 };
-use repo::Repository;
+use repo::{
+    ResolvePolicy, StateResolveFailure, resolve_state_for_command, Repository,
+};
 
 use super::advice::RecoveryAdvice;
+
+pub(crate) fn state_resolve_failure_to_error(failure: StateResolveFailure) -> anyhow::Error {
+    match failure {
+        StateResolveFailure::GitBranchHistoryNotImported { branch } => {
+            anyhow!(tip_only_branch_history_advice(&branch))
+        }
+        StateResolveFailure::GitTagHistoryNotImported { tag } => {
+            anyhow!(tip_only_tag_history_advice(&tag))
+        }
+        StateResolveFailure::NotFound { spec } => anyhow!(state_not_found_advice(&spec)),
+    }
+}
 
 /// Resolve a state spec to a typed [`ChangeId`].
 ///
@@ -42,21 +52,23 @@ use super::advice::RecoveryAdvice;
 /// * A targeted import-history hint when the spec matches a tip-only
 ///   Git-overlay ref whose history we haven't pulled yet.
 pub(crate) fn resolve_state_id(repo: &Repository, spec: &str) -> Result<ChangeId> {
-    match repo.resolve_state(spec)? {
-        Some(id) => Ok(id),
-        None => {
-            if let Some(tip) = repo.git_overlay_branch_tip(spec)?
-                && !tip.history_imported
-            {
-                return Err(anyhow!(tip_only_branch_history_advice(&tip.branch)));
-            }
-            if let Some(tip) = repo.git_overlay_tag_tip(spec)?
-                && !tip.history_imported
-            {
-                return Err(anyhow!(tip_only_tag_history_advice(&tip.tag)));
-            }
-            Err(anyhow!(state_not_found_advice(spec)))
-        }
+    resolve_state_id_with_policy(repo, spec, ResolvePolicy::with_git_overlay_hints())
+}
+
+pub(crate) fn resolve_state_id_with_policy(
+    repo: &Repository,
+    spec: &str,
+    policy: ResolvePolicy<'_>,
+) -> Result<ChangeId> {
+    resolve_state_for_command(repo, spec, policy)
+        .map(|resolved| resolved.change_id)
+        .map_err(state_resolve_error_to_anyhow)
+}
+
+fn state_resolve_error_to_anyhow(error: repo::StateResolveError) -> anyhow::Error {
+    match error {
+        repo::StateResolveError::Repository(err) => err.into(),
+        repo::StateResolveError::Failure(failure) => state_resolve_failure_to_error(failure),
     }
 }
 

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -198,7 +198,7 @@ fn resolve_state(repo: &Repository, spec: &str) -> Result<ChangeId> {
             repo::StateResolveError::Failure(repo::StateResolveFailure::NotFound { spec }) => {
                 anyhow!("state '{}' not found", spec)
             }
-            repo::StateResolveError::Failure(other) => anyhow!("{other}"),
+            repo::StateResolveError::Failure(other) => anyhow::Error::from(other),
         })
         .with_context(|| format!("resolve state '{}'", spec))
 }

--- a/crates/cli/src/cli/commands/purge.rs
+++ b/crates/cli/src/cli/commands/purge.rs
@@ -191,9 +191,16 @@ fn cmd_purge_list(cli: &Cli, repo: &Repository, _args: PurgeListArgs) -> Result<
 }
 
 fn resolve_state(repo: &Repository, spec: &str) -> Result<ChangeId> {
-    repo.resolve_state(spec)
-        .with_context(|| format!("resolve state '{}'", spec))?
-        .ok_or_else(|| anyhow!("state '{}' not found", spec))
+    repo::resolve_state_for_command(repo, spec, repo::ResolvePolicy::minimal())
+        .map(|resolved| resolved.change_id)
+        .map_err(|error| match error {
+            repo::StateResolveError::Repository(err) => err.into(),
+            repo::StateResolveError::Failure(repo::StateResolveFailure::NotFound { spec }) => {
+                anyhow!("state '{}' not found", spec)
+            }
+            repo::StateResolveError::Failure(other) => anyhow!("{other}"),
+        })
+        .with_context(|| format!("resolve state '{}'", spec))
 }
 
 fn blob_at_path(

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -489,9 +489,16 @@ fn emit_apply(cli: &Cli, output: &RedactApplyOutput) -> Result<()> {
 }
 
 fn resolve_state(repo: &Repository, spec: &str) -> Result<ChangeId> {
-    repo.resolve_state(spec)
-        .with_context(|| format!("resolve state '{}'", spec))?
-        .ok_or_else(|| anyhow!("state '{}' not found", spec))
+    repo::resolve_state_for_command(repo, spec, repo::ResolvePolicy::minimal())
+        .map(|resolved| resolved.change_id)
+        .map_err(|error| match error {
+            repo::StateResolveError::Repository(err) => err.into(),
+            repo::StateResolveError::Failure(repo::StateResolveFailure::NotFound { spec }) => {
+                anyhow!("state '{}' not found", spec)
+            }
+            repo::StateResolveError::Failure(other) => anyhow!("{other}"),
+        })
+        .with_context(|| format!("resolve state '{}'", spec))
 }
 
 pub(crate) fn blob_at_path(repo: &Repository, state: &ChangeId, path: &str) -> Result<ContentHash> {

--- a/crates/cli/src/cli/commands/redact.rs
+++ b/crates/cli/src/cli/commands/redact.rs
@@ -496,7 +496,7 @@ fn resolve_state(repo: &Repository, spec: &str) -> Result<ChangeId> {
             repo::StateResolveError::Failure(repo::StateResolveFailure::NotFound { spec }) => {
                 anyhow!("state '{}' not found", spec)
             }
-            repo::StateResolveError::Failure(other) => anyhow!("{other}"),
+            repo::StateResolveError::Failure(other) => anyhow::Error::from(other),
         })
         .with_context(|| format!("resolve state '{}'", spec))
 }

--- a/crates/core/src/diff/mod.rs
+++ b/crates/core/src/diff/mod.rs
@@ -16,7 +16,10 @@ use objects::{
     store::ObjectStore,
     worktree::{WorktreeStatus, diff_blobs},
 };
-use repo::Repository;
+use repo::{
+    ResolvePolicy, Repository, StateResolveError, StateResolveFailure,
+    resolve_state_for_command,
+};
 #[cfg(feature = "semantic")]
 use semantic::diff::{SemanticDiffOptions, WorktreeStatus as SemanticWorktreeStatus};
 use sley::{EntryKind, Repository as SleyRepository};
@@ -392,12 +395,16 @@ fn file_change_set_from_status(status: &WorktreeStatus) -> FileChangeSet {
     changes
 }
 
-fn resolve_state_id(repo: &Repository, spec: &str) -> Result<ChangeId> {
-    repo.resolve_state(spec)?.ok_or_else(|| {
-        anyhow!(HeddleError::recovery(RecoveryDetails::state_not_found(
-            spec
-        )))
-    })
+fn resolve_state_id(repository: &Repository, spec: &str) -> Result<ChangeId> {
+    resolve_state_for_command(repository, spec, ResolvePolicy::minimal())
+        .map(|resolved| resolved.change_id)
+        .map_err(|error| match error {
+            StateResolveError::Repository(err) => err.into(),
+            StateResolveError::Failure(StateResolveFailure::NotFound { spec }) => {
+                anyhow!(HeddleError::recovery(RecoveryDetails::state_not_found(spec)))
+            }
+            StateResolveError::Failure(other) => anyhow!("{other}"),
+        })
 }
 
 fn require_resolved_state(repo: &Repository, id: &ChangeId) -> Result<State> {
@@ -2628,6 +2635,41 @@ mod tests {
                 .map(|l| l.content.as_str()),
             Some("@ -1,2 +1,4 @@"),
             "display trim must not rewrite the `@@` header: {display:?}"
+        );
+    }
+
+    /// Characterization: core::diff maps minimal-policy not-found failures to
+    /// [`RecoveryDetails::state_not_found`], not plain strings.
+    #[test]
+    fn minimal_resolve_failure_maps_to_recovery_state_not_found() {
+        use objects::{
+            RecoveryDetails,
+            error::HeddleError,
+            store::ObjectStore,
+        };
+        use repo::{
+            ResolvePolicy, StateResolveError, StateResolveFailure, resolve_state_for_command,
+        };
+        use tempfile::TempDir;
+
+        let temp = TempDir::new().unwrap();
+        let repo = repo::Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+        repo.snapshot(Some("seed".into()), None).unwrap();
+
+        let err =
+            resolve_state_for_command(&repo, "hd-zzzzzzzzzzzz", ResolvePolicy::minimal())
+                .unwrap_err();
+        let mapped = match err {
+            StateResolveError::Failure(StateResolveFailure::NotFound { spec }) => {
+                HeddleError::recovery(RecoveryDetails::state_not_found(spec))
+            }
+            other => panic!("expected not-found failure, got {other:?}"),
+        };
+        assert!(matches!(mapped, HeddleError::Recovery(_)));
+        assert!(
+            mapped.to_string().contains("State not found"),
+            "unexpected message: {mapped}"
         );
     }
 }

--- a/crates/core/src/diff/mod.rs
+++ b/crates/core/src/diff/mod.rs
@@ -2642,11 +2642,7 @@ mod tests {
     /// [`RecoveryDetails::state_not_found`], not plain strings.
     #[test]
     fn minimal_resolve_failure_maps_to_recovery_state_not_found() {
-        use objects::{
-            RecoveryDetails,
-            error::HeddleError,
-            store::ObjectStore,
-        };
+        use objects::{RecoveryDetails, error::HeddleError};
         use repo::{
             ResolvePolicy, StateResolveError, StateResolveFailure, resolve_state_for_command,
         };

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -24,6 +24,8 @@ pub mod migration;
 pub mod namespace_policy;
 pub mod operation_dedup;
 mod repository;
+#[path = "repository_resolve_for_command.rs"]
+mod repository_resolve_for_command;
 mod repository_redaction;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
@@ -87,6 +89,10 @@ pub use objects::{
 };
 #[cfg(feature = "async-source")]
 pub use repository::query_history_async;
+pub use repository_resolve_for_command::{
+    ResolvePolicy, ResolvedState, StateResolveError, StateResolveFailure,
+    resolve_state_for_command,
+};
 pub use repository::{
     BlobHydrator, ChangeMonitorInspection, ChangedPathFilter, ChangedPathFilters,
     CheckoutMaterialization, CommitGraphIndex, CommitGraphInspection, ContextSuggestion,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -90,7 +90,7 @@ pub use objects::{
 #[cfg(feature = "async-source")]
 pub use repository::query_history_async;
 pub use repository_resolve_for_command::{
-    ResolvePolicy, ResolvedState, StateResolveError, StateResolveFailure,
+    EmptyHeadBootstrap, ResolvePolicy, ResolvedState, StateResolveError, StateResolveFailure,
     resolve_state_for_command,
 };
 pub use repository::{

--- a/crates/repo/src/repository_resolve_for_command.rs
+++ b/crates/repo/src/repository_resolve_for_command.rs
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Command-oriented state resolution with explicit per-caller policy.
+
+use objects::{
+    error::{HeddleError, Result as HeddleResult},
+    object::ChangeId,
+};
+
+use super::Repository;
+
+/// Policy knobs derived from the six pre-consolidation call sites.
+///
+/// * `git_overlay_import_hints` — history_target + context (via the rich
+///   resolver): when lookup returns `None`, check tip-only Git-overlay
+///   branch/tag refs and surface a structured import-history failure.
+/// * `bootstrap_on_empty_head` — context only: before resolving `HEAD` /
+///   `@` with no current state, run the supplied bootstrap hook (typically
+///   `ensure_current_state` in the CLI).
+#[derive(Clone, Copy, Default)]
+pub struct ResolvePolicy<'a> {
+    pub git_overlay_import_hints: bool,
+    pub bootstrap_on_empty_head: Option<&'a dyn Fn(&Repository) -> HeddleResult<()>>,
+}
+
+impl<'a> ResolvePolicy<'a> {
+    /// purge / redact / core::diff: plain lookup, no hints, no bootstrap.
+    pub fn minimal() -> Self {
+        Self {
+            git_overlay_import_hints: false,
+            bootstrap_on_empty_head: None,
+        }
+    }
+
+    /// history_target and other rich CLI resolvers.
+    pub fn with_git_overlay_hints() -> Self {
+        Self {
+            git_overlay_import_hints: true,
+            bootstrap_on_empty_head: None,
+        }
+    }
+}
+
+/// A state spec successfully resolved for command use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedState {
+    pub change_id: ChangeId,
+}
+
+/// Structured lookup failures callers map to their own user-facing text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StateResolveFailure {
+    NotFound { spec: String },
+    GitBranchHistoryNotImported { branch: String },
+    GitTagHistoryNotImported { tag: String },
+}
+
+impl std::fmt::Display for StateResolveFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { spec } => write!(f, "state not found: {spec}"),
+            Self::GitBranchHistoryNotImported { branch } => {
+                write!(f, "git branch history not imported: {branch}")
+            }
+            Self::GitTagHistoryNotImported { tag } => {
+                write!(f, "git tag history not imported: {tag}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StateResolveFailure {}
+
+/// Full error surface for command state resolution.
+#[derive(Debug)]
+pub enum StateResolveError {
+    Repository(HeddleError),
+    Failure(StateResolveFailure),
+}
+
+impl std::fmt::Display for StateResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Repository(err) => write!(f, "{err}"),
+            Self::Failure(failure) => write!(f, "{failure}"),
+        }
+    }
+}
+
+impl std::error::Error for StateResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Repository(err) => Some(err),
+            Self::Failure(failure) => Some(failure),
+        }
+    }
+}
+
+impl From<HeddleError> for StateResolveError {
+    fn from(value: HeddleError) -> Self {
+        Self::Repository(value)
+    }
+}
+
+/// Resolve a state specifier for command execution under explicit policy.
+///
+/// Ambiguous short-prefix conflicts from [`Repository::resolve_state`] still
+/// surface as [`HeddleError::Conflict`] via [`StateResolveError::Repository`].
+pub fn resolve_state_for_command(
+    repo: &Repository,
+    spec: &str,
+    policy: ResolvePolicy<'_>,
+) -> Result<ResolvedState, StateResolveError> {
+    if let Some(bootstrap) = policy.bootstrap_on_empty_head
+        && matches!(spec, "HEAD" | "@")
+        && repo.current_state()?.is_none()
+    {
+        bootstrap(repo)?;
+    }
+
+    match repo.resolve_state(spec)? {
+        Some(change_id) => Ok(ResolvedState { change_id }),
+        None => resolve_missing_state(repo, spec, policy),
+    }
+}
+
+fn resolve_missing_state(
+    repo: &Repository,
+    spec: &str,
+    policy: ResolvePolicy<'_>,
+) -> Result<ResolvedState, StateResolveError> {
+    if policy.git_overlay_import_hints {
+        if let Some(tip) = repo.git_overlay_branch_tip(spec)?
+            && !tip.history_imported
+        {
+            return Err(StateResolveError::Failure(
+                StateResolveFailure::GitBranchHistoryNotImported {
+                    branch: tip.branch,
+                },
+            ));
+        }
+        if let Some(tip) = repo.git_overlay_tag_tip(spec)?
+            && !tip.history_imported
+        {
+            return Err(StateResolveError::Failure(
+                StateResolveFailure::GitTagHistoryNotImported { tag: tip.tag },
+            ));
+        }
+    }
+
+    Err(StateResolveError::Failure(StateResolveFailure::NotFound {
+        spec: spec.to_string(),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use objects::store::ObjectStore;
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::Repository;
+
+    fn repo_with_snapshot() -> (TempDir, Repository, ChangeId) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+        let state = repo.snapshot(Some("first".into()), None).unwrap();
+        (temp, repo, state.change_id)
+    }
+
+    #[test]
+    fn minimal_policy_resolves_known_state() {
+        let (_temp, repo, id) = repo_with_snapshot();
+        let resolved =
+            resolve_state_for_command(&repo, &id.to_string_full(), ResolvePolicy::minimal())
+                .unwrap();
+        assert_eq!(resolved.change_id, id);
+    }
+
+    #[test]
+    fn minimal_policy_returns_not_found_without_hints() {
+        let (_temp, repo, _) = repo_with_snapshot();
+        let err = resolve_state_for_command(&repo, "hd-zzzzzzzzzzzz", ResolvePolicy::minimal())
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            StateResolveError::Failure(StateResolveFailure::NotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn bootstrap_runs_only_for_empty_head_spec() {
+        let (_temp, repo, id) = repo_with_snapshot();
+        let called = AtomicBool::new(false);
+        let bootstrap = |_: &Repository| {
+            called.store(true, Ordering::SeqCst);
+            Ok(())
+        };
+        let policy = ResolvePolicy {
+            git_overlay_import_hints: false,
+            bootstrap_on_empty_head: Some(&bootstrap),
+        };
+
+        let resolved = resolve_state_for_command(&repo, "HEAD", policy).unwrap();
+        assert_eq!(resolved.change_id, id);
+        assert!(!called.load(Ordering::SeqCst));
+
+        let resolved = resolve_state_for_command(&repo, &id.to_string_full(), policy).unwrap();
+        assert_eq!(resolved.change_id, id);
+        assert!(!called.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn bootstrap_runs_for_empty_head_before_resolving_head() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("a.txt"), "a").unwrap();
+
+        let bootstrapped = AtomicBool::new(false);
+        let bootstrap = |repo: &Repository| {
+            bootstrapped.store(true, Ordering::SeqCst);
+            repo.snapshot(Some("bootstrap".into()), None).map(|_| ())
+        };
+        let policy = ResolvePolicy {
+            git_overlay_import_hints: false,
+            bootstrap_on_empty_head: Some(&bootstrap),
+        };
+
+        let resolved = resolve_state_for_command(&repo, "HEAD", policy).unwrap();
+        assert!(bootstrapped.load(Ordering::SeqCst));
+        assert_eq!(repo.head().unwrap(), Some(resolved.change_id));
+    }
+
+    #[test]
+    fn git_overlay_hint_policy_distinguishes_not_found() {
+        let (_temp, repo, _) = repo_with_snapshot();
+        let err = resolve_state_for_command(
+            &repo,
+            "missing-branch",
+            ResolvePolicy::with_git_overlay_hints(),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            StateResolveError::Failure(StateResolveFailure::NotFound { .. })
+        ));
+    }
+}

--- a/crates/repo/src/repository_resolve_for_command.rs
+++ b/crates/repo/src/repository_resolve_for_command.rs
@@ -8,6 +8,10 @@ use objects::{
 
 use super::Repository;
 
+/// Bootstrap hook invoked when [`ResolvePolicy::bootstrap_on_empty_head`] is
+/// set and `HEAD` / `@` resolves against an empty current state.
+pub type EmptyHeadBootstrap<'a> = dyn Fn(&Repository) -> HeddleResult<()> + 'a;
+
 /// Policy knobs derived from the six pre-consolidation call sites.
 ///
 /// * `git_overlay_import_hints` — history_target + context (via the rich
@@ -19,7 +23,7 @@ use super::Repository;
 #[derive(Clone, Copy, Default)]
 pub struct ResolvePolicy<'a> {
     pub git_overlay_import_hints: bool,
-    pub bootstrap_on_empty_head: Option<&'a dyn Fn(&Repository) -> HeddleResult<()>>,
+    pub bootstrap_on_empty_head: Option<&'a EmptyHeadBootstrap<'a>>,
 }
 
 impl<'a> ResolvePolicy<'a> {
@@ -156,7 +160,6 @@ fn resolve_missing_state(
 mod tests {
     use std::sync::atomic::{AtomicBool, Ordering};
 
-    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use super::*;
@@ -215,7 +218,8 @@ mod tests {
     #[test]
     fn bootstrap_runs_for_empty_head_before_resolving_head() {
         let temp = TempDir::new().unwrap();
-        let repo = Repository::init_default(temp.path()).unwrap();
+        let repo = Repository::init(temp.path()).unwrap();
+        assert!(repo.current_state().unwrap().is_none());
         std::fs::write(temp.path().join("a.txt"), "a").unwrap();
 
         let bootstrapped = AtomicBool::new(false);


### PR DESCRIPTION
Closes #863.

## ResolvePolicy shape

```rust
pub struct ResolvePolicy<'a> {
    pub git_overlay_import_hints: bool,
    pub bootstrap_on_empty_head: Option<&'a EmptyHeadBootstrap<'a>>,
}
```

`resolve_state_for_command(repo, spec, policy) -> Result<ResolvedState, StateResolveError>` returns structured `StateResolveFailure` variants (`NotFound`, `GitBranchHistoryNotImported`, `GitTagHistoryNotImported`) for caller-side error mapping; repository errors (e.g. ambiguous prefix `HeddleError::Conflict`) propagate via `StateResolveError::Repository`.

## Per-callsite behavior (preserved)

| Call site | Policy | Error mapping at call site |
|---|---|---|
| `history_target` (show, goto, revert, …) | `git_overlay_import_hints: true`, no bootstrap | `RecoveryAdvice` envelopes (state not found + tip-only branch/tag import hints) |
| `context/mod.rs` | hints + bootstrap callback → `ensure_current_state` | same `RecoveryAdvice` mapping via `resolve_state_id_with_policy` |
| `purge.rs` / `redact.rs` | `ResolvePolicy::minimal()` | `with_context("resolve state …")` + `anyhow!("state '…' not found")` |
| `core::diff` | `ResolvePolicy::minimal()` | `HeddleError::recovery(RecoveryDetails::state_not_found)` |
| `snapshot::ensure_current_state` | unchanged bootstrap impl | invoked only through context bootstrap callback when `HEAD`/`@` has no current state |

## Preserved quirks (intentional, not unified)

- **Not-found copy differs** between CLI rich resolver (`RecoveryAdvice` with `heddle log` recovery command) and core diff (`RecoveryDetails::state_not_found` with shorter hint). Both kept via call-site mapping.
- **Bootstrap is context-only**; other commands that call `ensure_current_state` directly (show, log, goto, …) are unchanged.
- **Git-overlay import hints** are opt-in via policy; minimal callers skip tip-only branch/tag probes and go straight to not-found.

## Characterization tests

- `heddle-repo`: `repository_resolve_for_command::tests` — minimal not-found, hint policy, bootstrap runs only for empty `HEAD`/`@`.
- `heddle-core`: `diff::tests::minimal_resolve_failure_maps_to_recovery_state_not_found`.

## Gates

- `cargo build --locked --workspace` — pass
- `cargo clippy -p heddle-repo -p heddle-core -p heddle-cli --all-targets -- -D warnings` — pass
- `cargo test -p heddle-repo -p heddle-core -p heddle-cli` — repo/core lib tests pass; `cli_integration::oss_cli_polish` has 3 env-flaky actor-explain model assertions unrelated to this change (`claude-fable-5` vs `gpt-5.3-codex` from harness env)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785539559&installation_id=132405951&pr_number=871&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F871&signature=d96a70501dfe41de8170510105290a6ad6a8fda6787be4ce84ee276bbce9d1bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->