### PR TITLE
chore(release): draft 0.7.0 CHANGELOG + version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.7.0 - 2026-07-02
+
 ### Added
 
 - **`--git-mirror` hosted push + generic progress substrate.** A new
@@ -42,6 +44,19 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 - **Homebrew tap moved.** The tap repo is now `HeddleCo/homebrew-tap`, so
   install is `brew install HeddleCo/tap/heddle` instead of the redundant
   `HeddleCo/heddle/heddle` path. (#831)
+- **One status/next-action/advice engine.** Repo status, next-action
+  computation, and contextual advice now come from a single core engine;
+  the CLI only renders. Deletes the per-command copies that had drifted
+  apart. No user-visible behavior change. (#852, #941)
+- **sley substrate bumped to 0.4.0 and adopted deeper.** The git substrate
+  dependency moved to sley 0.4.0 and heddle now uses its purpose-built
+  APIs instead of local re-implementations: ahead/behind counts for
+  remote-tracking status (deleting a hand-rolled ancestry walk), the
+  `ReachablePackPlan` facade for building the hosted git-lane pack, and
+  `HeadState`/`set_head_symref` for reading and writing `.git/HEAD`
+  (deleting literal `ref: refs/heads/` string parsing; HEAD writes are now
+  crash-atomic). Behavior-neutral: identical counts, byte-identical packs
+  and HEAD contents. (#950, #951, #952, #953)
 
 ### Fixed
 
@@ -73,7 +88,23 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 - **`SHA256SUMS` checksum aggregation strips Windows CRLF.** The Windows
   build's `.sha256` sidecar used CRLF line endings, which broke the Scoop
   manifest's anchored checksum lookup; aggregation now normalizes to LF so
-  published checksums are consistent across platforms. (#824)
+  published checksums are consistent across platforms. This is the defect
+  that kept 0.6.0 from shipping. (#824)
+- **Concurrent discussion mutations no longer lose writes.** Discussion
+  mutations in the daemon ran read-modify-write without a lock, so two
+  concurrent `discuss` operations could silently drop one side's update;
+  mutations are now serialized per repo. (#875, #947)
+- **Deeply nested code no longer overflows the stack in semantic analysis.**
+  `walk_definitions` switched from recursion to an iterative DFS, so
+  pathologically nested source files can't crash capture/status with a
+  stack overflow. (#876, #945)
+- **Mount write/truncate offsets clamped at the trust boundary.** A hostile
+  or confused FUSE/ProjFS caller could pass offset+length combinations
+  that overflowed internal arithmetic; both are now clamped where the
+  request enters heddle. (#877, #946)
+- **Diff context summaries truncate on character boundaries.** Truncating
+  a context summary mid-multibyte-character panicked on UTF-8 slicing;
+  truncation is now char-boundary-safe. (#879, #944)
 
 ### Performance
 
@@ -93,7 +124,11 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   already computed at the top of the command, matching the fast-path
   threading `capture` already had. (#829)
 
-## 0.6.0 - Unreleased
+## 0.6.0 - 2026-06-29 [tagged, never shipped]
+
+> The `v0.6.0` tag exists but binaries were never published: the Windows
+> release pipeline produced CRLF-corrupted `SHA256SUMS` (fixed in #824,
+> above). Everything below ships in 0.7.0.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1661,7 +1661,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1768,7 +1768,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1861,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1931,14 +1931,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -1949,7 +1949,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5996,7 +5996,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.6.0",
+  "schemaVersion": "0.7.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.6.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.7.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,32 +32,32 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.7" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.6" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.7" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
-heddle-core = { path = "../core", version = "0.6" }
-heddle-format = { path = "../format", version = "0.6" }
-heddle-client = { path = "../client", version = "0.6", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.6" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
+heddle-core = { path = "../core", version = "0.7" }
+heddle-format = { path = "../format", version = "0.7" }
+heddle-client = { path = "../client", version = "0.7", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.7" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.6", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.7", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -106,13 +106,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.6", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -32,14 +32,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.7" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,17 +12,17 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.6" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
 sley.workspace = true
 
 [features]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.6", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.6" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.7" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,10 +15,10 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.6" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+heddle-format = { path = "../format", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 similar.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -70,7 +70,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.6" }
+heddle-format = { path = "../format", version = "0.7" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.6" }
+heddle-format = { path = "../format", version = "0.7" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.6" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+heddle-schema = { path = "../schema", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.6", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.7", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.6" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+heddle-schema = { path = "../schema", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.6", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.7", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.6" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.6" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.6", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.6", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.7", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.6" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.6", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.6", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.6" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Release-cut draft for **0.7.0** (0.6.0 was tagged but never shipped — Windows CRLF SHA256SUMS, fixed in #824).

- Workspace version 0.6.0 → 0.7.0; inter-crate caret pins 0.6 → 0.7 (19 manifests; third-party `windows = 0.62` untouched)
- CHANGELOG: dates 0.7.0 (2026-07-02), folds Unreleased + everything merged since #940 (sley 0.4.0 bump/adoption #950-953, status-engine consolidation #941, robustness fixes #944-947), marks 0.6.0 `[tagged, never shipped]` with the CRLF explanation
- Cargo.lock synced (22 heddle crates, version lines only)
- TS/JSON schemas regenerated via scripts/gen-ts-types.sh (schemaVersion → 0.7.0; 2-line diff)

Gates: `cargo build --locked --workspace` green. Merging does NOT tag or trigger release — the `v0.7.0` tag push follows after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/954"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785608582&installation_id=132405951&pr_number=954&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F954&signature=ebf1b4d21c44cb86f1e29bae3fea3f2beb7ee340792457fed52325cee1ba08e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->