### PR TITLE
chore(grpc): bump heddle-grpc 0.7.3 -> 0.8.0 (proto grew: #814 recovery RPCs)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,7 +1731,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "prost 0.14.4",

--- a/clients/grpc/package-lock.json
+++ b/clients/grpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heddleco/grpc",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heddleco/grpc",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.12.0",

--- a/clients/grpc/package.json
+++ b/clients/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleco/grpc",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "Generated TypeScript protobuf and Connect clients for Heddle gRPC.",
   "license": "Apache-2.0",
   "repository": {

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,7 +40,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.7" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.7" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.8" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
 heddle-core = { path = "../core", version = "0.7" }
 heddle-format = { path = "../format", version = "0.7" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -34,7 +34,7 @@ tracing.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.8" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.7" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.7" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.8" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.7" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.7.3"
+version = "0.8.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true


### PR DESCRIPTION
The v0.7.0 release run failed its **publish TypeScript gRPC client** job with:

> `@heddleco/grpc@0.7.3 already exists on GitHub Packages but the packed client differs; bump crates/grpc/Cargo.toml`

The guard is right: #814 added the account-recovery RPCs (+ namespace-visibility RPCs) to the proto without bumping heddle-grpc, so both GitHub Packages **and crates.io** still serve a stale 0.7.3. weft#182-186 explicitly expect these RPCs to ship as **heddle-grpc 0.8**.

- `crates/grpc`: 0.7.3 → 0.8.0
- Internal caret pins (cli/client/daemon): 0.7 → 0.8
- `clients/grpc/package.json` (+lock): 0.8.0 (CI enforces it matches the crate)
- Cargo.lock synced

On merge, publish-crates ships heddle-grpc 0.8.0 to crates.io — unblocking the weft repin. The npm client 0.8.0 publishes on the next release-pipeline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785612035&installation_id=132405951&pr_number=955&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F955&signature=d86478dcdb884b1518e193f07c7f412aa8d9bece6b719e3d61c72539fd83032b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->