### PR TITLE
feat(cli): surface human-tier deep-link from x-weft-sig-action-url (weft#338)

### DIFF
--- a/crates/cli/src/client/human_signature.rs
+++ b/crates/cli/src/client/human_signature.rs
@@ -41,17 +41,33 @@ pub fn cli_human_signature_callback() -> HumanSignatureCallback {
         // Show the consent surface: the user should always learn which action
         // was gated, even though the CLI can't complete the gesture itself.
         eprintln!(
-            "This action requires a hardware user-verification gesture (WebAuthn):\n  {}",
+            "⚠ This action requires user verification (WebAuthn), which the CLI can't perform in \
+             a headless terminal:\n  {}",
             req.action_summary
         );
-        eprintln!(
-            "The `heddle` CLI cannot perform the WebAuthn ceremony in a headless terminal."
-        );
-        Err(ProtocolError::AuthorizationFailed(format!(
-            "user verification required for {}: run this destructive action from a surface with a \
-             WebAuthn authenticator (the web UI), or re-run once CLI authenticator support lands",
-            req.method_path
-        )))
+        // When the server sent a deep-link (weft#338), point the user straight at the surface
+        // that CAN complete the ceremony; otherwise fall back to generic guidance. Either way
+        // we return a typed error and NEVER fabricate an assertion.
+        match req.action_url.as_deref() {
+            Some(url) => {
+                eprintln!("Complete it in the web app:\n  {url}");
+                Err(ProtocolError::AuthorizationFailed(format!(
+                    "user verification required for {}: complete this action in the web app:\n  {}",
+                    req.method_path, url
+                )))
+            }
+            None => {
+                eprintln!(
+                    "The `heddle` CLI cannot perform the WebAuthn ceremony in a headless terminal."
+                );
+                Err(ProtocolError::AuthorizationFailed(format!(
+                    "user verification required for {}: run this destructive action from a surface \
+                     with a WebAuthn authenticator (the web UI), or re-run once CLI authenticator \
+                     support lands",
+                    req.method_path
+                )))
+            }
+        }
     })
 }
 
