### PR TITLE
feat(auth): rotate proof keys for derived agents

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -56,32 +56,33 @@ floor, including for callers of the Rust helper. They restrict use of the
 derived token; they do not constrain device-key-authenticated `MintBiscuit`.
 
 By default the child replaces the active stored credential for `--server`, so
-the next push/pull and any further derivation use that child. Use `--stdout` to
-emit only the token without installing it, or `--out <DIR>` to write 0600
-`token` and `metadata.json` files. The metadata records the server, subject,
-effective expiry, and declared scopes. Neither export contains a private key.
+the next push/pull and any further derivation use that child and its fresh PoP
+key. Use `--out <DIR>` to write a portable 0600 bundle containing `token`,
+`device-key.pem` (the child key), and `metadata.json`. The parent device key is
+never written into the child credential or bundle. Token-only `--stdout`
+export is intentionally unsupported because the resulting bearer could not
+satisfy its request-proof binding.
 
 The derived token is strictly weaker than its parent: its operation fence and
 TTL are enforced server-side. Declared resource scopes await W3 enforcement.
-Hosted writes also require the matching device key from this host's shared
-identity store, so a token-only export is not a portable credential.
+Every child block carries one `pop_delegation(parent_revocation_id,
+child_public_key, signature)` fact. The parent signs a versioned payload over
+the preceding block's raw revocation id and the new 32-byte key. Weft verifies
+those transitions in block-id order and accepts request proofs only from the
+leaf key, so sub-derivation rotates again without exposing any ancestor key.
 
-W1 does not fully close G4 credential laundering. A process with the parent
-device root key can authenticate `MintBiscuit` independently of the attenuated
-token and obtain a fresh authority token. Do not treat a W1 derived token as a
-cross-trust-boundary security control. W2 delegated PoP gives each child its own
-block-bound key without handing over the parent device root key and closes that
-remaining path.
+## API: `heddle_client::auth`
 
-## API: `cli::auth`
-
-The CLI surface is small: one struct, one main function, two
+The Rust surface is small: one struct, one main function, two
 convenience constructors.
 
 ```rust
-use cli::auth::{
+use heddle_client::auth::{
     AgentAttenuation, attenuate_for_agent, time_bounded, read_only_repo_agent,
 };
+
+// `parent_signer` is the private key matching the parent token's effective
+// PoP key. Generate a fresh `child_signer` for every attenuation hop.
 
 // Simplest: time-bounded sub-agent that inherits everything else
 // from the parent.
@@ -89,6 +90,8 @@ let attenuated = time_bounded(
     &parent_token_b64,
     "agent-doc-pr-42",
     chrono::Utc::now() + chrono::Duration::hours(4),
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 
 // Read-only sub-agent on a single repo.
@@ -97,6 +100,8 @@ let attenuated = read_only_repo_agent(
     "agent-explorer",
     "org/acme/heddle",
     /* duration_hours = */ 2,
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 
 // Custom: build the AgentAttenuation field-by-field.
@@ -115,23 +120,24 @@ let attenuated = attenuate_for_agent(
         ]),
         declared_scopes: Vec::new(),
     },
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 ```
 
 ## Restriction semantics
 
-Every restriction emits a Biscuit `check if ...` clause. The
-verifier runs each check against the world (which contains the
-parent's facts plus whatever the verifier injects per-request:
-`time(now)`, `operation($name)`, `resource($kind, $path)` when
-applicable). A check that finds no binding is a hard reject — that's
-the secure default.
+Every restriction emits a Biscuit `check if ...` clause. The verifier runs each
+check against the world. Current servers inject `time(now)` and
+`operation($name)` per request. W3 plans to add `resource($kind, $path)`; until
+then, any `allowed_resources` check finds no binding and rejects every request.
+A check that finds no binding is a hard reject — that's the secure default.
 
 | Restriction | Datalog form | Default behaviour when no fact present |
 |---|---|---|
 | `expires_at` | `check if time($now), $now < <ts>` | Verifier always injects `time`, so always evaluated |
 | `allowed_operations: Some([...])` | `check if operation($op), $op == "X" \|\| ...` | Reject (no operation fact → check fails closed) |
-| `allowed_resources: Some([...])` | `check if resource($k, $p), (...path matches...)` | Reject (no resource fact → check fails closed) |
+| `allowed_resources: Some([...])` | `check if resource($k, $p), (...path matches...)` | Reject every request until W3 injects resource facts |
 | `declared_scopes` | `agent_scope($kind, $path)` facts | Inert until W3 server enforcement |
 | hard deny floor | one `operation($op), $op != …` check per forbidden method | Reject (the floor is always emitted) |
 
