### PR TITLE
refactor(wire): typed ref-name classifier, ObjectType wire impl, RevisionAddress expectations (#854, #864, #865)

### DIFF
--- a/crates/cli/src/bridge/git_core.rs
+++ b/crates/cli/src/bridge/git_core.rs
@@ -14,7 +14,9 @@ use objects::{
     store::ObjectStore,
 };
 use refs::Head;
-use repo::Repository as HeddleRepository;
+use repo::{GitRefName, Repository as HeddleRepository};
+pub use repo::{GitRefKind, ParsedGitRef, REMOTE_NAME_FOR_LOCAL_GIT_REPO};
+pub(crate) use repo::{GitRefContentNamespace as RefNamespace, is_reserved_git_remote_name};
 use sley::{
     BString as GitBString, DeleteRef, FullName, GitObjectType, GitTime, Index, IndexEntry,
     IndexWriteOptions, ObjectFormat, ObjectId, RefPrecondition, ReferenceTarget,
@@ -116,36 +118,11 @@ pub enum GitBridgeError {
 /// Type alias for Git bridge results.
 pub type GitResult<T> = std::result::Result<T, GitBridgeError>;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum RefNamespace {
-    Branch,
-    Tag,
-    /// `refs/notes/<name>` — heddle uses `refs/notes/heddle` to carry
-    /// per-commit metadata (change_id) without disturbing commit SHAs.
-    Note,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct RefUpdate {
     pub name: String,
     pub target: ObjectId,
     pub namespace: RefNamespace,
-}
-
-/// Sentinel remote name for refs owned by the local repository
-/// (`refs/heads/*` and `refs/tags/*`). Ported from jj's
-/// `REMOTE_NAME_FOR_LOCAL_GIT_REPO` (`lib/src/git.rs`). Because a remote
-/// literally named `git` would collide with this sentinel, such a name must
-/// be rejected when remotes are configured.
-pub const REMOTE_NAME_FOR_LOCAL_GIT_REPO: &str = "git";
-
-/// Whether `remote` collides with [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`], the
-/// sentinel reserved for refs owned by the local repository. A user remote
-/// with this name cannot be represented unambiguously against local refs, so
-/// it must be rejected at every site that parses or accepts a remote name.
-/// Single source of truth for the reserved-namespace check.
-pub(crate) fn is_reserved_git_remote_name(remote: &str) -> bool {
-    remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
 }
 
 /// Reject a remote name that collides with [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`].
@@ -166,11 +143,7 @@ fn reject_reserved_git_remote_name(remote: &str) -> GitResult<()> {
 }
 
 fn remote_name_from_remote_ref(ref_name: &str) -> Option<&str> {
-    let remote_and_name = ref_name.strip_prefix("refs/remotes/")?;
-    let remote = remote_and_name
-        .split_once('/')
-        .map_or(remote_and_name, |(remote, _)| remote);
-    (!remote.is_empty()).then_some(remote)
+    GitRefName::new(ref_name).remote_name()
 }
 
 fn validate_refspec_ref(ref_name: &str) -> GitResult<()> {
@@ -180,71 +153,16 @@ fn validate_refspec_ref(ref_name: &str) -> GitResult<()> {
     Ok(())
 }
 
-/// The kind of Git ref [`parse_git_ref`] recognizes. Ported from jj's
-/// `GitRefKind` (`lib/src/git.rs`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum GitRefKind {
-    /// `refs/heads/<name>` or `refs/remotes/<remote>/<name>`.
-    Branch,
-    /// `refs/tags/<name>`.
-    Tag,
-}
-
-/// A parsed Git ref name: its kind, short name, and owning remote. Borrows
-/// from the input ref name. Ported from jj's `RemoteRefSymbol` shape
-/// (`lib/src/git.rs`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ParsedGitRef<'a> {
-    pub kind: GitRefKind,
-    /// Short name beneath the namespace, e.g. `main` for `refs/heads/main`
-    /// or `feature/x` for `refs/remotes/origin/feature/x`.
-    pub name: &'a str,
-    /// Owning remote. Local refs (`refs/heads/*`, `refs/tags/*`) report
-    /// [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`].
-    pub remote: &'a str,
-}
-
 /// Parse a fully-qualified Git ref name into its [`GitRefKind`], short name,
 /// and owning remote. Returns `None` for refs outside the
-/// branch/remote-branch/tag namespaces (e.g. `refs/notes/*`, `HEAD`).
+/// branch/remote-branch/tag/notes namespaces (e.g. `HEAD`).
 ///
-/// Ported from jj's `parse_git_ref` (`lib/src/git.rs`); like jj, the symbolic
-/// `HEAD` and `refs/remotes/<remote>/HEAD` entries are not treated as refs.
+/// Ported from jj's `parse_git_ref` (`lib/src/git.rs`) and extended for
+/// Heddle's notes content namespace; the symbolic `HEAD` and
+/// `refs/remotes/<remote>/HEAD` entries are not treated as refs.
 pub fn parse_git_ref(ref_name: &str) -> Option<ParsedGitRef<'_>> {
     RefSpec::new(None, ref_name, false).ok()?;
-
-    if let Some(name) = ref_name.strip_prefix("refs/heads/") {
-        // Git rejects `HEAD` as a branch name.
-        (name != "HEAD").then_some(ParsedGitRef {
-            kind: GitRefKind::Branch,
-            name,
-            remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
-        })
-    } else if let Some(remote_and_name) = ref_name.strip_prefix("refs/remotes/") {
-        let (remote, name) = remote_and_name.split_once('/')?;
-        // `refs/remotes/<remote>/HEAD` is the remote's symbolic default, not a
-        // real remote-tracking branch. A remote literally named `git` collides
-        // with the local sentinel ([`REMOTE_NAME_FOR_LOCAL_GIT_REPO`]); aliasing
-        // it onto local refs would make remote-tracking branches
-        // indistinguishable from `refs/heads/*`. Such a remote is already
-        // rejected by the `RefSpec::new` validation at the top of this function
-        // (`validate_refspec_ref` → `reject_reserved_git_remote_name`), so by the
-        // time we reach this branch `remote` is guaranteed not to collide —
-        // matching jj's parser and the sentinel ownership contract.
-        (name != "HEAD").then_some(ParsedGitRef {
-            kind: GitRefKind::Branch,
-            name,
-            remote,
-        })
-    } else {
-        ref_name
-            .strip_prefix("refs/tags/")
-            .map(|name| ParsedGitRef {
-                kind: GitRefKind::Tag,
-                name,
-                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
-            })
-    }
+    GitRefName::new(ref_name).bridge_ref()
 }
 
 /// A Git refspec: an optional `source`, a `destination`, and a `forced` (`+`)
@@ -2791,23 +2709,14 @@ fn collect_ref_updates(repo: &SleyRepository) -> GitResult<Vec<RefUpdate>> {
         let ReferenceTarget::Direct(target) = reference.target else {
             continue;
         };
-        if let Some(name) = reference.name.strip_prefix("refs/heads/") {
+        let ref_name = GitRefName::new(&reference.name);
+        if let Some(namespace) = ref_name.content_namespace()
+            && let Some(name) = ref_name.short_name()
+        {
             updates.push(RefUpdate {
                 name: name.to_string(),
                 target,
-                namespace: RefNamespace::Branch,
-            });
-        } else if let Some(name) = reference.name.strip_prefix("refs/tags/") {
-            updates.push(RefUpdate {
-                name: name.to_string(),
-                target,
-                namespace: RefNamespace::Tag,
-            });
-        } else if let Some(name) = reference.name.strip_prefix("refs/notes/") {
-            updates.push(RefUpdate {
-                name: name.to_string(),
-                target,
-                namespace: RefNamespace::Note,
+                namespace,
             });
         }
     }
@@ -2920,11 +2829,7 @@ fn matches_import_ref(update: &RefUpdate, wanted: &HashSet<&str>) -> bool {
 }
 
 fn full_ref_name(update: &RefUpdate) -> String {
-    match update.namespace {
-        RefNamespace::Branch => format!("refs/heads/{}", update.name),
-        RefNamespace::Tag => format!("refs/tags/{}", update.name),
-        RefNamespace::Note => format!("refs/notes/{}", update.name),
-    }
+    GitRefName::content_full_name(update.namespace, &update.name)
 }
 
 #[cfg(test)]
@@ -4127,11 +4032,7 @@ fn push_network_remote(
         .map_err(|err| GitBridgeError::Git(format!("failed to list refs from {url}: {err}")))?;
     let remote_refs = records
         .into_iter()
-        .filter(|record| {
-            record.name.starts_with("refs/heads/")
-                || record.name.starts_with("refs/tags/")
-                || record.name.starts_with("refs/notes/")
-        })
+        .filter(|record| GitRefName::new(&record.name).content_namespace().is_some())
         .map(|record| (record.name, record.oid))
         .collect::<HashMap<_, _>>();
 
@@ -4229,6 +4130,14 @@ mod tests {
     }
 
     #[test]
+    fn parse_git_ref_note() {
+        let parsed = parse_git_ref("refs/notes/heddle").expect("note parses");
+        assert_eq!(parsed.kind, GitRefKind::Note);
+        assert_eq!(parsed.name, "heddle");
+        assert_eq!(parsed.remote, REMOTE_NAME_FOR_LOCAL_GIT_REPO);
+    }
+
+    #[test]
     fn parse_git_ref_skips_head_symrefs() {
         assert_eq!(parse_git_ref("refs/heads/HEAD"), None);
         assert_eq!(parse_git_ref("refs/remotes/origin/HEAD"), None);
@@ -4236,7 +4145,6 @@ mod tests {
 
     #[test]
     fn parse_git_ref_rejects_unknown_or_malformed() {
-        assert_eq!(parse_git_ref("refs/notes/heddle"), None);
         assert_eq!(parse_git_ref("HEAD"), None);
         // A remote ref with no branch component beneath the remote name.
         assert_eq!(parse_git_ref("refs/remotes/origin"), None);

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -91,17 +91,7 @@ pub(super) fn parse_object_id(
 }
 
 pub(super) fn parse_object_type(value: &str) -> Result<ObjectType, ProtocolError> {
-    match value {
-        "blob" => Ok(ObjectType::Blob),
-        "tree" => Ok(ObjectType::Tree),
-        "state" => Ok(ObjectType::State),
-        "action" => Ok(ObjectType::Action),
-        "redaction" => Ok(ObjectType::Redaction),
-        "state_visibility" => Ok(ObjectType::StateVisibility),
-        _ => Err(ProtocolError::InvalidState(format!(
-            "unknown object type: {value}"
-        ))),
-    }
+    ObjectType::from_wire(value)
 }
 
 pub(super) fn to_proto_object_info(info: &ObjectInfo) -> ObjectDescriptor {
@@ -132,14 +122,7 @@ pub(super) fn transport_mode_name(mode: i32) -> &'static str {
 }
 
 pub(super) fn object_type_name(obj_type: ObjectType) -> &'static str {
-    match obj_type {
-        ObjectType::Blob => "blob",
-        ObjectType::Tree => "tree",
-        ObjectType::State => "state",
-        ObjectType::Action => "action",
-        ObjectType::Redaction => "redaction",
-        ObjectType::StateVisibility => "state_visibility",
-    }
+    obj_type.wire_name()
 }
 
 pub(super) fn descriptor_id(descriptor: &ObjectDescriptor) -> (String, String) {

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -221,8 +221,10 @@ impl HostedGrpcClient {
                 .unwrap_or_default(),
             new_value: new_value.to_string_full(),
             thread_metadata: thread_metadata.map(to_proto_thread_metadata),
-            old_revision_address: old_value.map(native_revision_address).unwrap_or_default(),
-            new_revision_address: native_revision_address(new_value),
+            old_revision_address: old_value
+                .map(|value| RevisionAddress::heddle(value).to_string())
+                .unwrap_or_default(),
+            new_revision_address: RevisionAddress::heddle(new_value).to_string(),
             client_operation_id: String::new(),
         });
         self.apply_auth(&mut request)?;
@@ -260,7 +262,7 @@ impl HostedGrpcClient {
             local_state,
             target_thread,
             force,
-            native_revision_address(local_state),
+            RevisionAddress::heddle(local_state).to_string(),
             None,
             &Progress::null(),
         )
@@ -834,7 +836,7 @@ impl HostedGrpcClient {
                 fresh_full_pull,
                 target_revision_address: options
                     .target_state
-                    .map(native_revision_address)
+                    .map(|state| RevisionAddress::heddle(state).to_string())
                     .unwrap_or_default(),
                 client_operation_id: String::new(),
             })),
@@ -1743,14 +1745,6 @@ fn push_transfer_id(repo_path: &str, local_state: ChangeId, target_thread: &str)
     )
 }
 
-fn native_revision_address(change_id: ChangeId) -> String {
-    RevisionAddress::heddle(change_id).to_string()
-}
-
-fn git_revision_address(commit_oid: &GitObjectId) -> String {
-    RevisionAddress::git_commit(commit_oid.to_hex()).to_string()
-}
-
 /// Build the git-mirror push plan: read ALL refs from the git ODB, resolve
 /// each to its object oid, build ONE multi-root pack over the resolved
 /// targets, and emit N checkpoint-less `GitRefUpdateTransfer` messages.
@@ -1878,7 +1872,7 @@ fn build_git_mirror_plan_from_sley(
     // `local_revision_address` is advisory in mirror mode (per-ref
     // expectations are already applied); use the first resolved target.
     let local_revision_address = newest_root
-        .map(|oid| git_revision_address(&oid))
+        .map(|oid| RevisionAddress::git_commit(oid.to_hex()).to_string())
         .unwrap_or_default();
 
     Ok(GitLanePushPlan {
@@ -2208,23 +2202,21 @@ enum GitRefRemoteExpectation {
 fn parse_git_ref_expectation(
     remote_revision_address: &str,
 ) -> Result<GitRefRemoteExpectation, ProtocolError> {
-    if remote_revision_address.is_empty() || remote_revision_address.starts_with("heddle:") {
+    if remote_revision_address.is_empty() {
         return Ok(GitRefRemoteExpectation::Missing);
     }
-    let Some(hex_oid) = remote_revision_address.strip_prefix("git:") else {
-        return Err(ProtocolError::InvalidState(format!(
-            "server returned unsupported remote_revision_address {remote_revision_address:?}"
-        )));
-    };
-    let oid = hex::decode(hex_oid).map_err(|err| {
-        ProtocolError::InvalidState(format!(
-            "server returned invalid Git remote_revision_address: {err}"
-        ))
-    })?;
-    match oid.len() {
-        20 | 32 => Ok(GitRefRemoteExpectation::Value(oid)),
-        len => Err(ProtocolError::InvalidState(format!(
-            "server returned Git remote_revision_address with {len} bytes; expected SHA-1 or SHA-256"
+
+    match remote_revision_address.parse::<RevisionAddress>() {
+        Ok(RevisionAddress::Heddle(_)) => Ok(GitRefRemoteExpectation::Missing),
+        Ok(RevisionAddress::GitCommit(oid)) => hex::decode(&oid)
+            .map(GitRefRemoteExpectation::Value)
+            .map_err(|err| {
+                ProtocolError::InvalidState(format!(
+                    "server returned invalid Git remote_revision_address: {err}"
+                ))
+            }),
+        Err(err) => Err(ProtocolError::InvalidState(format!(
+            "server returned invalid remote_revision_address {remote_revision_address:?}: {err}"
         ))),
     }
 }
@@ -3757,7 +3749,7 @@ mod tests {
                         missing_objects: Vec::new(),
                         full_closure_available: false,
                         object_count: 1,
-                        remote_revision_address: native_revision_address(state),
+                        remote_revision_address: RevisionAddress::heddle(state).to_string(),
                     })),
                 };
                 if tx.send(Ok(ready)).await.is_err() {
@@ -3805,7 +3797,7 @@ mod tests {
                             checkpoint: b"heddle-markers-v1\n".to_vec(),
                             is_complete: true,
                         }),
-                        new_revision_address: native_revision_address(state),
+                        new_revision_address: RevisionAddress::heddle(state).to_string(),
                     })),
                 };
                 let _ = tx.send(Ok(complete)).await;
@@ -4137,7 +4129,7 @@ mod tests {
                         missing_objects: Vec::new(),
                         full_closure_available: false,
                         object_count: 2,
-                        remote_revision_address: native_revision_address(state),
+                        remote_revision_address: RevisionAddress::heddle(state).to_string(),
                     })),
                 };
                 if tx.send(Ok(ready)).await.is_err() {
@@ -4200,7 +4192,7 @@ mod tests {
                             checkpoint: b"heddle-markers-v1\n".to_vec(),
                             is_complete: true,
                         }),
-                        new_revision_address: native_revision_address(state),
+                        new_revision_address: RevisionAddress::heddle(state).to_string(),
                     })),
                 };
                 let _ = tx.send(Ok(complete)).await;
