### PR TITLE
feat(auth): headless credential install (auth login --token/--key-file) + fix private_key alias (heddle#1014, headless-agent P0)

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -12408,6 +12408,9 @@
           ],
           "type": "string"
         },
+        "proof_key_available": {
+          "type": "boolean"
+        },
         "recommended_action": {
           "type": [
             "string",
@@ -12427,7 +12430,8 @@
       "required": [
         "output_kind",
         "server",
-        "authenticated"
+        "authenticated",
+        "proof_key_available"
       ],
       "title": "AuthStatusSchema",
       "type": "object"

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -446,6 +446,7 @@ export interface AuthStatusSchema {
   credential_id?: string | null;
   expires_at?: string | null;
   output_kind: "auth_status";
+  proof_key_available: boolean;
   recommended_action?: string | null;
   server: string;
   subject?: string | null;

--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -7,13 +7,21 @@ use clap::Subcommand;
 pub enum AuthCommands {
     /// Authenticate with a Heddle server
     Login {
-        /// Heddle server address
-        #[arg(long, default_value = "grpc.heddle.sh")]
-        server: String,
+        /// Heddle server address (required for headless credential install).
+        #[arg(long)]
+        server: Option<String>,
 
         /// Open the authorization URL in the system browser.
-        #[arg(long)]
+        #[arg(long, conflicts_with = "token")]
         open_browser: bool,
+
+        /// Install an existing Biscuit credential without opening a browser.
+        #[arg(long, requires_all = ["key_file", "server"])]
+        token: Option<String>,
+
+        /// Device private-key PEM matching the token's proof key.
+        #[arg(long, value_name = "PEM_PATH", requires = "token")]
+        key_file: Option<std::path::PathBuf>,
     },
 
     /// Remove stored credentials for a server
@@ -55,9 +63,13 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
             AuthCommands::Login {
                 server,
                 open_browser,
+                token,
+                key_file,
             } => heddle_client::AuthCommand::Login {
                 server,
                 open_browser,
+                token,
+                key_file,
             },
             AuthCommands::Logout { server } => heddle_client::AuthCommand::Logout { server },
             AuthCommands::Status { server } => heddle_client::AuthCommand::Status { server },
@@ -75,5 +87,81 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
                 show_secrets,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::Parser;
+
+    use crate::cli::{AuthCommands, Cli, Commands};
+
+    #[test]
+    fn login_parses_headless_token_and_key_file() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "login",
+            "--server",
+            "127.0.0.1:8421",
+            "--token",
+            "biscuit-token",
+            "--key-file",
+            "/run/secrets/device.pem",
+        ])
+        .expect("headless login flags parse");
+
+        let Commands::Auth {
+            command:
+                AuthCommands::Login {
+                    server,
+                    token,
+                    key_file,
+                    open_browser,
+                },
+        } = cli.command
+        else {
+            panic!("expected auth login");
+        };
+        assert_eq!(server.as_deref(), Some("127.0.0.1:8421"));
+        assert_eq!(token.as_deref(), Some("biscuit-token"));
+        assert_eq!(
+            key_file.as_deref(),
+            Some(std::path::Path::new("/run/secrets/device.pem"))
+        );
+        assert!(!open_browser);
+    }
+
+    #[test]
+    fn login_requires_token_and_key_file_together() {
+        for incomplete in [
+            vec!["--token", "biscuit-token"],
+            vec!["--key-file", "/run/secrets/device.pem"],
+        ] {
+            let mut args = vec!["heddle", "auth", "login"];
+            args.extend(incomplete);
+            assert!(
+                Cli::try_parse_from(args).is_err(),
+                "incomplete headless credential must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn headless_login_requires_an_explicit_server() {
+        assert!(
+            Cli::try_parse_from([
+                "heddle",
+                "auth",
+                "login",
+                "--token",
+                "biscuit-token",
+                "--key-file",
+                "/run/secrets/device.pem",
+            ])
+            .is_err()
+        );
+        Cli::try_parse_from(["heddle", "auth", "login"])
+            .expect("interactive login may resolve the configured default server");
     }
 }

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -660,6 +660,7 @@ pub struct AuthStatusSchema {
     pub output_kind: String,
     pub server: String,
     pub authenticated: bool,
+    pub proof_key_available: bool,
     pub subject: Option<String>,
     pub credential_id: Option<String>,
     pub expires_at: Option<String>,

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -1,5 +1,7 @@
 //! `heddle auth` command implementations.
 
+use std::path::Path;
+
 use anyhow::{Context, Result, bail};
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::v1::{
@@ -40,6 +42,7 @@ struct AuthStatusOutput {
     output_kind: &'static str,
     server: String,
     authenticated: bool,
+    proof_key_available: bool,
     subject: Option<String>,
     credential_id: Option<String>,
     expires_at: Option<String>,
@@ -72,7 +75,25 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         AuthCommand::Login {
             server,
             open_browser,
-        } => cmd_auth_login(&server, open_browser).await,
+            token,
+            key_file,
+        } => match (token, key_file) {
+            (Some(token), Some(key_file)) => {
+                let server = server.as_deref().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "--server is required with --token/--key-file so a headless install cannot target the wrong server"
+                    )
+                })?;
+                let subject = install_headless_credential(server, &token, &key_file)?;
+                println!("Authenticated as {subject}. Credentials saved.");
+                Ok(())
+            }
+            (None, None) => {
+                let server = resolve_server(server.as_deref())?;
+                cmd_auth_login(&server, open_browser).await
+            }
+            _ => bail!("--token and --key-file must be provided together"),
+        },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
         AuthCommand::Status { server } => cmd_auth_status(ctx, server.as_deref()),
         AuthCommand::CreateServiceToken {
@@ -93,6 +114,126 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             .await
         }
     }
