### PR TITLE
test(auth): cover built headless login routing

### DIFF
--- a/crates/cli/tests/auth_login.rs
+++ b/crates/cli/tests/auth_login.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "client")]
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+#[test]
+fn built_cli_parses_headless_login_args_and_routes_to_install() {
+    let home = TempDir::new().expect("temp Heddle home");
+    let key_path = home.path().join("device.pem");
+    std::fs::write(&key_path, "not an Ed25519 private key").expect("write invalid device key");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args([
+            "auth",
+            "login",
+            "--token",
+            "biscuit-token",
+            "--key-file",
+            key_path.to_str().expect("UTF-8 key path"),
+            "--server",
+            "127.0.0.1:8421",
+        ])
+        .current_dir(home.path())
+        .env("HOME", home.path())
+        .env("HEDDLE_HOME", home.path())
+        .env_remove("HEDDLE_CONFIG")
+        .output()
+        .expect("run built heddle binary");
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("invalid Ed25519 device private key"),
+        "expected headless credential install error, got: {stderr}"
+    );
+}


### PR DESCRIPTION
Closes #1017.

Adds a black-box integration test that invokes the built heddle binary with auth login --token, --key-file, and --server. The assertion reaches the headless credential installer and observes its invalid-PEM diagnostic, proving Clap accepts the flags and dispatches them past argument parsing.

The flag registration and dispatch landed on main in #1016; the reported live failure came from a stale installed binary. This PR adds the missing built-binary regression coverage.

Validation:
- cargo build -p heddle-cli --all-features: pass
- cargo test -p heddle-cli --all-features --test auth_login: pass
- auth login parser constraint unit tests: pass
- all-feature clippy with the one pre-existing clone.rs redundant-closure lint exempted: pass

Known main failures reproduced but intentionally excluded from this scoped diff:
- The broad filtered cargo test command compiles stale tests/presence_publish.rs, which imports removed publisher APIs.
- Strict all-feature clippy reports the pre-existing redundant closure in crates/cli/src/cli/commands/clone.rs:1829.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786643340&installation_id=132405951&pr_number=1018&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1018&signature=51e0d2b366c7ca28d7f183789c60d7fc7df5c6d060279d2700e06d31d659bf46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->