@@ -4859,7 +4851,8 @@ mod tests {
                         missing_objects: Vec::new(),
                         full_closure_available: false,
                         object_count: objects.len() as u32,
-                        remote_revision_address: native_revision_address(svc.remote_state),
+                        remote_revision_address: RevisionAddress::heddle(svc.remote_state)
+                            .to_string(),
                     })),
                 };
                 if tx.send(Ok(ready)).await.is_err() {
@@ -4904,7 +4897,8 @@ mod tests {
                             checkpoint: b"heddle-markers-v1\n".to_vec(),
                             is_complete: true,
                         }),
-                        new_revision_address: native_revision_address(svc.remote_state),
+                        new_revision_address: RevisionAddress::heddle(svc.remote_state)
+                            .to_string(),
                     })),
                 };
                 let _ = tx.send(Ok(complete)).await;

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -11,7 +11,8 @@ use std::{
 use tempfile::NamedTempFile;
 
 use grpc::heddle::v1::{
-    GetBlobRequest, GitCheckpointTransfer, GitLaneTransfer, GitPackTransfer, GitRefKind,
+    GetBlobRequest, GitCheckpointTransfer, GitLaneTransfer, GitPackTransfer,
+    GitRefKind as GrpcGitRefKind,
     GitRefUpdateTransfer, ListRefsRequest, ObjectAvailabilityStatus, ObjectDescriptor, PackChunk,
     PackStreamKind, PartialFetchStatus, PullMessage, PullRequest, PushMessage, PushRequest,
     RedactionTransfer, StateVisibilityTransfer, ThreadConfidenceSummary, ThreadIntegrationPolicy,
@@ -24,7 +25,8 @@ use objects::{
     store::{AnyStore, ObjectStore, PackObjectId},
 };
 use repo::{
-    Repository, RepositoryCapability, RevisionAddress, SyncedThreadMetadata,
+    GitRefKind as ClassifiedGitRefKind, GitRefName, Repository, RepositoryCapability,
+    RevisionAddress, SyncedThreadMetadata,
     ThreadManager,
 };
 use sley::{
@@ -1811,7 +1813,7 @@ fn build_git_mirror_plan_from_sley(
         // stale `refs/original/*` backup) no longer fails the whole push.
         // Content refs — refs/heads/*, refs/tags/*, refs/notes/* (incl.
         // heddle's `refs/notes/heddle` state metadata) — are kept.
-        if is_local_only_ref(&reference.name) {
+        if GitRefName::new(&reference.name).is_local_only() {
             continue;
         }
 
@@ -1858,7 +1860,7 @@ fn build_git_mirror_plan_from_sley(
             .cloned()
             .unwrap_or(GitRefRemoteExpectation::Missing);
 
-        let kind = git_ref_kind_from_name(&reference.name);
+        let kind = grpc_git_ref_kind(GitRefName::new(&reference.name).wire_kind());
         let mut message =
             git_ref_update_message(&reference.name, kind, target_oid, peeled_oid, None);
         apply_git_ref_expectation_value(&mut message, &expectation)?;
@@ -1886,34 +1888,12 @@ fn build_git_mirror_plan_from_sley(
     })
 }
 
-/// Local-only bookkeeping ref namespaces that the default mirror push must NOT
-/// ship to the hosted server (#846). Denylist rather than allowlist so that
-/// content namespaces we do not enumerate here — heddle's `refs/notes/heddle`,
-/// any future content ref — are pushed by default; only these four purely-local
-/// git-machinery prefixes are dropped.
-///
-///   - `refs/stash`: the local stash reflog stack (exact match — the ref is
-///     `refs/stash`; individual entries live in the reflog).
-///   - `refs/remotes/`: this clone's remote-tracking refs.
-///   - `refs/original/`: filter-branch/-repo backups.
-///   - `refs/replace/`: local object replacements (grafts).
-fn is_local_only_ref(name: &str) -> bool {
-    name == "refs/stash"
-        || name.starts_with("refs/remotes/")
-        || name.starts_with("refs/original/")
-        || name.starts_with("refs/replace/")
-}
-
-/// Classify a full ref name into the wire `GitRefKind` the server expects.
-fn git_ref_kind_from_name(name: &str) -> GitRefKind {
-    if name.starts_with("refs/heads/") {
-        GitRefKind::Branch
-    } else if name.starts_with("refs/tags/") {
-        GitRefKind::Tag
-    } else if name.starts_with("refs/notes/") {
-        GitRefKind::Note
-    } else {
-        GitRefKind::Other
+fn grpc_git_ref_kind(kind: ClassifiedGitRefKind) -> GrpcGitRefKind {
+    match kind {
+        ClassifiedGitRefKind::Branch => GrpcGitRefKind::Branch,
+        ClassifiedGitRefKind::Tag => GrpcGitRefKind::Tag,
+        ClassifiedGitRefKind::Note => GrpcGitRefKind::Note,
+        ClassifiedGitRefKind::Other => GrpcGitRefKind::Other,
     }
 }
 
@@ -2175,7 +2155,7 @@ impl Write for GitPackPushMessageWriter {
 /// is set for annotated-tag refs (the underlying object the tag names).
 fn git_ref_update_message(
     name: &str,
-    kind: GitRefKind,
+    kind: GrpcGitRefKind,
     target_oid: GitObjectId,
     peeled_oid: Option<GitObjectId>,
     checkpoint: Option<GitCheckpointTransfer>,
@@ -2969,7 +2949,7 @@ mod tests {
         let state = ChangeId::from_bytes([9u8; 16]);
         let ref_message = git_ref_update_message(
             "refs/heads/main",
-            GitRefKind::Branch,
+            GrpcGitRefKind::Branch,
             commit_oid,
             None,
             Some(GitCheckpointTransfer {
@@ -2986,7 +2966,7 @@ mod tests {
             panic!("expected git ref update message");
         };
         assert_eq!(update.name, "refs/heads/main");
-        assert_eq!(update.kind, GitRefKind::Branch as i32);
+        assert_eq!(update.kind, GrpcGitRefKind::Branch as i32);
         assert_eq!(update.target_oid.as_ref(), commit_oid.as_bytes());
         let checkpoint = update.checkpoint.expect("checkpoint");
         assert_eq!(checkpoint.heddle_change_id.as_ref(), state.as_bytes());
@@ -2997,7 +2977,7 @@ mod tests {
     fn sample_ref_update_message(commit_oid: GitObjectId) -> PushMessage {
         git_ref_update_message(
             "refs/heads/main",
-            GitRefKind::Branch,
+            GrpcGitRefKind::Branch,
             commit_oid,
             None,
             Some(GitCheckpointTransfer {
@@ -3103,16 +3083,16 @@ mod tests {
             updates.iter().map(|u| (u.name.as_str(), u)).collect();
 
         let main = by_name["refs/heads/main"];
-        assert_eq!(main.kind, GitRefKind::Branch as i32);
+        assert_eq!(main.kind, GrpcGitRefKind::Branch as i32);
         assert_eq!(main.target_oid.as_ref(), main_commit.as_bytes());
         assert!(main.peeled_oid.is_empty(), "commit refs are not peeled");
 
         let feature = by_name["refs/heads/feature"];
-        assert_eq!(feature.kind, GitRefKind::Branch as i32);
+        assert_eq!(feature.kind, GrpcGitRefKind::Branch as i32);
         assert_eq!(feature.target_oid.as_ref(), feature_commit.as_bytes());
 
         let tag_update = by_name["refs/tags/v1"];
-        assert_eq!(tag_update.kind, GitRefKind::Tag as i32);
+        assert_eq!(tag_update.kind, GrpcGitRefKind::Tag as i32);
         assert_eq!(tag_update.target_oid.as_ref(), tag_oid.as_bytes());
         assert_eq!(
             tag_update.peeled_oid.as_ref(),
@@ -3249,7 +3229,7 @@ mod tests {
             .expect("refs/pull/* ref must be mirrored");
         assert_eq!(
             pull.kind,
-            GitRefKind::Other as i32,
+            GrpcGitRefKind::Other as i32,
             "refs/pull/* classifies as Other",
         );
         assert_eq!(pull.target_oid.as_ref(), pr_commit.as_bytes());

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -36,8 +36,8 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::Request;
 use wire::{
-    GitLaneTransferIntent, ObjectInfo, ObjectType, PlannedObject, ProtocolError, PullComplete,
-    PushComplete, RefEntry, RefUpdated, RepositoryTransferPlan,
+    GitLaneTransferIntent, ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject, ProtocolError,
+    PullComplete, PushComplete, RefEntry, RefUpdated, RepositoryTransferPlan,
 };
 
 use super::{
@@ -119,13 +119,13 @@ pub struct HostedRefEntry {
 
 impl PullObjectMix {
     fn record(&mut self, obj_type: ObjectType) {
-        match obj_type {
-            ObjectType::Blob => self.blobs += 1,
-            ObjectType::Tree => self.trees += 1,
-            ObjectType::State => self.states += 1,
-            ObjectType::Action => self.actions += 1,
-            ObjectType::Redaction => self.redactions += 1,
-            ObjectType::StateVisibility => self.state_visibilities += 1,
+        match obj_type.bucket() {
+            ObjectTypeBucket::Blob => self.blobs += 1,
+            ObjectTypeBucket::Tree => self.trees += 1,
+            ObjectTypeBucket::State => self.states += 1,
+            ObjectTypeBucket::Action => self.actions += 1,
+            ObjectTypeBucket::Redaction => self.redactions += 1,
+            ObjectTypeBucket::StateVisibility => self.state_visibilities += 1,
         }
     }
 
@@ -1284,7 +1284,7 @@ fn wanted_packable_type(wanted_types: &WantedTypes, pack_id: &PackObjectId) -> O
         types
             .iter()
             .copied()
-            .find(|obj_type| wire::is_native_packable_object_type(*obj_type))
+            .find(|obj_type| obj_type.packable())
     })
 }
 

--- a/crates/core/src/fsck/objects.rs
+++ b/crates/core/src/fsck/objects.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 
 use objects::{
     error::Result,
-    object::{TreeIntegrityEvent, walk_tree_integrity},
+    object::tree_walk::{TreeIntegrityEvent, walk_tree_integrity},
     store::ObjectStore,
 };
 use repo::Repository;

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -30,7 +30,7 @@ mod timeline;
 mod tree;
 mod tree_path;
 mod tree_diff;
-mod tree_walk;
+pub mod tree_walk;
 mod visibility_tier;
 
 pub use action_id::ActionId;

--- a/crates/repo/src/git_ref_name.rs
+++ b/crates/repo/src/git_ref_name.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed classification for fully-qualified Git ref names.
+
+/// Sentinel remote name for refs owned by the local repository.
+///
+/// Local branches, tags, and notes use this owner when represented in the
+/// bridge parser. A user remote named `git` would collide with that sentinel.
+pub const REMOTE_NAME_FOR_LOCAL_GIT_REPO: &str = "git";
+
+/// The content namespaces Heddle intentionally mirrors as named Git refs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GitRefContentNamespace {
+    /// `refs/heads/<name>`.
+    Branch,
+    /// `refs/tags/<name>`.
+    Tag,
+    /// `refs/notes/<name>`.
+    Note,
+}
+
+/// The wire-level kind used for hosted Git ref updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GitRefKind {
+    /// `refs/heads/<name>` or `refs/remotes/<remote>/<name>`.
+    Branch,
+    /// `refs/tags/<name>`.
+    Tag,
+    /// `refs/notes/<name>`.
+    Note,
+    /// Any non-local-only ref outside the known content namespaces.
+    Other,
+}
+
+/// The namespace family a full ref name belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GitRefNamespace {
+    /// `refs/heads/<name>`.
+    Branch,
+    /// `refs/remotes/<remote>/<name>`.
+    RemoteBranch,
+    /// `refs/tags/<name>`.
+    Tag,
+    /// `refs/notes/<name>`.
+    Note,
+    /// `refs/stash`.
+    Stash,
+    /// `refs/original/<name>`.
+    Original,
+    /// `refs/replace/<name>`.
+    Replace,
+    /// Anything outside the named namespaces above.
+    Other,
+}
+
+/// A parsed Git ref name: its kind, short name, and owning remote.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ParsedGitRef<'a> {
+    pub kind: GitRefKind,
+    /// Short name beneath the namespace, e.g. `main` for `refs/heads/main`
+    /// or `feature/x` for `refs/remotes/origin/feature/x`.
+    pub name: &'a str,
+    /// Owning remote. Local content refs report
+    /// [`REMOTE_NAME_FOR_LOCAL_GIT_REPO`].
+    pub remote: &'a str,
+}
+
+/// A fully-qualified Git ref name classified into Heddle's shared namespace
+/// semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GitRefName<'a> {
+    full_name: &'a str,
+}
+
+impl<'a> GitRefName<'a> {
+    /// Classify a fully-qualified Git ref name.
+    pub fn new(full_name: &'a str) -> Self {
+        Self { full_name }
+    }
+
+    /// Return the original fully-qualified name.
+    pub fn as_str(&self) -> &'a str {
+        self.full_name
+    }
+
+    /// Return the ref namespace family.
+    pub fn namespace(&self) -> GitRefNamespace {
+        if self.branch_name().is_some() {
+            GitRefNamespace::Branch
+        } else if self.remote_name().is_some() {
+            GitRefNamespace::RemoteBranch
+        } else if self.tag_name().is_some() {
+            GitRefNamespace::Tag
+        } else if self.note_name().is_some() {
+            GitRefNamespace::Note
+        } else if self.full_name == "refs/stash" {
+            GitRefNamespace::Stash
+        } else if self.full_name.starts_with("refs/original/") {
+            GitRefNamespace::Original
+        } else if self.full_name.starts_with("refs/replace/") {
+            GitRefNamespace::Replace
+        } else {
+            GitRefNamespace::Other
+        }
+    }
+
+    /// Whether this ref is local Git bookkeeping and must not be shipped by
+    /// the hosted mirror push path.
+    pub fn is_local_only(&self) -> bool {
+        matches!(
+            self.namespace(),
+            GitRefNamespace::RemoteBranch
+                | GitRefNamespace::Stash
+                | GitRefNamespace::Original
+                | GitRefNamespace::Replace
+        )
+    }
+
+    /// Whether this ref is content for the hosted mirror push path.
+    ///
+    /// This is intentionally denylist-based: future non-local namespaces are
+    /// mirrored as `Other` until product policy says otherwise.
+    pub fn is_hosted_mirror_content(&self) -> bool {
+        !self.is_local_only()
+    }
+
+    /// Return the named content namespace Heddle surfaces in local Git bridge
+    /// operations.
+    pub fn content_namespace(&self) -> Option<GitRefContentNamespace> {
+        match self.namespace() {
+            GitRefNamespace::Branch => Some(GitRefContentNamespace::Branch),
+            GitRefNamespace::Tag => Some(GitRefContentNamespace::Tag),
+            GitRefNamespace::Note => Some(GitRefContentNamespace::Note),
+            _ => None,
+        }
+    }
+
+    /// Return the hosted Git ref update kind for this ref.
+    pub fn wire_kind(&self) -> GitRefKind {
+        match self.namespace() {
+            GitRefNamespace::Branch | GitRefNamespace::RemoteBranch => GitRefKind::Branch,
+            GitRefNamespace::Tag => GitRefKind::Tag,
+            GitRefNamespace::Note => GitRefKind::Note,
+            _ => GitRefKind::Other,
+        }
+    }
+
+    /// Return the remote owner for `refs/remotes/<remote>/<name>`.
+    pub fn remote_name(&self) -> Option<&'a str> {
+        let remote_and_name = self.full_name.strip_prefix("refs/remotes/")?;
+        let remote = remote_and_name
+            .split_once('/')
+            .map_or(remote_and_name, |(remote, _)| remote);
+        (!remote.is_empty()).then_some(remote)
+    }
+
+    /// Return the short name for a branch, remote branch, tag, or note.
+    pub fn short_name(&self) -> Option<&'a str> {
+        self.branch_name()
+            .or_else(|| self.remote_branch_parts().map(|(_, name)| name))
+            .or_else(|| self.tag_name())
+            .or_else(|| self.note_name())
+    }
+
+    /// Parse a bridge-visible ref. Notes are content refs in Heddle and are
+    /// accepted here to match hosted mirror behavior.
+    pub fn bridge_ref(&self) -> Option<ParsedGitRef<'a>> {
+        match self.namespace() {
+            GitRefNamespace::Branch => {
+                let name = self.branch_name()?;
+                (name != "HEAD").then_some(ParsedGitRef {
+                    kind: GitRefKind::Branch,
+                    name,
+                    remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+                })
+            }
+            GitRefNamespace::RemoteBranch => {
+                let (remote, name) = self.remote_branch_parts()?;
+                (name != "HEAD" && !is_reserved_git_remote_name(remote)).then_some(
+                    ParsedGitRef {
+                        kind: GitRefKind::Branch,
+                        name,
+                        remote,
+                    },
+                )
+            }
+            GitRefNamespace::Tag => self.tag_name().map(|name| ParsedGitRef {
+                kind: GitRefKind::Tag,
+                name,
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            }),
+            GitRefNamespace::Note => self.note_name().map(|name| ParsedGitRef {
+                kind: GitRefKind::Note,
+                name,
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            }),
+            _ => None,
+        }
+    }
+
+    /// Format `refs/heads/<name>`.
+    pub fn branch_full_name(name: &str) -> String {
+        format!("refs/heads/{name}")
+    }
+
+    /// Format `refs/remotes/<remote>/<name>`.
+    pub fn remote_branch_full_name(remote: &str, name: &str) -> String {
+        format!("refs/remotes/{remote}/{name}")
+    }
+
+    /// Normalize either `refs/remotes/<remote>/<name>` or `<remote>/<name>`
+    /// into a full remote-tracking ref name.
+    pub fn remote_tracking_full_name(name: &str) -> String {
+        if GitRefName::new(name).remote_name().is_some() {
+            name.to_string()
+        } else {
+            format!("refs/remotes/{name}")
+        }
+    }
+
+    /// Format `refs/tags/<name>`.
+    pub fn tag_full_name(name: &str) -> String {
+        format!("refs/tags/{name}")
+    }
+
+    /// Format `refs/notes/<name>`.
+    pub fn note_full_name(name: &str) -> String {
+        format!("refs/notes/{name}")
+    }
+
+    /// Format a named content ref.
+    pub fn content_full_name(namespace: GitRefContentNamespace, name: &str) -> String {
+        match namespace {
+            GitRefContentNamespace::Branch => Self::branch_full_name(name),
+            GitRefContentNamespace::Tag => Self::tag_full_name(name),
+            GitRefContentNamespace::Note => Self::note_full_name(name),
+        }
+    }
+
+    fn branch_name(&self) -> Option<&'a str> {
+        self.full_name.strip_prefix("refs/heads/")
+    }
+
+    fn tag_name(&self) -> Option<&'a str> {
+        self.full_name.strip_prefix("refs/tags/")
+    }
+
+    fn note_name(&self) -> Option<&'a str> {
+        self.full_name.strip_prefix("refs/notes/")
+    }
+
+    fn remote_branch_parts(&self) -> Option<(&'a str, &'a str)> {
+        let remote_and_name = self.full_name.strip_prefix("refs/remotes/")?;
+        let (remote, name) = remote_and_name.split_once('/')?;
+        (!remote.is_empty() && !name.is_empty()).then_some((remote, name))
+    }
+}
+
+/// Whether a remote name collides with Heddle's local-ref sentinel.
+pub fn is_reserved_git_remote_name(remote: &str) -> bool {
+    remote == REMOTE_NAME_FOR_LOCAL_GIT_REPO
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classifies_every_git_namespace_used_by_sync_and_bridge() {
+        let cases = [
+            (
+                "refs/heads/main",
+                GitRefNamespace::Branch,
+                Some(GitRefContentNamespace::Branch),
+                GitRefKind::Branch,
+                false,
+                true,
+            ),
+            (
+                "refs/remotes/origin/main",
+                GitRefNamespace::RemoteBranch,
+                None,
+                GitRefKind::Branch,
+                true,
+                false,
+            ),
+            (
+                "refs/remotes/origin",
+                GitRefNamespace::RemoteBranch,
+                None,
+                GitRefKind::Branch,
+                true,
+                false,
+            ),
+            (
+                "refs/tags/v1.0",
+                GitRefNamespace::Tag,
+                Some(GitRefContentNamespace::Tag),
+                GitRefKind::Tag,
+                false,
+                true,
+            ),
+            (
+                "refs/notes/heddle",
+                GitRefNamespace::Note,
+                Some(GitRefContentNamespace::Note),
+                GitRefKind::Note,
+                false,
+                true,
+            ),
+            (
+                "refs/stash",
+                GitRefNamespace::Stash,
+                None,
+                GitRefKind::Other,
+                true,
+                false,
+            ),
+            (
+                "refs/original/refs/heads/main",
+                GitRefNamespace::Original,
+                None,
+                GitRefKind::Other,
+                true,
+                false,
+            ),
+            (
+                "refs/replace/deadbeef",
+                GitRefNamespace::Replace,
+                None,
+                GitRefKind::Other,
+                true,
+                false,
+            ),
+            (
+                "refs/heddle/internal",
+                GitRefNamespace::Other,
+                None,
+                GitRefKind::Other,
+                false,
+                true,
+            ),
+        ];
+
+        for (name, namespace, content_namespace, wire_kind, local_only, mirror_content) in cases {
+            let ref_name = GitRefName::new(name);
+            assert_eq!(ref_name.namespace(), namespace, "{name}");
+            assert_eq!(ref_name.content_namespace(), content_namespace, "{name}");
+            assert_eq!(ref_name.wire_kind(), wire_kind, "{name}");
+            assert_eq!(ref_name.is_local_only(), local_only, "{name}");
+            assert_eq!(
+                ref_name.is_hosted_mirror_content(),
+                mirror_content,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn parses_bridge_visible_refs() {
+        assert_eq!(
+            GitRefName::new("refs/heads/main").bridge_ref(),
+            Some(ParsedGitRef {
+                kind: GitRefKind::Branch,
+                name: "main",
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            })
+        );
+        assert_eq!(
+            GitRefName::new("refs/remotes/origin/feature/x").bridge_ref(),
+            Some(ParsedGitRef {
+                kind: GitRefKind::Branch,
+                name: "feature/x",
+                remote: "origin",
+            })
+        );
+        assert_eq!(
+            GitRefName::new("refs/tags/v1.0").bridge_ref(),
+            Some(ParsedGitRef {
+                kind: GitRefKind::Tag,
+                name: "v1.0",
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            })
+        );
+        assert_eq!(
+            GitRefName::new("refs/notes/heddle").bridge_ref(),
+            Some(ParsedGitRef {
+                kind: GitRefKind::Note,
+                name: "heddle",
+                remote: REMOTE_NAME_FOR_LOCAL_GIT_REPO,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_symbolic_head_and_reserved_remote_from_bridge_parse() {
+        assert_eq!(GitRefName::new("refs/heads/HEAD").bridge_ref(), None);
+        assert_eq!(GitRefName::new("refs/remotes/origin/HEAD").bridge_ref(), None);
+        assert_eq!(GitRefName::new("refs/remotes/git/main").bridge_ref(), None);
+    }
+
+    #[test]
+    fn formats_full_ref_names() {
+        assert_eq!(GitRefName::branch_full_name("main"), "refs/heads/main");
+        assert_eq!(
+            GitRefName::remote_branch_full_name("origin", "feature/x"),
+            "refs/remotes/origin/feature/x"
+        );
+        assert_eq!(
+            GitRefName::remote_tracking_full_name("origin/feature/x"),
+            "refs/remotes/origin/feature/x"
+        );
+        assert_eq!(
+            GitRefName::remote_tracking_full_name("refs/remotes/origin/feature/x"),
+            "refs/remotes/origin/feature/x"
+        );
+        assert_eq!(GitRefName::tag_full_name("v1.0"), "refs/tags/v1.0");
+        assert_eq!(GitRefName::note_full_name("heddle"), "refs/notes/heddle");
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -15,6 +15,7 @@ mod discussion_anchor_travel;
 mod discussion_snapshot_travel;
 mod ephemeral_thread;
 mod fsmonitor;
+mod git_ref_name;
 pub mod git_worktree_status;
 mod hooks;
 pub mod identity;
@@ -69,6 +70,10 @@ pub mod worktree_walk;
 // Re-export commonly used types from underlying crates.
 pub use ephemeral_thread::{CollapsedThread, collapse_expired_ephemeral_threads};
 pub use fsmonitor::{ChangeMonitorReport, run_local_monitor_helper};
+pub use git_ref_name::{
+    GitRefContentNamespace, GitRefKind, GitRefName, GitRefNamespace, ParsedGitRef,
+    REMOTE_NAME_FOR_LOCAL_GIT_REPO, is_reserved_git_remote_name,
+};
 pub use hooks::{Hook, HookContext, HookManager, HookResponse};
 pub use merge_state::{MergeState, MergeStateManager};
 pub use objects::{

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -81,6 +81,7 @@ use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
+use crate::{GitRefContentNamespace, GitRefName};
 // Review-epic config types — re-exported here so the new
 // `repository_signals.rs` (and external crates wanting to construct a
 // custom signals config) don't need to reach into a private module path.
@@ -920,7 +921,7 @@ impl Repository {
             return Ok(None);
         };
 
-        let local_ref_name = format!("refs/heads/{branch}");
+        let local_ref_name = GitRefName::branch_full_name(&branch);
         if git_find_reference(&git, &local_ref_name)?.is_some()
             && let Some(tracking_name) = git_configured_tracking_ref(&git, &branch)?
             && let Some(upstream_head) = git_resolve_oid(&git, &tracking_name)?
@@ -962,7 +963,7 @@ impl Repository {
             return Ok(None);
         }
         for remote in &remotes {
-            let remote_ref = format!("refs/remotes/{remote}/{branch}");
+            let remote_ref = GitRefName::remote_branch_full_name(remote, &branch);
             if let Some(remote_head) = git_resolve_oid(&git, &remote_ref)? {
                 if remote_head == head {
                     return Ok(None);
@@ -1089,10 +1090,13 @@ impl Repository {
                 error
             ))
         })? {
-            let Some(name) = branch.name.strip_prefix("refs/heads/") else {
+            let ref_name = GitRefName::new(&branch.name);
+            if ref_name.content_namespace() != Some(GitRefContentNamespace::Branch) {
                 continue;
             };
-            let name = name.to_string();
+            let Some(name) = ref_name.short_name().map(str::to_string) else {
+                continue;
+            };
             let Some(target) =
                 self.git_overlay_commit_tip_oid(&git_repo, &branch, "branch", &name)?
             else {
@@ -1165,10 +1169,13 @@ impl Repository {
                 error
             ))
         })? {
-            let Some(name) = tag.name.strip_prefix("refs/tags/") else {
+            let ref_name = GitRefName::new(&tag.name);
+            if ref_name.content_namespace() != Some(GitRefContentNamespace::Tag) {
                 continue;
             };
-            let name = name.to_string();
+            let Some(name) = ref_name.short_name().map(str::to_string) else {
+                continue;
+            };
             let Some(target) = self.git_overlay_commit_tip_oid(&git_repo, &tag, "tag", &name)?
             else {
                 continue;
@@ -1231,10 +1238,7 @@ impl Repository {
         let Some(git_repo) = self.git_overlay_sley_repository()? else {
             return Ok(None);
         };
-        let full_name = name
-            .strip_prefix("refs/remotes/")
-            .map(|short| format!("refs/remotes/{short}"))
-            .unwrap_or_else(|| format!("refs/remotes/{name}"));
+        let full_name = GitRefName::remote_tracking_full_name(name);
         let bridge_mapping = self.git_overlay_bridge_mapping()?;
         let ingest_mapping = self.git_overlay_ingest_commit_mapping()?;
         let checkpoint_mapping = self.git_overlay_checkpoint_mapping()?;
@@ -2603,10 +2607,14 @@ fn git_configured_tracking_ref(repo: &SleyRepository, branch: &str) -> Result<Op
     if remote == "." {
         return Ok(Some(merge.to_string()));
     }
-    let Some(short) = merge.strip_prefix("refs/heads/") else {
+    let merge_ref = GitRefName::new(merge);
+    if merge_ref.content_namespace() != Some(GitRefContentNamespace::Branch) {
         return Ok(None);
     };
-    Ok(Some(format!("refs/remotes/{remote}/{short}")))
+    let Some(short) = merge_ref.short_name() else {
+        return Ok(None);
+    };
+    Ok(Some(GitRefName::remote_branch_full_name(remote, short)))
 }
 
 fn git_ahead_behind(
@@ -2812,7 +2820,11 @@ fn detect_git_head_fast(path: &Path) -> Option<GitHeadState> {
     let content = std::fs::read_to_string(&head_path).ok()?;
     let trimmed = content.trim();
     let suffix = trimmed.strip_prefix("ref: ")?;
-    let name = suffix.strip_prefix("refs/heads/")?.to_string();
+    let suffix_ref = GitRefName::new(suffix);
+    if suffix_ref.content_namespace() != Some(GitRefContentNamespace::Branch) {
+        return None;
+    }
+    let name = suffix_ref.short_name()?.to_string();
     if name.is_empty() {
         return None;
     }
@@ -2839,7 +2851,10 @@ fn detect_git_in_progress_branch(path: &Path) -> Result<Option<String>> {
         }
         let raw = fs::read_to_string(&branch_path)?;
         let value = raw.trim();
-        if let Some(short) = value.strip_prefix("refs/heads/") {
+        let ref_name = GitRefName::new(value);
+        if ref_name.content_namespace() == Some(GitRefContentNamespace::Branch)
+            && let Some(short) = ref_name.short_name()
+        {
             return Ok(Some(short.to_string()));
         }
         if !value.is_empty() {

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -50,7 +50,7 @@ pub use native_pack::{
 };
 pub use object_availability::{ObjectAvailabilityPlan, has_object, plan_object_availability};
 pub use object_graph::{
-    ObjectId, ObjectInfo, ObjectType, PlannedObject, StateClosureOptions,
+    ObjectId, ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject, StateClosureOptions,
     StateClosureTransferObjects, enumerate_state_closure, enumerate_state_closure_plan,
     enumerate_state_closure_plan_with_options, enumerate_state_closure_transfer_with_options,
     enumerate_state_closure_with_options, is_ancestor, missing_blobs_in_tree,

--- a/crates/wire/src/native_pack.rs
+++ b/crates/wire/src/native_pack.rs
@@ -8,7 +8,7 @@ use std::{
 
 use objects::store::{
     CompressionConfig, ObjectStore,
-    pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId, StreamingPackBuilder},
+    pack::{PackBuilder, PackObjectId, StreamingPackBuilder},
 };
 
 use crate::{
@@ -230,7 +230,7 @@ impl NativePackStreamingWriter {
         })?;
         let pack_id = to_pack_object_id(&object.id);
         builder
-            .add_id(pack_id, to_pack_object_type(object.obj_type)?, object.data)
+            .add_id(pack_id, object.obj_type.pack_object_type()?, object.data)
             .map_err(ProtocolError::from)
     }
 
@@ -524,7 +524,7 @@ pub fn native_pack_excluded_object_types() -> &'static [ObjectType] {
 }
 
 pub fn is_native_packable_object_type(obj_type: ObjectType) -> bool {
-    !native_pack_excluded_object_types().contains(&obj_type)
+    obj_type.packable()
 }
 
 pub fn build_native_pack(
@@ -544,7 +544,7 @@ pub fn build_native_pack(
         }
         let object = load_object_data(store, &info.id, info.obj_type)?;
         let pack_id = to_pack_object_id(&object.id);
-        builder.add_id(pack_id, to_pack_object_type(object.obj_type)?, object.data);
+        builder.add_id(pack_id, object.obj_type.pack_object_type()?, object.data);
     }
 
     let (pack_data, index_data, _) = builder.build()?;
@@ -742,23 +742,6 @@ fn to_pack_object_id(id: &ObjectId) -> PackObjectId {
     match id {
         ObjectId::Hash(hash) => PackObjectId::Hash(*hash),
         ObjectId::ChangeId(change_id) => PackObjectId::ChangeId(*change_id),
-    }
-}
-
-fn to_pack_object_type(obj_type: ObjectType) -> Result<PackObjectType> {
-    match obj_type {
-        ObjectType::Blob => Ok(PackObjectType::Blob),
-        ObjectType::Tree => Ok(PackObjectType::Tree),
-        ObjectType::State => Ok(PackObjectType::State),
-        ObjectType::Action => Ok(PackObjectType::Action),
-        ObjectType::Redaction => Err(ProtocolError::InvalidState(
-            "Redaction sidecar records cannot be packed into the content-addressed object pack"
-                .to_string(),
-        )),
-        ObjectType::StateVisibility => Err(ProtocolError::InvalidState(
-            "StateVisibility sidecar records cannot be packed into the content-addressed object pack"
-                .to_string(),
-        )),
     }
 }
 

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -3,7 +3,7 @@ use std::collections::{HashSet, VecDeque};
 
 use objects::{
     object::{ChangeId, ContentHash, State, TreeEntryTarget},
-    store::ObjectStore,
+    store::{ObjectStore, pack::ObjectType as PackObjectType},
 };
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +54,75 @@ pub enum ObjectType {
     /// is a sidecar record that lives outside the content-addressed pack
     /// and ships via the per-object transfer path, not the pack.
     StateVisibility,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ObjectTypeBucket {
+    Blob,
+    Tree,
+    State,
+    Action,
+    Redaction,
+    StateVisibility,
+}
+
+impl ObjectType {
+    pub fn wire_name(self) -> &'static str {
+        match self {
+            ObjectType::Blob => "blob",
+            ObjectType::Tree => "tree",
+            ObjectType::State => "state",
+            ObjectType::Action => "action",
+            ObjectType::Redaction => "redaction",
+            ObjectType::StateVisibility => "state_visibility",
+        }
+    }
+
+    pub fn from_wire(value: &str) -> Result<Self> {
+        match value {
+            "blob" => Ok(ObjectType::Blob),
+            "tree" => Ok(ObjectType::Tree),
+            "state" => Ok(ObjectType::State),
+            "action" => Ok(ObjectType::Action),
+            "redaction" => Ok(ObjectType::Redaction),
+            "state_visibility" => Ok(ObjectType::StateVisibility),
+            _ => Err(ProtocolError::InvalidState(format!(
+                "unknown object type: {value}"
+            ))),
+        }
+    }
+
+    pub fn packable(self) -> bool {
+        !matches!(self, ObjectType::Redaction | ObjectType::StateVisibility)
+    }
+
+    pub fn pack_object_type(self) -> Result<PackObjectType> {
+        match self {
+            ObjectType::Blob => Ok(PackObjectType::Blob),
+            ObjectType::Tree => Ok(PackObjectType::Tree),
+            ObjectType::State => Ok(PackObjectType::State),
+            ObjectType::Action => Ok(PackObjectType::Action),
+            ObjectType::Redaction => Err(ProtocolError::InvalidState(
+                "Redaction sidecar records cannot be packed into the content-addressed object pack"
+                    .to_string(),
+            )),
+            ObjectType::StateVisibility => Err(ProtocolError::InvalidState(
+                "StateVisibility sidecar records cannot be packed into the content-addressed object pack"
+                    .to_string(),
+            )),
+        }
+    }
+
+    pub fn bucket(self) -> ObjectTypeBucket {
+        match self {
+            ObjectType::Blob => ObjectTypeBucket::Blob,
+            ObjectType::Tree => ObjectTypeBucket::Tree,
+            ObjectType::State => ObjectTypeBucket::State,
+            ObjectType::Action => ObjectTypeBucket::Action,
+            ObjectType::Redaction => ObjectTypeBucket::Redaction,
+            ObjectType::StateVisibility => ObjectTypeBucket::StateVisibility,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/wire/src/transfer_plan.rs
+++ b/crates/wire/src/transfer_plan.rs
@@ -9,8 +9,8 @@
 use objects::{object::ChangeId, store::ObjectStore};
 
 use crate::{
-    ObjectInfo, ObjectType, PlannedObject, Result, StateClosureOptions,
-    enumerate_state_closure_plan_with_options, is_native_packable_object_type,
+    ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject, Result, StateClosureOptions,
+    enumerate_state_closure_plan_with_options,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
@@ -109,7 +109,7 @@ impl<T> TransferPartitions<T> {
     }
 
     pub fn is_sidecar_object_type(obj_type: ObjectType) -> bool {
-        !is_native_packable_object_type(obj_type)
+        !obj_type.packable()
     }
 }
 
@@ -130,13 +130,13 @@ impl TransferPlanStats {
         } else {
             self.packable_objects += 1;
         }
-        match obj_type {
-            ObjectType::Blob => self.blobs += 1,
-            ObjectType::Tree => self.trees += 1,
-            ObjectType::State => self.states += 1,
-            ObjectType::Action => self.actions += 1,
-            ObjectType::Redaction => self.redactions += 1,
-            ObjectType::StateVisibility => self.state_visibilities += 1,
+        match obj_type.bucket() {
+            ObjectTypeBucket::Blob => self.blobs += 1,
+            ObjectTypeBucket::Tree => self.trees += 1,
+            ObjectTypeBucket::State => self.states += 1,
+            ObjectTypeBucket::Action => self.actions += 1,
+            ObjectTypeBucket::Redaction => self.redactions += 1,
+            ObjectTypeBucket::StateVisibility => self.state_visibilities += 1,
         }
     }
 }


### PR DESCRIPTION
Closes #854. Closes #864. Closes #865.

Summary:
- Part A: added a repo-owned GitRefName classifier/formatter and repointed hosted sync, git bridge parsing/filtering, and repository ref formatting to it.
- Part B: moved ObjectType wire_name/from_wire/packable/bucket behavior onto the ObjectType impl and removed parallel mapping blocks.
- Part C: replaced git ref expectation prefix parsing and revision-address string construction with RevisionAddress constructors/from_str.
- Gate fix: imported the tree integrity walker through its concrete module path so the workspace build resolves the current #869 exports reliably.

Refs/notes decision:
- refs/notes/* is now treated as git content by the shared classifier. This deliberately follows the hosted-sync behavior because hosted mirror sync already carries notes such as refs/notes/heddle for identity/provenance metadata. The old git bridge parser rejection was removed; local-only filtering still excludes stash, remotes, original, and replace refs from mirror-push content.

Gates run:
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo build --locked --workspace
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test -p heddle-repo -p heddle-wire -p heddle-client -p heddle-cli
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo clippy -p heddle-repo -p heddle-wire -p heddle-client --all-targets -- -D warnings
- CARGO_TARGET_DIR=/home/heddleco/dev/HeddleCo/.heddleco-orchestrator/target/heddle cargo test --workspace

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785541717&installation_id=132405951&pr_number=872&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F872&signature=8fe93fa753e763152fcd9e1077945c4e3602d63c5a1c19f1ca36315bd281f4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->