### PR TITLE
ci: dispatchable publish of the npm gRPC client (between-releases)

### DIFF
--- a/.github/workflows/publish-npm-client.yml
+++ b/.github/workflows/publish-npm-client.yml
@@ -1,0 +1,85 @@
+# Publish the generated @heddleco/grpc TypeScript client to GitHub Packages
+# on demand, from whatever ref the workflow is dispatched on (normally main).
+#
+# The release pipeline (release.yml) publishes the client as part of a tag
+# build; this workflow exists for the between-releases case where the proto
+# (and so heddle-grpc + the generated client) moved ahead of the last binary
+# release and a consumer (tapestry) needs the package now. The version guard
+# below is identical to release.yml's: an existing identical package skips,
+# an existing DIFFERENT package fails loudly (bump crates/grpc first).
+name: Publish npm gRPC client
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-grpc-client:
+    name: publish TypeScript gRPC client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install client dependencies
+        working-directory: clients/grpc
+        run: npm ci
+
+      # NOTE: no generate:check here — it needs the Rust toolchain and a large
+      # workspace build, and gen-currency on main is already enforced by the
+      # "Validate generated client" PR gate. Dispatch from main only.
+      - name: Typecheck generated gRPC client package
+        working-directory: clients/grpc
+        run: npm run typecheck
+
+      - name: Publish generated gRPC client to GitHub Packages
+        working-directory: clients/grpc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          package_name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          registry="https://npm.pkg.github.com"
+          printf '%s\n' \
+            "${package_name%%/*}:registry=${registry}" \
+            "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" \
+            > .npmrc
+
+          remote_dist="$(mktemp)"
+          remote_err="$(mktemp)"
+          if npm view "${package_name}@${version}" dist --json --registry="${registry}" >"${remote_dist}" 2>"${remote_err}"; then
+            local_pack="$(mktemp)"
+            npm pack --dry-run --json >"${local_pack}"
+
+            local_integrity="$(node -e 'const fs = require("fs"); const [entry] = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(entry?.integrity ?? "");' "${local_pack}")"
+            local_shasum="$(node -e 'const fs = require("fs"); const [entry] = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(entry?.shasum ?? "");' "${local_pack}")"
+            remote_integrity="$(node -e 'const fs = require("fs"); const text = fs.readFileSync(process.argv[1], "utf8").trim(); if (!text || text === "undefined" || text === "null") process.exit(0); const dist = JSON.parse(text); process.stdout.write(dist?.integrity ?? "");' "${remote_dist}")"
+            remote_shasum="$(node -e 'const fs = require("fs"); const text = fs.readFileSync(process.argv[1], "utf8").trim(); if (!text || text === "undefined" || text === "null") process.exit(0); const dist = JSON.parse(text); process.stdout.write(dist?.shasum ?? "");' "${remote_dist}")"
+
+            if [[ -n "$remote_integrity" && "$local_integrity" == "$remote_integrity" ]]; then
+              echo "::notice::${package_name}@${version} is already published with identical integrity; skipping"
+              exit 0
+            fi
+            if [[ -n "$remote_shasum" && "$local_shasum" == "$remote_shasum" ]]; then
+              echo "::notice::${package_name}@${version} is already published with identical shasum; skipping"
+              exit 0
+            fi
+
+            echo "::error::${package_name}@${version} already exists on GitHub Packages but the packed client differs; bump crates/grpc/Cargo.toml before changing generated client output"
+            exit 1
+          fi
+
+          if ! grep -Eiq '(E404|404|not[[:space:]-]?found)' "${remote_err}"; then
+            cat "${remote_err}" >&2
+            exit 1
+          fi
+
+          npm publish --registry="${registry}"


### PR DESCRIPTION
The `@heddleco/grpc` TS client only publishes from the tag-gated release pipeline, so this week's heddle-grpc 0.8.x/0.9.0 proto bumps left GitHub Packages serving a stale 0.7.3 client — blocking tapestry from consuming the new surface (TreeEntryKind, MarkerInfo, recovery RPCs).

Adds a `workflow_dispatch` workflow that publishes the client from the dispatched ref (main):
- `permissions: packages: write` via the Actions token (PATs here lack write:packages)
- **Identical version guard as release.yml** (verbatim): identical content → skip; different content under an existing version → loud failure telling you to bump crates/grpc
- npm ci + typecheck only — no Rust toolchain; gen-currency is already enforced by the *Validate generated client* PR gate before anything reaches main

First dispatch (after merge) publishes **@heddleco/grpc@0.9.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785630576&installation_id=132405951&pr_number=958&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F958&signature=4af59e27a07113c51127f73fb6f8c50d4552f71e21dd95ce22778437cfcbb30b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->