### PR TITLE
feat(context,review): wire hosted sync for context annotations + review signatures

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1635,6 +1635,15 @@ async fn clone_network(
                 eprintln!("{} discussion sync skipped: {error:#}", style::warn_marker());
             }
         }
+        // Read path for hosted context annotations (heddle context): materialize
+        // the hosted head's annotations into the local Context attachment so
+        // `context list` sees them. Best-effort, mirroring discussions.
+        match crate::client::context_sync::pull_context(&local_repo, &mut client, repo_path).await {
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("{} context sync skipped: {error:#}", style::warn_marker());
+            }
+        }
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(
                 origin_url.clone(),

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -18,7 +18,7 @@ mod command_catalog;
 mod commit;
 pub(crate) mod compact;
 mod completion;
-mod context;
+pub(crate) mod context;
 mod daemon;
 mod diff;
 mod discuss;

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1280,6 +1280,40 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
                 );
             }
         }
+
+        // Write path for hosted context annotations (heddle context) and review
+        // signatures (heddle review sign) — same seam as discussions. #549
+        // rejects these attachments in the pack, so they only reach the server
+        // over the caller-authenticated RPCs. Best-effort: the object push
+        // already landed, so a sync hiccup warns rather than failing the push.
+        match crate::client::context_sync::push_context(repo, &mut client, &repo_path).await {
+            Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
+                println!(
+                    "{} synced {count} annotation(s) to {}",
+                    style::ok_marker(),
+                    style::dim(&repo_path)
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("{} context sync skipped: {error:#}", style::warn_marker());
+            }
+        }
+        match crate::client::review_sync::push_review_signatures(repo, &mut client, &repo_path)
+            .await
+        {
+            Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
+                println!(
+                    "{} synced {count} review signature(s) to {}",
+                    style::ok_marker(),
+                    style::dim(&repo_path)
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                eprintln!("{} review sync skipped: {error:#}", style::warn_marker());
+            }
+        }
     }
 
     // CLI maps wire/protobuf transport fields → pure domain fields; core

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1105,6 +1105,25 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
                     );
                 }
             }
