### PR TITLE
ci(publish): add heddle-git-projection to publish set (unblock 0.10.1)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -90,9 +90,10 @@ env:
     heddle-grpc
     weft-client-shim
     heddle-client
+    heddle-ingest
+    heddle-git-projection
     heddle-core
     heddle-daemon
-    heddle-ingest
     heddle-mount
     heddle-cli
     heddle-devtools

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -56,6 +56,10 @@ name = "heddle-ingest"
 release = true
 
 [[package]]
+name = "heddle-git-projection"
+release = true
+
+[[package]]
 name = "heddle-mount"
 release = true
 


### PR DESCRIPTION
## Why
The heddle 0.10.1 auto-publish ([run 29214083212](https://github.com/HeddleCo/heddle/actions/runs/29214083212)) died at `heddle-core`:
```
error: failed to prepare local package for uploading
Caused by: no matching package named `heddle-git-projection` found
```
`heddle-core` gained a `[dependencies]` edge to `heddle-git-projection` (landed by the #985 arch-redo), but that crate was never added to `PUBLISHABLE_CRATES` / `release-plz.toml` — so it's absent from crates.io and core can't resolve it. 0.10.0 published fine because the edge didn't exist yet. **16 crates are already live at 0.10.1** (through `heddle-client`).

## Fix
- **`PUBLISHABLE_CRATES`**: add `heddle-git-projection`; reorder the tail so `ingest → git-projection → core` (git-projection also needs `heddle-ingest`, which previously sat *after* core). Validated: **0 topo violations**, set == the 23 publishable crates, `check-publish-pipeline.sh` green.
- **`release-plz.toml`**: add the `heddle-git-projection` `[[package]]` block.

## After merge
Merging re-fires `publish-crates.yml` (paths includes the workflow). Idempotent resume: the 16 already-live crates short-circuit on the version probe; then `ingest → git-projection → core → daemon → mount → cli → devtools` publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786493058&installation_id=132405951&pr_number=1010&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1010&signature=2e2691f4baba67fd915e62467236a651974ea11a398d140ca95dc38e7686ecb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->