### PR TITLE
chore(audit): mirror quick-xml advisory ignores into .cargo/audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,4 +22,12 @@ ignore = [
     # biscuit-quote → biscuit-auth 6.0 (heddle-client). No runtime exposure,
     # no CVE. Remove when biscuit-auth drops it. (Mirrors deny.toml.)
     "RUSTSEC-2026-0173",
+
+    # quick-xml 0.26 NsReader unbounded namespace-declaration allocation (DoS).
+    # Dev-only: inferno 0.11 → pprof 0.15 flamegraph, a [dev-dependencies] of
+    # heddle-semantic used by criterion benchmarks — not in any shipped binary,
+    # and the vulnerable untrusted-XML NsReader path is unreachable (inferno
+    # writes SVGs). Remove when pprof/inferno bump quick-xml. (Mirrors deny.toml.)
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
 ]


### PR DESCRIPTION
Follow-up to #943. cargo-audit (the main/schedule job in audit.yml) reads .cargo/audit.toml, not deny.toml — #943 only updated deny.toml (the PR-gate cargo-deny), so cargo-audit still reddened main on push. Mirrors RUSTSEC-2026-0194/0195 with the same rationale, satisfying audit.toml's own 'you MUST also ignore in deny.toml' contract both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785593435&installation_id=132405951&pr_number=948&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F948&signature=36461cc19897ae1b8ebae6f474c64678ea9bf5c9fcfea5b1805af225c0776cf9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->