### PR TITLE
fix(release): drop deleted heddle-review from publish set (unblock 0.10)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -96,7 +96,6 @@ env:
     heddle-mount
     heddle-cli
     heddle-devtools
-    heddle-review
 
 jobs:
   validate-publish:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -80,10 +80,6 @@ name = "heddle-devtools"
 release = true
 
 [[package]]
-name = "heddle-review"
-release = true
-
-[[package]]
 name = "heddle-state-review"
 release = true
 


### PR DESCRIPTION
The #974 dead-code sweep deleted `crates/review` (heddle-review) but left it in `publish-crates.yml` `PUBLISHABLE_CRATES` and `release-plz.toml`, so the heddle 0.10 publish (run 28920304688, sha aff6c79c) aborts at *validate publish set*: `PUBLISHABLE_CRATES lists 'heddle-review' but no crates/*/Cargo.toml has it`.

Removes both stale entries. `scripts/check-publish-pipeline.sh` passes. The publish workflow's `paths:` filter includes `.github/workflows/publish-crates.yml`, so merging this re-triggers the 0.10 publish automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786081573&installation_id=132405951&pr_number=976&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F976&signature=39a702b54f0fedda4718a77ec157e5fd6323db56557d58a86e8868f2c8b274f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->