### PR TITLE
chore(uuid,ci): OperationId → v7 + CI Postgres 18

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -448,7 +448,7 @@ jobs:
     timeout-minutes: 30
     services:
       postgres:
-        image: postgres:16
+        image: postgres:18
         env:
           POSTGRES_USER: heddle_test
           POSTGRES_PASSWORD: heddle_test

--- a/crates/objects/src/object/operation_id.rs
+++ b/crates/objects/src/object/operation_id.rs
@@ -18,7 +18,10 @@ pub struct OperationId(pub Uuid);
 
 impl OperationId {
     pub fn new() -> Self {
-        Self(Uuid::new_v4())
+        // v7 (time-ordered): OperationId is an idempotency/dedup key, never a
+        // secret, so a leaked creation-time is harmless and the ordering gives
+        // better index locality wherever these keys are persisted/indexed.
+        Self(Uuid::now_v7())
     }
 
     pub fn from_uuid(uuid: Uuid) -> Self {


### PR DESCRIPTION
Companion to weft #431 — the heddle half of the project-wide v4→v7 switch.

## Changes
- **`OperationId::new()` → `Uuid::now_v7()`** (`crates/objects/src/object/operation_id.rs`). It's an idempotency/dedup key, never a secret — security-audited across both repos (all real credentials use CSPRNG/Biscuit, not UUIDs). Time-ordered ids give better index locality where these keys persist.
- **CI Postgres 16 → 18** for parity with weft/dev. heddle has **no `gen_random_uuid()` DB defaults**, so no SQL change is needed — this is purely dev/CI parity + future-proofing.

## Left as-is (deliberate)
- The rebase-transaction id (`rebase_ops.rs`) stays v4: that string already leads with an explicit nanosecond timestamp, so its UUID is a pure random uniqueness suffix — v7 would just add a redundant timestamp.
- `pg_refs`/`pg_oplog` `new_v4()` sites are test scaffolding.

## Verification
`heddle-objects` builds + 366 tests pass; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786124616&installation_id=132405951&pr_number=978&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F978&signature=501840a44e9134aba601805dbce12a24c3644017d113a80da67e9a5764a90fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->