### PR TITLE
fix(clone): ignore git-ref-name companions in default thread selection (weft#633)

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1966,6 +1966,15 @@ fn select_hosted_clone_thread<'a>(
 
     let mut threads = remote_threads
         .into_iter()
+        // weft#633: for git-overlay repos, hosted ListRefs advertises each
+        // branch tip under a companion entry keyed by the FULL Git ref name
+        // (`refs/heads/main`), marked is_thread=true so the wire stays compatible
+        // with the pinned published client. Those companions are never a valid
+        // heddle track target — the real thread is the short name — so drop any
+        // `refs/`-prefixed candidate before default selection. Without this a
+        // repo whose default branch is not `main` mis-selects the companion:
+        // e.g. `refs/heads/trunk` sorts lexicographically before `trunk`.
+        .filter(|thread| !thread.starts_with("refs/"))
         .map(str::to_string)
         .collect::<Vec<_>>();
     threads.sort();
@@ -2309,6 +2318,35 @@ mod tests {
                 .expect("thread selected");
 
         assert_eq!(selected, "feature");
+    }
+
+    // weft#633: the hosted ListRefs response for a git-overlay repo carries
+    // companion entries keyed by the full Git ref name (`refs/heads/trunk`)
+    // alongside the real short-name thread. Those must never be selected as the
+    // clone track target — `refs/heads/trunk` sorts before `trunk`, so without
+    // the filter default selection would pick the companion and clone would
+    // fail on a bogus track name.
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_thread_selection_ignores_git_ref_companions() {
+        let selected = select_hosted_clone_thread(
+            None,
+            ["refs/heads/trunk", "trunk", "refs/heads/main", "main"],
+            "owner/repo",
+        )
+        .expect("thread selected");
+        assert_eq!(selected, "main", "companion refs/heads/* entries are ignored");
+
+        let non_main = select_hosted_clone_thread(
+            None,
+            ["refs/heads/trunk", "trunk"],
+            "owner/repo",
+        )
+        .expect("thread selected");
+        assert_eq!(
+            non_main, "trunk",
+            "a non-main default resolves to the short thread, not its companion"
+        );
     }
 
     #[cfg(feature = "client")]


### PR DESCRIPTION
Follow-up to the weft#633 server fix (weft PR #639).

## Context
weft's `ListRefs` now advertises a git-overlay branch's Git tip under a **companion** `RefEntry` keyed by the full Git ref name (`refs/heads/main`), marked `is_thread=true` so the wire stays compatible with the pinned published client. The mirror-push client matches that companion by full ref name to negotiate a fast-forward ref **update** on the second push.

## Bug this fixes
`select_hosted_clone_thread` (clone default-thread selection) keeps `is_thread` entries — **including the companion** — sorts them, and picks the lexicographically-first, special-casing only literal `main`. For a git-overlay repo whose default branch is **not** `main`, `refs/heads/<branch>` sorts before `<branch>` (`refs/heads/trunk` < `trunk`), so default selection would pick the companion and clone would fail on a bogus track name.

## Fix
Drop any `refs/`-prefixed candidate before default selection — those are Git-ref-name companions, never a valid heddle track target (the real thread is the short name). `main` and requested-thread paths are unchanged.

New unit test `hosted_clone_thread_selection_ignores_git_ref_companions` covers a `main`-default and a `trunk`-default repo.

### Narrow residual (documented, not fixable here)
This fixes the **current** heddle main CLI. The **already-published** heddle-client 0.10.2 has the old selection logic, so a 0.10.2 CLI cloning a git-overlay repo whose default branch is not `main` (and cloning without an explicit `--thread`) can still mis-select the companion. That can't be fixed for a released client; users on 0.10.2 can pass `--thread <branch>` as a workaround, and this PR fixes it going forward.

## Test
`cargo test -p heddle-cli --features client --lib clone::tests::hosted_clone_thread` → 4 passed. `clone.rs` is clippy-clean (an unrelated pre-existing `too_many_arguments` on `push_network_one_thread` in `remote/mod.rs` is untouched and out of scope).

Do not self-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786986027&installation_id=132405951&pr_number=1051&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1051&signature=22b46bd87724600141493505b48f8e6e453fff893a93ea6f3a2254766bc57575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->