+}
+
+struct HeadlessTokenMetadata {
+    subject: String,
+    credential_id: Option<String>,
+    expires_at: Option<String>,
+    proof_public_key_hex: String,
+}
+
+/// Install an operator-provisioned, device-bound credential without a browser.
+pub(crate) fn install_headless_credential(
+    server: &str,
+    token: &str,
+    key_file: &Path,
+) -> Result<String> {
+    let token = token.trim();
+    if token.is_empty() {
+        bail!("--token must not be empty");
+    }
+
+    let private_key_pem = std::fs::read_to_string(key_file)
+        .with_context(|| format!("reading device private key from {}", key_file.display()))?;
+    let signer = Ed25519Signer::from_pem(&private_key_pem)
+        .map_err(|error| anyhow::anyhow!("invalid Ed25519 device private key: {error}"))?;
+    let metadata = headless_token_metadata(token)?;
+    let public_key_hex = hex::encode(signer.public_key());
+    if !metadata
+        .proof_public_key_hex
+        .eq_ignore_ascii_case(&public_key_hex)
+    {
+        bail!(
+            "device private key does not match the token's device proof key; install the matching bootstrap key"
+        );
+    }
+
+    let credential = ServerCredential {
+        token: token.to_string(),
+        subject: metadata.subject.clone(),
+        device_id: None,
+        credential_id: metadata.credential_id,
+        private_key_pem: Some(private_key_pem.clone()),
+        expires_at: metadata.expires_at,
+    };
+    credentials::store_server_credential(server, credential)?;
+    repo::identity::link_device_key(signer.public_key(), &private_key_pem, server)
+        .with_context(|| format!("registering device identity for {server}"))?;
+
+    Ok(metadata.subject)
+}
+
+fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
+    use biscuit_auth::builder::{BlockBuilder, Term};
+
+    let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
+        .context("parsing --token as a Biscuit")?;
+    let authority_source = biscuit
+        .print_block_source(0)
+        .context("reading Biscuit authority block")?;
+    let authority = BlockBuilder::new()
+        .code(&authority_source)
+        .context("parsing Biscuit authority facts")?;
+
+    let string_fact = |name: &str| -> Result<Option<String>> {
+        let mut values = authority.facts.iter().filter_map(|fact| {
+            if fact.predicate.name != name || fact.predicate.terms.len() != 1 {
+                return None;
+            }
+            match &fact.predicate.terms[0] {
+                Term::Str(value) => Some(value.clone()),
+                _ => None,
+            }
+        });
+        let value = values.next();
+        if values.next().is_some() {
+            bail!("Biscuit authority block contains multiple {name} facts");
+        }
+        Ok(value)
+    };
+
+    let subject = string_fact("user")?
+        .filter(|subject| !subject.trim().is_empty())
+        .ok_or_else(|| anyhow::anyhow!("Biscuit authority block is missing user(subject)"))?;
+    let credential_id = string_fact("credential_id")?;
+    let proof_public_key_hex = string_fact("device_pop_key")?.ok_or_else(|| {
+        anyhow::anyhow!(
+            "Biscuit is not device-bound: authority block is missing device_pop_key(key)"
+        )
+    })?;
+    hex::decode(&proof_public_key_hex)
+        .context("Biscuit device_pop_key is not valid hexadecimal")?;
+
+    let mut expiries = authority.facts.iter().filter_map(|fact| {
+        if fact.predicate.name != "expires_at" || fact.predicate.terms.len() != 1 {
+            return None;
+        }
+        match fact.predicate.terms[0] {
+            Term::Date(seconds) => Some(seconds),
+            _ => None,
+        }
+    });
+    let expires_at = expiries
+        .next()
+        .map(|seconds| {
+            i64::try_from(seconds)
+                .ok()
+                .and_then(|seconds| chrono::DateTime::from_timestamp(seconds, 0))
+                .map(|expires_at| expires_at.to_rfc3339())
+                .ok_or_else(|| anyhow::anyhow!("Biscuit expires_at is outside the supported range"))
+        })
+        .transpose()?;
+    if expiries.next().is_some() {
+        bail!("Biscuit authority block contains multiple expires_at facts");
+    }
+
+    Ok(HeadlessTokenMetadata {
+        subject,
+        credential_id,
+        expires_at,
+        proof_public_key_hex,
+    })
 }
 
 /// Authenticate via device authorization flow.
