### PR TITLE
chore(deps): bump sley 0.4.0 → 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,9 +4304,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a1e920f9abd5089609cdda0554dd19fe5f919380fe4db83eb2fafa716ec5dc0"
+checksum = "eabaa8c695cbedf73cd5db5aed3afc4147cda1152c1c1b439b5794b851ab9725"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4328,27 +4328,27 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6863ac3547f6cd2e5644c725d51b0cb24c993240bcefdd264411dce0b5ecd3f0"
+checksum = "94faaa57b713cfb8c8d50a939627481fc523793e0b4a8b7b892c51afcf64dbd3"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1839ec62c5bb7f7bd4492fffa2a8f5c06d4960c9756386fe1300a7b0f7221d9"
+checksum = "528fb4d45fd8751a26852cdda26460ddf51ddcf5bfae668e5e0abbce9cef2304"
 dependencies = [
  "sha1 0.10.6",
 ]
 
 [[package]]
 name = "sley-diff-merge"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a194051cfedd5b767f6225b6a4435ffef62b5358c5aa32387f8db6458845c211"
+checksum = "28fd8e6b73a4b2b10fdfe5b4fb511a377e0bacf91a583c1a3c41433ce823bff5"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4363,9 +4363,9 @@ dependencies = [
 
 [[package]]
 name = "sley-formats"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09c9bc6f850c1d9373a3b67499f89306253b0ef3183c67b06f4769b2a357189"
+checksum = "7fb0b8dc669d636a9def11b8c25762d23524a6193dfa2f95173eb92a2e336b8d"
 dependencies = [
  "flate2",
  "sley-config",
@@ -4376,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "sley-fsck"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5395af31e3e52ca34c24cf1166c3ccde7e6dd65ce9bc86372b7dfecd7b8d298e"
+checksum = "4d1f34a0822f605ff55ed8b91612471a3eb14a6b0a618e766d4767b9581a99ac"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4390,18 +4390,18 @@ dependencies = [
 
 [[package]]
 name = "sley-grep"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6244732ff5719cabec18450c5e3381642c5fa7894705b377a6a619a35a031e36"
+checksum = "7bf1b140012f4cf26f6a209b4045be171fe96819e5be83836cdb85b740c0bc1b"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-index"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706a7a018b058914e174fa0711d5705a0a705f837dd5b9ec827e4ac96f25decc"
+checksum = "d8fa49be954798608e50bf3c5fda93084b825e84f14c570ff08993da11d8e20e"
 dependencies = [
  "sley-core",
  "sley-mmap",
@@ -4409,18 +4409,18 @@ dependencies = [
 
 [[package]]
 name = "sley-mmap"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f13c9e0ed603144b0780bc7c77f94700533cd551f8726cc9891e900bdd8b606"
+checksum = "5b6527a7eae78ef680bc00ef02c088c2c43667707524c11b0599821200afda4f"
 dependencies = [
  "memmap2",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a133c65a8572ca88f83b77778d73548cc141521d5c04c8545e2267aec50282"
+checksum = "8bd0957c53ec54a580607ff63d9380dcfbffffd19b96749eb11a44bc0740a381"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4433,18 +4433,18 @@ dependencies = [
 
 [[package]]
 name = "sley-object"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e44912d38ea716fff413613196a3e5fccb2e43a1496a80cbeb4e864220e5c85"
+checksum = "d205ad6a01d6dbdf4312a8645f180c5af44215ed38d59b9c6ebe0582479c4ac2"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc6a18e1c41bf0bb2c2eaccec3a27e9f401405ac5501217ca79dcebe87ac51c"
+checksum = "25a783d12ff01811f5fd055a6573b4ae3dc88d2129c4a51c1601f47e0606a12e"
 dependencies = [
  "flate2",
  "parking_lot",
@@ -4457,18 +4457,18 @@ dependencies = [
 
 [[package]]
 name = "sley-options"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b97bfcda678b1d9163d6f5c7a6ea967cd5ad4f3b7f917a431f11420c349469"
+checksum = "e0a517cd521c0304ddcbae36ca9244a7420262eca5b58e2303c2e85828ded17f"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pack"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac8569698a6337cfe0a32351388f49d790feb63bc01ba712c70cd54c39bf1aa"
+checksum = "7ce751041abf1254ea0f1b6ddc13bfeba9288d18ee1a5646faa7ef79fcd651f2"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -4479,18 +4479,18 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4d54aee1d435fe2cf6322bc70df3e7cb0167ba6dc032f988b102a4e6b63818"
+checksum = "d5dc3ceb3f153f07b58a47bcd1e3683ddc373184ee71c79d2cee3eeddf0fe4bb"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pretty"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7de52cf53ea3066a05fc0bf4d1d53cfcf50bde23e77f3c2ba45ee87174089bc"
+checksum = "eb6157e070655cc319d810472da68165a73968d0d3c1bc3205b5228552beee9e"
 dependencies = [
  "encoding_rs",
  "sley-config",
@@ -4505,18 +4505,18 @@ dependencies = [
 
 [[package]]
 name = "sley-protocol"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab62968c42efd180b3f04f2e639aa305212048d8ef2d6c5bad6c383c7d027ac"
+checksum = "53e226838051b476be89c201895bef404fe8ad14625ff281d62134db4309a66b"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-ref-filter"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b06e6fa4093382994927311623de75f9b788fb11b15c3f625e2ad32c2e19694"
+checksum = "f19614aa7392984063782b069f015319c5a08090dd71403100bc9c96a9d93a3f"
 dependencies = [
  "sley-core",
  "sley-strbuf-expand",
@@ -4524,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "sley-refs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47185792bc28d102149a36e0699268319a4863ac1996770b536cc124c5a686a0"
+checksum = "1ae53051846556a95f9753457247350f42cbeb4e834b4e6805add7ef4b261505"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4535,9 +4535,9 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34a3848edb219ebf99ca1f41aca4d50c7322deeb12245a3c027eb99ea9d3f92"
+checksum = "208255fbd3f506650fbab0a8d3e3b0fb942c15bf1bbb365bca61611e93e14396"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4555,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "sley-rev"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19cafc5ff337e2fc9ddcab84a4f3c8e61e0ca071416c1ccd8cb997e3559a9d62"
+checksum = "13ea2faf30a709200d29025c4c2dd44a989f553b5e54531302b3f4940fd6569e"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4574,9 +4574,9 @@ dependencies = [
 
 [[package]]
 name = "sley-sequencer"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453de2c95c84c7ab9b79851558affcaf15fe5745b4d380bd0f1ab239833a54ab"
+checksum = "9e5911e4d5fadc35221b5bac006ff895bf1dafc5f2716357915109b7e0dc3d64"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -4588,18 +4588,18 @@ dependencies = [
 
 [[package]]
 name = "sley-strbuf-expand"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce5dbae03a054a2d72a806a7503bd2b1699bee22f4c7bf2d08d591def846838"
+checksum = "be0b92bad35b32a9413f991a86b870667ea2da5cdebcd2918a55967f95384e47"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-submodule"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdbad8a2563530c4ac0f2cb46d2a4ae041cbe7d9e8adbffeee6df30e53695f0"
+checksum = "976339200f63726d1a1100732a51fea6675480c31849782210a9cc06d7c26830"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4607,9 +4607,9 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f177605f1d55d0356c2cdc937abcdd5b05a6e74dad067273d13f4c34a9023107"
+checksum = "6e3390ae70d30bbbc2cd20413e958242440ac55548d908939107bb855d4e6ea3"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4619,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ea7beac585898008eca3c9df6cc05277cf90d14d6685781eb6bbe965db418"
+checksum = "4f536b400f9bfb2a228bf8a33cc7dc46dca633dc0257aa153e2dc61f22199018"
 dependencies = [
  "encoding_rs",
  "sley-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4304,13 +4304,12 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "sley"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e5dfb5540857ea21ea49445a713ee704204860bb93cabdf930accdd0a12cc"
+checksum = "9a1e920f9abd5089609cdda0554dd19fe5f919380fe4db83eb2fafa716ec5dc0"
 dependencies = [
  "sley-config",
  "sley-core",
- "sley-diff-format",
  "sley-diff-merge",
  "sley-formats",
  "sley-grep",
@@ -4329,66 +4328,44 @@ dependencies = [
 
 [[package]]
 name = "sley-config"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abc5f4991a73047c939972061d8d1e272f79fafd4bd72615b8ed2eeeaa39c96e"
+checksum = "6863ac3547f6cd2e5644c725d51b0cb24c993240bcefdd264411dce0b5ecd3f0"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-core"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1798829d5393e5726fbfd453c74fb3187023e61bfe2d8184b9e654e530605a42"
+checksum = "e1839ec62c5bb7f7bd4492fffa2a8f5c06d4960c9756386fe1300a7b0f7221d9"
 dependencies = [
  "sha1 0.10.6",
 ]
 
 [[package]]
-name = "sley-diff-format"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0892de38e594012d916e153937c577c41ced0cfe088e8b17d4a8bcc7188c5fd8"
-dependencies = [
- "sley-config",
- "sley-core",
- "sley-diff-merge",
- "sley-grep",
-]
-
-[[package]]
 name = "sley-diff-merge"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5a5018ae395ea9e99b13ebe72914b06c402b21659a38fa19165dc95ac5031d"
+checksum = "a194051cfedd5b767f6225b6a4435ffef62b5358c5aa32387f8db6458845c211"
 dependencies = [
  "sley-config",
  "sley-core",
  "sley-formats",
+ "sley-grep",
  "sley-index",
  "sley-object",
  "sley-odb",
+ "sley-pack",
  "sley-refs",
 ]
 
 [[package]]
-name = "sley-fetch"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d543547a4bca62e89e5ab9bf7c5f3f21012f77618ec2b909f45fa1e09ecb55be"
-dependencies = [
- "sley-core",
- "sley-odb",
- "sley-protocol",
- "sley-transport",
-]
-
-[[package]]
 name = "sley-formats"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8936cb8acddf151ddb516a1efd02bf07c82323a9547301d72b991d356f4fba4"
+checksum = "b09c9bc6f850c1d9373a3b67499f89306253b0ef3183c67b06f4769b2a357189"
 dependencies = [
  "flate2",
  "sley-config",
@@ -4399,9 +4376,9 @@ dependencies = [
 
 [[package]]
 name = "sley-fsck"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "377505c6f934a047a589c48b59880cd60a0c1d5697453d2acbce2685378bbb4b"
+checksum = "5395af31e3e52ca34c24cf1166c3ccde7e6dd65ce9bc86372b7dfecd7b8d298e"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4413,61 +4390,64 @@ dependencies = [
 
 [[package]]
 name = "sley-grep"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d238531cf5ec5b2b4d0ce69f1d14cb8a5cba6b04484f6ebc7863b447e8b486"
+checksum = "6244732ff5719cabec18450c5e3381642c5fa7894705b377a6a619a35a031e36"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-index"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da1af696e2bc81c92966a88e1e1bf20306b261c5719ccd17ddf09113cee6f6db"
+checksum = "706a7a018b058914e174fa0711d5705a0a705f837dd5b9ec827e4ac96f25decc"
 dependencies = [
  "sley-core",
+ "sley-mmap",
 ]
 
 [[package]]
 name = "sley-mmap"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12130563149f518aed2cd8dcf856ed0a38d5b6fedf7e768e86fea9ce7b7f9f8c"
+checksum = "2f13c9e0ed603144b0780bc7c77f94700533cd551f8726cc9891e900bdd8b606"
 dependencies = [
  "memmap2",
 ]
 
 [[package]]
 name = "sley-notes"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fea827cfb302709f2b3ceef75425b953430a4f06cd49e3fde37a5bdd05b1560"
+checksum = "a5a133c65a8572ca88f83b77778d73548cc141521d5c04c8545e2267aec50282"
 dependencies = [
  "sley-config",
  "sley-core",
  "sley-object",
  "sley-odb",
  "sley-refs",
+ "sley-rev",
  "sley-sequencer",
 ]
 
 [[package]]
 name = "sley-object"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28510de0b80971e5f1f8c7a43fd017abd0cd4e2a626f5736b2bc4e7172d4f8a5"
+checksum = "3e44912d38ea716fff413613196a3e5fccb2e43a1496a80cbeb4e864220e5c85"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-odb"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e42b1141894f2b5a7bedc090ea4d340566f9ee1281e25ed31b0b2ac2082d290"
+checksum = "4bc6a18e1c41bf0bb2c2eaccec3a27e9f401405ac5501217ca79dcebe87ac51c"
 dependencies = [
  "flate2",
+ "parking_lot",
  "sley-core",
  "sley-formats",
  "sley-mmap",
@@ -4476,10 +4456,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "sley-pack"
-version = "0.4.0"
+name = "sley-options"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec22353f7ffb96d309200c5a7c002bb99632a938e85e1b1f20a2127bb1c9d021"
+checksum = "03b97bfcda678b1d9163d6f5c7a6ea967cd5ad4f3b7f917a431f11420c349469"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-pack"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac8569698a6337cfe0a32351388f49d790feb63bc01ba712c70cd54c39bf1aa"
 dependencies = [
  "crc32fast",
  "flate2",
@@ -4490,37 +4479,54 @@ dependencies = [
 
 [[package]]
 name = "sley-pathspec"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791ce05ddf1d1150e67b841e0a217796fb94a6143d35a5f0b008a15f3dfb4451"
+checksum = "1b4d54aee1d435fe2cf6322bc70df3e7cb0167ba6dc032f988b102a4e6b63818"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-pretty"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cd7edddaaf2fcd3e3bea53965c4ee6c4f17d0944042a5592d0461bb5ec7208"
+checksum = "b7de52cf53ea3066a05fc0bf4d1d53cfcf50bde23e77f3c2ba45ee87174089bc"
+dependencies = [
+ "encoding_rs",
+ "sley-config",
+ "sley-core",
+ "sley-object",
+ "sley-odb",
+ "sley-ref-filter",
+ "sley-refs",
+ "sley-rev",
+ "sley-strbuf-expand",
+]
+
+[[package]]
+name = "sley-protocol"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab62968c42efd180b3f04f2e639aa305212048d8ef2d6c5bad6c383c7d027ac"
+dependencies = [
+ "sley-core",
+]
+
+[[package]]
+name = "sley-ref-filter"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b06e6fa4093382994927311623de75f9b788fb11b15c3f625e2ad32c2e19694"
 dependencies = [
  "sley-core",
  "sley-strbuf-expand",
 ]
 
 [[package]]
-name = "sley-protocol"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16373a036549cb19b543919fcb14372992390faa39b3f64267b608106b630d5f"
-dependencies = [
- "sley-core",
-]
-
-[[package]]
 name = "sley-refs"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f62546457cb578bc8b205f4afa955908c98abcfb359ea656d93987561024164"
+checksum = "47185792bc28d102149a36e0699268319a4863ac1996770b536cc124c5a686a0"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4529,13 +4535,12 @@ dependencies = [
 
 [[package]]
 name = "sley-remote"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edbd4b49ee8fad778c61fe2309fbd4b0a071556bfa4a117c782522203f3cadc"
+checksum = "d34a3848edb219ebf99ca1f41aca4d50c7322deeb12245a3c027eb99ea9d3f92"
 dependencies = [
  "sley-config",
  "sley-core",
- "sley-fetch",
  "sley-formats",
  "sley-fsck",
  "sley-object",
@@ -4550,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "sley-rev"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e71780ea57a5a0dd5ddbf36a9a28217eca16c7d090d1a93e24fc50cbca6f4294"
+checksum = "19cafc5ff337e2fc9ddcab84a4f3c8e61e0ca071416c1ccd8cb997e3559a9d62"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4562,15 +4567,16 @@ dependencies = [
  "sley-mmap",
  "sley-object",
  "sley-odb",
+ "sley-options",
  "sley-pathspec",
  "sley-refs",
 ]
 
 [[package]]
 name = "sley-sequencer"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9263517a01ecd4a90294b00598e09792dc192afd6536851e169a26d9e8ef6ee3"
+checksum = "453de2c95c84c7ab9b79851558affcaf15fe5745b4d380bd0f1ab239833a54ab"
 dependencies = [
  "sley-core",
  "sley-formats",
@@ -4582,18 +4588,18 @@ dependencies = [
 
 [[package]]
 name = "sley-strbuf-expand"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171ee5775823f19d5d2436213b1bdf3c0ebb168fef0836ab5185aceb8ffe198b"
+checksum = "4ce5dbae03a054a2d72a806a7503bd2b1699bee22f4c7bf2d08d591def846838"
 dependencies = [
  "sley-core",
 ]
 
 [[package]]
 name = "sley-submodule"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91f464c5bb84373ead03875b7438c9aab1f8aaa099d2baa759a994b4288b675"
+checksum = "8cdbad8a2563530c4ac0f2cb46d2a4ae041cbe7d9e8adbffeee6df30e53695f0"
 dependencies = [
  "sley-config",
  "sley-core",
@@ -4601,10 +4607,11 @@ dependencies = [
 
 [[package]]
 name = "sley-transport"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf389ebe65186247411ab15f14adbbe5185f60572fce3f8c87ee6ddee052302"
+checksum = "f177605f1d55d0356c2cdc937abcdd5b05a6e74dad067273d13f4c34a9023107"
 dependencies = [
+ "sley-config",
  "sley-core",
  "sley-protocol",
  "ureq",
@@ -4612,9 +4619,9 @@ dependencies = [
 
 [[package]]
 name = "sley-worktree"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a73c0c0b56e0181ac40133c93634cc733a23ea785ac00457d17692bd31cc544"
+checksum = "d92ea7beac585898008eca3c9df6cc05277cf90d14d6685781eb6bbe965db418"
 dependencies = [
  "encoding_rs",
  "sley-config",
@@ -5000,7 +5007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ ed25519-dalek = { version = "3", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
 getrandom = { version = "0.4", features = ["sys_rng"] }
-sley = { version = "0.4.1", features = ["mmap", "fast-sha1"] }
+sley = { version = "0.4.2", features = ["mmap", "fast-sha1"] }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ ed25519-dalek = { version = "3", features = ["pem", "rand_core"] }
 fs2 = "0.4.3"
 futures = "0.3"
 getrandom = { version = "0.4", features = ["sys_rng"] }
-sley = { version = "0.4.0", features = ["mmap", "fast-sha1"] }
+sley = { version = "0.4.1", features = ["mmap", "fast-sha1"] }
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"

--- a/crates/cli/src/git_projection_engine/git_core.rs
+++ b/crates/cli/src/git_projection_engine/git_core.rs
@@ -2084,7 +2084,7 @@ fn fetch_heddle_notes_into_repo(
         url,
         &[refspec],
         FetchOptions {
-            // sley 0.4.1 negotiation/shallow controls — heddle uses defaults
+            // sley 0.4.2 negotiation/shallow controls — heddle uses defaults
             // (no CLI override; use remote config), matching git's defaults.
             negotiation_include: None,
             negotiation_restrict: None,

--- a/crates/cli/src/git_projection_engine/git_core.rs
+++ b/crates/cli/src/git_projection_engine/git_core.rs
@@ -2084,6 +2084,11 @@ fn fetch_heddle_notes_into_repo(
         url,
         &[refspec],
         FetchOptions {
+            // sley 0.4.1 negotiation/shallow controls — heddle uses defaults
+            // (no CLI override; use remote config), matching git's defaults.
+            negotiation_include: None,
+            negotiation_restrict: None,
+            reject_shallow: false,
             quiet: true,
             auto_follow_tags: false,
             fetch_all_tags: false,
@@ -3740,6 +3745,9 @@ fn clone_url_to_bare_via_sley(
             url,
             &heddle_mirror_fetch_refspecs()?,
             FetchOptions {
+                negotiation_include: None,
+                negotiation_restrict: None,
+                reject_shallow: false,
                 quiet: true,
                 auto_follow_tags: true,
                 fetch_all_tags: true,
@@ -3978,6 +3986,9 @@ fn fetch_network_remote(
             url,
             &heddle_mirror_fetch_refspecs()?,
             FetchOptions {
+                negotiation_include: None,
+                negotiation_restrict: None,
+                reject_shallow: false,
                 quiet: true,
                 auto_follow_tags: matches!(scope, GitFetchScope::AllRefs),
                 fetch_all_tags: matches!(scope, GitFetchScope::AllRefs),


### PR DESCRIPTION
## Summary
- Bumps heddle's sley manifest pin from `0.4.1` to `0.4.2`.
- Refreshes the resolved sley crate closure in `Cargo.lock` so `sley-transport` and the facade resolve to the published Windows fix.
- Keeps the existing `FetchOptions` negotiation/shallow defaults and updates the nearby version comment.

## Test evidence
```
$ cargo build --locked --workspace
   Compiling sley-core v0.4.2
   Compiling sley-transport v0.4.2
   Compiling sley v0.4.2
   Compiling heddle-mount v0.10.0 (/home/heddleco/dev/HeddleCo/workspace/sley041/crates/mount)
   Compiling heddle-cli v0.10.0 (/home/heddleco/dev/HeddleCo/workspace/sley041/crates/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3m 01s

$ cargo check -p heddle-mount --features projfs --target x86_64-pc-windows-gnu
    Checking sley-transport v0.4.2
    Checking sley-remote v0.4.2
    Checking sley v0.4.2
   Compiling heddle-mount v0.10.0 (/home/heddleco/dev/HeddleCo/workspace/sley041/crates/mount)
warning: unused import: `validate_symlink_target`
  --> crates/repo/src/repository_materialization.rs:26:52
   |
26 |     worktree_walk::{build_cached_entry, cache_key, validate_symlink_target},
   |                                                    ^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

warning: `heddle-repo` (lib) generated 1 warning (run `cargo fix --lib -p heddle-repo` to apply 1 suggestion)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 25s
```

## Manual verification
N/A — covered by tests

## Blocked by → resolved
- sley 0.4.2 is published on crates.io (`sley` 0.4.2 created 2026-07-08T19:28:41Z).
