### PR TITLE
fix(mount): clamp write/truncate offset+len at the trust boundary (HEDDLE-DR-5, #877)

### DIFF
--- a/crates/mount/src/core.rs
+++ b/crates/mount/src/core.rs
@@ -103,6 +103,48 @@ const DEFAULT_PROMOTION_IDLE: Duration = Duration::from_secs(2);
 /// catches process-pause/agent-crash leaks without burning CPU.
 const DEFAULT_SWEEP_INTERVAL: Option<Duration> = Some(Duration::from_secs(5));
 
+/// Maximum hot-buffer size accepted by [`ContentAddressedMount::write`] and
+/// [`ContentAddressedMount::apply_truncate`]. Matches the 100 MiB cap in
+/// `repo::worktree_walk` so mount promotion cannot build blobs capture would
+/// reject anyway.
+pub(crate) const MAX_MOUNT_HOT_FILE_SIZE: u64 = 100 * 1024 * 1024;
+
+/// Reject wire offsets/sizes at the trust boundary before they reach
+/// `Vec::resize` (overflow panic or multi-TiB allocation abort).
+fn validate_write_extent(offset: u64, data_len: usize) -> Result<usize> {
+    let data_len_u64 = u64::try_from(data_len).map_err(|_| {
+        MountError::InvalidArgument(format!("write length {data_len} does not fit in u64"))
+    })?;
+    let end = offset.checked_add(data_len_u64).ok_or_else(|| {
+        MountError::InvalidArgument(format!(
+            "write offset {offset} + length {data_len} overflows u64"
+        ))
+    })?;
+    if end > MAX_MOUNT_HOT_FILE_SIZE {
+        return Err(MountError::FileTooLarge(format!(
+            "write would extend file to {end} bytes (max {MAX_MOUNT_HOT_FILE_SIZE})"
+        )));
+    }
+    usize::try_from(end).map_err(|_| {
+        MountError::InvalidArgument(format!(
+            "write extent end {end} does not fit in usize on this platform"
+        ))
+    })
+}
+
+fn validate_truncate_size(new_size: u64) -> Result<usize> {
+    if new_size > MAX_MOUNT_HOT_FILE_SIZE {
+        return Err(MountError::FileTooLarge(format!(
+            "truncate to {new_size} bytes exceeds max {MAX_MOUNT_HOT_FILE_SIZE}"
+        )));
+    }
+    usize::try_from(new_size).map_err(|_| {
+        MountError::InvalidArgument(format!(
+            "truncate size {new_size} does not fit in usize on this platform"
+        ))
+    })
+}
+
 /// Tunables for when buffered writes get promoted to CAS.
 #[derive(Clone, Copy, Debug)]
 pub struct PromotionPolicy {
@@ -2364,6 +2406,7 @@ impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
     }
 
     fn apply_truncate(&self, node: NodeId, new_size: u64) -> Result<()> {
+        let new_size = validate_truncate_size(new_size)?;
         let record = self.record_for(node)?;
         let (path, mode, captured_blob) = match &record {
             NodeRecord::File {
@@ -2419,7 +2462,7 @@ impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
             if let Some(id) = id
                 && let Some(buf) = pending.hot.get_mut(&id)
             {
-                buf.bytes.resize(new_size as usize, 0);
+                buf.bytes.resize(new_size, 0);
                 buf.last_touched = Instant::now();
                 Phase1::ResizedInPlace
             } else {
@@ -2449,7 +2492,7 @@ impl<S: ObjectStore + 'static> ContentAddressedMount<S> {
             Some(hash) => (*self.load_blob_bytes(&hash)?).to_vec(),
             None => Vec::new(),
         };
-        bytes.resize(new_size as usize, 0);
+        bytes.resize(new_size, 0);
         let mut pending = self.inner.pending.lock_or_poisoned();
         if orphan {
             // Per-NodeId buffer only. Skip the tombstone-clear and
@@ -3386,6 +3429,10 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
     }
 
     fn write(&self, node: NodeId, offset: u64, data: &[u8]) -> Result<usize> {
+        let end = validate_write_extent(offset, data.len())?;
+        let offset = usize::try_from(offset).map_err(|_| {
+            MountError::InvalidArgument(format!("write offset {offset} does not fit in usize"))
+        })?;
         // Determine the mount-relative path and mode to key the hot
         // buffer on. New files (`PendingFile`) carry their path
         // directly; pre-existing files identify by the parent's
@@ -3534,8 +3581,6 @@ impl<S: ObjectStore + 'static> PlatformShell for ContentAddressedMount<S> {
             bytes: seed_bytes.unwrap_or_default(),
             last_touched: Instant::now(),
         });
-        let offset = offset as usize;
-        let end = offset + data.len();
         // POSIX `pwrite` past EOF zero-fills the gap.
         if buf.bytes.len() < end {
             buf.bytes.resize(end, 0);

--- a/crates/mount/src/error.rs
+++ b/crates/mount/src/error.rs
@@ -59,6 +59,11 @@ pub enum MountError {
     #[error("invalid argument: {0}")]
     InvalidArgument(String),
 
+    /// A write or truncate would grow the hot buffer past the mount's
+    /// configured maximum file size. Maps to `EFBIG`.
+    #[error("file too large: {0}")]
+    FileTooLarge(String),
+
     /// The platform shell failed to construct its mount session
     /// (e.g. the Swift FSKit shim returned a null session handle).
     /// Maps to `EIO`: the mount never came up, nothing to retry
@@ -91,6 +96,7 @@ impl MountError {
             MountError::IsADirectory(_) => libc::EISDIR,
             MountError::NotEmpty(_) => libc::ENOTEMPTY,
             MountError::InvalidArgument(_) => libc::EINVAL,
+            MountError::FileTooLarge(_) => libc::EFBIG,
             MountError::SessionInit(_) => libc::EIO,
             MountError::Store(HeddleError::NotFound(_))
             | MountError::Store(HeddleError::StateNotFound(_))

--- a/crates/mount/src/nfs.rs
+++ b/crates/mount/src/nfs.rs
@@ -720,6 +720,7 @@ fn mount_err_to_nfs(err: &MountError) -> nfsstat3 {
         MountError::IsADirectory(_) => nfsstat3::NFS3ERR_ISDIR,
         MountError::NotEmpty(_) => nfsstat3::NFS3ERR_NOTEMPTY,
         MountError::InvalidArgument(_) => nfsstat3::NFS3ERR_INVAL,
+        MountError::FileTooLarge(_) => nfsstat3::NFS3ERR_FBIG,
         // Session construction happens before the NFS server ever
         // dispatches a request, so this can't surface mid-protocol;
         // map it like any other infrastructure failure.

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -33,7 +33,7 @@ use sley::ObjectId as GitObjectId;
 use tempfile::TempDir;
 
 use crate::{
-    core::ContentAddressedMount,
+    core::{ContentAddressedMount, MAX_MOUNT_HOT_FILE_SIZE},
     error::MountError,
     shell::{NodeId, NodeKind, PlatformShell},
 };
@@ -489,6 +489,61 @@ fn write_past_end_zero_fills() {
     let bytes = read_captured_blob(&mount, &new_id, "short.txt");
     assert_eq!(bytes, b"abc\0\0\0\0\0\0\0XYZ");
     assert_eq!(bytes.len(), 13);
+}
+
+/// heddle#877 / HEDDLE-DR-5: wire offset+len must be clamped before
+/// `Vec::resize` — overflow must not panic and huge offsets must not
+/// attempt multi-TiB allocations.
+#[test]
+fn write_rejects_overflowing_offset_plus_length() {
+    let (_temp, mount) = mount_with_seed("big.txt", b"x");
+    let node = mount.lookup_path("big.txt").unwrap();
+    let err = mount.write(node, u64::MAX, &[0u8]).unwrap_err();
+    assert!(
+        matches!(err, MountError::InvalidArgument(_)),
+        "got {err:?}"
+    );
+    assert_eq!(err.to_errno(), libc::EINVAL);
+}
+
+#[test]
+fn write_rejects_extent_beyond_max_hot_file_size() {
+    let (_temp, mount) = mount_with_seed("cap.txt", b"x");
+    let node = mount.lookup_path("cap.txt").unwrap();
+    let err = mount
+        .write(node, MAX_MOUNT_HOT_FILE_SIZE, &[0u8])
+        .unwrap_err();
+    assert!(matches!(err, MountError::FileTooLarge(_)), "got {err:?}");
+    assert_eq!(err.to_errno(), libc::EFBIG);
+}
+
+#[test]
+fn write_in_bounds_at_max_hot_file_size_succeeds() {
+    let (_temp, mount) = mount_with_seed("edge.txt", b"");
+    let node = mount.lookup_path("edge.txt").unwrap();
+    let written = mount
+        .write(node, MAX_MOUNT_HOT_FILE_SIZE - 1, b"z")
+        .unwrap();
+    assert_eq!(written, 1);
+}
+
+#[test]
+fn set_attrs_truncate_rejects_beyond_max_hot_file_size() {
+    use crate::shell::AttrUpdate;
+
+    let (_temp, mount) = mount_with_seed("trunc.txt", b"hi");
+    let node = mount.lookup_path("trunc.txt").unwrap();
+    let err = mount
+        .set_attrs(
+            node,
+            AttrUpdate {
+                size: Some(MAX_MOUNT_HOT_FILE_SIZE + 1),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+    assert!(matches!(err, MountError::FileTooLarge(_)), "got {err:?}");
+    assert_eq!(err.to_errno(), libc::EFBIG);
 }
 
 /// Serializes the env-mutating signing test(s) below: they pin the


### PR DESCRIPTION
Closes #877.

## Fix
Core-level guards in `ContentAddressedMount::write()` and `apply_truncate()`:
- `validate_write_extent()` rejects `offset + len` overflow (`EINVAL`) or extents beyond `MAX_MOUNT_HOT_FILE_SIZE` (`EFBIG`) before `Vec::resize`.
- `validate_truncate_size()` applies the same max-size check for truncate/setattr paths.

FUSE, NFS, and FSKit all call into the shared core shell, so they inherit the clamp without per-frontend duplication.

## Max size
`MAX_MOUNT_HOT_FILE_SIZE` = 100 MiB, aligned with `repo::worktree_walk` capture limits.

## Proof tests
- `write_rejects_overflowing_offset_plus_length` — `u64::MAX` + 1 byte → `InvalidArgument` / `EINVAL`, no panic
- `write_rejects_extent_beyond_max_hot_file_size` — offset at cap + 1 byte → `FileTooLarge` / `EFBIG`
- `write_in_bounds_at_max_hot_file_size_succeeds` — write at `MAX - 1` still succeeds
- `set_attrs_truncate_rejects_beyond_max_hot_file_size` — symmetric truncate guard

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593180&installation_id=132405951&pr_number=946&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F946&signature=5cd0e3cdcc0af062e5157c7005d2dce460fba252d8778495d9001f75b61b4cde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->