### PR TITLE
docs(auth): pin contributor template == safe agent ceiling (#1059)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -5,8 +5,10 @@ use clap::{Subcommand, ValueEnum};
 
 /// Preset operation ceilings for `heddle auth derive-agent`.
 ///
-/// Each variant expands to a curated subset of the safe agent operation
-/// ceiling. `--scope`/`--allow` stay usable alongside a template and, when
+/// Each variant expands to a curated set of safe agent operations. `reviewer`
+/// and `ci-landing` are strict subsets of the safe ceiling; `contributor` is
+/// the full safe ceiling (the named form of the default `--allow`-less
+/// derivation). `--scope`/`--allow` stay usable alongside a template and, when
 /// combined, may only *narrow* it (they intersect the template's set).
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AgentTemplateArg {
@@ -18,6 +20,8 @@ pub enum AgentTemplateArg {
     /// Read + collaboration writes: the reviewer set plus Push, UpdateRef,
     /// SetContext/ReviseContext/SupersedeContext, and
     /// OpenDiscussion/AppendTurn/ResolveDiscussion. No repo/namespace admin.
+    /// This is the full safe agent ceiling — the named form of deriving with
+    /// no --template/--allow.
     Contributor,
     /// Read + Pull + the Push/UpdateRef a CI lander needs to run ready/land.
     /// No context or discussion writes.

--- a/crates/client/src/device_flow.rs
+++ b/crates/client/src/device_flow.rs
@@ -244,6 +244,16 @@ pub enum AgentTemplate {
     Reviewer,
     /// Read + collaboration writes: reviewer plus `Push`/`UpdateRef`, context
     /// writes, and discussion writes. No repo/namespace admin.
+    ///
+    /// This is intentionally the **full safe agent ceiling** — its operation
+    /// set equals [`SAFE_AGENT_OPERATIONS`], so `--template contributor` is
+    /// the named, self-documenting form of "everything an agent may safely do"
+    /// (equivalent to deriving with no `--template`/`--allow`). Every op in
+    /// `SAFE_AGENT_OPERATIONS` is either a read or one of the collaboration
+    /// writes a contributor holds; there is nothing safe left to withhold.
+    /// `contributor_ceiling_equals_safe_agent_operations` pins this: if the
+    /// safe ceiling ever grows, that test fails and forces a conscious
+    /// decision about whether the new op belongs to `contributor`.
     Contributor,
     /// Read + `Pull` + the `Push`/`UpdateRef` a CI lander needs to run
     /// `ready`/`land`. No context or discussion writes.
@@ -251,6 +261,16 @@ pub enum AgentTemplate {
 }
 
 impl AgentTemplate {
+    /// Every template variant, in privilege order. A new variant added to the
+    /// enum must be added here too — the `operations()` match already forces
+    /// handling it, and the template invariant tests iterate `ALL` so a new
+    /// variant is automatically held to the safe-ceiling and ordering checks.
+    pub const ALL: [AgentTemplate; 3] = [
+        AgentTemplate::Reviewer,
+        AgentTemplate::CiLanding,
+        AgentTemplate::Contributor,
+    ];
+
     /// Stable lower-kebab name used on the CLI and in metadata.
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -754,11 +774,7 @@ mod tests {
     #[test]
     fn templates_stay_within_safe_ceiling() {
         let safe: BTreeSet<&str> = SAFE_AGENT_OPERATIONS.iter().copied().collect();
-        for template in [
-            AgentTemplate::Reviewer,
-            AgentTemplate::Contributor,
-            AgentTemplate::CiLanding,
-        ] {
+        for template in AgentTemplate::ALL {
             for operation in template.operations() {
                 assert!(
                     safe.contains(operation.as_str()),
@@ -767,6 +783,26 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn contributor_ceiling_equals_safe_agent_operations() {
+        // `contributor` is intentionally the full safe agent ceiling. Pin the
+        // equivalence so it can't silently drift: if `SAFE_AGENT_OPERATIONS`
+        // grows a new op, this fails and forces a conscious decision about
+        // whether the new op belongs to `contributor` (or should be withheld
+        // from it, at which point contributor becomes a genuine proper subset).
+        let contributor: BTreeSet<String> =
+            AgentTemplate::Contributor.operations().into_iter().collect();
+        let safe: BTreeSet<String> = SAFE_AGENT_OPERATIONS
+            .iter()
+            .map(|op| (*op).to_string())
+            .collect();
+        assert_eq!(
+            contributor, safe,
+            "contributor template must equal SAFE_AGENT_OPERATIONS; update the \
+             template (or SAFE_AGENT_OPERATIONS) and this assertion together"
+        );
     }
 
     #[test]
@@ -779,6 +815,9 @@ mod tests {
         // Reviewer is the read-only floor; both write templates are supersets.
         assert!(reviewer.is_subset(&contributor));
         assert!(reviewer.is_subset(&ci));
+        // CI landing sits between reviewer and contributor: it adds only
+        // Push/UpdateRef, so it is a proper subset of contributor (the ceiling).
+        assert!(ci.is_subset(&contributor));
         // Contributor carries collaboration writes CI landing does not.
         assert!(contributor.contains("OpenDiscussion"));
         assert!(!ci.contains("OpenDiscussion"));


### PR DESCRIPTION
Resolves the substantive finding from the Fable review of #1058.

## What
The `contributor` derive-agent template expands to a set **equal to `SAFE_AGENT_OPERATIONS`** — every safe op is either a read or one of the collaboration writes a contributor holds, so there's nothing safe left to withhold. It is therefore the *full* safe agent ceiling, not a "curated subset" as the docs implied.

This is **intentional** (a contributor agent may do everything an agent safely can; `SAFE_AGENT_OPERATIONS` already excludes deletes/admin via the mandatory deny floor), so the fix is to document + enforce the equivalence rather than carve an artificial subset.

## Changes (no behavior change)
- Document the equivalence on `AgentTemplate::Contributor` and in the `heddle auth derive-agent --template` help.
- New test `contributor_ceiling_equals_safe_agent_operations` pins it: if `SAFE_AGENT_OPERATIONS` grows, this fails and forces a conscious decision about whether the new op belongs to `contributor`.
- New `AgentTemplate::ALL`, iterated by the invariant tests, so a future 4th template variant is automatically held to the safe-ceiling + ordering checks.
- Assert `ci-landing ⊂ contributor` in the ordering test.

## Verified
`cargo test -p heddle-client --lib device_flow::` → 21 passed, incl. the new test.

Refs #1059, #1058, weft#642.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787088194&installation_id=132405951&pr_number=1060&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1060&signature=100e3214f94dc72100bcf8b6ba74303cde34ea53f90e6daaa515be15571cdfc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->