### PR TITLE
release: publish StateId wire model as 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1745,7 +1745,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -1842,7 +1842,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "futures",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "libc",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1935,7 +1935,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1978,7 +1978,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "base32",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "criterion",
@@ -2052,7 +2052,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2082,14 +2082,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2100,7 +2100,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2130,7 +2130,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5961,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.1"
+version = "0.10.2"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.10.1",
+  "schemaVersion": "0.10.2",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.10.1" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.10.2" as const;
 
 export interface AbortSchema {
   action: string;


### PR DESCRIPTION
## Summary

- bump the synchronized Heddle workspace release from 0.10.1 to 0.10.2
- publish the #1011 StateId wire identity required by hosted sync: `wire::ObjectId::StateId` and tag-1 native-pack framing as 32-byte `StateId`
- refresh generated schema version stamps

This is the release prerequisite for HeddleCo/weft#631. The weft dependency/migration PR must remain gated until crates.io has published `heddle-objects` and `heddle-wire` 0.10.2.

## Verification

- `cargo test -p heddle-objects store::pack` (66 passed)
- `cargo test -p heddle-wire` (53 passed)
- `cargo check -p heddle-objects -p heddle-wire`
- `scripts/check-publish-pipeline.sh`
- `cargo package -p heddle-objects --allow-dirty --no-verify`
- `cargo package -p heddle-wire --allow-dirty --no-verify`
- inspected packaged tarballs: tag 1 decodes tag + 32-byte `StateId`; wire package contains `ObjectId::StateId`

`cargo fmt --check` currently reports unrelated pre-existing formatting drift on `main`; this release changes no Rust source.

Do not merge until the Fable review gate and CI are complete. Do not self-merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786927012&installation_id=132405951&pr_number=1048&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1048&signature=d004abc09129bcf3407b01b4774607001e471ef1b853160bca7dc78e0fdd3fd4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->