### PR TITLE
feat(auth): heddle auth derive-agent — offline scoped Biscuit attenuation (headless-agent W1)

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -31,6 +31,38 @@ keyed on the `session()` fact in the authority block; a sub-agent
 inherits that fact, so revoking the parent's session id rejects
 every descendant on the next request.
 
+## CLI: `heddle auth derive-agent`
+
+Derive from the credential currently stored for a server without contacting
+that server:
+
+```bash
+heddle auth derive-agent \
+  --server grpc.heddle.sh \
+  --agent-id review-worker \
+  --ttl 3600 \
+  --scope repo:acme/heddle \
+  --allow Push \
+  --allow GetState
+```
+
+Without `--allow`, the command installs the curated safe set: push/pull,
+repository reads, context operations, discussions, and `WhoAmI`. Repeating
+`--allow` selects a subset; it cannot opt into an unsafe method. Every derived
+block independently rejects `CreateServiceAccount`,
+`IssueServiceAccountCredential`, `DeleteRepository`, and `DeleteNamespace`.
+Those checks are the non-optional G4 laundering and destructive-operation
+floor, including for callers of the Rust helper.
+
+By default the child replaces the active stored credential for `--server`, so
+the next push/pull and any further derivation use that child. Use `--stdout` to
+emit only the token without installing it, or `--out <DIR>` to write 0600
+`token` and `device-key.pem` files for another process on the same host.
+
+W1 reuses the parent's device key for hosted proof-of-possession. Do not copy
+the bundle to another host or give it to an untrusted process; delegated PoP
+with a distinct child key is W2.
+
 ## API: `cli::auth`
 
 The CLI surface is small: one struct, one main function, two
@@ -71,6 +103,7 @@ let attenuated = attenuate_for_agent(
             ("repo".to_string(), "org/acme/heddle".to_string()),
             ("repo".to_string(), "org/acme/docs".to_string()),
         ]),
+        declared_scopes: Vec::new(),
     },
 )?;
 ```
@@ -89,6 +122,8 @@ the secure default.
 | `expires_at` | `check if time($now), $now < <ts>` | Verifier always injects `time`, so always evaluated |
 | `allowed_operations: Some([...])` | `check if operation($op), $op == "X" \|\| ...` | Reject (no operation fact → check fails closed) |
 | `allowed_resources: Some([...])` | `check if resource($k, $p), (...path matches...)` | Reject (no resource fact → check fails closed) |
+| `declared_scopes` | `agent_scope($kind, $path)` facts | Inert until W3 server enforcement |
+| hard deny floor | one `operation($op), $op != …` check per forbidden method | Reject (the floor is always emitted) |
 
 The path-prefix matcher accepts an exact match or any nested path:
 an entry of `("repo", "org/acme")` covers `repo:org/acme`,
@@ -124,8 +159,8 @@ let attenuated = time_bounded(
 )?;
 ```
 
-No operation or resource narrowing — the agent can do whatever the
-parent could, but only for the next 12 hours.
+No operation or resource allowlist — the agent inherits the parent except for
+the non-optional G4/delete deny floor, and only for the next 12 hours.
 
 ### 3. Multi-repo writer
 
@@ -137,13 +172,15 @@ let attenuated = attenuate_for_agent(
     AgentAttenuation {
         agent_id: "agent-cross-repo".to_string(),
         expires_at: chrono::Utc::now() + chrono::Duration::hours(2),
-        // No operation allowlist → can do anything the parent can.
+        // No operation allowlist → inherits the parent except for the
+        // non-optional G4/delete deny floor.
         allowed_operations: None,
         // But only on these two repos.
         allowed_resources: Some(vec![
             ("repo".to_string(), "org/acme/heddle".to_string()),
             ("repo".to_string(), "org/acme/docs".to_string()),
         ]),
+        declared_scopes: Vec::new(),
     },
 )?;
 ```
@@ -166,6 +203,7 @@ let sub_agent_token = attenuate_for_agent(
         allowed_resources: Some(vec![
             ("repo".to_string(), "org/acme/heddle".to_string()),
         ]),
+        declared_scopes: Vec::new(),
     },
 )?;
 ```
@@ -212,6 +250,10 @@ boundary is:
 - **Re-sign the chain.** The server's public key is the trust
   anchor. The server rejects any chain whose authority block
   doesn't trace back to it.
+- **Enforce CLI `--scope` on today's server.** W1 carries each scope as an
+  `agent_scope` fact and prevents sub-derivation from declaring a broader
+  scope. Request-level repository enforcement begins with W3. Operation and
+  TTL caveats are enforced today.
 
 ## Where the server enforces this
 

--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -51,17 +51,27 @@ repository reads, context operations, discussions, and `WhoAmI`. Repeating
 `--allow` selects a subset; it cannot opt into an unsafe method. Every derived
 block independently rejects `CreateServiceAccount`,
 `IssueServiceAccountCredential`, `DeleteRepository`, and `DeleteNamespace`.
-Those checks are the non-optional G4 laundering and destructive-operation
-floor, including for callers of the Rust helper.
+Those checks are the non-optional credential-issuing and destructive-operation
+floor, including for callers of the Rust helper. They restrict use of the
+derived token; they do not constrain device-key-authenticated `MintBiscuit`.
 
 By default the child replaces the active stored credential for `--server`, so
 the next push/pull and any further derivation use that child. Use `--stdout` to
 emit only the token without installing it, or `--out <DIR>` to write 0600
-`token` and `device-key.pem` files for another process on the same host.
+`token` and `metadata.json` files. The metadata records the server, subject,
+effective expiry, and declared scopes. Neither export contains a private key.
 
-W1 reuses the parent's device key for hosted proof-of-possession. Do not copy
-the bundle to another host or give it to an untrusted process; delegated PoP
-with a distinct child key is W2.
+The derived token is strictly weaker than its parent: its operation fence and
+TTL are enforced server-side. Declared resource scopes await W3 enforcement.
+Hosted writes also require the matching device key from this host's shared
+identity store, so a token-only export is not a portable credential.
+
+W1 does not fully close G4 credential laundering. A process with the parent
+device root key can authenticate `MintBiscuit` independently of the attenuated
+token and obtain a fresh authority token. Do not treat a W1 derived token as a
+cross-trust-boundary security control. W2 delegated PoP gives each child its own
+block-bound key without handing over the parent device root key and closes that
+remaining path.
 
 ## API: `cli::auth`
 