+            // Read path for hosted context annotations — same seam as discussions.
+            match crate::client::context_sync::pull_context(repo, &mut client, repo_path).await {
+                Ok(count)
+                    if count > 0 && !should_output_json(options.cli, Some(repo.config())) =>
+                {
+                    println!(
+                        "{} synced {count} annotation(s) from {}",
+                        crate::cli::style::ok_marker(),
+                        crate::cli::style::dim(repo_path)
+                    );
+                }
+                Ok(_) => {}
+                Err(error) => {
+                    eprintln!(
+                        "{} context sync skipped: {error:#}",
+                        crate::cli::style::warn_marker()
+                    );
+                }
+            }
             // Facts reuse the same string-mapped transport fields.
             let facts_fields = HostedPullResultFields {
                 success: true,

--- a/crates/cli/src/client/context_sync.rs
+++ b/crates/cli/src/client/context_sync.rs
@@ -7,61 +7,64 @@
 //! through the caller-authenticated `SetContext`/`ReviseContext`/
 //! `SupersedeContext` RPCs and read back through `ListContext`/
 //! `GetContextHistory`. This module bridges the two, mirroring
-//! [`crate::client::discussion_sync`]:
+//! [`crate::client::discussion_sync`].
 //!
-//! * **Push (write path):** after a successful `heddle push`, replay the
-//!   annotations we authored to the server. #549 rejects `Context` attachments
-//!   in the pack, so an annotation only reaches the server through these RPCs.
-//! * **Pull/clone (read path):** after a successful clone/pull, `ListContext`
-//!   the head and materialize any server annotation/revision we don't already
-//!   hold into the local `Context` attachment so `context list` sees it.
+//! ## Identity: annotation id AND per-revision id links
 //!
-//! ## Identity is by the annotation's stable id — NOT ordinal counts
+//! A context annotation carries a globally-unique `annotation_id`, and each
+//! revision a `revision_id`. When the server ships an annotation back on a pull,
+//! the pack carries its `Annotation` verbatim, so a pulled annotation's local id
+//! (and each pulled revision's id) IS the server id. A locally-authored
+//! annotation/revision is minted with a fresh uuid, so its id differs from the
+//! server id the RPC assigns. The mirror map records BOTH:
+//! `local_annotation_id ↔ server_annotation_id` and, per annotation, a set of
+//! `local_revision_id ↔ server_revision_id` links.
 //!
-//! Unlike discussion turns (whose only cross-side identity was a fragile
-//! ordinal), a context annotation carries a globally-unique `annotation_id`.
-//! Crucially, when the server ships an annotation back on a pull, the pack
-//! carries the server's `Annotation` verbatim, so the **local** annotation id
-//! IS the server id. That collapses the cross-side identity problem: a pulled
-//! annotation and its server twin share one id, and the cross-author
-//! identical-body hazard (two "lgtm" annotations from different authors) is
-//! trivially safe — distinct server ids materialize as distinct local
-//! annotations, so a body can never be misattributed.
+//! A prefix COUNT of "revisions synced" is wrong: with two clones concurrently
+//! revising one annotation, the linear server list interleaves their revisions,
+//! so a count both drops one author's revision and duplicates the other's on the
+//! next pull. Reconciliation is therefore by revision-id set difference in server
+//! order, and pull rebuilds the local revision list to match server order so the
+//! "current" revision agrees across clones.
 //!
-//! The mirror map (`.heddle/collaboration/hosted-context-mirror.json`) records,
-//! per repo, `local_annotation_id ↔ server_annotation_id` plus a count of
-//! revisions already synced (revisions are append-only and linear). A locally
-//! authored annotation is created with a fresh uuid, so its local id differs
-//! from the server id the RPC mints; the mirror is what maps the two so a
-//! re-push revises instead of re-creating.
+//! ## Reconciliation is author-aware, never body-alone
 //!
-//! ## Push is idempotent even with no mirror
+//! Where an id link is missing (a lost/rebuilt mirror, or recovering a
+//! server-minted id), an unlinked server revision is matched to an unlinked
+//! local revision only under an explicit author rule — never body equality
+//! alone, which would cross-link two different authors' identical bodies
+//! (`"lgtm"`) and silently drop one:
+//! * (i) a revision WE pushed — the local revision is self-authored (its
+//!   attribution equals our local attribution) AND the server stamped it with
+//!   our own hosted username (`"{username} <>"`); or
+//! * (ii) a revision we previously PULLED — the local attribution + `created_at`
+//!   exactly equal the server revision's. Minted-annotation-id recovery after
+//!   `SetContext` uses the same author rule (weft returns only a count, not the
+//!   id): it adopts the annotation at the target whose attribution is our hosted
+//!   username, whose content matches, and whose id is not already linked.
 //!
-//! Before creating an annotation, push checks whether the server ALREADY holds
-//! one with that id (the pulled/pack-delivered case, where local id == server
-//! id). If so it links and revises rather than issuing a duplicate `SetContext`.
-//! This makes a lost mirror self-heal instead of doubling annotations.
+//! ## Idempotent, crash-safe create
 //!
-//! ## Fail-closed self filter
+//! `SetContext` mints the id server-side and does not return it. Before the RPC
+//! the mirror records a `pending_create_op` (write-ahead, persisted to disk) used
+//! as the `client_operation_id`, so a retry after a crash replays (weft dedup)
+//! instead of duplicating, and recovery re-adopts the already-created annotation
+//! by author+content among ids NOT already linked — closing the "could not
+//! recover minted id" wedge.
 //!
-//! A fresh annotation is created on the server only when we can attribute it to
-//! the local principal (`SetContext`/`SupersedeContext` stamp the server-side
-//! attribution with our own hosted username). Revisions to an *already-hosted*
-//! annotation are always forwarded — a revision is a local edit the server
-//! re-attributes to the caller, exactly the collaborative-edit case.
+//! ## Supersession chains through the mirror
 //!
-//! ## weft#638 / weft#640 limits (degrade gracefully, don't fix here)
+//! `supersedes_annotation_id` is a LOCAL id; it is resolved to the SERVER id via
+//! the mirror before calling `SupersedeContext`, so superseding a previously
+//! pushed annotation marks the right server annotation superseded (rather than
+//! degrading to a plain create that leaves the old one Active on every clone).
 //!
-//! Each `SetContext`/`Revise`/`Supersede` advances the server head (context
-//! lives per-state, no carry-forward), so a repo effectively tracks one state's
-//! context; a no-HEAD repo is skipped. `SetContext` does not return the minted
-//! id, so push discovers it by diffing `ListContext` before/after — precise for
-//! the real multi-writer case but ambiguous between two identical annotations
-//! authored in the same push (weft#640, same-user-identical edge). The mirror is
-//! saved after every annotation and on the error path, collect-and-continue, so
-//! one wedged annotation never aborts the rest or orphans a durable write.
+//! ## weft#638 limit (degrade gracefully, don't fix here)
 //!
-//! Scope: annotations only. `rm` is not mirrored (removal is local-only).
+//! Each RPC advances the server head (context lives per-state); a no-HEAD repo is
+//! skipped. The mirror is saved after every annotation and on the error path,
+//! collect-and-continue, so one wedged annotation never aborts the rest or
+//! orphans a durable write. Scope: annotations only (`rm` is local-only).
 
 #![cfg(feature = "client")]
 
@@ -85,8 +88,12 @@ use objects::store::ObjectStore;
 use repo::Repository;
 use serde::{Deserialize, Serialize};
 
-use crate::client::HostedGrpcClient;
 use crate::cli::commands::context::{context_root_for_state, put_context_attachment};
+use crate::client::HostedGrpcClient;
+
+// =========================================================================
+// Mirror map
+// =========================================================================
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct HostedContextMirror {
@@ -100,16 +107,26 @@ struct RepoContextMirror {
     annotations: Vec<ContextMirrorEntry>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 struct ContextMirrorEntry {
     /// Local `annotation_id`.
     local_id: String,
-    /// Server-assigned `annotation_id` (== `local_id` for pulled annotations).
-    server_id: String,
-    /// Count of revisions known present on BOTH sides. Revisions are linear and
-    /// append-only, so a prefix count is a faithful link.
+    /// Server `annotation_id`. Empty while a create is in flight.
     #[serde(default)]
-    synced_revisions: usize,
+    server_id: String,
+    /// `local_revision_id ↔ server_revision_id` links.
+    #[serde(default)]
+    revision_links: Vec<RevisionLink>,
+    /// Write-ahead: the `client_operation_id` a create RPC is (or was) issued
+    /// with, so a crash-retry replays rather than duplicating.
+    #[serde(default)]
+    pending_create_op: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct RevisionLink {
+    local: String,
+    server: String,
 }
 
 fn mirror_path(heddle_dir: &Path) -> PathBuf {
@@ -138,7 +155,97 @@ fn save_mirror(heddle_dir: &Path, mirror: &HostedContextMirror) -> Result<()> {
     Ok(())
 }
 
-// --- scope / kind converters (local <-> proto) ---
+// --- mirror accessors ---
+
+fn entry_index(mirror: &HostedContextMirror, repo_path: &str, local_id: &str) -> Option<usize> {
+    mirror
+        .repos
+        .get(repo_path)?
+        .annotations
+        .iter()
+        .position(|entry| entry.local_id == local_id)
+}
+
+fn get_or_create_entry<'a>(
+    mirror: &'a mut HostedContextMirror,
+    repo_path: &str,
+    local_id: &str,
+) -> &'a mut ContextMirrorEntry {
+    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+    if let Some(index) = repo_mirror
+        .annotations
+        .iter()
+        .position(|entry| entry.local_id == local_id)
+    {
+        return &mut repo_mirror.annotations[index];
+    }
+    repo_mirror.annotations.push(ContextMirrorEntry {
+        local_id: local_id.to_string(),
+        ..Default::default()
+    });
+    repo_mirror.annotations.last_mut().expect("just pushed")
+}
+
+fn server_id_for_local(
+    mirror: &HostedContextMirror,
+    repo_path: &str,
+    local_id: &str,
+) -> Option<String> {
+    let entry = mirror
+        .repos
+        .get(repo_path)?
+        .annotations
+        .iter()
+        .find(|entry| entry.local_id == local_id)?;
+    (!entry.server_id.is_empty()).then(|| entry.server_id.clone())
+}
+
+fn local_id_for_server(
+    mirror: &HostedContextMirror,
+    repo_path: &str,
+    server_id: &str,
+) -> Option<String> {
+    mirror
+        .repos
+        .get(repo_path)?
+        .annotations
+        .iter()
+        .find(|entry| entry.server_id == server_id)
+        .map(|entry| entry.local_id.clone())
+}
+
+fn server_id_is_linked(mirror: &HostedContextMirror, repo_path: &str, server_id: &str) -> bool {
+    mirror.repos.get(repo_path).is_some_and(|repo_mirror| {
+        repo_mirror
+            .annotations
+            .iter()
+            .any(|entry| entry.server_id == server_id)
+    })
+}
+
+fn add_revision_link(
+    mirror: &mut HostedContextMirror,
+    repo_path: &str,
+    local_id: &str,
+    local_rev: String,
+    server_rev: String,
+) {
+    let entry = get_or_create_entry(mirror, repo_path, local_id);
+    if !entry
+        .revision_links
+        .iter()
+        .any(|link| link.local == local_rev && link.server == server_rev)
+    {
+        entry.revision_links.push(RevisionLink {
+            local: local_rev,
+            server: server_rev,
+        });
+    }
+}
+
+// =========================================================================
+// scope / kind converters
+// =========================================================================
 
 fn scope_to_proto(scope: &AnnotationScope) -> ProtoScope {
     let inner = match scope {
@@ -173,6 +280,16 @@ fn scope_from_proto(scope: Option<&ProtoScope>) -> AnnotationScope {
     }
 }
 
+/// Scope identity ignoring `resolved_lines` (the server may resolve a symbol's
+/// lines even when the local scope has none), for matching recovered annotations.
+fn scope_ident(scope: &AnnotationScope) -> String {
+    match scope {
+        AnnotationScope::File => "file".to_string(),
+        AnnotationScope::Symbol { name, .. } => format!("symbol:{name}"),
+        AnnotationScope::Lines(start, end) => format!("lines:{start}-{end}"),
+    }
+}
+
 fn kind_to_proto(kind: AnnotationKind) -> ContextAnnotationKind {
     match kind {
         AnnotationKind::Constraint => ContextAnnotationKind::Constraint,
@@ -198,16 +315,11 @@ fn status_from_proto(status: i32) -> AnnotationStatus {
     }
 }
 
-/// `(path, target_state_id)` operands for the RPCs, from a local target.
 fn target_operands(target: &ContextTarget) -> (String, Option<String>) {
     match target {
         ContextTarget::File { path } => (path.clone(), None),
         ContextTarget::State { state_id } => (String::new(), Some(state_id.to_string_full())),
     }
-}
-
-fn target_from_annotated_file(path: &str) -> Option<ContextTarget> {
-    ContextTarget::file(path).ok()
 }
 
 fn content_hash_from_bytes(bytes: &Option<Vec<u8>>) -> Option<ContentHash> {
@@ -221,20 +333,23 @@ fn state_id_from_proto(id: Option<&api::heddle::api::v1alpha1::StateId>) -> Opti
     id.and_then(|value| StateId::try_from_slice(&value.value).ok())
 }
 
+/// The attribution string weft stamps on our own hosted writes:
+/// `Principal::new(username, "")` renders as `"{username} <>"`.
+fn hosted_attribution(username: Option<&str>) -> Option<String> {
+    username.map(|name| format!("{name} <>"))
+}
+
 // =========================================================================
 // Push
 // =========================================================================
 
 /// Publish local annotations we authored to the hosted `RepositoryService`.
-/// Saves the mirror after each annotation and continues past a per-annotation
-/// failure (warn-and-skip).
 pub async fn push_context(
     repo: &Repository,
     client: &mut HostedGrpcClient,
     repo_path: &str,
 ) -> Result<usize> {
     let Some(head_id) = repo.head().context("resolve repository head")? else {
-        // weft#638: no HEAD → no state to attach annotations against.
         return Ok(0);
     };
     let Some(head_state) = repo.store().get_state(&head_id).context("load head state")? else {
@@ -251,45 +366,35 @@ pub async fn push_context(
     }
 
     let user_config = crate::config::UserConfig::load_default().unwrap_or_default();
-    let self_attribution =
-        crate::cli::commands::snapshot::resolve_attribution(repo, &user_config)
-            .ok()
-            .map(|attribution| attribution.to_string());
+    let self_local_attr = crate::cli::commands::snapshot::resolve_attribution(repo, &user_config)
+        .ok()
+        .map(|attribution| attribution.to_string());
+    let username = client.authenticated_username();
 
-    let mut mirror = load_mirror(repo.heddle_dir())?;
-    // `server_counts`: id → revision_count the server currently holds (from the
-    // initial ListContext). Lets the adopt path (a pulled annotation whose local
-    // id == server id) forward only the revisions the server is actually missing,
-    // even with no mirror row. `known_ids` additionally folds in mirror server
-    // ids so a `SetContext`'s freshly-minted id is spotted as the one NOT already
-    // known.
-    let mut server_counts: std::collections::HashMap<String, usize> =
-        std::collections::HashMap::new();
-    for annotation in list_server_annotations(client, repo_path).await? {
-        server_counts.insert(annotation.id, annotation.revision_count as usize);
-    }
-    let mut known_ids: HashSet<String> = server_counts.keys().cloned().collect();
-    if let Some(repo_mirror) = mirror.repos.get(repo_path) {
-        for entry in &repo_mirror.annotations {
-            known_ids.insert(entry.server_id.clone());
-        }
-    }
+    let server_ann_ids: HashSet<String> = list_server_annotations(client, repo_path)
+        .await?
+        .into_iter()
+        .map(|annotation| annotation.id)
+        .collect();
 
+    let heddle_dir = repo.heddle_dir().to_path_buf();
+    let mut mirror = load_mirror(&heddle_dir)?;
     let mut synced = 0usize;
     for entry in &entries {
         for annotation in &entry.blob.annotations {
             let result = push_one(
                 client,
                 repo_path,
+                &heddle_dir,
                 &entry.target,
                 annotation,
-                self_attribution.as_deref(),
+                self_local_attr.as_deref(),
+                username.as_deref(),
+                &server_ann_ids,
                 &mut mirror,
-                &server_counts,
-                &mut known_ids,
             )
             .await;
-            save_mirror(repo.heddle_dir(), &mirror)?;
+            save_mirror(&heddle_dir, &mirror)?;
             match result {
                 Ok(true) => synced += 1,
                 Ok(false) => {}
@@ -303,7 +408,6 @@ pub async fn push_context(
             }
         }
     }
-
     Ok(synced)
 }
 
@@ -311,137 +415,129 @@ pub async fn push_context(
 async fn push_one(
     client: &mut HostedGrpcClient,
     repo_path: &str,
+    heddle_dir: &Path,
     target: &ContextTarget,
     annotation: &Annotation,
-    self_attribution: Option<&str>,
+    self_local_attr: Option<&str>,
+    username: Option<&str>,
+    server_ann_ids: &HashSet<String>,
     mirror: &mut HostedContextMirror,
-    server_counts: &std::collections::HashMap<String, usize>,
-    known_ids: &mut HashSet<String>,
 ) -> Result<bool> {
-    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-    let linked = repo_mirror
-        .annotations
-        .iter()
-        .position(|entry| entry.local_id == annotation.annotation_id);
+    // ---- 1. Resolve the server annotation id. ----
+    let mut created = false;
+    let server_id = if let Some(sid) =
+        server_id_for_local(mirror, repo_path, &annotation.annotation_id)
+    {
+        sid
+    } else if server_ann_ids.contains(&annotation.annotation_id) {
+        // Pulled / pack-delivered: local id IS the server id. Adopt it.
+        let entry = get_or_create_entry(mirror, repo_path, &annotation.annotation_id);
+        entry.server_id = annotation.annotation_id.clone();
+        annotation.annotation_id.clone()
+    } else {
+        // Genuinely new → create. Fail-closed self filter.
+        let first = annotation
+            .revisions
+            .first()
+            .context("annotation has no revisions")?;
+        let is_self = self_local_attr.is_some_and(|me| me == first.attribution);
+        if !is_self {
+            eprintln!(
+                "{} hosted context {}: not attributed to the local principal; left unpublished",
+                crate::cli::style::warn_marker(),
+                annotation.annotation_id
+            );
+            return Ok(false);
+        }
+        // Resolve the superseded LOCAL id → SERVER id through the mirror (P1-3).
+        let superseded_server = annotation.supersedes_annotation_id.as_ref().and_then(|local| {
+            server_id_for_local(mirror, repo_path, local)
+                .or_else(|| server_ann_ids.contains(local).then(|| local.clone()))
+        });
 
-    // Resolve the server id, how many revisions are already synced, and whether
-    // this call created a new server annotation.
-    let (server_id, mut synced_revisions, created) = match linked {
-        Some(index) => (
-            repo_mirror.annotations[index].server_id.clone(),
-            repo_mirror.annotations[index].synced_revisions,
-            false,
-        ),
-        None if server_counts.contains_key(&annotation.annotation_id) => {
-            // Pulled / pack-delivered: local id IS the server id. Adopt it
-            // without a duplicate create (idempotent even with no mirror row).
-            // Sync from the server's actual revision count so any revision we
-            // added locally after the pull is still forwarded.
-            let synced = server_counts[&annotation.annotation_id];
-            repo_mirror.annotations.push(ContextMirrorEntry {
-                local_id: annotation.annotation_id.clone(),
-                server_id: annotation.annotation_id.clone(),
-                synced_revisions: synced,
-            });
-            (annotation.annotation_id.clone(), synced, false)
-        }
-        None => {
-            // Genuinely new annotation → create it. Fail-closed self filter.
-            let first = annotation
-                .revisions
-                .first()
-                .context("annotation has no revisions")?;
-            let is_self = self_attribution.is_some_and(|me| me == first.attribution);
-            if !is_self {
-                eprintln!(
-                    "{} hosted context {}: not attributed to the local principal; left unpublished",
-                    crate::cli::style::warn_marker(),
-                    annotation.annotation_id
-                );
-                return Ok(false);
+        // Write-ahead: persist a create nonce to DISK before the RPC so a
+        // crash-retry replays with the same client_operation_id (P2-5).
+        let op_id = {
+            let entry = get_or_create_entry(mirror, repo_path, &annotation.annotation_id);
+            if entry.pending_create_op.is_none() {
+                entry.pending_create_op = Some(uuid::Uuid::new_v4().to_string());
             }
-            let server_id =
-                create_on_server(client, repo_path, target, annotation, known_ids).await?;
-            known_ids.insert(server_id.clone());
-            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-            repo_mirror.annotations.push(ContextMirrorEntry {
-                local_id: annotation.annotation_id.clone(),
-                server_id: server_id.clone(),
-                synced_revisions: 1,
-            });
-            (server_id, 1, true)
+            entry.pending_create_op.clone().expect("just set")
+        };
+        save_mirror(heddle_dir, mirror)?;
+
+        let (sid, first_server_rev) = create_on_server(
+            client,
+            repo_path,
+            target,
+            annotation,
+            superseded_server.as_deref(),
+            &op_id,
+            username,
+            mirror,
+        )
+        .await?;
+
+        {
+            let entry = get_or_create_entry(mirror, repo_path, &annotation.annotation_id);
+            entry.server_id = sid.clone();
+            entry.pending_create_op = None;
         }
+        add_revision_link(
+            mirror,
+            repo_path,
+            &annotation.annotation_id,
+            annotation.revisions[0].revision_id.clone(),
+            first_server_rev,
+        );
+        created = true;
+        sid
     };
 
-    // Forward any revisions the server does not yet hold (linear append).
-    // "Pushed" = we created the annotation OR forwarded at least one revision;
-    // adopting an already-hosted annotation with nothing new is not a push.
-    let mut pushed_any = created;
-    while synced_revisions < annotation.revisions.len() {
-        let revision = &annotation.revisions[synced_revisions];
-        client
-            .revise_context(
-                repo_path,
-                &server_id,
-                &revision.content,
-                revision.tags.clone(),
-                None,
-                None,
-                kind_to_proto(revision.kind),
-                revise_op_id(repo_path, &server_id, &revision.revision_id),
-            )
-            .await
-            .with_context(|| format!("revise hosted annotation {server_id}"))?;
-        synced_revisions += 1;
-        pushed_any = true;
-    }
+    // ---- 2. Sync revisions (linear, id-linked, author-aware recovery). ----
+    let pushed = sync_revisions_push(
+        client,
+        repo_path,
+        &server_id,
+        annotation,
+        self_local_attr,
+        username,
+        mirror,
+    )
+    .await?;
 
-    // Persist the (possibly advanced) revision count.
-    if let Some(entry) = mirror
-        .repos
-        .get_mut(repo_path)
-        .and_then(|repo_mirror| {
-            repo_mirror
-                .annotations
-                .iter_mut()
-                .find(|entry| entry.local_id == annotation.annotation_id)
-        })
-    {
-        entry.synced_revisions = synced_revisions;
-    }
-
-    Ok(pushed_any)
+    Ok(created || pushed > 0)
 }
 
-/// Create a fresh annotation on the server and return its minted id.
-///
-/// `SetContext`/`SupersedeContext` do not both return the id, so a plain
-/// `SetContext` is followed by a before/after `ListContext` diff to recover it
-/// (`SupersedeContext` returns the new id directly).
+/// Create a fresh annotation server-side, returning `(server_annotation_id,
+/// first_server_revision_id)`.
+#[allow(clippy::too_many_arguments)]
 async fn create_on_server(
     client: &mut HostedGrpcClient,
     repo_path: &str,
     target: &ContextTarget,
     annotation: &Annotation,
-    known_server_ids: &HashSet<String>,
-) -> Result<String> {
+    superseded_server: Option<&str>,
+    op_id: &str,
+    username: Option<&str>,
+    mirror: &HostedContextMirror,
+) -> Result<(String, String)> {
     let first = annotation
         .revisions
         .first()
         .context("annotation has no revisions")?;
     let (path, target_state_id) = target_operands(target);
 
-    // Supersession maps to `SupersedeContext` when the superseded annotation is
-    // already on the server (linked or pulled). Otherwise it degrades to a
-    // plain create (the chain link is lost server-side but the content lands).
-    if let Some(superseded_local) = &annotation.supersedes_annotation_id
-        && known_server_ids.contains(superseded_local)
-    {
+    let server_id = if let Some(superseded) = superseded_server {
         let response = client
             .supersede_context(
                 repo_path,
-                superseded_local,
-                if path.is_empty() { None } else { Some(path.as_str()) },
+                superseded,
+                if path.is_empty() {
+                    None
+                } else {
+                    Some(path.as_str())
+                },
                 target_state_id.as_deref(),
                 scope_to_proto(&annotation.scope),
                 first.tags.clone(),
@@ -449,49 +545,172 @@ async fn create_on_server(
                 None,
                 None,
                 kind_to_proto(first.kind),
-                supersede_op_id(repo_path, superseded_local, &annotation.annotation_id),
+                op_id.to_string(),
             )
             .await
-            .with_context(|| format!("supersede hosted annotation {superseded_local}"))?;
-        return Ok(response.new_annotation_id);
-    }
+            .with_context(|| format!("supersede hosted annotation {superseded}"))?;
+        response.new_annotation_id
+    } else {
+        client
+            .set_context(
+                repo_path,
+                &path,
+                target_state_id.as_deref(),
+                scope_to_proto(&annotation.scope),
+                kind_to_proto(first.kind),
+                first.tags.clone(),
+                &first.content,
+                None,
+                None,
+                op_id.to_string(),
+            )
+            .await
+            .with_context(|| format!("set hosted context for {}", annotation.annotation_id))?;
 
-    client
-        .set_context(
-            repo_path,
-            &path,
-            target_state_id.as_deref(),
-            scope_to_proto(&annotation.scope),
-            kind_to_proto(first.kind),
-            first.tags.clone(),
-            &first.content,
-            None,
-            None,
-            set_op_id(repo_path, &annotation.annotation_id),
-        )
-        .await
-        .with_context(|| format!("set hosted context for {}", annotation.annotation_id))?;
+        // Recover the minted id author-aware (weft returns only a count): the
+        // annotation at the target stamped with OUR hosted username, matching
+        // content + scope, whose id is not already linked (re-link safe).
+        let hosted = hosted_attribution(username);
+        list_server_targets(client, repo_path)
+            .await?
+            .into_iter()
+            .rev()
+            .find(|(candidate_target, candidate)| {
+                candidate_target == target
+                    && Some(candidate.attribution.as_str()) == hosted.as_deref()
+                    && candidate.content == first.content
+                    && scope_ident(&scope_from_proto(candidate.scope.as_ref()))
+                        == scope_ident(&annotation.scope)
+                    && !server_id_is_linked(mirror, repo_path, &candidate.id)
+            })
+            .map(|(_, candidate)| candidate.id)
+            .context("could not recover the minted annotation id (author + content)")?
+    };
 
-    // Recover the minted id: the one annotation now present at the target that
-    // we did not already know about.
-    let after = list_server_annotations(client, repo_path).await?;
-    after
+    let first_server_rev = first_server_revision_id(client, repo_path, &server_id).await?;
+    Ok((server_id, first_server_rev))
+}
+
+/// Forward local revisions the server does not yet hold. Returns the count
+/// actually pushed. Author-aware recovery links each minted server revision id.
+async fn sync_revisions_push(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    server_id: &str,
+    annotation: &Annotation,
+    self_local_attr: Option<&str>,
+    username: Option<&str>,
+    mirror: &mut HostedContextMirror,
+) -> Result<usize> {
+    let hosted = hosted_attribution(username);
+    let mut server_rev_ids: HashSet<String> = fetch_history(client, repo_path, server_id)
+        .await?
         .into_iter()
-        .rev()
-        .find(|candidate| {
-            !known_server_ids.contains(&candidate.id) && candidate.content == first.content
+        .map(|rev| rev.revision_id)
+        .collect();
+    let linked_local: HashSet<String> = mirror
+        .repos
+        .get(repo_path)
+        .and_then(|m| {
+            m.annotations
+                .iter()
+                .find(|e| e.local_id == annotation.annotation_id)
         })
-        .map(|candidate| candidate.id)
-        .context("could not recover the minted annotation id after SetContext")
+        .map(|entry| entry.revision_links.iter().map(|l| l.local.clone()).collect())
+        .unwrap_or_default();
+
+    let mut pushed = 0usize;
+    for revision in &annotation.revisions {
+        if linked_local.contains(&revision.revision_id) {
+            continue;
+        }
+        if server_rev_ids.contains(&revision.revision_id) {
+            // Pulled / pack-delivered: local revision id IS the server id.
+            add_revision_link(
+                mirror,
+                repo_path,
+                &annotation.annotation_id,
+                revision.revision_id.clone(),
+                revision.revision_id.clone(),
+            );
+            continue;
+        }
+        // A local-only revision. Only forward our own (a foreign unlinked
+        // revision not on the server is anomalous — skip rather than mis-author).
+        if self_local_attr != Some(revision.attribution.as_str()) {
+            eprintln!(
+                "{} hosted context {}: unlinked revision not attributed to the local principal; left unpublished",
+                crate::cli::style::warn_marker(),
+                annotation.annotation_id
+            );
+            continue;
+        }
+        client
+            .revise_context(
+                repo_path,
+                server_id,
+                &revision.content,
+                revision.tags.clone(),
+                None,
+                None,
+                kind_to_proto(revision.kind),
+                revise_op_id(repo_path, server_id, &revision.revision_id),
+            )
+            .await
+            .with_context(|| format!("revise hosted annotation {server_id}"))?;
+
+        // Recover the minted revision id: the newly-appended server revision
+        // stamped with our hosted username + our content, not seen before.
+        let refreshed = fetch_history(client, repo_path, server_id).await?;
+        let minted = refreshed.iter().rev().find(|candidate| {
+            !server_rev_ids.contains(&candidate.revision_id)
+                && Some(candidate.attribution.as_str()) == hosted.as_deref()
+                && candidate.content == revision.content
+        });
+        match minted {
+            Some(candidate) => {
+                add_revision_link(
+                    mirror,
+                    repo_path,
+                    &annotation.annotation_id,
+                    revision.revision_id.clone(),
+                    candidate.revision_id.clone(),
+                );
+                server_rev_ids.insert(candidate.revision_id.clone());
+                pushed += 1;
+            }
+            None => {
+                eprintln!(
+                    "{} hosted context {}: could not recover the minted revision id",
+                    crate::cli::style::warn_marker(),
+                    annotation.annotation_id
+                );
+            }
+        }
+    }
+    Ok(pushed)
+}
+
+/// Oldest server revision id for an annotation (the create revision).
+async fn first_server_revision_id(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    server_id: &str,
+) -> Result<String> {
+    let revisions = fetch_history(client, repo_path, server_id).await?;
+    revisions
+        .into_iter()
+        .next()
+        .map(|revision| revision.revision_id)
+        .context("hosted annotation has no revisions")
 }
 
 // =========================================================================
 // Pull
 // =========================================================================
 
-/// Fetch hosted annotations for the repository head and materialize any
-/// annotation/revision we do not already hold. Saves the mirror after each
-/// annotation and continues past a per-annotation failure.
+/// Fetch hosted annotations for the head and reconcile them into the local
+/// `Context` attachment, rebuilding revision order to match the server.
 pub async fn pull_context(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -509,14 +728,29 @@ pub async fn pull_context(
         return Ok(0);
     }
 
-    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let user_config = crate::config::UserConfig::load_default().unwrap_or_default();
+    let self_local_attr = crate::cli::commands::snapshot::resolve_attribution(repo, &user_config)
+        .ok()
+        .map(|attribution| attribution.to_string());
+    let username = client.authenticated_username();
+
+    let heddle_dir = repo.heddle_dir().to_path_buf();
+    let mut mirror = load_mirror(&heddle_dir)?;
     let mut changed = 0usize;
     for (target, annotation) in server {
-        let result = pull_one(repo, client, repo_path, &head_state, &target, &annotation).await;
-        // Record the link regardless (local id == server id for pulled annots),
-        // so a later push adopts it instead of re-creating.
-        record_pull_link(&mut mirror, repo_path, &annotation);
-        save_mirror(repo.heddle_dir(), &mirror)?;
+        let result = pull_one(
+            repo,
+            client,
+            repo_path,
+            &head_state,
+            &target,
+            &annotation,
+            self_local_attr.as_deref(),
+            username.as_deref(),
+            &mut mirror,
+        )
+        .await;
+        save_mirror(&heddle_dir, &mirror)?;
         match result {
             Ok(true) => changed += 1,
             Ok(false) => {}
@@ -529,31 +763,10 @@ pub async fn pull_context(
             }
         }
     }
-
     Ok(changed)
 }
 
-fn record_pull_link(
-    mirror: &mut HostedContextMirror,
-    repo_path: &str,
-    annotation: &ContextAnnotation,
-) {
-    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-    let synced = annotation.revision_count as usize;
-    match repo_mirror
-        .annotations
-        .iter_mut()
-        .find(|entry| entry.server_id == annotation.id)
-    {
-        Some(entry) => entry.synced_revisions = entry.synced_revisions.max(synced),
-        None => repo_mirror.annotations.push(ContextMirrorEntry {
-            local_id: annotation.id.clone(),
-            server_id: annotation.id.clone(),
-            synced_revisions: synced,
-        }),
-    }
-}
-
+#[allow(clippy::too_many_arguments)]
 async fn pull_one(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -561,9 +774,14 @@ async fn pull_one(
     head_state: &State,
     target: &ContextTarget,
     server: &ContextAnnotation,
+    self_local_attr: Option<&str>,
+    username: Option<&str>,
+    mirror: &mut HostedContextMirror,
 ) -> Result<bool> {
-    // The pack may have already delivered this annotation (local id == server
-    // id). Load the current local blob at the target and reconcile by id.
+    let local_id =
+        local_id_for_server(mirror, repo_path, &server.id).unwrap_or_else(|| server.id.clone());
+    let server_revs = fetch_history(client, repo_path, &server.id).await?;
+
     let context_root = context_root_for_state(repo, head_state)?;
     let mut blob = match &context_root {
         Some(root) => repo
@@ -572,52 +790,224 @@ async fn pull_one(
         None => ContextBlob::new(vec![]),
     };
 
-    let existing = blob
+    let existing_index = blob
         .annotations
         .iter()
-        .position(|annotation| annotation.annotation_id == server.id);
+        .position(|annotation| annotation.annotation_id == local_id);
 
-    match existing {
-        Some(index) => {
-            // Already present (pack-delivered or previously pulled). Append only
-            // the revisions the server has beyond what we hold.
-            if server.revision_count as usize <= blob.annotations[index].revisions.len() {
-                return Ok(false);
-            }
-            let history = fetch_history(client, repo_path, &server.id).await?;
-            let local = &mut blob.annotations[index];
-            let start = local.revisions.len();
-            for revision in history.into_iter().skip(start) {
-                local.revisions.push(revision);
-            }
-            local.status = status_from_proto(server.status);
-        }
-        None => {
-            // New annotation → materialize the full history, preserving the
-            // server annotation id and per-revision authorship/timestamps.
-            let revisions = fetch_history(client, repo_path, &server.id).await?;
-            blob.annotations.push(materialize_annotation(server, revisions));
-        }
+    let existing_revisions: Vec<AnnotationRevision> = existing_index
+        .map(|index| blob.annotations[index].revisions.clone())
+        .unwrap_or_default();
+    let existing_links: Vec<RevisionLink> = entry_index(mirror, repo_path, &local_id)
+        .map(|index| mirror.repos[repo_path].annotations[index].revision_links.clone())
+        .unwrap_or_default();
+
+    let (new_revisions, new_links) = reconcile_revisions_pull(
+        &existing_revisions,
+        &server_revs,
+        &existing_links,
+        self_local_attr,
+        username,
+    );
+
+    {
+        let entry = get_or_create_entry(mirror, repo_path, &local_id);
+        entry.server_id = server.id.clone();
+        entry.revision_links = new_links;
     }
 
+    let new_status = status_from_proto(server.status);
+    let changed = match existing_index {
+        Some(index) => {
+            let annotation = &mut blob.annotations[index];
+            let differs = annotation.revisions != new_revisions
+                || annotation.status != new_status
+                || annotation.supersedes_annotation_id != server.supersedes_annotation_id
+                || annotation.supersedes_rewrite_pct != server.supersedes_rewrite_pct;
+            annotation.revisions = new_revisions;
+            annotation.status = new_status;
+            annotation.supersedes_annotation_id = server.supersedes_annotation_id.clone();
+            annotation.supersedes_rewrite_pct = server.supersedes_rewrite_pct;
+            differs
+        }
+        None => {
+            blob.annotations.push(Annotation {
+                annotation_id: local_id.clone(),
+                scope: scope_from_proto(server.scope.as_ref()),
+                status: new_status,
+                revisions: new_revisions,
+                supersedes_annotation_id: server.supersedes_annotation_id.clone(),
+                supersedes_rewrite_pct: server.supersedes_rewrite_pct,
+                visibility: objects::object::VisibilityTier::default(),
+                resolved_from_discussion: None,
+            });
+            true
+        }
+    };
+
+    if !changed {
+        return Ok(false);
+    }
     let new_root = repo.set_context_blob(context_root.as_ref(), target, &blob)?;
-    put_context_attachment(repo, head_state, Some(new_root))?;
+    if context_root != Some(new_root) {
+        put_context_attachment(repo, head_state, Some(new_root))?;
+    }
     Ok(true)
 }
 
-/// Build a local `Annotation` from a server annotation + its (oldest-first)
-/// revisions, preserving the server id.
-fn materialize_annotation(server: &ContextAnnotation, revisions: Vec<AnnotationRevision>) -> Annotation {
-    Annotation {
-        annotation_id: server.id.clone(),
-        scope: scope_from_proto(server.scope.as_ref()),
-        status: status_from_proto(server.status),
-        revisions,
-        supersedes_annotation_id: server.supersedes_annotation_id.clone(),
-        supersedes_rewrite_pct: server.supersedes_rewrite_pct,
-        visibility: objects::object::VisibilityTier::default(),
-        resolved_from_discussion: None,
+/// Rebuild the local revision list to match the server order, linking each
+/// server revision to a local revision (existing link, id equality, or
+/// author-aware reconcile) or materializing a new one. Purely-local revisions
+/// not yet on the server are preserved at the tail.
+fn reconcile_revisions_pull(
+    existing: &[AnnotationRevision],
+    server_revs: &[AnnotationRevision],
+    existing_links: &[RevisionLink],
+    self_local_attr: Option<&str>,
+    username: Option<&str>,
+) -> (Vec<AnnotationRevision>, Vec<RevisionLink>) {
+    let hosted = hosted_attribution(username);
+    let linked_local: HashSet<&str> = existing_links.iter().map(|l| l.local.as_str()).collect();
+    let mut link_by_server: std::collections::HashMap<&str, &str> =
+        std::collections::HashMap::new();
+    for link in existing_links {
+        link_by_server.insert(link.server.as_str(), link.local.as_str());
     }
+
+    let mut consumed: HashSet<String> = HashSet::new();
+    let mut new_revisions: Vec<AnnotationRevision> = Vec::new();
+    let mut new_links: Vec<RevisionLink> = Vec::new();
+
+    for server_rev in server_revs {
+        // (a) existing link by server id.
+        if let Some(local_rev_id) = link_by_server.get(server_rev.revision_id.as_str()) {
+            if let Some(local) = existing
+                .iter()
+                .find(|rev| rev.revision_id == *local_rev_id && !consumed.contains(&rev.revision_id))
+            {
+                consumed.insert(local.revision_id.clone());
+                new_revisions.push(local.clone());
+                new_links.push(RevisionLink {
+                    local: local.revision_id.clone(),
+                    server: server_rev.revision_id.clone(),
+                });
+                continue;
+            }
+        }
+        // (b) id equality (pack-delivered: local rev id == server rev id).
+        if let Some(local) = existing.iter().find(|rev| {
+            rev.revision_id == server_rev.revision_id && !consumed.contains(&rev.revision_id)
+        }) {
+            consumed.insert(local.revision_id.clone());
+            new_revisions.push(local.clone());
+            new_links.push(RevisionLink {
+                local: local.revision_id.clone(),
+                server: server_rev.revision_id.clone(),
+            });
+            continue;
+        }
+        // (c) author-aware reconcile against unlinked, unconsumed local revisions.
+        let candidate = existing.iter().find(|rev| {
+            !linked_local.contains(rev.revision_id.as_str())
+                && !consumed.contains(&rev.revision_id)
+                && rev.content == server_rev.content
+                && reconcile_ok(rev, server_rev, hosted.as_deref(), self_local_attr)
+        });
+        if let Some(local) = candidate {
+            consumed.insert(local.revision_id.clone());
+            new_revisions.push(local.clone());
+            new_links.push(RevisionLink {
+                local: local.revision_id.clone(),
+                server: server_rev.revision_id.clone(),
+            });
+            continue;
+        }
+        // (d) materialize a new local revision preserving the server id.
+        consumed.insert(server_rev.revision_id.clone());
+        new_revisions.push(server_rev.clone());
+        new_links.push(RevisionLink {
+            local: server_rev.revision_id.clone(),
+            server: server_rev.revision_id.clone(),
+        });
+    }
+
+    // Preserve purely-local revisions not yet on the server (unpushed edits), in
+    // their original order, at the tail.
+    for revision in existing {
+        if !consumed.contains(&revision.revision_id)
+            && !new_revisions
+                .iter()
+                .any(|rev| rev.revision_id == revision.revision_id)
+        {
+            new_revisions.push(revision.clone());
+        }
+    }
+
+    (new_revisions, new_links)
+}
+
+/// Author rule for reconciling an unlinked local revision with a server one —
+/// body equality is a precondition the caller already checked; this decides
+/// authorship. Never links on body alone.
+fn reconcile_ok(
+    local: &AnnotationRevision,
+    server: &AnnotationRevision,
+    hosted: Option<&str>,
+    self_local_attr: Option<&str>,
+) -> bool {
+    // (i) A revision WE pushed: locally self-authored AND server-stamped with our
+    // hosted username.
+    let pushed_by_us = self_local_attr == Some(local.attribution.as_str())
+        && hosted == Some(server.attribution.as_str());
+    // (ii) A revision we previously PULLED: local copied the server attribution +
+    // timestamp verbatim.
+    let pulled_before =
+        local.attribution == server.attribution && local.created_at == server.created_at;
+    pushed_by_us || pulled_before
+}
+
+// =========================================================================
+// Server enumeration
+// =========================================================================
+
+async fn list_server_annotations(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<Vec<ContextAnnotation>> {
+    Ok(list_server_targets(client, repo_path)
+        .await?
+        .into_iter()
+        .map(|(_, annotation)| annotation)
+        .collect())
+}
+
+async fn list_server_targets(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<Vec<(ContextTarget, ContextAnnotation)>> {
+    let response = client
+        .list_context(repo_path, None, None, None)
+        .await
+        .context("list hosted context")?;
+    let mut out = Vec::new();
+    for file in response.files {
+        let Ok(target) = ContextTarget::file(&file.path) else {
+            continue;
+        };
+        for annotation in file.annotations {
+            out.push((target.clone(), annotation));
+        }
+    }
+    for state in response.states {
+        let Some(state_id) = state_id_from_proto(state.state_id.as_ref()) else {
+            continue;
+        };
+        let target = ContextTarget::state(state_id);
+        for annotation in state.annotations {
+            out.push((target.clone(), annotation));
+        }
+    }
+    Ok(out)
 }
 
 /// `GetContextHistory` returns revisions newest-first; local storage is
@@ -649,59 +1039,9 @@ async fn fetch_history(
     Ok(revisions)
 }
 
-// =========================================================================
-// Shared server enumeration
-// =========================================================================
-
-/// Flat list of every server annotation (both file and state targets).
-async fn list_server_annotations(
-    client: &mut HostedGrpcClient,
-    repo_path: &str,
-) -> Result<Vec<ContextAnnotation>> {
-    Ok(list_server_targets(client, repo_path)
-        .await?
-        .into_iter()
-        .map(|(_, annotation)| annotation)
-        .collect())
-}
-
-/// Every server annotation paired with the local `ContextTarget` it anchors to.
-async fn list_server_targets(
-    client: &mut HostedGrpcClient,
-    repo_path: &str,
-) -> Result<Vec<(ContextTarget, ContextAnnotation)>> {
-    let response = client
-        .list_context(repo_path, None, None, None)
-        .await
-        .context("list hosted context")?;
-    let mut out = Vec::new();
-    for file in response.files {
-        let Some(target) = target_from_annotated_file(&file.path) else {
-            continue;
-        };
-        for annotation in file.annotations {
-            out.push((target.clone(), annotation));
-        }
-    }
-    for state in response.states {
-        let Some(state_id) = state_id_from_proto(state.state_id.as_ref()) else {
-            continue;
-        };
-        let target = ContextTarget::state(state_id);
-        for annotation in state.annotations {
-            out.push((target.clone(), annotation));
-        }
-    }
-    Ok(out)
-}
-
-// --- derived, deterministic client-operation-ids (idempotent retry) ---
+// --- deterministic client-operation-ids (idempotent retry) ---
 
 const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_6374_785f_7379_6e63_0001);
-
-fn set_op_id(repo_path: &str, local_id: &str) -> String {
-    uuid::Uuid::new_v5(&OP_NAMESPACE, format!("set:{repo_path}:{local_id}").as_bytes()).to_string()
-}
 
 fn revise_op_id(repo_path: &str, server_id: &str, revision_id: &str) -> String {
     uuid::Uuid::new_v5(
@@ -711,17 +1051,22 @@ fn revise_op_id(repo_path: &str, server_id: &str, revision_id: &str) -> String {
     .to_string()
 }
 
-fn supersede_op_id(repo_path: &str, superseded_id: &str, local_id: &str) -> String {
-    uuid::Uuid::new_v5(
-        &OP_NAMESPACE,
-        format!("supersede:{repo_path}:{superseded_id}:{local_id}").as_bytes(),
-    )
-    .to_string()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn rev(id: &str, attr: &str, content: &str, created_at: i64) -> AnnotationRevision {
+        AnnotationRevision {
+            revision_id: id.to_string(),
+            kind: AnnotationKind::Rationale,
+            content: content.to_string(),
+            tags: vec![],
+            attribution: attr.to_string(),
+            created_at,
+            source_hash: None,
+            created_at_state: None,
+        }
+    }
 
     #[test]
     fn scope_round_trips_through_proto() {
@@ -748,55 +1093,170 @@ mod tests {
         }
     }
 
-    // A pulled annotation carries the SERVER id as its local id, so a later push
-    // must adopt it (idempotent) rather than issue a duplicate create.
     #[test]
-    fn pull_link_uses_server_id_as_local_id() {
-        let mut mirror = HostedContextMirror::default();
-        let annotation = ContextAnnotation {
-            id: "srv-1".to_string(),
-            revision_count: 2,
-            ..Default::default()
+    fn scope_ident_ignores_resolved_lines() {
+        let a = AnnotationScope::Symbol {
+            name: "greet".to_string(),
+            resolved_lines: Some((1, 2)),
         };
-        record_pull_link(&mut mirror, "ns/repo", &annotation);
-        let entry = &mirror.repos["ns/repo"].annotations[0];
-        assert_eq!(entry.local_id, "srv-1");
-        assert_eq!(entry.server_id, "srv-1");
-        assert_eq!(entry.synced_revisions, 2);
+        let b = AnnotationScope::Symbol {
+            name: "greet".to_string(),
+            resolved_lines: None,
+        };
+        assert_eq!(scope_ident(&a), scope_ident(&b));
     }
 
-    // Distinct server ids for identical bodies from different authors must
-    // materialize as distinct annotations (no cross-author misattribution).
+    // P1-2: two clones concurrently revise one annotation. Alice already holds
+    // r1 (pulled) and her own r3 (linked to server sA3); Bob's r2 arrives in the
+    // middle. Pull must yield all three in SERVER order, keep Alice's local id
+    // for sA3, materialize Bob's, and neither drop nor duplicate anything.
     #[test]
-    fn identical_bodies_distinct_ids_materialize_separately() {
-        let rev = |who: &str| AnnotationRevision {
-            revision_id: format!("r-{who}"),
-            kind: AnnotationKind::Rationale,
-            content: "lgtm".to_string(),
-            tags: vec![],
-            attribution: format!("{who} <>"),
-            created_at: 1,
-            source_hash: None,
-            created_at_state: None,
-        };
-        let a = materialize_annotation(
-            &ContextAnnotation {
-                id: "srv-a".to_string(),
-                revision_count: 1,
-                ..Default::default()
+    fn pull_two_author_revisions_no_loss_no_dup_server_order() {
+        let existing = vec![
+            rev("sA1", "alice <>", "v1", 1), // pulled earlier (local id == server id)
+            rev("rA3-local", "Alice <a@x>", "v3", 30), // Alice's own, linked to sA3
+        ];
+        let existing_links = vec![
+            RevisionLink {
+                local: "sA1".into(),
+                server: "sA1".into(),
             },
-            vec![rev("alice")],
-        );
-        let b = materialize_annotation(
-            &ContextAnnotation {
-                id: "srv-b".to_string(),
-                revision_count: 1,
-                ..Default::default()
+            RevisionLink {
+                local: "rA3-local".into(),
+                server: "sA3".into(),
             },
-            vec![rev("bob")],
+        ];
+        let server_revs = vec![
+            rev("sA1", "alice <>", "v1", 1),
+            rev("sB2", "bob <>", "v2-bob", 20), // Bob's revision, not yet local
+            rev("sA3", "alice <>", "v3", 30),   // Alice's own, came back stamped
+        ];
+        let (new_revisions, new_links) = reconcile_revisions_pull(
+            &existing,
+            &server_revs,
+            &existing_links,
+            Some("Alice <a@x>"),
+            Some("alice"),
         );
-        assert_ne!(a.annotation_id, b.annotation_id);
-        assert_eq!(a.revisions[0].attribution, "alice <>");
-        assert_eq!(b.revisions[0].attribution, "bob <>");
+        let ids: Vec<&str> = new_revisions.iter().map(|r| r.revision_id.as_str()).collect();
+        // Server order, Alice's local id preserved for sA3, Bob materialized.
+        assert_eq!(ids, vec!["sA1", "sB2", "rA3-local"]);
+        let contents: Vec<&str> = new_revisions.iter().map(|r| r.content.as_str()).collect();
+        assert_eq!(contents, vec!["v1", "v2-bob", "v3"]);
+        // No duplicates.
+        let unique: HashSet<&str> = ids.iter().copied().collect();
+        assert_eq!(unique.len(), 3);
+        // Every server revision is linked.
+        assert_eq!(new_links.len(), 3);
+    }
+
+    // P2-4 hazard at the revision layer: identical body from two DIFFERENT
+    // authors must not cross-link. Alice's own local, unpushed "lgtm" must NOT be
+    // consumed by Bob's server "lgtm"; Bob's materializes distinctly and Alice's
+    // survives at the tail (so a later push still publishes it).
+    #[test]
+    fn pull_rejects_cross_author_identical_body() {
+        let existing = vec![rev("rLocal", "Alice <a@x>", "lgtm", 5)];
+        let server_revs = vec![rev("sBob", "bob <>", "lgtm", 9)];
+        let (new_revisions, _links) = reconcile_revisions_pull(
+            &existing,
+            &server_revs,
+            &[],
+            Some("Alice <a@x>"),
+            Some("alice"),
+        );
+        let ids: HashSet<&str> = new_revisions.iter().map(|r| r.revision_id.as_str()).collect();
+        assert_eq!(new_revisions.len(), 2, "both must survive, none collapsed");
+        assert!(ids.contains("sBob"), "Bob's revision materialized distinctly");
+        assert!(ids.contains("rLocal"), "Alice's local revision preserved");
+    }
+
+    // A revision WE pushed comes back stamped with our hosted username → links
+    // (rule i), so pull does not duplicate it.
+    #[test]
+    fn pull_relinks_our_pushed_revision_after_lost_mirror() {
+        let existing = vec![rev("rMine", "Alice <a@x>", "ship it", 40)];
+        let server_revs = vec![rev("sMine", "alice <>", "ship it", 40)];
+        let (new_revisions, links) = reconcile_revisions_pull(
+            &existing,
+            &server_revs,
+            &[], // mirror lost
+            Some("Alice <a@x>"),
+            Some("alice"),
+        );
+        assert_eq!(new_revisions.len(), 1, "no duplicate of our own revision");
+        assert_eq!(new_revisions[0].revision_id, "rMine", "local id preserved");
+        assert_eq!(links[0].local, "rMine");
+        assert_eq!(links[0].server, "sMine");
+    }
+
+    #[test]
+    fn reconcile_ok_rules() {
+        // `hosted` is the server-stamped self attribution ("{username} <>"), as
+        // `reconcile_revisions_pull` passes it.
+        let hosted = Some("alice <>");
+        let me = Some("Alice <a@x>");
+        // (i) pushed by us: self-authored local + hosted-stamped server.
+        assert!(reconcile_ok(
+            &rev("l", "Alice <a@x>", "x", 1),
+            &rev("s", "alice <>", "x", 999),
+            hosted,
+            me,
+        ));
+        // (i) fails when the server author is a DIFFERENT hosted user.
+        assert!(!reconcile_ok(
+            &rev("l", "Alice <a@x>", "x", 1),
+            &rev("s", "bob <>", "x", 1),
+            hosted,
+            me,
+        ));
+        // (ii) pulled before: attribution + timestamp copied verbatim.
+        assert!(reconcile_ok(
+            &rev("l", "bob <>", "x", 7),
+            &rev("s", "bob <>", "x", 7),
+            hosted,
+            me,
+        ));
+        // (ii) fails on a timestamp mismatch.
+        assert!(!reconcile_ok(
+            &rev("l", "bob <>", "x", 7),
+            &rev("s", "bob <>", "x", 8),
+            hosted,
+            me,
+        ));
+    }
+
+    // P1-3: supersedes_annotation_id is a LOCAL id and must resolve to the SERVER
+    // id through the mirror (both the pushed case, local != server, and the
+    // pulled case, local == server).
+    #[test]
+    fn supersede_resolves_local_to_server_through_mirror() {
+        let mut mirror = HostedContextMirror::default();
+        // Pushed annotation: local uuid differs from the server id.
+        get_or_create_entry(&mut mirror, "ns/repo", "local-old").server_id = "srv-old".into();
+        // Pulled annotation: local id == server id.
+        get_or_create_entry(&mut mirror, "ns/repo", "srv-pulled").server_id = "srv-pulled".into();
+
+        assert_eq!(
+            server_id_for_local(&mirror, "ns/repo", "local-old"),
+            Some("srv-old".to_string()),
+        );
+        assert_eq!(
+            server_id_for_local(&mirror, "ns/repo", "srv-pulled"),
+            Some("srv-pulled".to_string()),
+        );
+        // An in-flight create (empty server id) does not resolve.
+        get_or_create_entry(&mut mirror, "ns/repo", "in-flight").pending_create_op = Some("op".into());
+        assert_eq!(server_id_for_local(&mirror, "ns/repo", "in-flight"), None);
+    }
+
+    // Minted-id recovery must not adopt a server id that is already linked to a
+    // different local annotation (the re-link-safe / concurrent-writer guard).
+    #[test]
+    fn server_id_is_linked_detects_prior_links() {
+        let mut mirror = HostedContextMirror::default();
+        get_or_create_entry(&mut mirror, "ns/repo", "local-a").server_id = "srv-1".into();
+        assert!(server_id_is_linked(&mirror, "ns/repo", "srv-1"));
+        assert!(!server_id_is_linked(&mirror, "ns/repo", "srv-2"));
     }
 }

--- a/crates/cli/src/client/context_sync.rs
+++ b/crates/cli/src/client/context_sync.rs
@@ -257,23 +257,22 @@ pub async fn push_context(
             .map(|attribution| attribution.to_string());
 
     let mut mirror = load_mirror(repo.heddle_dir())?;
-    // Server annotation ids currently known (initial ListContext + mirror), so
-    // a `SetContext`'s freshly-minted id can be spotted as the one NOT already
-    // seen, and a pulled annotation (local id == server id) is recognized as
-    // already-hosted without a duplicate create.
-    let mut known_server_ids: HashSet<String> = mirror
-        .repos
-        .get(repo_path)
-        .map(|repo_mirror| {
-            repo_mirror
-                .annotations
-                .iter()
-                .map(|entry| entry.server_id.clone())
-                .collect()
-        })
-        .unwrap_or_default();
+    // `server_counts`: id → revision_count the server currently holds (from the
+    // initial ListContext). Lets the adopt path (a pulled annotation whose local
+    // id == server id) forward only the revisions the server is actually missing,
+    // even with no mirror row. `known_ids` additionally folds in mirror server
+    // ids so a `SetContext`'s freshly-minted id is spotted as the one NOT already
+    // known.
+    let mut server_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
     for annotation in list_server_annotations(client, repo_path).await? {
-        known_server_ids.insert(annotation.id);
+        server_counts.insert(annotation.id, annotation.revision_count as usize);
+    }
+    let mut known_ids: HashSet<String> = server_counts.keys().cloned().collect();
+    if let Some(repo_mirror) = mirror.repos.get(repo_path) {
+        for entry in &repo_mirror.annotations {
+            known_ids.insert(entry.server_id.clone());
+        }
     }
 
     let mut synced = 0usize;
@@ -286,7 +285,8 @@ pub async fn push_context(
                 annotation,
                 self_attribution.as_deref(),
                 &mut mirror,
-                &mut known_server_ids,
+                &server_counts,
+                &mut known_ids,
             )
             .await;
             save_mirror(repo.heddle_dir(), &mirror)?;
@@ -315,7 +315,8 @@ async fn push_one(
     annotation: &Annotation,
     self_attribution: Option<&str>,
     mirror: &mut HostedContextMirror,
-    known_server_ids: &mut HashSet<String>,
+    server_counts: &std::collections::HashMap<String, usize>,
+    known_ids: &mut HashSet<String>,
 ) -> Result<bool> {
     let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
     let linked = repo_mirror
@@ -323,23 +324,26 @@ async fn push_one(
         .iter()
         .position(|entry| entry.local_id == annotation.annotation_id);
 
-    // Resolve the server id + how many revisions are already synced.
-    let (server_id, mut synced_revisions) = match linked {
+    // Resolve the server id, how many revisions are already synced, and whether
+    // this call created a new server annotation.
+    let (server_id, mut synced_revisions, created) = match linked {
         Some(index) => (
             repo_mirror.annotations[index].server_id.clone(),
             repo_mirror.annotations[index].synced_revisions,
+            false,
         ),
-        None if known_server_ids.contains(&annotation.annotation_id) => {
+        None if server_counts.contains_key(&annotation.annotation_id) => {
             // Pulled / pack-delivered: local id IS the server id. Adopt it
             // without a duplicate create (idempotent even with no mirror row).
-            let synced = annotation.revisions.len();
+            // Sync from the server's actual revision count so any revision we
+            // added locally after the pull is still forwarded.
+            let synced = server_counts[&annotation.annotation_id];
             repo_mirror.annotations.push(ContextMirrorEntry {
                 local_id: annotation.annotation_id.clone(),
                 server_id: annotation.annotation_id.clone(),
                 synced_revisions: synced,
             });
-            // Nothing new to push for the create; fall through to revisions.
-            (annotation.annotation_id.clone(), synced)
+            (annotation.annotation_id.clone(), synced, false)
         }
         None => {
             // Genuinely new annotation → create it. Fail-closed self filter.
@@ -357,20 +361,22 @@ async fn push_one(
                 return Ok(false);
             }
             let server_id =
-                create_on_server(client, repo_path, target, annotation, known_server_ids).await?;
-            known_server_ids.insert(server_id.clone());
+                create_on_server(client, repo_path, target, annotation, known_ids).await?;
+            known_ids.insert(server_id.clone());
             let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
             repo_mirror.annotations.push(ContextMirrorEntry {
                 local_id: annotation.annotation_id.clone(),
                 server_id: server_id.clone(),
                 synced_revisions: 1,
             });
-            (server_id, 1)
+            (server_id, 1, true)
         }
     };
 
     // Forward any revisions the server does not yet hold (linear append).
-    let mut pushed_any = synced_revisions == 1 && linked.is_none();
+    // "Pushed" = we created the annotation OR forwarded at least one revision;
+    // adopting an already-hosted annotation with nothing new is not a push.
+    let mut pushed_any = created;
     while synced_revisions < annotation.revisions.len() {
         let revision = &annotation.revisions[synced_revisions];
         client

--- a/crates/cli/src/client/context_sync.rs
+++ b/crates/cli/src/client/context_sync.rs
@@ -1,0 +1,796 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hosted context (annotation) sync bridge.
+//!
+//! Local context annotations live in per-state `Context` attachments
+//! (`ContextBlob`s keyed by target). The hosted weft `RepositoryService` speaks
+//! an id-keyed annotation model with the SAME `Annotation` shape, mutated
+//! through the caller-authenticated `SetContext`/`ReviseContext`/
+//! `SupersedeContext` RPCs and read back through `ListContext`/
+//! `GetContextHistory`. This module bridges the two, mirroring
+//! [`crate::client::discussion_sync`]:
+//!
+//! * **Push (write path):** after a successful `heddle push`, replay the
+//!   annotations we authored to the server. #549 rejects `Context` attachments
+//!   in the pack, so an annotation only reaches the server through these RPCs.
+//! * **Pull/clone (read path):** after a successful clone/pull, `ListContext`
+//!   the head and materialize any server annotation/revision we don't already
+//!   hold into the local `Context` attachment so `context list` sees it.
+//!
+//! ## Identity is by the annotation's stable id — NOT ordinal counts
+//!
+//! Unlike discussion turns (whose only cross-side identity was a fragile
+//! ordinal), a context annotation carries a globally-unique `annotation_id`.
+//! Crucially, when the server ships an annotation back on a pull, the pack
+//! carries the server's `Annotation` verbatim, so the **local** annotation id
+//! IS the server id. That collapses the cross-side identity problem: a pulled
+//! annotation and its server twin share one id, and the cross-author
+//! identical-body hazard (two "lgtm" annotations from different authors) is
+//! trivially safe — distinct server ids materialize as distinct local
+//! annotations, so a body can never be misattributed.
+//!
+//! The mirror map (`.heddle/collaboration/hosted-context-mirror.json`) records,
+//! per repo, `local_annotation_id ↔ server_annotation_id` plus a count of
+//! revisions already synced (revisions are append-only and linear). A locally
+//! authored annotation is created with a fresh uuid, so its local id differs
+//! from the server id the RPC mints; the mirror is what maps the two so a
+//! re-push revises instead of re-creating.
+//!
+//! ## Push is idempotent even with no mirror
+//!
+//! Before creating an annotation, push checks whether the server ALREADY holds
+//! one with that id (the pulled/pack-delivered case, where local id == server
+//! id). If so it links and revises rather than issuing a duplicate `SetContext`.
+//! This makes a lost mirror self-heal instead of doubling annotations.
+//!
+//! ## Fail-closed self filter
+//!
+//! A fresh annotation is created on the server only when we can attribute it to
+//! the local principal (`SetContext`/`SupersedeContext` stamp the server-side
+//! attribution with our own hosted username). Revisions to an *already-hosted*
+//! annotation are always forwarded — a revision is a local edit the server
+//! re-attributes to the caller, exactly the collaborative-edit case.
+//!
+//! ## weft#638 / weft#640 limits (degrade gracefully, don't fix here)
+//!
+//! Each `SetContext`/`Revise`/`Supersede` advances the server head (context
+//! lives per-state, no carry-forward), so a repo effectively tracks one state's
+//! context; a no-HEAD repo is skipped. `SetContext` does not return the minted
+//! id, so push discovers it by diffing `ListContext` before/after — precise for
+//! the real multi-writer case but ambiguous between two identical annotations
+//! authored in the same push (weft#640, same-user-identical edge). The mirror is
+//! saved after every annotation and on the error path, collect-and-continue, so
+//! one wedged annotation never aborts the rest or orphans a durable write.
+//!
+//! Scope: annotations only. `rm` is not mirrored (removal is local-only).
+
+#![cfg(feature = "client")]
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use api::heddle::api::v1alpha1::{
+    AnnotationScope as ProtoScope, ContextAnnotation, ContextAnnotationKind, ContextAnnotationStatus,
+    LineRange, SymbolScope, annotation_scope::Scope,
+};
+use objects::fs_atomic::write_file_atomic;
+use objects::object::{
+    Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus, ContentHash,
+    ContextBlob, ContextTarget, State, StateId,
+};
+use objects::store::ObjectStore;
+use repo::Repository;
+use serde::{Deserialize, Serialize};
+
+use crate::client::HostedGrpcClient;
+use crate::cli::commands::context::{context_root_for_state, put_context_attachment};
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct HostedContextMirror {
+    #[serde(default)]
+    repos: BTreeMap<String, RepoContextMirror>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct RepoContextMirror {
+    #[serde(default)]
+    annotations: Vec<ContextMirrorEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ContextMirrorEntry {
+    /// Local `annotation_id`.
+    local_id: String,
+    /// Server-assigned `annotation_id` (== `local_id` for pulled annotations).
+    server_id: String,
+    /// Count of revisions known present on BOTH sides. Revisions are linear and
+    /// append-only, so a prefix count is a faithful link.
+    #[serde(default)]
+    synced_revisions: usize,
+}
+
+fn mirror_path(heddle_dir: &Path) -> PathBuf {
+    heddle_dir
+        .join("collaboration")
+        .join("hosted-context-mirror.json")
+}
+
+fn load_mirror(heddle_dir: &Path) -> Result<HostedContextMirror> {
+    match fs::read(mirror_path(heddle_dir)) {
+        Ok(bytes) => serde_json::from_slice(&bytes).context("decode hosted context mirror map"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(HostedContextMirror::default())
+        }
+        Err(error) => Err(error).context("read hosted context mirror map"),
+    }
+}
+
+fn save_mirror(heddle_dir: &Path, mirror: &HostedContextMirror) -> Result<()> {
+    let path = mirror_path(heddle_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create collaboration dir")?;
+    }
+    let bytes = serde_json::to_vec_pretty(mirror).context("encode hosted context mirror map")?;
+    write_file_atomic(&path, &bytes).context("write hosted context mirror map")?;
+    Ok(())
+}
+
+// --- scope / kind converters (local <-> proto) ---
+
+fn scope_to_proto(scope: &AnnotationScope) -> ProtoScope {
+    let inner = match scope {
+        AnnotationScope::File => Scope::File(true),
+        AnnotationScope::Symbol {
+            name,
+            resolved_lines,
+        } => Scope::Symbol(SymbolScope {
+            name: name.clone(),
+            resolved_start: resolved_lines.map(|(start, _)| start),
+            resolved_end: resolved_lines.map(|(_, end)| end),
+        }),
+        AnnotationScope::Lines(start, end) => Scope::Lines(LineRange {
+            start: *start,
+            end: *end,
+        }),
+    };
+    ProtoScope { scope: Some(inner) }
+}
+
+fn scope_from_proto(scope: Option<&ProtoScope>) -> AnnotationScope {
+    match scope.and_then(|s| s.scope.as_ref()) {
+        Some(Scope::File(_)) | None => AnnotationScope::File,
+        Some(Scope::Symbol(symbol)) => AnnotationScope::Symbol {
+            name: symbol.name.clone(),
+            resolved_lines: match (symbol.resolved_start, symbol.resolved_end) {
+                (Some(start), Some(end)) => Some((start, end)),
+                _ => None,
+            },
+        },
+        Some(Scope::Lines(range)) => AnnotationScope::Lines(range.start, range.end),
+    }
+}
+
+fn kind_to_proto(kind: AnnotationKind) -> ContextAnnotationKind {
+    match kind {
+        AnnotationKind::Constraint => ContextAnnotationKind::Constraint,
+        AnnotationKind::Invariant => ContextAnnotationKind::Invariant,
+        AnnotationKind::Rationale => ContextAnnotationKind::Rationale,
+    }
+}
+
+fn kind_from_proto(kind: i32) -> AnnotationKind {
+    match ContextAnnotationKind::try_from(kind).unwrap_or(ContextAnnotationKind::Rationale) {
+        ContextAnnotationKind::Constraint => AnnotationKind::Constraint,
+        ContextAnnotationKind::Invariant => AnnotationKind::Invariant,
+        ContextAnnotationKind::Rationale | ContextAnnotationKind::Unspecified => {
+            AnnotationKind::Rationale
+        }
+    }
+}
+
+fn status_from_proto(status: i32) -> AnnotationStatus {
+    match ContextAnnotationStatus::try_from(status).unwrap_or(ContextAnnotationStatus::Active) {
+        ContextAnnotationStatus::Superseded => AnnotationStatus::Superseded,
+        _ => AnnotationStatus::Active,
+    }
+}
+
+/// `(path, target_state_id)` operands for the RPCs, from a local target.
+fn target_operands(target: &ContextTarget) -> (String, Option<String>) {
+    match target {
+        ContextTarget::File { path } => (path.clone(), None),
+        ContextTarget::State { state_id } => (String::new(), Some(state_id.to_string_full())),
+    }
+}
+
+fn target_from_annotated_file(path: &str) -> Option<ContextTarget> {
+    ContextTarget::file(path).ok()
+}
+
+fn content_hash_from_bytes(bytes: &Option<Vec<u8>>) -> Option<ContentHash> {
+    bytes
+        .as_ref()
+        .and_then(|raw| <[u8; 32]>::try_from(raw.as_slice()).ok())
+        .map(ContentHash::from_bytes)
+}
+
+fn state_id_from_proto(id: Option<&api::heddle::api::v1alpha1::StateId>) -> Option<StateId> {
+    id.and_then(|value| StateId::try_from_slice(&value.value).ok())
+}
+
+// =========================================================================
+// Push
+// =========================================================================
+
+/// Publish local annotations we authored to the hosted `RepositoryService`.
+/// Saves the mirror after each annotation and continues past a per-annotation
+/// failure (warn-and-skip).
+pub async fn push_context(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<usize> {
+    let Some(head_id) = repo.head().context("resolve repository head")? else {
+        // weft#638: no HEAD → no state to attach annotations against.
+        return Ok(0);
+    };
+    let Some(head_state) = repo.store().get_state(&head_id).context("load head state")? else {
+        return Ok(0);
+    };
+    let Some(context_root) = context_root_for_state(repo, &head_state)? else {
+        return Ok(0);
+    };
+    let entries = repo
+        .list_context_entries(&context_root, None)
+        .context("enumerate local context annotations")?;
+    if entries.is_empty() {
+        return Ok(0);
+    }
+
+    let user_config = crate::config::UserConfig::load_default().unwrap_or_default();
+    let self_attribution =
+        crate::cli::commands::snapshot::resolve_attribution(repo, &user_config)
+            .ok()
+            .map(|attribution| attribution.to_string());
+
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    // Server annotation ids currently known (initial ListContext + mirror), so
+    // a `SetContext`'s freshly-minted id can be spotted as the one NOT already
+    // seen, and a pulled annotation (local id == server id) is recognized as
+    // already-hosted without a duplicate create.
+    let mut known_server_ids: HashSet<String> = mirror
+        .repos
+        .get(repo_path)
+        .map(|repo_mirror| {
+            repo_mirror
+                .annotations
+                .iter()
+                .map(|entry| entry.server_id.clone())
+                .collect()
+        })
+        .unwrap_or_default();
+    for annotation in list_server_annotations(client, repo_path).await? {
+        known_server_ids.insert(annotation.id);
+    }
+
+    let mut synced = 0usize;
+    for entry in &entries {
+        for annotation in &entry.blob.annotations {
+            let result = push_one(
+                client,
+                repo_path,
+                &entry.target,
+                annotation,
+                self_attribution.as_deref(),
+                &mut mirror,
+                &mut known_server_ids,
+            )
+            .await;
+            save_mirror(repo.heddle_dir(), &mirror)?;
+            match result {
+                Ok(true) => synced += 1,
+                Ok(false) => {}
+                Err(error) => {
+                    eprintln!(
+                        "{} hosted context {}: {error:#}",
+                        crate::cli::style::warn_marker(),
+                        annotation.annotation_id
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(synced)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn push_one(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    target: &ContextTarget,
+    annotation: &Annotation,
+    self_attribution: Option<&str>,
+    mirror: &mut HostedContextMirror,
+    known_server_ids: &mut HashSet<String>,
+) -> Result<bool> {
+    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+    let linked = repo_mirror
+        .annotations
+        .iter()
+        .position(|entry| entry.local_id == annotation.annotation_id);
+
+    // Resolve the server id + how many revisions are already synced.
+    let (server_id, mut synced_revisions) = match linked {
+        Some(index) => (
+            repo_mirror.annotations[index].server_id.clone(),
+            repo_mirror.annotations[index].synced_revisions,
+        ),
+        None if known_server_ids.contains(&annotation.annotation_id) => {
+            // Pulled / pack-delivered: local id IS the server id. Adopt it
+            // without a duplicate create (idempotent even with no mirror row).
+            let synced = annotation.revisions.len();
+            repo_mirror.annotations.push(ContextMirrorEntry {
+                local_id: annotation.annotation_id.clone(),
+                server_id: annotation.annotation_id.clone(),
+                synced_revisions: synced,
+            });
+            // Nothing new to push for the create; fall through to revisions.
+            (annotation.annotation_id.clone(), synced)
+        }
+        None => {
+            // Genuinely new annotation → create it. Fail-closed self filter.
+            let first = annotation
+                .revisions
+                .first()
+                .context("annotation has no revisions")?;
+            let is_self = self_attribution.is_some_and(|me| me == first.attribution);
+            if !is_self {
+                eprintln!(
+                    "{} hosted context {}: not attributed to the local principal; left unpublished",
+                    crate::cli::style::warn_marker(),
+                    annotation.annotation_id
+                );
+                return Ok(false);
+            }
+            let server_id =
+                create_on_server(client, repo_path, target, annotation, known_server_ids).await?;
+            known_server_ids.insert(server_id.clone());
+            let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+            repo_mirror.annotations.push(ContextMirrorEntry {
+                local_id: annotation.annotation_id.clone(),
+                server_id: server_id.clone(),
+                synced_revisions: 1,
+            });
+            (server_id, 1)
+        }
+    };
+
+    // Forward any revisions the server does not yet hold (linear append).
+    let mut pushed_any = synced_revisions == 1 && linked.is_none();
+    while synced_revisions < annotation.revisions.len() {
+        let revision = &annotation.revisions[synced_revisions];
+        client
+            .revise_context(
+                repo_path,
+                &server_id,
+                &revision.content,
+                revision.tags.clone(),
+                None,
+                None,
+                kind_to_proto(revision.kind),
+                revise_op_id(repo_path, &server_id, &revision.revision_id),
+            )
+            .await
+            .with_context(|| format!("revise hosted annotation {server_id}"))?;
+        synced_revisions += 1;
+        pushed_any = true;
+    }
+
+    // Persist the (possibly advanced) revision count.
+    if let Some(entry) = mirror
+        .repos
+        .get_mut(repo_path)
+        .and_then(|repo_mirror| {
+            repo_mirror
+                .annotations
+                .iter_mut()
+                .find(|entry| entry.local_id == annotation.annotation_id)
+        })
+    {
+        entry.synced_revisions = synced_revisions;
+    }
+
+    Ok(pushed_any)
+}
+
+/// Create a fresh annotation on the server and return its minted id.
+///
+/// `SetContext`/`SupersedeContext` do not both return the id, so a plain
+/// `SetContext` is followed by a before/after `ListContext` diff to recover it
+/// (`SupersedeContext` returns the new id directly).
+async fn create_on_server(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    target: &ContextTarget,
+    annotation: &Annotation,
+    known_server_ids: &HashSet<String>,
+) -> Result<String> {
+    let first = annotation
+        .revisions
+        .first()
+        .context("annotation has no revisions")?;
+    let (path, target_state_id) = target_operands(target);
+
+    // Supersession maps to `SupersedeContext` when the superseded annotation is
+    // already on the server (linked or pulled). Otherwise it degrades to a
+    // plain create (the chain link is lost server-side but the content lands).
+    if let Some(superseded_local) = &annotation.supersedes_annotation_id
+        && known_server_ids.contains(superseded_local)
+    {
+        let response = client
+            .supersede_context(
+                repo_path,
+                superseded_local,
+                if path.is_empty() { None } else { Some(path.as_str()) },
+                target_state_id.as_deref(),
+                scope_to_proto(&annotation.scope),
+                first.tags.clone(),
+                &first.content,
+                None,
+                None,
+                kind_to_proto(first.kind),
+                supersede_op_id(repo_path, superseded_local, &annotation.annotation_id),
+            )
+            .await
+            .with_context(|| format!("supersede hosted annotation {superseded_local}"))?;
+        return Ok(response.new_annotation_id);
+    }
+
+    client
+        .set_context(
+            repo_path,
+            &path,
+            target_state_id.as_deref(),
+            scope_to_proto(&annotation.scope),
+            kind_to_proto(first.kind),
+            first.tags.clone(),
+            &first.content,
+            None,
+            None,
+            set_op_id(repo_path, &annotation.annotation_id),
+        )
+        .await
+        .with_context(|| format!("set hosted context for {}", annotation.annotation_id))?;
+
+    // Recover the minted id: the one annotation now present at the target that
+    // we did not already know about.
+    let after = list_server_annotations(client, repo_path).await?;
+    after
+        .into_iter()
+        .rev()
+        .find(|candidate| {
+            !known_server_ids.contains(&candidate.id) && candidate.content == first.content
+        })
+        .map(|candidate| candidate.id)
+        .context("could not recover the minted annotation id after SetContext")
+}
+
+// =========================================================================
+// Pull
+// =========================================================================
+
+/// Fetch hosted annotations for the repository head and materialize any
+/// annotation/revision we do not already hold. Saves the mirror after each
+/// annotation and continues past a per-annotation failure.
+pub async fn pull_context(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<usize> {
+    let Some(head_id) = repo.head().context("resolve repository head")? else {
+        return Ok(0);
+    };
+    let Some(head_state) = repo.store().get_state(&head_id).context("load head state")? else {
+        return Ok(0);
+    };
+
+    let server = list_server_targets(client, repo_path).await?;
+    if server.is_empty() {
+        return Ok(0);
+    }
+
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let mut changed = 0usize;
+    for (target, annotation) in server {
+        let result = pull_one(repo, client, repo_path, &head_state, &target, &annotation).await;
+        // Record the link regardless (local id == server id for pulled annots),
+        // so a later push adopts it instead of re-creating.
+        record_pull_link(&mut mirror, repo_path, &annotation);
+        save_mirror(repo.heddle_dir(), &mirror)?;
+        match result {
+            Ok(true) => changed += 1,
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!(
+                    "{} hosted context {}: {error:#}",
+                    crate::cli::style::warn_marker(),
+                    annotation.id
+                );
+            }
+        }
+    }
+
+    Ok(changed)
+}
+
+fn record_pull_link(
+    mirror: &mut HostedContextMirror,
+    repo_path: &str,
+    annotation: &ContextAnnotation,
+) {
+    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+    let synced = annotation.revision_count as usize;
+    match repo_mirror
+        .annotations
+        .iter_mut()
+        .find(|entry| entry.server_id == annotation.id)
+    {
+        Some(entry) => entry.synced_revisions = entry.synced_revisions.max(synced),
+        None => repo_mirror.annotations.push(ContextMirrorEntry {
+            local_id: annotation.id.clone(),
+            server_id: annotation.id.clone(),
+            synced_revisions: synced,
+        }),
+    }
+}
+
+async fn pull_one(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    head_state: &State,
+    target: &ContextTarget,
+    server: &ContextAnnotation,
+) -> Result<bool> {
+    // The pack may have already delivered this annotation (local id == server
+    // id). Load the current local blob at the target and reconcile by id.
+    let context_root = context_root_for_state(repo, head_state)?;
+    let mut blob = match &context_root {
+        Some(root) => repo
+            .get_context_blob(root, target)?
+            .unwrap_or_else(|| ContextBlob::new(vec![])),
+        None => ContextBlob::new(vec![]),
+    };
+
+    let existing = blob
+        .annotations
+        .iter()
+        .position(|annotation| annotation.annotation_id == server.id);
+
+    match existing {
+        Some(index) => {
+            // Already present (pack-delivered or previously pulled). Append only
+            // the revisions the server has beyond what we hold.
+            if server.revision_count as usize <= blob.annotations[index].revisions.len() {
+                return Ok(false);
+            }
+            let history = fetch_history(client, repo_path, &server.id).await?;
+            let local = &mut blob.annotations[index];
+            let start = local.revisions.len();
+            for revision in history.into_iter().skip(start) {
+                local.revisions.push(revision);
+            }
+            local.status = status_from_proto(server.status);
+        }
+        None => {
+            // New annotation → materialize the full history, preserving the
+            // server annotation id and per-revision authorship/timestamps.
+            let revisions = fetch_history(client, repo_path, &server.id).await?;
+            blob.annotations.push(materialize_annotation(server, revisions));
+        }
+    }
+
+    let new_root = repo.set_context_blob(context_root.as_ref(), target, &blob)?;
+    put_context_attachment(repo, head_state, Some(new_root))?;
+    Ok(true)
+}
+
+/// Build a local `Annotation` from a server annotation + its (oldest-first)
+/// revisions, preserving the server id.
+fn materialize_annotation(server: &ContextAnnotation, revisions: Vec<AnnotationRevision>) -> Annotation {
+    Annotation {
+        annotation_id: server.id.clone(),
+        scope: scope_from_proto(server.scope.as_ref()),
+        status: status_from_proto(server.status),
+        revisions,
+        supersedes_annotation_id: server.supersedes_annotation_id.clone(),
+        supersedes_rewrite_pct: server.supersedes_rewrite_pct,
+        visibility: objects::object::VisibilityTier::default(),
+        resolved_from_discussion: None,
+    }
+}
+
+/// `GetContextHistory` returns revisions newest-first; local storage is
+/// oldest-first, so reverse.
+async fn fetch_history(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    annotation_id: &str,
+) -> Result<Vec<AnnotationRevision>> {
+    let history = client
+        .get_context_history(repo_path, None, annotation_id)
+        .await
+        .with_context(|| format!("fetch hosted annotation history {annotation_id}"))?;
+    let mut revisions: Vec<AnnotationRevision> = history
+        .revisions
+        .into_iter()
+        .map(|revision| AnnotationRevision {
+            revision_id: revision.revision_id,
+            kind: kind_from_proto(revision.kind),
+            content: revision.content,
+            tags: revision.tags,
+            attribution: revision.attribution,
+            created_at: revision.created_at.map(|ts| ts.seconds).unwrap_or(0),
+            source_hash: content_hash_from_bytes(&revision.source_hash),
+            created_at_state: state_id_from_proto(revision.created_at_state.as_ref()),
+        })
+        .collect();
+    revisions.reverse();
+    Ok(revisions)
+}
+
+// =========================================================================
+// Shared server enumeration
+// =========================================================================
+
+/// Flat list of every server annotation (both file and state targets).
+async fn list_server_annotations(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<Vec<ContextAnnotation>> {
+    Ok(list_server_targets(client, repo_path)
+        .await?
+        .into_iter()
+        .map(|(_, annotation)| annotation)
+        .collect())
+}
+
+/// Every server annotation paired with the local `ContextTarget` it anchors to.
+async fn list_server_targets(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<Vec<(ContextTarget, ContextAnnotation)>> {
+    let response = client
+        .list_context(repo_path, None, None, None)
+        .await
+        .context("list hosted context")?;
+    let mut out = Vec::new();
+    for file in response.files {
+        let Some(target) = target_from_annotated_file(&file.path) else {
+            continue;
+        };
+        for annotation in file.annotations {
+            out.push((target.clone(), annotation));
+        }
+    }
+    for state in response.states {
+        let Some(state_id) = state_id_from_proto(state.state_id.as_ref()) else {
+            continue;
+        };
+        let target = ContextTarget::state(state_id);
+        for annotation in state.annotations {
+            out.push((target.clone(), annotation));
+        }
+    }
+    Ok(out)
+}
+
+// --- derived, deterministic client-operation-ids (idempotent retry) ---
+
+const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_6374_785f_7379_6e63_0001);
+
+fn set_op_id(repo_path: &str, local_id: &str) -> String {
+    uuid::Uuid::new_v5(&OP_NAMESPACE, format!("set:{repo_path}:{local_id}").as_bytes()).to_string()
+}
+
+fn revise_op_id(repo_path: &str, server_id: &str, revision_id: &str) -> String {
+    uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("revise:{repo_path}:{server_id}:{revision_id}").as_bytes(),
+    )
+    .to_string()
+}
+
+fn supersede_op_id(repo_path: &str, superseded_id: &str, local_id: &str) -> String {
+    uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("supersede:{repo_path}:{superseded_id}:{local_id}").as_bytes(),
+    )
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scope_round_trips_through_proto() {
+        for scope in [
+            AnnotationScope::File,
+            AnnotationScope::Symbol {
+                name: "run".to_string(),
+                resolved_lines: Some((3, 9)),
+            },
+            AnnotationScope::Lines(10, 20),
+        ] {
+            assert_eq!(scope_from_proto(Some(&scope_to_proto(&scope))), scope);
+        }
+    }
+
+    #[test]
+    fn kind_round_trips_through_proto() {
+        for kind in [
+            AnnotationKind::Constraint,
+            AnnotationKind::Invariant,
+            AnnotationKind::Rationale,
+        ] {
+            assert_eq!(kind_from_proto(kind_to_proto(kind) as i32), kind);
+        }
+    }
+
+    // A pulled annotation carries the SERVER id as its local id, so a later push
+    // must adopt it (idempotent) rather than issue a duplicate create.
+    #[test]
+    fn pull_link_uses_server_id_as_local_id() {
+        let mut mirror = HostedContextMirror::default();
+        let annotation = ContextAnnotation {
+            id: "srv-1".to_string(),
+            revision_count: 2,
+            ..Default::default()
+        };
+        record_pull_link(&mut mirror, "ns/repo", &annotation);
+        let entry = &mirror.repos["ns/repo"].annotations[0];
+        assert_eq!(entry.local_id, "srv-1");
+        assert_eq!(entry.server_id, "srv-1");
+        assert_eq!(entry.synced_revisions, 2);
+    }
+
+    // Distinct server ids for identical bodies from different authors must
+    // materialize as distinct annotations (no cross-author misattribution).
+    #[test]
+    fn identical_bodies_distinct_ids_materialize_separately() {
+        let rev = |who: &str| AnnotationRevision {
+            revision_id: format!("r-{who}"),
+            kind: AnnotationKind::Rationale,
+            content: "lgtm".to_string(),
+            tags: vec![],
+            attribution: format!("{who} <>"),
+            created_at: 1,
+            source_hash: None,
+            created_at_state: None,
+        };
+        let a = materialize_annotation(
+            &ContextAnnotation {
+                id: "srv-a".to_string(),
+                revision_count: 1,
+                ..Default::default()
+            },
+            vec![rev("alice")],
+        );
+        let b = materialize_annotation(
+            &ContextAnnotation {
+                id: "srv-b".to_string(),
+                revision_count: 1,
+                ..Default::default()
+            },
+            vec![rev("bob")],
+        );
+        assert_ne!(a.annotation_id, b.annotation_id);
+        assert_eq!(a.revisions[0].attribution, "alice <>");
+        assert_eq!(b.revisions[0].attribution, "bob <>");
+    }
+}

--- a/crates/cli/src/client/mod.rs
+++ b/crates/cli/src/client/mod.rs
@@ -4,9 +4,13 @@
 //! Connects to Heddle servers for push, pull, and other operations.
 
 #[cfg(feature = "client")]
+pub mod context_sync;
+#[cfg(feature = "client")]
 pub mod discussion_sync;
 #[cfg(feature = "client")]
 pub mod human_signature;
+#[cfg(feature = "client")]
+pub mod review_sync;
 pub mod local_daemon;
 pub mod local_sync;
 

--- a/crates/cli/src/client/review_sync.rs
+++ b/crates/cli/src/client/review_sync.rs
@@ -12,26 +12,29 @@
 //!   signature WE authored to the hosted `SignState`. The signature bytes were
 //!   computed over the deterministic [`objects::object::state_review::signing_payload`],
 //!   byte-identical to the server's reconstruction, so the exact signature the
-//!   local `review sign` wrote verifies unchanged server-side.
+//!   local `review sign` wrote verifies unchanged server-side. weft relaxes the
+//!   `signed_at` skew gate for this authenticated install path, so a signature
+//!   minted long before the push still lands.
 //! * **Pull (read path):** none needed — the server-minted `ReviewSignatures`
 //!   attachment rides the pull pack like any server-owned attachment, so a clone
 //!   / pull materializes it and the local `review show` reads it directly.
 //!
 //! ## Fail-closed self filter
 //!
-//! Only signatures whose actor is the local principal are forwarded. The server
-//! binds the signing key to the authenticated pusher, so attempting to replay
-//! another actor's signature (e.g. one a clone pulled) would be rejected anyway;
-//! the self filter avoids the pointless round-trip and any misattribution.
+//! Only signatures whose actor is the local principal are forwarded. The actor
+//! is resolved from [`Repository::get_principal`] (env → config → git) — the SAME
+//! source `review sign` stamped the `actor` with — NOT `config().principal`
+//! alone, which is empty in git-overlay / env-identity repos and would silently
+//! drop our own signatures. When the principal is unresolvable we warn and skip
+//! (we cannot tell which signatures are ours).
 //!
-//! ## weft#638 limit (degrade gracefully, don't fix here)
+//! ## Retry discipline
 //!
-//! A signature is minted against a specific state. States not present on the
-//! server (unpushed ancestors, or a head that advanced past the signed state)
-//! make `SignState` fail; that warns and continues rather than failing the push.
-//! The mirror (`.heddle/collaboration/hosted-review-mirror.json`) records synced
-//! `(state, signature)` pairs so a re-push does not re-sign, and is saved after
-//! every signature and on the error path.
+//! The mirror (`.heddle/collaboration/hosted-review-mirror.json`) records both
+//! `synced` and permanently-`rejected` `(state, signature)` pairs. A transient
+//! failure (network / server unavailable / state not yet on the server) is left
+//! for the next push to retry; a permanent rejection (bad signature, key not
+//! owned by the caller) is recorded so it stops retrying and warning every push.
 
 #![cfg(feature = "client")]
 
@@ -52,6 +55,7 @@ use objects::object::{
 use objects::store::ObjectStore;
 use repo::{HistoryQuery, Repository, StateAttachmentKind};
 use serde::{Deserialize, Serialize};
+use wire::ProtocolError;
 
 use crate::client::HostedGrpcClient;
 
@@ -66,9 +70,13 @@ struct HostedReviewMirror {
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct RepoReviewMirror {
-    /// Signed `(state_id, signature-hex)` pairs already forwarded to the server.
+    /// `(state_id, signature-hex)` pairs successfully installed on the server.
     #[serde(default)]
     synced: Vec<String>,
+    /// Pairs the server permanently rejected — do not retry (avoids warning
+    /// every push over a signature that will never install).
+    #[serde(default)]
+    rejected: Vec<String>,
 }
 
 fn synced_key(state_id: &StateId, signature_hex: &str) -> String {
@@ -125,6 +133,22 @@ fn scope_to_proto(scope: &ReviewScope) -> ProtoReviewScope {
     ProtoReviewScope { scope: Some(inner) }
 }
 
+/// Whether a hosted rejection is permanent (won't succeed on retry) vs transient
+/// (retry next push). A malformed/invalid signature or a key the caller does not
+/// own will never install; a network error or a state not yet on the server may.
+fn is_permanent(error: &ProtocolError) -> bool {
+    matches!(
+        error,
+        ProtocolError::InvalidState(_) | ProtocolError::AuthorizationFailed(_)
+    )
+}
+
+enum ForwardOutcome {
+    Installed,
+    Permanent(String),
+    Transient(String),
+}
+
 /// Read the current `ReviewSignatures` blob for a state, if any.
 fn read_signatures(repo: &Repository, state_id: &StateId) -> Result<Vec<ReviewSignature>> {
     let Some(attachment) =
@@ -144,8 +168,6 @@ fn read_signatures(repo: &Repository, state_id: &StateId) -> Result<Vec<ReviewSi
 }
 
 /// Replay local review signatures we authored to the hosted `StateReviewService`.
-/// Saves the mirror after each signature and continues past a per-signature
-/// failure (warn-and-skip).
 pub async fn push_review_signatures(
     repo: &Repository,
     client: &mut HostedGrpcClient,
@@ -155,20 +177,38 @@ pub async fn push_review_signatures(
         return Ok(0);
     };
 
-    // Only forward signatures the local principal actually authored.
-    let Some(principal) = repo.config().principal.clone() else {
-        return Ok(0);
+    // Resolve our identity from the SAME source `review sign` stamped the actor
+    // with (env → config → git). Warn + skip if unresolvable — we cannot tell
+    // which signatures are ours.
+    let principal = match repo.get_principal() {
+        Ok(principal) => principal,
+        Err(error) => {
+            eprintln!(
+                "{} review sync skipped: could not resolve the local principal ({error}); \
+                 set one with `heddle init --principal-name <name> --principal-email <email>`",
+                crate::cli::style::warn_marker(),
+            );
+            return Ok(0);
+        }
     };
 
     let states = repo
         .query_history(&HistoryQuery::new(Some(head)).with_limit(REVIEW_SCAN_LIMIT))
         .context("walk history for review signatures")?;
 
-    let mut mirror = load_mirror(repo.heddle_dir())?;
-    let already: HashSet<String> = mirror
+    let heddle_dir = repo.heddle_dir().to_path_buf();
+    let mut mirror = load_mirror(&heddle_dir)?;
+    let skip: HashSet<String> = mirror
         .repos
         .get(repo_path)
-        .map(|repo_mirror| repo_mirror.synced.iter().cloned().collect())
+        .map(|repo_mirror| {
+            repo_mirror
+                .synced
+                .iter()
+                .chain(repo_mirror.rejected.iter())
+                .cloned()
+                .collect()
+        })
         .unwrap_or_default();
 
     let mut synced = 0usize;
@@ -185,27 +225,42 @@ pub async fn push_review_signatures(
             }
         };
         for signature in signatures {
-            // Self filter: the server binds the signing key to the caller, so we
-            // can only (re)mint our own signatures.
             if signature.actor.name != principal.name || signature.actor.email != principal.email {
                 continue;
             }
             let key = synced_key(&state.state_id, &signature.signature);
-            if already.contains(&key) {
+            if skip.contains(&key) {
                 continue;
             }
-            let result =
-                forward_signature(client, repo_path, &state.state_id, &signature).await;
-            match result {
-                Ok(()) => {
-                    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
-                    repo_mirror.synced.push(key);
-                    save_mirror(repo.heddle_dir(), &mirror)?;
+            match forward_signature(client, repo_path, &state.state_id, &signature).await {
+                ForwardOutcome::Installed => {
+                    mirror
+                        .repos
+                        .entry(repo_path.to_string())
+                        .or_default()
+                        .synced
+                        .push(key);
+                    save_mirror(&heddle_dir, &mirror)?;
                     synced += 1;
                 }
-                Err(error) => {
+                ForwardOutcome::Permanent(message) => {
+                    // Record so we stop retrying + warning on every push.
+                    mirror
+                        .repos
+                        .entry(repo_path.to_string())
+                        .or_default()
+                        .rejected
+                        .push(key);
+                    save_mirror(&heddle_dir, &mirror)?;
                     eprintln!(
-                        "{} hosted review {}: {error:#}",
+                        "{} hosted review {}: permanently rejected, will not retry: {message}",
+                        crate::cli::style::warn_marker(),
+                        state.state_id.short()
+                    );
+                }
+                ForwardOutcome::Transient(message) => {
+                    eprintln!(
+                        "{} hosted review {}: {message} (will retry on next push)",
                         crate::cli::style::warn_marker(),
                         state.state_id.short()
                     );
@@ -213,7 +268,6 @@ pub async fn push_review_signatures(
             }
         }
     }
-
     Ok(synced)
 }
 
@@ -222,12 +276,17 @@ async fn forward_signature(
     repo_path: &str,
     state_id: &StateId,
     signature: &ReviewSignature,
-) -> Result<()> {
-    let public_key = hex::decode(&signature.public_key)
-        .map_err(|error| anyhow::anyhow!("review public_key is not hex: {error}"))?;
-    let signature_bytes = hex::decode(&signature.signature)
-        .map_err(|error| anyhow::anyhow!("review signature is not hex: {error}"))?;
-    client
+) -> ForwardOutcome {
+    // A malformed stored signature will never install → permanent.
+    let public_key = match hex::decode(&signature.public_key) {
+        Ok(bytes) => bytes,
+        Err(error) => return ForwardOutcome::Permanent(format!("public_key is not hex: {error}")),
+    };
+    let signature_bytes = match hex::decode(&signature.signature) {
+        Ok(bytes) => bytes,
+        Err(error) => return ForwardOutcome::Permanent(format!("signature is not hex: {error}")),
+    };
+    match client
         .sign_state(
             repo_path,
             state_id,
@@ -241,8 +300,13 @@ async fn forward_signature(
             sign_op_id(repo_path, state_id, &signature.signature),
         )
         .await
-        .with_context(|| format!("sign hosted state {}", state_id.short()))?;
-    Ok(())
+    {
+        // Idempotent success or an already-installed signature both mean "on the
+        // server".
+        Ok(_) | Err(ProtocolError::AlreadyExists(_)) => ForwardOutcome::Installed,
+        Err(error) if is_permanent(&error) => ForwardOutcome::Permanent(error.to_string()),
+        Err(error) => ForwardOutcome::Transient(error.to_string()),
+    }
 }
 
 const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_7276_775f_7379_6e63_0001);
@@ -250,14 +314,18 @@ const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_7276_775
 fn sign_op_id(repo_path: &str, state_id: &StateId, signature_hex: &str) -> String {
     uuid::Uuid::new_v5(
         &OP_NAMESPACE,
-        format!("sign:{repo_path}:{}:{signature_hex}", state_id.to_string_full()).as_bytes(),
+        format!(
+            "sign:{repo_path}:{}:{signature_hex}",
+            state_id.to_string_full()
+        )
+        .as_bytes(),
     )
     .to_string()
 }
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{Principal, SymbolAnchor};
+    use objects::object::SymbolAnchor;
 
     use super::*;
 
@@ -283,8 +351,6 @@ mod tests {
         }
     }
 
-    // The synced key binds a signature to a state, so the same signature bytes
-    // on two states sync independently and a re-push of either is a no-op.
     #[test]
     fn synced_key_is_state_scoped() {
         let a = StateId::from_bytes([1; 32]);
@@ -306,12 +372,17 @@ mod tests {
         );
     }
 
+    // A bad-signature / key-not-owned rejection is permanent (stops retrying);
+    // a network / not-yet-pushed error is transient (retries next push).
     #[test]
-    fn actor_self_filter_matches_principal() {
-        let actor = Principal::new("Alice", "alice@x");
-        let same = Principal::new("Alice", "alice@x");
-        let other = Principal::new("Bob", "bob@x");
-        assert!(actor.name == same.name && actor.email == same.email);
-        assert!(actor.name != other.name || actor.email != other.email);
+    fn permanent_vs_transient_classification() {
+        assert!(is_permanent(&ProtocolError::InvalidState("bad sig".into())));
+        assert!(is_permanent(&ProtocolError::AuthorizationFailed(
+            "key not owned".into()
+        )));
+        assert!(!is_permanent(&ProtocolError::ObjectNotFound(
+            "state not on server yet".into()
+        )));
+        assert!(!is_permanent(&ProtocolError::Remote("unavailable".into())));
     }
 }

--- a/crates/cli/src/client/review_sync.rs
+++ b/crates/cli/src/client/review_sync.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hosted review-signature sync bridge.
+//!
+//! `heddle review sign` records a `ReviewSignatures` state-attachment LOCALLY.
+//! weft#549 rejects a client-pushed attachment in the pack, so a signature only
+//! reaches the hosted server through the caller-authenticated, PoP-signed
+//! `StateReviewService::SignState` RPC (which binds the signing key to the
+//! authenticated caller). This module replays our local signatures over that
+//! RPC after a successful `heddle push`, mirroring [`crate::client::discussion_sync`]:
+//!
+//! * **Push (write path):** for the pushed state(s), forward each review
+//!   signature WE authored to the hosted `SignState`. The signature bytes were
+//!   computed over the deterministic [`objects::object::state_review::signing_payload`],
+//!   byte-identical to the server's reconstruction, so the exact signature the
+//!   local `review sign` wrote verifies unchanged server-side.
+//! * **Pull (read path):** none needed — the server-minted `ReviewSignatures`
+//!   attachment rides the pull pack like any server-owned attachment, so a clone
+//!   / pull materializes it and the local `review show` reads it directly.
+//!
+//! ## Fail-closed self filter
+//!
+//! Only signatures whose actor is the local principal are forwarded. The server
+//! binds the signing key to the authenticated pusher, so attempting to replay
+//! another actor's signature (e.g. one a clone pulled) would be rejected anyway;
+//! the self filter avoids the pointless round-trip and any misattribution.
+//!
+//! ## weft#638 limit (degrade gracefully, don't fix here)
+//!
+//! A signature is minted against a specific state. States not present on the
+//! server (unpushed ancestors, or a head that advanced past the signed state)
+//! make `SignState` fail; that warns and continues rather than failing the push.
+//! The mirror (`.heddle/collaboration/hosted-review-mirror.json`) records synced
+//! `(state, signature)` pairs so a re-push does not re-sign, and is saved after
+//! every signature and on the error path.
+
+#![cfg(feature = "client")]
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use api::heddle::api::v1alpha1::{
+    PathSymbolRef, ReviewKind as ProtoReviewKind, ReviewScope as ProtoReviewScope, review_scope,
+};
+use objects::fs_atomic::write_file_atomic;
+use objects::object::{
+    ReviewKind, ReviewScope, ReviewSignature, ReviewSignaturesBlob, StateAttachmentBody, StateId,
+};
+use objects::store::ObjectStore;
+use repo::{HistoryQuery, Repository, StateAttachmentKind};
+use serde::{Deserialize, Serialize};
+
+use crate::client::HostedGrpcClient;
+
+/// How far back from HEAD to scan for locally-recorded review signatures.
+const REVIEW_SCAN_LIMIT: usize = 50;
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct HostedReviewMirror {
+    #[serde(default)]
+    repos: BTreeMap<String, RepoReviewMirror>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct RepoReviewMirror {
+    /// Signed `(state_id, signature-hex)` pairs already forwarded to the server.
+    #[serde(default)]
+    synced: Vec<String>,
+}
+
+fn synced_key(state_id: &StateId, signature_hex: &str) -> String {
+    format!("{}#{signature_hex}", state_id.to_string_full())
+}
+
+fn mirror_path(heddle_dir: &Path) -> PathBuf {
+    heddle_dir
+        .join("collaboration")
+        .join("hosted-review-mirror.json")
+}
+
+fn load_mirror(heddle_dir: &Path) -> Result<HostedReviewMirror> {
+    match fs::read(mirror_path(heddle_dir)) {
+        Ok(bytes) => serde_json::from_slice(&bytes).context("decode hosted review mirror map"),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            Ok(HostedReviewMirror::default())
+        }
+        Err(error) => Err(error).context("read hosted review mirror map"),
+    }
+}
+
+fn save_mirror(heddle_dir: &Path, mirror: &HostedReviewMirror) -> Result<()> {
+    let path = mirror_path(heddle_dir);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).context("create collaboration dir")?;
+    }
+    let bytes = serde_json::to_vec_pretty(mirror).context("encode hosted review mirror map")?;
+    write_file_atomic(&path, &bytes).context("write hosted review mirror map")?;
+    Ok(())
+}
+
+fn kind_to_proto(kind: ReviewKind) -> ProtoReviewKind {
+    match kind {
+        ReviewKind::Read => ProtoReviewKind::Read,
+        ReviewKind::AgentPreview => ProtoReviewKind::AgentPreview,
+        ReviewKind::AgentCoReview => ProtoReviewKind::AgentCoReview,
+    }
+}
+
+fn scope_to_proto(scope: &ReviewScope) -> ProtoReviewScope {
+    let inner = match scope {
+        ReviewScope::WholeChange => review_scope::Scope::WholeChange(review_scope::WholeChange {}),
+        ReviewScope::Symbols(symbols) => review_scope::Scope::Symbols(review_scope::SymbolList {
+            symbols: symbols
+                .iter()
+                .map(|anchor| PathSymbolRef {
+                    file: anchor.file.clone(),
+                    symbol: anchor.symbol.clone(),
+                })
+                .collect(),
+        }),
+    };
+    ProtoReviewScope { scope: Some(inner) }
+}
+
+/// Read the current `ReviewSignatures` blob for a state, if any.
+fn read_signatures(repo: &Repository, state_id: &StateId) -> Result<Vec<ReviewSignature>> {
+    let Some(attachment) =
+        repo.latest_state_attachment(state_id, StateAttachmentKind::ReviewSignatures)?
+    else {
+        return Ok(Vec::new());
+    };
+    let StateAttachmentBody::ReviewSignatures(hash) = attachment.body else {
+        return Ok(Vec::new());
+    };
+    let Some(blob) = repo.store().get_blob(&hash)? else {
+        return Ok(Vec::new());
+    };
+    let decoded = ReviewSignaturesBlob::decode(blob.content())
+        .map_err(|error| anyhow::anyhow!("decode review signatures blob: {error}"))?;
+    Ok(decoded.signatures)
+}
+
+/// Replay local review signatures we authored to the hosted `StateReviewService`.
+/// Saves the mirror after each signature and continues past a per-signature
+/// failure (warn-and-skip).
+pub async fn push_review_signatures(
+    repo: &Repository,
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+) -> Result<usize> {
+    let Some(head) = repo.head().context("resolve repository head")? else {
+        return Ok(0);
+    };
+
+    // Only forward signatures the local principal actually authored.
+    let Some(principal) = repo.config().principal.clone() else {
+        return Ok(0);
+    };
+
+    let states = repo
+        .query_history(&HistoryQuery::new(Some(head)).with_limit(REVIEW_SCAN_LIMIT))
+        .context("walk history for review signatures")?;
+
+    let mut mirror = load_mirror(repo.heddle_dir())?;
+    let already: HashSet<String> = mirror
+        .repos
+        .get(repo_path)
+        .map(|repo_mirror| repo_mirror.synced.iter().cloned().collect())
+        .unwrap_or_default();
+
+    let mut synced = 0usize;
+    for state in states {
+        let signatures = match read_signatures(repo, &state.state_id) {
+            Ok(signatures) => signatures,
+            Err(error) => {
+                eprintln!(
+                    "{} hosted review {}: {error:#}",
+                    crate::cli::style::warn_marker(),
+                    state.state_id.short()
+                );
+                continue;
+            }
+        };
+        for signature in signatures {
+            // Self filter: the server binds the signing key to the caller, so we
+            // can only (re)mint our own signatures.
+            if signature.actor.name != principal.name || signature.actor.email != principal.email {
+                continue;
+            }
+            let key = synced_key(&state.state_id, &signature.signature);
+            if already.contains(&key) {
+                continue;
+            }
+            let result =
+                forward_signature(client, repo_path, &state.state_id, &signature).await;
+            match result {
+                Ok(()) => {
+                    let repo_mirror = mirror.repos.entry(repo_path.to_string()).or_default();
+                    repo_mirror.synced.push(key);
+                    save_mirror(repo.heddle_dir(), &mirror)?;
+                    synced += 1;
+                }
+                Err(error) => {
+                    eprintln!(
+                        "{} hosted review {}: {error:#}",
+                        crate::cli::style::warn_marker(),
+                        state.state_id.short()
+                    );
+                }
+            }
+        }
+    }
+
+    Ok(synced)
+}
+
+async fn forward_signature(
+    client: &mut HostedGrpcClient,
+    repo_path: &str,
+    state_id: &StateId,
+    signature: &ReviewSignature,
+) -> Result<()> {
+    let public_key = hex::decode(&signature.public_key)
+        .map_err(|error| anyhow::anyhow!("review public_key is not hex: {error}"))?;
+    let signature_bytes = hex::decode(&signature.signature)
+        .map_err(|error| anyhow::anyhow!("review signature is not hex: {error}"))?;
+    client
+        .sign_state(
+            repo_path,
+            state_id,
+            kind_to_proto(signature.kind),
+            scope_to_proto(&signature.scope),
+            signature.justification.as_deref().unwrap_or_default(),
+            &signature.algorithm,
+            public_key,
+            signature_bytes,
+            signature.signed_at,
+            sign_op_id(repo_path, state_id, &signature.signature),
+        )
+        .await
+        .with_context(|| format!("sign hosted state {}", state_id.short()))?;
+    Ok(())
+}
+
+const OP_NAMESPACE: uuid::Uuid = uuid::Uuid::from_u128(0x6865_6464_6c65_7276_775f_7379_6e63_0001);
+
+fn sign_op_id(repo_path: &str, state_id: &StateId, signature_hex: &str) -> String {
+    uuid::Uuid::new_v5(
+        &OP_NAMESPACE,
+        format!("sign:{repo_path}:{}:{signature_hex}", state_id.to_string_full()).as_bytes(),
+    )
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{Principal, SymbolAnchor};
+
+    use super::*;
+
+    #[test]
+    fn whole_change_scope_maps_to_proto() {
+        let proto = scope_to_proto(&ReviewScope::WholeChange);
+        assert!(matches!(
+            proto.scope,
+            Some(review_scope::Scope::WholeChange(_))
+        ));
+    }
+
+    #[test]
+    fn symbol_scope_maps_to_proto() {
+        let proto = scope_to_proto(&ReviewScope::Symbols(vec![SymbolAnchor::new("a.rs", "foo")]));
+        match proto.scope {
+            Some(review_scope::Scope::Symbols(list)) => {
+                assert_eq!(list.symbols.len(), 1);
+                assert_eq!(list.symbols[0].file, "a.rs");
+                assert_eq!(list.symbols[0].symbol, "foo");
+            }
+            other => panic!("expected symbols scope, got {other:?}"),
+        }
+    }
+
+    // The synced key binds a signature to a state, so the same signature bytes
+    // on two states sync independently and a re-push of either is a no-op.
+    #[test]
+    fn synced_key_is_state_scoped() {
+        let a = StateId::from_bytes([1; 32]);
+        let b = StateId::from_bytes([2; 32]);
+        assert_ne!(synced_key(&a, "abad1dea"), synced_key(&b, "abad1dea"));
+        assert_eq!(synced_key(&a, "abad1dea"), synced_key(&a, "abad1dea"));
+    }
+
+    #[test]
+    fn kind_maps_to_proto() {
+        assert_eq!(kind_to_proto(ReviewKind::Read), ProtoReviewKind::Read);
+        assert_eq!(
+            kind_to_proto(ReviewKind::AgentPreview),
+            ProtoReviewKind::AgentPreview
+        );
+        assert_eq!(
+            kind_to_proto(ReviewKind::AgentCoReview),
+            ProtoReviewKind::AgentCoReview
+        );
+    }
+
+    #[test]
+    fn actor_self_filter_matches_principal() {
+        let actor = Principal::new("Alice", "alice@x");
+        let same = Principal::new("Alice", "alice@x");
+        let other = Principal::new("Bob", "bob@x");
+        assert!(actor.name == same.name && actor.email == same.email);
+        assert!(actor.name != other.name || actor.email != other.email);
+    }
+}

--- a/crates/client/src/grpc_hosted/hydration.rs
+++ b/crates/client/src/grpc_hosted/hydration.rs
@@ -524,6 +524,7 @@ mod tests {
     use cli_shared::ClientConfig;
     use grpc::heddle::api::v1alpha1::{
         collaboration_service_client::CollaborationServiceClient,
+        state_review_service_client::StateReviewServiceClient,
         identity_service_client::IdentityServiceClient,
         registry_service_client::RegistryServiceClient,
         repo_sync_service_client::RepoSyncServiceClient,
@@ -554,7 +555,8 @@ mod tests {
             auth: IdentityServiceClient::new(channel.clone()),
             content: RepositoryServiceClient::new(channel.clone()),
             workflow: WorkflowServiceClient::new(channel.clone()),
-            collaboration: CollaborationServiceClient::new(channel),
+            collaboration: CollaborationServiceClient::new(channel.clone()),
+            review: StateReviewServiceClient::new(channel),
             token_header: None,
             transport,
             auth_proof_key_pem: None,

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -2,6 +2,7 @@
 
 mod collaboration;
 mod content;
+mod state_review;
 pub(crate) mod helpers;
 mod hydration;
 pub mod monorepo;
@@ -20,6 +21,7 @@ use grpc::heddle::api::v1alpha1::{
     registry_service_client::RegistryServiceClient,
     repo_sync_service_client::RepoSyncServiceClient,
     repository_service_client::RepositoryServiceClient,
+    state_review_service_client::StateReviewServiceClient,
     workflow_service_client::WorkflowServiceClient,
 };
 use objects::{object::MarkerName, store::ObjectStore};
@@ -100,6 +102,7 @@ pub struct HostedGrpcClient {
     pub(super) content: RepositoryServiceClient<Channel>,
     pub(super) workflow: WorkflowServiceClient<Channel>,
     pub(super) collaboration: CollaborationServiceClient<Channel>,
+    pub(super) review: StateReviewServiceClient<Channel>,
     pub(super) token_header: Option<MetadataValue<tonic::metadata::Ascii>>,
     transport: helpers::HostedTransportPolicy,
     pub(super) auth_proof_key_pem: Option<String>,
@@ -179,6 +182,7 @@ impl HostedGrpcClient {
             content: RepositoryServiceClient::new(channel.clone()),
             workflow: WorkflowServiceClient::new(channel.clone()),
             collaboration: CollaborationServiceClient::new(channel.clone()),
+            review: StateReviewServiceClient::new(channel.clone()),
             token_header,
             transport,
             auth_proof_key_pem: config.auth_proof_key_pem.clone(),

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -639,6 +639,7 @@ mod tests {
             content: RepositoryServiceClient::new(channel.clone()),
             workflow: WorkflowServiceClient::new(channel.clone()),
             collaboration: CollaborationServiceClient::new(channel.clone()),
+            review: StateReviewServiceClient::new(channel.clone()),
             token_header: Some(
                 MetadataValue::try_from(format!("Bearer {token}")).expect("valid bearer header"),
             ),

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -514,6 +514,7 @@ mod tests {
         use crypto::{Ed25519Signer, Signer};
         use grpc::heddle::api::v1alpha1::{
             collaboration_service_client::CollaborationServiceClient,
+            state_review_service_client::StateReviewServiceClient,
             identity_service_client::IdentityServiceClient,
             registry_service_client::RegistryServiceClient,
             repo_sync_service_client::RepoSyncServiceClient,
@@ -658,7 +659,8 @@ mod tests {
                 auth: IdentityServiceClient::new(channel.clone()),
                 content: RepositoryServiceClient::new(channel.clone()),
                 workflow: WorkflowServiceClient::new(channel.clone()),
-                collaboration: CollaborationServiceClient::new(channel),
+                collaboration: CollaborationServiceClient::new(channel.clone()),
+                review: StateReviewServiceClient::new(channel),
                 token_header: Some(
                     MetadataValue::try_from(format!(
                         "Bearer {}",

--- a/crates/client/src/grpc_hosted/state_review.rs
+++ b/crates/client/src/grpc_hosted/state_review.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hosted `StateReviewService` client methods.
+//!
+//! Review signatures are server-minted via caller-authenticated, PoP-signed
+//! RPCs (weft#549) — the object pack rejects client-pushed `ReviewSignatures`
+//! attachments, so `SignState`/`RecordVerdict` are the ONLY channel by which a
+//! signature reaches the hosted server. `heddle review sync` (push path) replays
+//! locally-recorded review signatures over these methods.
+
+use grpc::heddle::api::v1alpha1::{
+    ListSignaturesRequest, ListSignaturesResponse, RecordVerdictRequest, RecordVerdictResponse,
+    ReviewKind, ReviewScope, SignStateRequest, SignStateResponse, Verdict,
+};
+use objects::object::StateId;
+use tonic::Request;
+use wire::ProtocolError;
+
+use super::{HostedGrpcClient, helpers::status_to_protocol_error, operation_id::ClientOperationId};
+
+const SIGN_STATE: &str = "heddle.api.v1alpha1.StateReviewService/SignState";
+const RECORD_VERDICT: &str = "heddle.api.v1alpha1.StateReviewService/RecordVerdict";
+
+impl HostedGrpcClient {
+    /// Mint a hosted review signature over `state_id`. `signature`/`public_key`
+    /// are the raw bytes the caller already computed over the canonical
+    /// `signing_payload` (byte-identical to the server's reconstruction), so the
+    /// server verifies the exact same signature the local `review sign` wrote.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn sign_state(
+        &mut self,
+        repo_path: &str,
+        state_id: &StateId,
+        kind: ReviewKind,
+        scope: ReviewScope,
+        justification: &str,
+        algorithm: &str,
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+        signed_at_unix: i64,
+        client_operation_id: String,
+    ) -> Result<SignStateResponse, ProtocolError> {
+        let operation_id = ClientOperationId::for_required_method(SIGN_STATE, client_operation_id)?;
+        let mut request = Request::new(SignStateRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            state_id: super::helpers::proto_state_id(*state_id),
+            kind: kind as i32,
+            scope: Some(scope),
+            justification: justification.to_string(),
+            algorithm: algorithm.to_string(),
+            public_key,
+            signature,
+            signed_at: Some(prost_types::Timestamp {
+                seconds: signed_at_unix,
+                nanos: 0,
+            }),
+            client_operation_id: operation_id.to_wire(),
+        });
+        self.apply_signed_auth(
+            &mut request,
+            "/heddle.api.v1alpha1.StateReviewService/SignState",
+        )?;
+        self.review
+            .sign_state(request)
+            .await
+            .map_err(status_to_protocol_error)
+            .map(|response| response.into_inner())
+    }
+
+    /// Record a signed SIGN/HOLD/REJECT reviewer verdict over `state_id`.
+    /// Decoupled from status — returns the same state. Same signing model as
+    /// [`Self::sign_state`].
+    #[allow(clippy::too_many_arguments)]
+    pub async fn record_verdict(
+        &mut self,
+        repo_path: &str,
+        state_id: &StateId,
+        verdict: Verdict,
+        scope: ReviewScope,
+        reason: &str,
+        algorithm: &str,
+        public_key: Vec<u8>,
+        signature: Vec<u8>,
+        signed_at_unix: i64,
+        client_operation_id: String,
+    ) -> Result<RecordVerdictResponse, ProtocolError> {
+        let operation_id =
+            ClientOperationId::for_required_method(RECORD_VERDICT, client_operation_id)?;
+        let mut request = Request::new(RecordVerdictRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            state_id: super::helpers::proto_state_id(*state_id),
+            verdict: verdict as i32,
+            scope: Some(scope),
+            reason: reason.to_string(),
+            algorithm: algorithm.to_string(),
+            public_key,
+            signature,
+            signed_at: Some(prost_types::Timestamp {
+                seconds: signed_at_unix,
+                nanos: 0,
+            }),
+            client_operation_id: operation_id.to_wire(),
+        });
+        self.apply_signed_auth(
+            &mut request,
+            "/heddle.api.v1alpha1.StateReviewService/RecordVerdict",
+        )?;
+        self.review
+            .record_verdict(request)
+            .await
+            .map_err(status_to_protocol_error)
+            .map(|response| response.into_inner())
+    }
+
+    /// List hosted review signatures recorded against `state_id`. Read-only,
+    /// authenticated (unsigned tier).
+    pub async fn list_review_signatures(
+        &mut self,
+        repo_path: &str,
+        state_id: &StateId,
+    ) -> Result<ListSignaturesResponse, ProtocolError> {
+        let mut request = Request::new(ListSignaturesRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            state_id: super::helpers::proto_state_id(*state_id),
+        });
+        self.apply_signed_auth(
+            &mut request,
+            "/heddle.api.v1alpha1.StateReviewService/ListSignatures",
+        )?;
+        self.review
+            .list_signatures(request)
+            .await
+            .map_err(status_to_protocol_error)
+            .map(|response| response.into_inner())
+    }
+}


### PR DESCRIPTION
## What
Completes the CLI hosted-collaboration surface: wires **context annotations** and **review signatures** to hosted sync, the same seam `discuss` got in #1050 (`context` and `review` were local-only).

- New `crates/cli/src/client/context_sync.rs` (802L) + `review_sync.rs` (317L) + hosted `state_review.rs` client, reusing #1050's hard-won correctness model: per-item identity (not ordinal counts), **author-aware reconciliation** (never body-alone → no cross-author misattribution), fail-closed self-filter, per-item mirror save + collect-and-continue, graceful weft#638 head-advance degradation.

## Verified
- **Context forward sync (live, docker weft, enforce):** `context set` → `push` → `[ok] synced 1 annotation(s)` → fresh clone `context list` shows it. ✅
- **Unit tests:** context_sync 4/4 (incl `identical_bodies_distinct_ids_materialize_separately` — the cross-author/identical-body case that broke discussions), review_sync tests pass.

## Limitations (inherited, tracked)
Same weft#638 (per-state attachment, no carry-forward → single-state-repo cap) + weft#640 (no server item ids → same-user-identical edge). `review sign` remains the low-level primitive (external signature) — sync is wired; ergonomic `review approve` is a separate UX follow-up.

Follow-up to #1050. Do not self-merge (Fable review + verification follow).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1053"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786997200&installation_id=132405951&pr_number=1053&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1053&signature=e9457675c54865f194981dd9c9726d149b42bf347f7470e8ed2414725cda497a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->