### PR TITLE
feat(oplog): generalize OperationScope to an open facet-lineage set (Spool epic P2, weft#358)

### DIFF
--- a/crates/refs/src/refs/facet.rs
+++ b/crates/refs/src/refs/facet.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Facet lineages — the open generalization of the oplog's scope partition.
+//!
+//! Heddle's oplog is already scope-partitioned: a per-worktree scope token
+//! (`wt-<digest>`) threads through [`record_batch_scoped`] and
+//! `IsolationKey::LocalHead { scope }`, keeping distinct local-HEAD lineages as
+//! independent undo/redo streams within one repo. The Git-overlay lineage and
+//! the Heddle lineage are the two well-known content-side histories that ride
+//! this partition today.
+//!
+//! A [`SpoolFacet`] generalizes that same partition to an **open set** of named
+//! lineages. Each facet is a fully independent history:
+//!
+//! - its own oplog batches — the scope token gains a `/<facet>` suffix, so
+//!   `record_batch_scoped`/`recent_batches_scoped`/`undo_batches_scoped` filter
+//!   each facet's batches into their own gap-free per-scope sequence;
+//! - its own undo/redo isolation — the suffixed scope flows into
+//!   `IsolationKey::LocalHead { scope }`, so a `governance` op never conflicts
+//!   with (or rewinds) `content` undo state and vice-versa;
+//! - its own refs, under the `refs/spool/<facet>/…` prefix (`validate_ref_name`
+//!   already accepts these — no ref-schema change);
+//! - its own HEAD, modeled as an attached-thread ref under that prefix using the
+//!   existing [`Head`](crate::Head) enum unchanged.
+//!
+//! This is **additive**: [`SpoolFacet::Content`] is the well-known default and
+//! composes to the *unchanged* per-worktree scope token, so existing
+//! Git/Heddle/content behavior is byte-for-byte preserved. Named facets
+//! (`governance`, `membership`, or any other token) get their own suffixed
+//! scope + ref prefix.
+
+/// A named facet lineage within one repo/spool.
+///
+/// The three well-known variants name the content-side lineages the Spool model
+/// versions independently. [`SpoolFacet::Named`] carries any other facet token
+/// so the set is genuinely open — the substrate treats the facet purely as a
+/// string that suffixes the scope and prefixes ref names.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SpoolFacet {
+    /// The versioned file tree — "a repo" today. The **default** facet: it maps
+    /// to the unchanged per-worktree scope token and the `refs/spool/content/…`
+    /// prefix, so pre-facet callers keep their exact behavior.
+    Content,
+    /// Visibility + policy-as-code, versioned as content.
+    Governance,
+    /// Grants + roles, versioned as content.
+    Membership,
+    /// Any other named facet lineage. The set of facets is open; callers may
+    /// version an arbitrary named lineage on the same substrate.
+    Named(String),
+}
+
+impl SpoolFacet {
+    /// The facet token as it appears in scope tokens and ref names.
+    pub fn token(&self) -> &str {
+        match self {
+            SpoolFacet::Content => "content",
+            SpoolFacet::Governance => "governance",
+            SpoolFacet::Membership => "membership",
+            SpoolFacet::Named(token) => token.as_str(),
+        }
+    }
+
+    /// True for the default (content) facet, which composes to the unchanged
+    /// per-worktree scope token. A `Named("content")` also normalizes here so
+    /// the well-known token and its string spelling never diverge.
+    pub fn is_default(&self) -> bool {
+        matches!(self, SpoolFacet::Content) || self.token() == "content"
+    }
+
+    /// Compose a facet-qualified oplog scope token from the per-worktree base
+    /// scope (`wt-<digest>`, from `Repository::op_scope`).
+    ///
+    /// The default (content) facet returns the base scope **unchanged**, so the
+    /// scope string — and therefore every existing oplog batch, undo record, and
+    /// `IsolationKey::LocalHead` — is byte-identical to the pre-facet world.
+    /// Every other facet appends `/<token>`, giving that facet its own scope
+    /// partition: its batches, its undo/redo view, its isolation key.
+    pub fn scope_token(&self, base_scope: &str) -> String {
+        if self.is_default() {
+            base_scope.to_string()
+        } else {
+            format!("{base_scope}/{}", self.token())
+        }
+    }
+
+    /// The ref-name prefix for this facet: `refs/spool/<facet>`.
+    ///
+    /// All of a facet's refs live under this prefix; `validate_ref_name` accepts
+    /// it as an ordinary hierarchical name.
+    pub fn ref_prefix(&self) -> String {
+        format!("refs/spool/{}", self.token())
+    }
+
+    /// The facet's thread ref for `name` — `refs/spool/<facet>/threads/<name>`.
+    /// A facet's HEAD attaches to one of these ([`Head::Attached`]).
+    pub fn thread_ref(&self, name: &str) -> String {
+        format!("{}/threads/{name}", self.ref_prefix())
+    }
+
+    /// The facet's marker ref for `name` — `refs/spool/<facet>/markers/<name>`.
+    pub fn marker_ref(&self, name: &str) -> String {
+        format!("{}/markers/{name}", self.ref_prefix())
+    }
+}
+
+impl std::fmt::Display for SpoolFacet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.token())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validate_ref_name;
+
+    #[test]
+    fn content_facet_scope_token_is_unchanged_base() {
+        // The default facet must NOT alter the per-worktree scope token, so all
+        // existing content/Git/Heddle oplog + undo behavior is preserved.
+        let base = "wt-0123456789abcdef";
+        assert_eq!(SpoolFacet::Content.scope_token(base), base);
+        // A Named("content") normalizes to the same default behavior.
+        assert_eq!(
+            SpoolFacet::Named("content".into()).scope_token(base),
+            base
+        );
+    }
+
+    #[test]
+    fn named_facets_get_independent_suffixed_scopes() {
+        let base = "wt-0123456789abcdef";
+        assert_eq!(
+            SpoolFacet::Governance.scope_token(base),
+            "wt-0123456789abcdef/governance"
+        );
+        assert_eq!(
+            SpoolFacet::Membership.scope_token(base),
+            "wt-0123456789abcdef/membership"
+        );
+        // Two different facets never collide in scope space.
+        assert_ne!(
+            SpoolFacet::Governance.scope_token(base),
+            SpoolFacet::Membership.scope_token(base)
+        );
+        assert_ne!(
+            SpoolFacet::Governance.scope_token(base),
+            SpoolFacet::Content.scope_token(base)
+        );
+    }
+
+    #[test]
+    fn facet_ref_names_validate() {
+        for facet in [
+            SpoolFacet::Content,
+            SpoolFacet::Governance,
+            SpoolFacet::Membership,
+            SpoolFacet::Named("audit".into()),
+        ] {
+            assert!(validate_ref_name(&facet.ref_prefix()).is_ok());
+            assert!(validate_ref_name(&facet.thread_ref("main")).is_ok());
+            assert!(validate_ref_name(&facet.marker_ref("v1")).is_ok());
+        }
+    }
+
+    #[test]
+    fn distinct_facets_have_distinct_ref_prefixes() {
+        assert_eq!(
+            SpoolFacet::Governance.thread_ref("main"),
+            "refs/spool/governance/threads/main"
+        );
+        assert_ne!(
+            SpoolFacet::Governance.thread_ref("main"),
+            SpoolFacet::Content.thread_ref("main")
+        );
+    }
+}