@@ -160,7 +170,8 @@ let attenuated = time_bounded(
 ```
 
 No operation or resource allowlist — the agent inherits the parent except for
-the non-optional G4/delete deny floor, and only for the next 12 hours.
+the non-optional credential-issuance/delete floor, and only for the next 12
+hours.
 
 ### 3. Multi-repo writer
 
@@ -173,7 +184,7 @@ let attenuated = attenuate_for_agent(
         agent_id: "agent-cross-repo".to_string(),
         expires_at: chrono::Utc::now() + chrono::Duration::hours(2),
         // No operation allowlist → inherits the parent except for the
-        // non-optional G4/delete deny floor.
+        // non-optional credential-issuance/delete floor.
         allowed_operations: None,
         // But only on these two repos.
         allowed_resources: Some(vec![
@@ -237,6 +248,10 @@ boundary is:
   `MintBiscuit + KeypairProof`.
 
 ## What you can't do
+
+The statements in this section describe attenuation of the token itself. They
+do not apply to a holder of the W1 parent device root key, which remains able to
+authenticate `MintBiscuit` until W2 delegated PoP separates child proofs.
 
 - **Widen authority.** A child block can only emit *additional*
   checks. There is no way to add rights the parent didn't have.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,6 +1791,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tonic",
  "tracing",
+ "uuid",
  "weft-client-shim",
 ]
 

--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -38,7 +38,7 @@ pub enum AuthCommands {
         server: Option<String>,
     },
 
-    /// Derive a scoped, short-lived agent credential offline
+    /// Derive a scoped, short-lived agent token offline
     DeriveAgent {
         /// Server whose stored credential is the parent.
         #[arg(long)]
@@ -60,11 +60,11 @@ pub enum AuthCommands {
         #[arg(long = "allow")]
         allowed_operations: Vec<String>,
 
-        /// Write `token` and inherited `device-key.pem` files to this directory instead of installing.
+        /// Write `token` and `metadata.json` files to this directory without exporting the device key.
         #[arg(long, value_name = "DIR", conflicts_with = "stdout")]
         out: Option<std::path::PathBuf>,
 
-        /// Print only the child token instead of installing it.
+        /// Print only the child token instead of installing it (security note goes to stderr).
         #[arg(long, conflicts_with = "out")]
         stdout: bool,
     },

--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -38,6 +38,37 @@ pub enum AuthCommands {
         server: Option<String>,
     },
 
+    /// Derive a scoped, short-lived agent credential offline
+    DeriveAgent {
+        /// Server whose stored credential is the parent.
+        #[arg(long)]
+        server: String,
+
+        /// Delegation name recorded in the Biscuit chain.
+        #[arg(long)]
+        agent_id: Option<String>,
+
+        /// Child lifetime in seconds (clamped by the parent expiry).
+        #[arg(long = "ttl", default_value_t = 3600)]
+        ttl_secs: u64,
+
+        /// Forward-compatible resource scope (`repo:org/name`, `namespace:org`, or a bare repo path).
+        #[arg(long = "scope")]
+        scopes: Vec<String>,
+
+        /// Narrow the safe operation set (repeatable, using gRPC method names such as `Push`).
+        #[arg(long = "allow")]
+        allowed_operations: Vec<String>,
+
+        /// Write `token` and inherited `device-key.pem` files to this directory instead of installing.
+        #[arg(long, value_name = "DIR", conflicts_with = "stdout")]
+        out: Option<std::path::PathBuf>,
+
+        /// Print only the child token instead of installing it.
+        #[arg(long, conflicts_with = "out")]
+        stdout: bool,
+    },
+
     /// Create a service token for CI/scripts, scoped to a namespace
     CreateServiceToken {
         /// Display name for the service account (e.g. "github-ci-main")
@@ -73,6 +104,23 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
             },
             AuthCommands::Logout { server } => heddle_client::AuthCommand::Logout { server },
             AuthCommands::Status { server } => heddle_client::AuthCommand::Status { server },
+            AuthCommands::DeriveAgent {
+                server,
+                agent_id,
+                ttl_secs,
+                scopes,
+                allowed_operations,
+                out,
+                stdout,
+            } => heddle_client::AuthCommand::DeriveAgent {
+                server,
+                agent_id,
+                ttl_secs,
+                scopes,
+                allowed_operations,
+                out,
+                stdout,
+            },
             AuthCommands::CreateServiceToken {
                 name,
                 namespace,
@@ -163,5 +211,45 @@ mod tests {
         );
         Cli::try_parse_from(["heddle", "auth", "login"])
             .expect("interactive login may resolve the configured default server");
+    }
+
+    #[test]
+    fn derive_agent_parses_repeatable_scopes_and_operation_narrowing() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "derive-agent",
+            "--server",
+            "grpc.heddle.test",
+            "--ttl",
+            "900",
+            "--scope",
+            "repo:acme/api",
+            "--scope",
+            "namespace:acme",
+            "--allow",
+            "Push",
+            "--allow",
+            "GetState",
+        ])
+        .expect("derive-agent flags parse");
+
+        let Commands::Auth {
+            command:
+                AuthCommands::DeriveAgent {
+                    server,
+                    ttl_secs,
+                    scopes,
+                    allowed_operations,
+                    ..
+                },
+        } = cli.command
+        else {
+            panic!("expected auth derive-agent");
+        };
+        assert_eq!(server, "grpc.heddle.test");
+        assert_eq!(ttl_secs, 900);
+        assert_eq!(scopes, ["repo:acme/api", "namespace:acme"]);
+        assert_eq!(allowed_operations, ["Push", "GetState"]);
     }
 }

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1823,10 +1823,7 @@ fn monorepo_node_facts_from_resolved(node: &grpc::heddle::v1::MonorepoNode) -> M
             MonorepoEdgeFacts {
                 mount_name: edge.mount_name.clone(),
                 child_spool_id: edge.child_spool_id.clone(),
-                child: edge
-                    .subtree
-                    .as_ref()
-                    .map(|subtree| monorepo_node_facts_from_resolved(subtree)),
+                child: edge.subtree.as_ref().map(monorepo_node_facts_from_resolved),
                 skip_reason,
             }
         })

--- a/crates/cli/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli/src/cli/commands/command_catalog/mod.rs
@@ -761,6 +761,13 @@ const CONFIG_MUTATION_NO_OP_ID: CommandContract = CommandContract {
     ..CONFIG_MUTATION
 };
 
+const CONFIG_MUTATION_TEXT: CommandContract = CommandContract {
+    supports_json: false,
+    supports_op_id: false,
+    json_kind: "none",
+    ..CONFIG_MUTATION
+};
+
 const NETWORK_CONFIG_MUTATION_TEXT: CommandContract = CommandContract {
     supports_json: false,
     supports_op_id: false,
@@ -1439,6 +1446,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ),
             "client",
         ),
+    ),
+    entry(
+        &["auth", "derive-agent"],
+        feature_gated(CONFIG_MUTATION_TEXT, "client"),
     ),
     entry(
         &["auth", "create-service-token"],
@@ -4505,6 +4516,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             AuthCommands::Login { .. } => vec!["auth", "login"],
             AuthCommands::Logout { .. } => vec!["auth", "logout"],
             AuthCommands::Status { .. } => vec!["auth", "status"],
+            AuthCommands::DeriveAgent { .. } => vec!["auth", "derive-agent"],
             AuthCommands::CreateServiceToken { .. } => vec!["auth", "create-service-token"],
         },
         Commands::Context { command } => match command {

--- a/crates/cli/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli/src/cli/commands/command_catalog/tests.rs
@@ -128,6 +128,18 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["auth", "status"], &["auth", "status"]),
     #[cfg(feature = "client")]
     sample(
+        &["auth", "derive-agent"],
+        &[
+            "auth",
+            "derive-agent",
+            "--server",
+            "grpc.heddle.test",
+            "--scope",
+            "repo:acme/heddle",
+        ],
+    ),
+    #[cfg(feature = "client")]
+    sample(
         &["auth", "create-service-token"],
         &[
             "auth",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -30,6 +30,7 @@ tokio-tungstenite.workspace = true
 toml.workspace = true
 tonic.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 
 # Workspace heddle crates — sibling paths plus crates.io versions so
 # downstream consumers (closed weft, third parties) pull the published

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -1,6 +1,6 @@
 //! `heddle auth` command implementations.
 
-use std::path::Path;
+use std::{collections::BTreeSet, path::Path};
 
 use anyhow::{Context, Result, bail};
 use crypto::{Ed25519Signer, Signer};
@@ -19,6 +19,7 @@ use tonic::{
 };
 use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
+use crate::device_flow::{AgentAttenuation, SAFE_AGENT_OPERATIONS, attenuate_for_agent};
 use crate::{auth_requests::AuthCommand, credentials, credentials::ServerCredential};
 
 /// Top-level dispatch for `heddle auth <subcommand>`. `_ctx` is
@@ -96,6 +97,23 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
         AuthCommand::Status { server } => cmd_auth_status(ctx, server.as_deref()),
+        AuthCommand::DeriveAgent {
+            server,
+            agent_id,
+            ttl_secs,
+            scopes,
+            allowed_operations,
+            out,
+            stdout,
+        } => cmd_auth_derive_agent(
+            &server,
+            agent_id,
+            ttl_secs,
+            scopes,
+            allowed_operations,
+            out.as_deref(),
+            stdout,
+        ),
         AuthCommand::CreateServiceToken {
             name,
             namespace,
@@ -114,6 +132,251 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             .await
         }
     }
+}
+
+/// Derive an offline child Biscuit and either install it as the active
+/// credential for `server`, write a same-host bundle, or emit the token.
+fn cmd_auth_derive_agent(
+    server: &str,
+    agent_id: Option<String>,
+    ttl_secs: u64,
+    scopes: Vec<String>,
+    requested_operations: Vec<String>,
+    out: Option<&Path>,
+    stdout: bool,
+) -> Result<()> {
+    if ttl_secs == 0 {
+        bail!("--ttl must be greater than zero seconds");
+    }
+    let ttl_secs = i64::try_from(ttl_secs).context("--ttl is too large")?;
+    let parent = credentials::get_server_credential(server)?
+        .ok_or_else(|| anyhow::anyhow!(HostedRecoveryAdvice::auth_required(server)))?;
+    let private_key_pem = parent.private_key_pem.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "stored credential for {server} has no device proof key; run `heddle auth login --server {server}` first"
+        )
+    })?;
+    let signer = Ed25519Signer::from_pem(private_key_pem)
+        .map_err(|error| anyhow::anyhow!("stored device proof key is invalid: {error}"))?;
+    let metadata = headless_token_metadata(&parent.token)?;
+    if !metadata
+        .proof_public_key_hex
+        .eq_ignore_ascii_case(&hex::encode(signer.public_key()))
+    {
+        bail!("stored device proof key does not match the parent Biscuit");
+    }
+
+    let now = chrono::Utc::now();
+    let requested_expiry = now
+        .checked_add_signed(chrono::Duration::seconds(ttl_secs))
+        .ok_or_else(|| anyhow::anyhow!("--ttl produces an unsupported expiry"))?;
+    let expires_at = match parent.expires_at.as_deref() {
+        Some(value) => {
+            let parent_expiry = chrono::DateTime::parse_from_rfc3339(value)
+                .with_context(|| format!("stored parent expiry is invalid: {value}"))?
+                .with_timezone(&chrono::Utc);
+            if parent_expiry <= now {
+                bail!("stored parent credential expired at {parent_expiry}");
+            }
+            requested_expiry.min(parent_expiry)
+        }
+        None => requested_expiry,
+    };
+
+    let agent_id = agent_id.unwrap_or_else(|| format!("agent-{}", uuid::Uuid::new_v4()));
+    let allowed_operations = select_agent_operations(requested_operations)?;
+    let declared_scopes = parse_agent_scopes(scopes)?;
+    validate_scope_narrowing(&parent.token, &declared_scopes)?;
+    let child_token = attenuate_for_agent(
+        &parent.token,
+        AgentAttenuation {
+            agent_id: agent_id.clone(),
+            expires_at,
+            allowed_operations: Some(allowed_operations.clone()),
+            // W3 will enforce the declarations below. Adding a resource check
+            // in W1 would reject every request against today's servers.
+            allowed_resources: None,
+            declared_scopes: declared_scopes.clone(),
+        },
+    )?;
+
+    if stdout {
+        println!("{child_token}");
+        return Ok(());
+    }
+    if let Some(out) = out {
+        write_agent_bundle(out, &child_token, private_key_pem)?;
+        println!("Agent credential {agent_id} written to {}.", out.display());
+        println!(
+            "The inherited device key is for same-host use only; cross-host delegation is W2."
+        );
+        return Ok(());
+    }
+
+    // Derived credentials must not auto-rotate through MintBiscuit: renewal
+    // would produce a fresh authority token without this block's caveats.
+    // Keeping credential_id unset disables the client's rotation path while
+    // preserving the authority block and server-side revocation bindings.
+    credentials::store_server_credential(
+        server,
+        ServerCredential {
+            token: child_token,
+            subject: parent.subject,
+            device_id: parent.device_id,
+            credential_id: None,
+            private_key_pem: Some(private_key_pem.to_string()),
+            expires_at: Some(expires_at.to_rfc3339()),
+        },
+    )?;
+
+    println!("Derived and installed agent credential {agent_id} for {server}.");
+    println!("Expires: {expires_at}");
+    println!("Allowed operations: {}", allowed_operations.join(", "));
+    if declared_scopes.is_empty() {
+        println!("Scopes: none declared");
+    } else {
+        println!(
+            "Scopes: {} (recorded now; server enforcement begins with W3)",
+            declared_scopes
+                .iter()
+                .map(|(kind, path)| format!("{kind}:{path}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+    }
+    println!("PoP: inherited parent device key (same-host W1 mode)");
+    Ok(())
+}
+
+fn select_agent_operations(requested: Vec<String>) -> Result<Vec<String>> {
+    if requested.is_empty() {
+        return Ok(SAFE_AGENT_OPERATIONS
+            .iter()
+            .map(|operation| (*operation).to_string())
+            .collect());
+    }
+    let safe = SAFE_AGENT_OPERATIONS
+        .iter()
+        .copied()
+        .collect::<BTreeSet<_>>();
+    let mut selected = BTreeSet::new();
+    for operation in requested {
+        if !safe.contains(operation.as_str()) {
+            bail!(
+                "operation {operation:?} is outside the safe agent operation ceiling; --allow can only narrow the default set"
+            );
+        }
+        selected.insert(operation);
+    }
+    Ok(selected.into_iter().collect())
+}
+
+fn parse_agent_scopes(scopes: Vec<String>) -> Result<Vec<(String, String)>> {
+    let mut parsed = BTreeSet::new();
+    for scope in scopes {
+        let (kind, path) = match scope.split_once(':') {
+            Some(("repo", path)) => ("repo", path),
+            Some(("namespace" | "ns", path)) => ("namespace", path),
+            Some((kind, _)) => bail!(
+                "unsupported scope kind {kind:?}; use repo:<path>, namespace:<path>, or a bare repo path"
+            ),
+            None => ("repo", scope.as_str()),
+        };
+        let path = path.trim_matches('/');
+        if path.is_empty() {
+            bail!("--scope path must not be empty");
+        }
+        parsed.insert((kind.to_string(), path.to_string()));
+    }
+    Ok(parsed.into_iter().collect())
+}
+
+fn validate_scope_narrowing(parent_token: &str, child: &[(String, String)]) -> Result<()> {
+    if child.is_empty() {
+        // Omitting a scope adds no new declaration; all ancestor declarations
+        // remain in the immutable chain for W3 to enforce.
+        return Ok(());
+    }
+    for ancestor in agent_scope_blocks(parent_token)? {
+        if ancestor.is_empty() {
+            continue;
+        }
+        for child_scope in child {
+            if !ancestor
+                .iter()
+                .any(|parent_scope| scope_is_within(child_scope, parent_scope))
+            {
+                bail!(
+                    "scope {}:{} would widen an ancestor agent scope; sub-derivation may only narrow",
+                    child_scope.0,
+                    child_scope.1
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn agent_scope_blocks(token: &str) -> Result<Vec<Vec<(String, String)>>> {
+    use biscuit_auth::builder::{BlockBuilder, Term};
+
+    let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
+        .context("parsing parent Biscuit scopes")?;
+    let mut blocks = Vec::new();
+    for index in 1..biscuit.block_count() {
+        let source = biscuit
+            .print_block_source(index)
+            .with_context(|| format!("reading Biscuit attenuation block {index}"))?;
+        let block = BlockBuilder::new()
+            .code(&source)
+            .with_context(|| format!("parsing Biscuit attenuation block {index}"))?;
+        let scopes = block
+            .facts
+            .iter()
+            .filter_map(|fact| {
+                if fact.predicate.name != "agent_scope" || fact.predicate.terms.len() != 2 {
+                    return None;
+                }
+                match (&fact.predicate.terms[0], &fact.predicate.terms[1]) {
+                    (Term::Str(kind), Term::Str(path)) => Some((kind.clone(), path.clone())),
+                    _ => None,
+                }
+            })
+            .collect();
+        blocks.push(scopes);
+    }
+    Ok(blocks)
+}
+
+fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool {
+    let path_is_within = child.1 == parent.1
+        || child
+            .1
+            .strip_prefix(&parent.1)
+            .is_some_and(|suffix| suffix.starts_with('/'));
+    match (parent.0.as_str(), child.0.as_str()) {
+        ("repo", "repo") => path_is_within,
+        ("namespace", "namespace") => path_is_within,
+        ("namespace", "repo") => child.1 != parent.1 && path_is_within,
+        _ => false,
+    }
+}
+
+fn write_agent_bundle(directory: &Path, token: &str, private_key_pem: &str) -> Result<()> {
+    objects::fs_atomic::create_private_dir_all(directory).with_context(|| {
+        format!(
+            "creating agent credential directory {}",
+            directory.display()
+        )
+    })?;
+    objects::fs_atomic::write_file_atomic_secret(&directory.join("token"), token.as_bytes())
+        .with_context(|| format!("writing agent token under {}", directory.display()))?;
+    objects::fs_atomic::write_file_atomic_secret(
+        &directory.join("device-key.pem"),
+        private_key_pem.as_bytes(),
+    )
+    .with_context(|| format!("writing inherited device key under {}", directory.display()))?;
+    Ok(())
 }
 
 struct HeadlessTokenMetadata {
@@ -169,6 +432,7 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
 
     let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
         .context("parsing --token as a Biscuit")?;
+    let block_count = biscuit.block_count();
     let authority_source = biscuit
         .print_block_source(0)
         .context("reading Biscuit authority block")?;
@@ -196,7 +460,15 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
     let subject = string_fact("user")?
         .filter(|subject| !subject.trim().is_empty())
         .ok_or_else(|| anyhow::anyhow!("Biscuit authority block is missing user(subject)"))?;
-    let credential_id = string_fact("credential_id")?;
+    // An attenuated token must never use keypair renewal: MintBiscuit would
+    // return a new authority token without the appended caveats. The
+    // authority credential id remains cryptographically intact in the token,
+    // but is intentionally omitted from the local child credential metadata.
+    let credential_id = if block_count > 1 {
+        None
+    } else {
+        string_fact("credential_id")?
+    };
     let proof_public_key_hex = string_fact("device_pop_key")?.ok_or_else(|| {
         anyhow::anyhow!(
             "Biscuit is not device-bound: authority block is missing device_pop_key(key)"
@@ -214,7 +486,7 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
             _ => None,
         }
     });
-    let expires_at = expiries
+    let authority_expires_at = expiries
         .next()
         .map(|seconds| {
             i64::try_from(seconds)
@@ -227,6 +499,35 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
     if expiries.next().is_some() {
         bail!("Biscuit authority block contains multiple expires_at facts");
     }
+
+    let mut effective_expiry = authority_expires_at
+        .as_deref()
+        .map(chrono::DateTime::parse_from_rfc3339)
+        .transpose()
+        .context("parsing Biscuit authority expiry")?
+        .map(|value| value.with_timezone(&chrono::Utc));
+    for index in 1..block_count {
+        let source = biscuit
+            .print_block_source(index)
+            .with_context(|| format!("reading Biscuit attenuation block {index}"))?;
+        let block = BlockBuilder::new()
+            .code(&source)
+            .with_context(|| format!("parsing Biscuit attenuation block {index}"))?;
+        for fact in &block.facts {
+            if fact.predicate.name != "agent_expires_at" || fact.predicate.terms.len() != 1 {
+                continue;
+            }
+            let Term::Date(seconds) = fact.predicate.terms[0] else {
+                bail!("Biscuit attenuation block {index} has invalid agent_expires_at fact");
+            };
+            let seconds = i64::try_from(seconds)
+                .with_context(|| format!("attenuation block {index} expiry is too large"))?;
+            let value = chrono::DateTime::from_timestamp(seconds, 0)
+                .ok_or_else(|| anyhow::anyhow!("attenuation block {index} expiry is invalid"))?;
+            effective_expiry = Some(effective_expiry.map_or(value, |current| current.min(value)));
+        }
+    }
+    let expires_at = effective_expiry.map(|value| value.to_rfc3339());
 
     Ok(HeadlessTokenMetadata {
         subject,
@@ -1456,6 +1757,131 @@ mod tests {
             credential_id: None,
             private_key_pem: None,
             expires_at: None,
+        }
+    }
+
+    fn stored_device_parent() -> (ServerCredential, String) {
+        let signer = Ed25519Signer::generate().expect("device key");
+        let private_key_pem = signer.to_pem().expect("device PEM");
+        let expires_at = chrono::Utc::now() + chrono::Duration::hours(2);
+        let token = biscuit_auth::Biscuit::builder()
+            .fact(r#"user("alice")"#)
+            .expect("user fact")
+            .fact(r#"credential_id("root-credential")"#)
+            .expect("credential fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("device PoP fact")
+            .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
+            .expect("expiry fact")
+            .check(format!("check if time($now), $now < {}", expires_at.to_rfc3339()).as_str())
+            .expect("expiry check")
+            .build(&biscuit_auth::KeyPair::new())
+            .expect("build parent")
+            .to_base64()
+            .expect("encode parent");
+        (
+            ServerCredential {
+                token,
+                subject: "alice".to_string(),
+                device_id: Some("device-root".to_string()),
+                credential_id: Some("root-credential".to_string()),
+                private_key_pem: Some(private_key_pem.clone()),
+                expires_at: Some(expires_at.to_rfc3339()),
+            },
+            private_key_pem,
+        )
+    }
+
+    #[test]
+    fn derive_agent_installs_inherited_pop_child_and_supports_narrower_subderivation() {
+        with_isolated_home(|| {
+            let server = "grpc.S";
+            let (parent, private_key_pem) = stored_device_parent();
+            credentials::store_server_credential(server, parent).expect("store parent");
+
+            cmd_auth_derive_agent(
+                server,
+                Some("agent-parent".to_string()),
+                3600,
+                vec!["repo:acme/heddle".to_string()],
+                vec!["Push".to_string()],
+                None,
+                false,
+            )
+            .expect("derive and install parent agent");
+            let installed = credentials::get_server_credential(server)
+                .expect("load installed child")
+                .expect("installed child");
+            assert_eq!(
+                installed.private_key_pem.as_deref(),
+                Some(private_key_pem.as_str()),
+                "W1 child inherits the parent PoP key"
+            );
+            assert_eq!(installed.device_id.as_deref(), Some("device-root"));
+            assert!(
+                installed.credential_id.is_none(),
+                "derived credentials must not auto-rotate into an unattenuated token"
+            );
+            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(installed.token.as_bytes())
+                .expect("parse installed child");
+            assert_eq!(parsed.block_count(), 2);
+            assert!(
+                parsed
+                    .print_block_source(1)
+                    .expect("child block")
+                    .contains("agent_scope(\"repo\", \"acme/heddle\")")
+            );
+
+            cmd_auth_derive_agent(
+                server,
+                Some("agent-child".to_string()),
+                600,
+                vec!["repo:acme/heddle/subtree".to_string()],
+                vec!["Push".to_string()],
+                None,
+                false,
+            )
+            .expect("derive narrower subagent");
+            let subagent = credentials::get_server_credential(server)
+                .expect("load subagent")
+                .expect("installed subagent");
+            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(subagent.token.as_bytes())
+                .expect("parse subagent");
+            assert_eq!(
+                parsed.block_count(),
+                3,
+                "delegation tree adds one block per hop"
+            );
+
+            let error = cmd_auth_derive_agent(
+                server,
+                Some("agent-widening".to_string()),
+                300,
+                vec!["repo:acme".to_string()],
+                vec!["Push".to_string()],
+                None,
+                false,
+            )
+            .expect_err("subagent scope widening must be rejected");
+            assert!(error.to_string().contains("would widen"));
+        });
+    }
+
+    #[test]
+    fn derive_agent_allow_flag_cannot_select_unsafe_operations() {
+        for operation in [
+            "CreateServiceAccount",
+            "IssueServiceAccountCredential",
+            "DeleteRepository",
+            "DeleteNamespace",
+        ] {
+            let error = select_agent_operations(vec![operation.to_string()])
+                .expect_err("unsafe operation must be outside CLI ceiling");
+            assert!(
+                error
+                    .to_string()
+                    .contains("outside the safe agent operation ceiling")
+            );
         }
     }
 

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -65,6 +65,16 @@ struct ServiceTokenOutput {
     expires_in_days: u32,
 }
 
+#[derive(Serialize)]
+struct AgentTokenExportMetadata<'a> {
+    server: &'a str,
+    subject: &'a str,
+    expires_at: String,
+    scopes: Vec<String>,
+}
+
+const DERIVED_TOKEN_SECURITY_NOTE: &str = "Derived token is operation/TTL-limited and enforced server-side; declared scopes await W3 enforcement. It uses this host's device key for hosted-write proofs (same-host only); it is not a portable credential -- cross-host delegation lands in W2.";
+
 const SERVICE_TOKEN_TTL_DAYS: u32 = 30;
 const SERVICE_TOKEN_TTL_SECS: i64 = SERVICE_TOKEN_TTL_DAYS as i64 * 24 * 3600;
 const ISSUE_SA_PROOF_DOMAIN: &[u8] = b"heddle-sa-credential-issue-v1";
@@ -134,8 +144,8 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
     }
 }
 
-/// Derive an offline child Biscuit and either install it as the active
-/// credential for `server`, write a same-host bundle, or emit the token.
+/// Derive an offline child Biscuit and either install it as the active token,
+/// write a token-only export, or emit the token.
 fn cmd_auth_derive_agent(
     server: &str,
     agent_id: Option<String>,
@@ -202,21 +212,29 @@ fn cmd_auth_derive_agent(
 
     if stdout {
         println!("{child_token}");
+        eprintln!("{DERIVED_TOKEN_SECURITY_NOTE}");
         return Ok(());
     }
     if let Some(out) = out {
-        write_agent_bundle(out, &child_token, private_key_pem)?;
-        println!("Agent credential {agent_id} written to {}.", out.display());
-        println!(
-            "The inherited device key is for same-host use only; cross-host delegation is W2."
-        );
+        let export_metadata = AgentTokenExportMetadata {
+            server,
+            subject: &metadata.subject,
+            expires_at: expires_at.to_rfc3339(),
+            scopes: declared_scopes
+                .iter()
+                .map(|(kind, path)| format!("{kind}:{path}"))
+                .collect(),
+        };
+        write_agent_bundle(out, &child_token, &export_metadata)?;
+        println!("Agent token {agent_id} written to {}.", out.display());
+        println!("{DERIVED_TOKEN_SECURITY_NOTE}");
         return Ok(());
     }
 
-    // Derived credentials must not auto-rotate through MintBiscuit: renewal
-    // would produce a fresh authority token without this block's caveats.
-    // Keeping credential_id unset disables the client's rotation path while
-    // preserving the authority block and server-side revocation bindings.
+    // The installed derived token must not auto-rotate through MintBiscuit:
+    // renewal would produce a fresh authority token without this block's
+    // caveats. Keeping credential_id unset disables the client's rotation path
+    // while preserving the authority block and server-side revocation bindings.
     credentials::store_server_credential(
         server,
         ServerCredential {
@@ -229,7 +247,7 @@ fn cmd_auth_derive_agent(
         },
     )?;
 
-    println!("Derived and installed agent credential {agent_id} for {server}.");
+    println!("Derived and installed agent token {agent_id} for {server}.");
     println!("Expires: {expires_at}");
     println!("Allowed operations: {}", allowed_operations.join(", "));
     if declared_scopes.is_empty() {
@@ -244,7 +262,7 @@ fn cmd_auth_derive_agent(
                 .join(", ")
         );
     }
-    println!("PoP: inherited parent device key (same-host W1 mode)");
+    println!("{DERIVED_TOKEN_SECURITY_NOTE}");
     Ok(())
 }
 
@@ -362,20 +380,33 @@ fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool 
     }
 }
 
-fn write_agent_bundle(directory: &Path, token: &str, private_key_pem: &str) -> Result<()> {
+fn write_agent_bundle(
+    directory: &Path,
+    token: &str,
+    metadata: &AgentTokenExportMetadata<'_>,
+) -> Result<()> {
     objects::fs_atomic::create_private_dir_all(directory).with_context(|| {
         format!(
-            "creating agent credential directory {}",
+            "creating agent token export directory {}",
             directory.display()
         )
     })?;
+    let legacy_key_path = directory.join("device-key.pem");
+    match std::fs::remove_file(&legacy_key_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("removing legacy key {}", legacy_key_path.display()));
+        }
+    }
     objects::fs_atomic::write_file_atomic_secret(&directory.join("token"), token.as_bytes())
         .with_context(|| format!("writing agent token under {}", directory.display()))?;
-    objects::fs_atomic::write_file_atomic_secret(
-        &directory.join("device-key.pem"),
-        private_key_pem.as_bytes(),
-    )
-    .with_context(|| format!("writing inherited device key under {}", directory.display()))?;
+    let mut metadata_json =
+        serde_json::to_vec_pretty(metadata).context("serializing agent token metadata")?;
+    metadata_json.push(b'\n');
+    objects::fs_atomic::write_file_atomic_secret(&directory.join("metadata.json"), &metadata_json)
+        .with_context(|| format!("writing agent token metadata under {}", directory.display()))?;
     Ok(())
 }
 
@@ -1820,7 +1851,7 @@ mod tests {
             assert_eq!(installed.device_id.as_deref(), Some("device-root"));
             assert!(
                 installed.credential_id.is_none(),
-                "derived credentials must not auto-rotate into an unattenuated token"
+                "derived tokens must not auto-rotate into an unattenuated token"
             );
             let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(installed.token.as_bytes())
                 .expect("parse installed child");
@@ -1864,6 +1895,73 @@ mod tests {
             )
             .expect_err("subagent scope widening must be rejected");
             assert!(error.to_string().contains("would widen"));
+        });
+    }
+
+    #[test]
+    fn derive_agent_export_contains_token_and_metadata_but_no_device_key() {
+        with_isolated_home(|| {
+            let server = "grpc.S";
+            let (parent, private_key_pem) = stored_device_parent();
+            credentials::store_server_credential(server, parent).expect("store parent");
+            let export_dir = repo::identity::heddle_home_dir().join("agent-export");
+            objects::fs_atomic::create_private_dir_all(&export_dir)
+                .expect("create legacy export directory");
+            objects::fs_atomic::write_file_atomic_secret(
+                &export_dir.join("device-key.pem"),
+                private_key_pem.as_bytes(),
+            )
+            .expect("seed legacy exported device key");
+
+            cmd_auth_derive_agent(
+                server,
+                Some("agent-export".to_string()),
+                3600,
+                vec!["repo:acme/heddle".to_string()],
+                vec!["Push".to_string()],
+                Some(&export_dir),
+                false,
+            )
+            .expect("derive token-only export");
+
+            let mut entries = std::fs::read_dir(&export_dir)
+                .expect("read export directory")
+                .map(|entry| {
+                    entry
+                        .expect("export entry")
+                        .file_name()
+                        .into_string()
+                        .expect("UTF-8 export name")
+                })
+                .collect::<Vec<_>>();
+            entries.sort();
+            assert_eq!(entries, ["metadata.json", "token"]);
+
+            let token = std::fs::read(export_dir.join("token")).expect("read exported token");
+            let metadata =
+                std::fs::read(export_dir.join("metadata.json")).expect("read export metadata");
+            let export_bytes = [token.as_slice(), metadata.as_slice()].concat();
+            assert!(
+                !export_bytes
+                    .windows(private_key_pem.len())
+                    .any(|window| window == private_key_pem.as_bytes()),
+                "portable export must not contain the device private key"
+            );
+            assert!(
+                !export_bytes
+                    .windows(b"-----BEGIN PRIVATE KEY-----".len())
+                    .any(|window| window == b"-----BEGIN PRIVATE KEY-----"),
+                "portable export must not contain a PEM private-key header"
+            );
+
+            let metadata: serde_json::Value =
+                serde_json::from_slice(&metadata).expect("parse export metadata");
+            assert_eq!(metadata["server"], server);
+            assert_eq!(metadata["subject"], "alice");
+            assert_eq!(metadata["scopes"], serde_json::json!(["repo:acme/heddle"]));
+            assert!(metadata["expires_at"].as_str().is_some());
+            biscuit_auth::UnverifiedBiscuit::from_base64(&token)
+                .expect("exported token is a Biscuit");
         });
     }
 

--- a/crates/client/src/auth_requests.rs
+++ b/crates/client/src/auth_requests.rs
@@ -14,6 +14,15 @@ pub enum AuthCommand {
     Status {
         server: Option<String>,
     },
+    DeriveAgent {
+        server: String,
+        agent_id: Option<String>,
+        ttl_secs: u64,
+        scopes: Vec<String>,
+        allowed_operations: Vec<String>,
+        out: Option<std::path::PathBuf>,
+        stdout: bool,
+    },
     CreateServiceToken {
         name: String,
         namespace: String,

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -16,9 +16,10 @@ use chrono::{DateTime, Utc};
 /// Operations that an agent attenuation can never authorize, even when a
 /// caller constructs [`AgentAttenuation`] directly without an allowlist.
 ///
-/// The credential-issuing methods are the G4 laundering fence: an attenuated
-/// token must not mint a fresh credential that omits its TTL and operation
-/// checks. Repository/namespace deletion is also outside the W1 agent surface.
+/// Credential-issuing and destructive methods excluded from the W1 agent
+/// operation surface. This floor limits use of the attenuated token, but it
+/// cannot constrain device-key-authenticated `MintBiscuit`; closing that G4
+/// laundering path requires W2 delegated PoP.
 pub const AGENT_OPERATION_DENY_FLOOR: &[&str] = &[
     "CreateServiceAccount",
     "IssueServiceAccountCredential",
@@ -182,8 +183,8 @@ fn build_attenuation_block(
         )
         .context("expiry check")?;
     // This independent check is deliberately present even when the caller
-    // supplies no operation allowlist. It is the non-optional G4/destructive
-    // operation floor for every token produced by this primitive.
+    // supplies no operation allowlist. It is the non-optional credential-
+    // issuing/destructive operation floor for every token from this primitive.
     for denied in AGENT_OPERATION_DENY_FLOOR {
         block = block
             .check(format!("check if operation($op), $op != {}", biscuit_string(denied)).as_str())
@@ -441,7 +442,7 @@ mod tests {
     }
 
     #[test]
-    fn server_accepts_allowed_operation_and_rejects_g4_and_delete_floor() {
+    fn server_accepts_allowed_operation_and_rejects_credential_issuance_and_delete_floor() {
         let (parent, root) = fresh_parent_token();
         let child = attenuate_for_agent(
             &parent,

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -13,6 +13,60 @@
 use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 
+/// Operations that an agent attenuation can never authorize, even when a
+/// caller constructs [`AgentAttenuation`] directly without an allowlist.
+///
+/// The credential-issuing methods are the G4 laundering fence: an attenuated
+/// token must not mint a fresh credential that omits its TTL and operation
+/// checks. Repository/namespace deletion is also outside the W1 agent surface.
+pub const AGENT_OPERATION_DENY_FLOOR: &[&str] = &[
+    "CreateServiceAccount",
+    "IssueServiceAccountCredential",
+    "DeleteRepository",
+    "DeleteNamespace",
+];
+
+/// Curated W1 operation ceiling for `heddle auth derive-agent`.
+///
+/// `--allow` may select a subset of these methods. Parent and child blocks are
+/// both evaluated by the server, so sub-derivation computes an intersection
+/// and cannot widen an ancestor's selection.
+pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
+    // Hosted push and pull.
+    "Push",
+    "Pull",
+    "ListRefs",
+    "UpdateRef",
+    // Repository reads.
+    "GetRefs",
+    "ListStates",
+    "GetState",
+    "GetBlame",
+    "ListProvenanceSummaries",
+    "GetTree",
+    "GetBlob",
+    "GetCompare",
+    "GetDiff",
+    "GetSemanticHotSpots",
+    "ListActions",
+    // Context reads and writes.
+    "ListContext",
+    "GetContextHistory",
+    "ListContextSuggestions",
+    "SetContext",
+    "ReviseContext",
+    "SupersedeContext",
+    // Discussions.
+    "OpenDiscussion",
+    "AppendTurn",
+    "ResolveDiscussion",
+    "ListByState",
+    "ListBySymbol",
+    "GetDiscussion",
+    // Session identity.
+    "WhoAmI",
+];
+
 /// Restrictions applied to a sub-agent's Biscuit. Constructed via
 /// [`AgentAttenuation::time_bounded`] for the simplest case (no
 /// operation/resource narrowing) or built up field-by-field for
@@ -41,6 +95,13 @@ pub struct AgentAttenuation {
     /// path matches one of the entries. Format: `(kind, path)`
     /// where `kind ∈ {"repo", "namespace"}`.
     pub allowed_resources: Option<Vec<(String, String)>>,
+    /// Resource scopes carried for forward-compatible W3 enforcement.
+    ///
+    /// Today's server does not inject request `resource(...)` facts, so an
+    /// `allowed_resources` check fails closed for every RPC. W1 records these
+    /// declarations as `agent_scope(kind, path)` facts instead. They are inert
+    /// until W3 teaches the server to enforce them.
+    pub declared_scopes: Vec<(String, String)>,
 }
 
 impl AgentAttenuation {
@@ -52,6 +113,7 @@ impl AgentAttenuation {
             expires_at,
             allowed_operations: None,
             allowed_resources: None,
+            declared_scopes: Vec::new(),
         }
     }
 }
@@ -98,11 +160,18 @@ fn build_attenuation_block(
             validate_biscuit_token_string("resource path", path)?;
         }
     }
+    for (kind, path) in &restrictions.declared_scopes {
+        validate_biscuit_token_string("scope kind", kind)?;
+        validate_biscuit_token_string("scope path", path)?;
+    }
 
     let mut block = biscuit_auth::builder::BlockBuilder::new();
     block = block
         .fact(format!("agent({})", biscuit_string(&restrictions.agent_id)).as_str())
         .context("agent fact")?;
+    block = block
+        .fact(format!("agent_expires_at({})", restrictions.expires_at.to_rfc3339()).as_str())
+        .context("agent expiry fact")?;
     block = block
         .check(
             format!(
@@ -112,14 +181,25 @@ fn build_attenuation_block(
             .as_str(),
         )
         .context("expiry check")?;
-    if let Some(ops) = &restrictions.allowed_operations
-        && !ops.is_empty()
-    {
-        let pred = ops
-            .iter()
-            .map(|op| format!("$op == {}", biscuit_string(op)))
-            .collect::<Vec<_>>()
-            .join(" || ");
+    // This independent check is deliberately present even when the caller
+    // supplies no operation allowlist. It is the non-optional G4/destructive
+    // operation floor for every token produced by this primitive.
+    for denied in AGENT_OPERATION_DENY_FLOOR {
+        block = block
+            .check(format!("check if operation($op), $op != {}", biscuit_string(denied)).as_str())
+            .context("agent operation deny floor")?;
+    }
+    if let Some(ops) = &restrictions.allowed_operations {
+        let pred = if ops.is_empty() {
+            // A syntactically valid predicate that no real gRPC method can
+            // match. `Some(vec![])` therefore means deny all, not unrestricted.
+            "$op == \"__heddle_no_agent_operations__\"".to_string()
+        } else {
+            ops.iter()
+                .map(|op| format!("$op == {}", biscuit_string(op)))
+                .collect::<Vec<_>>()
+                .join(" || ")
+        };
         block = block
             .check(format!("check if operation($op), {pred}").as_str())
             .context("operation allowlist check")?;
@@ -141,6 +221,18 @@ fn build_attenuation_block(
         block = block
             .check(format!("check if resource($k, $p), {pred}").as_str())
             .context("resource allowlist check")?;
+    }
+    for (kind, path) in &restrictions.declared_scopes {
+        block = block
+            .fact(
+                format!(
+                    "agent_scope({}, {})",
+                    biscuit_string(kind),
+                    biscuit_string(path)
+                )
+                .as_str(),
+            )
+            .context("forward-compatible resource scope")?;
     }
     Ok(block)
 }
@@ -224,13 +316,14 @@ pub fn read_only_repo_agent(
                 "ListContext".to_string(),
             ]),
             allowed_resources: Some(vec![("repo".to_string(), repo_path.into())]),
+            declared_scopes: Vec::new(),
         },
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use biscuit_auth::KeyPair;
+    use biscuit_auth::{Biscuit, KeyPair, builder::AuthorizerBuilder};
 
     use super::*;
 
@@ -252,6 +345,24 @@ mod tests {
             .expect("expiry check");
         let biscuit = builder.build(&kp).expect("build parent biscuit");
         (biscuit.to_base64().expect("to_base64"), kp)
+    }
+
+    /// Exercise the same Biscuit chain verification and request-fact shape as
+    /// the hosted server (`time` + bare gRPC `operation`).
+    fn server_authorizes(
+        token: &str,
+        root: &KeyPair,
+        operation: &str,
+        now: DateTime<Utc>,
+    ) -> Result<(), biscuit_auth::error::Token> {
+        let root_public = root.public();
+        let biscuit = Biscuit::from_base64(token, move |_| Ok(root_public))?;
+        let mut authorizer = AuthorizerBuilder::new()
+            .fact(format!("time({})", now.to_rfc3339()).as_str())?
+            .fact(format!("operation({})", biscuit_string(operation)).as_str())?
+            .policy("allow if true")?
+            .build(&biscuit)?;
+        authorizer.authorize().map(|_| ())
     }
 
     #[test]
@@ -302,6 +413,7 @@ mod tests {
                 expires_at: Utc::now() + chrono::Duration::hours(1),
                 allowed_operations: Some(vec![r#"x" || true || $op == "y"#.to_string()]),
                 allowed_resources: None,
+                declared_scopes: Vec::new(),
             },
         )
         .expect_err("injection payload must be rejected");
@@ -322,9 +434,125 @@ mod tests {
                 expires_at: Utc::now() + chrono::Duration::hours(1),
                 allowed_operations: Some(vec!["GetState".to_string(), "ListRefs".to_string()]),
                 allowed_resources: Some(vec![("repo".to_string(), "org/acme/heddle".to_string())]),
+                declared_scopes: Vec::new(),
             },
         )
         .expect("normal ops must attenuate");
+    }
+
+    #[test]
+    fn server_accepts_allowed_operation_and_rejects_g4_and_delete_floor() {
+        let (parent, root) = fresh_parent_token();
+        let child = attenuate_for_agent(
+            &parent,
+            AgentAttenuation {
+                agent_id: "agent-safe".to_string(),
+                expires_at: Utc::now() + chrono::Duration::hours(1),
+                allowed_operations: Some(
+                    SAFE_AGENT_OPERATIONS
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect(),
+                ),
+                allowed_resources: None,
+                declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
+            },
+        )
+        .expect("derive safe child");
+
+        let parent_authority = biscuit_auth::UnverifiedBiscuit::from_base64(parent.as_bytes())
+            .expect("parse parent")
+            .print_block_source(0)
+            .expect("parent authority");
+        let child_authority = biscuit_auth::UnverifiedBiscuit::from_base64(child.as_bytes())
+            .expect("parse child")
+            .print_block_source(0)
+            .expect("child authority");
+        assert_eq!(
+            child_authority, parent_authority,
+            "offline attenuation must leave the root-human authority block unchanged"
+        );
+
+        server_authorizes(&child, &root, "Push", Utc::now())
+            .expect("server accepts an allowlisted push");
+        for denied in AGENT_OPERATION_DENY_FLOOR {
+            assert!(
+                server_authorizes(&child, &root, denied, Utc::now()).is_err(),
+                "server must reject hard-denied operation {denied}"
+            );
+        }
+    }
+
+    #[test]
+    fn server_rejects_child_after_attenuation_ttl() {
+        let (parent, root) = fresh_parent_token();
+        let expires_at = Utc::now() + chrono::Duration::minutes(5);
+        let child = attenuate_for_agent(
+            &parent,
+            AgentAttenuation {
+                agent_id: "agent-expiring".to_string(),
+                expires_at,
+                allowed_operations: Some(vec!["GetState".to_string()]),
+                allowed_resources: None,
+                declared_scopes: Vec::new(),
+            },
+        )
+        .expect("derive expiring child");
+
+        server_authorizes(&child, &root, "GetState", Utc::now())
+            .expect("server accepts child before expiry");
+        assert!(
+            server_authorizes(
+                &child,
+                &root,
+                "GetState",
+                expires_at + chrono::Duration::seconds(1)
+            )
+            .is_err(),
+            "server must reject child after TTL"
+        );
+    }
+
+    #[test]
+    fn sub_derivation_intersects_every_operation_block() {
+        let (parent, root) = fresh_parent_token();
+        let parent_agent = attenuate_for_agent(
+            &parent,
+            AgentAttenuation {
+                agent_id: "agent-parent".to_string(),
+                expires_at: Utc::now() + chrono::Duration::hours(1),
+                allowed_operations: Some(vec!["Push".to_string()]),
+                allowed_resources: None,
+                declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
+            },
+        )
+        .expect("derive parent agent");
+        let subagent = attenuate_for_agent(
+            &parent_agent,
+            AgentAttenuation {
+                agent_id: "agent-child".to_string(),
+                expires_at: Utc::now() + chrono::Duration::minutes(30),
+                // Attempt to add GetState cannot override the parent's block.
+                allowed_operations: Some(vec!["Push".to_string(), "GetState".to_string()]),
+                allowed_resources: None,
+                declared_scopes: vec![("repo".to_string(), "acme/heddle/subdir".to_string())],
+            },
+        )
+        .expect("derive subagent");
+
+        server_authorizes(&subagent, &root, "Push", Utc::now())
+            .expect("operation retained by both blocks is allowed");
+        assert!(
+            server_authorizes(&subagent, &root, "GetState", Utc::now()).is_err(),
+            "a child cannot widen its parent's operation set"
+        );
+        let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(subagent.as_bytes())
+            .expect("parse subagent");
+        assert_eq!(parsed.block_count(), 3, "authority plus two agent hops");
+        let parent_source = parsed.print_block_source(1).expect("parent block source");
+        let child_source = parsed.print_block_source(2).expect("child block source");
+        assert!(parent_source.contains("agent_scope(\"repo\", \"acme/heddle\")"));
+        assert!(child_source.contains("agent_scope(\"repo\", \"acme/heddle/subdir\")"));
     }
 
     #[test]

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -166,7 +166,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn headless_install_supplies_a_verifiable_hosted_proof() {
+    async fn derived_child_supplies_a_verifiable_inherited_hosted_proof() {
         use base64::Engine as _;
         use biscuit_auth::{Biscuit, KeyPair};
         use crypto::{Ed25519Signer, Signer};
@@ -232,6 +232,27 @@ mod tests {
             assert_eq!(identity.public_key, hex::encode(signer.public_key()));
             assert_eq!(identity.server, server);
 
+            let child_token = crate::device_flow::attenuate_for_agent(
+                &token,
+                crate::device_flow::AgentAttenuation {
+                    agent_id: "agent-push".to_string(),
+                    expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+                    allowed_operations: Some(vec!["Push".to_string()]),
+                    allowed_resources: None,
+                    declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
+                },
+            )
+            .expect("derive child credential");
+            auth_cmd::install_headless_credential(server, &child_token, &key_path)
+                .expect("install derived child bundle");
+            let installed_child = credentials::get_server_credential(server)
+                .expect("load derived child")
+                .expect("installed derived child");
+            assert!(
+                installed_child.credential_id.is_none(),
+                "installing an attenuated bundle must disable caveat-shedding renewal"
+            );
+
             let session = HostedSession::build(
                 &cli_shared::UserConfig::default(),
                 Some(server.to_string()),
@@ -292,14 +313,14 @@ mod tests {
                 .expect("decode proof signature");
             crypto::pop::verify_pop(
                 signer.public_key(),
-                &token,
+                &child_token,
                 proof_ts,
                 "POST",
                 method,
                 nonce,
                 &signature,
             )
-            .expect("proof verifies against installed device key");
+            .expect("derived-token proof verifies against inherited device key");
         });
 
         unsafe {

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -9,7 +9,7 @@
 
 use std::net::SocketAddr;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use cli_shared::{ClientConfig, UserConfig};
 use wire::{AuthToken, ProtocolError};
 
@@ -41,14 +41,15 @@ pub struct HostedSession {
 impl HostedSession {
     /// Resolve auth + build the validated client config for a hosted session.
     /// Owns credential-store fallback (per `mode`), server-key attachment, and
-    /// proof-key attachment — the assembly the command modules used to
+    /// proof-key attachment from either a credential or the matching shared
+    /// same-host device identity — the assembly the command modules used to
     /// hand-roll.
     pub fn build(
         user_config: &UserConfig,
         server_key: Option<String>,
         mode: HostedAuthMode,
     ) -> Result<Self> {
-        let (token, credential_proof_key) = match mode {
+        let (token, mut credential_proof_key) = match mode {
             HostedAuthMode::ConfigToken => (user_config.remote_token()?, None),
             HostedAuthMode::CredentialFallback => {
                 let mut token = user_config.remote_token()?;
@@ -73,6 +74,13 @@ impl HostedSession {
                 (token, credential_proof_key)
             }
         };
+
+        if credential_proof_key.is_none()
+            && let Some(ref key) = server_key
+            && let Some(token) = token.as_ref()
+        {
+            credential_proof_key = shared_device_proof_key(key, &token.id)?;
+        }
 
         let mut config = user_config.heddle_client_config(token)?;
         if let Some(key) = server_key {
@@ -107,6 +115,59 @@ impl HostedSession {
         client.auto_rotate_if_needed().await;
         Ok(client)
     }
+}
+
+fn shared_device_proof_key(server_key: &str, token: &str) -> Result<Option<String>> {
+    let identity = repo::identity::load_device(&repo::identity::device_identity_path())
+        .context("loading this host's shared device identity")?;
+    let Some(identity) = identity else {
+        return Ok(None);
+    };
+    if !server_keys_match(&identity.server, server_key)
+        || !token_proof_key_matches(token, &identity.public_key)
+    {
+        return Ok(None);
+    }
+    Ok(Some(identity.private_key_pem))
+}
+
+fn token_proof_key_matches(token: &str, expected_public_key_hex: &str) -> bool {
+    use biscuit_auth::builder::{BlockBuilder, Term};
+
+    let Ok(biscuit) = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes()) else {
+        return false;
+    };
+    let Ok(authority_source) = biscuit.print_block_source(0) else {
+        return false;
+    };
+    let Ok(authority) = BlockBuilder::new().code(&authority_source) else {
+        return false;
+    };
+    let mut proof_keys = authority.facts.iter().filter_map(|fact| {
+        if fact.predicate.name != "device_pop_key" || fact.predicate.terms.len() != 1 {
+            return None;
+        }
+        match &fact.predicate.terms[0] {
+            Term::Str(value) => Some(value),
+            _ => None,
+        }
+    });
+    let Some(proof_key) = proof_keys.next() else {
+        return false;
+    };
+    proof_keys.next().is_none() && proof_key.eq_ignore_ascii_case(expected_public_key_hex)
+}
+
+fn server_keys_match(left: &str, right: &str) -> bool {
+    fn without_scheme(value: &str) -> &str {
+        value
+            .strip_prefix("http://")
+            .or_else(|| value.strip_prefix("https://"))
+            .or_else(|| value.strip_prefix("heddle://"))
+            .unwrap_or(value)
+    }
+
+    without_scheme(left) == without_scheme(right)
 }
 
 impl HostedGrpcClient {
@@ -166,7 +227,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn derived_child_supplies_a_verifiable_inherited_hosted_proof() {
+    async fn token_only_derived_child_uses_shared_same_host_device_proof() {
         use base64::Engine as _;
         use biscuit_auth::{Biscuit, KeyPair};
         use crypto::{Ed25519Signer, Signer};
@@ -178,6 +239,7 @@ mod tests {
         let _guard = credentials::lock_test_env();
         let home = tempfile::TempDir::new().expect("temp Heddle home");
         let previous_home = std::env::var_os("HEDDLE_HOME");
+        let previous_remote_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
         unsafe { std::env::set_var("HEDDLE_HOME", home.path()) };
 
         let result = std::panic::catch_unwind(|| {
@@ -242,24 +304,21 @@ mod tests {
                     declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
                 },
             )
-            .expect("derive child credential");
-            auth_cmd::install_headless_credential(server, &child_token, &key_path)
-                .expect("install derived child bundle");
-            let installed_child = credentials::get_server_credential(server)
-                .expect("load derived child")
-                .expect("installed derived child");
-            assert!(
-                installed_child.credential_id.is_none(),
-                "installing an attenuated bundle must disable caveat-shedding renewal"
-            );
+            .expect("derive child token");
+            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
 
             let session = HostedSession::build(
                 &cli_shared::UserConfig::default(),
                 Some(server.to_string()),
-                HostedAuthMode::CredentialFallback,
+                HostedAuthMode::ConfigToken,
             )
-            .expect("build hosted session from installed credential");
+            .expect("build hosted session from token-only same-host handoff");
             let config = session.config;
+            assert_eq!(
+                config.auth_proof_key_pem.as_deref(),
+                Some(private_key_pem.as_str()),
+                "token-only handoff must resolve the proof key from the shared device identity"
+            );
             let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
             let client = HostedGrpcClient {
                 inner: grpc::heddle::v1::repo_sync_service_client::RepoSyncServiceClient::new(
@@ -320,13 +379,17 @@ mod tests {
                 nonce,
                 &signature,
             )
-            .expect("derived-token proof verifies against inherited device key");
+            .expect("derived-token proof verifies against the shared same-host device key");
         });
 
         unsafe {
             match previous_home {
                 Some(path) => std::env::set_var("HEDDLE_HOME", path),
                 None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match previous_remote_token {
+                Some(token) => std::env::set_var("HEDDLE_REMOTE_TOKEN", token),
+                None => std::env::remove_var("HEDDLE_REMOTE_TOKEN"),
             }
         }
         if let Err(payload) = result {

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -2955,8 +2955,8 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
     "advanced_scope_mutating_commands_total": 61,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 22,
-    "catalog_commands_total": 183,
-    "catalog_mutating_commands_total": 89,
+    "catalog_commands_total": 184,
+    "catalog_mutating_commands_total": 90,
     "json_commands_total": 148,
     "json_commands_with_accepted_opaque_schema": 39,
     "json_commands_with_schema": 109,
@@ -2970,7 +2970,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "183 command(s), 148 JSON command(s), 89 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "184 command(s), 148 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3008,7 +3008,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "183 command(s), 148 JSON command(s), 89 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "184 command(s), 148 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
Closes #1019

## What changed

- adds `heddle auth derive-agent` with offline Biscuit attenuation from the stored server credential
- defaults to a one-hour TTL, a curated push/read/pull/context/discuss operation ceiling, repeatable `--scope`, and optional `--allow` narrowing
- installs the child token locally, emits the raw token with `--stdout`, or writes a 0600 token-only export with `--out`
- `--out` now contains exactly `token` plus `metadata.json` (`server`, `subject`, effective `expires_at`, declared `scopes`); it never exports the device private key and removes a stale legacy `device-key.pem`
- token-only same-host use resolves the matching shared device identity for hosted-write PoP, bound to both server and the token `device_pop_key`
- preserves every ancestor block for subagent derivation, rejects declared scope widening, and disables child auto-rotation

## Security boundaries

The derived token is strictly weaker: the operation fence and TTL are enforced server-side. Resource scopes are carried as `agent_scope(kind, path)` declarations now and remain inert until W3 request-resource enforcement.

W1 does not fully close G4 credential laundering. Hosted writes require the same-host device root key, and a holder of that key can authenticate bootstrap-exempt `MintBiscuit(KeypairProof)` without consulting the attenuated token. A W1 derived token is therefore not a portable credential or a cross-trust-boundary security control. W2 delegated PoP gives the child a distinct block-bound proof key and closes that remaining path.

The hard deny floor for `CreateServiceAccount`, `IssueServiceAccountCredential`, `DeleteRepository`, and `DeleteNamespace` remains unchanged and limits use of the attenuated token itself.

## Validation

- `CARGO_INCREMENTAL=0 cargo test -p heddle-client --lib` (125 passed)
- focused token-only export regression (actual PEM bytes + PEM header absent; stale legacy key removed)
- focused same-host proof regression (token supplied alone through config; proof key read from shared device identity and signature verified)
- `CARGO_INCREMENTAL=0 cargo test -p heddle-cli --features client cli::cli_args::commands_client::tests --lib` (4 passed)
- `CARGO_INCREMENTAL=0 cargo test -p heddle-cli --features client command_catalog --lib` (44 passed)
- `CARGO_INCREMENTAL=0 cargo build --workspace`
- `CARGO_INCREMENTAL=0 cargo clippy --workspace --all-targets -- -D warnings`