@@ -59,20 +75,47 @@ pub fn cli_human_signature_callback() -> HumanSignatureCallback {
 mod tests {
     use super::*;
 
-    #[test]
-    fn cli_callback_returns_typed_error_and_never_fakes_an_assertion() {
-        let cb = cli_human_signature_callback();
-        let req = HumanSignatureRequest {
+    fn req_with_action_url(action_url: Option<String>) -> HumanSignatureRequest {
+        HumanSignatureRequest {
             method_path: "/heddle.v1.HostedUserService/DeleteRepository".to_string(),
             action_summary: "Authorize /heddle.v1.HostedUserService/DeleteRepository".to_string(),
             challenge: "abc".to_string(),
             canonical: b"weft-req-sig-v1:...".to_vec(),
-        };
-        let result = cb(req);
+            action_url,
+        }
+    }
+
+    /// Without a server deep-link, the callback keeps the generic guidance and still returns a
+    /// typed error, never an assertion.
+    #[test]
+    fn cli_callback_returns_typed_error_and_never_fakes_an_assertion() {
+        let cb = cli_human_signature_callback();
+        let result = cb(req_with_action_url(None));
         match result {
             Err(ProtocolError::AuthorizationFailed(msg)) => {
                 assert!(msg.contains("user verification required"));
                 assert!(msg.contains("DeleteRepository"));
+                // No URL was provided → generic guidance, no link.
+                assert!(msg.contains("web UI"));
+                assert!(!msg.contains("https://"));
+            }
+            other => panic!("expected a typed AuthorizationFailed error, got {other:?}"),
+        }
+    }
+
+    /// With a server deep-link (weft#338), the typed error message includes the URL so the user
+    /// can open it — and the callback still returns a typed error, never an assertion.
+    #[test]
+    fn cli_callback_includes_action_url_in_typed_error_when_present() {
+        let cb = cli_human_signature_callback();
+        let url = "https://app.heddle.sh/verify-action?method=%2Fheddle.v1.HostedUserService%2FDeleteRepository&challenge=CHAL";
+        let result = cb(req_with_action_url(Some(url.to_string())));
+        match result {
+            Err(ProtocolError::AuthorizationFailed(msg)) => {
+                assert!(msg.contains("user verification required"));
+                assert!(msg.contains("DeleteRepository"));
+                assert!(msg.contains(url), "message must carry the deep-link URL: {msg}");
+                assert!(msg.contains("web app"));
             }
             other => panic!("expected a typed AuthorizationFailed error, got {other:?}"),
         }

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -177,6 +177,7 @@ impl HostedGrpcClient {
         &self,
         method_path: &str,
         ctx: &request_signing::SignedRequestContext,
+        action_url: Option<String>,
     ) -> Result<request_signing::WebAuthnAssertion, ProtocolError> {
         let callback = self.on_human_signature.as_ref().ok_or_else(|| {
             ProtocolError::AuthorizationFailed(format!(
@@ -190,6 +191,9 @@ impl HostedGrpcClient {
             action_summary: format!("Authorize {method_path}"),
             challenge,
             canonical: ctx.canonical.clone(),
+            // Deep-link the server sent on the rejection (weft#338), if any — a display hint
+            // the callback can show; the signed challenge above is unaffected.
+            action_url,
         };
         callback(req)
     }

--- a/crates/client/src/grpc_hosted/request_signing.rs
+++ b/crates/client/src/grpc_hosted/request_signing.rs
@@ -57,6 +57,12 @@ pub(super) const HDR_SIG_WEBAUTHN_USER_HANDLE_BIN: &str = "x-weft-sig-webauthn-u
 /// Discovery trailer/header the server sets on a signature-required rejection.
 pub(super) const HDR_SIG_REQUIRED: &str = "x-weft-sig-required";
 
+/// Deep-link trailer (weft#338): on a human-tier rejection the server MAY set this to the
+/// tapestry `/verify-action` URL where the user can complete the action. Present only when the
+/// server has a web origin configured; the client surfaces it in the human-signature callback.
+/// MUST match `weft-server`'s `HDR_SIG_ACTION_URL`.
+pub(super) const HDR_SIG_ACTION_URL: &str = "x-weft-sig-action-url";
+
 /// Alg tag values.
 const ALG_ED25519: &str = "ed25519";
 const ALG_WEBAUTHN: &str = "webauthn";
@@ -217,6 +223,13 @@ pub struct HumanSignatureRequest {
     /// The raw canonical bytes the challenge is derived from (for callbacks that
     /// want to re-derive or display the covered action).
     pub canonical: Vec<u8>,
+    /// Deep-link to the surface that CAN complete this action (weft#338), taken
+    /// verbatim from the server's `x-weft-sig-action-url` rejection trailer, e.g.
+    /// `https://app.heddle.sh/verify-action?method=...&challenge=...`. `None` when
+    /// the server did not send it (no web origin configured) — callbacks then fall
+    /// back to generic guidance. It is a display hint only; the challenge the
+    /// callback signs over is still the client-derived [`Self::challenge`].
+    pub action_url: Option<String>,
 }
 
 /// App-registered callback that turns a [`HumanSignatureRequest`] into a
@@ -280,6 +293,18 @@ pub(super) fn requires_human_signature(status: &tonic::Status) -> bool {
         .and_then(|v| v.to_str().ok())
         .map(|v| v.eq_ignore_ascii_case("human"))
         .unwrap_or(false)
+}
+
+/// Extract the server's `x-weft-sig-action-url` deep-link (weft#338) from a rejection
+/// `Status`, if present. `None` when the trailer is absent (server has no web origin
+/// configured) or non-ASCII. Read from the same rejection metadata as
+/// [`requires_human_signature`].
+pub(super) fn action_url_from_status(status: &tonic::Status) -> Option<String> {
+    status
+        .metadata()
+        .get(HDR_SIG_ACTION_URL)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string())
 }
 
 #[cfg(test)]

--- a/crates/client/src/grpc_hosted/user.rs
+++ b/crates/client/src/grpc_hosted/user.rs
@@ -48,7 +48,11 @@ macro_rules! signed_call {
                 // `attach_human` re-stamps `x-weft-sig-ts`/`-nonce-bin` from that
                 // context; we only need bearer auth (not a fresh PoP) on retry.
                 let ctx = $self.require_human_sig_context(sig_ctx)?;
-                let assertion = $self.request_human_signature(path, &ctx)?;
+                // The server may include a deep-link (weft#338) on the rejection pointing at a
+                // surface that can complete the WebAuthn ceremony; forward it to the callback.
+                let action_url =
+                    $crate::grpc_hosted::request_signing::action_url_from_status(&status);
+                let assertion = $self.request_human_signature(path, &ctx, action_url)?;
                 let mut retry = Request::new(message);
                 $self.apply_auth(&mut retry)?;
                 $crate::grpc_hosted::request_signing::attach_human(&mut retry, &ctx, &assertion)?;
@@ -644,10 +648,15 @@ mod human_retry_tests {
     use wire::ProtocolError;
 
     use super::super::request_signing::{
-        HDR_SIG_ALG, HDR_SIG_BIN, HDR_SIG_KEY_BIN, HDR_SIG_REQUIRED,
+        HDR_SIG_ACTION_URL, HDR_SIG_ALG, HDR_SIG_BIN, HDR_SIG_KEY_BIN, HDR_SIG_REQUIRED,
         HDR_SIG_WEBAUTHN_AUTH_DATA_BIN, HDR_SIG_WEBAUTHN_CLIENT_DATA_BIN, WebAuthnAssertion,
     };
     use super::HostedGrpcClient;
+
+    /// The deep-link the human-tier mock returns on its rejection (weft#338), so the retry test
+    /// can assert the client threads it into `HumanSignatureRequest.action_url`.
+    const MOCK_ACTION_URL: &str =
+        "https://app.heddle.sh/verify-action?method=%2Fheddle.v1.TreeEditService%2FStatusForThread&challenge=CHAL";
 
     /// A `TreeEditService` mock for `StatusForThread` that models a `human`-tier
     /// endpoint: the first request (no WebAuthn assertion) is rejected with
@@ -686,6 +695,12 @@ mod human_retry_tests {
                 }
                 let mut trailer = tonic::metadata::MetadataMap::new();
                 trailer.insert(HDR_SIG_REQUIRED, "human".parse().unwrap());
+                // Emit the weft#338 deep-link trailer so the client-side plumbing that reads it
+                // into `HumanSignatureRequest.action_url` is exercised end-to-end.
+                trailer.insert(
+                    HDR_SIG_ACTION_URL,
+                    MOCK_ACTION_URL.parse().unwrap(),
+                );
                 return Err(Status::with_metadata(
                     tonic::Code::Unauthenticated,
                     "user verification required",
@@ -785,6 +800,8 @@ mod human_retry_tests {
                     super::super::request_signing::human_challenge(&req.canonical);
                 assert_eq!(req.challenge, expected);
                 assert!(req.method_path.ends_with("/StatusForThread"));
+                // The server's deep-link trailer (weft#338) reaches the callback verbatim.
+                assert_eq!(req.action_url.as_deref(), Some(MOCK_ACTION_URL));
                 Ok(WebAuthnAssertion {
                     credential_id: b"cred-id".to_vec(),
                     signature: b"assertion-sig".to_vec(),


### PR DESCRIPTION
## What

Client half of the human-tier deep-link. When a `human`-tier RPC is rejected with `x-weft-sig-required: human`, the server ([weft PR HeddleCo/weft#355](https://github.com/HeddleCo/weft/pull/355)) may also send an `x-weft-sig-action-url` trailer pointing at the tapestry `/verify-action` page. The headless CLI now shows a clear warning **and that link** instead of a bare error.

## Changes

**heddle-client** (`crates/client/src/grpc_hosted/`)
- `HumanSignatureRequest` gains `action_url: Option<String>` — a display hint taken verbatim from the server's rejection trailer.
- New `action_url_from_status()` reads `x-weft-sig-action-url` from the **same** rejection status metadata the required-trailer is read from.
- The `signed_call!` retry path extracts it and threads it through `request_human_signature` into the callback.

**heddle-cli** (`crates/cli/src/client/human_signature.rs`)
- `cli_human_signature_callback` includes the URL in its warning + typed error when present:
  > ⚠ This action requires user verification (WebAuthn), which the CLI can't perform in a headless terminal:
  >   Authorize /heddle.v1.HostedUserService/DeleteRepository
  > Complete it in the web app:
  >   https://app.heddle.sh/verify-action?method=...&challenge=...
- When `action_url` is `None` (server has no web origin configured) it keeps the current generic guidance ("run this from a surface with a WebAuthn authenticator (the web UI)…").
- **Always** returns a typed `ProtocolError::AuthorizationFailed` and **never** fabricates an assertion — just with the link in the message when available.

## Additive only

The challenge derivation (`SHA256(canonical)`) and the existing required-trailer handling are unchanged. The link is a display hint; the challenge the callback signs over is still the client-derived one.

## Tests / gates

- Interceptor test: the human-tier mock now emits `x-weft-sig-action-url`; the callback asserts it arrives verbatim in `HumanSignatureRequest.action_url` (end-to-end).
- CLI callback tests: message includes the URL when `Some`, generic guidance + no URL when `None`; both return a typed error, never an assertion.
- `cargo build --workspace --locked`: pass
- `cargo test -p heddle-client --lib`: 100 passed / 0 failed
- `cargo test -p heddle-cli --features client` (human_signature): pass
- `cargo clippy -p heddle-client -p heddle-cli --features client --all-targets -- -D warnings`: clean

### Note on pre-existing test failures
3 `oss_cli_polish` harness-detection tests (`actor_explain_json_detects_harness_without_active_actor`, `actor_explain_detached_head_recommends_minting_spawn_not_no_thread`, `actor_and_session_json_outputs_match_registered_schemas`) fail in this environment because the agent harness's ambient env (`CLAUDE_*`/`ANTHROPIC_*`) makes the model detector report `claude-fable-5` instead of the test's hardcoded `gpt-5.3-codex`. They reference none of the files in this PR and **fail identically on clean `origin/main`** with these changes stashed — pre-existing / environment-driven, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785646313&installation_id=132405951&pr_number=960&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F960&signature=ddd1f2181acfaf0c6a4cc6bcca59c66b76e9e445e891ffbb3958afcf2f6f412a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->