### PR TITLE
feat(grpc): multi-repo event stream — SubscribeRepoEventsMulti + RepoEvent.repo_path (heddle-grpc 0.22, weft#504)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-grpc"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bytes",
  "prost 0.14.4",

--- a/clients/grpc/package-lock.json
+++ b/clients/grpc/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@heddleco/grpc",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@heddleco/grpc",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@bufbuild/protobuf": "^2.12.0",

--- a/clients/grpc/package.json
+++ b/clients/grpc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@heddleco/grpc",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Generated TypeScript protobuf and Connect clients for Heddle gRPC.",
   "license": "Apache-2.0",
   "repository": {

--- a/clients/grpc/src/gen/heddle/v1/repo_events_pb.ts
+++ b/clients/grpc/src/gen/heddle/v1/repo_events_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file heddle/v1/repo_events.proto.
  */
 export const file_heddle_v1_repo_events: GenFile = /*@__PURE__*/
-  fileDesc("ChtoZWRkbGUvdjEvcmVwb19ldmVudHMucHJvdG8SCWhlZGRsZS52MSJqChpTdWJzY3JpYmVSZXBvRXZlbnRzUmVxdWVzdBIPCgdyZXBvX2lkGAEgASgJEg4KBnRocmVhZBgCIAEoCRIWCg5hZnRlcl9ldmVudF9pZBgDIAEoAxITCgtldmVudF90eXBlcxgEIAMoCSL6AQoJUmVwb0V2ZW50EhAKCGV2ZW50X2lkGAEgASgDEg8KB3JlcG9faWQYAiABKAkSEgoKZXZlbnRfdHlwZRgDIAEoCRIOCgZ0aHJlYWQYBCABKAkSEAoIcmVmX25hbWUYBSABKAkSEQoJaXNfdGhyZWFkGAYgASgIEhEKCW9sZF9zdGF0ZRgHIAEoCRIRCgluZXdfc3RhdGUYCCABKAkSFQoNYWN0b3Jfc3ViamVjdBgJIAEoCRIUCgxwYXlsb2FkX2pzb24YCiABKAkSLgoKY3JlYXRlZF9hdBgLIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAyaAoQUmVwb0V2ZW50U2VydmljZRJUChNTdWJzY3JpYmVSZXBvRXZlbnRzEiUuaGVkZGxlLnYxLlN1YnNjcmliZVJlcG9FdmVudHNSZXF1ZXN0GhQuaGVkZGxlLnYxLlJlcG9FdmVudDABYgZwcm90bzM", [file_google_protobuf_timestamp]);
+  fileDesc("ChtoZWRkbGUvdjEvcmVwb19ldmVudHMucHJvdG8SCWhlZGRsZS52MSJqChpTdWJzY3JpYmVSZXBvRXZlbnRzUmVxdWVzdBIPCgdyZXBvX2lkGAEgASgJEg4KBnRocmVhZBgCIAEoCRIWCg5hZnRlcl9ldmVudF9pZBgDIAEoAxITCgtldmVudF90eXBlcxgEIAMoCSJaCh9TdWJzY3JpYmVSZXBvRXZlbnRzTXVsdGlSZXF1ZXN0EhIKCnJlcG9fcGF0aHMYASADKAkSDgoGdGhyZWFkGAIgASgJEhMKC2V2ZW50X3R5cGVzGAMgAygJIo0CCglSZXBvRXZlbnQSEAoIZXZlbnRfaWQYASABKAMSDwoHcmVwb19pZBgCIAEoCRISCgpldmVudF90eXBlGAMgASgJEg4KBnRocmVhZBgEIAEoCRIQCghyZWZfbmFtZRgFIAEoCRIRCglpc190aHJlYWQYBiABKAgSEQoJb2xkX3N0YXRlGAcgASgJEhEKCW5ld19zdGF0ZRgIIAEoCRIVCg1hY3Rvcl9zdWJqZWN0GAkgASgJEhQKDHBheWxvYWRfanNvbhgKIAEoCRIuCgpjcmVhdGVkX2F0GAsgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIRCglyZXBvX3BhdGgYDCABKAkyyAEKEFJlcG9FdmVudFNlcnZpY2USVAoTU3Vic2NyaWJlUmVwb0V2ZW50cxIlLmhlZGRsZS52MS5TdWJzY3JpYmVSZXBvRXZlbnRzUmVxdWVzdBoULmhlZGRsZS52MS5SZXBvRXZlbnQwARJeChhTdWJzY3JpYmVSZXBvRXZlbnRzTXVsdGkSKi5oZWRkbGUudjEuU3Vic2NyaWJlUmVwb0V2ZW50c011bHRpUmVxdWVzdBoULmhlZGRsZS52MS5SZXBvRXZlbnQwAWIGcHJvdG8z", [file_google_protobuf_timestamp]);
 
 /**
  * @generated from message heddle.v1.SubscribeRepoEventsRequest
@@ -45,6 +45,33 @@ export type SubscribeRepoEventsRequest = Message<"heddle.v1.SubscribeRepoEventsR
  */
 export const SubscribeRepoEventsRequestSchema: GenMessage<SubscribeRepoEventsRequest> = /*@__PURE__*/
   messageDesc(file_heddle_v1_repo_events, 0);
+
+/**
+ * @generated from message heddle.v1.SubscribeRepoEventsMultiRequest
+ */
+export type SubscribeRepoEventsMultiRequest = Message<"heddle.v1.SubscribeRepoEventsMultiRequest"> & {
+  /**
+   * @generated from field: repeated string repo_paths = 1;
+   */
+  repoPaths: string[];
+
+  /**
+   * @generated from field: string thread = 2;
+   */
+  thread: string;
+
+  /**
+   * @generated from field: repeated string event_types = 3;
+   */
+  eventTypes: string[];
+};
+
+/**
+ * Describes the message heddle.v1.SubscribeRepoEventsMultiRequest.
+ * Use `create(SubscribeRepoEventsMultiRequestSchema)` to create a new message.
+ */
+export const SubscribeRepoEventsMultiRequestSchema: GenMessage<SubscribeRepoEventsMultiRequest> = /*@__PURE__*/
+  messageDesc(file_heddle_v1_repo_events, 1);
 
 /**
  * @generated from message heddle.v1.RepoEvent
@@ -104,6 +131,13 @@ export type RepoEvent = Message<"heddle.v1.RepoEvent"> & {
    * @generated from field: google.protobuf.Timestamp created_at = 11;
    */
   createdAt?: Timestamp | undefined;
+
+  /**
+   * Visible path of repo_id, for multi-repo client routing.
+   *
+   * @generated from field: string repo_path = 12;
+   */
+  repoPath: string;
 };
 
 /**
@@ -111,7 +145,7 @@ export type RepoEvent = Message<"heddle.v1.RepoEvent"> & {
  * Use `create(RepoEventSchema)` to create a new message.
  */
 export const RepoEventSchema: GenMessage<RepoEvent> = /*@__PURE__*/
-  messageDesc(file_heddle_v1_repo_events, 1);
+  messageDesc(file_heddle_v1_repo_events, 2);
 
 /**
  * @generated from service heddle.v1.RepoEventService
@@ -123,6 +157,14 @@ export const RepoEventService: GenService<{
   subscribeRepoEvents: {
     methodKind: "server_streaming";
     input: typeof SubscribeRepoEventsRequestSchema;
+    output: typeof RepoEventSchema;
+  },
+  /**
+   * @generated from rpc heddle.v1.RepoEventService.SubscribeRepoEventsMulti
+   */
+  subscribeRepoEventsMulti: {
+    methodKind: "server_streaming";
+    input: typeof SubscribeRepoEventsMultiRequestSchema;
     output: typeof RepoEventSchema;
   },
 }> = /*@__PURE__*/

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,7 +40,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.21" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.22" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-core = { path = "../core", version = "0.10", default-features = false }
 heddle-format = { path = "../format", version = "0.10" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -36,7 +36,7 @@ tracing.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.21" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.22" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.10" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
-grpc = { path = "../grpc", package = "heddle-grpc", version = "0.21" }
+grpc = { path = "../grpc", package = "heddle-grpc", version = "0.22" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }

--- a/crates/grpc/Cargo.toml
+++ b/crates/grpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heddle-grpc"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 authors.workspace = true
 description.workspace = true

--- a/crates/grpc/proto/heddle/v1/repo_events.proto
+++ b/crates/grpc/proto/heddle/v1/repo_events.proto
@@ -6,6 +6,7 @@ import "google/protobuf/timestamp.proto";
 
 service RepoEventService {
   rpc SubscribeRepoEvents(SubscribeRepoEventsRequest) returns (stream RepoEvent);
+  rpc SubscribeRepoEventsMulti(SubscribeRepoEventsMultiRequest) returns (stream RepoEvent);
 }
 
 message SubscribeRepoEventsRequest {
@@ -13,6 +14,12 @@ message SubscribeRepoEventsRequest {
   string thread = 2;
   int64 after_event_id = 3;
   repeated string event_types = 4;
+}
+
+message SubscribeRepoEventsMultiRequest {
+  repeated string repo_paths = 1;
+  string thread = 2;
+  repeated string event_types = 3;
 }
 
 message RepoEvent {
@@ -27,4 +34,6 @@ message RepoEvent {
   string actor_subject = 9;
   string payload_json = 10;
   google.protobuf.Timestamp created_at = 11;
+  // Visible path of repo_id, for multi-repo client routing.
+  string repo_path = 12;
 }


### PR DESCRIPTION
## What changed

- Add `RepoEventService.SubscribeRepoEventsMulti`, returning a merged stream of `RepoEvent` values.
- Add `SubscribeRepoEventsMultiRequest` with `repo_paths = 1`, `thread = 2`, and `event_types = 3`.
- Add `RepoEvent.repo_path = 12` for visible-path client routing.
- Regenerate the TypeScript gRPC client using the canonical devtool.
- Bump `heddle-grpc`, `@heddleco/grpc`, inter-crate pins, and `Cargo.lock` from 0.21 to 0.22.

## Why

This is the additive proto contract required by heddle#1003 / weft#504 so weft can replace N per-repository subscriptions with one caller-scoped multi-repository event stream keyed by visible repository paths.

The existing `SubscribeRepoEventsRequest` fields 1–4 and `RepoEvent` fields 1–11 are unchanged. No handlers or publishing changes are included.

## Validation

- `cargo run --locked -p heddle-devtools -- grpc-ts`
- `cargo run --locked -p heddle-devtools -- grpc-ts --check`
- `cargo build --locked`
- `cargo build --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`

Closes #1003. Downstream handler work: weft#504.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1004"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786427453&installation_id=132405951&pr_number=1004&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1004&signature=5a6a13e0fc72f03f8bdd5e1586f19f5f1afadeab27db19589111c2eec0b9a814"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->