### PR TITLE
feat(discuss): wire hosted discussion sync into the CLI

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1623,6 +1623,18 @@ async fn clone_network(
                 .context("failed to materialize hosted clone worktree")?;
         }
         configure_hosted_clone_origin(&local_repo, &endpoint_spec, repo_path)?;
+        // Read path for hosted discussions (heddle discuss): materialize the
+        // hosted CollaborationService discussions for the cloned head into the
+        // local op-log so `discuss list` / `discuss show` see them. Best-effort:
+        // a fetch hiccup warns rather than failing an otherwise-good clone.
+        match crate::client::discussion_sync::pull_discussions(&local_repo, &mut client, repo_path)
+            .await
+        {
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("{} discussion sync skipped: {error:#}", style::warn_marker());
+            }
+        }
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(
                 origin_url.clone(),

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1257,6 +1257,31 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
     .await?;
     clear_line(&progress);
 
+    // Write path for hosted discussions (heddle discuss): the pushed state(s)
+    // are now on the server, so replay any local symbol-anchored discussions to
+    // the hosted CollaborationService over the same signed client. Best-effort:
+    // the object push already succeeded, so a discussion-sync hiccup warns
+    // rather than failing the push (the next push resumes from the mirror map).
+    if result.success {
+        match crate::client::discussion_sync::push_discussions(repo, &mut client, &repo_path).await
+        {
+            Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
+                println!(
+                    "{} synced {count} discussion(s) to {}",
+                    style::ok_marker(),
+                    style::dim(&repo_path)
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!(
+                    "{} discussion sync skipped: {error:#}",
+                    style::warn_marker()
+                );
+            }
+        }
+    }
+
     // CLI maps wire/protobuf transport fields → pure domain fields; core
     // parses success/failure and builds execution facts / outcome.
     let fields = HostedPushResultFields {

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1081,6 +1081,30 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
                     }
                 }
             }