--- a/crates/refs/src/refs/mod.rs
+++ b/crates/refs/src/refs/mod.rs
@@ -2,6 +2,7 @@
 //! References: threads (branches), markers (tags), and HEAD.
 
 mod backend;
+mod facet;
 mod head;
 mod name;
 pub mod operation_index;
@@ -31,6 +32,7 @@ mod refs_packed_tests;
 mod reftable_tests;
 
 pub use backend::CoreRefBackend;
+pub use facet::SpoolFacet;
 pub use head::{Head, HeadParseError};
 pub use heddle_schema::refs::{
     FOOTER_LEN, HEADER_LEN, MAGIC, PackedRefsModel, ReftableError, ReftableModel,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -109,6 +109,7 @@ pub use repository::{
     RefCountsInspection, RefSummaryIndexInspection, RepoConfig, Repository, RepositoryCapability,
     RepositoryMaintenanceRunReport, RepositoryOperationStatus,
     RepositoryPerformanceInspectionReport, ResignOutcome, SUGGESTION_WINDOW, SnapshotExecution,
+    SpoolFacet,
     SnapshotProfile, ThreadCaptureOutcome, TreeBuildProfile, TrustedKey, UntrackedSet,
     UntrackedSubtree, WarmCanonicalStoreStats, WorktreeCompareProfile, WorktreeIndexInspection,
     WorktreeStatusDetailed, compute_rewrite_pct, find_merge_base, is_major_rewrite,

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -79,6 +79,7 @@ use objects::{
 };
 use oplog::{OpLog, OpLogBackend, OpRecord};
 pub use refs::RefSummaryIndexInspection;
+pub use refs::SpoolFacet;
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
 pub use repo_config::{HostedConfig, OutputFormat, RedactConfig, RepoConfig, TrustedKey};
 use crate::{GitRefContentNamespace, GitRefName};
@@ -1838,6 +1839,81 @@ impl Repository {
         //   * opaque on disk — the user's home directory and username
         //     never end up serialized into oplog entries
         compute_op_scope(&self.root)
+    }
+
+    /// The oplog scope token for a named facet lineage.
+    ///
+    /// Generalizes [`op_scope`](Self::op_scope) to the open facet set (Spool
+    /// epic P2). The default (content) facet returns the **unchanged** base
+    /// scope, so existing content/Git/Heddle oplog batches, undo records, and
+    /// `IsolationKey::LocalHead` are byte-identical to today. Every other facet
+    /// (`governance`, `membership`, …) gets its own suffixed scope
+    /// (`wt-<digest>/<facet>`), so that facet's batches, undo/redo view, and
+    /// isolation key are fully independent of every other facet's.
+    ///
+    /// Thread this into `record_batch_scoped` / `recent_batches_scoped` /
+    /// `undo_batches_scoped` to run the same `Repository` operations against a
+    /// different facet lineage.
+    pub fn op_scope_for_facet(&self, facet: &SpoolFacet) -> String {
+        facet.scope_token(&self.op_scope())
+    }
+
+    /// Read a named facet's HEAD.
+    ///
+    /// A facet's HEAD is modeled with the existing [`Head`] enum unchanged: it
+    /// attaches to the facet's canonical thread ref
+    /// (`refs/spool/<facet>/threads/<main_thread>`) when that thread exists
+    /// ([`Head::Attached`]), or resolves to a detached state otherwise. The
+    /// **content** facet is the physical `.heddle/HEAD` (delegates to
+    /// [`head_ref`](Self::head_ref)), preserving today's behavior exactly.
+    ///
+    /// This is the heddle-side per-`(repo, facet)` HEAD the Spool model needs;
+    /// the weft `heads` PK change is a later weft phase.
+    pub fn facet_head(&self, facet: &SpoolFacet, main_thread: &str) -> Result<Option<Head>> {
+        if facet.is_default() {
+            return Ok(Some(self.head_ref()?));
+        }
+        let thread = ThreadName::from(facet.thread_ref(main_thread).as_str());
+        match self.refs.get_thread(&thread)? {
+            Some(_) => Ok(Some(Head::Attached { thread })),
+            None => Ok(None),
+        }
+    }
+
+    /// Resolve a named facet's HEAD to a concrete state, if any.
+    pub fn facet_head_state(
+        &self,
+        facet: &SpoolFacet,
+        main_thread: &str,
+    ) -> Result<Option<ChangeId>> {
+        if facet.is_default() {
+            return self.head();
+        }
+        let thread = ThreadName::from(facet.thread_ref(main_thread).as_str());
+        self.refs.get_thread(&thread)
+    }
+
+    /// Advance a named facet's HEAD thread to `state`.
+    ///
+    /// Moves the facet's canonical thread ref
+    /// (`refs/spool/<facet>/threads/<main_thread>`) under the facet's own ref
+    /// prefix — it does **not** touch any other facet's refs. Rejected for the
+    /// default (content) facet, whose HEAD is the physical `.heddle/HEAD` and is
+    /// moved through the existing snapshot/goto write paths.
+    pub fn set_facet_head(
+        &self,
+        facet: &SpoolFacet,
+        main_thread: &str,
+        state: &ChangeId,
+    ) -> Result<()> {
+        if facet.is_default() {
+            return Err(HeddleError::InvalidObject(
+                "set_facet_head is for named facets; the content facet HEAD moves via snapshot/goto"
+                    .to_string(),
+            ));
+        }
+        let thread = ThreadName::from(facet.thread_ref(main_thread).as_str());
+        self.refs.set_thread(&thread, state)
     }
 
     /// The write chokepoint (heddle#330 §2.2): commit the ref-carrying

--- a/crates/repo/tests/facet_scope_isolation.rs
+++ b/crates/repo/tests/facet_scope_isolation.rs
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Proof that facet lineages are independent (Spool epic P2, weft#358).
+//!
+//! On ONE repo, operations recorded under two different facet scopes
+//! (`content` vs `governance`) must maintain:
+//!   1. independent oplog batch views (each facet sees only its own batches);
+//!   2. independent undo (undoing a governance batch does not rewind content);
+//!   3. independent HEADs/refs (each facet's HEAD lives under its own ref prefix
+//!      and moving one never moves the other).
+//!
+//! Plus: the well-known Git/Heddle content-side behavior is unchanged — the
+//! `content` facet composes to the same per-worktree scope token as before.
+
+use objects::object::ChangeId;
+use oplog::{OpLogBackend, OpLogRecorder};
+use repo::{Repository, SpoolFacet};
+use tempfile::TempDir;
+
+#[test]
+fn facets_have_independent_scope_tokens() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+
+    let base = repo.op_scope();
+    // Content is the default facet: byte-identical to the pre-facet scope token,
+    // so all existing content/Git/Heddle oplog + undo behavior is preserved.
+    assert_eq!(repo.op_scope_for_facet(&SpoolFacet::Content), base);
+
+    let gov = repo.op_scope_for_facet(&SpoolFacet::Governance);
+    let mem = repo.op_scope_for_facet(&SpoolFacet::Membership);
+    assert_eq!(gov, format!("{base}/governance"));
+    assert_eq!(mem, format!("{base}/membership"));
+    assert_ne!(gov, base);
+    assert_ne!(gov, mem);
+}
+
+#[test]
+fn facets_have_independent_batch_numbering_and_undo() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    let oplog = repo.oplog();
+
+    let content_scope = repo.op_scope_for_facet(&SpoolFacet::Content);
+    let gov_scope = repo.op_scope_for_facet(&SpoolFacet::Governance);
+
+    // Two content ops, one governance op — interleaved, one shared repo.
+    let c1 = ChangeId::generate();
+    let c2 = ChangeId::generate();
+    let g1 = ChangeId::generate();
+
+    oplog
+        .record_snapshot(&c1, None, None, Some(&content_scope))
+        .expect("content snapshot 1");
+    oplog
+        .record_snapshot(&g1, None, None, Some(&gov_scope))
+        .expect("governance snapshot 1");
+    oplog
+        .record_snapshot(&c2, Some(&c1), None, Some(&content_scope))
+        .expect("content snapshot 2");
+
+    // Each facet sees only its own batches — independent per-scope numbering.
+    let content_batches = oplog
+        .recent_batches_scoped(10, Some(&content_scope))
+        .expect("content batches");
+    let gov_batches = oplog
+        .recent_batches_scoped(10, Some(&gov_scope))
+        .expect("governance batches");
+    assert_eq!(content_batches.len(), 2, "content facet sees its 2 batches");
+    assert_eq!(gov_batches.len(), 1, "governance facet sees its 1 batch");
+
+    // Undoing the governance batch must NOT rewind content.
+    let gov_undo = oplog
+        .undo_batches_scoped(1, Some(&gov_scope))
+        .expect("governance undo candidates");
+    assert_eq!(gov_undo.len(), 1);
+    oplog
+        .mark_batch_undone(&gov_undo[0])
+        .expect("undo governance batch");
+
+    // Governance now has nothing to undo; content is untouched (still 2 to undo).
+    assert_eq!(
+        oplog
+            .undo_batches_scoped(1, Some(&gov_scope))
+            .expect("gov undo after")
+            .len(),
+        0,
+        "governance undo consumed its only batch"
+    );
+    assert_eq!(
+        oplog
+            .undo_batches_scoped(10, Some(&content_scope))
+            .expect("content undo after")
+            .len(),
+        2,
+        "content undo state is unaffected by the governance undo"
+    );
+
+    // Redo is likewise facet-local: governance has one redo candidate, content none.
+    assert_eq!(
+        oplog
+            .redo_batches_scoped(10, Some(&gov_scope))
+            .expect("gov redo")
+            .len(),
+        1
+    );
+    assert_eq!(
+        oplog
+            .redo_batches_scoped(10, Some(&content_scope))
+            .expect("content redo")
+            .len(),
+        0
+    );
+}
+
+#[test]
+fn facets_have_independent_heads_and_refs() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+
+    // The content facet HEAD is the physical `.heddle/HEAD` (unchanged path).
+    let content_head = repo
+        .facet_head(&SpoolFacet::Content, "main")
+        .expect("content head")
+        .expect("content facet always has a HEAD");
+
+    // Named facets start with no HEAD (their thread ref does not yet exist).
+    assert!(
+        repo.facet_head(&SpoolFacet::Governance, "main")
+            .expect("gov head read")
+            .is_none(),
+        "governance HEAD absent before any governance op"
+    );
+    assert!(
+        repo.facet_head_state(&SpoolFacet::Membership, "main")
+            .expect("mem head state")
+            .is_none()
+    );
+
+    // Advance the governance HEAD — this moves only the governance thread ref.
+    let gov_state = ChangeId::generate();
+    repo.set_facet_head(&SpoolFacet::Governance, "main", &gov_state)
+        .expect("set governance head");
+
+    assert_eq!(
+        repo.facet_head_state(&SpoolFacet::Governance, "main")
+            .expect("gov head after set"),
+        Some(gov_state),
+        "governance HEAD now resolves to the state we set"
+    );
+
+    // Membership HEAD is still absent — moving governance did not touch it.
+    assert!(
+        repo.facet_head_state(&SpoolFacet::Membership, "main")
+            .expect("mem head after gov set")
+            .is_none(),
+        "membership facet HEAD unaffected by governance move"
+    );
+
+    // The content facet HEAD is unchanged — moving governance did not touch it.
+    assert_eq!(
+        repo.facet_head(&SpoolFacet::Content, "main")
+            .expect("content head after gov set")
+            .expect("content HEAD present"),
+        content_head,
+        "content facet HEAD unaffected by governance move"
+    );
+
+    // Governance's HEAD lives under its own ref prefix, distinct from content's.
+    assert_eq!(
+        SpoolFacet::Governance.thread_ref("main"),
+        "refs/spool/governance/threads/main"
+    );
+    assert_ne!(
+        SpoolFacet::Governance.thread_ref("main"),
+        SpoolFacet::Content.thread_ref("main")
+    );
+
+    // set_facet_head is rejected for the content facet (its HEAD moves via
+    // snapshot/goto, not this named-facet helper).
+    assert!(
+        repo.set_facet_head(&SpoolFacet::Content, "main", &gov_state)
+            .is_err(),
+        "content facet HEAD must not be moved via set_facet_head"
+    );
+}


