### PR TITLE
[codex] feat(auth)!: v2 request-bound PoP client signing + shared heddle-crypto builder; bump 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1742,7 +1742,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "futures",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1899,7 +1899,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1923,7 +1923,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1934,7 +1934,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1965,7 +1965,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2016,7 +2016,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2068,14 +2068,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2107,7 +2107,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2116,7 +2116,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5919,7 +5919,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.9.0",
+  "schemaVersion": "0.10.0",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.9.0" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.10.0" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,32 +32,32 @@ futures.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.9" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
-heddle-core = { path = "../core", version = "0.9" }
-heddle-format = { path = "../format", version = "0.9" }
-heddle-client = { path = "../client", version = "0.9", optional = true }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.9" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
+heddle-core = { path = "../core", version = "0.10" }
+heddle-format = { path = "../format", version = "0.10" }
+heddle-client = { path = "../client", version = "0.10", optional = true }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.10" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.9", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.10", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -106,13 +106,13 @@ walkdir.workspace = true
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.10", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.10", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.9", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.10", optional = true }
 
 [features]
 # Keep the default `heddle` build focused on the local invisible-VCS

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -34,14 +34,14 @@ tracing.workspace = true
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published
 # matching versions from the registry.
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.10" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -144,7 +144,7 @@ impl HostedGrpcClient {
         request: &mut Request<T>,
         method_path: &str,
     ) -> Result<Option<request_signing::SignedRequestContext>, ProtocolError> {
-        self.apply_auth(request)?;
+        self.apply_auth(request, method_path)?;
         let Some(signer) = self.device_signer()? else {
             return Ok(None);
         };
@@ -199,7 +199,11 @@ impl HostedGrpcClient {
         callback(req)
     }
 
-    pub(super) fn apply_auth<T>(&self, request: &mut Request<T>) -> Result<(), ProtocolError> {
+    pub(super) fn apply_auth<T>(
+        &self,
+        request: &mut Request<T>,
+        method_path: &str,
+    ) -> Result<(), ProtocolError> {
         if let Some(token) = &self.token_header {
             request
                 .metadata_mut()
@@ -219,17 +223,27 @@ impl HostedGrpcClient {
                     .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?
                     .as_secs()
                     .to_string();
-                let signature = signer
-                    .sign(format!("{bearer}|{proof_ts}").as_bytes())
-                    .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
+                let mut nonce_bytes = [0u8; 16];
+                rand::fill(&mut nonce_bytes);
+                let nonce = hex::encode(nonce_bytes);
+                let signature =
+                    crypto::pop::sign_pop(&signer, bearer, &proof_ts, "POST", method_path, &nonce)
+                        .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
                 use base64::Engine;
                 let encoded = base64::engine::general_purpose::STANDARD.encode(signature);
                 let proof = MetadataValue::try_from(encoded)
                     .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
-                request.metadata_mut().insert("x-heddle-proof", proof);
+                request.metadata_mut().insert(crypto::pop::HDR_PROOF, proof);
                 let proof_ts = MetadataValue::try_from(proof_ts)
                     .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
-                request.metadata_mut().insert("x-heddle-proof-ts", proof_ts);
+                request
+                    .metadata_mut()
+                    .insert(crypto::pop::HDR_PROOF_TS, proof_ts);
+                let nonce = MetadataValue::try_from(nonce)
+                    .map_err(|err| ProtocolError::AuthenticationFailed(err.to_string()))?;
+                request
+                    .metadata_mut()
+                    .insert(crypto::pop::HDR_PROOF_NONCE, nonce);
             }
         }
         Ok(())
@@ -463,3 +477,65 @@ pub use hydration::{LazyHostedHydrator, PullMaterialization, register_hosted_fac
 pub use monorepo::{MonorepoCloneOp, MonorepoClonePlan, SkippedChild};
 pub use session::{HostedAuthMode, HostedSession};
 pub use sync::HostedRefEntry;
+
+#[cfg(test)]
+mod tests {
+    use base64::Engine as _;
+
+    use super::*;
+
+    fn test_client(auth_proof_key_pem: String, token: &str) -> HostedGrpcClient {
+        let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
+        let config = ClientConfig::default();
+        HostedGrpcClient {
+            inner: RepoSyncServiceClient::new(channel.clone())
+                .max_decoding_message_size(wire::MAX_PULL_DECODE_MESSAGE_SIZE),
+            user: HostedUserServiceClient::new(channel.clone()),
+            auth: AuthServiceClient::new(channel.clone()),
+            content: ContentServiceClient::new(channel.clone()),
+            tree_edit: TreeEditServiceClient::new(channel),
+            token_header: Some(
+                MetadataValue::try_from(format!("Bearer {token}")).expect("valid bearer header"),
+            ),
+            transport: helpers::HostedTransportPolicy::from_client_config(&config),
+            auth_proof_key_pem: Some(auth_proof_key_pem),
+            server_key: None,
+            on_human_signature: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_auth_attaches_verifiable_v2_pop_proof() {
+        let signer = Ed25519Signer::generate().expect("generate signer");
+        let pem = signer.to_pem().expect("export signer pem");
+        let token = "test-token";
+        let path = "/heddle.v1.AuthService/WhoAmI";
+        let client = test_client(pem, token);
+        let mut request = Request::new(());
+
+        client.apply_auth(&mut request, path).expect("apply auth");
+
+        let md = request.metadata();
+        let proof_ts = md
+            .get(crypto::pop::HDR_PROOF_TS)
+            .and_then(|v| v.to_str().ok())
+            .expect("proof timestamp header");
+        let nonce = md
+            .get(crypto::pop::HDR_PROOF_NONCE)
+            .and_then(|v| v.to_str().ok())
+            .expect("proof nonce header");
+        assert!(!nonce.is_empty());
+        assert!(nonce.len() <= 256);
+
+        let proof = md
+            .get(crypto::pop::HDR_PROOF)
+            .and_then(|v| v.to_str().ok())
+            .expect("proof header");
+        let sig = base64::engine::general_purpose::STANDARD
+            .decode(proof)
+            .expect("proof decodes");
+        let canonical = crypto::pop::pop_canonical_payload(token, proof_ts, "POST", path, nonce);
+        crypto::verify_payload_signature(&canonical, "ed25519", signer.public_key(), &sig)
+            .expect("proof verifies against device public key");
+    }
+}

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -408,7 +408,7 @@ impl HostedGrpcClient {
             ProtocolError::InvalidState("failed to initialize push stream".to_string())
         })?;
         let mut request = Request::new(ReceiverStream::new(rx));
-        self.apply_auth(&mut request)?;
+        self.apply_auth(&mut request, "/heddle.v1.RepoSyncService/Push")?;
         let mut response = self
             .inner
             .push(request)
@@ -857,7 +857,7 @@ impl HostedGrpcClient {
             ProtocolError::InvalidState("failed to initialize pull stream".to_string())
         })?;
         let mut request = Request::new(ReceiverStream::new(rx));
-        self.apply_auth(&mut request)?;
+        self.apply_auth(&mut request, "/heddle.v1.RepoSyncService/Pull")?;
         let mut response = self
             .inner
             .pull(request)

--- a/crates/client/src/grpc_hosted/user.rs
+++ b/crates/client/src/grpc_hosted/user.rs
@@ -56,7 +56,7 @@ macro_rules! signed_call {
                     $crate::grpc_hosted::request_signing::action_url_from_status(&status);
                 let assertion = $self.request_human_signature(path, &ctx, action_url)?;
                 let mut retry = Request::new(message);
-                $self.apply_auth(&mut retry)?;
+                $self.apply_auth(&mut retry, path)?;
                 $crate::grpc_hosted::request_signing::attach_human(&mut retry, &ctx, &assertion)?;
                 $self
                     .$client

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,18 +12,18 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.9" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 ignore.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10", optional = true }
 sley.workspace = true
 
 [features]

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -5,6 +5,7 @@ mod ed25519;
 mod error;
 mod p256;
 mod pem_loader;
+pub mod pop;
 mod state_signature;
 mod state_signing;
 

--- a/crates/crypto/src/pop.rs
+++ b/crates/crypto/src/pop.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Bearer-token proof-of-possession signing.
+
+use crate::{Ed25519Signer, Signer, SignerError, verify_payload_signature};
+
+pub const POP_V2_DOMAIN: &str = "heddle-bearer-pop-v2";
+pub const HDR_PROOF: &str = "x-heddle-proof";
+pub const HDR_PROOF_TS: &str = "x-heddle-proof-ts";
+pub const HDR_PROOF_NONCE: &str = "x-heddle-proof-nonce";
+
+/// Canonical bytes the v2 PoP signature covers. Each field line is
+/// `key=<byte-len>:<value>\n`; `<byte-len>` is computed from
+/// `value.as_bytes().len()`.
+pub fn pop_canonical_payload(
+    token: &str,
+    proof_ts: &str,
+    method: &str,
+    path: &str,
+    nonce: &str,
+) -> Vec<u8> {
+    let mut out = String::with_capacity(
+        POP_V2_DOMAIN.len()
+            + 1
+            + field_len("token", token)
+            + field_len("proof_ts", proof_ts)
+            + field_len("method", method)
+            + field_len("path", path)
+            + field_len("nonce", nonce),
+    );
+    out.push_str(POP_V2_DOMAIN);
+    out.push('\n');
+    push_field(&mut out, "token", token);
+    push_field(&mut out, "proof_ts", proof_ts);
+    push_field(&mut out, "method", method);
+    push_field(&mut out, "path", path);
+    push_field(&mut out, "nonce", nonce);
+    out.into_bytes()
+}
+
+/// Sign a v2 bearer-token proof-of-possession payload.
+pub fn sign_pop(
+    signer: &Ed25519Signer,
+    token: &str,
+    proof_ts: &str,
+    method: &str,
+    path: &str,
+    nonce: &str,
+) -> Result<Vec<u8>, SignerError> {
+    let payload = pop_canonical_payload(token, proof_ts, method, path, nonce);
+    signer.sign(&payload)
+}
+
+/// Verify a v2 bearer-token proof-of-possession signature.
+pub fn verify_pop(
+    public_key: &[u8],
+    token: &str,
+    proof_ts: &str,
+    method: &str,
+    path: &str,
+    nonce: &str,
+    sig: &[u8],
+) -> Result<(), SignerError> {
+    let payload = pop_canonical_payload(token, proof_ts, method, path, nonce);
+    verify_payload_signature(&payload, "ed25519", public_key, sig)
+}
+
+fn push_field(out: &mut String, key: &str, value: &str) {
+    out.push_str(key);
+    out.push('=');
+    out.push_str(&utf8_byte_len(value).to_string());
+    out.push(':');
+    out.push_str(value);
+    out.push('\n');
+}
+
+fn field_len(key: &str, value: &str) -> usize {
+    key.len() + 1 + utf8_byte_len(value).to_string().len() + 1 + value.len() + 1
+}
+
+#[allow(clippy::needless_as_bytes)]
+fn utf8_byte_len(value: &str) -> usize {
+    value.as_bytes().len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const PINNED_TOKEN: &str = "tok-é";
+    const PINNED_PROOF_TS: &str = "1700000000";
+    const PINNED_METHOD: &str = "POST";
+    const PINNED_PATH: &str = "/heddle.v1.AuthService/WhoAmI";
+    const PINNED_NONCE: &str = "nøñce";
+    const PINNED_CANONICAL: &str = concat!(
+        "heddle-bearer-pop-v2\n",
+        "token=6:tok-é\n",
+        "proof_ts=10:1700000000\n",
+        "method=4:POST\n",
+        "path=29:/heddle.v1.AuthService/WhoAmI\n",
+        "nonce=7:nøñce\n",
+    );
+
+    #[test]
+    fn pop_canonical_payload_matches_pinned_vector() {
+        let got = pop_canonical_payload(
+            PINNED_TOKEN,
+            PINNED_PROOF_TS,
+            PINNED_METHOD,
+            PINNED_PATH,
+            PINNED_NONCE,
+        );
+        assert_eq!(got, PINNED_CANONICAL.as_bytes());
+    }
+
+    #[test]
+    fn sign_pop_verifies() {
+        let signer = Ed25519Signer::generate().expect("generate signer");
+        let sig = sign_pop(
+            &signer,
+            PINNED_TOKEN,
+            PINNED_PROOF_TS,
+            PINNED_METHOD,
+            PINNED_PATH,
+            PINNED_NONCE,
+        )
+        .expect("sign pop");
+
+        verify_pop(
+            signer.public_key(),
+            PINNED_TOKEN,
+            PINNED_PROOF_TS,
+            PINNED_METHOD,
+            PINNED_PATH,
+            PINNED_NONCE,
+            &sig,
+        )
+        .expect("verify pop");
+    }
+}

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,27 +11,27 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
 grpc = { path = "../grpc", package = "heddle-grpc", version = "0.13" }
 hex.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10", default-features = false }
 prost.workspace = true
 prost-types.workspace = true
-refs = { path = "../refs", package = "heddle-refs", version = "0.9", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.9" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.10" }
 tokio.workspace = true
 tokio-stream.workspace = true
 tonic.workspace = true
 toml.workspace = true
 tracing.workspace = true
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay"] }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false, features = ["git-overlay"] }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10" }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,10 +15,10 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.9" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+heddle-format = { path = "../format", version = "0.10" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 similar.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -70,7 +70,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.9" }
+heddle-format = { path = "../format", version = "0.10" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,7 +17,7 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.9" }
+heddle-format = { path = "../format", version = "0.10" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,12 +11,12 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.9" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+heddle-schema = { path = "../schema", version = "0.10" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.9", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.10", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,15 +12,15 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.9" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+heddle-schema = { path = "../schema", version = "0.10" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.9", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.10", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -16,16 +16,16 @@ chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.9" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.9" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.9", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.10" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.9", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.10", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -75,7 +75,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10", features = ["async-source", "memory-backend"] }
 tempfile.workspace = true
 
 [lib]

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -28,8 +28,8 @@ lang-java = ["dep:tree-sitter-java"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.9" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.9", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.10" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.9", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -16,7 +16,7 @@ categories.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.9" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
## Summary

- Adds `crypto::pop` as the shared v2 bearer PoP canonical payload builder, signer, verifier, and header constants.
- Replaces the hosted client bearer proof with v2 request-bound signing over token, proof timestamp, `POST`, actual gRPC method path, and a fresh hex nonce.
- Threads method paths through direct streaming/human-retry `apply_auth` call sites.
- Bumps the workspace and Heddle inter-crate pins to 0.10.0/0.10 and regenerates schema version artifacts.

## Pinned canonical vector

```text
heddle-bearer-pop-v2
token=6:tok-é
proof_ts=10:1700000000
method=4:POST
path=29:/heddle.v1.AuthService/WhoAmI
nonce=7:nøñce
```

## Validation

- `bash scripts/gen-ts-types.sh` passed; generated schemas pinned to `heddle-cli 0.10.0`.
- `cargo run --locked -p heddle-devtools -- grpc-ts --check` passed; emitted existing warning: `hosted.proto: Import heddle/v1/threads.proto is unused`.
- `cargo build --workspace --locked` passed.
- `cargo test -p heddle-crypto --locked` passed: 24 passed, including pinned vector and sign/verify roundtrip.
- `cargo test -p heddle-client --locked` passed: 112 passed, including v2 PoP interceptor verification.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed.
- `cargo tree -p heddle-cli 2>/dev/null | grep -E "heddle-\\w+ v0\\.9" || echo "OK: no heddle crate left at 0.9"` output: `OK: no heddle crate left at 0.9`.
- `bash scripts/check-doctor-schemas-clean.sh` passed: no registered-schema/documented-sample drift.
- `git diff --check` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/975"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786079960&installation_id=132405951&pr_number=975&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F975&signature=20333db4deb046b2bb4953ae37c1969ae53800e227c271bc47f2fb9b61eb90e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->