+            // Read path for hosted discussions (heddle discuss): materialize any
+            // new hosted CollaborationService discussions/turns for the pulled
+            // head into the local op-log. Best-effort — a fetch hiccup warns
+            // rather than failing the pull.
+            match crate::client::discussion_sync::pull_discussions(repo, &mut client, repo_path)
+                .await
+            {
+                Ok(count)
+                    if count > 0 && !should_output_json(options.cli, Some(repo.config())) =>
+                {
+                    println!(
+                        "{} synced {count} discussion(s) from {}",
+                        crate::cli::style::ok_marker(),
+                        crate::cli::style::dim(repo_path)
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!(
+                        "{} discussion sync skipped: {error:#}",
+                        crate::cli::style::warn_marker()
+                    );
+                }
+            }
             // Facts reuse the same string-mapped transport fields.
             let facts_fields = HostedPullResultFields {
                 success: true,

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -51,7 +51,7 @@ use objects::{
     },
 };
 use objects::store::ObjectStore;
-use repo::{CollaborationStore, Repository};
+use repo::{CollaborationStore, Repository, mark_legacy_discussions_migrated};
 use serde::{Deserialize, Serialize};
 
 use crate::client::HostedGrpcClient;
@@ -238,6 +238,15 @@ pub async fn pull_discussions(
     client: &mut HostedGrpcClient,
     repo_path: &str,
 ) -> Result<usize> {
+    // Hosted discussions arrive as server-minted `Discussions` state-attachments
+    // on the pulled objects. Those are the transport form of what we
+    // authoritatively re-materialize below via the CollaborationService RPCs —
+    // so claim the one-shot legacy blob->op-log migration marker to keep it from
+    // also converting them (which would duplicate every discussion and diverge
+    // on multi-turn supersede history). Fresh clones have no genuine local
+    // legacy discussions, and existing repos already hold the marker.
+    mark_legacy_discussions_migrated(repo).context("claim legacy discussion migration marker")?;
+
     let Some(head_state) = repo.head().context("resolve repository head")? else {
         return Ok(0);
     };

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -6,59 +6,79 @@
 //! a different, per-state `DiscussionsBlob` model (id-keyed discussions with a
 //! linear turn list). This module bridges the two:
 //!
-//! * **Push (write path):** after a successful `heddle push`, replay every
-//!   symbol-anchored local discussion to the server via the caller-authenticated
-//!   `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode signed — the CLI's
-//!   existing signed hosted client). New turns authored offline ride the next
-//!   push; #549 rejects attachments in the pack, so they cannot ride the pack.
+//! * **Push (write path):** after a successful `heddle push`, replay local
+//!   symbol-anchored discussion turns *we authored* to the server via the
+//!   caller-authenticated `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode
+//!   signed — the CLI's existing signed hosted client). #549 rejects attachments
+//!   in the pack, so they cannot ride the pack.
 //! * **Pull/clone (read path):** after a successful clone/pull, `ListByState`
-//!   the head state's discussions and materialize any new ones (and any new
-//!   turns) into the local op-log so `discuss list` / `discuss show` see them.
+//!   the head state's discussions and materialize any turns we do not already
+//!   hold into the local op-log so `discuss list` / `discuss show` see them.
 //!
-//! A per-repo mirror map (`.heddle/collaboration/hosted-mirror.json`) records
-//! the local↔server discussion id pairing and how many turns are known-synced,
-//! so re-push / re-pull only ship the delta and stay idempotent.
+//! ## Turn identity (why not an ordinal count)
+//!
+//! Local turn order is op-log materialization order `(occurred_at_ms, op_id)`;
+//! server turn order is push/append order. The moment both sides append these
+//! diverge, so a single "N turns synced" prefix count is a lie — it would
+//! re-publish another author's pulled turn under our identity and drop our own.
+//!
+//! Instead the per-repo mirror map (`.heddle/collaboration/hosted-mirror.json`)
+//! records, per discussion, an explicit set of **turn links**: local
+//! `CollabOpId` ↔ server turn ordinal. A turn is on the server iff its local
+//! op-id is linked. Push sends only turns that are (a) authored by us and (b)
+//! not yet linked; pull materializes only server ordinals not yet linked. Client
+//! operation ids for the RPCs are derived deterministically from that stable
+//! turn identity (the local `CollabOpId`), so a retry replays server-side
+//! instead of duplicating or hitting a `with_idempotency` body-conflict.
+//!
+//! The mirror is saved after **each** discussion completes and on the error
+//! path, and per-discussion failures are collected-and-continued — one wedged
+//! discussion (e.g. weft#638's no-HEAD `AppendTurn`) cannot abort the rest, and
+//! a mid-run failure never leaves durable writes without their mapping.
 //!
 //! Scope: discussions only. `context` (annotations) and `review` anchor to the
 //! same state-attachment seam and can follow this exact pattern (a hosted
-//! ContextService / StateReviewService sync using the same mirror-map + delta
+//! ContextService / StateReviewService sync using the same mirror-map + link
 //! design) — deliberately not built here.
 //!
-//! Known limitations (linear-model bridge):
-//! * Only `Symbol`-anchored discussions map to the hosted `PathSymbolRef`
-//!   model; repository/state/change/path-anchored discussions are skipped.
-//! * The op-log is a DAG; the hosted blob is a linear turn list. Turn sync is
-//!   ordinal (common-prefix by count), which is correct for the non-branching
-//!   authoring path but does not reconcile concurrent op-log branches.
+//! Known limitations (first cut):
+//! * Only `Symbol`-anchored discussions map to the hosted `PathSymbolRef` model;
+//!   other anchors are skipped.
+//! * Content reconciliation (matching an unlinked turn when the mirror map was
+//!   lost/rebuilt) keys on the turn **body** only — author and `posted_at`
+//!   diverge across the push boundary (local authoring principal vs the server
+//!   principal; local `occurred_at_ms` vs server `posted_at`).
 //! * `resolve` / `reopen` are not yet mirrored (turns only).
+//! * weft#638: weft resolves `AppendTurn` / `ListByState` against a single state
+//!   with no head carry-forward, so after a head-advancing push, sync of an
+//!   already-opened discussion degrades (warn-and-skip). We only degrade
+//!   gracefully here; the durable fix is server-side.
 
 #![cfg(feature = "client")]
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashSet},
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use anyhow::{Context, Result, anyhow};
-use objects::{
-    fs_atomic::write_file_atomic,
-    object::{
-        Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
-        CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
-        DiscussionTurnV1, Principal, VisibilityTier,
-    },
-};
+use objects::fs_atomic::write_file_atomic;
 use objects::store::ObjectStore;
+use objects::object::{
+    Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
+    CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
+    DiscussionTurnV1, MaterializedDiscussion, Principal, StateId, VisibilityTier,
+};
 use repo::{CollaborationStore, Repository, mark_legacy_discussions_migrated};
 use serde::{Deserialize, Serialize};
 
 use crate::client::HostedGrpcClient;
-use heddle_client::grpc_hosted::HostedDiscussionTurn;
+use heddle_client::grpc_hosted::{HostedDiscussion, HostedDiscussionTurn};
 
 /// Deterministic namespace for the derived client-operation-ids so a retried
-/// push replays (server-side idempotent) rather than duplicating a discussion.
+/// push replays (server-side idempotent) rather than duplicating a turn.
 const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_6469_7363_7573_7379_6e63);
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -80,8 +100,18 @@ struct MirrorEntry {
     local_id: String,
     /// Server-assigned discussion id.
     server_id: String,
-    /// Number of turns known to be present on BOTH sides (common prefix length).
-    synced_turns: usize,
+    /// Turns known to exist on BOTH sides, each carrying its identity on both:
+    /// the local op-id and the server turn ordinal.
+    #[serde(default)]
+    links: Vec<TurnLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TurnLink {
+    /// Local `CollabOpId` (`to_string_full`) — the stable turn identity.
+    local_op_id: String,
+    /// Position of the turn in the server's linear turn list.
+    server_ordinal: usize,
 }
 
 fn mirror_path(heddle_dir: &Path) -> PathBuf {
@@ -106,8 +136,16 @@ fn save_mirror(heddle_dir: &Path, mirror: &HostedMirror) -> Result<()> {
     Ok(())
 }
 
-fn op_operation_id(key: &str) -> String {
-    uuid::Uuid::new_v5(&OP_NAMESPACE, key.as_bytes()).to_string()
+fn open_op_id(repo_path: &str, local_id: &str) -> String {
+    uuid::Uuid::new_v5(&OP_NAMESPACE, format!("open:{repo_path}:{local_id}").as_bytes()).to_string()
+}
+
+fn append_op_id(repo_path: &str, server_id: &str, local_op_id: &str) -> String {
+    uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("append:{repo_path}:{server_id}:{local_op_id}").as_bytes(),
+    )
+    .to_string()
 }
 
 fn now_ms() -> i64 {
@@ -117,12 +155,10 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
-/// Publish local symbol-anchored discussions (and any new turns) to the hosted
-/// `CollaborationService`. Returns the number of discussions created or extended.
-///
-/// Best-effort: a per-discussion RPC failure aborts with context, but the
-/// mirror map is only advanced for discussions that fully synced, so a re-push
-/// resumes cleanly.
+/// Publish local symbol-anchored discussion turns we authored to the hosted
+/// `CollaborationService`. Returns the number of discussions created or
+/// extended. Saves the mirror after each discussion and continues past a
+/// per-discussion failure (warn-and-skip).
 pub async fn push_discussions(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -133,106 +169,170 @@ pub async fn push_discussions(
     if materialized.discussions.is_empty() {
         return Ok(0);
     }
+    let self_attr = repo.get_attribution().ok();
 
     let mut mirror = load_mirror(repo.heddle_dir())?;
     let mut synced = 0usize;
 
     for (discussion_id, discussion) in &materialized.discussions {
-        let CollaborationAnchor::Symbol {
-            state_id,
-            path,
-            symbol,
-        } = &discussion.anchor
-        else {
-            // Only symbol-anchored discussions map to the hosted PathSymbolRef.
-            continue;
-        };
-        let Some(state) = repo
-            .store()
-            .get_state(state_id)
-            .context("load discussion anchor state")?
-        else {
-            continue;
-        };
-        let change_id = state.change_id;
-        let visibility = discussion.visibility.as_str().to_string();
-        let bodies: Vec<String> = discussion.turns.iter().map(|(_, t)| t.body.clone()).collect();
-        if bodies.is_empty() {
-            continue;
-        }
-        let local_id = discussion_id.to_string();
-
-        let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-        let existing = repo_mirror
-            .discussions
-            .iter()
-            .position(|entry| entry.local_id == local_id);
-
-        match existing {
-            None => {
-                let hosted = client
-                    .open_discussion(
-                        repo_path,
-                        change_id,
-                        path,
-                        symbol,
-                        &bodies[0],
-                        &visibility,
-                        op_operation_id(&format!("open:{repo_path}:{local_id}")),
-                    )
-                    .await
-                    .with_context(|| format!("open hosted discussion for {local_id}"))?;
-                let server_id = hosted.id.clone();
-                for (index, body) in bodies.iter().enumerate().skip(1) {
-                    client
-                        .append_turn(
-                            repo_path,
-                            &server_id,
-                            body,
-                            op_operation_id(&format!("append:{repo_path}:{local_id}:{index}")),
-                        )
-                        .await
-                        .with_context(|| format!("append hosted turn {index} for {local_id}"))?;
-                }
-                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-                repo_mirror.discussions.push(MirrorEntry {
-                    local_id,
-                    server_id,
-                    synced_turns: bodies.len(),
-                });
-                synced += 1;
-            }
-            Some(index) => {
-                let already = repo_mirror.discussions[index].synced_turns;
-                if bodies.len() <= already {
-                    continue;
-                }
-                let server_id = repo_mirror.discussions[index].server_id.clone();
-                for (turn_index, body) in bodies.iter().enumerate().skip(already) {
-                    client
-                        .append_turn(
-                            repo_path,
-                            &server_id,
-                            body,
-                            op_operation_id(&format!("append:{repo_path}:{local_id}:{turn_index}")),
-                        )
-                        .await
-                        .with_context(|| format!("append hosted turn {turn_index} for {local_id}"))?;
-                }
-                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-                repo_mirror.discussions[index].synced_turns = bodies.len();
-                synced += 1;
+        let result = push_one(
+            client,
+            &store,
+            repo,
+            repo_path,
+            &mut mirror,
+            self_attr.as_ref(),
+            &discussion_id.to_string(),
+            discussion,
+        )
+        .await;
+        // Persist links after every discussion — including the error path, where
+        // some turns may already be on the server — so a retry resumes cleanly.
+        save_mirror(repo.heddle_dir(), &mirror)?;
+        match result {
+            Ok(true) => synced += 1,
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!(
+                    "{} hosted discussion {}: {error:#}",
+                    crate::cli::style::warn_marker(),
+                    discussion_id
+                );
             }
         }
     }
 
-    save_mirror(repo.heddle_dir(), &mirror)?;
     Ok(synced)
 }
 
-/// Fetch hosted discussions for the repository head and materialize any new
-/// ones (and any new turns) into the local op-log. Returns the number of
-/// discussions created or extended locally.
+#[allow(clippy::too_many_arguments)]
+async fn push_one(
+    client: &mut HostedGrpcClient,
+    store: &CollaborationStore,
+    repo: &Repository,
+    repo_path: &str,
+    mirror: &mut HostedMirror,
+    self_attr: Option<&Attribution>,
+    local_id: &str,
+    discussion: &MaterializedDiscussion,
+) -> Result<bool> {
+    let CollaborationAnchor::Symbol {
+        state_id,
+        path,
+        symbol,
+    } = &discussion.anchor
+    else {
+        // Only symbol-anchored discussions map to the hosted PathSymbolRef.
+        return Ok(false);
+    };
+    let Some(state) = repo
+        .store()
+        .get_state(state_id)
+        .context("load discussion anchor state")?
+    else {
+        return Ok(false);
+    };
+    let change_id = state.change_id;
+    let visibility = discussion.visibility.as_str().to_string();
+
+    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+    let entry_index = repo_mirror
+        .discussions
+        .iter()
+        .position(|entry| entry.local_id == local_id);
+    let linked: HashSet<String> = match entry_index {
+        Some(i) => repo_mirror.discussions[i]
+            .links
+            .iter()
+            .map(|link| link.local_op_id.clone())
+            .collect(),
+        None => HashSet::new(),
+    };
+
+    // Candidates: turns we authored that the server does not already hold.
+    // Filtering to *self-authored* is the load-bearing guard against
+    // re-publishing a pulled turn (another author's) under our identity even if
+    // the mirror map was lost; the link check skips turns already synced.
+    let mut candidates: Vec<(CollabOpId, String)> = Vec::new();
+    for (op_id, turn) in &discussion.turns {
+        if linked.contains(&op_id.to_string_full()) {
+            continue;
+        }
+        if !author_is_self(store, op_id, self_attr) {
+            continue;
+        }
+        candidates.push((*op_id, turn.body.clone()));
+    }
+    if candidates.is_empty() {
+        return Ok(false);
+    }
+
+    match entry_index {
+        None => {
+            // A discussion with no mapping is one we opened locally (pulled
+            // discussions always carry an entry), so its first turn is ours.
+            let (open_op, open_body) = candidates[0].clone();
+            let hosted = client
+                .open_discussion(
+                    repo_path,
+                    change_id,
+                    path,
+                    symbol,
+                    &open_body,
+                    &visibility,
+                    open_op_id(repo_path, local_id),
+                )
+                .await
+                .with_context(|| format!("open hosted discussion for {local_id}"))?;
+            let server_id = hosted.id.clone();
+            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+            repo_mirror.discussions.push(MirrorEntry {
+                local_id: local_id.to_string(),
+                server_id: server_id.clone(),
+                links: vec![TurnLink {
+                    local_op_id: open_op.to_string_full(),
+                    server_ordinal: 0,
+                }],
+            });
+            let index = repo_mirror.discussions.len() - 1;
+            for (op_id, body) in &candidates[1..] {
+                let hosted = client
+                    .append_turn(
+                        repo_path,
+                        &server_id,
+                        body,
+                        append_op_id(repo_path, &server_id, &op_id.to_string_full()),
+                    )
+                    .await
+                    .with_context(|| format!("append hosted turn for {local_id}"))?;
+                let ordinal = hosted.turns.len().saturating_sub(1);
+                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+            }
+            Ok(true)
+        }
+        Some(index) => {
+            let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
+            for (op_id, body) in &candidates {
+                let hosted = client
+                    .append_turn(
+                        repo_path,
+                        &server_id,
+                        body,
+                        append_op_id(repo_path, &server_id, &op_id.to_string_full()),
+                    )
+                    .await
+                    .with_context(|| format!("append hosted turn for {local_id}"))?;
+                let ordinal = hosted.turns.len().saturating_sub(1);
+                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+            }
+            Ok(true)
+        }
+    }
+}
+
+/// Fetch hosted discussions for the repository head and materialize any turns we
+/// do not already hold into the local op-log. Saves the mirror after each
+/// discussion and continues past a per-discussion failure.
 pub async fn pull_discussions(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -248,6 +348,8 @@ pub async fn pull_discussions(
     mark_legacy_discussions_migrated(repo).context("claim legacy discussion migration marker")?;
 
     let Some(head_state) = repo.head().context("resolve repository head")? else {
+        // weft#638: a repo with no HEAD cannot resolve a state to list against.
+        // Degrade gracefully — nothing to materialize.
         return Ok(0);
     };
     let Some(state) = repo
@@ -272,101 +374,192 @@ pub async fn pull_discussions(
     let mut changed = 0usize;
 
     for discussion in hosted {
-        if discussion.turns.is_empty() {
-            continue;
-        }
-        let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-        let existing = repo_mirror
-            .discussions
-            .iter()
-            .position(|entry| entry.server_id == discussion.id);
-
-        match existing {
-            None => {
-                let local_id = DiscussionRecordId::generate();
-                let anchor = CollaborationAnchor::Symbol {
-                    state_id: discussion.opened_against_state.unwrap_or(head_state),
-                    path: discussion.file.clone(),
-                    symbol: discussion.symbol.clone(),
-                };
-                let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
-                let visibility = parse_visibility_token(&discussion.visibility);
-
-                let first = &discussion.turns[0];
-                let mut head = write_local_operation(
-                    &store,
-                    local_id,
-                    Vec::new(),
-                    turn_attribution(first),
-                    turn_ms(first),
-                    CollaborationOperationBodyV1::Open {
-                        title,
-                        anchor,
-                        visibility,
-                        turn: DiscussionTurnV1::new(first.body.clone())
-                            .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
-                    },
-                )?;
-                for turn in &discussion.turns[1..] {
-                    head = write_local_operation(
-                        &store,
-                        local_id,
-                        vec![head],
-                        turn_attribution(turn),
-                        turn_ms(turn),
-                        CollaborationOperationBodyV1::AppendTurn {
-                            turn: DiscussionTurnV1::new(turn.body.clone())
-                                .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
-                        },
-                    )?;
-                }
-
-                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-                repo_mirror.discussions.push(MirrorEntry {
-                    local_id: local_id.to_string(),
-                    server_id: discussion.id.clone(),
-                    synced_turns: discussion.turns.len(),
-                });
-                changed += 1;
-            }
-            Some(index) => {
-                let already = repo_mirror.discussions[index].synced_turns;
-                if discussion.turns.len() <= already {
-                    continue;
-                }
-                let local_id: DiscussionRecordId = repo_mirror.discussions[index]
-                    .local_id
-                    .parse()
-                    .map_err(|e| anyhow!("mirror map has an invalid local discussion id: {e}"))?;
-                let existing_discussion = store
-                    .materialize_discussion(&local_id)
-                    .context("materialize mirrored discussion")?
-                    .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
-                let mut heads: Vec<CollabOpId> =
-                    existing_discussion.heads.iter().copied().collect();
-                for turn in &discussion.turns[already..] {
-                    let id = write_local_operation(
-                        &store,
-                        local_id,
-                        heads.clone(),
-                        turn_attribution(turn),
-                        turn_ms(turn),
-                        CollaborationOperationBodyV1::AppendTurn {
-                            turn: DiscussionTurnV1::new(turn.body.clone())
-                                .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
-                        },
-                    )?;
-                    heads = vec![id];
-                }
-                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-                repo_mirror.discussions[index].synced_turns = discussion.turns.len();
-                changed += 1;
+        let result = pull_one(&store, repo_path, &mut mirror, head_state, &discussion);
+        save_mirror(repo.heddle_dir(), &mirror)?;
+        match result {
+            Ok(true) => changed += 1,
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!(
+                    "{} hosted discussion {}: {error:#}",
+                    crate::cli::style::warn_marker(),
+                    discussion.id
+                );
             }
         }
     }
 
-    save_mirror(repo.heddle_dir(), &mirror)?;
     Ok(changed)
+}
+
+fn pull_one(
+    store: &CollaborationStore,
+    repo_path: &str,
+    mirror: &mut HostedMirror,
+    head_state: StateId,
+    discussion: &HostedDiscussion,
+) -> Result<bool> {
+    if discussion.turns.is_empty() {
+        return Ok(false);
+    }
+    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+    let entry_index = repo_mirror
+        .discussions
+        .iter()
+        .position(|entry| entry.server_id == discussion.id);
+
+    match entry_index {
+        None => {
+            let local_id = DiscussionRecordId::generate();
+            let anchor = CollaborationAnchor::Symbol {
+                state_id: discussion.opened_against_state.unwrap_or(head_state),
+                path: discussion.file.clone(),
+                symbol: discussion.symbol.clone(),
+            };
+            let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
+            let visibility = parse_visibility_token(&discussion.visibility);
+
+            let first = &discussion.turns[0];
+            let open_op = write_local_operation(
+                store,
+                local_id,
+                Vec::new(),
+                turn_attribution(first),
+                turn_ms(first),
+                CollaborationOperationBodyV1::Open {
+                    title,
+                    anchor,
+                    visibility,
+                    turn: turn_body(first)?,
+                },
+            )?;
+            // Record the mapping immediately so a mid-materialization failure
+            // resumes into the `Some` arm instead of orphaning the written ops.
+            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+            repo_mirror.discussions.push(MirrorEntry {
+                local_id: local_id.to_string(),
+                server_id: discussion.id.clone(),
+                links: vec![TurnLink {
+                    local_op_id: open_op.to_string_full(),
+                    server_ordinal: 0,
+                }],
+            });
+            let index = repo_mirror.discussions.len() - 1;
+
+            let mut heads = vec![open_op];
+            for (ordinal, turn) in discussion.turns.iter().enumerate().skip(1) {
+                let op_id = write_local_operation(
+                    store,
+                    local_id,
+                    heads.clone(),
+                    turn_attribution(turn),
+                    turn_ms(turn),
+                    CollaborationOperationBodyV1::AppendTurn { turn: turn_body(turn)? },
+                )?;
+                heads = vec![op_id];
+                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+            }
+            Ok(true)
+        }
+        Some(index) => {
+            let local_id: DiscussionRecordId = repo_mirror.discussions[index]
+                .local_id
+                .parse()
+                .map_err(|e| anyhow!("mirror map has an invalid local discussion id: {e}"))?;
+            let linked_ordinals: HashSet<usize> = repo_mirror.discussions[index]
+                .links
+                .iter()
+                .map(|link| link.server_ordinal)
+                .collect();
+            let linked_local: HashSet<String> = repo_mirror.discussions[index]
+                .links
+                .iter()
+                .map(|link| link.local_op_id.clone())
+                .collect();
+
+            let existing = store
+                .materialize_discussion(&local_id)
+                .context("materialize mirrored discussion")?
+                .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
+            let mut heads: Vec<CollabOpId> = existing.heads.iter().copied().collect();
+            // Unlinked local turns available to reconcile against server turns by
+            // body (mirror-loss / re-sync guard — see the module note on why body
+            // is the identity here).
+            let mut available: Vec<(CollabOpId, String)> = existing
+                .turns
+                .iter()
+                .filter(|(op, _)| !linked_local.contains(&op.to_string_full()))
+                .map(|(op, turn)| (*op, turn.body.clone()))
+                .collect();
+
+            let mut changed = false;
+            for (ordinal, turn) in discussion.turns.iter().enumerate() {
+                if linked_ordinals.contains(&ordinal) {
+                    continue;
+                }
+                if let Some(pos) = available.iter().position(|(_, body)| body == &turn.body) {
+                    // Already present locally (we authored+pushed it, or a prior
+                    // partial sync) — link, don't duplicate.
+                    let (op_id, _) = available.swap_remove(pos);
+                    push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                    changed = true;
+                    continue;
+                }
+                let op_id = write_local_operation(
+                    store,
+                    local_id,
+                    heads.clone(),
+                    turn_attribution(turn),
+                    turn_ms(turn),
+                    CollaborationOperationBodyV1::AppendTurn { turn: turn_body(turn)? },
+                )?;
+                heads = vec![op_id];
+                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                changed = true;
+            }
+            Ok(changed)
+        }
+    }
+}
+
+fn push_link(
+    mirror: &mut HostedMirror,
+    repo_path: &str,
+    index: usize,
+    local_op_id: String,
+    server_ordinal: usize,
+) {
+    if let Some(entry) = mirror
+        .repos
+        .get_mut(repo_path)
+        .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
+    {
+        entry.links.push(TurnLink {
+            local_op_id,
+            server_ordinal,
+        });
+    }
+}
+
+/// Whether the op at `op_id` was authored by the local principal. On any
+/// uncertainty (no local principal, unreadable op) we do not filter — the link
+/// check remains the primary "already on the server" guard.
+fn author_is_self(
+    store: &CollaborationStore,
+    op_id: &CollabOpId,
+    self_attr: Option<&Attribution>,
+) -> bool {
+    let Some(self_attr) = self_attr else {
+        return true;
+    };
+    match store.read_operation(op_id) {
+        Ok(Some(decoded)) => principals_match(&decoded.operation.author, self_attr),
+        _ => true,
+    }
+}
+
+fn principals_match(a: &Attribution, b: &Attribution) -> bool {
+    a.principal.name == b.principal.name && a.principal.email == b.principal.email
 }
 
 fn write_local_operation(
@@ -379,19 +572,17 @@ fn write_local_operation(
 ) -> Result<CollabOpId> {
     let key = CollaborationIdempotencyKey::new(uuid::Uuid::new_v4().to_string())
         .map_err(|e| anyhow!("invalid idempotency key: {e}"))?;
-    let operation = CollaborationOperationEnvelope::new(
-        discussion_id,
-        parents,
-        key,
-        author,
-        occurred_at_ms,
-        body,
-    )
-    .map_err(|e| anyhow!("build collaboration operation: {e}"))?;
+    let operation =
+        CollaborationOperationEnvelope::new(discussion_id, parents, key, author, occurred_at_ms, body)
+            .map_err(|e| anyhow!("build collaboration operation: {e}"))?;
     Ok(store
         .write_operation(&operation)
         .context("write collaboration operation")?
         .operation_id)
+}
+
+fn turn_body(turn: &HostedDiscussionTurn) -> Result<DiscussionTurnV1> {
+    DiscussionTurnV1::new(turn.body.clone()).map_err(|e| anyhow!("invalid discussion turn: {e}"))
 }
 
 fn turn_attribution(turn: &HostedDiscussionTurn) -> Attribution {

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -9,55 +9,61 @@
 //! * **Push (write path):** after a successful `heddle push`, replay local
 //!   symbol-anchored discussion turns *we authored* to the server via the
 //!   caller-authenticated `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode
-//!   signed — the CLI's existing signed hosted client). #549 rejects attachments
-//!   in the pack, so they cannot ride the pack.
+//!   signed). #549 rejects attachments in the pack, so they cannot ride it.
 //! * **Pull/clone (read path):** after a successful clone/pull, `ListByState`
 //!   the head state's discussions and materialize any turns we do not already
 //!   hold into the local op-log so `discuss list` / `discuss show` see them.
 //!
-//! ## Turn identity (why not an ordinal count)
+//! ## Turn identity
 //!
-//! Local turn order is op-log materialization order `(occurred_at_ms, op_id)`;
-//! server turn order is push/append order. The moment both sides append these
-//! diverge, so a single "N turns synced" prefix count is a lie — it would
-//! re-publish another author's pulled turn under our identity and drop our own.
+//! Local turn order is op-log materialization order; server turn order is
+//! push/append order. They diverge the moment both sides append, so a single
+//! "N turns synced" prefix count is a lie. Instead the per-repo mirror map
+//! (`.heddle/collaboration/hosted-mirror.json`) records, per discussion, an
+//! explicit set of **turn links**: a local turn id ↔ a server turn ordinal.
 //!
-//! Instead the per-repo mirror map (`.heddle/collaboration/hosted-mirror.json`)
-//! records, per discussion, an explicit set of **turn links**: local
-//! `CollabOpId` ↔ server turn ordinal. A turn is on the server iff its local
-//! op-id is linked. Push sends only turns that are (a) authored by us and (b)
-//! not yet linked; pull materializes only server ordinals not yet linked. Client
-//! operation ids for the RPCs are derived deterministically from that stable
-//! turn identity (the local `CollabOpId`), so a retry replays server-side
-//! instead of duplicating or hitting a `with_idempotency` body-conflict.
+//! A local turn id is `(CollabOpId, index-within-op)` — NOT the `CollabOpId`
+//! alone, because a `LegacyImported` op (a migrated blob→op-log discussion)
+//! materializes *all* its turns under one shared `CollabOpId`. Keying on the op
+//! alone would give turns 2..N the same idempotency key with different bodies
+//! (a weft `with_idempotency` conflict) and collapse them into one link, so the
+//! rest would be silently dropped on exactly the migrated repos.
 //!
-//! The mirror is saved after **each** discussion completes and on the error
-//! path, and per-discussion failures are collected-and-continued — one wedged
-//! discussion (e.g. weft#638's no-HEAD `AppendTurn`) cannot abort the rest, and
-//! a mid-run failure never leaves durable writes without their mapping.
+//! Push sends only turns that are self-authored AND unlinked; pull materializes
+//! only server ordinals not yet linked. Client operation ids are derived from
+//! the stable turn id, so a retry replays instead of conflicting.
 //!
-//! Scope: discussions only. `context` (annotations) and `review` anchor to the
-//! same state-attachment seam and can follow this exact pattern (a hosted
-//! ContextService / StateReviewService sync using the same mirror-map + link
-//! design) — deliberately not built here.
+//! ## Reconciliation is author-aware, never body-alone
 //!
-//! Known limitations (first cut):
-//! * Only `Symbol`-anchored discussions map to the hosted `PathSymbolRef` model;
-//!   other anchors are skipped.
-//! * Content reconciliation (matching an unlinked turn when the mirror map was
-//!   lost/rebuilt) keys on the turn **body** only — author and `posted_at`
-//!   diverge across the push boundary (local authoring principal vs the server
-//!   principal; local `occurred_at_ms` vs server `posted_at`).
-//! * `resolve` / `reopen` are not yet mirrored (turns only).
-//! * weft#638: weft resolves `AppendTurn` / `ListByState` against a single state
-//!   with no head carry-forward, so after a head-advancing push, sync of an
-//!   already-opened discussion degrades (warn-and-skip). We only degrade
-//!   gracefully here; the durable fix is server-side.
+//! When the mirror map is lost/rebuilt, an unlinked server turn is reconciled
+//! against an unlinked local turn only under an explicit **author** rule — never
+//! body equality alone, which would cross-link two different authors' identical
+//! bodies (`"lgtm"`, `"+1"`) and silently drop one:
+//! * (i) a turn WE pushed — the local turn is self-authored AND the server
+//!   turn's author is our own hosted username (weft stamps
+//!   `Principal::new(username, "")`); or
+//! * (ii) a turn we previously PULLED — the local op's author (written as
+//!   `Principal::new(author_name, author_email)`) and `occurred_at_ms` exactly
+//!   equal the server turn's author and `posted_at`.
+//!
+//! Anything matching neither rule materializes as a new, distinct turn.
+//! Distinguishing "a turn I pushed" from "a turn another clone of the SAME user
+//! pushed" is impossible client-side without server-minted turn ids (weft#640);
+//! rule (i) is precise across distinct hosted principals, which is the real
+//! multi-party case.
+//!
+//! The mirror is saved after **each** discussion and on the error path, with
+//! collect-and-continue per discussion — one wedged discussion (e.g. weft#638's
+//! no-HEAD `AppendTurn`) cannot abort the rest, and a mid-run failure never
+//! leaves durable writes without their mapping.
+//!
+//! Scope: discussions only; `context`/`review` share the same seam (not built).
+//! `resolve`/`reopen` are not yet mirrored (turns only).
 
 #![cfg(feature = "client")]
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     time::{SystemTime, UNIX_EPOCH},
@@ -65,12 +71,12 @@ use std::{
 
 use anyhow::{Context, Result, anyhow};
 use objects::fs_atomic::write_file_atomic;
-use objects::store::ObjectStore;
 use objects::object::{
     Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
     CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
     DiscussionTurnV1, MaterializedDiscussion, Principal, StateId, VisibilityTier,
 };
+use objects::store::ObjectStore;
 use repo::{CollaborationStore, Repository, mark_legacy_discussions_migrated};
 use serde::{Deserialize, Serialize};
 
@@ -100,18 +106,32 @@ struct MirrorEntry {
     local_id: String,
     /// Server-assigned discussion id.
     server_id: String,
-    /// Turns known to exist on BOTH sides, each carrying its identity on both:
-    /// the local op-id and the server turn ordinal.
+    /// Turns known to exist on BOTH sides, each carrying its identity on both.
     #[serde(default)]
     links: Vec<TurnLink>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct TurnLink {
-    /// Local `CollabOpId` (`to_string_full`) — the stable turn identity.
-    local_op_id: String,
+    /// Local turn id: `{CollabOpId}#{index-within-op}` — the stable turn
+    /// identity (unique even when a `LegacyImported` op carries many turns).
+    local_turn_id: String,
     /// Position of the turn in the server's linear turn list.
     server_ordinal: usize,
+}
+
+/// One local turn with the identity + attribution the sync bridge reasons over.
+struct LocalTurn {
+    turn_id: String,
+    body: String,
+    author_name: String,
+    author_email: String,
+    occurred_at_ms: i64,
+    is_self: bool,
+}
+
+fn turn_identity(op_id: &CollabOpId, index_within_op: usize) -> String {
+    format!("{}#{index_within_op}", op_id.to_string_full())
 }
 
 fn mirror_path(heddle_dir: &Path) -> PathBuf {
@@ -140,10 +160,10 @@ fn open_op_id(repo_path: &str, local_id: &str) -> String {
     uuid::Uuid::new_v5(&OP_NAMESPACE, format!("open:{repo_path}:{local_id}").as_bytes()).to_string()
 }
 
-fn append_op_id(repo_path: &str, server_id: &str, local_op_id: &str) -> String {
+fn append_op_id(repo_path: &str, server_id: &str, turn_id: &str) -> String {
     uuid::Uuid::new_v5(
         &OP_NAMESPACE,
-        format!("append:{repo_path}:{server_id}:{local_op_id}").as_bytes(),
+        format!("append:{repo_path}:{server_id}:{turn_id}").as_bytes(),
     )
     .to_string()
 }
@@ -155,10 +175,57 @@ fn now_ms() -> i64 {
         .unwrap_or(0)
 }
 
+/// Enumerate a materialized discussion's turns with their per-op index (turn
+/// identity), author, and whether the local principal authored them. Reads each
+/// distinct op once for its author/timestamp.
+fn collect_local_turns(
+    store: &CollaborationStore,
+    discussion: &MaterializedDiscussion,
+    self_attr: Option<&Attribution>,
+) -> Result<Vec<LocalTurn>> {
+    let mut per_op: HashMap<CollabOpId, usize> = HashMap::new();
+    let mut op_author: HashMap<CollabOpId, (Principal, i64)> = HashMap::new();
+    let mut turns = Vec::with_capacity(discussion.turns.len());
+    for (op_id, turn) in &discussion.turns {
+        let index_within_op = {
+            let slot = per_op.entry(*op_id).or_insert(0);
+            let value = *slot;
+            *slot += 1;
+            value
+        };
+        let (principal, occurred_at_ms) = match op_author.get(op_id) {
+            Some(cached) => cached.clone(),
+            None => {
+                let decoded = store
+                    .read_operation(op_id)
+                    .context("read collaboration operation")?
+                    .ok_or_else(|| anyhow!("collaboration operation {op_id} missing"))?;
+                let entry = (
+                    decoded.operation.author.principal.clone(),
+                    decoded.operation.occurred_at_ms,
+                );
+                op_author.insert(*op_id, entry.clone());
+                entry
+            }
+        };
+        // F3: fail closed — an op we cannot attribute to the local principal is
+        // NOT treated as ours (no `self_attr` ⇒ never self).
+        let is_self = self_attr.is_some_and(|attr| principals_match(&principal, &attr.principal));
+        turns.push(LocalTurn {
+            turn_id: turn_identity(op_id, index_within_op),
+            body: turn.body.clone(),
+            author_name: principal.name.clone(),
+            author_email: principal.email.clone(),
+            occurred_at_ms,
+            is_self,
+        });
+    }
+    Ok(turns)
+}
+
 /// Publish local symbol-anchored discussion turns we authored to the hosted
-/// `CollaborationService`. Returns the number of discussions created or
-/// extended. Saves the mirror after each discussion and continues past a
-/// per-discussion failure (warn-and-skip).
+/// `CollaborationService`. Saves the mirror after each discussion and continues
+/// past a per-discussion failure (warn-and-skip).
 pub async fn push_discussions(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -244,24 +311,33 @@ async fn push_one(
         Some(i) => repo_mirror.discussions[i]
             .links
             .iter()
-            .map(|link| link.local_op_id.clone())
+            .map(|link| link.local_turn_id.clone())
             .collect(),
         None => HashSet::new(),
     };
 
     // Candidates: turns we authored that the server does not already hold.
-    // Filtering to *self-authored* is the load-bearing guard against
-    // re-publishing a pulled turn (another author's) under our identity even if
-    // the mirror map was lost; the link check skips turns already synced.
-    let mut candidates: Vec<(CollabOpId, String)> = Vec::new();
-    for (op_id, turn) in &discussion.turns {
-        if linked.contains(&op_id.to_string_full()) {
+    let local_turns = collect_local_turns(store, discussion, self_attr)?;
+    let mut candidates: Vec<(String, String)> = Vec::new(); // (turn_id, body)
+    let mut skipped_foreign = 0usize;
+    for turn in &local_turns {
+        if linked.contains(&turn.turn_id) {
             continue;
         }
-        if !author_is_self(store, op_id, self_attr) {
+        if !turn.is_self {
+            // Never re-publish another author's turn under our identity.
+            skipped_foreign += 1;
             continue;
         }
-        candidates.push((*op_id, turn.body.clone()));
+        candidates.push((turn.turn_id.clone(), turn.body.clone()));
+    }
+    if skipped_foreign > 0 {
+        // F3: surface principal drift / foreign-authored unpushed turns instead
+        // of silently producing an empty candidate set.
+        eprintln!(
+            "{} hosted discussion {local_id}: {skipped_foreign} unlinked turn(s) not attributed to the local principal were left unpublished",
+            crate::cli::style::warn_marker(),
+        );
     }
     if candidates.is_empty() {
         return Ok(false);
@@ -269,9 +345,7 @@ async fn push_one(
 
     match entry_index {
         None => {
-            // A discussion with no mapping is one we opened locally (pulled
-            // discussions always carry an entry), so its first turn is ours.
-            let (open_op, open_body) = candidates[0].clone();
+            let (open_turn_id, open_body) = candidates[0].clone();
             let hosted = client
                 .open_discussion(
                     repo_path,
@@ -290,40 +364,50 @@ async fn push_one(
                 local_id: local_id.to_string(),
                 server_id: server_id.clone(),
                 links: vec![TurnLink {
-                    local_op_id: open_op.to_string_full(),
+                    local_turn_id: open_turn_id,
                     server_ordinal: 0,
                 }],
             });
             let index = repo_mirror.discussions.len() - 1;
-            for (op_id, body) in &candidates[1..] {
+            for (turn_id, body) in &candidates[1..] {
                 let hosted = client
                     .append_turn(
                         repo_path,
                         &server_id,
                         body,
-                        append_op_id(repo_path, &server_id, &op_id.to_string_full()),
+                        append_op_id(repo_path, &server_id, turn_id),
                     )
                     .await
                     .with_context(|| format!("append hosted turn for {local_id}"))?;
-                let ordinal = hosted.turns.len().saturating_sub(1);
-                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                push_link(
+                    mirror,
+                    repo_path,
+                    index,
+                    turn_id.clone(),
+                    hosted.turns.len().saturating_sub(1),
+                );
             }
             Ok(true)
         }
         Some(index) => {
             let server_id = mirror.repos[repo_path].discussions[index].server_id.clone();
-            for (op_id, body) in &candidates {
+            for (turn_id, body) in &candidates {
                 let hosted = client
                     .append_turn(
                         repo_path,
                         &server_id,
                         body,
-                        append_op_id(repo_path, &server_id, &op_id.to_string_full()),
+                        append_op_id(repo_path, &server_id, turn_id),
                     )
                     .await
                     .with_context(|| format!("append hosted turn for {local_id}"))?;
-                let ordinal = hosted.turns.len().saturating_sub(1);
-                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                push_link(
+                    mirror,
+                    repo_path,
+                    index,
+                    turn_id.clone(),
+                    hosted.turns.len().saturating_sub(1),
+                );
             }
             Ok(true)
         }
@@ -331,8 +415,8 @@ async fn push_one(
 }
 
 /// Fetch hosted discussions for the repository head and materialize any turns we
-/// do not already hold into the local op-log. Saves the mirror after each
-/// discussion and continues past a per-discussion failure.
+/// do not already hold. Saves the mirror after each discussion and continues
+/// past a per-discussion failure.
 pub async fn pull_discussions(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -349,7 +433,6 @@ pub async fn pull_discussions(
 
     let Some(head_state) = repo.head().context("resolve repository head")? else {
         // weft#638: a repo with no HEAD cannot resolve a state to list against.
-        // Degrade gracefully — nothing to materialize.
         return Ok(0);
     };
     let Some(state) = repo
@@ -368,13 +451,25 @@ pub async fn pull_discussions(
     if hosted.is_empty() {
         return Ok(0);
     }
+    // Our own hosted principal name, so reconciliation can recognize the turns
+    // we pushed (weft stamps `Principal::new(username, "")`).
+    let hosted_username = client.authenticated_username();
 
     let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
+    let self_attr = repo.get_attribution().ok();
     let mut mirror = load_mirror(repo.heddle_dir())?;
     let mut changed = 0usize;
 
     for discussion in hosted {
-        let result = pull_one(&store, repo_path, &mut mirror, head_state, &discussion);
+        let result = pull_one(
+            &store,
+            repo_path,
+            &mut mirror,
+            head_state,
+            hosted_username.as_deref(),
+            self_attr.as_ref(),
+            &discussion,
+        );
         save_mirror(repo.heddle_dir(), &mirror)?;
         match result {
             Ok(true) => changed += 1,
@@ -392,11 +487,14 @@ pub async fn pull_discussions(
     Ok(changed)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn pull_one(
     store: &CollaborationStore,
     repo_path: &str,
     mirror: &mut HostedMirror,
     head_state: StateId,
+    hosted_username: Option<&str>,
+    self_attr: Option<&Attribution>,
     discussion: &HostedDiscussion,
 ) -> Result<bool> {
     if discussion.turns.is_empty() {
@@ -440,7 +538,7 @@ fn pull_one(
                 local_id: local_id.to_string(),
                 server_id: discussion.id.clone(),
                 links: vec![TurnLink {
-                    local_op_id: open_op.to_string_full(),
+                    local_turn_id: turn_identity(&open_op, 0),
                     server_ordinal: 0,
                 }],
             });
@@ -457,7 +555,7 @@ fn pull_one(
                     CollaborationOperationBodyV1::AppendTurn { turn: turn_body(turn)? },
                 )?;
                 heads = vec![op_id];
-                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                push_link(mirror, repo_path, index, turn_identity(&op_id, 0), ordinal);
             }
             Ok(true)
         }
@@ -471,10 +569,10 @@ fn pull_one(
                 .iter()
                 .map(|link| link.server_ordinal)
                 .collect();
-            let linked_local: HashSet<String> = repo_mirror.discussions[index]
+            let linked_turn_ids: HashSet<String> = repo_mirror.discussions[index]
                 .links
                 .iter()
-                .map(|link| link.local_op_id.clone())
+                .map(|link| link.local_turn_id.clone())
                 .collect();
 
             let existing = store
@@ -482,26 +580,21 @@ fn pull_one(
                 .context("materialize mirrored discussion")?
                 .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
             let mut heads: Vec<CollabOpId> = existing.heads.iter().copied().collect();
-            // Unlinked local turns available to reconcile against server turns by
-            // body (mirror-loss / re-sync guard — see the module note on why body
-            // is the identity here).
-            let mut available: Vec<(CollabOpId, String)> = existing
-                .turns
-                .iter()
-                .filter(|(op, _)| !linked_local.contains(&op.to_string_full()))
-                .map(|(op, turn)| (*op, turn.body.clone()))
+            // Unlinked local turns available to reconcile against server turns —
+            // author-aware only (see the module note on why body alone is wrong).
+            let mut available: Vec<LocalTurn> = collect_local_turns(store, &existing, self_attr)?
+                .into_iter()
+                .filter(|turn| !linked_turn_ids.contains(&turn.turn_id))
                 .collect();
 
             let mut changed = false;
-            for (ordinal, turn) in discussion.turns.iter().enumerate() {
+            for (ordinal, server_turn) in discussion.turns.iter().enumerate() {
                 if linked_ordinals.contains(&ordinal) {
                     continue;
                 }
-                if let Some(pos) = available.iter().position(|(_, body)| body == &turn.body) {
-                    // Already present locally (we authored+pushed it, or a prior
-                    // partial sync) — link, don't duplicate.
-                    let (op_id, _) = available.swap_remove(pos);
-                    push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                if let Some(pos) = reconcile(&available, server_turn, hosted_username) {
+                    let local = available.swap_remove(pos);
+                    push_link(mirror, repo_path, index, local.turn_id, ordinal);
                     changed = true;
                     continue;
                 }
@@ -509,12 +602,12 @@ fn pull_one(
                     store,
                     local_id,
                     heads.clone(),
-                    turn_attribution(turn),
-                    turn_ms(turn),
-                    CollaborationOperationBodyV1::AppendTurn { turn: turn_body(turn)? },
+                    turn_attribution(server_turn),
+                    turn_ms(server_turn),
+                    CollaborationOperationBodyV1::AppendTurn { turn: turn_body(server_turn)? },
                 )?;
                 heads = vec![op_id];
-                push_link(mirror, repo_path, index, op_id.to_string_full(), ordinal);
+                push_link(mirror, repo_path, index, turn_identity(&op_id, 0), ordinal);
                 changed = true;
             }
             Ok(changed)
@@ -522,11 +615,37 @@ fn pull_one(
     }
 }
 
+/// Match an unlinked server turn against an unlinked local turn by AUTHOR, never
+/// body alone. Returns the index into `available` when one of the two identity
+/// rules holds.
+fn reconcile(
+    available: &[LocalTurn],
+    server_turn: &HostedDiscussionTurn,
+    hosted_username: Option<&str>,
+) -> Option<usize> {
+    let server_ms = server_turn.posted_at_secs.saturating_mul(1000);
+    available.iter().position(|local| {
+        if local.body != server_turn.body {
+            return false;
+        }
+        // (i) A turn we pushed: locally self-authored AND the server stamped it
+        // with our own hosted username.
+        let pushed_by_us = local.is_self
+            && hosted_username.is_some_and(|username| username == server_turn.author_name);
+        // (ii) A turn we previously pulled: the local op copied the server
+        // author + timestamp verbatim.
+        let pulled_before = local.author_name == server_turn.author_name
+            && local.author_email == server_turn.author_email
+            && local.occurred_at_ms == server_ms;
+        pushed_by_us || pulled_before
+    })
+}
+
 fn push_link(
     mirror: &mut HostedMirror,
     repo_path: &str,
     index: usize,
-    local_op_id: String,
+    local_turn_id: String,
     server_ordinal: usize,
 ) {
     if let Some(entry) = mirror
@@ -535,31 +654,14 @@ fn push_link(
         .and_then(|repo_mirror| repo_mirror.discussions.get_mut(index))
     {
         entry.links.push(TurnLink {
-            local_op_id,
+            local_turn_id,
             server_ordinal,
         });
     }
 }
 
-/// Whether the op at `op_id` was authored by the local principal. On any
-/// uncertainty (no local principal, unreadable op) we do not filter — the link
-/// check remains the primary "already on the server" guard.
-fn author_is_self(
-    store: &CollaborationStore,
-    op_id: &CollabOpId,
-    self_attr: Option<&Attribution>,
-) -> bool {
-    let Some(self_attr) = self_attr else {
-        return true;
-    };
-    match store.read_operation(op_id) {
-        Ok(Some(decoded)) => principals_match(&decoded.operation.author, self_attr),
-        _ => true,
-    }
-}
-
-fn principals_match(a: &Attribution, b: &Attribution) -> bool {
-    a.principal.name == b.principal.name && a.principal.email == b.principal.email
+fn principals_match(a: &Principal, b: &Principal) -> bool {
+    a.name == b.name && a.email == b.email
 }
 
 fn write_local_operation(
@@ -622,5 +724,169 @@ fn parse_visibility_token(token: &str) -> VisibilityTier {
             scope_label: String::new(),
         },
         _ => VisibilityTier::Internal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{
+        CollaborationAnchor, CollaborationIdempotencyKey, CollaborationOperationBodyV1,
+        CollaborationOperationEnvelope, DiscussionRecordId, DiscussionTurnV1, LegacyDiscussionId,
+        LegacyDiscussionResolutionV1, LegacySourceLocator, Principal, StateAttachmentId, StateId,
+        VisibilityTier,
+    };
+    use objects::object::{Attribution, ContentHash};
+
+    use super::*;
+
+    fn local(body: &str, author_name: &str, author_email: &str, is_self: bool, ms: i64) -> LocalTurn {
+        LocalTurn {
+            turn_id: format!("co-{author_name}#0"),
+            body: body.to_string(),
+            author_name: author_name.to_string(),
+            author_email: author_email.to_string(),
+            occurred_at_ms: ms,
+            is_self,
+        }
+    }
+
+    fn server(body: &str, author_name: &str, author_email: &str, posted_at_secs: i64) -> HostedDiscussionTurn {
+        HostedDiscussionTurn {
+            author_name: author_name.to_string(),
+            author_email: author_email.to_string(),
+            body: body.to_string(),
+            posted_at_secs,
+        }
+    }
+
+    // F1: identical bodies from DIFFERENT authors must NOT reconcile — the
+    // server turn materializes as its own distinct turn; the local turn is left
+    // unlinked (so push will still publish it). Body equality alone never links.
+    #[test]
+    fn reconcile_rejects_identical_body_across_authors() {
+        // A's own unpushed "lgtm" (local principal "alice", not yet on server).
+        let available = vec![local("lgtm", "alice", "alice@x", true, 111)];
+        // B pushed "lgtm" (server stamped it "bob"); our hosted username is "alice".
+        let st = server("lgtm", "bob", "", 5);
+        assert_eq!(
+            reconcile(&available, &st, Some("alice")),
+            None,
+            "a self turn must not link to a DIFFERENT author's identical body (rule i needs our username to be the server author)"
+        );
+    }
+
+    // F1 rule (i): a turn WE pushed (self-authored locally, stamped with our
+    // hosted username on the server) reconciles.
+    #[test]
+    fn reconcile_links_turn_we_pushed() {
+        let available = vec![local("ship it", "alice-local", "alice@x", true, 111)];
+        let st = server("ship it", "alice", "", 9); // server stamped our hosted username
+        assert_eq!(reconcile(&available, &st, Some("alice")), Some(0));
+    }
+
+    // F1 rule (ii): a turn we previously PULLED (local op copied the server
+    // author + posted_at verbatim) reconciles.
+    #[test]
+    fn reconcile_links_turn_we_pulled() {
+        let available = vec![local("+1", "bob", "bob@x", false, 7000)]; // occurred = 7 * 1000
+        let st = server("+1", "bob", "bob@x", 7);
+        assert_eq!(reconcile(&available, &st, Some("alice")), Some(0));
+        // Same body, wrong author → no match.
+        let st_other = server("+1", "carol", "carol@x", 7);
+        assert_eq!(reconcile(&available, &st_other, Some("alice")), None);
+    }
+
+    // F2: a LegacyImported op carries N turns under ONE CollabOpId. They must
+    // yield N DISTINCT turn ids and thus N DISTINCT append idempotency keys —
+    // otherwise weft dedup conflicts on turn 3 and turns 3..N are dropped.
+    #[test]
+    fn legacy_imported_multi_turn_op_has_distinct_identities_and_keys() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let store = CollaborationStore::open(temp.path()).unwrap();
+        let discussion_id: DiscussionRecordId =
+            "disc-018f47ea-4a54-7c89-b012-3456789abcde".parse().unwrap();
+        let author = Attribution::human(Principal::new("Importer", "importer@x"));
+        let anchor = CollaborationAnchor::Symbol {
+            state_id: StateId::from_bytes([1; 32]),
+            path: "src/lib.rs".to_string(),
+            symbol: "run".to_string(),
+        };
+        let op = CollaborationOperationEnvelope::new(
+            discussion_id,
+            Vec::new(),
+            CollaborationIdempotencyKey::new("legacy-1").unwrap(),
+            author.clone(),
+            1_000,
+            CollaborationOperationBodyV1::LegacyImported {
+                source: LegacySourceLocator::new(
+                    StateId::from_bytes([1; 32]),
+                    StateAttachmentId::from_hash(ContentHash::from_bytes([4; 32])),
+                    ContentHash::from_bytes([5; 32]),
+                ),
+                legacy_discussion_id: LegacyDiscussionId::new("legacy-1".to_string()).unwrap(),
+                aliases: Vec::new(),
+                title: "run".to_string(),
+                anchor,
+                visibility: VisibilityTier::Internal,
+                turns: vec![
+                    DiscussionTurnV1::new("turn one").unwrap(),
+                    DiscussionTurnV1::new("turn two").unwrap(),
+                    DiscussionTurnV1::new("turn three").unwrap(),
+                ],
+                resolution: LegacyDiscussionResolutionV1::Open,
+            },
+        )
+        .unwrap();
+        store.write_operation(&op).unwrap();
+
+        let materialized = store.materialize_discussion(&discussion_id).unwrap().unwrap();
+        assert_eq!(materialized.turns.len(), 3);
+        let self_attr = Attribution::human(Principal::new("Importer", "importer@x"));
+        let turns = collect_local_turns(&store, &materialized, Some(&self_attr)).unwrap();
+
+        // All three turns share ONE CollabOpId but MUST have distinct ids…
+        let ids: HashSet<&String> = turns.iter().map(|t| &t.turn_id).collect();
+        assert_eq!(ids.len(), 3, "multi-turn op must yield distinct turn ids");
+        // …and distinct append idempotency keys.
+        let keys: HashSet<String> = turns
+            .iter()
+            .map(|t| append_op_id("ns/repo", "server-1", &t.turn_id))
+            .collect();
+        assert_eq!(keys.len(), 3, "each turn must get a distinct idempotency key");
+        // All authored by the importer (self) → all are push candidates.
+        assert!(turns.iter().all(|t| t.is_self));
+    }
+
+    // F3: no local principal ⇒ turns are NOT treated as ours (fail closed).
+    #[test]
+    fn collect_local_turns_fails_closed_without_self_principal() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let store = CollaborationStore::open(temp.path()).unwrap();
+        let discussion_id = DiscussionRecordId::generate();
+        let op = CollaborationOperationEnvelope::new(
+            discussion_id,
+            Vec::new(),
+            CollaborationIdempotencyKey::new("k").unwrap(),
+            Attribution::human(Principal::new("Ada", "ada@x")),
+            1,
+            CollaborationOperationBodyV1::Open {
+                title: "t".to_string(),
+                anchor: CollaborationAnchor::Symbol {
+                    state_id: StateId::from_bytes([2; 32]),
+                    path: "a.rs".to_string(),
+                    symbol: "a".to_string(),
+                },
+                visibility: VisibilityTier::Internal,
+                turn: DiscussionTurnV1::new("hi").unwrap(),
+            },
+        )
+        .unwrap();
+        store.write_operation(&op).unwrap();
+        let materialized = store.materialize_discussion(&discussion_id).unwrap().unwrap();
+        let turns = collect_local_turns(&store, &materialized, None).unwrap();
+        assert!(
+            turns.iter().all(|t| !t.is_self),
+            "with no local principal, no turn may be classified as ours"
+        );
     }
 }

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -1,0 +1,426 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hosted discussion sync bridge.
+//!
+//! Local discussions live in the append-only [`CollaborationStore`] op-log
+//! (`.heddle/collaboration/ops`). The hosted weft `CollaborationService` speaks
+//! a different, per-state `DiscussionsBlob` model (id-keyed discussions with a
+//! linear turn list). This module bridges the two:
+//!
+//! * **Push (write path):** after a successful `heddle push`, replay every
+//!   symbol-anchored local discussion to the server via the caller-authenticated
+//!   `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode signed — the CLI's
+//!   existing signed hosted client). New turns authored offline ride the next
+//!   push; #549 rejects attachments in the pack, so they cannot ride the pack.
+//! * **Pull/clone (read path):** after a successful clone/pull, `ListByState`
+//!   the head state's discussions and materialize any new ones (and any new
+//!   turns) into the local op-log so `discuss list` / `discuss show` see them.
+//!
+//! A per-repo mirror map (`.heddle/collaboration/hosted-mirror.json`) records
+//! the local↔server discussion id pairing and how many turns are known-synced,
+//! so re-push / re-pull only ship the delta and stay idempotent.
+//!
+//! Scope: discussions only. `context` (annotations) and `review` anchor to the
+//! same state-attachment seam and can follow this exact pattern (a hosted
+//! ContextService / StateReviewService sync using the same mirror-map + delta
+//! design) — deliberately not built here.
+//!
+//! Known limitations (linear-model bridge):
+//! * Only `Symbol`-anchored discussions map to the hosted `PathSymbolRef`
+//!   model; repository/state/change/path-anchored discussions are skipped.
+//! * The op-log is a DAG; the hosted blob is a linear turn list. Turn sync is
+//!   ordinal (common-prefix by count), which is correct for the non-branching
+//!   authoring path but does not reconcile concurrent op-log branches.
+//! * `resolve` / `reopen` are not yet mirrored (turns only).
+
+#![cfg(feature = "client")]
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, anyhow};
+use objects::{
+    fs_atomic::write_file_atomic,
+    object::{
+        Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
+        DiscussionTurnV1, Principal, VisibilityTier,
+    },
+};
+use objects::store::ObjectStore;
+use repo::{CollaborationStore, Repository};
+use serde::{Deserialize, Serialize};
+
+use crate::client::HostedGrpcClient;
+use heddle_client::grpc_hosted::HostedDiscussionTurn;
+
+/// Deterministic namespace for the derived client-operation-ids so a retried
+/// push replays (server-side idempotent) rather than duplicating a discussion.
+const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_6469_7363_7573_7379_6e63);
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct HostedMirror {
+    /// Server repo path → mirror state for that hosted repo.
+    #[serde(default)]
+    repos: BTreeMap<String, RepoMirror>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct RepoMirror {
+    #[serde(default)]
+    discussions: Vec<MirrorEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MirrorEntry {
+    /// Local `DiscussionRecordId` (string form).
+    local_id: String,
+    /// Server-assigned discussion id.
+    server_id: String,
+    /// Number of turns known to be present on BOTH sides (common prefix length).
+    synced_turns: usize,
+}
+
+fn mirror_path(heddle_dir: &Path) -> PathBuf {
+    heddle_dir.join("collaboration").join("hosted-mirror.json")
+}
+
+fn load_mirror(heddle_dir: &Path) -> Result<HostedMirror> {
+    match fs::read(mirror_path(heddle_dir)) {
+        Ok(bytes) => serde_json::from_slice(&bytes).context("decode hosted discussion mirror map"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(HostedMirror::default()),
+        Err(error) => Err(error).context("read hosted discussion mirror map"),
+    }
+}
+
+fn save_mirror(heddle_dir: &Path, mirror: &HostedMirror) -> Result<()> {
+    let path = mirror_path(heddle_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create collaboration dir")?;
+    }
+    let bytes = serde_json::to_vec_pretty(mirror).context("encode hosted discussion mirror map")?;
+    write_file_atomic(&path, &bytes).context("write hosted discussion mirror map")?;
+    Ok(())
+}
+
+fn op_operation_id(key: &str) -> String {
+    uuid::Uuid::new_v5(&OP_NAMESPACE, key.as_bytes()).to_string()
+}
+
+fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Publish local symbol-anchored discussions (and any new turns) to the hosted
+/// `CollaborationService`. Returns the number of discussions created or extended.
+///
+/// Best-effort: a per-discussion RPC failure aborts with context, but the
+/// mirror map is only advanced for discussions that fully synced, so a re-push
+/// resumes cleanly.
+pub async fn push_discussions(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<usize> {
+    let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
+    let materialized = store.materialize().context("materialize local discussions")?;
+    if materialized.discussions.is_empty() {
+        return Ok(0);
+    }
+
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let mut synced = 0usize;
+
+    for (discussion_id, discussion) in &materialized.discussions {
+        let CollaborationAnchor::Symbol {
+            state_id,
+            path,
+            symbol,
+        } = &discussion.anchor
+        else {
+            // Only symbol-anchored discussions map to the hosted PathSymbolRef.
+            continue;
+        };
+        let Some(state) = repo
+            .store()
+            .get_state(state_id)
+            .context("load discussion anchor state")?
+        else {
+            continue;
+        };
+        let change_id = state.change_id;
+        let visibility = discussion.visibility.as_str().to_string();
+        let bodies: Vec<String> = discussion.turns.iter().map(|(_, t)| t.body.clone()).collect();
+        if bodies.is_empty() {
+            continue;
+        }
+        let local_id = discussion_id.to_string();
+
+        let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+        let existing = repo_mirror
+            .discussions
+            .iter()
+            .position(|entry| entry.local_id == local_id);
+
+        match existing {
+            None => {
+                let hosted = client
+                    .open_discussion(
+                        repo_path,
+                        change_id,
+                        path,
+                        symbol,
+                        &bodies[0],
+                        &visibility,
+                        op_operation_id(&format!("open:{repo_path}:{local_id}")),
+                    )
+                    .await
+                    .with_context(|| format!("open hosted discussion for {local_id}"))?;
+                let server_id = hosted.id.clone();
+                for (index, body) in bodies.iter().enumerate().skip(1) {
+                    client
+                        .append_turn(
+                            repo_path,
+                            &server_id,
+                            body,
+                            op_operation_id(&format!("append:{repo_path}:{local_id}:{index}")),
+                        )
+                        .await
+                        .with_context(|| format!("append hosted turn {index} for {local_id}"))?;
+                }
+                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                repo_mirror.discussions.push(MirrorEntry {
+                    local_id,
+                    server_id,
+                    synced_turns: bodies.len(),
+                });
+                synced += 1;
+            }
+            Some(index) => {
+                let already = repo_mirror.discussions[index].synced_turns;
+                if bodies.len() <= already {
+                    continue;
+                }
+                let server_id = repo_mirror.discussions[index].server_id.clone();
+                for (turn_index, body) in bodies.iter().enumerate().skip(already) {
+                    client
+                        .append_turn(
+                            repo_path,
+                            &server_id,
+                            body,
+                            op_operation_id(&format!("append:{repo_path}:{local_id}:{turn_index}")),
+                        )
+                        .await
+                        .with_context(|| format!("append hosted turn {turn_index} for {local_id}"))?;
+                }
+                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                repo_mirror.discussions[index].synced_turns = bodies.len();
+                synced += 1;
+            }
+        }
+    }
+
+    save_mirror(repo.heddle_dir(), &mirror)?;
+    Ok(synced)
+}
+
+/// Fetch hosted discussions for the repository head and materialize any new
+/// ones (and any new turns) into the local op-log. Returns the number of
+/// discussions created or extended locally.
+pub async fn pull_discussions(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<usize> {
+    let Some(head_state) = repo.head().context("resolve repository head")? else {
+        return Ok(0);
+    };
+    let Some(state) = repo
+        .store()
+        .get_state(&head_state)
+        .context("load head state")?
+    else {
+        return Ok(0);
+    };
+    let change_id = state.change_id;
+
+    let hosted = client
+        .list_discussions_by_state(repo_path, change_id, "all")
+        .await
+        .context("list hosted discussions")?;
+    if hosted.is_empty() {
+        return Ok(0);
+    }
+
+    let store = CollaborationStore::open(repo.heddle_dir()).context("open collaboration store")?;
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let mut changed = 0usize;
+
+    for discussion in hosted {
+        if discussion.turns.is_empty() {
+            continue;
+        }
+        let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+        let existing = repo_mirror
+            .discussions
+            .iter()
+            .position(|entry| entry.server_id == discussion.id);
+
+        match existing {
+            None => {
+                let local_id = DiscussionRecordId::generate();
+                let anchor = CollaborationAnchor::Symbol {
+                    state_id: discussion.opened_against_state.unwrap_or(head_state),
+                    path: discussion.file.clone(),
+                    symbol: discussion.symbol.clone(),
+                };
+                let title = derive_title(&discussion.turns[0].body, &discussion.symbol);
+                let visibility = parse_visibility_token(&discussion.visibility);
+
+                let first = &discussion.turns[0];
+                let mut head = write_local_operation(
+                    &store,
+                    local_id,
+                    Vec::new(),
+                    turn_attribution(first),
+                    turn_ms(first),
+                    CollaborationOperationBodyV1::Open {
+                        title,
+                        anchor,
+                        visibility,
+                        turn: DiscussionTurnV1::new(first.body.clone())
+                            .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
+                    },
+                )?;
+                for turn in &discussion.turns[1..] {
+                    head = write_local_operation(
+                        &store,
+                        local_id,
+                        vec![head],
+                        turn_attribution(turn),
+                        turn_ms(turn),
+                        CollaborationOperationBodyV1::AppendTurn {
+                            turn: DiscussionTurnV1::new(turn.body.clone())
+                                .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
+                        },
+                    )?;
+                }
+
+                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                repo_mirror.discussions.push(MirrorEntry {
+                    local_id: local_id.to_string(),
+                    server_id: discussion.id.clone(),
+                    synced_turns: discussion.turns.len(),
+                });
+                changed += 1;
+            }
+            Some(index) => {
+                let already = repo_mirror.discussions[index].synced_turns;
+                if discussion.turns.len() <= already {
+                    continue;
+                }
+                let local_id: DiscussionRecordId = repo_mirror.discussions[index]
+                    .local_id
+                    .parse()
+                    .map_err(|e| anyhow!("mirror map has an invalid local discussion id: {e}"))?;
+                let existing_discussion = store
+                    .materialize_discussion(&local_id)
+                    .context("materialize mirrored discussion")?
+                    .ok_or_else(|| anyhow!("mirrored discussion {local_id} missing locally"))?;
+                let mut heads: Vec<CollabOpId> =
+                    existing_discussion.heads.iter().copied().collect();
+                for turn in &discussion.turns[already..] {
+                    let id = write_local_operation(
+                        &store,
+                        local_id,
+                        heads.clone(),
+                        turn_attribution(turn),
+                        turn_ms(turn),
+                        CollaborationOperationBodyV1::AppendTurn {
+                            turn: DiscussionTurnV1::new(turn.body.clone())
+                                .map_err(|e| anyhow!("invalid discussion turn: {e}"))?,
+                        },
+                    )?;
+                    heads = vec![id];
+                }
+                let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                repo_mirror.discussions[index].synced_turns = discussion.turns.len();
+                changed += 1;
+            }
+        }
+    }
+
+    save_mirror(repo.heddle_dir(), &mirror)?;
+    Ok(changed)
+}
+
+fn write_local_operation(
+    store: &CollaborationStore,
+    discussion_id: DiscussionRecordId,
+    parents: Vec<CollabOpId>,
+    author: Attribution,
+    occurred_at_ms: i64,
+    body: CollaborationOperationBodyV1,
+) -> Result<CollabOpId> {
+    let key = CollaborationIdempotencyKey::new(uuid::Uuid::new_v4().to_string())
+        .map_err(|e| anyhow!("invalid idempotency key: {e}"))?;
+    let operation = CollaborationOperationEnvelope::new(
+        discussion_id,
+        parents,
+        key,
+        author,
+        occurred_at_ms,
+        body,
+    )
+    .map_err(|e| anyhow!("build collaboration operation: {e}"))?;
+    Ok(store
+        .write_operation(&operation)
+        .context("write collaboration operation")?
+        .operation_id)
+}
+
+fn turn_attribution(turn: &HostedDiscussionTurn) -> Attribution {
+    Attribution::human(Principal::new(
+        turn.author_name.clone(),
+        turn.author_email.clone(),
+    ))
+}
+
+fn turn_ms(turn: &HostedDiscussionTurn) -> i64 {
+    if turn.posted_at_secs > 0 {
+        turn.posted_at_secs.saturating_mul(1000)
+    } else {
+        now_ms()
+    }
+}
+
+fn derive_title(body: &str, symbol: &str) -> String {
+    body.lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or(symbol)
+        .to_string()
+}
+
+fn parse_visibility_token(token: &str) -> VisibilityTier {
+    match token {
+        "public" => VisibilityTier::Public,
+        "internal" => VisibilityTier::Internal,
+        "team_scoped" => VisibilityTier::TeamScoped {
+            team_id: String::new(),
+        },
+        "restricted" => VisibilityTier::Restricted {
+            scope_label: String::new(),
+        },
+        "private" => VisibilityTier::Private {
+            scope_label: String::new(),
+        },
+        _ => VisibilityTier::Internal,
+    }
+}

--- a/crates/cli/src/client/mod.rs
+++ b/crates/cli/src/client/mod.rs
@@ -4,6 +4,8 @@
 //! Connects to Heddle servers for push, pull, and other operations.
 
 #[cfg(feature = "client")]
+pub mod discussion_sync;
+#[cfg(feature = "client")]
 pub mod human_signature;
 pub mod local_daemon;
 pub mod local_sync;

--- a/crates/client/src/grpc_hosted/collaboration.rs
+++ b/crates/client/src/grpc_hosted/collaboration.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hosted `CollaborationService` client wrappers.
+//!
+//! These are the caller-authenticated, PoP-signed RPCs the CLI uses to publish
+//! and fetch discussions against a hosted weft. They are the write/read seam
+//! for hosted collaboration: local discussions live in the append-only
+//! [`repo::CollaborationStore`] op-log, and the CLI-side sync orchestrator
+//! ([`heddle_cli`'s `discussion_sync`]) bridges that model to the server's
+//! per-state `DiscussionsBlob` shape through these calls.
+//!
+//! Wire identity note: the canonical `CollaborationService` proto types the
+//! discussion anchor state as a 32-byte `StateId`, but the hosted server still
+//! resolves the inbound `state_id` field through a 16-byte `ChangeId` decode
+//! (`OpenDiscussion`/`ListByState`). We therefore send the **ChangeId** bytes in
+//! that field (matching weft's own canonical integration tests), while the
+//! server echoes the genuine 32-byte `StateId` back in
+//! `Discussion.opened_against_state`.
+
+use grpc::heddle::api::v1alpha1::{
+    AppendTurnRequest, Discussion as ProtoDiscussion, ListDiscussionsByStateRequest,
+    OpenDiscussionRequest, PathSymbolRef, StateId as ProtoStateId,
+};
+use objects::object::{ChangeId, StateId};
+use tonic::Request;
+use wire::ProtocolError;
+
+use super::{HostedGrpcClient, helpers::status_to_protocol_error};
+
+/// One turn of a hosted discussion, decoded from the wire.
+#[derive(Debug, Clone)]
+pub struct HostedDiscussionTurn {
+    pub author_name: String,
+    pub author_email: String,
+    pub body: String,
+    pub posted_at_secs: i64,
+}
+
+/// A hosted discussion decoded from the `CollaborationService` wire types into
+/// the shape the CLI-side sync bridge consumes.
+#[derive(Debug, Clone)]
+pub struct HostedDiscussion {
+    /// Server-assigned discussion id (opaque string).
+    pub id: String,
+    pub file: String,
+    pub symbol: String,
+    /// Genuine 32-byte anchor `StateId` echoed by the server, when present.
+    pub opened_against_state: Option<StateId>,
+    pub visibility: String,
+    pub turns: Vec<HostedDiscussionTurn>,
+}
+
+const OPEN_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/OpenDiscussion";
+const APPEND_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/AppendTurn";
+const LIST_BY_STATE_METHOD: &str = "/heddle.api.v1alpha1.CollaborationService/ListByState";
+
+fn decode_discussion(proto: ProtoDiscussion) -> HostedDiscussion {
+    let anchor = proto.anchor.unwrap_or_default();
+    HostedDiscussion {
+        id: proto.id,
+        file: anchor.file,
+        symbol: anchor.symbol,
+        opened_against_state: proto
+            .opened_against_state
+            .and_then(|state| StateId::try_from_slice(&state.value).ok()),
+        visibility: proto.visibility,
+        turns: proto
+            .turns
+            .into_iter()
+            .map(|turn| HostedDiscussionTurn {
+                author_name: turn.author_name,
+                author_email: turn.author_email,
+                body: turn.body,
+                posted_at_secs: turn.posted_at.map(|ts| ts.seconds).unwrap_or(0),
+            })
+            .collect(),
+    }
+}
+
+/// The hosted server decodes the discussion anchor `state_id` field as a
+/// 16-byte `ChangeId` (see the module note); wrap the change id in the proto
+/// `StateId` message accordingly.
+fn change_id_state_field(change_id: ChangeId) -> Option<ProtoStateId> {
+    Some(ProtoStateId {
+        value: change_id.as_bytes().to_vec(),
+    })
+}
+
+impl HostedGrpcClient {
+    /// Open a hosted discussion anchored at `change_id`'s state, seeded with
+    /// `body` as the first turn. Caller-authenticated + PoP-signed.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn open_discussion(
+        &mut self,
+        repo_path: &str,
+        change_id: ChangeId,
+        file: &str,
+        symbol: &str,
+        body: &str,
+        visibility: &str,
+        client_operation_id: String,
+    ) -> Result<HostedDiscussion, ProtocolError> {
+        let mut request = Request::new(OpenDiscussionRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            state_id: change_id_state_field(change_id),
+            anchor: Some(PathSymbolRef {
+                file: file.to_string(),
+                symbol: symbol.to_string(),
+            }),
+            body: body.to_string(),
+            visibility: visibility.to_string(),
+            thread_ref: String::new(),
+            client_operation_id,
+        });
+        self.apply_signed_auth(&mut request, OPEN_METHOD)?;
+        let response = self
+            .collaboration
+            .open_discussion(request)
+            .await
+            .map_err(status_to_protocol_error)?
+            .into_inner();
+        Ok(decode_discussion(response))
+    }
+
+    /// Append `body` as a new turn on an existing hosted discussion.
+    /// Caller-authenticated + PoP-signed.
+    pub async fn append_turn(
+        &mut self,
+        repo_path: &str,
+        discussion_id: &str,
+        body: &str,
+        client_operation_id: String,
+    ) -> Result<HostedDiscussion, ProtocolError> {
+        let mut request = Request::new(AppendTurnRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            discussion_id: discussion_id.to_string(),
+            body: body.to_string(),
+            client_operation_id,
+        });
+        self.apply_signed_auth(&mut request, APPEND_METHOD)?;
+        let response = self
+            .collaboration
+            .append_turn(request)
+            .await
+            .map_err(status_to_protocol_error)?
+            .into_inner();
+        Ok(decode_discussion(response))
+    }
+
+    /// List hosted discussions anchored at `change_id`'s state. `status` is one
+    /// of `open` | `resolved` | `all` | `orphaned`.
+    pub async fn list_discussions_by_state(
+        &mut self,
+        repo_path: &str,
+        change_id: ChangeId,
+        status: &str,
+    ) -> Result<Vec<HostedDiscussion>, ProtocolError> {
+        let mut request = Request::new(ListDiscussionsByStateRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            state_id: change_id_state_field(change_id),
+            status: status.to_string(),
+        });
+        self.apply_signed_auth(&mut request, LIST_BY_STATE_METHOD)?;
+        let response = self
+            .collaboration
+            .list_by_state(request)
+            .await
+            .map_err(status_to_protocol_error)?
+            .into_inner();
+        Ok(response.discussions.into_iter().map(decode_discussion).collect())
+    }
+}

--- a/crates/client/src/grpc_hosted/collaboration.rs
+++ b/crates/client/src/grpc_hosted/collaboration.rs
@@ -86,6 +86,19 @@ fn change_id_state_field(change_id: ChangeId) -> Option<ProtoStateId> {
 }
 
 impl HostedGrpcClient {
+    /// The authenticated hosted username (the bearer token's `principal:<subject>`
+    /// subject). weft stamps discussion turns with `Principal::new(username, "")`,
+    /// so this is the author name our own pushed turns carry server-side — the
+    /// identity the discussion-sync bridge uses to recognize turns we published.
+    /// `None` for an anonymous/unsigned client.
+    pub fn authenticated_username(&self) -> Option<String> {
+        self.authenticated_principal
+            .as_deref()
+            .and_then(|principal| principal.strip_prefix("principal:"))
+            .map(|subject| subject.trim().to_string())
+            .filter(|subject| !subject.is_empty())
+    }
+
     /// Open a hosted discussion anchored at `change_id`'s state, seeded with
     /// `body` as the first turn. Caller-authenticated + PoP-signed.
     #[allow(clippy::too_many_arguments)]

--- a/crates/client/src/grpc_hosted/hydration.rs
+++ b/crates/client/src/grpc_hosted/hydration.rs
@@ -523,6 +523,7 @@ mod tests {
 
     use cli_shared::ClientConfig;
     use grpc::heddle::api::v1alpha1::{
+        collaboration_service_client::CollaborationServiceClient,
         identity_service_client::IdentityServiceClient,
         registry_service_client::RegistryServiceClient,
         repo_sync_service_client::RepoSyncServiceClient,
@@ -552,7 +553,8 @@ mod tests {
             user: RegistryServiceClient::new(channel.clone()),
             auth: IdentityServiceClient::new(channel.clone()),
             content: RepositoryServiceClient::new(channel.clone()),
-            workflow: WorkflowServiceClient::new(channel),
+            workflow: WorkflowServiceClient::new(channel.clone()),
+            collaboration: CollaborationServiceClient::new(channel),
             token_header: None,
             transport,
             auth_proof_key_pem: None,

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -1,5 +1,6 @@
 //! Hosted gRPC client for the transport rewrite.
 
+mod collaboration;
 mod content;
 pub(crate) mod helpers;
 mod hydration;
@@ -13,8 +14,10 @@ mod user;
 use cli_shared::{ClientConfig, cleartext_connect_allowed, cleartext_refused_message};
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::api::v1alpha1::{
-    KeypairProof, MintBiscuitRequest, identity_service_client::IdentityServiceClient,
-    mint_biscuit_request::Proof, registry_service_client::RegistryServiceClient,
+    KeypairProof, MintBiscuitRequest,
+    collaboration_service_client::CollaborationServiceClient,
+    identity_service_client::IdentityServiceClient, mint_biscuit_request::Proof,
+    registry_service_client::RegistryServiceClient,
     repo_sync_service_client::RepoSyncServiceClient,
     repository_service_client::RepositoryServiceClient,
     workflow_service_client::WorkflowServiceClient,
@@ -96,6 +99,7 @@ pub struct HostedGrpcClient {
     pub(super) auth: IdentityServiceClient<Channel>,
     pub(super) content: RepositoryServiceClient<Channel>,
     pub(super) workflow: WorkflowServiceClient<Channel>,
+    pub(super) collaboration: CollaborationServiceClient<Channel>,
     pub(super) token_header: Option<MetadataValue<tonic::metadata::Ascii>>,
     transport: helpers::HostedTransportPolicy,
     pub(super) auth_proof_key_pem: Option<String>,
@@ -174,6 +178,7 @@ impl HostedGrpcClient {
             auth: IdentityServiceClient::new(channel.clone()),
             content: RepositoryServiceClient::new(channel.clone()),
             workflow: WorkflowServiceClient::new(channel.clone()),
+            collaboration: CollaborationServiceClient::new(channel.clone()),
             token_header,
             transport,
             auth_proof_key_pem: config.auth_proof_key_pem.clone(),
@@ -606,6 +611,7 @@ impl HostedGrpcClient {
     }
 }
 
+pub use collaboration::{HostedDiscussion, HostedDiscussionTurn};
 pub use hydration::{LazyHostedHydrator, PullMaterialization, register_hosted_factory};
 pub use monorepo::{MonorepoCloneOp, MonorepoClonePlan, SkippedChild};
 pub use session::{HostedAuthMode, HostedSession};
@@ -628,6 +634,7 @@ mod tests {
             auth: IdentityServiceClient::new(channel.clone()),
             content: RepositoryServiceClient::new(channel.clone()),
             workflow: WorkflowServiceClient::new(channel.clone()),
+            collaboration: CollaborationServiceClient::new(channel.clone()),
             token_header: Some(
                 MetadataValue::try_from(format!("Bearer {token}")).expect("valid bearer header"),
             ),

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -513,6 +513,7 @@ mod tests {
         use biscuit_auth::{Biscuit, KeyPair};
         use crypto::{Ed25519Signer, Signer};
         use grpc::heddle::api::v1alpha1::{
+            collaboration_service_client::CollaborationServiceClient,
             identity_service_client::IdentityServiceClient,
             registry_service_client::RegistryServiceClient,
             repo_sync_service_client::RepoSyncServiceClient,
@@ -656,7 +657,8 @@ mod tests {
                 user: RegistryServiceClient::new(channel.clone()),
                 auth: IdentityServiceClient::new(channel.clone()),
                 content: RepositoryServiceClient::new(channel.clone()),
-                workflow: WorkflowServiceClient::new(channel),
+                workflow: WorkflowServiceClient::new(channel.clone()),
+                collaboration: CollaborationServiceClient::new(channel),
                 token_header: Some(
                     MetadataValue::try_from(format!(
                         "Bearer {}",

--- a/crates/repo/src/collaboration_migration.rs
+++ b/crates/repo/src/collaboration_migration.rs
@@ -171,14 +171,41 @@ pub fn apply_legacy_discussion_migration(
     Ok(report)
 }
 
+fn legacy_discussion_migration_marker(repository: &Repository) -> std::path::PathBuf {
+    repository
+        .heddle_dir()
+        .join("collaboration/migrations/legacy-discussions-v1")
+}
+
+/// Claim the one-shot legacy-discussion migration marker without running the
+/// migration. Idempotent.
+///
+/// Hosted repositories carry their discussions as server-minted `Discussions`
+/// state-attachments that ride the normal pull. Those attachments are the
+/// *transport* form of the hosted `CollaborationService` discussions, which the
+/// hosted-sync bridge materializes into the op-log directly (RPC read path). If
+/// the one-shot legacy blob→op-log migration were also allowed to run over the
+/// same pulled attachments it would (a) duplicate every hosted discussion and
+/// (b) diverge on multi-turn discussions, whose `AppendTurn` supersede history
+/// leaves several differing blobs on one state. A fresh clone has no genuine
+/// *local* legacy discussions to migrate, so claiming the marker at hosted-sync
+/// time is safe and leaves the RPC-materialized op-log authoritative.
+pub fn mark_legacy_discussions_migrated(repository: &Repository) -> Result<()> {
+    let marker = legacy_discussion_migration_marker(repository);
+    if marker.exists() {
+        return Ok(());
+    }
+    fs::create_dir_all(marker.parent().expect("migration marker has parent"))?;
+    write_file_atomic(&marker, b"1\n")?;
+    Ok(())
+}
+
 pub fn migrate_legacy_discussions_once(
     repository: &Repository,
     store: &CollaborationStore,
     import_actor: Attribution,
 ) -> Result<Option<LegacyDiscussionMigrationReport>> {
-    let marker = repository
-        .heddle_dir()
-        .join("collaboration/migrations/legacy-discussions-v1");
+    let marker = legacy_discussion_migration_marker(repository);
     if marker.exists() {
         return Ok(None);
     }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -86,7 +86,8 @@ pub mod worktree_walk;
 pub use collaboration_migration::{
     LegacyDiscussionMigrationBlocker, LegacyDiscussionMigrationItem, LegacyDiscussionMigrationPlan,
     LegacyDiscussionMigrationReport, apply_legacy_discussion_migration,
-    migrate_legacy_discussions_once, plan_legacy_discussion_migration,
+    mark_legacy_discussions_migrated, migrate_legacy_discussions_once,
+    plan_legacy_discussion_migration,
 };
 pub use collaboration_store::{
     CollaborationIntegrityReport, CollaborationStore, CollaborationWriteDisposition,


### PR DESCRIPTION
## What
Wires the heddle CLI's `discuss` surface to the hosted weft **CollaborationService** so discussions authored on one clone are visible on another. Previously `heddle discuss` wrote local-only state-attachments that never reached the server (the #549 pack scan deliberately rejects client-sent attachments; no CLI verb published them). Push-time sync + clone/pull fetch.

- New `crates/client/src/grpc_hosted/collaboration.rs` (hosted CollaborationService client: OpenDiscussion/AppendTurn/…).
- New `crates/cli/src/client/discussion_sync.rs` (sync orchestration), wired into `push`, `clone`, `pull`, and `remote`.

## Verified end-to-end (fresh docker weft, merged main, enforce mode)
```
# author on clone proj:
heddle discuss open main.rs main 'Body needed?'; heddle discuss append <id> 'Print hello.'
heddle push weft  → [ok] synced 1 discussion(s) to dtester/proj

# fresh clone CL:
heddle clone …/dtester/proj CL
heddle discuss show <id>  → renders BOTH turns (Body needed? / Print hello.)

# bidirectional: append on CL → push → pull on proj:
heddle push origin  → [ok] synced 1 discussion(s)
heddle pull weft    → [ok] synced 1 discussion(s) from dtester/proj  (proj now shows CL's reply)
```

## Known minor issues (follow-up, non-blocking)
- A pulled turn can display **duplicated** (dedup on pull-merge).
- `repository has no HEAD` error syncing discussions on a repo pushed without a proper `main` HEAD (e.g. git-default `master`).
- Discussion local-ID differs across clones (content/anchor/turns round-trip correctly).

Implemented by a background agent; **round-trip verified by me**. Fable review requested (correctness + perf). Context/review sync are the same seam, follow-up. Do not self-merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786980283&installation_id=132405951&pr_number=1050&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1050&signature=48451fb992586cc228d4d9fc9b5351552ba13fcca421b0e9394e0c988f7e830e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->