### PR TITLE
chore(deny): scope-ignore quick-xml NsReader advisories (dev-only via pprof flamegraph)

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,17 @@ ignore = [
     # CVE, no runtime attack surface. Remove this ignore when biscuit-auth drops
     # proc-macro-error2 upstream.
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive build-time proc-macro via biscuit-quote → biscuit-auth 6.0; no runtime exposure, no CVE. Remove when biscuit-auth drops it." },
+
+    # quick-xml 0.26.0: unbounded namespace-declaration allocation in `NsReader`
+    # → memory-exhaustion DoS (RUSTSEC-2026-0194 / -0195). Pulled ONLY via
+    # inferno 0.11 → pprof 0.15 (`flamegraph` feature), which is a
+    # `[dev-dependencies]` of heddle-semantic used exclusively by criterion
+    # benchmarks. It is NOT in any shipped binary, and the vulnerable path
+    # (parsing untrusted XML namespaces with NsReader) is not reachable —
+    # inferno WRITES flamegraph SVGs, it does not parse attacker-controlled XML.
+    # Remove when pprof/inferno bump to a patched quick-xml.
+    { id = "RUSTSEC-2026-0194", reason = "quick-xml 0.26 NsReader DoS; dev-only via pprof flamegraph→inferno (benchmark tooling, not shipped); vulnerable NsReader path not reachable. Remove when pprof/inferno bump quick-xml." },
+    { id = "RUSTSEC-2026-0195", reason = "quick-xml 0.26 NsReader DoS; dev-only via pprof flamegraph→inferno (benchmark tooling, not shipped); vulnerable NsReader path not reachable. Remove when pprof/inferno bump quick-xml." },
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes the red Supply-chain audit on main. RUSTSEC-2026-0194/0195 (quick-xml 0.26 NsReader unbounded namespace-declaration allocation → DoS) enter the tree ONLY via inferno 0.11 → pprof 0.15 `flamegraph`, a `[dev-dependencies]` of heddle-semantic used by criterion benchmarks — not in any shipped binary, and the vulnerable untrusted-XML-namespace path is unreachable (inferno writes SVGs, it doesn't parse attacker XML). Documented scoped ignore consistent with the existing rsa / proc-macro-error2 convention in deny.toml; removes when pprof/inferno bump quick-xml. Verified `cargo deny check advisories` → ok locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785592258&installation_id=132405951&pr_number=943&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F943&signature=020a69f608cf260b750f50184c8d987d588cadfd7c05a1132e2df527e6481e58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->