### PR TITLE
perf(oplog): early-break the packed-batch since-scan on the newest-first invariant (heddle#878)

### DIFF
--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -561,8 +561,11 @@ impl PackedOpLogIndex {
         let mut batches = Vec::new();
 
         for record in batch_dir {
+            #[cfg(test)]
+            BATCH_DIR_RECORDS_VISITED.with(|visits| visits.set(visits.get() + 1));
             if record.newest_entry_id <= since_head_id {
-                continue;
+                // Fsck enforces newest-first order, so every remaining batch is also at/before it.
+                break;
             }
             if let Some(scope) = scope
                 && record.scope_state == ScopeState::None as u8
@@ -993,6 +996,11 @@ impl PackedOpLogIndex {
             HeddleError::InvalidObject("oplog index missing OpRecord schema version".to_string())
         })
     }
+}
+
+#[cfg(test)]
+thread_local! {
+    static BATCH_DIR_RECORDS_VISITED: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
 }
 
 impl PackedFooter {
@@ -3583,6 +3591,40 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![1, 2, 5, 6]
         );
+    }
+
+    #[test]
+    fn index_collect_batches_after_stops_at_newest_first_since_boundary() {
+        const BATCH_COUNT: u64 = 128;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("oplog.bin");
+        let mut log = PackedOpLog::new(path.clone());
+        log.append(
+            (1..=BATCH_COUNT)
+                .map(|id| make_entry(id, None))
+                .collect(),
+        );
+        log.head_id = BATCH_COUNT;
+        log.save().unwrap();
+
+        let index = PackedOpLogIndex::open(&path).unwrap();
+        BATCH_DIR_RECORDS_VISITED.with(|visits| visits.set(0));
+        let batches = index
+            .collect_batches_after_scoped(BATCH_COUNT - 2, usize::MAX, |_| true, None)
+            .unwrap();
+
+        assert_eq!(
+            batches.iter().map(|batch| batch.id).collect::<Vec<_>>(),
+            vec![BATCH_COUNT, BATCH_COUNT - 1]
+        );
+        BATCH_DIR_RECORDS_VISITED.with(|visits| {
+            assert_eq!(
+                visits.get(),
+                3,
+                "the newest-first batch directory must stop at the since boundary"
+            );
+        });
     }
 
     #[test]


### PR DESCRIPTION
## What changed

- Stop the packed oplog batch-directory since-cursor scan at the first batch whose newest entry is at or before the cursor.
- Document the fsck-enforced newest-first invariant that makes the early break valid.
- Add a deterministic regression test that instruments batch-directory visits across 128 batches.

## Why

The previous `continue` traversed the entire remaining batch history after reaching the since boundary. Reconcile passes `usize::MAX`, so the count limit did not bound this hot path, making lagging-ref reads/writes O(total history).

With the newest-first invariant, every later batch is also at or before the cursor, so the scan can terminate immediately.

## Validation

- `cargo build --locked`
- `cargo test --locked -p heddle-oplog` (49 passed)
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- RED proof: old `continue` visited 128 records where the test expected 3
- GREEN proof: new `break` visits exactly 3 records and returns the expected two batches

No `OpRecord` match was touched, so the devtools exhaustiveness gate is not applicable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786478832&installation_id=132405951&pr_number=1005&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1005&signature=c45f9ff3eeae941d5eb273808ea56d05cb768c678a056d6ab0572921c7165e55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->