### PR TITLE
test(cli): de-flake daemon staleness test (fork→exec race)

### DIFF
--- a/crates/cli/src/client/local_daemon.rs
+++ b/crates/cli/src/client/local_daemon.rs
@@ -509,6 +509,22 @@ mod tests {
             .env_clear()
             .spawn()
             .expect("spawn sleep");
+        // `spawn()` returns after fork() but before the child reaches
+        // exec("/bin/sleep"). Inside that fork→exec window /proc/<pid>/exe
+        // still resolves to THIS test binary, so `is_heddle_process` — and
+        // therefore `probe` — would correctly (but unhelpfully for this test)
+        // report the pid as a live heddle daemon. Under load the window
+        // widens and the probe races into it, so wait for the child to finish
+        // exec'ing away from our executable before probing. Only this test
+        // hits the window; real pidfile pids are long exec'd daemons.
+        let exec_deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while is_heddle_process(child.id() as i32) {
+            assert!(
+                std::time::Instant::now() < exec_deadline,
+                "spawned child never exec'd away from the test binary"
+            );
+            std::thread::sleep(Duration::from_millis(2));
+        }
         let temp = TempDir::new().unwrap();
         let sockets = temp.path().join("sockets");
         std::fs::create_dir_all(&sockets).unwrap();


### PR DESCRIPTION
## Symptom
`client::local_daemon::tests::stale_when_pidfile_holds_live_non_heddle_pid` intermittently failed under heavy concurrent build load with `expected Stale for live non-Heddle pid, got Running`. Surfaced while verifying #1057/#1058; passes reliably in isolation.

## Cause
The test spawns `/bin/sleep`, writes its pid to a pidfile, and expects `probe` → `Stale`. `Command::spawn()` returns after `fork()` but **before** the child reaches `exec("/bin/sleep")`. Inside that fork→exec window, `/proc/<pid>/exe` still resolves to the **test binary**, so `is_heddle_process` correctly sees the pid running our own executable and reports `Running`. Under load the window widens and `probe()` races into it.

## Fix (test-only)
`is_heddle_process` is correct for production — real pidfile pids are long-since-exec'd daemons, never mid-`fork`. So this is purely a test artifact. The test now polls `is_heddle_process(child)` until it returns `false` (the child has finished exec'ing away from our binary) before probing, with a 5s safety deadline. No production code changes; the assertion is unchanged.

## Verified
40/40 green under a concurrent `cargo build` load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1061"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787088221&installation_id=132405951&pr_number=1061&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1061&signature=f9c7705c9bd1fa5220f977bb7c51ee8b4fcef54b116f10d4d1e777f5ff80e6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->