### PR TITLE
fix(diff): char-boundary-safe context-summary truncation (HEDDLE-DR-7, #879)

### DIFF
--- a/crates/core/src/diff/mod.rs
+++ b/crates/core/src/diff/mod.rs
@@ -1727,10 +1727,14 @@ fn summarize_context(content: &str) -> String {
         .lines()
         .find(|line| !line.trim().is_empty())
         .unwrap_or("");
-    if first_line.len() <= 88 {
+    let char_count = first_line.chars().count();
+    if char_count <= 88 {
         first_line.to_string()
     } else {
-        format!("{}...", &first_line[..85])
+        format!(
+            "{}...",
+            first_line.chars().take(85).collect::<String>()
+        )
     }
 }
 
@@ -2486,7 +2490,7 @@ fn change_file_modes(
 mod tests {
     use super::{
         DiffStats, FileChange, FileEolState, LineCounts, LineDiff, change_line_counts,
-        unified_hunks,
+        summarize_context, unified_hunks,
     };
 
     fn stat_change(kind: &str, counts: LineCounts) -> FileChange {
@@ -2636,6 +2640,35 @@ mod tests {
             Some("@ -1,2 +1,4 @@"),
             "display trim must not rewrite the `@@` header: {display:?}"
         );
+    }
+
+    /// Byte-index truncation at 85 panicked when a multi-byte code point straddled
+    /// that offset (HEDDLE-DR-7 / #879). Summaries must truncate on char boundaries.
+    #[test]
+    fn summarize_context_truncates_on_char_boundary_not_byte_index() {
+        let first_line = format!("{}中中", "a".repeat(83));
+        assert!(first_line.len() > 88);
+        assert!(!first_line.is_char_boundary(85));
+
+        let summary = summarize_context(&format!("{first_line}\nsecond line"));
+        assert_eq!(summary, first_line);
+    }
+
+    #[test]
+    fn summarize_context_char_cap_truncates_multibyte_line() {
+        let first_line = format!("{}中中中", "a".repeat(86));
+        assert!(first_line.chars().count() > 88);
+
+        let summary = summarize_context(&first_line);
+        let expected = format!("{}...", "a".repeat(85));
+        assert_eq!(summary, expected);
+    }
+
+    #[test]
+    fn summarize_context_ascii_truncation_unchanged() {
+        let line = "b".repeat(90);
+        let summary = summarize_context(&line);
+        assert_eq!(summary, format!("{}...", "b".repeat(85)));
     }
 
     /// Characterization: core::diff maps minimal-policy not-found failures to


### PR DESCRIPTION
Closes #879.

## Verification (bug is real)

`summarize_context` in `crates/core/src/diff/mod.rs` used `first_line.len() <= 88` (byte length) and truncated with `&first_line[..85]`. When the first non-blank annotation line exceeded 88 bytes and byte index 85 fell inside a multi-byte UTF-8 code point, Rust panicked and aborted `diff --show-context`. Annotation revision content is repo- and wire-controlled (pull/sync), so this was a practical DoS vector.

## Fix

- Guard on `chars().count() <= 88` instead of byte `len()`.
- Truncate with `chars().take(85).collect::<String>()` instead of `&first_line[..85]`.
- ASCII / short lines behave identically (char count equals byte length).

## Proof tests

- `summarize_context_truncates_on_char_boundary_not_byte_index`: 83 ASCII + `中中` straddles byte 85 (old code panicked); returns the full first line without panic.
- `summarize_context_char_cap_truncates_multibyte_line`: >88 chars with CJK suffix truncates cleanly on char boundaries.
- `summarize_context_ascii_truncation_unchanged`: 90-byte ASCII line still becomes 85 chars + `...`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/944"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785592709&installation_id=132405951&pr_number=944&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F944&signature=24d4db9040993d7dd48c9f5fbc37ed15a79953fb55e5d5498bc7c1825f446273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->