### PR TITLE
fix(daemon): locked read-modify-write for discussion mutations (HEDDLE-DR-2, #875)

### DIFF
--- a/crates/daemon/src/grpc_local_impl/discussion.rs
+++ b/crates/daemon/src/grpc_local_impl/discussion.rs
@@ -572,7 +572,6 @@ impl DiscussionService for LocalDiscussionService {
                         ChangeId::try_from_slice(&req.state_id).map_err(|err| {
                             Status::invalid_argument(format!("invalid state_id: {err}"))
                         })?;
-                    let (state, mut blob) = load_discussions_blob(repo, &opened_against)?;
                     let now = now_secs();
                     let principal = principal_for(repo);
                     let visibility = if req.visibility.trim().is_empty() {
@@ -600,6 +599,11 @@ impl DiscussionService for LocalDiscussionService {
                     discussion
                         .validate()
                         .map_err(|err| Status::invalid_argument(err.to_string()))?;
+                    let _lock = repo
+                        .locker()
+                        .write()
+                        .map_err(|err| Status::internal(err.to_string()))?;
+                    let (state, mut blob) = load_discussions_blob(repo, &opened_against)?;
                     blob.discussions.push(discussion.clone());
                     save_discussions_blob(repo, &state, &blob)?;
                     Ok(discussion_to_proto(&discussion))
@@ -639,6 +643,11 @@ impl DiscussionService for LocalDiscussionService {
                     // This local mutation API is HEAD-scoped because the
                     // request carries no state_id. It must not pretend to find
                     // and mutate discussions across the whole repository.
+                    let principal = principal_for(repo);
+                    let _lock = repo
+                        .locker()
+                        .write()
+                        .map_err(|err| Status::internal(err.to_string()))?;
                     let head = head_state(repo)?;
                     let mut blob = decode_blob_for_state(repo, &head)?;
                     let idx = blob
@@ -648,7 +657,6 @@ impl DiscussionService for LocalDiscussionService {
                         .ok_or_else(|| {
                             Status::not_found(format!("discussion {} not found", req.discussion_id))
                         })?;
-                    let principal = principal_for(repo);
                     blob.discussions[idx].turns.push(DiscussionTurn {
                         author: principal,
                         body: req.body.clone(),
@@ -693,6 +701,23 @@ impl DiscussionService for LocalDiscussionService {
                     // This local mutation API is HEAD-scoped because the
                     // request carries no state_id. It must not pretend to find
                     // and mutate discussions across the whole repository.
+                    use grpc::heddle::v1::resolve_discussion_request::Resolution;
+                    let resolution = req
+                        .resolution
+                        .clone()
+                        .ok_or_else(|| Status::invalid_argument("resolution mode is required"))?;
+                    if let Resolution::Dismissed(ref payload) = resolution
+                        && payload.reason.trim().is_empty()
+                    {
+                        return Err(Status::invalid_argument(
+                            "dismissal requires a non-empty reason",
+                        ));
+                    }
+
+                    let _lock = repo
+                        .locker()
+                        .write()
+                        .map_err(|err| Status::internal(err.to_string()))?;
                     let head = head_state(repo)?;
                     let mut blob = decode_blob_for_state(repo, &head)?;
                     let idx = blob
@@ -703,29 +728,8 @@ impl DiscussionService for LocalDiscussionService {
                             Status::not_found(format!("discussion {} not found", req.discussion_id))
                         })?;
 
-                    use grpc::heddle::v1::resolve_discussion_request::Resolution;
-                    let resolution = req
-                        .resolution
-                        .clone()
-                        .ok_or_else(|| Status::invalid_argument("resolution mode is required"))?;
                     match resolution {
                         Resolution::IntoAnnotation(payload) => {
-                            let _lock = repo
-                                .locker()
-                                .write()
-                                .map_err(|err| Status::internal(err.to_string()))?;
-                            let head = head_state(repo)?;
-                            let mut blob = decode_blob_for_state(repo, &head)?;
-                            let idx = blob
-                                .discussions
-                                .iter()
-                                .position(|d| d.id == req.discussion_id)
-                                .ok_or_else(|| {
-                                    Status::not_found(format!(
-                                        "discussion {} not found",
-                                        req.discussion_id
-                                    ))
-                                })?;
                             let updated = resolve_discussion_into_annotation(
                                 repo, &head, &mut blob, idx, payload,
                             )?;
@@ -740,11 +744,6 @@ impl DiscussionService for LocalDiscussionService {
                                 DiscussionResolution::ResolvedByEdit { state_id };
                         }
                         Resolution::Dismissed(payload) => {
-                            if payload.reason.trim().is_empty() {
-                                return Err(Status::invalid_argument(
-                                    "dismissal requires a non-empty reason",
-                                ));
-                            }
                             blob.discussions[idx].resolution = DiscussionResolution::Dismissed {
                                 reason: payload.reason,
                             };
@@ -943,6 +942,47 @@ mod tests {
         assert_eq!(first.id, second.id);
         assert_eq!(first.turns.len(), 1);
         assert_eq!(second.turns.len(), 1);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(process_global)]
+    async fn open_discussion_serializes_concurrent_appends() {
+        // Regression for the lost-update race: two OpenDiscussions with
+        // different operation ids could both read the same base
+        // `DiscussionsBlob`, then the second `put_state` would clobber the
+        // first discussion. The fix wraps the read-modify-write in
+        // `repo.locker().write()` and re-loads the blob inside the lock.
+        let (_t, state_id, svc) = fresh_service();
+        let op_a = objects::object::OperationId::new().to_string();
+        let op_b = objects::object::OperationId::new().to_string();
+        let mut req_a = open_request(&state_id, "body a", &op_a);
+        req_a.anchor.as_mut().unwrap().symbol = "sym_a".into();
+        let mut req_b = open_request(&state_id, "body b", &op_b);
+        req_b.anchor.as_mut().unwrap().symbol = "sym_b".into();
+
+        let svc_a = svc.clone();
+        let svc_b = svc.clone();
+        let (a, b) = tokio::join!(
+            svc_a.open_discussion(Request::new(req_a)),
+            svc_b.open_discussion(Request::new(req_b)),
+        );
+        a.expect("first open_discussion");
+        b.expect("second open_discussion");
+
+        let listed = svc
+            .list_by_state(Request::new(ListDiscussionsByStateRequest {
+                repo_path: String::new(),
+                state_id: state_id.as_bytes().to_vec(),
+                status: "all".into(),
+            }))
+            .await
+            .expect("list_by_state");
+        assert_eq!(
+            listed.get_ref().discussions.len(),
+            2,
+            "both concurrent discussions must land — neither should be lost \
+             to a stale-blob clobber"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #875.

## Summary
Discussion mutations (`open_discussion`, `append_turn`, and all mutating `resolve_discussion` branches) now take `repo.locker().write()` and re-read the discussions blob inside the critical section, mirroring `sign_state`.

## Sites fixed
1. `open_discussion` — lock + `load_discussions_blob` before push/save
2. `append_turn` — lock + re-read HEAD blob before append
3. `resolve_discussion` — single lock + re-read for IntoAnnotation, ByEdit, and Dismissed (removed the partial lock that only covered IntoAnnotation)

## Proof
- `open_discussion_serializes_concurrent_appends` — two concurrent `OpenDiscussion` RPCs with distinct operation ids both persist (regression for stale-blob clobber).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593362&installation_id=132405951&pr_number=947&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F947&signature=5d59e57ab8e5a3b0d63c668e12f2c1a9a22d6dc53637bcedadda79a0c4a96faf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->