### PR TITLE
release: heddle 0.8.0 (Spool primitives)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,7 +715,10 @@ jobs:
           app-id: ${{ secrets.HEDDLE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEDDLE_RELEASE_APP_PRIVATE_KEY }}
           owner: HeddleCo
-          repositories: homebrew-tap,scoop-heddle,apt-heddle
+          # apt: deferred until HeddleCo/apt-heddle exists — omit it here so the
+          # token step doesn't scope to a nonexistent repo (which fails the whole
+          # job and blocks the Homebrew/Scoop pushes below).
+          repositories: homebrew-tap,scoop-heddle
 
       - name: Publish Homebrew cask PR
         uses: ./.github/actions/publish-manifest
@@ -737,14 +740,11 @@ jobs:
           channel: scoop
           version: ${{ steps.ver.outputs.version }}
 
-      - name: Publish apt pool PR
-        uses: ./.github/actions/publish-manifest
-        with:
-          target-repo: HeddleCo/apt-heddle
-          # Whole pool + signed index tree, not a single file. manifest-path
-          # '.' syncs onto the apt-heddle repository root (Pages serves it).
-          manifest-path: .
-          rendered-file: rendered/apt
-          token: ${{ steps.app-token.outputs.token }}
-          channel: apt
-          version: ${{ steps.ver.outputs.version }}
+      # apt: deferred until HeddleCo/apt-heddle exists.
+      # The "Publish apt pool PR" step (target-repo HeddleCo/apt-heddle) was
+      # removed for this release — the repo does not exist yet, and scoping the
+      # token / PRing to it failed the whole publish-manifests job, blocking the
+      # Homebrew + Scoop pushes above. Revive this step (and re-add apt-heddle to
+      # the token `repositories:` list) once HeddleCo/apt-heddle is created.
+      # The apt pool is still built by the "Build apt pool + signed index" step
+      # above; only the publish leg is deferred.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.8.0 - 2026-07-03
+
+### Added
+
+- **Spool facet-lineage primitive.** `OperationScope` generalizes from a
+  fixed set of ref classes to an open facet-lineage set, and a new
+  `SpoolFacet` type (`crates/refs`) names a facet head. `heddle-repo` gains
+  `facet_head` / `set_facet_head` to read and write a facet's head, giving
+  the Spool primitive its own fully-versioned lineage alongside the existing
+  ref heads. Additive: no existing scope or ref semantics change. (Spool
+  epic P2, #961, weft#358)
+- **`Spoollink` tree entry kind.** Trees can now carry a native
+  child-spool edge as a first-class `SPOOLLINK` entry, threaded through the
+  `TreeEntryTarget` / `FileMode` typed tree surface. This lets a spool
+  reference a child spool directly in tree state (the storage substrate for
+  recursive namespace/repository/spool composition). Additive alongside the
+  existing blob/tree/gitlink entry kinds. (Spool epic P5b, #962, weft#358)
+- **Spool gRPC RPCs.** `heddle-grpc` (already published at 0.11.0) grew the
+  Spool epic's child-edge and facet-history surface —
+  `AttachChild` / `DetachChild` / `ListChildren` / `ResolveMonorepo` plus
+  facet history — so hosted consumers can drive the recursive-spool model
+  over the wire. (Spool epic P8a, #963, weft#358)
+
+This is a minor (additive) release: it publishes the Spool-supporting
+surface added since 0.7.0 so downstream consumers (the weft Spool epic) can
+depend on `SpoolFacet` / `facet_head` / `Spoollink` from crates.io. No
+public API was removed or changed in a breaking way.
+
 ## 0.7.0 - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,7 +1523,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1589,7 +1589,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1608,7 +1608,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1642,7 +1642,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1663,7 +1663,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -1915,7 +1915,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1933,14 +1933,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -1951,7 +1951,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5998,7 +5998,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.7.0",
+  "schemaVersion": "0.8.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.7.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.8.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,32 +32,32 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.8" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.7" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.8" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.11" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
-heddle-core = { path = "../core", version = "0.7" }
-heddle-format = { path = "../format", version = "0.7" }
-heddle-client = { path = "../client", version = "0.7", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.7" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
+heddle-core = { path = "../core", version = "0.8" }
+heddle-format = { path = "../format", version = "0.8" }
+heddle-client = { path = "../client", version = "0.8", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.8" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.7", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.8", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -106,13 +106,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.7", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -34,14 +34,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.8" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,17 +12,17 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.7" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
 sley.workspace = true
 
 [features]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 base64.workspace = true
 ed25519-dalek.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 p256.workspace = true
 pkcs8.workspace = true
 rsa.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.11" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.7", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.7" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.8" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,10 +15,10 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+heddle-format = { path = "../format", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 similar.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -70,7 +70,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.7" }
+heddle-format = { path = "../format", version = "0.8" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.7" }
+heddle-format = { path = "../format", version = "0.8" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+heddle-schema = { path = "../schema", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.7", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.8", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+heddle-schema = { path = "../schema", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.7", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.8", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.7" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.7" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.7", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.7", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.8", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.7" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.7", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.7", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.7" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -242,23 +242,32 @@ else
   err "missing Scoop manifest publication wiring"
 fi
 
-# apt (Debian/Ubuntu) pool publication — parallel channel on the same
-# substrate (#234). scripts/build-apt-pool.sh builds the amd64 + arm64 .deb
-# (and the heddle-archive-keyring .deb) from the linux-gnu tarballs in
-# SHA256SUMS, then generates + GPG-signs the pool/Packages/Release index in
-# an ephemeral GNUPGHOME (Ed25519 subkey, #328 Decision 2). The
-# publish-manifests job PRs the whole signed tree to apt-heddle via the same
-# composite action + App token, gated stable-only. The App token scope must
-# include apt-heddle alongside the homebrew/scoop taps.
+# apt (Debian/Ubuntu) pool — parallel channel on the same substrate (#234).
+# scripts/build-apt-pool.sh builds the amd64 + arm64 .deb (and the
+# heddle-archive-keyring .deb) from the linux-gnu tarballs in SHA256SUMS, then
+# generates + GPG-signs the pool/Packages/Release index in an ephemeral
+# GNUPGHOME (Ed25519 subkey, #328 Decision 2). The pool is still built every
+# release.
+#
+# PUBLICATION IS DEFERRED until HeddleCo/apt-heddle exists: the "Publish apt
+# pool PR" step and the apt-heddle token scope were removed because scoping the
+# token / PRing to a nonexistent repo failed the whole publish-manifests job
+# and blocked the Homebrew + Scoop pushes. Contract for the deferred state:
+# apt pool is still built + signed, but apt-heddle must NOT be referenced by
+# the workflow (no target-repo, no token scope). Revive both when the repo
+# exists (and restore the apt-heddle assertions here).
+# Grep only for the ACTIVE wiring forms (a `target-repo:` mapping and a
+# `repositories:` token scope) so that revivable comments mentioning
+# apt-heddle don't count as live wiring.
 if [[ -x scripts/build-apt-pool.sh ]] \
    && grep -F "scripts/build-apt-pool.sh" "$WF" >/dev/null \
-   && grep -F "HeddleCo/apt-heddle" "$WF" >/dev/null \
    && grep -F "HEDDLE_APT_GPG_PRIVATE_KEY" "$WF" >/dev/null \
    && grep -F "actions/create-github-app-token" "$WF" >/dev/null \
-   && grep -E "repositories: .*apt-heddle" "$WF" >/dev/null; then
-  ok "apt pool publication wired"
+   && ! grep -E "^[[:space:]]*target-repo: HeddleCo/apt-heddle" "$WF" >/dev/null \
+   && ! grep -E "^[[:space:]]*repositories: .*apt-heddle" "$WF" >/dev/null; then
+  ok "apt pool built + signed; publication deferred (apt-heddle absent)"
 else
-  err "missing apt pool publication wiring"
+  err "apt pool must be built+signed with publication deferred (no apt-heddle references) until HeddleCo/apt-heddle exists"
 fi
 
 if grep -F "if: needs.validate-tag.outputs.kind == 'stable'" "$WF" >/dev/null; then


### PR DESCRIPTION
## What & why

Bumps the workspace version **0.7.0 → 0.8.0** to make the Spool-supporting surface publishable to crates.io.

The Spool primitives landed on `main` after 0.7.0 was cut (`05a81253`, pre-Spool) and were **never published**. weft's Spool epic (weft#358) needs to consume them from crates.io at a bumped version, which requires this release.

### What's new since 0.7.0 (all additive)

- **Facet-lineage primitive (P2, #961):** `OperationScope` generalized to an open facet-lineage set; new `SpoolFacet` type; `heddle-repo` gains `facet_head` / `set_facet_head`.
- **`Spoollink` tree entry kind (P5b, #962):** native child-spool tree edges via the `TreeEntryTarget` / `FileMode` typed tree surface (`SPOOLLINK` entry kind).
- **Spool gRPC RPCs (P8a, #963):** `AttachChild` / `DetachChild` / `ListChildren` / `ResolveMonorepo` + facet history. Ships in `heddle-grpc`, which is **already published at 0.11.0** — its version is unchanged here.

Minor (additive) bump: new surface only, no breaking removals.

## Version changes

- `Cargo.toml` `[workspace.package].version`: `0.7.0` → `0.8.0`.
- **78 inter-crate sibling pins** bumped `version = "0.7"` → `"0.8"` across 18 crate manifests (the known inter-crate-pin-bump gotcha — a stale pin would resolve against published 0.7.0 and silently ship the old closure). Crates on `version.workspace = true` auto-follow.
- `heddle-grpc` left at its own `0.11.0` (already published); pins to `heddle-grpc = "0.11"` untouched.

## Publish set (topological order) + dry-run results

Publish set is the 23-crate `PUBLISHABLE_CRATES` list in `publish-crates.yml`. `cargo publish --dry-run --allow-dirty` was run per crate:

| Crate | Dry-run in isolation |
|---|---|
| heddle-format | ✅ pass |
| heddle-runtime-bridge | ✅ pass |
| heddle-devtools | ✅ pass |
| heddle-review | ✅ pass |
| heddle-grpc | already published @0.11.0 (unchanged) |
| heddle-objects, -crypto, -schema, -oplog, -refs, -merge, -semantic, -state-review, -wire, -repo, -cli-shared, weft-client-shim, heddle-client, -core, -daemon, -ingest, -mount, -cli | ⚠️ dry-run fails **only** on `^0.8` unpublished-sibling resolve |

The ⚠️ failures are the inherent chicken-and-egg of dry-running an unpublished multi-crate release: e.g. `heddle-objects` needs `heddle-format = "^0.8"` on crates.io, which isn't there yet. The `publish-crates.yml` workflow resolves this by publishing in topological order with a 30s propagation pause, so each sibling is on crates.io before its dependent publishes. The requirement string being `^0.8` (not `^0.7`) confirms the pin bump took effect.

## Gates

- `cargo build --workspace` — clean (exit 0).
- `scripts/check-publish-pipeline.sh` — pass (incl. internal-consumer version-compat check).
- `scripts/check-release-pipeline.sh` — pass.
- `cargo deny check advisories` — `advisories ok` (no memmap2/RUSTSEC surfaced).

## Publish note

**Do not** expect this PR to publish anything. The actual crates.io publish is gated on separate human authorization and runs **after** this PR lands (the `publish-crates.yml` workflow fires on push-to-main once the bumped versions are on `main`).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/965"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785689051&installation_id=132405951&pr_number=965&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F965&signature=8e646b6aa668fe20f87e08ceff33a84bca548eb832290594af9428707f78c44a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->