@@ -150,14 +156,17 @@ let attenuated = read_only_repo_agent(
     "agent-pr-review",
     "org/acme/heddle",
     4,  // hours
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 // Hand `attenuated` to the agent.
 ```
 
 The `read_only_repo_agent` constructor allowlists the read RPCs
 (`GetState`, `GetTree`, `GetBlob`, `GetCompare`, `GetDiff`,
-`ListRefs`, `ListStates`, `ListContext`) and pins the resource list
-to the repo path. Any write RPC fails with `PermissionDenied`.
+`ListRefs`, `ListStates`, `ListContext`) and adds a resource check for
+the repo path. The operation fence is active today; the resource-scoped recipe
+remains fail-closed until W3 injects resource facts.
 
 ### 2. Time-bounded background agent
 
@@ -166,6 +175,8 @@ let attenuated = time_bounded(
     &parent,
     "agent-overnight-build",
     chrono::Utc::now() + chrono::Duration::hours(12),
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 ```
 
@@ -176,7 +187,7 @@ hours.
 ### 3. Multi-repo writer
 
 ```rust
-use cli::auth::{AgentAttenuation, attenuate_for_agent};
+use heddle_client::auth::{AgentAttenuation, attenuate_for_agent};
 
 let attenuated = attenuate_for_agent(
     &parent,
@@ -193,14 +204,25 @@ let attenuated = attenuate_for_agent(
         ]),
         declared_scopes: Vec::new(),
     },
+    &parent_signer,
+    child_signer.public_key(),
 )?;
 ```
+
+This resource-scoped recipe remains fail-closed until W3 injects resource facts.
 
 ### 4. Sub-sub-agent (further attenuation)
 
 ```rust
 // Parent attenuates for the agent.
-let agent_token = read_only_repo_agent(&parent, "agent-1", "org/acme/heddle", 8)?;
+let agent_token = read_only_repo_agent(
+    &parent,
+    "agent-1",
+    "org/acme/heddle",
+    8,
+    &root_signer,
+    agent_signer.public_key(),
+)?;
 
 // Inside the agent process, attenuate further for a sub-agent.
 let sub_agent_token = attenuate_for_agent(
@@ -216,6 +238,8 @@ let sub_agent_token = attenuate_for_agent(
         ]),
         declared_scopes: Vec::new(),
     },
+    &agent_signer,
+    subagent_signer.public_key(),
 )?;
 ```
 
@@ -249,9 +273,9 @@ boundary is:
 
 ## What you can't do
 
-The statements in this section describe attenuation of the token itself. They
-do not apply to a holder of the W1 parent device root key, which remains able to
-authenticate `MintBiscuit` until W2 delegated PoP separates child proofs.
+The statements in this section describe the attenuated token and its delegated
+leaf proof key. The derive path never copies an ancestor private key into the
+child credential.
 
 - **Widen authority.** A child block can only emit *additional*
   checks. There is no way to add rights the parent didn't have.

--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -69,7 +69,11 @@ Every child block carries one `pop_delegation(parent_revocation_id,
 child_public_key, signature)` fact. The parent signs a versioned payload over
 the preceding block's raw revocation id and the new 32-byte key. Weft verifies
 those transitions in block-id order and accepts request proofs only from the
-leaf key, so sub-derivation rotates again without exposing any ancestor key.
+leaf key in coordinated, pending PR
+[weft#577](https://github.com/HeddleCo/weft/pull/577). This client half is
+pending in [heddle#1022](https://github.com/HeddleCo/heddle/pull/1022); the two
+PRs must merge together. Once they do, sub-derivation rotates again without
+exposing any ancestor key.
 
 ## API: `heddle_client::auth`
 

--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -49,11 +49,15 @@ heddle auth derive-agent \
 Without `--allow`, the command installs the curated safe set: push/pull,
 repository reads, context operations, discussions, and `WhoAmI`. Repeating
 `--allow` selects a subset; it cannot opt into an unsafe method. Every derived
-block independently rejects `CreateServiceAccount`,
-`IssueServiceAccountCredential`, `DeleteRepository`, and `DeleteNamespace`.
-Those checks are the non-optional credential-issuing and destructive-operation
-floor, including for callers of the Rust helper. They restrict use of the
-derived token; they do not constrain device-key-authenticated `MintBiscuit`.
+block independently applies the mandatory deny policy in
+[`device_flow.rs`](../crates/client/src/device_flow.rs). That policy rejects
+bearer-authorized credential issuance, auth-trust mutation, recovery-method
+enrollment, and presence-token issuance, plus `DeleteRepository` and
+`DeleteNamespace`. Its `AuthService` table is checked for exact agreement with
+`auth.proto`, so a new auth RPC cannot land without an explicit agent-policy
+classification. These checks also apply to direct callers of the Rust helper.
+They restrict use of the derived token; they do not constrain
+device-key-authenticated `MintBiscuit`.
 
 By default the child replaces the active stored credential for `--server`, so
 the next push/pull and any further derivation use that child and its fresh PoP
@@ -185,8 +189,8 @@ let attenuated = time_bounded(
 ```
 
 No operation or resource allowlist — the agent inherits the parent except for
-the non-optional credential-issuance/delete floor, and only for the next 12
-hours.
+the mandatory auth-trust/credential/recovery-enrollment/presence and delete
+floor, and only for the next 12 hours.
 
 ### 3. Multi-repo writer
 
@@ -199,7 +203,7 @@ let attenuated = attenuate_for_agent(
         agent_id: "agent-cross-repo".to_string(),
         expires_at: chrono::Utc::now() + chrono::Duration::hours(2),
         // No operation allowlist → inherits the parent except for the
-        // non-optional credential-issuance/delete floor.
+        // mandatory auth-trust/credential/recovery/presence/delete floor.
         allowed_operations: None,
         // But only on these two repos.
         allowed_resources: Some(vec![

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Breaking
 
+- **Derived agent credentials no longer support `--stdout`.** A derived token
+  is bound to its freshly generated child proof key, so `heddle auth
+  derive-agent --out <directory>` writes the portable token-and-key bundle;
+  omitting `--out` installs both together in the local credential store.
+
 - **Repository and wire format v3.** Physical state identity is now a 32-byte
   content-addressed `StateId`, distinct from rewrite-stable `ChangeId`, and
   signatures are attachments rather than identity-bearing state fields. Heddle

--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -60,13 +60,9 @@ pub enum AuthCommands {
         #[arg(long = "allow")]
         allowed_operations: Vec<String>,
 
-        /// Write `token` and `metadata.json` files to this directory without exporting the device key.
-        #[arg(long, value_name = "DIR", conflicts_with = "stdout")]
+        /// Write `token`, child `device-key.pem`, and `metadata.json` files to this directory.
+        #[arg(long, value_name = "DIR")]
         out: Option<std::path::PathBuf>,
-
-        /// Print only the child token instead of installing it (security note goes to stderr).
-        #[arg(long, conflicts_with = "out")]
-        stdout: bool,
     },
 
     /// Create a service token for CI/scripts, scoped to a namespace
@@ -111,7 +107,6 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
                 scopes,
                 allowed_operations,
                 out,
-                stdout,
             } => heddle_client::AuthCommand::DeriveAgent {
                 server,
                 agent_id,
@@ -119,7 +114,6 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
                 scopes,
                 allowed_operations,
                 out,
-                stdout,
             },
             AuthCommands::CreateServiceToken {
                 name,
@@ -251,5 +245,18 @@ mod tests {
         assert_eq!(ttl_secs, 900);
         assert_eq!(scopes, ["repo:acme/api", "namespace:acme"]);
         assert_eq!(allowed_operations, ["Push", "GetState"]);
+
+        assert!(
+            Cli::try_parse_from([
+                "heddle",
+                "auth",
+                "derive-agent",
+                "--server",
+                "grpc.heddle.test",
+                "--stdout",
+            ])
+            .is_err(),
+            "token-only child export is unsafe because it cannot carry its proof key"
+        );
     }
 }

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -1824,7 +1824,7 @@ mod tests {
     }
 
     #[test]
-    fn derive_agent_installs_inherited_pop_child_and_supports_narrower_subderivation() {
+    fn derive_agent_installs_fresh_pop_child_and_supports_narrower_subderivation() {
         with_isolated_home(|| {
             let server = "grpc.S";
             let (parent, private_key_pem) = stored_device_parent();
@@ -1843,12 +1843,20 @@ mod tests {
             let installed = credentials::get_server_credential(server)
                 .expect("load installed child")
                 .expect("installed child");
-            assert_eq!(
-                installed.private_key_pem.as_deref(),
-                Some(private_key_pem.as_str()),
-                "W1 child inherits the parent PoP key"
+            let installed_private_key = installed
+                .private_key_pem
+                .as_deref()
+                .expect("derived child stores its own PoP key");
+            assert_ne!(
+                installed_private_key, private_key_pem,
+                "the parent device private key must never be handed to a derived child"
             );
-            assert_eq!(installed.device_id.as_deref(), Some("device-root"));
+            let installed_signer =
+                Ed25519Signer::from_pem(installed_private_key).expect("parse child PoP key");
+            assert!(
+                installed.device_id.is_none(),
+                "a derived PoP key is not the registered root device key"
+            );
             assert!(
                 installed.credential_id.is_none(),
                 "derived tokens must not auto-rotate into an unattenuated token"
@@ -1861,6 +1869,13 @@ mod tests {
                     .print_block_source(1)
                     .expect("child block")
                     .contains("agent_scope(\"repo\", \"acme/heddle\")")
+            );
+            assert!(
+                parsed
+                    .print_block_source(1)
+                    .expect("child block")
+                    .contains(&hex::encode(installed_signer.public_key())),
+                "the child attenuation block must bind the child's PoP public key"
             );
 
             cmd_auth_derive_agent(
@@ -1876,12 +1891,29 @@ mod tests {
             let subagent = credentials::get_server_credential(server)
                 .expect("load subagent")
                 .expect("installed subagent");
+            let subagent_private_key = subagent
+                .private_key_pem
+                .as_deref()
+                .expect("subagent stores its own PoP key");
+            assert_ne!(
+                subagent_private_key, installed_private_key,
+                "each delegation hop must generate a fresh private key"
+            );
+            let subagent_signer =
+                Ed25519Signer::from_pem(subagent_private_key).expect("parse subagent PoP key");
             let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(subagent.token.as_bytes())
                 .expect("parse subagent");
             assert_eq!(
                 parsed.block_count(),
                 3,
                 "delegation tree adds one block per hop"
+            );
+            assert!(
+                parsed
+                    .print_block_source(2)
+                    .expect("subagent block")
+                    .contains(&hex::encode(subagent_signer.public_key())),
+                "the subagent attenuation block must bind the subagent's PoP public key"
             );
 
             let error = cmd_auth_derive_agent(
@@ -1899,7 +1931,7 @@ mod tests {
     }
 
     #[test]
-    fn derive_agent_export_contains_token_and_metadata_but_no_device_key() {
+    fn derive_agent_export_contains_token_metadata_and_a_fresh_child_key() {
         with_isolated_home(|| {
             let server = "grpc.S";
             let (parent, private_key_pem) = stored_device_parent();
@@ -1922,7 +1954,7 @@ mod tests {
                 Some(&export_dir),
                 false,
             )
-            .expect("derive token-only export");
+            .expect("derive portable child credential");
 
             let mut entries = std::fs::read_dir(&export_dir)
                 .expect("read export directory")
@@ -1935,24 +1967,19 @@ mod tests {
                 })
                 .collect::<Vec<_>>();
             entries.sort();
-            assert_eq!(entries, ["metadata.json", "token"]);
+            assert_eq!(entries, ["device-key.pem", "metadata.json", "token"]);
 
             let token = std::fs::read(export_dir.join("token")).expect("read exported token");
+            let child_private_key = std::fs::read_to_string(export_dir.join("device-key.pem"))
+                .expect("read exported child key");
             let metadata =
                 std::fs::read(export_dir.join("metadata.json")).expect("read export metadata");
-            let export_bytes = [token.as_slice(), metadata.as_slice()].concat();
-            assert!(
-                !export_bytes
-                    .windows(private_key_pem.len())
-                    .any(|window| window == private_key_pem.as_bytes()),
-                "portable export must not contain the device private key"
+            assert_ne!(
+                child_private_key, private_key_pem,
+                "portable export must contain a fresh child key, never the parent device key"
             );
-            assert!(
-                !export_bytes
-                    .windows(b"-----BEGIN PRIVATE KEY-----".len())
-                    .any(|window| window == b"-----BEGIN PRIVATE KEY-----"),
-                "portable export must not contain a PEM private-key header"
-            );
+            let child_signer =
+                Ed25519Signer::from_pem(&child_private_key).expect("parse exported child key");
 
             let metadata: serde_json::Value =
                 serde_json::from_slice(&metadata).expect("parse export metadata");
@@ -1960,8 +1987,15 @@ mod tests {
             assert_eq!(metadata["subject"], "alice");
             assert_eq!(metadata["scopes"], serde_json::json!(["repo:acme/heddle"]));
             assert!(metadata["expires_at"].as_str().is_some());
-            biscuit_auth::UnverifiedBiscuit::from_base64(&token)
+            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(&token)
                 .expect("exported token is a Biscuit");
+            assert!(
+                parsed
+                    .print_block_source(1)
+                    .expect("exported child block")
+                    .contains(&hex::encode(child_signer.public_key())),
+                "the exported token must bind the key exported beside it"
+            );
         });
     }
 

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -454,6 +454,7 @@ fn write_agent_bundle(
 
 struct HeadlessTokenMetadata {
     subject: String,
+    is_derived: bool,
     credential_id: Option<String>,
     expires_at: Option<String>,
     proof_public_key_hex: String,
@@ -494,8 +495,10 @@ pub(crate) fn install_headless_credential(
         expires_at: metadata.expires_at,
     };
     credentials::store_server_credential(server, credential)?;
-    repo::identity::link_device_key(signer.public_key(), &private_key_pem, server)
-        .with_context(|| format!("registering device identity for {server}"))?;
+    if !metadata.is_derived {
+        repo::identity::link_device_key(signer.public_key(), &private_key_pem, server)
+            .with_context(|| format!("registering device identity for {server}"))?;
+    }
 
     Ok(metadata.subject)
 }
@@ -598,6 +601,7 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
 
     Ok(HeadlessTokenMetadata {
         subject,
+        is_derived: block_count > 1,
         credential_id,
         expires_at,
         proof_public_key_hex,

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -19,7 +19,9 @@ use tonic::{
 };
 use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
-use crate::device_flow::{AgentAttenuation, SAFE_AGENT_OPERATIONS, attenuate_for_agent};
+use crate::device_flow::{
+    AgentAttenuation, SAFE_AGENT_OPERATIONS, attenuate_for_agent, effective_pop_public_key_hex,
+};
 use crate::{auth_requests::AuthCommand, credentials, credentials::ServerCredential};
 
 /// Top-level dispatch for `heddle auth <subcommand>`. `_ctx` is
@@ -73,7 +75,7 @@ struct AgentTokenExportMetadata<'a> {
     scopes: Vec<String>,
 }
 
-const DERIVED_TOKEN_SECURITY_NOTE: &str = "Derived token is operation/TTL-limited and enforced server-side; declared scopes await W3 enforcement. It uses this host's device key for hosted-write proofs (same-host only); it is not a portable credential -- cross-host delegation lands in W2.";
+const DERIVED_TOKEN_SECURITY_NOTE: &str = "Derived credential has its own proof key and is operation/TTL-limited server-side; declared scopes await W3 enforcement. Keep the token and child key together; the parent device key is not exported.";
 
 const SERVICE_TOKEN_TTL_DAYS: u32 = 30;
 const SERVICE_TOKEN_TTL_SECS: i64 = SERVICE_TOKEN_TTL_DAYS as i64 * 24 * 3600;
@@ -114,7 +116,6 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             scopes,
             allowed_operations,
             out,
-            stdout,
         } => cmd_auth_derive_agent(
             &server,
             agent_id,
@@ -122,7 +123,6 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             scopes,
             allowed_operations,
             out.as_deref(),
-            stdout,
         ),
         AuthCommand::CreateServiceToken {
             name,
@@ -144,8 +144,8 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
     }
 }
 
-/// Derive an offline child Biscuit and either install it as the active token,
-/// write a token-only export, or emit the token.
+/// Derive an offline child credential with a fresh PoP key, then either install
+/// it as the active credential or write a portable token + child-key bundle.
 fn cmd_auth_derive_agent(
     server: &str,
     agent_id: Option<String>,
@@ -153,7 +153,6 @@ fn cmd_auth_derive_agent(
     scopes: Vec<String>,
     requested_operations: Vec<String>,
     out: Option<&Path>,
-    stdout: bool,
 ) -> Result<()> {
     if ttl_secs == 0 {
         bail!("--ttl must be greater than zero seconds");
@@ -197,6 +196,8 @@ fn cmd_auth_derive_agent(
     let allowed_operations = select_agent_operations(requested_operations)?;
     let declared_scopes = parse_agent_scopes(scopes)?;
     validate_scope_narrowing(&parent.token, &declared_scopes)?;
+    let child_signer = Ed25519Signer::generate()
+        .map_err(|error| anyhow::anyhow!("failed to generate child proof key: {error}"))?;
     let child_token = attenuate_for_agent(
         &parent.token,
         AgentAttenuation {
@@ -208,13 +209,12 @@ fn cmd_auth_derive_agent(
             allowed_resources: None,
             declared_scopes: declared_scopes.clone(),
         },
+        &signer,
+        child_signer.public_key(),
     )?;
-
-    if stdout {
-        println!("{child_token}");
-        eprintln!("{DERIVED_TOKEN_SECURITY_NOTE}");
-        return Ok(());
-    }
+    let child_private_key_pem = child_signer
+        .to_pem()
+        .map_err(|error| anyhow::anyhow!("failed to export child proof key: {error}"))?;
     if let Some(out) = out {
         let export_metadata = AgentTokenExportMetadata {
             server,
@@ -225,7 +225,7 @@ fn cmd_auth_derive_agent(
                 .map(|(kind, path)| format!("{kind}:{path}"))
                 .collect(),
         };
-        write_agent_bundle(out, &child_token, &export_metadata)?;
+        write_agent_bundle(out, &child_token, &child_private_key_pem, &export_metadata)?;
         println!("Agent token {agent_id} written to {}.", out.display());
         println!("{DERIVED_TOKEN_SECURITY_NOTE}");
         return Ok(());
@@ -240,9 +240,9 @@ fn cmd_auth_derive_agent(
         ServerCredential {
             token: child_token,
             subject: parent.subject,
-            device_id: parent.device_id,
+            device_id: None,
             credential_id: None,
-            private_key_pem: Some(private_key_pem.to_string()),
+            private_key_pem: Some(child_private_key_pem),
             expires_at: Some(expires_at.to_rfc3339()),
         },
     )?;
@@ -383,31 +383,73 @@ fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool 
 fn write_agent_bundle(
     directory: &Path,
     token: &str,
+    child_private_key_pem: &str,
     metadata: &AgentTokenExportMetadata<'_>,
 ) -> Result<()> {
-    objects::fs_atomic::create_private_dir_all(directory).with_context(|| {
-        format!(
-            "creating agent token export directory {}",
-            directory.display()
-        )
-    })?;
-    let legacy_key_path = directory.join("device-key.pem");
-    match std::fs::remove_file(&legacy_key_path) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(error)
-                .with_context(|| format!("removing legacy key {}", legacy_key_path.display()));
-        }
-    }
-    objects::fs_atomic::write_file_atomic_secret(&directory.join("token"), token.as_bytes())
-        .with_context(|| format!("writing agent token under {}", directory.display()))?;
     let mut metadata_json =
         serde_json::to_vec_pretty(metadata).context("serializing agent token metadata")?;
     metadata_json.push(b'\n');
-    objects::fs_atomic::write_file_atomic_secret(&directory.join("metadata.json"), &metadata_json)
-        .with_context(|| format!("writing agent token metadata under {}", directory.display()))?;
-    Ok(())
+
+    match std::fs::symlink_metadata(directory) {
+        Ok(_) => bail!(
+            "agent bundle destination {} already exists; choose a new --out directory",
+            directory.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("checking agent bundle destination {}", directory.display())
+            });
+        }
+    }
+
+    let parent = directory
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    objects::fs_atomic::create_private_dir_all(parent)
+        .with_context(|| format!("creating agent bundle parent {}", parent.display()))?;
+    let bundle_name = directory
+        .file_name()
+        .context("--out must name an agent bundle directory")?
+        .to_string_lossy();
+    let staging = parent.join(format!(
+        ".{bundle_name}.{}.tmp",
+        uuid::Uuid::new_v4().simple()
+    ));
+
+    let write_result = (|| -> Result<()> {
+        objects::fs_atomic::create_private_dir_all(&staging).with_context(|| {
+            format!(
+                "creating private agent bundle staging directory {}",
+                staging.display()
+            )
+        })?;
+        objects::fs_atomic::write_file_atomic_secret(
+            &staging.join("device-key.pem"),
+            child_private_key_pem.as_bytes(),
+        )
+        .with_context(|| format!("writing child proof key under {}", staging.display()))?;
+        objects::fs_atomic::write_file_atomic_secret(&staging.join("token"), token.as_bytes())
+            .with_context(|| format!("writing agent token under {}", staging.display()))?;
+        objects::fs_atomic::write_file_atomic_secret(
+            &staging.join("metadata.json"),
+            &metadata_json,
+        )
+        .with_context(|| format!("writing agent metadata under {}", staging.display()))?;
+        std::fs::rename(&staging, directory).with_context(|| {
+            format!(
+                "publishing completed agent bundle at {}",
+                directory.display()
+            )
+        })?;
+        Ok(())
+    })();
+
+    if write_result.is_err() {
+        let _ = std::fs::remove_dir_all(&staging);
+    }
+    write_result
 }
 
 struct HeadlessTokenMetadata {
@@ -500,13 +542,7 @@ fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
     } else {
         string_fact("credential_id")?
     };
-    let proof_public_key_hex = string_fact("device_pop_key")?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Biscuit is not device-bound: authority block is missing device_pop_key(key)"
-        )
-    })?;
-    hex::decode(&proof_public_key_hex)
-        .context("Biscuit device_pop_key is not valid hexadecimal")?;
+    let proof_public_key_hex = effective_pop_public_key_hex(token)?;
 
     let mut expiries = authority.facts.iter().filter_map(|fact| {
         if fact.predicate.name != "expires_at" || fact.predicate.terms.len() != 1 {
@@ -1837,7 +1873,6 @@ mod tests {
                 vec!["repo:acme/heddle".to_string()],
                 vec!["Push".to_string()],
                 None,
-                false,
             )
             .expect("derive and install parent agent");
             let installed = credentials::get_server_credential(server)
@@ -1885,7 +1920,6 @@ mod tests {
                 vec!["repo:acme/heddle/subtree".to_string()],
                 vec!["Push".to_string()],
                 None,
-                false,
             )
             .expect("derive narrower subagent");
             let subagent = credentials::get_server_credential(server)
@@ -1923,7 +1957,6 @@ mod tests {
                 vec!["repo:acme".to_string()],
                 vec!["Push".to_string()],
                 None,
-                false,
             )
             .expect_err("subagent scope widening must be rejected");
             assert!(error.to_string().contains("would widen"));
@@ -1937,13 +1970,6 @@ mod tests {
             let (parent, private_key_pem) = stored_device_parent();
             credentials::store_server_credential(server, parent).expect("store parent");
             let export_dir = repo::identity::heddle_home_dir().join("agent-export");
-            objects::fs_atomic::create_private_dir_all(&export_dir)
-                .expect("create legacy export directory");
-            objects::fs_atomic::write_file_atomic_secret(
-                &export_dir.join("device-key.pem"),
-                private_key_pem.as_bytes(),
-            )
-            .expect("seed legacy exported device key");
 
             cmd_auth_derive_agent(
                 server,
@@ -1952,7 +1978,6 @@ mod tests {
                 vec!["repo:acme/heddle".to_string()],
                 vec!["Push".to_string()],
                 Some(&export_dir),
-                false,
             )
             .expect("derive portable child credential");
 
@@ -1995,6 +2020,22 @@ mod tests {
                     .expect("exported child block")
                     .contains(&hex::encode(child_signer.public_key())),
                 "the exported token must bind the key exported beside it"
+            );
+
+            let error = cmd_auth_derive_agent(
+                server,
+                Some("agent-export-again".to_string()),
+                3600,
+                vec!["repo:acme/heddle".to_string()],
+                vec!["Push".to_string()],
+                Some(&export_dir),
+            )
+            .expect_err("an existing bundle must not be replaced piecemeal");
+            assert!(error.to_string().contains("already exists"));
+            assert_eq!(
+                std::fs::read(export_dir.join("token")).expect("re-read original token"),
+                token,
+                "a refused replacement must leave the completed bundle unchanged"
             );
         });
     }

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -437,12 +437,7 @@ fn write_agent_bundle(
             &metadata_json,
         )
         .with_context(|| format!("writing agent metadata under {}", staging.display()))?;
-        std::fs::rename(&staging, directory).with_context(|| {
-            format!(
-                "publishing completed agent bundle at {}",
-                directory.display()
-            )
-        })?;
+        publish_agent_bundle(&staging, directory, parent)?;
         Ok(())
     })();
 
@@ -450,6 +445,30 @@ fn write_agent_bundle(
         let _ = std::fs::remove_dir_all(&staging);
     }
     write_result
+}
+
+fn publish_agent_bundle(staging: &Path, directory: &Path, parent: &Path) -> Result<()> {
+    publish_agent_bundle_with_sync(
+        staging,
+        directory,
+        parent,
+        objects::fs_atomic::sync_directory,
+    )
+}
+
+fn publish_agent_bundle_with_sync(
+    staging: &Path,
+    directory: &Path,
+    parent: &Path,
+    sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
+) -> Result<()> {
+    std::fs::rename(staging, directory).with_context(|| {
+        format!(
+            "publishing completed agent bundle at {}",
+            directory.display()
+        )
+    })?;
+    sync_parent(parent).with_context(|| format!("syncing agent bundle parent {}", parent.display()))
 }
 
 struct HeadlessTokenMetadata {
@@ -2042,6 +2061,30 @@ mod tests {
                 "a refused replacement must leave the completed bundle unchanged"
             );
         });
+    }
+
+    #[test]
+    fn publishing_agent_bundle_syncs_the_parent_after_rename_and_reports_sync_failure() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let parent = temp.path();
+        let staging = parent.join(".agent.tmp");
+        let destination = parent.join("agent");
+        std::fs::create_dir(&staging).expect("create staging directory");
+        std::fs::write(staging.join("token"), b"token").expect("write staged token");
+
+        let error =
+            publish_agent_bundle_with_sync(&staging, &destination, parent, |synced_parent| {
+                assert_eq!(synced_parent, parent);
+                assert!(
+                    destination.join("token").is_file(),
+                    "the completed rename must precede the parent sync"
+                );
+                Err(std::io::Error::other("injected parent sync failure"))
+            })
+            .expect_err("a parent sync failure must not be reported as success");
+
+        assert!(error.to_string().contains("syncing agent bundle parent"));
+        assert!(format!("{error:#}").contains("injected parent sync failure"));
     }
 
     #[test]

--- a/crates/client/src/auth_requests.rs
+++ b/crates/client/src/auth_requests.rs
@@ -21,7 +21,6 @@ pub enum AuthCommand {
         scopes: Vec<String>,
         allowed_operations: Vec<String>,
         out: Option<std::path::PathBuf>,
-        stdout: bool,
     },
     CreateServiceToken {
         name: String,

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -3,14 +3,13 @@
 //! Spawning a sub-agent in Heddle doesn't require a server round trip:
 //! the parent process appends an attenuation block to its own Biscuit and
 //! binds a fresh child proof key to that block. The agent receives the
-//! resulting bytes plus only its child private key. The verifier enforces
-//! every block's checks and key transition on every request.
+//! resulting bytes plus only its child private key. The coordinated, pending
+//! Weft PR HeddleCo/weft#577 enforces every block's checks and key transition;
+//! this client half is HeddleCo/heddle#1022 and must merge with it.
 //!
 //! See `.agents/agent-attenuation.md` for cookbook recipes (read-only
 //! agent, single-repo agent, time-bounded inspector, sub-sub-agent
 //! chain).
-
-use std::collections::HashMap;
 
 use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
@@ -173,9 +172,12 @@ pub fn attenuate_for_agent(
 
 /// Versioned byte domain shared with weft's delegated-PoP verifier. The
 /// payload is exactly `domain || raw parent revocation id || raw child key`.
-pub const POP_DELEGATION_DOMAIN: &[u8] = b"heddle-pop-delegation-v1\0";
+pub(crate) const POP_DELEGATION_DOMAIN: &[u8] = b"heddle-pop-delegation-v1\0";
 
-pub fn pop_delegation_payload(parent_revocation_id: &[u8], child_public_key: &[u8]) -> Vec<u8> {
+pub(crate) fn pop_delegation_payload(
+    parent_revocation_id: &[u8],
+    child_public_key: &[u8],
+) -> Vec<u8> {
     [
         POP_DELEGATION_DOMAIN,
         parent_revocation_id,
@@ -186,9 +188,9 @@ pub fn pop_delegation_payload(parent_revocation_id: &[u8], child_public_key: &[u
 
 /// Resolve and verify the leaf PoP key of a root or delegated token without
 /// trusting its server signature. Callers use this only after obtaining the
-/// token from their local credential store; the server performs the same walk
-/// after full Biscuit verification.
-pub fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
+/// token from their local credential store. The coordinated, pending server
+/// PR HeddleCo/weft#577 performs the same walk after full Biscuit verification.
+pub(crate) fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
     use biscuit_auth::builder::{BlockBuilder, Term};
 
     let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token_b64.as_bytes())
@@ -199,6 +201,13 @@ pub fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
     let authority = BlockBuilder::new()
         .code(&authority_source)
         .context("parse Biscuit authority block")?;
+    if authority
+        .facts
+        .iter()
+        .any(|fact| fact.predicate.name == "pop_delegation")
+    {
+        bail!("pop_delegation is valid only in post-authority blocks");
+    }
     let authority_keys = authority
         .facts
         .iter()
@@ -218,12 +227,6 @@ pub fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
     let mut effective_key = decode_fixed_hex(authority_key_hex, 32, "device_pop_key")?;
 
     let revocation_ids = biscuit.revocation_identifiers();
-    let ordered_parent_ids = revocation_ids
-        .iter()
-        .take(revocation_ids.len().saturating_sub(1))
-        .map(|id| id.to_vec())
-        .collect::<Vec<_>>();
-    let mut by_parent = HashMap::new();
     for index in 1..biscuit.block_count() {
         let source = biscuit
             .print_block_source(index)
@@ -231,34 +234,30 @@ pub fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
         let block = BlockBuilder::new()
             .code(&source)
             .with_context(|| format!("parse Biscuit attenuation block {index}"))?;
-        for fact in &block.facts {
-            if fact.predicate.name != "pop_delegation" {
-                continue;
-            }
-            let [Term::Str(parent), Term::Str(child), Term::Str(signature)] =
-                fact.predicate.terms.as_slice()
-            else {
-                bail!("attenuation block {index} has malformed pop_delegation fact");
-            };
-            let parent = hex::decode(parent).context("pop_delegation parent is not hex")?;
-            if !ordered_parent_ids
-                .iter()
-                .any(|candidate| candidate == &parent)
-            {
-                bail!("pop_delegation references an id outside the token's parent chain");
-            }
-            let child = decode_fixed_hex(child, 32, "pop_delegation child public key")?;
-            let signature = decode_fixed_hex(signature, 64, "pop_delegation signature")?;
-            if by_parent.insert(parent, (child, signature)).is_some() {
-                bail!("token contains duplicate pop_delegation parent references");
-            }
-        }
-    }
-
-    for parent in ordered_parent_ids {
-        let Some((child, signature)) = by_parent.remove(&parent) else {
-            continue;
+        let delegations = block
+            .facts
+            .iter()
+            .filter(|fact| fact.predicate.name == "pop_delegation")
+            .collect::<Vec<_>>();
+        let [delegation] = delegations.as_slice() else {
+            bail!("attenuation block {index} must contain exactly one pop_delegation fact");
         };
+        let [Term::Str(parent), Term::Str(child), Term::Str(signature)] =
+            delegation.predicate.terms.as_slice()
+        else {
+            bail!("attenuation block {index} has malformed pop_delegation fact");
+        };
+        let parent = hex::decode(parent).context("pop_delegation parent is not hex")?;
+        let expected_parent = revocation_ids
+            .get(index - 1)
+            .with_context(|| format!("attenuation block {index} has no preceding block"))?;
+        if parent.as_slice() != *expected_parent {
+            bail!(
+                "attenuation block {index} pop_delegation must reference its immediately preceding block"
+            );
+        }
+        let child = decode_fixed_hex(child, 32, "pop_delegation child public key")?;
+        let signature = decode_fixed_hex(signature, 64, "pop_delegation signature")?;
         Ed25519Signer::verify_with_public_key(
             &pop_delegation_payload(&parent, &child),
             &effective_key,
@@ -519,6 +518,30 @@ mod tests {
             child
         );
         assert_eq!(payload.len(), POP_DELEGATION_DOMAIN.len() + 64 + 32);
+    }
+
+    #[test]
+    fn effective_pop_key_rejects_a_delegationless_attenuation_block() {
+        let signer = Ed25519Signer::generate().expect("root PoP key");
+        let token = Biscuit::builder()
+            .fact(r#"user("alice")"#)
+            .expect("user fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("root PoP fact")
+            .build(&KeyPair::new())
+            .expect("build root")
+            .append(
+                biscuit_auth::builder::BlockBuilder::new()
+                    .fact(r#"agent("raw-child")"#)
+                    .expect("raw attenuation fact"),
+            )
+            .expect("append raw attenuation")
+            .to_base64()
+            .expect("encode raw attenuation");
+
+        let error = effective_pop_public_key_hex(&token)
+            .expect_err("a child block without a key transition must fail closed");
+        assert!(error.to_string().contains("exactly one pop_delegation"));
     }
 
     /// Exercise the same Biscuit chain verification and request-fact shape as

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -136,11 +136,16 @@ pub fn attenuate_for_agent(
     parent_signer: &Ed25519Signer,
     child_public_key: &[u8],
 ) -> Result<String> {
-    let unverified = biscuit_auth::UnverifiedBiscuit::from_base64(parent_token_b64.as_bytes())
-        .context("parse parent biscuit (unverified)")?;
     if child_public_key.len() != 32 {
         bail!("child PoP public key must be 32 bytes");
     }
+    let effective_parent_key = effective_pop_public_key_hex(parent_token_b64)
+        .context("resolve parent token's effective PoP key")?;
+    if !effective_parent_key.eq_ignore_ascii_case(&hex::encode(parent_signer.public_key())) {
+        bail!("parent signer does not match the parent token's effective PoP key");
+    }
+    let unverified = biscuit_auth::UnverifiedBiscuit::from_base64(parent_token_b64.as_bytes())
+        .context("parse parent biscuit (unverified)")?;
     let parent_revocation_id = unverified
         .revocation_identifiers()
         .last()
@@ -476,11 +481,21 @@ mod tests {
     /// pulling `weft_server::biscuit::mint` because that would force
     /// server into the regular dep graph; the goal here is to
     /// keep the CLI small.
-    fn fresh_parent_token() -> (String, KeyPair) {
+    fn fresh_parent_token() -> (String, KeyPair, Ed25519Signer) {
         let kp = KeyPair::new();
+        let parent_pop = Ed25519Signer::generate().expect("parent PoP key");
         let mut builder = biscuit_auth::Biscuit::builder();
         builder = builder.fact(r#"user("alice")"#).expect("user fact");
         builder = builder.fact(r#"session("sess-1")"#).expect("session fact");
+        builder = builder
+            .fact(
+                format!(
+                    "device_pop_key(\"{}\")",
+                    hex::encode(parent_pop.public_key())
+                )
+                .as_str(),
+            )
+            .expect("device PoP fact");
         let exp = chrono::Utc::now() + chrono::Duration::hours(2);
         builder = builder
             .fact(format!("expires_at({})", exp.to_rfc3339()).as_str())
@@ -489,14 +504,7 @@ mod tests {
             .check(format!("check if time($now), $now < {}", exp.to_rfc3339()).as_str())
             .expect("expiry check");
         let biscuit = builder.build(&kp).expect("build parent biscuit");
-        (biscuit.to_base64().expect("to_base64"), kp)
-    }
-
-    fn pop_keypair() -> (Ed25519Signer, Ed25519Signer) {
-        (
-            Ed25519Signer::generate().expect("parent PoP key"),
-            Ed25519Signer::generate().expect("child PoP key"),
-        )
+        (biscuit.to_base64().expect("to_base64"), kp, parent_pop)
     }
 
     #[test]
@@ -544,6 +552,56 @@ mod tests {
         assert!(error.to_string().contains("exactly one pop_delegation"));
     }
 
+    #[test]
+    fn every_public_derivation_entrypoint_rejects_the_wrong_parent_signer() {
+        let (parent, _root, _parent_pop) = fresh_parent_token();
+        let wrong_parent_pop = Ed25519Signer::generate().expect("wrong parent PoP key");
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
+        let expires_at = Utc::now() + chrono::Duration::hours(1);
+
+        let direct_error = attenuate_for_agent(
+            &parent,
+            AgentAttenuation::time_bounded("direct", expires_at),
+            &wrong_parent_pop,
+            child_pop.public_key(),
+        )
+        .expect_err("direct derivation must reject a non-matching parent signer");
+        assert!(
+            direct_error
+                .to_string()
+                .contains("parent signer does not match")
+        );
+
+        let time_bounded_error = time_bounded(
+            &parent,
+            "time-bounded",
+            expires_at,
+            &wrong_parent_pop,
+            child_pop.public_key(),
+        )
+        .expect_err("time-bounded derivation must use the validated chokepoint");
+        assert!(
+            time_bounded_error
+                .to_string()
+                .contains("parent signer does not match")
+        );
+
+        let read_only_error = read_only_repo_agent(
+            &parent,
+            "read-only",
+            "acme/heddle",
+            1,
+            &wrong_parent_pop,
+            child_pop.public_key(),
+        )
+        .expect_err("read-only derivation must use the validated chokepoint");
+        assert!(
+            read_only_error
+                .to_string()
+                .contains("parent signer does not match")
+        );
+    }
+
     /// Exercise the same Biscuit chain verification and request-fact shape as
     /// the hosted server (`time` + bare gRPC `operation`).
     fn server_authorizes(
@@ -569,8 +627,8 @@ mod tests {
 
     #[test]
     fn attenuate_appends_a_block_with_agent_marker() {
-        let (parent, _kp) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, _kp, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let attenuated = time_bounded(
             &parent,
             "agent-1",
@@ -593,8 +651,8 @@ mod tests {
         // gets rejected at verify time. This test just guards
         // against the helper accidentally rejecting timestamps it
         // doesn't like.
-        let (parent, _kp) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, _kp, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let result = time_bounded(
             &parent,
             "agent-1",
@@ -607,8 +665,8 @@ mod tests {
 
     #[test]
     fn read_only_repo_agent_builds_with_op_and_resource_restrictions() {
-        let (parent, _kp) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, _kp, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let attenuated = read_only_repo_agent(
             &parent,
             "agent-r",
@@ -629,8 +687,8 @@ mod tests {
 
     #[test]
     fn rejects_injection_in_allowed_operations() {
-        let (parent, _kp) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, _kp, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let err = attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -653,8 +711,8 @@ mod tests {
 
     #[test]
     fn accepts_normal_operation_names() {
-        let (parent, _kp) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, _kp, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -672,8 +730,8 @@ mod tests {
 
     #[test]
     fn server_accepts_allowed_operation_and_rejects_credential_issuance_and_delete_floor() {
-        let (parent, root) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, root, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let child = attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -718,8 +776,8 @@ mod tests {
 
     #[test]
     fn server_rejects_child_after_attenuation_ttl() {
-        let (parent, root) = fresh_parent_token();
-        let (parent_pop, child_pop) = pop_keypair();
+        let (parent, root, parent_pop) = fresh_parent_token();
+        let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let expires_at = Utc::now() + chrono::Duration::minutes(5);
         let child = attenuate_for_agent(
             &parent,
@@ -751,8 +809,7 @@ mod tests {
 
     #[test]
     fn sub_derivation_intersects_every_operation_block() {
-        let (parent, root) = fresh_parent_token();
-        let root_pop = Ed25519Signer::generate().expect("root PoP key");
+        let (parent, root, root_pop) = fresh_parent_token();
         let parent_agent_pop = Ed25519Signer::generate().expect("parent-agent PoP key");
         let subagent_pop = Ed25519Signer::generate().expect("subagent PoP key");
         let parent_agent = attenuate_for_agent(
@@ -768,6 +825,28 @@ mod tests {
             parent_agent_pop.public_key(),
         )
         .expect("derive parent agent");
+        assert_eq!(
+            effective_pop_public_key_hex(&parent_agent).expect("resolve parent-agent PoP key"),
+            hex::encode(parent_agent_pop.public_key())
+        );
+        let wrong_signer_error = attenuate_for_agent(
+            &parent_agent,
+            AgentAttenuation {
+                agent_id: "agent-wrong-signer".to_string(),
+                expires_at: Utc::now() + chrono::Duration::minutes(30),
+                allowed_operations: Some(vec!["Push".to_string()]),
+                allowed_resources: None,
+                declared_scopes: Vec::new(),
+            },
+            &root_pop,
+            subagent_pop.public_key(),
+        )
+        .expect_err("an attenuated parent requires its current leaf signer");
+        assert!(
+            wrong_signer_error
+                .to_string()
+                .contains("parent signer does not match")
+        );
         let subagent = attenuate_for_agent(
             &parent_agent,
             AgentAttenuation {

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -1,25 +1,28 @@
 //! Client-side Biscuit attenuation helpers for the agent flow.
 //!
 //! Spawning a sub-agent in Heddle doesn't require a server round trip:
-//! the parent process appends an attenuation block to its own
-//! Biscuit and hands the resulting bytes to the agent. The verifier
-//! enforces every block's checks on every request, so an attenuated
-//! token can only ever be a strict subset of the parent's authority.
+//! the parent process appends an attenuation block to its own Biscuit and
+//! binds a fresh child proof key to that block. The agent receives the
+//! resulting bytes plus only its child private key. The verifier enforces
+//! every block's checks and key transition on every request.
 //!
 //! See `.agents/agent-attenuation.md` for cookbook recipes (read-only
 //! agent, single-repo agent, time-bounded inspector, sub-sub-agent
 //! chain).
 
-use anyhow::{Context, Result};
+use std::collections::HashMap;
+
+use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
+use crypto::{Ed25519Signer, Signer};
 
 /// Operations that an agent attenuation can never authorize, even when a
 /// caller constructs [`AgentAttenuation`] directly without an allowlist.
 ///
 /// Credential-issuing and destructive methods excluded from the W1 agent
-/// operation surface. This floor limits use of the attenuated token, but it
-/// cannot constrain device-key-authenticated `MintBiscuit`; closing that G4
-/// laundering path requires W2 delegated PoP.
+/// operation surface. This floor limits use of the attenuated token; delegated
+/// PoP separately prevents the derive path from handing an ancestor proof key
+/// to the child process.
 pub const AGENT_OPERATION_DENY_FLOOR: &[&str] = &[
     "CreateServiceAccount",
     "IssueServiceAccountCredential",
@@ -131,14 +134,148 @@ impl AgentAttenuation {
 pub fn attenuate_for_agent(
     parent_token_b64: &str,
     restrictions: AgentAttenuation,
+    parent_signer: &Ed25519Signer,
+    child_public_key: &[u8],
 ) -> Result<String> {
     let unverified = biscuit_auth::UnverifiedBiscuit::from_base64(parent_token_b64.as_bytes())
         .context("parse parent biscuit (unverified)")?;
-    let block = build_attenuation_block(&restrictions)?;
+    if child_public_key.len() != 32 {
+        bail!("child PoP public key must be 32 bytes");
+    }
+    let parent_revocation_id = unverified
+        .revocation_identifiers()
+        .last()
+        .context("parent Biscuit has no revocation identifier")?
+        .to_vec();
+    let signature = parent_signer
+        .sign(&pop_delegation_payload(
+            &parent_revocation_id,
+            child_public_key,
+        ))
+        .context("sign child PoP delegation")?;
+    let mut block = build_attenuation_block(&restrictions)?;
+    block = block
+        .fact(
+            format!(
+                "pop_delegation({}, {}, {})",
+                biscuit_string(&hex::encode(parent_revocation_id)),
+                biscuit_string(&hex::encode(child_public_key)),
+                biscuit_string(&hex::encode(signature)),
+            )
+            .as_str(),
+        )
+        .context("child PoP delegation fact")?;
     let attenuated = unverified
         .append(block)
         .context("append attenuation block")?;
     attenuated.to_base64().context("encode attenuated biscuit")
+}
+
+/// Versioned byte domain shared with weft's delegated-PoP verifier. The
+/// payload is exactly `domain || raw parent revocation id || raw child key`.
+pub const POP_DELEGATION_DOMAIN: &[u8] = b"heddle-pop-delegation-v1\0";
+
+pub fn pop_delegation_payload(parent_revocation_id: &[u8], child_public_key: &[u8]) -> Vec<u8> {
+    [
+        POP_DELEGATION_DOMAIN,
+        parent_revocation_id,
+        child_public_key,
+    ]
+    .concat()
+}
+
+/// Resolve and verify the leaf PoP key of a root or delegated token without
+/// trusting its server signature. Callers use this only after obtaining the
+/// token from their local credential store; the server performs the same walk
+/// after full Biscuit verification.
+pub fn effective_pop_public_key_hex(token_b64: &str) -> Result<String> {
+    use biscuit_auth::builder::{BlockBuilder, Term};
+
+    let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token_b64.as_bytes())
+        .context("parse Biscuit while resolving its proof key")?;
+    let authority_source = biscuit
+        .print_block_source(0)
+        .context("read Biscuit authority block")?;
+    let authority = BlockBuilder::new()
+        .code(&authority_source)
+        .context("parse Biscuit authority block")?;
+    let authority_keys = authority
+        .facts
+        .iter()
+        .filter_map(|fact| {
+            match (
+                fact.predicate.name.as_str(),
+                fact.predicate.terms.as_slice(),
+            ) {
+                ("device_pop_key", [Term::Str(key)]) => Some(key.clone()),
+                _ => None,
+            }
+        })
+        .collect::<Vec<_>>();
+    let [authority_key_hex] = authority_keys.as_slice() else {
+        bail!("Biscuit authority block must contain exactly one device_pop_key fact");
+    };
+    let mut effective_key = decode_fixed_hex(authority_key_hex, 32, "device_pop_key")?;
+
+    let revocation_ids = biscuit.revocation_identifiers();
+    let ordered_parent_ids = revocation_ids
+        .iter()
+        .take(revocation_ids.len().saturating_sub(1))
+        .map(|id| id.to_vec())
+        .collect::<Vec<_>>();
+    let mut by_parent = HashMap::new();
+    for index in 1..biscuit.block_count() {
+        let source = biscuit
+            .print_block_source(index)
+            .with_context(|| format!("read Biscuit attenuation block {index}"))?;
+        let block = BlockBuilder::new()
+            .code(&source)
+            .with_context(|| format!("parse Biscuit attenuation block {index}"))?;
+        for fact in &block.facts {
+            if fact.predicate.name != "pop_delegation" {
+                continue;
+            }
+            let [Term::Str(parent), Term::Str(child), Term::Str(signature)] =
+                fact.predicate.terms.as_slice()
+            else {
+                bail!("attenuation block {index} has malformed pop_delegation fact");
+            };
+            let parent = hex::decode(parent).context("pop_delegation parent is not hex")?;
+            if !ordered_parent_ids
+                .iter()
+                .any(|candidate| candidate == &parent)
+            {
+                bail!("pop_delegation references an id outside the token's parent chain");
+            }
+            let child = decode_fixed_hex(child, 32, "pop_delegation child public key")?;
+            let signature = decode_fixed_hex(signature, 64, "pop_delegation signature")?;
+            if by_parent.insert(parent, (child, signature)).is_some() {
+                bail!("token contains duplicate pop_delegation parent references");
+            }
+        }
+    }
+
+    for parent in ordered_parent_ids {
+        let Some((child, signature)) = by_parent.remove(&parent) else {
+            continue;
+        };
+        Ed25519Signer::verify_with_public_key(
+            &pop_delegation_payload(&parent, &child),
+            &effective_key,
+            &signature,
+        )
+        .context("pop_delegation signature does not match the effective parent key")?;
+        effective_key = child;
+    }
+    Ok(hex::encode(effective_key))
+}
+
+fn decode_fixed_hex(value: &str, expected_len: usize, label: &str) -> Result<Vec<u8>> {
+    let decoded = hex::decode(value).with_context(|| format!("{label} is not valid hex"))?;
+    if decoded.len() != expected_len {
+        bail!("{label} must decode to {expected_len} bytes");
+    }
+    Ok(decoded)
 }
 
 /// Build the BlockBuilder that holds the attenuation's facts +
@@ -283,10 +420,14 @@ pub fn time_bounded(
     parent_token_b64: &str,
     agent_id: impl Into<String>,
     expires_at: DateTime<Utc>,
+    parent_signer: &Ed25519Signer,
+    child_public_key: &[u8],
 ) -> Result<String> {
     attenuate_for_agent(
         parent_token_b64,
         AgentAttenuation::time_bounded(agent_id, expires_at),
+        parent_signer,
+        child_public_key,
     )
 }
 
@@ -300,6 +441,8 @@ pub fn read_only_repo_agent(
     agent_id: impl Into<String>,
     repo_path: impl Into<String>,
     duration_hours: i64,
+    parent_signer: &Ed25519Signer,
+    child_public_key: &[u8],
 ) -> Result<String> {
     attenuate_for_agent(
         parent_token_b64,
@@ -319,12 +462,14 @@ pub fn read_only_repo_agent(
             allowed_resources: Some(vec![("repo".to_string(), repo_path.into())]),
             declared_scopes: Vec::new(),
         },
+        parent_signer,
+        child_public_key,
     )
 }
 
 #[cfg(test)]
 mod tests {
-    use biscuit_auth::{Biscuit, KeyPair, builder::AuthorizerBuilder};
+    use biscuit_auth::{Biscuit, KeyPair, builder::AuthorizerBuilder, datalog::RunLimits};
 
     use super::*;
 
@@ -348,6 +493,34 @@ mod tests {
         (biscuit.to_base64().expect("to_base64"), kp)
     }
 
+    fn pop_keypair() -> (Ed25519Signer, Ed25519Signer) {
+        (
+            Ed25519Signer::generate().expect("parent PoP key"),
+            Ed25519Signer::generate().expect("child PoP key"),
+        )
+    }
+
+    #[test]
+    fn pop_delegation_payload_layout_matches_the_versioned_server_contract() {
+        let parent = [0x11; 64];
+        let child = [0x22; 32];
+        let payload = pop_delegation_payload(&parent, &child);
+
+        assert_eq!(
+            &payload[..POP_DELEGATION_DOMAIN.len()],
+            POP_DELEGATION_DOMAIN
+        );
+        assert_eq!(
+            &payload[POP_DELEGATION_DOMAIN.len()..POP_DELEGATION_DOMAIN.len() + parent.len()],
+            parent
+        );
+        assert_eq!(
+            &payload[POP_DELEGATION_DOMAIN.len() + parent.len()..],
+            child
+        );
+        assert_eq!(payload.len(), POP_DELEGATION_DOMAIN.len() + 64 + 32);
+    }
+
     /// Exercise the same Biscuit chain verification and request-fact shape as
     /// the hosted server (`time` + bare gRPC `operation`).
     fn server_authorizes(
@@ -359,6 +532,11 @@ mod tests {
         let root_public = root.public();
         let biscuit = Biscuit::from_base64(token, move |_| Ok(root_public))?;
         let mut authorizer = AuthorizerBuilder::new()
+            .set_limits(RunLimits {
+                max_facts: 1000,
+                max_iterations: 100,
+                max_time: std::time::Duration::from_secs(1),
+            })
             .fact(format!("time({})", now.to_rfc3339()).as_str())?
             .fact(format!("operation({})", biscuit_string(operation)).as_str())?
             .policy("allow if true")?
@@ -369,8 +547,15 @@ mod tests {
     #[test]
     fn attenuate_appends_a_block_with_agent_marker() {
         let (parent, _kp) = fresh_parent_token();
-        let attenuated = time_bounded(&parent, "agent-1", Utc::now() + chrono::Duration::hours(2))
-            .expect("attenuate");
+        let (parent_pop, child_pop) = pop_keypair();
+        let attenuated = time_bounded(
+            &parent,
+            "agent-1",
+            Utc::now() + chrono::Duration::hours(2),
+            &parent_pop,
+            child_pop.public_key(),
+        )
+        .expect("attenuate");
         // The attenuated bytes are strictly longer than the parent's
         // (the new block adds bytes). End-to-end verify happens in
         // the integration tests where a real server's keypair is
@@ -386,15 +571,30 @@ mod tests {
         // against the helper accidentally rejecting timestamps it
         // doesn't like.
         let (parent, _kp) = fresh_parent_token();
-        let result = time_bounded(&parent, "agent-1", Utc::now() - chrono::Duration::hours(1));
+        let (parent_pop, child_pop) = pop_keypair();
+        let result = time_bounded(
+            &parent,
+            "agent-1",
+            Utc::now() - chrono::Duration::hours(1),
+            &parent_pop,
+            child_pop.public_key(),
+        );
         assert!(result.is_ok());
     }
 
     #[test]
     fn read_only_repo_agent_builds_with_op_and_resource_restrictions() {
         let (parent, _kp) = fresh_parent_token();
-        let attenuated =
-            read_only_repo_agent(&parent, "agent-r", "org/acme/heddle", 2).expect("attenuate");
+        let (parent_pop, child_pop) = pop_keypair();
+        let attenuated = read_only_repo_agent(
+            &parent,
+            "agent-r",
+            "org/acme/heddle",
+            2,
+            &parent_pop,
+            child_pop.public_key(),
+        )
+        .expect("attenuate");
         // Sanity: the attenuated bytes parse back as a Biscuit (via
         // the unverified path so we don't need the parent's root
         // key). The verifier round-trip is exercised in the
@@ -407,6 +607,7 @@ mod tests {
     #[test]
     fn rejects_injection_in_allowed_operations() {
         let (parent, _kp) = fresh_parent_token();
+        let (parent_pop, child_pop) = pop_keypair();
         let err = attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -416,6 +617,8 @@ mod tests {
                 allowed_resources: None,
                 declared_scopes: Vec::new(),
             },
+            &parent_pop,
+            child_pop.public_key(),
         )
         .expect_err("injection payload must be rejected");
         let message = format!("{err:#}");
@@ -428,6 +631,7 @@ mod tests {
     #[test]
     fn accepts_normal_operation_names() {
         let (parent, _kp) = fresh_parent_token();
+        let (parent_pop, child_pop) = pop_keypair();
         attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -437,6 +641,8 @@ mod tests {
                 allowed_resources: Some(vec![("repo".to_string(), "org/acme/heddle".to_string())]),
                 declared_scopes: Vec::new(),
             },
+            &parent_pop,
+            child_pop.public_key(),
         )
         .expect("normal ops must attenuate");
     }
@@ -444,6 +650,7 @@ mod tests {
     #[test]
     fn server_accepts_allowed_operation_and_rejects_credential_issuance_and_delete_floor() {
         let (parent, root) = fresh_parent_token();
+        let (parent_pop, child_pop) = pop_keypair();
         let child = attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -458,6 +665,8 @@ mod tests {
                 allowed_resources: None,
                 declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
             },
+            &parent_pop,
+            child_pop.public_key(),
         )
         .expect("derive safe child");
 
@@ -487,6 +696,7 @@ mod tests {
     #[test]
     fn server_rejects_child_after_attenuation_ttl() {
         let (parent, root) = fresh_parent_token();
+        let (parent_pop, child_pop) = pop_keypair();
         let expires_at = Utc::now() + chrono::Duration::minutes(5);
         let child = attenuate_for_agent(
             &parent,
@@ -497,6 +707,8 @@ mod tests {
                 allowed_resources: None,
                 declared_scopes: Vec::new(),
             },
+            &parent_pop,
+            child_pop.public_key(),
         )
         .expect("derive expiring child");
 
@@ -517,6 +729,9 @@ mod tests {
     #[test]
     fn sub_derivation_intersects_every_operation_block() {
         let (parent, root) = fresh_parent_token();
+        let root_pop = Ed25519Signer::generate().expect("root PoP key");
+        let parent_agent_pop = Ed25519Signer::generate().expect("parent-agent PoP key");
+        let subagent_pop = Ed25519Signer::generate().expect("subagent PoP key");
         let parent_agent = attenuate_for_agent(
             &parent,
             AgentAttenuation {
@@ -526,6 +741,8 @@ mod tests {
                 allowed_resources: None,
                 declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
             },
+            &root_pop,
+            parent_agent_pop.public_key(),
         )
         .expect("derive parent agent");
         let subagent = attenuate_for_agent(
@@ -538,6 +755,8 @@ mod tests {
                 allowed_resources: None,
                 declared_scopes: vec![("repo".to_string(), "acme/heddle/subdir".to_string())],
             },
+            &parent_agent_pop,
+            subagent_pop.public_key(),
         )
         .expect("derive subagent");
 

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -15,19 +15,145 @@ use anyhow::{Context, Result, bail};
 use chrono::{DateTime, Utc};
 use crypto::{Ed25519Signer, Signer};
 
-/// Operations that an agent attenuation can never authorize, even when a
-/// caller constructs [`AgentAttenuation`] directly without an allowlist.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AgentAuthOperationDisposition {
+    ReviewedSafe,
+    Denied,
+}
+
+/// Exhaustive agent-policy classification for `AuthService`.
 ///
-/// Credential-issuing and destructive methods excluded from the W1 agent
-/// operation surface. This floor limits use of the attenuated token; delegated
-/// PoP separately prevents the derive path from handing an ancestor proof key
-/// to the child process.
-pub const AGENT_OPERATION_DENY_FLOOR: &[&str] = &[
-    "CreateServiceAccount",
-    "IssueServiceAccountCredential",
-    "DeleteRepository",
-    "DeleteNamespace",
+/// The exact-set test below compares this table with `auth.proto`, so adding an
+/// auth RPC requires an explicit decision before derived-agent CI can pass.
+const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
+    (
+        "BeginWebAuthnRegistration",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    ("RegisterPublicKey", AgentAuthOperationDisposition::Denied),
+    (
+        "BeginWebAuthnAuthentication",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "FinishWebAuthnAuthentication",
+        // The WebAuthn ceremony, not an attached bearer, proves this request.
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "CreateDeviceAuthorization",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "ApproveDeviceAuthorization",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "ExchangeDeviceAuthorization",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "WaitForDeviceAuthorization",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    ("RotateCredential", AgentAuthOperationDisposition::Denied),
+    ("RevokeCredential", AgentAuthOperationDisposition::Denied),
+    (
+        "CreateServiceAccount",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "IssueServiceAccountCredential",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "RevokeServiceAccount",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    ("WhoAmI", AgentAuthOperationDisposition::ReviewedSafe),
+    (
+        "RecordSubscription",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "IntrospectCredential",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "ListServiceAccounts",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "ListScopeCapabilities",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    ("LinkOAuthIdentity", AgentAuthOperationDisposition::Denied),
+    ("StoreProviderToken", AgentAuthOperationDisposition::Denied),
+    (
+        "VerifySignupEmail",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "AnalyzeExternalDiff",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "GetInvitationSummary",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    ("ListSessions", AgentAuthOperationDisposition::ReviewedSafe),
+    ("RevokeSession", AgentAuthOperationDisposition::Denied),
+    // MintBiscuit authenticates its own keypair/device proof; an attached
+    // derived bearer cannot authorize or widen the minted credential.
+    ("MintBiscuit", AgentAuthOperationDisposition::ReviewedSafe),
+    // Presence currently re-mints an authority token instead of preserving
+    // the caller's complete attenuation chain, so agents must not invoke it.
+    ("IssuePresenceToken", AgentAuthOperationDisposition::Denied),
+    (
+        "MintAnonBiscuit",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "DeclareRecoveryMethod",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "DeclareHardwareKeyRecovery",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "DeclareSocialGuardians",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    ("DeclarePaperCode", AgentAuthOperationDisposition::Denied),
+    ("BeginRecovery", AgentAuthOperationDisposition::ReviewedSafe),
+    (
+        "SubmitRecoveryProof",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    ("VetoRecovery", AgentAuthOperationDisposition::ReviewedSafe),
+    // Recovery completion is authorized by the in-flight recovery proof and
+    // veto-window state, not by the caller's attached bearer.
+    (
+        "CompleteRecovery",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
 ];
+
+/// Destructive non-auth methods that remain mandatory denials for every
+/// derived token, even when the caller constructs [`AgentAttenuation`]
+/// directly without an allowlist.
+const NON_AUTH_AGENT_OPERATION_DENY_FLOOR: &[&str] = &["DeleteRepository", "DeleteNamespace"];
+
+fn mandatory_agent_denied_operations() -> impl Iterator<Item = &'static str> {
+    NON_AUTH_AGENT_OPERATION_DENY_FLOOR.iter().copied().chain(
+        AUTH_SERVICE_AGENT_POLICY
+            .iter()
+            .filter_map(|(operation, disposition)| {
+                (*disposition == AgentAuthOperationDisposition::Denied).then_some(*operation)
+            }),
+    )
+}
 
 /// Curated W1 operation ceiling for `heddle auth derive-agent`.
 ///
@@ -323,10 +449,11 @@ fn build_attenuation_block(
             .as_str(),
         )
         .context("expiry check")?;
-    // This independent check is deliberately present even when the caller
-    // supplies no operation allowlist. It is the non-optional credential-
-    // issuing/destructive operation floor for every token from this primitive.
-    for denied in AGENT_OPERATION_DENY_FLOOR {
+    // These independent checks are deliberately present even when the caller
+    // supplies no operation allowlist. They are the mandatory auth-trust,
+    // credential, recovery-enrollment, presence, and destructive-operation
+    // floor for every token from this primitive.
+    for denied in mandatory_agent_denied_operations() {
         block = block
             .check(format!("check if operation($op), $op != {}", biscuit_string(denied)).as_str())
             .context("agent operation deny floor")?;
@@ -473,6 +600,8 @@ pub fn read_only_repo_agent(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeSet;
+
     use biscuit_auth::{Biscuit, KeyPair, builder::AuthorizerBuilder, datalog::RunLimits};
 
     use super::*;
@@ -550,6 +679,74 @@ mod tests {
         let error = effective_pop_public_key_hex(&token)
             .expect_err("a child block without a key transition must fail closed");
         assert!(error.to_string().contains("exactly one pop_delegation"));
+    }
+
+    #[test]
+    fn effective_pop_key_rejects_duplicate_authority_anchors() {
+        let first = Ed25519Signer::generate().expect("first root PoP key");
+        let second = Ed25519Signer::generate().expect("second root PoP key");
+        let token = Biscuit::builder()
+            .fact(r#"user("alice")"#)
+            .expect("user fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(first.public_key())).as_str())
+            .expect("first root PoP fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(second.public_key())).as_str())
+            .expect("second root PoP fact")
+            .build(&KeyPair::new())
+            .expect("build root")
+            .to_base64()
+            .expect("encode root");
+
+        let error = effective_pop_public_key_hex(&token)
+            .expect_err("multiple authority proof anchors must fail closed");
+        assert!(error.to_string().contains("exactly one device_pop_key"));
+    }
+
+    #[test]
+    fn effective_pop_key_rejects_authority_block_delegations() {
+        let signer = Ed25519Signer::generate().expect("root PoP key");
+        let token = Biscuit::builder()
+            .fact(r#"user("alice")"#)
+            .expect("user fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("root PoP fact")
+            .fact(r#"pop_delegation("parent", "child", "signature")"#)
+            .expect("misplaced delegation fact")
+            .build(&KeyPair::new())
+            .expect("build malformed root")
+            .to_base64()
+            .expect("encode malformed root");
+
+        let error = effective_pop_public_key_hex(&token)
+            .expect_err("an authority-block delegation must fail closed");
+        assert!(error.to_string().contains("only in post-authority blocks"));
+    }
+
+    #[test]
+    fn auth_service_agent_policy_exactly_matches_the_proto_catalog() {
+        let proto = include_str!("../../grpc/proto/heddle/v1/auth.proto");
+        let proto_operations = proto
+            .lines()
+            .filter_map(|line| {
+                line.trim()
+                    .strip_prefix("rpc ")
+                    .and_then(|rpc| rpc.split_once('(').map(|(name, _)| name))
+            })
+            .collect::<BTreeSet<_>>();
+        let policy_operations = AUTH_SERVICE_AGENT_POLICY
+            .iter()
+            .map(|(operation, _)| *operation)
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            policy_operations.len(),
+            AUTH_SERVICE_AGENT_POLICY.len(),
+            "the agent auth policy must classify each RPC exactly once"
+        );
+        assert_eq!(
+            policy_operations, proto_operations,
+            "every AuthService RPC must be explicitly classified for derived agents"
+        );
     }
 
     #[test]
@@ -729,7 +926,7 @@ mod tests {
     }
 
     #[test]
-    fn server_accepts_allowed_operation_and_rejects_credential_issuance_and_delete_floor() {
+    fn server_accepts_allowed_operation_and_rejects_the_mandatory_operation_floor() {
         let (parent, root, parent_pop) = fresh_parent_token();
         let child_pop = Ed25519Signer::generate().expect("child PoP key");
         let child = attenuate_for_agent(
@@ -766,7 +963,7 @@ mod tests {
 
         server_authorizes(&child, &root, "Push", Utc::now())
             .expect("server accepts an allowlisted push");
-        for denied in AGENT_OPERATION_DENY_FLOOR {
+        for denied in mandatory_agent_denied_operations() {
             assert!(
                 server_authorizes(&child, &root, denied, Utc::now()).is_err(),
                 "server must reject hard-denied operation {denied}"

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -28,6 +28,66 @@ use wire::ProtocolError;
 
 use crate::credentials;
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct RenewableAuthorityCredential {
+    token: String,
+    credential_id: String,
+}
+
+impl RenewableAuthorityCredential {
+    pub(super) fn from_stored(credential: &credentials::ServerCredential) -> Option<Self> {
+        let credential_id = credential.credential_id.clone()?;
+        let signer = Ed25519Signer::from_pem(credential.private_key_pem.as_ref()?).ok()?;
+        let biscuit =
+            biscuit_auth::UnverifiedBiscuit::from_base64(credential.token.as_bytes()).ok()?;
+        if biscuit.block_count() != 1 {
+            return None;
+        }
+        let authority = biscuit_auth::builder::BlockBuilder::new()
+            .code(&biscuit.print_block_source(0).ok()?)
+            .ok()?;
+        let credential_ids = authority
+            .facts
+            .iter()
+            .filter_map(|fact| {
+                match (
+                    fact.predicate.name.as_str(),
+                    fact.predicate.terms.as_slice(),
+                ) {
+                    ("credential_id", [biscuit_auth::builder::Term::Str(id)]) => Some(id),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>();
+        let [token_credential_id] = credential_ids.as_slice() else {
+            return None;
+        };
+        if token_credential_id.as_str() != credential_id.as_str()
+            || !crate::device_flow::effective_pop_public_key_hex(&credential.token)
+                .is_ok_and(|key| key.eq_ignore_ascii_case(&hex::encode(signer.public_key())))
+        {
+            return None;
+        }
+        Some(Self {
+            token: credential.token.clone(),
+            credential_id,
+        })
+    }
+
+    fn matches_active_client(
+        &self,
+        credential: &credentials::ServerCredential,
+        token_header: Option<&MetadataValue<tonic::metadata::Ascii>>,
+    ) -> bool {
+        credential.token == self.token
+            && credential.credential_id.as_deref() == Some(self.credential_id.as_str())
+            && token_header
+                .and_then(|header| header.to_str().ok())
+                .and_then(|header| header.strip_prefix("Bearer "))
+                == Some(self.token.as_str())
+    }
+}
+
 pub struct HostedGrpcClient {
     pub(super) inner: RepoSyncServiceClient<Channel>,
     pub(super) user: HostedUserServiceClient<Channel>,
@@ -37,8 +97,9 @@ pub struct HostedGrpcClient {
     transport: helpers::HostedTransportPolicy,
     pub(super) auth_proof_key_pem: Option<String>,
     /// The key used to look up this server's credential in the credential
-    /// store.  When set, `auto_rotate_if_needed` will use it to read and
-    /// update `~/.heddle/credentials.toml` transparently.
+    /// store. When the session also carries an exact renewable-authority
+    /// binding, `auto_rotate_if_needed` uses this key to re-read and update
+    /// `~/.heddle/credentials.toml` transparently.
     server_key: Option<String>,
     /// App-registered WebAuthn signer invoked when a `human`-tier RPC is
     /// rejected with `x-weft-sig-required: human`. `None` => human-tier RPCs
@@ -253,18 +314,30 @@ impl HostedGrpcClient {
 
     /// Transparently rotate the credential for this client if it is near expiry.
     ///
-    /// No-ops if `server_key` was not set on `ClientConfig` at construction
-    /// time, or if no credential is stored for the server, or if the token is
-    /// not within 10 minutes of expiry.
-    pub async fn auto_rotate_if_needed(&mut self) {
+    /// No-ops unless session construction proved that the active bearer is the
+    /// exact authority credential loaded from this server's credential-store
+    /// row. Explicit config/env tokens and attenuated tokens never enter this
+    /// renewal path.
+    pub(super) async fn auto_rotate_if_needed(
+        &mut self,
+        renewable: Option<&RenewableAuthorityCredential>,
+    ) {
+        let Some(renewable) = renewable else {
+            return;
+        };
         let server_key = match &self.server_key {
             Some(k) => k.clone(),
             None => return,
         };
-        self.rotate_credential_for_server(&server_key).await;
+        self.rotate_credential_for_server(&server_key, renewable)
+            .await;
     }
 
-    async fn rotate_credential_for_server(&mut self, server_key: &str) {
+    async fn rotate_credential_for_server(
+        &mut self,
+        server_key: &str,
+        renewable: &RenewableAuthorityCredential,
+    ) {
         // Load the stored credential.
         let cred = match credentials::resolve_credential_for_server(server_key) {
             Ok(Some(c)) => c,
@@ -274,6 +347,16 @@ impl HostedGrpcClient {
                 return;
             }
         };
+
+        // The store may have changed after session construction. Renewal is
+        // permitted only while both the active bearer and the current row are
+        // still the exact token + credential id that were selected together.
+        if !renewable.matches_active_client(&cred, self.token_header.as_ref()) {
+            tracing::debug!(
+                "credential rotation: active bearer no longer matches the selected stored credential"
+            );
+            return;
+        }
 
         // Check whether the Biscuit's stored expiry is within the
         // rotation window.
@@ -483,6 +566,7 @@ pub use sync::HostedRefEntry;
 #[cfg(test)]
 mod tests {
     use base64::Engine as _;
+    use biscuit_auth::{Biscuit, KeyPair};
 
     use super::*;
 
@@ -503,6 +587,69 @@ mod tests {
             server_key: None,
             on_human_signature: None,
         }
+    }
+
+    #[test]
+    fn renewable_authority_binding_requires_exact_token_and_credential_id() {
+        let signer = Ed25519Signer::generate().expect("proof signer");
+        let token = Biscuit::builder()
+            .fact(r#"user("alice")"#)
+            .expect("user fact")
+            .fact(r#"credential_id("cred-1")"#)
+            .expect("credential fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("proof key fact")
+            .build(&KeyPair::new())
+            .expect("mint authority token")
+            .to_base64()
+            .expect("encode authority token");
+        let credential = credentials::ServerCredential {
+            token: token.clone(),
+            subject: "alice".to_string(),
+            device_id: Some("device-1".to_string()),
+            credential_id: Some("cred-1".to_string()),
+            private_key_pem: Some(signer.to_pem().expect("proof PEM")),
+            expires_at: None,
+        };
+        let binding = RenewableAuthorityCredential::from_stored(&credential)
+            .expect("valid stored authority credential");
+        let mut mismatched_claim = credential.clone();
+        mismatched_claim.credential_id = Some("cred-2".to_string());
+        assert!(
+            RenewableAuthorityCredential::from_stored(&mismatched_claim).is_none(),
+            "the stored credential id must match the authority token claim"
+        );
+        let attenuated_token = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
+            .expect("parse authority token")
+            .append(
+                biscuit_auth::builder::BlockBuilder::new()
+                    .fact(r#"agent("child")"#)
+                    .expect("child fact"),
+            )
+            .expect("append child block")
+            .to_base64()
+            .expect("encode attenuated token");
+        let mut attenuated_credential = credential.clone();
+        attenuated_credential.token = attenuated_token;
+        assert!(
+            RenewableAuthorityCredential::from_stored(&attenuated_credential).is_none(),
+            "an attenuated token is never an authority-renewal source"
+        );
+        let matching_header =
+            MetadataValue::try_from(format!("Bearer {token}")).expect("matching bearer header");
+        assert!(binding.matches_active_client(&credential, Some(&matching_header)));
+
+        let wrong_header =
+            MetadataValue::try_from("Bearer explicit-child").expect("different bearer header");
+        assert!(!binding.matches_active_client(&credential, Some(&wrong_header)));
+
+        let mut wrong_id = credential.clone();
+        wrong_id.credential_id = Some("cred-2".to_string());
+        assert!(!binding.matches_active_client(&wrong_id, Some(&matching_header)));
+
+        let mut wrong_token = credential;
+        wrong_token.token = "different-stored-token".to_string();
+        assert!(!binding.matches_active_client(&wrong_token, Some(&matching_header)));
     }
 
     #[tokio::test]

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -4,8 +4,9 @@
 //! every hosted entry point (push, pull, fetch, clone, support, approval,
 //! lazy hydration): resolve the auth token, fall back to the credential
 //! store, attach the proof key, build the validated client config, connect,
-//! then run mandatory credential rotation. This module owns that assembly so
-//! the command modules choose only intent + remote and call one seam.
+//! then rotate only an eligible stored authority credential. This module owns
+//! that assembly so the command modules choose only intent + remote and call
+//! one seam.
 
 use std::net::SocketAddr;
 
@@ -13,7 +14,10 @@ use anyhow::{Context, Result};
 use cli_shared::{ClientConfig, UserConfig};
 use wire::{AuthToken, ProtocolError};
 
-use crate::{credentials, grpc_hosted::HostedGrpcClient};
+use crate::{
+    credentials,
+    grpc_hosted::{HostedGrpcClient, RenewableAuthorityCredential},
+};
 
 /// How a hosted session resolves its auth token.
 pub enum HostedAuthMode {
@@ -36,6 +40,7 @@ pub enum HostedAuthMode {
 /// [`HostedGrpcClient::open_session`], which builds and connects in one call.
 pub struct HostedSession {
     config: ClientConfig,
+    renewable_authority_credential: Option<RenewableAuthorityCredential>,
 }
 
 impl HostedSession {
@@ -49,11 +54,12 @@ impl HostedSession {
         server_key: Option<String>,
         mode: HostedAuthMode,
     ) -> Result<Self> {
-        let (token, mut credential_proof_key) = match mode {
-            HostedAuthMode::ConfigToken => (user_config.remote_token()?, None),
+        let (token, mut credential_proof_key, renewable_authority_credential) = match mode {
+            HostedAuthMode::ConfigToken => (user_config.remote_token()?, None, None),
             HostedAuthMode::CredentialFallback => {
                 let mut token = user_config.remote_token()?;
                 let mut credential_proof_key = None;
+                let mut renewable_authority_credential = None;
                 if token.is_none()
                     && let Some(ref key) = server_key
                 {
@@ -67,11 +73,13 @@ impl HostedSession {
                     // file. A *missing* file still returns Ok(None) and falls
                     // back cleanly.
                     if let Some(cred) = credentials::resolve_credential_for_server(key)? {
+                        renewable_authority_credential =
+                            RenewableAuthorityCredential::from_stored(&cred);
                         token = Some(AuthToken::new(cred.token, "credential-store"));
                         credential_proof_key = cred.private_key_pem;
                     }
                 }
-                (token, credential_proof_key)
+                (token, credential_proof_key, renewable_authority_credential)
             }
         };
 
@@ -91,7 +99,10 @@ impl HostedSession {
         {
             config = config.with_auth_proof_key_pem(pem);
         }
-        Ok(Self { config })
+        Ok(Self {
+            config,
+            renewable_authority_credential,
+        })
     }
 
     /// Explicitly allow cleartext to non-loopback hosts for this session
@@ -104,15 +115,17 @@ impl HostedSession {
         self
     }
 
-    /// Connect and run mandatory credential rotation.
+    /// Connect and evaluate renewal for an eligible stored authority token.
     ///
-    /// The rotation MUST run immediately after connect — every hosted entry
-    /// point relies on a fresh token before its first RPC. This is the single
-    /// place that pairs connect with rotation; see the source-presence guard
-    /// in this module's tests.
+    /// The eligibility check runs immediately after connect and requires the
+    /// active bearer to remain byte-for-byte identical to the stored one-block
+    /// authority credential selected during [`HostedSession::build`]. Explicit
+    /// config/env and attenuated tokens are never rotated here.
     pub async fn connect(&self, addr: SocketAddr) -> Result<HostedGrpcClient, ProtocolError> {
         let mut client = HostedGrpcClient::connect(addr, &self.config).await?;
-        client.auto_rotate_if_needed().await;
+        client
+            .auto_rotate_if_needed(self.renewable_authority_credential.as_ref())
+            .await;
         Ok(client)
     }
 }
@@ -150,9 +163,9 @@ fn server_keys_match(left: &str, right: &str) -> bool {
 
 impl HostedGrpcClient {
     /// Open a usable hosted session in one call: resolve auth, build the
-    /// validated client config, connect, and run mandatory rotation. Callers
-    /// that must prevalidate the config before irreversible work build a
-    /// [`HostedSession`] first, then [`HostedSession::connect`].
+    /// validated client config, connect, and evaluate eligible stored-authority
+    /// renewal. Callers that must prevalidate the config before irreversible
+    /// work build a [`HostedSession`] first, then [`HostedSession::connect`].
     pub async fn open_session(
         addr: SocketAddr,
         user_config: &UserConfig,
@@ -180,15 +193,14 @@ impl HostedGrpcClient {
 
 #[cfg(test)]
 mod tests {
-    //! The connect/rotate invariant now lives here, in the one seam every
-    //! hosted entry point opens its session through. This source-presence
-    //! guard replaces the per-call-site rotation checks: rotation MUST run
-    //! immediately after `HostedGrpcClient::connect`, or a process whose
-    //! cached token has slipped past expiry hits an auth failure on its first
-    //! RPC even though the rotation data is on disk.
+    //! The connect/renewal-eligibility invariant lives here, in the one seam
+    //! every hosted entry point opens its session through. This source-presence
+    //! guard replaces the per-call-site checks: an eligible stored authority
+    //! credential must be considered immediately after connect, while explicit
+    //! and attenuated tokens carry no renewal binding.
 
     #[test]
-    fn session_connect_rotates_credentials_after_connect() {
+    fn session_connect_checks_eligible_renewal_after_connect() {
         let source = include_str!("session.rs");
         let connect_idx = source
             .find("HostedGrpcClient::connect(addr, &self.config)")
@@ -202,6 +214,134 @@ mod tests {
             "auto_rotate_if_needed must follow HostedGrpcClient::connect within the \
              same async block (found {rotate_offset} chars later)",
         );
+    }
+
+    #[test]
+    fn explicit_derived_token_cannot_rotate_from_a_nearly_expired_stored_parent() {
+        use biscuit_auth::{Biscuit, KeyPair};
+        use crypto::{Ed25519Signer, Signer};
+
+        use super::{HostedAuthMode, HostedSession};
+        use crate::credentials;
+
+        let _guard = credentials::lock_test_env();
+        let home = tempfile::TempDir::new().expect("temp Heddle home");
+        let previous_home = std::env::var_os("HEDDLE_HOME");
+        let previous_remote_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", home.path());
+            std::env::remove_var("HEDDLE_REMOTE_TOKEN");
+        }
+
+        let result = std::panic::catch_unwind(|| {
+            let parent_signer = Ed25519Signer::generate().expect("parent proof key");
+            let expires_at = chrono::Utc::now() + chrono::Duration::minutes(5);
+            let parent_token = Biscuit::builder()
+                .fact(r#"user("alice")"#)
+                .expect("user fact")
+                .fact(r#"credential_id("cred-parent")"#)
+                .expect("credential fact")
+                .fact(
+                    format!(
+                        "device_pop_key(\"{}\")",
+                        hex::encode(parent_signer.public_key())
+                    )
+                    .as_str(),
+                )
+                .expect("proof key fact")
+                .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
+                .expect("expiry fact")
+                .build(&KeyPair::new())
+                .expect("mint parent")
+                .to_base64()
+                .expect("encode parent");
+            let server = "127.0.0.1:8421";
+            let stored_parent = credentials::ServerCredential {
+                token: parent_token.clone(),
+                subject: "alice".to_string(),
+                device_id: Some("device-parent".to_string()),
+                credential_id: Some("cred-parent".to_string()),
+                private_key_pem: Some(parent_signer.to_pem().expect("parent PEM")),
+                expires_at: Some(expires_at.to_rfc3339()),
+            };
+            assert!(
+                credentials::token_needs_rotation(&stored_parent),
+                "the stored parent fixture must exercise the renewal window"
+            );
+            credentials::store_server_credential(server, stored_parent)
+                .expect("store nearly expired parent");
+
+            let child_signer = Ed25519Signer::generate().expect("child proof key");
+            let child_token = crate::device_flow::attenuate_for_agent(
+                &parent_token,
+                crate::device_flow::AgentAttenuation {
+                    agent_id: "explicit-child".to_string(),
+                    expires_at: chrono::Utc::now() + chrono::Duration::minutes(3),
+                    allowed_operations: Some(vec!["Push".to_string()]),
+                    allowed_resources: None,
+                    declared_scopes: Vec::new(),
+                },
+                &parent_signer,
+                child_signer.public_key(),
+            )
+            .expect("derive explicit child");
+
+            let stored_session = HostedSession::build(
+                &cli_shared::UserConfig::default(),
+                Some(server.to_string()),
+                HostedAuthMode::CredentialFallback,
+            )
+            .expect("build stored-parent session");
+            assert_eq!(
+                stored_session
+                    .config
+                    .token
+                    .as_ref()
+                    .map(|token| token.id.as_str()),
+                Some(parent_token.as_str())
+            );
+            assert!(
+                stored_session.renewable_authority_credential.is_some(),
+                "the exact stored authority token is renewable"
+            );
+
+            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
+            let explicit_child_session = HostedSession::build(
+                &cli_shared::UserConfig::default(),
+                Some(server.to_string()),
+                HostedAuthMode::CredentialFallback,
+            )
+            .expect("build explicit-child session");
+            assert_eq!(
+                explicit_child_session
+                    .config
+                    .token
+                    .as_ref()
+                    .map(|token| token.id.as_str()),
+                Some(child_token.as_str()),
+                "the explicit child remains the active bearer"
+            );
+            assert!(
+                explicit_child_session
+                    .renewable_authority_credential
+                    .is_none(),
+                "an explicit derived bearer must not borrow the stored parent's renewal identity"
+            );
+        });
+
+        unsafe {
+            match previous_home {
+                Some(path) => std::env::set_var("HEDDLE_HOME", path),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match previous_remote_token {
+                Some(token) => std::env::set_var("HEDDLE_REMOTE_TOKEN", token),
+                None => std::env::remove_var("HEDDLE_REMOTE_TOKEN"),
+            }
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
     }
 
     #[tokio::test]

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -132,30 +132,8 @@ fn shared_device_proof_key(server_key: &str, token: &str) -> Result<Option<Strin
 }
 
 fn token_proof_key_matches(token: &str, expected_public_key_hex: &str) -> bool {
-    use biscuit_auth::builder::{BlockBuilder, Term};
-
-    let Ok(biscuit) = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes()) else {
-        return false;
-    };
-    let Ok(authority_source) = biscuit.print_block_source(0) else {
-        return false;
-    };
-    let Ok(authority) = BlockBuilder::new().code(&authority_source) else {
-        return false;
-    };
-    let mut proof_keys = authority.facts.iter().filter_map(|fact| {
-        if fact.predicate.name != "device_pop_key" || fact.predicate.terms.len() != 1 {
-            return None;
-        }
-        match &fact.predicate.terms[0] {
-            Term::Str(value) => Some(value),
-            _ => None,
-        }
-    });
-    let Some(proof_key) = proof_keys.next() else {
-        return false;
-    };
-    proof_keys.next().is_none() && proof_key.eq_ignore_ascii_case(expected_public_key_hex)
+    crate::device_flow::effective_pop_public_key_hex(token)
+        .is_ok_and(|proof_key| proof_key.eq_ignore_ascii_case(expected_public_key_hex))
 }
 
 fn server_keys_match(left: &str, right: &str) -> bool {
@@ -227,8 +205,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn token_only_derived_child_uses_shared_same_host_device_proof() {
-        use base64::Engine as _;
+    async fn token_only_derived_child_does_not_fall_back_to_the_parent_device_key() {
         use biscuit_auth::{Biscuit, KeyPair};
         use crypto::{Ed25519Signer, Signer};
         use tonic::{Request, metadata::MetadataValue, transport::Endpoint};
@@ -294,6 +271,20 @@ mod tests {
             assert_eq!(identity.public_key, hex::encode(signer.public_key()));
             assert_eq!(identity.server, server);
 
+            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &token) };
+            let root_session = HostedSession::build(
+                &cli_shared::UserConfig::default(),
+                Some(server.to_string()),
+                HostedAuthMode::ConfigToken,
+            )
+            .expect("build root same-host session");
+            assert_eq!(
+                root_session.config.auth_proof_key_pem.as_deref(),
+                Some(private_key_pem.as_str()),
+                "a root token still resolves its matching same-host device key"
+            );
+
+            let child_signer = Ed25519Signer::generate().expect("child PoP key");
             let child_token = crate::device_flow::attenuate_for_agent(
                 &token,
                 crate::device_flow::AgentAttenuation {
@@ -303,6 +294,8 @@ mod tests {
                     allowed_resources: None,
                     declared_scopes: vec![("repo".to_string(), "acme/heddle".to_string())],
                 },
+                &signer,
+                child_signer.public_key(),
             )
             .expect("derive child token");
             unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
@@ -314,10 +307,9 @@ mod tests {
             )
             .expect("build hosted session from token-only same-host handoff");
             let config = session.config;
-            assert_eq!(
-                config.auth_proof_key_pem.as_deref(),
-                Some(private_key_pem.as_str()),
-                "token-only handoff must resolve the proof key from the shared device identity"
+            assert!(
+                config.auth_proof_key_pem.is_none(),
+                "a token-only child must not silently sign with its ancestor device key"
             );
             let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
             let client = HostedGrpcClient {
@@ -355,31 +347,9 @@ mod tests {
                 .expect("attach hosted auth");
 
             let metadata = request.metadata();
-            let proof_ts = metadata
-                .get(crypto::pop::HDR_PROOF_TS)
-                .and_then(|value| value.to_str().ok())
-                .expect("proof timestamp");
-            let nonce = metadata
-                .get(crypto::pop::HDR_PROOF_NONCE)
-                .and_then(|value| value.to_str().ok())
-                .expect("proof nonce");
-            let proof = metadata
-                .get(crypto::pop::HDR_PROOF)
-                .and_then(|value| value.to_str().ok())
-                .expect("proof signature");
-            let signature = base64::engine::general_purpose::STANDARD
-                .decode(proof)
-                .expect("decode proof signature");
-            crypto::pop::verify_pop(
-                signer.public_key(),
-                &child_token,
-                proof_ts,
-                "POST",
-                method,
-                nonce,
-                &signature,
-            )
-            .expect("derived-token proof verifies against the shared same-host device key");
+            assert!(metadata.get(crypto::pop::HDR_PROOF_TS).is_none());
+            assert!(metadata.get(crypto::pop::HDR_PROOF_NONCE).is_none());
+            assert!(metadata.get(crypto::pop::HDR_PROOF).is_none());
         });
 
         unsafe {

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -298,6 +298,33 @@ mod tests {
                 child_signer.public_key(),
             )
             .expect("derive child token");
+
+            let child_private_key_pem = child_signer.to_pem().expect("child PEM");
+            let child_key_path = home.path().join("child-key.pem");
+            std::fs::write(&child_key_path, &child_private_key_pem)
+                .expect("write child key for install");
+            auth_cmd::install_headless_credential(server, &child_token, &child_key_path)
+                .expect("install derived child credential");
+
+            let stored_child = credentials::get_server_credential(server)
+                .expect("read installed child credential")
+                .expect("installed child credential");
+            assert_eq!(
+                stored_child.private_key_pem.as_deref(),
+                Some(child_private_key_pem.as_str()),
+                "the per-server child credential must retain its matching child key"
+            );
+            let preserved_identity =
+                repo::identity::load_device(&repo::identity::device_identity_path())
+                    .expect("reload shared device identity")
+                    .expect("shared root identity remains installed");
+            assert_eq!(
+                preserved_identity.public_key,
+                hex::encode(signer.public_key()),
+                "installing a derived child must not replace the host-wide root identity"
+            );
+            assert_eq!(preserved_identity.private_key_pem, private_key_pem);
+
             unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
 
             let session = HostedSession::build(


### PR DESCRIPTION
## Summary
- require exactly one valid delegated-PoP transition in every derived credential block and validate every public derivation helper against the parent token's effective PoP key
- retain the child PEM in the per-server credential while preventing derived installs from replacing the shared root device identity
- publish portable child-token bundles with staged secret writes, an atomic rename, and a durable parent-directory sync
- restrict automatic renewal to the exact stored one-block authority credential and exact active bearer, so explicit or attenuated credentials cannot be re-minted from a stored parent
- apply an exhaustive, proto-drift-checked AuthService policy to every derived token; presence issuance remains denied until the server preserves the caller's complete Biscuit chain
- reject duplicate device proof anchors and authority-block delegation facts on the client, matching the server fail-closed model

Part of HeddleCo/weft#576

## Red commit
`066e774e`

## Test evidence
```
$ git rev-parse HEAD
b61e60ac6f5192e5e84ee764c8d9689996daafa6

$ cargo test --locked -p heddle-client
test result: ok. 134 passed; 0 failed; 0 ignored

$ cargo test --locked --workspace
exit 0

$ cargo clippy --locked --workspace --all-targets -- -D warnings
exit 0

$ cargo build --locked --workspace
exit 0

$ cargo check --locked -p repo --no-default-features --features git-overlay,zstd
exit 0
$ cargo check --locked -p repo --no-default-features --features native,zstd
exit 0
$ cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd
exit 0
$ cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd
exit 0

$ bash scripts/check-default-cli-contracts.sh
exit 0
$ target/debug/heddle doctor docs --all
exit 0
$ target/debug/heddle doctor schemas
exit 0

$ git diff --check HEAD^ HEAD
exit 0
```

## Manual verification
N/A — covered by tests

## Blocked by → resolved
N/A