### PR DESCRIPTION
## Spool epic (weft#358) — Phase 2: heddle facet-scope foundation

Additive substrate that the whole Spool model rests on. Generalizes heddle's existing scope partition — which today keeps the Git-overlay and Heddle content-side histories as independent undo/redo streams via a per-worktree scope token — to an **open set of named facet lineages** (content / governance / membership / …). Each facet is a fully independent history: its own oplog batches (gap-free per-scope numbering), its own undo/redo isolation, its own `refs/spool/<facet>/…` prefix, its own HEAD.

**No new versioning engine** — this is the P1 finding (facet-lineage = the existing `(scope, ref-prefix)` partition generalized from the `{Git, Heddle}` pair to a fixed small facet set), realized on the substrate that already carries it.

### What changed (all additive)
- **`heddle-refs`**: new `SpoolFacet` open enum `{Content, Governance, Membership, Named(String)}`.
  - `Content` is the well-known **default** and composes to the **unchanged** per-worktree scope token, so existing Git/Heddle/content oplog batches, undo records, and `IsolationKey::LocalHead` are byte-identical.
  - Named facets get a `/<token>`-suffixed scope and their own `refs/spool/<facet>/…` prefix. `validate_ref_name` already accepts these (no ref-schema change).
- **`heddle-repo`**: `Repository::op_scope_for_facet` (facet-qualified oplog scope), plus per-facet HEAD API `facet_head` / `facet_head_state` / `set_facet_head` over facet-scoped thread refs, reusing `Head::{Attached,Detached}` unchanged. `SpoolFacet` re-exported for consumers (weft).
- **Proof test** (`crates/repo/tests/facet_scope_isolation.rs`): on one repo, content vs governance ops maintain **independent batch numbering**, **independent undo** (undoing governance never rewinds content), and **independent HEADs/refs**.

