### PR TITLE
⚠️ release: heddle workspace v0.9.0 (auto-publishes closure on merge)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1900,7 +1900,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1921,7 +1921,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1945,7 +1945,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1956,7 +1956,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1987,7 +1987,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2090,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-review"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2108,14 +2108,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2147,7 +2147,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -6291,7 +6291,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.8.0",
+  "schemaVersion": "0.9.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.8.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.9.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,32 +32,32 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.9" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.8" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.9" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
-heddle-core = { path = "../core", version = "0.8" }
-heddle-format = { path = "../format", version = "0.8" }
-heddle-client = { path = "../client", version = "0.8", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.8" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
+heddle-core = { path = "../core", version = "0.9" }
+heddle-format = { path = "../format", version = "0.9" }
+heddle-client = { path = "../client", version = "0.9", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.9" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.8", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.9", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -106,13 +106,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.8", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -34,14 +34,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.9" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,18 +12,18 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.8" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
 ignore.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
 sley.workspace = true
 
 [features]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.8", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.8" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.9" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,10 +15,10 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.8" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+heddle-format = { path = "../format", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 similar.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -70,7 +70,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.8" }
+heddle-format = { path = "../format", version = "0.9" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.8" }
+heddle-format = { path = "../format", version = "0.9" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.8" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+heddle-schema = { path = "../schema", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.8", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.9", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.8" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+heddle-schema = { path = "../schema", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.8", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.9", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.8" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.8" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.8", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.8", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.9", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.8" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.8", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.8", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.8" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
**⚠️ Merging AUTO-PUBLISHES the heddle 0.9.0 crate closure to crates.io** (publish-crates.yml, ~21 crates, rate-limited topological). Release authorized by the user.

## Why
The workspace crates are at 0.8.0 = what's on crates.io, but content diverged since (heddle-client now pins heddle-grpc 0.13, RSA signer dropped in #972, deps upgraded), so they can't republish at 0.8.0. Bump the workspace **0.8.0 → 0.9.0** (pre-1.0; breaking ⇒ minor) and every heddle inter-crate pin **0.8 → 0.9**.

## Scope (surgical)
- `[workspace.package] version` 0.8.0 → 0.9.0.
- All heddle inter-crate `version = "0.8"` pins → `"0.9"`.
- **heddle-grpc stays 0.13.0** (independently versioned); its consumers stay `"0.13"`.
- **External `0.8` deps untouched** (`sec1`, `criterion`).
- Cargo.lock + `clients/npm/generated/heddle-schemas.{ts,json}` regenerated to 0.9.0.

## Verification (cross-reviewed)
- `cargo build --workspace --locked` green (a missed pin or an over-eager external bump would fail here).
- `cargo tree -p heddle-cli | grep 'heddle-\w+ v0.8'` → empty (all heddle crates v0.9.0; heddle-grpc v0.13.0).
- No heddle pin left at 0.8; `check-doctor-schemas-clean` passes; diff scoped to manifests/lock/schemas (22 files).

## Downstream
Unblocks weft moving its heddle deps 0.8 → 0.9, dropping the transitive heddle-grpc 0.11 that published heddle-client 0.8.0 dragged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786067792&installation_id=132405951&pr_number=973&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F973&signature=80a73e3b72fc7de660302761d114ab901c191fc26fd039d839c8ff91370b3557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->