@@ -246,50 +387,70 @@ fn cmd_auth_logout(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
 /// Show current authentication status.
 fn cmd_auth_status(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     let server = resolve_server(server)?;
-    match credentials::get_server_credential(&server)? {
-        Some(cred) => {
-            if ctx.should_output_json(None) {
-                let output = AuthStatusOutput {
-                    output_kind: "auth_status",
-                    server,
-                    authenticated: true,
-                    subject: Some(cred.subject),
-                    credential_id: cred.credential_id,
-                    expires_at: cred.expires_at,
-                    recommended_action: None,
-                };
-                println!("{}", serde_json::to_string(&output)?);
-            } else {
-                println!("Server:        {server}");
-                println!("Subject:       {}", cred.subject);
-                if let Some(ref cred_id) = cred.credential_id {
-                    println!("Credential:    {cred_id}");
-                }
-                if let Some(ref expires) = cred.expires_at {
-                    println!("Expires:       {expires}");
-                }
+    let output = auth_status_output(&server, credentials::get_server_credential(&server)?);
+    if ctx.should_output_json(None) {
+        println!("{}", serde_json::to_string(&output)?);
+    } else if output.authenticated {
+        println!("Server:        {server}");
+        println!(
+            "Subject:       {}",
+            output.subject.as_deref().unwrap_or_default()
+        );
+        if let Some(ref cred_id) = output.credential_id {
+            println!("Credential:    {cred_id}");
+        }
+        if let Some(ref expires) = output.expires_at {
+            println!("Expires:       {expires}");
+        }
+        if output.proof_key_available {
+            println!("Hosted writes: ready (device proof key available)");
+        } else {
+            println!(
+                "Hosted writes: unavailable — credential missing device proof key; re-login / re-install"
+            );
+            if let Some(ref action) = output.recommended_action {
+                println!("Run `{action}` to repair the credential.");
             }
         }
-        None => {
-            let recommended_action = format!("heddle auth login --server {server}");
-            if ctx.should_output_json(None) {
-                let output = AuthStatusOutput {
-                    output_kind: "auth_status",
-                    server,
-                    authenticated: false,
-                    subject: None,
-                    credential_id: None,
-                    expires_at: None,
-                    recommended_action: Some(recommended_action),
-                };
-                println!("{}", serde_json::to_string(&output)?);
-            } else {
-                println!("Not authenticated with {server}.");
-                println!("Run `{recommended_action}` to authenticate.");
-            }
+    } else {
+        println!("Not authenticated with {server}.");
+        if let Some(ref action) = output.recommended_action {
+            println!("Run `{action}` to authenticate.");
         }
     }
     Ok(())
+}
+
+fn auth_status_output(server: &str, credential: Option<ServerCredential>) -> AuthStatusOutput {
+    match credential {
+        Some(credential) => {
+            let proof_key_available = credential
+                .private_key_pem
+                .as_deref()
+                .is_some_and(|pem| Ed25519Signer::from_pem(pem).is_ok());
+            AuthStatusOutput {
+                output_kind: "auth_status",
+                server: server.to_string(),
+                authenticated: true,
+                proof_key_available,
+                subject: Some(credential.subject),
+                credential_id: credential.credential_id,
+                expires_at: credential.expires_at,
+                recommended_action: (!proof_key_available)
+                    .then(|| format!("heddle auth login --server {server}")),
+            }
+        }
+        None => AuthStatusOutput {
+            output_kind: "auth_status",
+            server: server.to_string(),
+            authenticated: false,
+            proof_key_available: false,
+            subject: None,
+            credential_id: None,
+            expires_at: None,
+            recommended_action: Some(format!("heddle auth login --server {server}")),
+        },
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1296,6 +1457,37 @@ mod tests {
             private_key_pem: None,
             expires_at: None,
         }
+    }
+
+    #[test]
+    fn auth_status_qualifies_a_credential_without_a_proof_key() {
+        let output = auth_status_output("grpc.S", Some(sample_credential()));
+
+        assert!(output.authenticated);
+        assert!(!output.proof_key_available);
+        assert!(
+            output
+                .recommended_action
+                .as_deref()
+                .is_some_and(|action| action.contains("auth login --server grpc.S"))
+        );
+    }
+
+    #[tokio::test]
+    async fn headless_login_requires_an_explicit_server() {
+        let error = cmd_auth(
+            &TextCtx,
+            AuthCommand::Login {
+                server: None,
+                open_browser: false,
+                token: Some("token".to_string()),
+                key_file: Some(std::path::PathBuf::from("device.pem")),
+            },
+        )
+        .await
+        .expect_err("headless install without --server must fail closed");
+
+        assert!(error.to_string().contains("--server is required"));
     }
 
     /// On a successful logout, both the credential and the matching device

--- a/crates/client/src/auth_requests.rs
+++ b/crates/client/src/auth_requests.rs
@@ -3,8 +3,10 @@
 #[derive(Clone, Debug)]
 pub enum AuthCommand {
     Login {
-        server: String,
+        server: Option<String>,
         open_browser: bool,
+        token: Option<String>,
+        key_file: Option<std::path::PathBuf>,
     },
     Logout {
         server: Option<String>,

--- a/crates/client/src/credentials.rs
+++ b/crates/client/src/credentials.rs
@@ -45,7 +45,11 @@ pub struct ServerCredential {
     pub device_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_id: Option<String>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        alias = "private_key",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub private_key_pem: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,

--- a/crates/client/src/credentials.rs
+++ b/crates/client/src/credentials.rs
@@ -271,6 +271,27 @@ mod tests {
         let _ = fs::remove_dir_all(home);
     }
 
+    #[test]
+    fn legacy_private_key_loads_and_saves_as_private_key_pem() {
+        let legacy = r#"
+[servers."heddle.example:8421"]
+token = "token-123"
+subject = "dev"
+private_key = "legacy-pem"
+"#;
+
+        let store: CredentialStore = toml::from_str(legacy).expect("load legacy credential");
+        let credential = store
+            .servers
+            .get("heddle.example:8421")
+            .expect("legacy credential");
+        assert_eq!(credential.private_key_pem.as_deref(), Some("legacy-pem"));
+
+        let canonical = toml::to_string_pretty(&store).expect("serialize canonical credential");
+        assert!(canonical.contains("private_key_pem = \"legacy-pem\""));
+        assert!(!canonical.contains("\nprivate_key ="));
+    }
+
     #[cfg(unix)]
     #[test]
     fn save_credentials_writes_credential_file_0600() {

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -162,14 +162,22 @@ pub(super) fn descriptor_id_from_info(info: &ObjectInfo) -> (String, String) {
 }
 
 pub(super) fn status_to_protocol_error(status: Status) -> ProtocolError {
+    let message = if status.message().contains("missing x-heddle-proof-ts") {
+        format!(
+            "{}; credential missing device proof key — re-login / re-install the credential with its matching private key",
+            status.message()
+        )
+    } else {
+        status.message().to_string()
+    };
     match status.code() {
         tonic::Code::Unauthenticated | tonic::Code::PermissionDenied => {
-            ProtocolError::AuthorizationFailed(status.message().to_string())
+            ProtocolError::AuthorizationFailed(message)
         }
-        tonic::Code::NotFound => ProtocolError::ObjectNotFound(status.message().to_string()),
-        tonic::Code::AlreadyExists => ProtocolError::AlreadyExists(status.message().to_string()),
-        tonic::Code::InvalidArgument => ProtocolError::InvalidState(status.message().to_string()),
-        _ => ProtocolError::Remote(status.message().to_string()),
+        tonic::Code::NotFound => ProtocolError::ObjectNotFound(message),
+        tonic::Code::AlreadyExists => ProtocolError::AlreadyExists(message),
+        tonic::Code::InvalidArgument => ProtocolError::InvalidState(message),
+        _ => ProtocolError::Remote(message),
     }
 }
 
@@ -228,5 +236,21 @@ pub(super) fn hosted_role_proto_to_string(role: i32) -> String {
         HostedRole::Admin => "admin".into(),
         HostedRole::Owner => "owner".into(),
         HostedRole::Unspecified => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_proof_timestamp_error_explains_how_to_recover() {
+        let error = status_to_protocol_error(Status::unauthenticated(
+            "missing x-heddle-proof-ts metadata",
+        ));
+        let message = error.to_string();
+
+        assert!(message.contains("credential missing device proof key"));
+        assert!(message.contains("re-login / re-install"));
     }
 }

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -164,4 +164,152 @@ mod tests {
              same async block (found {rotate_offset} chars later)",
         );
     }
+
+    #[tokio::test]
+    async fn headless_install_supplies_a_verifiable_hosted_proof() {
+        use base64::Engine as _;
+        use biscuit_auth::{Biscuit, KeyPair};
+        use crypto::{Ed25519Signer, Signer};
+        use tonic::{Request, metadata::MetadataValue, transport::Endpoint};
+
+        use super::{HostedAuthMode, HostedSession};
+        use crate::{auth_cmd, credentials, grpc_hosted::HostedGrpcClient};
+
+        let _guard = credentials::lock_test_env();
+        let home = tempfile::TempDir::new().expect("temp Heddle home");
+        let previous_home = std::env::var_os("HEDDLE_HOME");
+        unsafe { std::env::set_var("HEDDLE_HOME", home.path()) };
+
+        let result = std::panic::catch_unwind(|| {
+            let signer = Ed25519Signer::generate().expect("device key");
+            let private_key_pem = signer.to_pem().expect("device PEM");
+            let key_path = home.path().join("bootstrap-key.pem");
+            std::fs::write(&key_path, &private_key_pem).expect("write bootstrap key");
+
+            let subject = "headless-agent";
+            let credential_id = "cred-headless";
+            let expires_at = chrono::Utc::now() + chrono::Duration::days(30);
+            let user_fact = format!("user(\"{subject}\")");
+            let credential_fact = format!("credential_id(\"{credential_id}\")");
+            let expiry_fact = format!("expires_at({})", expires_at.to_rfc3339());
+            let pop_fact = format!("device_pop_key(\"{}\")", hex::encode(signer.public_key()));
+            let token = Biscuit::builder()
+                .fact(user_fact.as_str())
+                .expect("user fact")
+                .fact(credential_fact.as_str())
+                .expect("credential fact")
+                .fact(expiry_fact.as_str())
+                .expect("expiry fact")
+                .fact(pop_fact.as_str())
+                .expect("PoP key fact")
+                .build(&KeyPair::new())
+                .expect("mint fixture biscuit")
+                .to_base64()
+                .expect("encode fixture biscuit");
+            let server = "127.0.0.1:8421";
+
+            auth_cmd::install_headless_credential(server, &token, &key_path)
+                .expect("headless credential install");
+
+            let stored = credentials::get_server_credential(server)
+                .expect("read credentials")
+                .expect("stored credential");
+            assert_eq!(stored.subject, subject);
+            assert_eq!(stored.credential_id.as_deref(), Some(credential_id));
+            assert_eq!(
+                stored.private_key_pem.as_deref(),
+                Some(private_key_pem.as_str())
+            );
+            assert!(stored.expires_at.is_some());
+            let credential_file = std::fs::read_to_string(credentials::credentials_path())
+                .expect("read installed credential file");
+            assert!(credential_file.contains("private_key_pem ="));
+            assert!(!credential_file.contains("\nprivate_key ="));
+
+            let identity = repo::identity::load_device(&repo::identity::device_identity_path())
+                .expect("load device identity")
+                .expect("linked device identity");
+            assert_eq!(identity.public_key, hex::encode(signer.public_key()));
+            assert_eq!(identity.server, server);
+
+            let session = HostedSession::build(
+                &cli_shared::UserConfig::default(),
+                Some(server.to_string()),
+                HostedAuthMode::CredentialFallback,
+            )
+            .expect("build hosted session from installed credential");
+            let config = session.config;
+            let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
+            let client = HostedGrpcClient {
+                inner: grpc::heddle::v1::repo_sync_service_client::RepoSyncServiceClient::new(
+                    channel.clone(),
+                )
+                .max_decoding_message_size(wire::MAX_PULL_DECODE_MESSAGE_SIZE),
+                user: grpc::heddle::v1::hosted_user_service_client::HostedUserServiceClient::new(
+                    channel.clone(),
+                ),
+                auth: grpc::heddle::v1::auth_service_client::AuthServiceClient::new(
+                    channel.clone(),
+                ),
+                content: grpc::heddle::v1::content_service_client::ContentServiceClient::new(
+                    channel,
+                ),
+                token_header: Some(
+                    MetadataValue::try_from(format!(
+                        "Bearer {}",
+                        config.token.as_ref().expect("session token").id
+                    ))
+                    .expect("bearer metadata"),
+                ),
+                transport: crate::grpc_hosted::helpers::HostedTransportPolicy::from_client_config(
+                    &config,
+                ),
+                auth_proof_key_pem: config.auth_proof_key_pem,
+                server_key: config.server_key,
+                on_human_signature: None,
+            };
+            let method = "/heddle.v1.RepoSyncService/Push";
+            let mut request = Request::new(());
+            client
+                .apply_auth(&mut request, method)
+                .expect("attach hosted auth");
+
+            let metadata = request.metadata();
+            let proof_ts = metadata
+                .get(crypto::pop::HDR_PROOF_TS)
+                .and_then(|value| value.to_str().ok())
+                .expect("proof timestamp");
+            let nonce = metadata
+                .get(crypto::pop::HDR_PROOF_NONCE)
+                .and_then(|value| value.to_str().ok())
+                .expect("proof nonce");
+            let proof = metadata
+                .get(crypto::pop::HDR_PROOF)
+                .and_then(|value| value.to_str().ok())
+                .expect("proof signature");
+            let signature = base64::engine::general_purpose::STANDARD
+                .decode(proof)
+                .expect("decode proof signature");
+            crypto::pop::verify_pop(
+                signer.public_key(),
+                &token,
+                proof_ts,
+                "POST",
+                method,
+                nonce,
+                &signature,
+            )
+            .expect("proof verifies against installed device key");
+        });
+
+        unsafe {
+            match previous_home {
+                Some(path) => std::env::set_var("HEDDLE_HOME", path),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
 }

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1806,6 +1806,7 @@ the same ready envelope.
   "output_kind": "auth_status",
   "server": "grpc.heddle.sh",
   "authenticated": true,
+  "proof_key_available": true,
   "subject": "did:key:z6Mk...",
   "credential_id": "cred-123",
   "expires_at": "2026-06-27T00:00:00Z",


### PR DESCRIPTION
## Summary

- Add headless auth login with --token, --key-file, and an explicit --server; derive subject, credential id, expiry, and PoP binding from the Biscuit, persist the canonical credential, and link the device identity.
- Accept legacy private_key credential fields while writing private_key_pem canonically; qualify auth status when the proof key is absent and add recovery context to missing x-heddle-proof-ts errors.
- Cover the install-to-hosted-proof path by verifying the emitted push proof cryptographically against the bootstrap device key.
- Preserve interactive login and resolve its omitted server from the configured credential default before falling back to production.

## Closes

Closes HeddleCo/heddle#1014

## Red commit

e52bb8fac809c41287f70af3a04854f473e6ed3d

## Test evidence

```
CARGO_INCREMENTAL=0 cargo test -p heddle-client
# test result: ok. 119 passed; 0 failed

CARGO_INCREMENTAL=0 cargo test -p heddle-cli --features client --lib
# test result: ok. 589 passed; 0 failed

CARGO_INCREMENTAL=0 cargo build -p heddle-cli --features client
# Finished dev profile

CARGO_INCREMENTAL=0 cargo clippy -p heddle-client --all-targets -- -D warnings
# Finished dev profile

CARGO_INCREMENTAL=0 cargo clippy -p heddle-cli --features client --lib --bins -- -D warnings -A clippy::redundant_closure
# Finished dev profile

rustfmt --edition 2024 --check <changed Rust files>
git diff --check
# clean
```

The unmodified workspace has a Rust 1.97 clippy::redundant_closure warning in crates/cli/src/cli/commands/clone.rs:1829 and unrelated cargo fmt --check drift. This PR does not alter those out-of-scope files; all changed Rust files pass rustfmt check, and strict clippy passes the client targets.

## Manual verification

N/A — covered by tests. The generated auth login help exposes --token and --key-file and identifies --server as required for headless credential install.

## Blocked by → resolved

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1016"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786635943&installation_id=132405951&pr_number=1016&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1016&signature=6031898a207485dbaf3c87627e3c339b32e9644339ef362268b9b549b6771be0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->