### Isolation mechanism
The oplog `scope` is already `Option<&str>` at the storage layer and every batch view (`recent_batches_scoped` / `undo_batches_scoped` / `redo_batches_scoped`) filters by exact scope match; the scope also flows into `IsolationKey::LocalHead { scope }`. A facet just supplies a distinct scope token, so each facet's batches, undo/redo view, and isolation key are independent — mechanically the same partition that keeps Git and Heddle apart today.

### Not in scope (later phases)
No `spools` table (weft), no `SPOOLLINK`/child edges, no RPC changes, no weft changes. `OperationScope {Git,Heddle}` and `OpRecord` are untouched — no OpRecord-exhaustiveness-gate delta. **Source-additive to the published heddle API (weft consumes published heddle) — no break.**

### Gates
- `cargo build --workspace --locked` → 0 errors
- `cargo test -p heddle-repo -p heddle-oplog -p heddle-schema` → green (incl. 3 new facet-isolation tests)
- `cargo test -p heddle-devtools` (OpRecord exhaustiveness gate) → 64 passed
- `cargo clippy -p heddle-repo -p heddle-oplog -p heddle-refs --all-targets -- -D warnings` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785654153&installation_id=132405951&pr_number=961&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F961&signature=9fe83884feb7fdc10ff07bdb7668d42362b6d50682f44f070683c4493a029651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->