### PR TITLE
[codex] perf: bound delta scan, cache semantic parses, incremental tree diff

### DIFF
--- a/crates/format/src/delta/delta_encoder.rs
+++ b/crates/format/src/delta/delta_encoder.rs
@@ -18,6 +18,8 @@ use std::collections::HashMap;
 const MIN_MATCH_LENGTH_LARGE: usize = 16;
 /// Minimum match length for small targets (< 1024 bytes).
 const MIN_MATCH_LENGTH_SMALL: usize = 8;
+/// Maximum offsets to inspect for a single 4-byte key.
+const MAX_MATCH_CANDIDATES: usize = 1024;
 
 /// Delta encoder.
 #[derive(Debug)]
@@ -275,11 +277,33 @@ impl DeltaEncoder {
         let mut best_offset = 0;
         let mut best_length = 0;
 
-        for &offset in offsets {
+        let target_remaining = target.len() - pos;
+        let recent_start = offsets.len().saturating_sub(MAX_MATCH_CANDIDATES);
+        let mut examined = 0usize;
+
+        if recent_start > 0 {
+            let offset = offsets[0];
             let length = Self::match_length(base, offset, target, pos);
             if length > best_length {
                 best_length = length;
                 best_offset = offset;
+            }
+            if length == target_remaining {
+                return Some((best_offset, best_length));
+            }
+            examined += 1;
+        }
+
+        let remaining_budget = MAX_MATCH_CANDIDATES - examined;
+        let start = offsets.len().saturating_sub(remaining_budget);
+        for &offset in &offsets[start..] {
+            let length = Self::match_length(base, offset, target, pos);
+            if length > best_length {
+                best_length = length;
+                best_offset = offset;
+            }
+            if length == target_remaining {
+                break;
             }
         }
 

--- a/crates/format/src/delta/delta_tests.rs
+++ b/crates/format/src/delta/delta_tests.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-use super::{DeltaDecoder, DeltaEncoder, DeltaError, MAX_DELTA_OUTPUT_SIZE, compute_delta};
+use super::{compute_delta, DeltaDecoder, DeltaEncoder, DeltaError, MAX_DELTA_OUTPUT_SIZE};
 
 #[test]
 fn test_delta_roundtrip() {
@@ -43,6 +43,24 @@ fn test_delta_no_match() {
     let decoded = DeltaDecoder::decode(base, &delta, MAX_DELTA_OUTPUT_SIZE).unwrap();
 
     assert_eq!(decoded, target);
+}
+
+#[test]
+fn test_delta_repeated_key_adversarial_roundtrip() {
+    let base = vec![0u8; 2 * 1024 * 1024];
+    let mut target = base.clone();
+    target.extend_from_slice(b"tail");
+
+    let delta = DeltaEncoder::encode(&base, &target);
+    let decoded = DeltaDecoder::decode(&base, &delta, MAX_DELTA_OUTPUT_SIZE)
+        .expect("adversarial repeated-key delta should decode");
+
+    assert_eq!(decoded, target);
+    assert!(
+        delta.len() < 64,
+        "all-zero prefix should encode as a compact copy plus tail literal, got {} bytes",
+        delta.len()
+    );
 }
 
 #[test]

--- a/crates/ingest/src/reasoning_pipeline.rs
+++ b/crates/ingest/src/reasoning_pipeline.rs
@@ -31,7 +31,7 @@
 //! etc.) without the pipeline caring.
 
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     path::{Component, Path, PathBuf},
 };
 
@@ -238,6 +238,7 @@ impl<'a> ReasoningPipeline<'a> {
             .emit_annotations
             .then(|| ReasoningEmitter::new(self.repo, self.sha_map));
         let mut preview = Vec::new();
+        let mut seen_commits: HashMap<String, crate::git_walk::CommitEntry> = HashMap::new();
 
         let mut last_progress = 0usize;
         for (idx, sha) in git_shas.iter().enumerate() {
@@ -252,7 +253,11 @@ impl<'a> ReasoningPipeline<'a> {
                 }
             };
 
-            let changed = match self.changed_files(&commit) {
+            let parent_commit = commit
+                .parents
+                .first()
+                .and_then(|parent| seen_commits.get(parent));
+            let changed = match self.changed_files(&commit, parent_commit) {
                 Ok(v) => v,
                 Err(PipelineFileError::UntranslatedTree(_)) => {
                     debug!(sha, "commit tree not in sha_map — skipping");
@@ -265,6 +270,7 @@ impl<'a> ReasoningPipeline<'a> {
                     continue;
                 }
             };
+            seen_commits.insert(commit.sha.clone(), commit.clone());
 
             let ranked = matcher.score_commit(&commit, &changed);
             let eligible: Vec<_> = ranked
@@ -454,55 +460,54 @@ impl<'a> ReasoningPipeline<'a> {
     /// it would surface `"src"` instead of `"src/auth.rs"` — wrong for
     /// our transcript matcher, which keys on file paths).
     ///
-    /// Strategy: walk both trees fully into `(path → blob_hash)` maps
-    /// and compare. Any path present on only one side, or with a
-    /// different hash, is "changed". Root commits go through the same
-    /// path with an empty `from` map.
+    /// Strategy: compare trees recursively and skip any subtree whose
+    /// content hash is identical on both sides. Any leaf path present
+    /// on only one side, or with a different hash, is "changed". Root
+    /// commits go through the same path with an empty `from` side.
     ///
     /// Assumes `Importer` already translated the commit tree and (if
     /// present) the parent tree into the Heddle store.
     fn changed_files(
         &self,
         commit: &crate::git_walk::CommitEntry,
+        parsed_parent: Option<&crate::git_walk::CommitEntry>,
     ) -> Result<Vec<String>, PipelineFileError> {
         let to_hash = self
             .sha_map
             .get_tree(&commit.tree_sha)
             .ok_or_else(|| PipelineFileError::UntranslatedTree(commit.tree_sha.clone()))?;
 
-        let from_files = if let Some(parent) = commit.parents.first() {
-            let parent_commit = self
-                .git
-                .read_commit(parent)
-                .map_err(|e| PipelineFileError::Other(e.to_string()))?;
+        let from_hash = if let Some(parent) = commit.parents.first() {
+            let fallback_parent;
+            let parent_commit = if let Some(parsed_parent) = parsed_parent {
+                parsed_parent
+            } else {
+                fallback_parent = self
+                    .git
+                    .read_commit(parent)
+                    .map_err(|e| PipelineFileError::Other(e.to_string()))?;
+                &fallback_parent
+            };
             let from_hash = self
                 .sha_map
                 .get_tree(&parent_commit.tree_sha)
                 .ok_or_else(|| {
                     PipelineFileError::UntranslatedTree(parent_commit.tree_sha.clone())
                 })?;
-            collect_tree_files(self.repo.store(), &from_hash)
-                .map_err(|e| PipelineFileError::Other(e.to_string()))?
+            Some(from_hash)
         } else {
-            BTreeMap::new()
+            None
         };
 
-        let to_files = collect_tree_files(self.repo.store(), &to_hash)
-            .map_err(|e| PipelineFileError::Other(e.to_string()))?;
-
         let mut changed: Vec<String> = Vec::new();
-        for (path, to_blob) in &to_files {
-            match from_files.get(path) {
-                None => changed.push(path.clone()),
-                Some(from_blob) if from_blob != to_blob => changed.push(path.clone()),
-                _ => {}
-            }
-        }
-        for path in from_files.keys() {
-            if !to_files.contains_key(path) {
-                changed.push(path.clone());
-            }
-        }
+        diff_tree_files(
+            self.repo.store(),
+            from_hash.as_ref(),
+            Some(&to_hash),
+            "",
+            &mut changed,
+        )
+        .map_err(|e| PipelineFileError::Other(e.to_string()))?;
         changed.sort();
         changed.dedup();
         Ok(changed)
@@ -802,24 +807,152 @@ fn has_durable_language(lower: &str) -> bool {
     DURABLE.iter().any(|needle| lower.contains(needle))
 }
 
+/// Diff two trees recursively, skipping equal subtree hashes.
+fn diff_tree_files<S: ObjectStore + ?Sized>(
+    store: &S,
+    from_hash: Option<&ContentHash>,
+    to_hash: Option<&ContentHash>,
+    prefix: &str,
+    changed: &mut Vec<String>,
+) -> Result<(), anyhow::Error> {
+    if from_hash.is_some() && from_hash == to_hash {
+        return Ok(());
+    }
+
+    let from_tree = match from_hash {
+        Some(hash) => store.get_tree(hash)?,
+        None => None,
+    };
+    let to_tree = match to_hash {
+        Some(hash) => store.get_tree(hash)?,
+        None => None,
+    };
+
+    let from_entries = from_tree.as_ref().map_or(&[][..], |tree| tree.entries());
+    let to_entries = to_tree.as_ref().map_or(&[][..], |tree| tree.entries());
+    let mut from_idx = 0usize;
+    let mut to_idx = 0usize;
+
+    while from_idx < from_entries.len() || to_idx < to_entries.len() {
+        match (from_entries.get(from_idx), to_entries.get(to_idx)) {
+            (Some(from), Some(to)) if from.name() == to.name() => {
+                diff_matching_entries(store, from, to, prefix, changed)?;
+                from_idx += 1;
+                to_idx += 1;
+            }
+            (Some(from), Some(to)) if from.name() < to.name() => {
+                collect_entry_files(store, from, prefix, changed)?;
+                from_idx += 1;
+            }
+            (Some(_), Some(to)) => {
+                collect_entry_files(store, to, prefix, changed)?;
+                to_idx += 1;
+            }
+            (Some(from), None) => {
+                collect_entry_files(store, from, prefix, changed)?;
+                from_idx += 1;
+            }
+            (None, Some(to)) => {
+                collect_entry_files(store, to, prefix, changed)?;
+                to_idx += 1;
+            }
+            (None, None) => break,
+        }
+    }
+
+    Ok(())
+}
+
+fn diff_matching_entries<S: ObjectStore + ?Sized>(
+    store: &S,
+    from: &objects::object::TreeEntry,
+    to: &objects::object::TreeEntry,
+    prefix: &str,
+    changed: &mut Vec<String>,
+) -> Result<(), anyhow::Error> {
+    let path = join_diff_path(prefix, from.name());
+    match (from.entry_type(), to.entry_type()) {
+        (EntryType::Tree, EntryType::Tree) => {
+            let from_hash = from.tree_hash();
+            let to_hash = to.tree_hash();
+            diff_tree_files(store, from_hash.as_ref(), to_hash.as_ref(), &path, changed)?;
+        }
+        (EntryType::Blob | EntryType::Symlink, EntryType::Blob | EntryType::Symlink) => {
+            if from.leaf_content_hash() != to.leaf_content_hash() {
+                changed.push(path);
+            }
+        }
+        (EntryType::Gitlink | EntryType::Spoollink, EntryType::Gitlink | EntryType::Spoollink) => {}
+        _ => {
+            collect_entry_files(store, from, prefix, changed)?;
+            collect_entry_files(store, to, prefix, changed)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_entry_files<S: ObjectStore + ?Sized>(
+    store: &S,
+    entry: &objects::object::TreeEntry,
+    prefix: &str,
+    out: &mut Vec<String>,
+) -> Result<(), anyhow::Error> {
+    let path = join_diff_path(prefix, entry.name());
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Symlink => out.push(path),
+        EntryType::Tree => {
+            if let Some(hash) = entry.tree_hash() {
+                collect_tree_file_paths(store, &hash, &path, out)?;
+            }
+        }
+        EntryType::Gitlink | EntryType::Spoollink => {}
+    }
+    Ok(())
+}
+
+fn collect_tree_file_paths<S: ObjectStore + ?Sized>(
+    store: &S,
+    root: &ContentHash,
+    prefix: &str,
+    out: &mut Vec<String>,
+) -> Result<(), anyhow::Error> {
+    let Some(tree) = store.get_tree(root)? else {
+        return Ok(());
+    };
+    for entry in tree.entries() {
+        collect_entry_files(store, entry, prefix, out)?;
+    }
+    Ok(())
+}
+
+fn join_diff_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
 /// Walk a tree recursively, returning every leaf file with its blob
 /// hash. Directory entries expand; the returned map is keyed on the
 /// slash-joined repo-relative path. Missing tree objects (shouldn't
 /// happen if `Importer` succeeded) propagate as store errors.
+#[cfg(test)]
 fn collect_tree_files<S: ObjectStore + ?Sized>(
     store: &S,
     root: &ContentHash,
-) -> Result<BTreeMap<String, ContentHash>, anyhow::Error> {
-    let mut out = BTreeMap::new();
+) -> Result<std::collections::BTreeMap<String, ContentHash>, anyhow::Error> {
+    let mut out = std::collections::BTreeMap::new();
     walk_tree(store, root, "", &mut out)?;
     Ok(out)
 }
 
+#[cfg(test)]
 fn walk_tree<S: ObjectStore + ?Sized>(
     store: &S,
     hash: &ContentHash,
     prefix: &str,
-    out: &mut BTreeMap<String, ContentHash>,
+    out: &mut std::collections::BTreeMap<String, ContentHash>,
 ) -> Result<(), anyhow::Error> {
     let Some(tree) = store.get_tree(hash)? else {
         // Empty tree hash resolves to None; that's fine — nothing to
@@ -899,6 +1032,10 @@ mod tests {
     use std::{fs, path::PathBuf, process::Command};
 
     use chrono::{Duration as ChronoDuration, Utc};
+    use objects::{
+        object::{Blob, Tree, TreeEntry},
+        store::InMemoryStore,
+    };
     use repo::Repository;
     use tempfile::TempDir;
 
@@ -997,6 +1134,64 @@ mod tests {
             .output()
             .unwrap();
         String::from_utf8(out.stdout).unwrap().trim().to_string()
+    }
+
+    fn put_test_blob(store: &InMemoryStore, content: &str) -> ContentHash {
+        store
+            .put_blob(&Blob::from_slice(content.as_bytes()))
+            .expect("put test blob")
+    }
+
+    fn put_test_tree(store: &InMemoryStore, entries: Vec<TreeEntry>) -> ContentHash {
+        store
+            .put_tree(&Tree::from_entries(entries))
+            .expect("put test tree")
+    }
+
+    fn test_file(name: &str, hash: ContentHash) -> TreeEntry {
+        TreeEntry::file(name.to_string(), hash, false).expect("valid file entry")
+    }
+
+    fn test_dir(name: &str, hash: ContentHash) -> TreeEntry {
+        TreeEntry::directory(name.to_string(), hash).expect("valid directory entry")
+    }
+
+    fn old_full_walk_changed_files(
+        store: &InMemoryStore,
+        from_hash: &ContentHash,
+        to_hash: &ContentHash,
+    ) -> Vec<String> {
+        let from_files = collect_tree_files(store, from_hash).expect("collect from tree");
+        let to_files = collect_tree_files(store, to_hash).expect("collect to tree");
+        let mut changed = Vec::new();
+        for (path, to_blob) in &to_files {
+            match from_files.get(path) {
+                None => changed.push(path.clone()),
+                Some(from_blob) if from_blob != to_blob => changed.push(path.clone()),
+                _ => {}
+            }
+        }
+        for path in from_files.keys() {
+            if !to_files.contains_key(path) {
+                changed.push(path.clone());
+            }
+        }
+        changed.sort();
+        changed.dedup();
+        changed
+    }
+
+    fn incremental_changed_files(
+        store: &InMemoryStore,
+        from_hash: &ContentHash,
+        to_hash: &ContentHash,
+    ) -> Vec<String> {
+        let mut changed = Vec::new();
+        diff_tree_files(store, Some(from_hash), Some(to_hash), "", &mut changed)
+            .expect("diff test trees");
+        changed.sort();
+        changed.dedup();
+        changed
     }
 
     /// Load transcripts from a test-local `.claude/projects/<slug>/*.jsonl`
@@ -1118,6 +1313,87 @@ mod tests {
         assert_eq!(stats.commits_with_matches, 0);
         assert_eq!(stats.points_extracted, 0);
         assert_eq!(stats.emit.annotations_written, 0);
+    }
+
+    #[test]
+    fn incremental_tree_diff_reports_only_deep_changed_file() {
+        let store = InMemoryStore::new();
+        let stable = put_test_blob(&store, "stable\n");
+        let old_leaf = put_test_blob(&store, "old\n");
+        let new_leaf = put_test_blob(&store, "new\n");
+
+        let old_deep = put_test_tree(
+            &store,
+            vec![test_file("target.rs", old_leaf), test_file("stable.rs", stable)],
+        );
+        let new_deep = put_test_tree(
+            &store,
+            vec![test_file("target.rs", new_leaf), test_file("stable.rs", stable)],
+        );
+        let old_mid = put_test_tree(&store, vec![test_dir("deep", old_deep)]);
+        let new_mid = put_test_tree(&store, vec![test_dir("deep", new_deep)]);
+        let old_src = put_test_tree(&store, vec![test_dir("mid", old_mid)]);
+        let new_src = put_test_tree(&store, vec![test_dir("mid", new_mid)]);
+        let docs = put_test_tree(&store, vec![test_file("guide.md", stable)]);
+        let old_root = put_test_tree(
+            &store,
+            vec![test_dir("docs", docs), test_dir("src", old_src)],
+        );
+        let new_root = put_test_tree(
+            &store,
+            vec![test_dir("docs", docs), test_dir("src", new_src)],
+        );
+
+        let changed = incremental_changed_files(&store, &old_root, &new_root);
+
+        assert_eq!(changed, vec!["src/mid/deep/target.rs"]);
+    }
+
+    #[test]
+    fn incremental_tree_diff_matches_old_full_walk_fixture() {
+        let store = InMemoryStore::new();
+        let same = put_test_blob(&store, "same\n");
+        let old_a = put_test_blob(&store, "old a\n");
+        let new_a = put_test_blob(&store, "new a\n");
+        let deleted = put_test_blob(&store, "deleted\n");
+        let added = put_test_blob(&store, "added\n");
+        let link_old = put_test_blob(&store, "old target\n");
+        let link_new = put_test_blob(&store, "new target\n");
+
+        let old_lib = put_test_tree(
+            &store,
+            vec![
+                test_file("a.rs", old_a),
+                test_file("deleted.rs", deleted),
+                TreeEntry::symlink("link".to_string(), link_old).expect("valid symlink"),
+            ],
+        );
+        let new_lib = put_test_tree(
+            &store,
+            vec![
+                test_file("a.rs", new_a),
+                test_file("added.rs", added),
+                TreeEntry::symlink("link".to_string(), link_new).expect("valid symlink"),
+            ],
+        );
+        let unchanged_dir = put_test_tree(&store, vec![test_file("same.rs", same)]);
+        let old_root = put_test_tree(
+            &store,
+            vec![test_dir("lib", old_lib), test_dir("unchanged", unchanged_dir)],
+        );
+        let new_root = put_test_tree(
+            &store,
+            vec![test_dir("lib", new_lib), test_dir("unchanged", unchanged_dir)],
+        );
+
+        let incremental = incremental_changed_files(&store, &old_root, &new_root);
+        let full_walk = old_full_walk_changed_files(&store, &old_root, &new_root);
+
+        assert_eq!(incremental, full_walk);
+        assert_eq!(
+            incremental,
+            vec!["lib/a.rs", "lib/added.rs", "lib/deleted.rs", "lib/link"]
+        );
     }
 
     #[test]

--- a/crates/semantic/src/analysis/analysis_classify.rs
+++ b/crates/semantic/src/analysis/analysis_classify.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 
 use objects::object::{ChangeImportance, ModificationKind};
 
-use super::analysis_similarity::{SimilarityMethod, compute_similarity};
+use super::analysis_similarity::{compute_similarity, SimilarityMethod};
 use crate::parser::{Language, ParsedFile};
 
 /// Classification result: kind, importance, and confidence.
@@ -35,25 +35,9 @@ pub fn classify_modification_with_confidence(
     old_content: &str,
     new_content: &str,
 ) -> ClassificationResult {
-    // Identical content should not reach here, but handle it gracefully.
-    if old_content == new_content {
-        return (
-            ModificationKind::WhitespaceOnly,
-            ChangeImportance::Noise,
-            1.0,
-        );
-    }
-
-    // --- Check 1: Token-identical means formatting/whitespace only ---
-    let token_sim = compute_similarity(old_content, new_content, SimilarityMethod::Tokens);
-    if token_sim >= 1.0 {
-        // Tokens are identical but raw text differs → pure formatting/whitespace.
-        // High confidence: token identity is a strong signal.
-        return (
-            ModificationKind::FormattingOnly,
-            ChangeImportance::Noise,
-            0.95,
-        );
+    let token_sim = classify_common_prefix(old_content, new_content);
+    if let Some(result) = token_sim.result {
+        return result;
     }
 
     let language = Language::from_path(path);
@@ -62,7 +46,76 @@ pub fn classify_modification_with_confidence(
     let old_parsed = ParsedFile::parse(old_content, language);
     let new_parsed = ParsedFile::parse(new_content, language);
 
-    match (&old_parsed, &new_parsed) {
+    classify_parse_result(
+        old_content,
+        new_content,
+        old_parsed.as_ref(),
+        new_parsed.as_ref(),
+        token_sim.value,
+    )
+}
+
+pub(crate) fn classify_modification_with_parsed(
+    old_content: &str,
+    new_content: &str,
+    old_ast: &ParsedFile,
+    new_ast: &ParsedFile,
+) -> ClassificationResult {
+    let token_sim = classify_common_prefix(old_content, new_content);
+    if let Some(result) = token_sim.result {
+        return result;
+    }
+
+    classify_with_ast(old_content, new_content, old_ast, new_ast)
+}
+
+struct TokenSimilarityCheck {
+    value: f64,
+    result: Option<ClassificationResult>,
+}
+
+fn classify_common_prefix(old_content: &str, new_content: &str) -> TokenSimilarityCheck {
+    // Identical content should not reach here, but handle it gracefully.
+    if old_content == new_content {
+        return TokenSimilarityCheck {
+            value: 1.0,
+            result: Some((
+                ModificationKind::WhitespaceOnly,
+                ChangeImportance::Noise,
+                1.0,
+            )),
+        };
+    }
+
+    // --- Check 1: Token-identical means formatting/whitespace only ---
+    let token_sim = compute_similarity(old_content, new_content, SimilarityMethod::Tokens);
+    if token_sim >= 1.0 {
+        // Tokens are identical but raw text differs → pure formatting/whitespace.
+        // High confidence: token identity is a strong signal.
+        return TokenSimilarityCheck {
+            value: token_sim,
+            result: Some((
+                ModificationKind::FormattingOnly,
+                ChangeImportance::Noise,
+                0.95,
+            )),
+        };
+    }
+
+    TokenSimilarityCheck {
+        value: token_sim,
+        result: None,
+    }
+}
+
+fn classify_parse_result(
+    old_content: &str,
+    new_content: &str,
+    old_parsed: Option<&ParsedFile>,
+    new_parsed: Option<&ParsedFile>,
+    token_sim: f64,
+) -> ClassificationResult {
+    match (old_parsed, new_parsed) {
         (Some(old_ast), Some(new_ast)) => {
             classify_with_ast(old_content, new_content, old_ast, new_ast)
         }
@@ -311,5 +364,18 @@ mod tests {
         let (kind, importance) = classify_modification(Path::new("test.xyz"), old, new);
         assert_eq!(kind, ModificationKind::FormattingOnly);
         assert_eq!(importance, ChangeImportance::Noise);
+    }
+
+    #[test]
+    fn test_classify_with_parsed_matches_direct_classifier() {
+        let old = "use std::io;\n\nfn compute() -> i32 {\n    1\n}\n";
+        let new = "use std::io;\nuse std::fs;\n\nfn compute() -> i32 {\n    1\n}\n";
+        let old_ast = ParsedFile::parse(old, Language::Rust).expect("old Rust should parse");
+        let new_ast = ParsedFile::parse(new, Language::Rust).expect("new Rust should parse");
+
+        let direct = classify_modification_with_confidence(Path::new("test.rs"), old, new);
+        let cached = classify_modification_with_parsed(old, new, &old_ast, &new_ast);
+
+        assert_eq!(cached, direct);
     }
 }

--- a/crates/semantic/src/analysis/mod.rs
+++ b/crates/semantic/src/analysis/mod.rs
@@ -16,6 +16,7 @@ pub use analysis_aggregate::{
     AggregateKind, AggregatedChange, AggregationResult, aggregate_changes,
 };
 pub use analysis_classify::{classify_modification, classify_modification_with_confidence};
+pub(crate) use analysis_classify::classify_modification_with_parsed;
 pub use analysis_functions::detect_function_changes;
 pub(crate) use analysis_functions::detect_function_changes_with_parsed;
 pub(crate) use analysis_imports::detect_import_changes_with_parsed;

--- a/crates/semantic/src/diff/diff_engine.rs
+++ b/crates/semantic/src/diff/diff_engine.rs
@@ -11,9 +11,9 @@ use objects::object::{DiffKind, FileChangeSet};
 use super::{
     diff_options::SemanticDiffOptions,
     diff_support::{
-        EngineOutput, LoadedChange, ParsedChangeSet, apply_renames, build_file_level_changes,
-        detect_renames, fallback_file_changes, function_and_import_changes, load_manifest,
-        suppress_redundant_file_modified,
+        apply_renames, build_file_level_changes, detect_renames, fallback_file_changes,
+        function_and_import_changes, load_manifest, suppress_redundant_file_modified, EngineOutput,
+        LoadedChange, ParsedChangeSet,
     },
     diff_types::{
         SemanticCheckOnlyResult, SemanticCheckStatus, SemanticDiffResult, SemanticFallbackReason,
@@ -133,14 +133,20 @@ where
         }
 
         let LoadOutcome { loaded, overflow } = self.load_changes(&mut output.fallback_reasons)?;
-        output.changes = build_file_level_changes(&loaded);
+        let parsed = self
+            .options
+            .analyze_functions
+            .then(|| self.parse_files(&loaded, &mut output.fallback_reasons));
+        output.changes = build_file_level_changes(&loaded, parsed.as_ref());
         output.file_renames = detect_renames(&loaded, self.options);
         apply_renames(&mut output.changes, &output.file_renames);
 
         if self.options.analyze_functions {
-            let parsed = self.parse_files(&loaded, &mut output.fallback_reasons);
+            let parsed = parsed
+                .as_ref()
+                .expect("parsed changes should be available when function analysis is enabled");
             let manifest = if self.options.analyze_dependencies
-                && super::diff_support::dependency_manifest_may_be_needed(&loaded, &parsed)
+                && super::diff_support::dependency_manifest_may_be_needed(&loaded, parsed)
             {
                 load_manifest(&loaded, &mut self.load_new, self.options)?
             } else {
@@ -148,7 +154,7 @@ where
             };
             output.changes.extend(function_and_import_changes(
                 &loaded,
-                &parsed,
+                parsed,
                 self.options,
                 manifest.as_deref(),
                 &output.file_renames,
@@ -519,6 +525,42 @@ mod tests {
             "byte-budget fallback reason must still be recorded: {:?}",
             result.fallback_reasons
         );
+    }
+
+    #[test]
+    fn file_level_classification_reuses_cached_parse_result() {
+        let old = "use std::io;\n\nfn compute() -> i32 {\n    1\n}\n";
+        let new = "use std::io;\nuse std::fs;\n\nfn compute() -> i32 {\n    1\n}\n";
+        let file_changes = FileChangeSet::from(vec![("lib.rs".to_string(), DiffKind::Modified)]);
+        let cache = SemanticParseCache::default();
+        cache.clear();
+        let options = SemanticDiffOptions::default();
+
+        let engine = SemanticEngine::new(
+            file_changes,
+            |_path| Ok(Some(old.to_string())),
+            |_path| Ok(Some(new.to_string())),
+            &options,
+            &cache,
+        );
+
+        let result = engine.full().expect("semantic diff should succeed");
+        let expected =
+            crate::analysis::classify_modification_with_confidence(Path::new("lib.rs"), old, new);
+
+        assert!(result.changes.iter().any(|change| matches!(
+            change,
+            objects::object::SemanticChange::FileModified {
+                path,
+                classification,
+                importance,
+                confidence
+            } if path == Path::new("lib.rs")
+                && classification == &Some(expected.0)
+                && importance == &Some(expected.1)
+                && confidence == &Some(expected.2)
+        )));
+        assert_eq!(cache.stats().stores, 2);
     }
 
     #[test]

--- a/crates/semantic/src/diff/diff_support.rs
+++ b/crates/semantic/src/diff/diff_support.rs
@@ -12,8 +12,9 @@ use objects::object::{DiffKind, FileChange, FileChangeSet, SemanticChange};
 use super::{diff_options::SemanticDiffOptions, diff_types::SemanticFallbackReason};
 use crate::{
     analysis::{
-        AggregationResult, classify_modification_with_confidence, detect_file_renames,
-        detect_function_changes_with_parsed, detect_import_changes_with_parsed,
+        classify_modification_with_confidence, classify_modification_with_parsed,
+        detect_file_renames, detect_function_changes_with_parsed,
+        detect_import_changes_with_parsed, AggregationResult,
     },
     parser::ParsedFile,
 };
@@ -87,7 +88,10 @@ pub(super) fn fallback_file_changes(file_changes: &FileChangeSet) -> Vec<Semanti
         .collect()
 }
 
-pub(super) fn build_file_level_changes(loaded: &[LoadedChange]) -> Vec<SemanticChange> {
+pub(super) fn build_file_level_changes(
+    loaded: &[LoadedChange],
+    parsed: Option<&ParsedChangeSet>,
+) -> Vec<SemanticChange> {
     let mut changes = Vec::with_capacity(loaded.len());
     for change in loaded {
         match change.change.kind {
@@ -97,7 +101,7 @@ pub(super) fn build_file_level_changes(loaded: &[LoadedChange]) -> Vec<SemanticC
             DiffKind::Added => changes.push(SemanticChange::FileAdded {
                 path: change.path.clone(),
             }),
-            DiffKind::Modified => push_modified_change(&mut changes, change),
+            DiffKind::Modified => push_modified_change(&mut changes, change, parsed),
             DiffKind::Unchanged => {}
         }
     }
@@ -264,13 +268,38 @@ fn import_dependency_names(parsed: &ParsedFile) -> HashSet<String> {
         .collect()
 }
 
-fn push_modified_change(changes: &mut Vec<SemanticChange>, change: &LoadedChange) {
+fn push_modified_change(
+    changes: &mut Vec<SemanticChange>,
+    change: &LoadedChange,
+    parsed: Option<&ParsedChangeSet>,
+) {
     let metadata = change
         .old_content
         .as_deref()
         .zip(change.new_content.as_deref())
         .map(|(old_content, new_content)| {
-            classify_modification_with_confidence(&change.path, old_content, new_content)
+            match parsed.and_then(|parsed| {
+                parsed
+                    .old
+                    .get(&change.path)
+                    .and_then(|value| value.as_deref())
+                    .zip(
+                        parsed
+                            .new
+                            .get(&change.path)
+                            .and_then(|value| value.as_deref()),
+                    )
+            }) {
+                Some((old_parsed, new_parsed)) => classify_modification_with_parsed(
+                    old_content,
+                    new_content,
+                    old_parsed,
+                    new_parsed,
+                ),
+                None => {
+                    classify_modification_with_confidence(&change.path, old_content, new_content)
+                }
+            }
         });
     changes.push(SemanticChange::FileModified {
         path: change.path.clone(),


### PR DESCRIPTION
## Summary

- Bound delta encoder per-key candidate scans and added an adversarial repeated-key round-trip regression.
- Reused cached semantic parses for file-level classification when parsed ASTs are already available, preserving the existing classifier fallback behavior.
- Replaced reasoning pipeline full-tree changed-file collection with an incremental tree diff that skips equal subtree hashes, plus a parent commit cache when the parent was already seen.

## Validation

- `cargo build --workspace --locked` passed.
- `cargo test -p heddle-format -p heddle-semantic -p heddle-ingest --locked` passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed.
- Bench grep found only `crates/semantic/benches/merge_function_level.rs`, which is not near these delta/diff/reasoning hot paths; the delta adversarial regression test is the perf proof here.

## Notes

Output preservation is pinned by round-trip/classification/path-set tests and existing suites. The reasoning tree-diff fixture compares the new incremental result against the old full-walk map result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786114230&installation_id=132405951&pr_number=977&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F977&signature=5045f188bd2639a09d07baabeb1cc4d8f5267439fe5429384f0e59969b38277b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->