### PR TITLE
feat(client): single-file .hcred credential artifact (#1063)

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -61,9 +61,13 @@ device-key-authenticated `MintBiscuit`.
 
 By default the child replaces the active stored credential for `--server`, so
 the next push/pull and any further derivation use that child and its fresh PoP
-key. Use `--out <DIR>` to write a portable 0600 bundle containing `token`,
-`device-key.pem` (the child key), and `metadata.json`. The parent device key is
-never written into the child credential or bundle. Token-only `--stdout`
+key. Use `--out <name>.hcred` to write a single self-verifying `0600`
+credential file instead: one JSON object carrying the child `token`, its
+`proof_key_pem`, and audit-only `provenance` (template, scopes, allowed
+operations, agent id). The parent device key is never written into the child
+credential or file. `heddle auth login --credential <name>.hcred` installs it,
+re-verifying the proof key, subject, and expiry against the token before
+storing. `--out` refuses to overwrite an existing path. Token-only `--stdout`
 export is intentionally unsupported because the resulting bearer could not
 satisfy its request-proof binding.
 

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -12309,6 +12309,10 @@
     "auth create-service-token": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "credential_path": {
+          "description": "Path to the `.hcred` credential file written with mode 0600. The token\nand proof key live inside this file and never appear in the contract.",
+          "type": "string"
+        },
         "expires_in_days": {
           "format": "uint32",
           "minimum": 0,
@@ -12326,21 +12330,7 @@
           ],
           "type": "string"
         },
-        "private_key_path": {
-          "description": "Path to the private-key PEM written with mode 0600.",
-          "type": "string"
-        },
-        "private_key_pem": {
-          "description": "Present only when `--show-secrets` was passed.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "scope": {
-          "type": "string"
-        },
-        "token": {
           "type": "string"
         }
       },
@@ -12349,8 +12339,7 @@
         "name",
         "namespace",
         "scope",
-        "token",
-        "private_key_path",
+        "credential_path",
         "expires_in_days"
       ],
       "title": "AuthCreateServiceTokenSchema",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -422,16 +422,13 @@ export type Array_of_ThreadApprovalSchema = ThreadApprovalSchema[];
 export type Array_of_ThreadCaptureEntrySchema = ThreadCaptureEntrySchema[];
 
 export interface AuthCreateServiceTokenSchema {
+  /** Path to the `.hcred` credential file written with mode 0600. The token and proof key live inside this file and never appear in the contract. */
+  credential_path: string;
   expires_in_days: number;
   name: string;
   namespace: string;
   output_kind: "auth_create_service_token";
-  /** Path to the private-key PEM written with mode 0600. */
-  private_key_path: string;
-  /** Present only when `--show-secrets` was passed. */
-  private_key_pem?: string | null;
   scope: string;
-  token: string;
 }
 
 export interface AuthLogoutSchema {

--- a/crates/cli/src/cli/cli_args/commands_client.rs
+++ b/crates/cli/src/cli/cli_args/commands_client.rs
@@ -43,21 +43,19 @@ impl From<AgentTemplateArg> for heddle_client::device_flow::AgentTemplate {
 pub enum AuthCommands {
     /// Authenticate with a Heddle server
     Login {
-        /// Heddle server address (required for headless credential install).
+        /// Heddle server address (browser flow). Omit to use the configured
+        /// default server.
         #[arg(long)]
         server: Option<String>,
 
         /// Open the authorization URL in the system browser.
-        #[arg(long, conflicts_with = "token")]
+        #[arg(long)]
         open_browser: bool,
 
-        /// Install an existing Biscuit credential without opening a browser.
-        #[arg(long, requires_all = ["key_file", "server"])]
-        token: Option<String>,
-
-        /// Device private-key PEM matching the token's proof key.
-        #[arg(long, value_name = "PEM_PATH", requires = "token")]
-        key_file: Option<std::path::PathBuf>,
+        /// Install a verified `.hcred` credential file without a browser.
+        /// The server is taken from the file.
+        #[arg(long, value_name = "HCRED_PATH", conflicts_with_all = ["server", "open_browser"])]
+        credential: Option<std::path::PathBuf>,
     },
 
     /// Remove stored credentials for a server
@@ -103,8 +101,9 @@ pub enum AuthCommands {
         #[arg(long, value_enum)]
         template: Option<AgentTemplateArg>,
 
-        /// Write `token`, child `device-key.pem`, and `metadata.json` files to this directory.
-        #[arg(long, value_name = "DIR")]
+        /// Write a single self-verifying `<name>.hcred` credential file to this
+        /// path instead of installing the child into the keystore.
+        #[arg(long, value_name = "HCRED_PATH")]
         out: Option<std::path::PathBuf>,
     },
 
@@ -118,12 +117,10 @@ pub enum AuthCommands {
         /// Heddle server address
         #[arg(long)]
         server: Option<String>,
-        /// Write the private-key PEM to this path (default: under ~/.heddle/service-accounts/)
-        #[arg(long)]
-        key_out: Option<String>,
-        /// Include the private key PEM in stdout / JSON (default: write file only)
-        #[arg(long)]
-        show_secrets: bool,
+        /// Write the `.hcred` credential file to this path
+        /// (default: ~/.heddle/service-accounts/<name>.hcred)
+        #[arg(long, value_name = "HCRED_PATH")]
+        out: Option<std::path::PathBuf>,
     },
 }
 
@@ -133,13 +130,11 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
             AuthCommands::Login {
                 server,
                 open_browser,
-                token,
-                key_file,
+                credential,
             } => heddle_client::AuthCommand::Login {
                 server,
                 open_browser,
-                token,
-                key_file,
+                credential,
             },
             AuthCommands::Logout { server } => heddle_client::AuthCommand::Logout { server },
             AuthCommands::Status { server } => heddle_client::AuthCommand::Status { server },
@@ -164,14 +159,12 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
                 name,
                 namespace,
                 server,
-                key_out,
-                show_secrets,
+                out,
             } => heddle_client::AuthCommand::CreateServiceToken {
                 name,
                 namespace,
                 server,
-                key_out,
-                show_secrets,
+                out,
             },
         }
     }
@@ -184,70 +177,52 @@ mod tests {
     use crate::cli::{AuthCommands, Cli, Commands};
 
     #[test]
-    fn login_parses_headless_token_and_key_file() {
+    fn login_parses_credential_path() {
         let cli = Cli::try_parse_from([
             "heddle",
             "auth",
             "login",
-            "--server",
-            "127.0.0.1:8421",
-            "--token",
-            "biscuit-token",
-            "--key-file",
-            "/run/secrets/device.pem",
+            "--credential",
+            "/run/secrets/agent.hcred",
         ])
-        .expect("headless login flags parse");
+        .expect("credential login flag parses");
 
         let Commands::Auth {
             command:
                 AuthCommands::Login {
                     server,
-                    token,
-                    key_file,
+                    credential,
                     open_browser,
                 },
         } = cli.command
         else {
             panic!("expected auth login");
         };
-        assert_eq!(server.as_deref(), Some("127.0.0.1:8421"));
-        assert_eq!(token.as_deref(), Some("biscuit-token"));
+        assert_eq!(server, None, "server comes from the credential file");
         assert_eq!(
-            key_file.as_deref(),
-            Some(std::path::Path::new("/run/secrets/device.pem"))
+            credential.as_deref(),
+            Some(std::path::Path::new("/run/secrets/agent.hcred"))
         );
         assert!(!open_browser);
     }
 
     #[test]
-    fn login_requires_token_and_key_file_together() {
-        for incomplete in [
-            vec!["--token", "biscuit-token"],
-            vec!["--key-file", "/run/secrets/device.pem"],
+    fn login_credential_conflicts_with_browser_flags() {
+        for conflicting in [
+            vec!["--credential", "/run/secrets/agent.hcred", "--server", "grpc.heddle.sh"],
+            vec!["--credential", "/run/secrets/agent.hcred", "--open-browser"],
         ] {
             let mut args = vec!["heddle", "auth", "login"];
-            args.extend(incomplete);
+            args.extend(conflicting);
             assert!(
                 Cli::try_parse_from(args).is_err(),
-                "incomplete headless credential must be rejected"
+                "--credential must not combine with the browser-login flags"
             );
         }
     }
 
     #[test]
-    fn headless_login_requires_an_explicit_server() {
-        assert!(
-            Cli::try_parse_from([
-                "heddle",
-                "auth",
-                "login",
-                "--token",
-                "biscuit-token",
-                "--key-file",
-                "/run/secrets/device.pem",
-            ])
-            .is_err()
-        );
+    fn interactive_login_needs_no_flags() {
         Cli::try_parse_from(["heddle", "auth", "login"])
             .expect("interactive login may resolve the configured default server");
     }

--- a/crates/cli/src/cli/commands/schemas.rs
+++ b/crates/cli/src/cli/commands/schemas.rs
@@ -775,12 +775,9 @@ pub struct AuthCreateServiceTokenSchema {
     pub name: String,
     pub namespace: String,
     pub scope: String,
-    pub token: String,
-    /// Path to the private-key PEM written with mode 0600.
-    pub private_key_path: String,
-    /// Present only when `--show-secrets` was passed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub private_key_pem: Option<String>,
+    /// Path to the `.hcred` credential file written with mode 0600. The token
+    /// and proof key live inside this file and never appear in the contract.
+    pub credential_path: String,
     pub expires_in_days: u32,
 }
 

--- a/crates/cli/tests/auth_login.rs
+++ b/crates/cli/tests/auth_login.rs
@@ -7,21 +7,26 @@ use std::process::Command;
 use tempfile::TempDir;
 
 #[test]
-fn built_cli_parses_headless_login_args_and_routes_to_install() {
+fn built_cli_parses_credential_login_and_routes_to_verifying_load() {
     let home = TempDir::new().expect("temp Heddle home");
-    let key_path = home.path().join("device.pem");
-    std::fs::write(&key_path, "not an Ed25519 private key").expect("write invalid device key");
+    let credential_path = home.path().join("agent.hcred");
+    // A structurally invalid `.hcred` must be rejected by the verifying load
+    // chokepoint — this proves `--credential` routes into that path.
+    std::fs::write(&credential_path, "{\"not\":\"a credential\"}\n")
+        .expect("write invalid credential file");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&credential_path, std::fs::Permissions::from_mode(0o600))
+            .expect("restrict credential perms");
+    }
 
     let output = Command::new(env!("CARGO_BIN_EXE_heddle"))
         .args([
             "auth",
             "login",
-            "--token",
-            "biscuit-token",
-            "--key-file",
-            key_path.to_str().expect("UTF-8 key path"),
-            "--server",
-            "127.0.0.1:8421",
+            "--credential",
+            credential_path.to_str().expect("UTF-8 credential path"),
         ])
         .current_dir(home.path())
         .env("HOME", home.path())
@@ -33,7 +38,8 @@ fn built_cli_parses_headless_login_args_and_routes_to_install() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("invalid Ed25519 device private key"),
-        "expected headless credential install error, got: {stderr}"
+        stderr.contains("parsing credential file")
+            || stderr.contains("not a Heddle credential file"),
+        "expected verifying-load error, got: {stderr}"
     );
 }

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -22,6 +22,7 @@ use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
 use crate::{
     auth_requests::AuthCommand,
+    credential_file::{self, CredentialKind, CredentialProvenance, VerifiedCredential},
     credentials,
     credentials::ServerCredential,
     device_flow::{
@@ -64,29 +65,13 @@ struct ServiceTokenOutput {
     name: String,
     namespace: String,
     scope: String,
-    token: String,
-    /// Absolute path of the private-key PEM file written with mode 0600.
-    private_key_path: String,
-    /// Only populated when `--show-secrets` is passed; omitted from JSON otherwise.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    private_key_pem: Option<String>,
+    /// Absolute path of the `.hcred` credential file written with mode 0600.
+    /// The token and proof key never appear on stdout or in JSON.
+    credential_path: String,
     expires_in_days: u32,
 }
 
-#[derive(Serialize)]
-struct AgentTokenExportMetadata<'a> {
-    server: &'a str,
-    subject: &'a str,
-    expires_at: String,
-    scopes: Vec<String>,
-    /// Preset the ceiling was derived from, when `--template` was used.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    template: Option<&'a str>,
-    /// Exact operation ceiling recorded in the token's attenuation block.
-    allowed_operations: Vec<String>,
-}
-
-const DERIVED_TOKEN_SECURITY_NOTE: &str = "Derived credential has its own proof key and is operation/TTL/resource-scope-limited and enforced server-side. Keep the token and child key together; the parent device key is not exported.";
+const DERIVED_TOKEN_SECURITY_NOTE: &str = "Derived credential has its own proof key and is operation/TTL/resource-scope-limited and enforced server-side. The token and proof key travel together inside the .hcred file; the parent device key is not exported.";
 
 const SERVICE_TOKEN_TTL_DAYS: u32 = 30;
 const SERVICE_TOKEN_TTL_SECS: i64 = SERVICE_TOKEN_TTL_DAYS as i64 * 24 * 3600;
@@ -99,24 +84,17 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         AuthCommand::Login {
             server,
             open_browser,
-            token,
-            key_file,
-        } => match (token, key_file) {
-            (Some(token), Some(key_file)) => {
-                let server = server.as_deref().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "--server is required with --token/--key-file so a headless install cannot target the wrong server"
-                    )
-                })?;
-                let subject = install_headless_credential(server, &token, &key_file)?;
+            credential,
+        } => match credential {
+            Some(credential) => {
+                let subject = install_credential_file(&credential)?;
                 println!("Authenticated as {subject}. Credentials saved.");
                 Ok(())
             }
-            (None, None) => {
+            None => {
                 let server = resolve_server(server.as_deref())?;
                 cmd_auth_login(&server, open_browser).await
             }
-            _ => bail!("--token and --key-file must be provided together"),
         },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
         AuthCommand::Status { server } => cmd_auth_status(ctx, server.as_deref()),
@@ -141,18 +119,9 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             name,
             namespace,
             server,
-            key_out,
-            show_secrets,
+            out,
         } => {
-            cmd_create_service_token(
-                ctx,
-                server.as_deref(),
-                name,
-                namespace,
-                key_out,
-                show_secrets,
-            )
-            .await
+            cmd_create_service_token(ctx, server.as_deref(), name, namespace, out.as_deref()).await
         }
     }
 }
@@ -235,19 +204,31 @@ fn cmd_auth_derive_agent(
         .to_pem()
         .map_err(|error| anyhow::anyhow!("failed to export child proof key: {error}"))?;
     if let Some(out) = out {
-        let export_metadata = AgentTokenExportMetadata {
-            server,
-            subject: &metadata.subject,
-            expires_at: expires_at.to_rfc3339(),
-            scopes: declared_scopes
-                .iter()
-                .map(|(kind, path)| format!("{kind}:{path}"))
-                .collect(),
-            template: template.map(|template| template.as_str()),
-            allowed_operations: allowed_operations.clone(),
+        let provenance = CredentialProvenance {
+            template: template.map(|template| template.as_str().to_string()),
+            scopes: (!declared_scopes.is_empty()).then(|| {
+                declared_scopes
+                    .iter()
+                    .map(|(kind, path)| format!("{kind}:{path}"))
+                    .collect()
+            }),
+            allowed_operations: Some(allowed_operations.clone()),
+            agent_id: Some(agent_id.clone()),
         };
-        write_agent_bundle(out, &child_token, &child_private_key_pem, &export_metadata)?;
-        println!("Agent token {agent_id} written to {}.", out.display());
+        let verified = VerifiedCredential {
+            server: server.to_string(),
+            kind: CredentialKind::Agent,
+            subject: metadata.subject.clone(),
+            token: child_token,
+            proof_key_pem: child_private_key_pem,
+            expires_at: Some(expires_at.to_rfc3339()),
+            // A derived child must never auto-rotate through MintBiscuit (that
+            // would drop this block's caveats), so it carries no credential id.
+            credential_id: None,
+            provenance: Some(provenance),
+        };
+        credential_file::write_credential_file(out, &verified)?;
+        println!("Agent credential {agent_id} written to {}.", out.display());
         if let Some(template) = template {
             println!("Template: {} ceiling", template.as_str());
         }
@@ -425,97 +406,6 @@ fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool 
     }
 }
 
-fn write_agent_bundle(
-    directory: &Path,
-    token: &str,
-    child_private_key_pem: &str,
-    metadata: &AgentTokenExportMetadata<'_>,
-) -> Result<()> {
-    let mut metadata_json =
-        serde_json::to_vec_pretty(metadata).context("serializing agent token metadata")?;
-    metadata_json.push(b'\n');
-
-    match std::fs::symlink_metadata(directory) {
-        Ok(_) => bail!(
-            "agent bundle destination {} already exists; choose a new --out directory",
-            directory.display()
-        ),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(error).with_context(|| {
-                format!("checking agent bundle destination {}", directory.display())
-            });
-        }
-    }
-
-    let parent = directory
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .unwrap_or_else(|| Path::new("."));
-    objects::fs_atomic::create_private_dir_all(parent)
-        .with_context(|| format!("creating agent bundle parent {}", parent.display()))?;
-    let bundle_name = directory
-        .file_name()
-        .context("--out must name an agent bundle directory")?
-        .to_string_lossy();
-    let staging = parent.join(format!(
-        ".{bundle_name}.{}.tmp",
-        uuid::Uuid::new_v4().simple()
-    ));
-
-    let write_result = (|| -> Result<()> {
-        objects::fs_atomic::create_private_dir_all(&staging).with_context(|| {
-            format!(
-                "creating private agent bundle staging directory {}",
-                staging.display()
-            )
-        })?;
-        objects::fs_atomic::write_file_atomic_secret(
-            &staging.join("device-key.pem"),
-            child_private_key_pem.as_bytes(),
-        )
-        .with_context(|| format!("writing child proof key under {}", staging.display()))?;
-        objects::fs_atomic::write_file_atomic_secret(&staging.join("token"), token.as_bytes())
-            .with_context(|| format!("writing agent token under {}", staging.display()))?;
-        objects::fs_atomic::write_file_atomic_secret(
-            &staging.join("metadata.json"),
-            &metadata_json,
-        )
-        .with_context(|| format!("writing agent metadata under {}", staging.display()))?;
-        publish_agent_bundle(&staging, directory, parent)?;
-        Ok(())
-    })();
-
-    if write_result.is_err() {
-        let _ = std::fs::remove_dir_all(&staging);
-    }
-    write_result
-}
-
-fn publish_agent_bundle(staging: &Path, directory: &Path, parent: &Path) -> Result<()> {
-    publish_agent_bundle_with_sync(
-        staging,
-        directory,
-        parent,
-        objects::fs_atomic::sync_directory,
-    )
-}
-
-fn publish_agent_bundle_with_sync(
-    staging: &Path,
-    directory: &Path,
-    parent: &Path,
-    sync_parent: impl FnOnce(&Path) -> std::io::Result<()>,
-) -> Result<()> {
-    std::fs::rename(staging, directory).with_context(|| {
-        format!(
-            "publishing completed agent bundle at {}",
-            directory.display()
-        )
-    })?;
-    sync_parent(parent).with_context(|| format!("syncing agent bundle parent {}", parent.display()))
-}
-
 pub(crate) struct HeadlessTokenMetadata {
     pub(crate) subject: String,
     pub(crate) is_derived: bool,
@@ -524,54 +414,38 @@ pub(crate) struct HeadlessTokenMetadata {
     pub(crate) proof_public_key_hex: String,
 }
 
-/// Install an operator-provisioned, device-bound credential without a browser.
-pub(crate) fn install_headless_credential(
-    server: &str,
-    token: &str,
-    key_file: &Path,
-) -> Result<String> {
-    let token = token.trim();
-    if token.is_empty() {
-        bail!("--token must not be empty");
-    }
+/// Install a verified `.hcred` credential file without a browser.
+///
+/// [`credential_file::load_credential_file`] is the trust chokepoint: it
+/// re-verifies the proof key, subject, and expiry against the token before we
+/// store anything. The server is taken from the file. A `device`-kind
+/// credential is a machine bootstrap key, so it also registers the host's
+/// device signing identity (heddle#482); `agent`/`service` credentials never
+/// do.
+pub(crate) fn install_credential_file(path: &Path) -> Result<String> {
+    let credential = credential_file::load_credential_file(path)?;
+    let server = credential.server.clone();
+    let subject = credential.subject.clone();
+    let register_device_identity = matches!(credential.kind, CredentialKind::Device);
+    let proof_key_pem = credential.proof_key_pem.clone();
 
-    let private_key_pem = std::fs::read_to_string(key_file)
-        .with_context(|| format!("reading device private key from {}", key_file.display()))?;
-    let signer = Ed25519Signer::from_pem(&private_key_pem)
-        .map_err(|error| anyhow::anyhow!("invalid Ed25519 device private key: {error}"))?;
-    let metadata = headless_token_metadata(token)?;
-    let public_key_hex = hex::encode(signer.public_key());
-    if !metadata
-        .proof_public_key_hex
-        .eq_ignore_ascii_case(&public_key_hex)
-    {
-        bail!(
-            "device private key does not match the token's device proof key; install the matching bootstrap key"
-        );
-    }
+    credentials::store_server_credential(&server, credential.into_server_credential())?;
 
-    let credential = ServerCredential {
-        token: token.to_string(),
-        subject: metadata.subject.clone(),
-        device_id: None,
-        credential_id: metadata.credential_id,
-        private_key_pem: Some(private_key_pem.clone()),
-        expires_at: metadata.expires_at,
-    };
-    credentials::store_server_credential(server, credential)?;
-    if !metadata.is_derived {
-        repo::identity::link_device_key(signer.public_key(), &private_key_pem, server)
+    if register_device_identity {
+        let signer = Ed25519Signer::from_pem(&proof_key_pem)
+            .map_err(|error| anyhow::anyhow!("credential proof key is invalid: {error}"))?;
+        repo::identity::link_device_key(signer.public_key(), &proof_key_pem, &server)
             .with_context(|| format!("registering device identity for {server}"))?;
     }
 
-    Ok(metadata.subject)
+    Ok(subject)
 }
 
 pub(crate) fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetadata> {
     use biscuit_auth::builder::{BlockBuilder, Term};
 
     let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
-        .context("parsing --token as a Biscuit")?;
+        .context("parsing credential token as a Biscuit")?;
     let block_count = biscuit.block_count();
     let authority_source = biscuit
         .print_block_source(0)
@@ -894,19 +768,33 @@ fn auth_status_output(server: &str, credential: Option<ServerCredential>) -> Aut
 // ---------------------------------------------------------------------------
 
 /// Create a namespace-scoped service token for CI/ephemeral runners.
+///
+/// Emits a single self-verifying `.hcred` credential file. The token and proof
+/// key never touch stdout or the JSON contract — only the credential path,
+/// scope, and expiry are reported.
 async fn cmd_create_service_token(
     ctx: &dyn CliContext,
     server: Option<&str>,
     name: String,
     namespace: String,
-    key_out: Option<String>,
-    show_secrets: bool,
+    out: Option<&Path>,
 ) -> Result<()> {
     let server = resolve_server(server)?;
     let scope = format!("repo:{namespace}/*");
 
+    // Resolve (and fail-fast reject an existing) credential path BEFORE any
+    // server round trip, so a name collision doesn't strand a created service
+    // account with no locally-written credential.
+    let credential_path = resolve_service_account_credential_path(&name, out);
+    if std::fs::symlink_metadata(&credential_path).is_ok() {
+        bail!(
+            "credential destination {} already exists; choose a new --out path",
+            credential_path.display()
+        );
+    }
+
     // Select and validate the exact stored bearer + matching device proof key
-    // before generating or writing the new service-account key.
+    // before generating the new service-account key.
     let user_config = UserConfig::load_default()?;
     let session = HostedSession::build_stored_credential(&user_config, &server)?;
     let channel = connect_channel(&server).await?;
@@ -927,18 +815,6 @@ async fn cmd_create_service_token(
     let private_key_pem = signer
         .to_pem()
         .map_err(|e| anyhow::anyhow!("failed to export service-account private key: {e}"))?;
-
-    // Always persist the private key to a 0600 file; never dump PEM to stdout
-    // by default (shell history / CI logs). `--show-secrets` opts into printing
-    // the PEM (and including it in JSON).
-    let key_path = resolve_service_account_key_path(&name, key_out.as_deref())?;
-    if let Some(parent) = key_path.parent() {
-        objects::fs_atomic::create_private_dir_all(parent)
-            .with_context(|| format!("creating private key directory {}", parent.display()))?;
-    }
-    objects::fs_atomic::write_file_atomic_secret(&key_path, private_key_pem.as_bytes())
-        .with_context(|| format!("writing private key to {}", key_path.display()))?;
-    let key_path_display = key_path.display().to_string();
 
     // 1. Create the service account.
     let sa_response = auth_client
@@ -978,51 +854,63 @@ async fn cmd_create_service_token(
         .await
         .map_err(|error| anyhow::anyhow!("issue_service_account_credential failed: {error}"))?;
 
+    // Re-derive the subject from the issued token so the written credential is
+    // self-consistent (`load_credential_file` re-checks this on every read).
+    let subject = crate::device_flow::authenticated_subject(&issued.token)
+        .context("reading the issued service token's authenticated subject")?;
+    let expires_at = (chrono::Utc::now()
+        + chrono::Duration::seconds(SERVICE_TOKEN_TTL_SECS))
+    .to_rfc3339();
+
+    let verified = VerifiedCredential {
+        server: server.clone(),
+        kind: CredentialKind::Service,
+        subject,
+        token: issued.token,
+        proof_key_pem: private_key_pem,
+        expires_at: Some(expires_at),
+        credential_id: None,
+        provenance: Some(CredentialProvenance {
+            scopes: Some(vec![scope.clone()]),
+            ..CredentialProvenance::default()
+        }),
+    };
+    credential_file::write_credential_file(&credential_path, &verified)?;
+    let credential_path_display = credential_path.display().to_string();
+
     if ctx.should_output_json(None) {
         let output = ServiceTokenOutput {
             output_kind: "auth_create_service_token",
             name,
             namespace,
             scope,
-            token: issued.token,
-            private_key_path: key_path_display,
-            private_key_pem: show_secrets.then_some(private_key_pem),
+            credential_path: credential_path_display,
             expires_in_days: SERVICE_TOKEN_TTL_DAYS,
         };
         println!("{}", serde_json::to_string(&output)?);
     } else {
         println!();
-        println!("Service token created for \"{}\" (scope: {scope})", name);
+        println!("Service token created for \"{name}\" (scope: {scope})");
         println!();
-        println!("Token: {}", issued.token);
-        println!();
-        println!("Private key written to: {key_path_display}");
-        if show_secrets {
-            println!();
-            println!("Private key PEM:");
-            println!("{private_key_pem}");
-        }
-        println!("This token is proof-of-possession bound to the private key file above.");
-        println!("Set the token as HEDDLE_REMOTE_TOKEN in your CI environment.");
+        println!("Credential written to: {credential_path_display}");
+        println!("Expires in {SERVICE_TOKEN_TTL_DAYS} days.");
         println!(
-            "Configure remote.auth_proof_key_pem_path to {key_path_display} (or copy the key securely)."
+            "The single .hcred file carries the token and its proof key; keep it secret (mode 0600)."
         );
+        println!("Point the runtime at it with HEDDLE_CREDENTIAL={credential_path_display}.");
         println!("This token is scoped to the {namespace} namespace.");
     }
 
     Ok(())
 }
 
-/// Resolve where to write the service-account private key.
+/// Resolve where to write the service-account `.hcred` credential.
 ///
-/// Prefers an explicit `--key-out` path; otherwise writes under
-/// `<heddle_home>/service-accounts/<sanitized-name>.pem`.
-fn resolve_service_account_key_path(
-    name: &str,
-    key_out: Option<&str>,
-) -> Result<std::path::PathBuf> {
-    if let Some(path) = key_out {
-        return Ok(std::path::PathBuf::from(path));
+/// Prefers an explicit `--out` path; otherwise writes under
+/// `<heddle_home>/service-accounts/<sanitized-name>.hcred`.
+fn resolve_service_account_credential_path(name: &str, out: Option<&Path>) -> std::path::PathBuf {
+    if let Some(path) = out {
+        return path.to_path_buf();
     }
     let mut safe: String = name
         .chars()
@@ -1037,9 +925,9 @@ fn resolve_service_account_key_path(
     if safe.is_empty() {
         safe = "service-account".to_string();
     }
-    Ok(repo::identity::heddle_home_dir()
+    repo::identity::heddle_home_dir()
         .join("service-accounts")
-        .join(format!("{safe}.pem")))
+        .join(format!("{safe}.hcred"))
 }
 
 fn issue_service_account_credential_request(
@@ -2042,12 +1930,12 @@ mod tests {
     }
 
     #[test]
-    fn derive_agent_export_contains_token_metadata_and_a_fresh_child_key() {
+    fn derive_agent_out_writes_one_verifiable_hcred_with_a_fresh_child_key() {
         with_isolated_home(|| {
             let server = "grpc.S";
             let (parent, private_key_pem) = stored_device_parent();
             credentials::store_server_credential(server, parent).expect("store parent");
-            let export_dir = repo::identity::heddle_home_dir().join("agent-export");
+            let out = repo::identity::heddle_home_dir().join("agent-export.hcred");
 
             cmd_auth_derive_agent(
                 server,
@@ -2056,49 +1944,44 @@ mod tests {
                 vec!["repo:acme/heddle".to_string()],
                 vec!["Push".to_string()],
                 None,
-                Some(&export_dir),
+                Some(&out),
             )
             .expect("derive portable child credential");
 
-            let mut entries = std::fs::read_dir(&export_dir)
-                .expect("read export directory")
-                .map(|entry| {
-                    entry
-                        .expect("export entry")
-                        .file_name()
-                        .into_string()
-                        .expect("UTF-8 export name")
-                })
-                .collect::<Vec<_>>();
-            entries.sort();
-            assert_eq!(entries, ["device-key.pem", "metadata.json", "token"]);
+            // Exactly one file is emitted — no sibling token/key/metadata files.
+            assert!(out.is_file(), "expected a single .hcred file");
 
-            let token = std::fs::read(export_dir.join("token")).expect("read exported token");
-            let child_private_key = std::fs::read_to_string(export_dir.join("device-key.pem"))
-                .expect("read exported child key");
-            let metadata =
-                std::fs::read(export_dir.join("metadata.json")).expect("read export metadata");
+            // The self-verifying load chokepoint accepts it and re-derives the
+            // effective identity from the token.
+            let loaded = credential_file::load_credential_file(&out).expect("load written .hcred");
+            assert_eq!(loaded.server, server);
+            assert_eq!(loaded.subject, "alice");
+            assert_eq!(loaded.kind, credential_file::CredentialKind::Agent);
             assert_ne!(
-                child_private_key, private_key_pem,
-                "portable export must contain a fresh child key, never the parent device key"
+                loaded.proof_key_pem, private_key_pem,
+                "the .hcred must carry a fresh child key, never the parent device key"
             );
-            let child_signer =
-                Ed25519Signer::from_pem(&child_private_key).expect("parse exported child key");
+            let provenance = loaded.provenance.expect("audit provenance recorded");
+            assert_eq!(provenance.agent_id.as_deref(), Some("agent-export"));
+            assert_eq!(
+                provenance.scopes.as_deref(),
+                Some(["repo:acme/heddle".to_string()].as_slice())
+            );
+            assert_eq!(
+                provenance.allowed_operations.as_deref(),
+                Some(["Push".to_string()].as_slice())
+            );
 
-            let metadata: serde_json::Value =
-                serde_json::from_slice(&metadata).expect("parse export metadata");
-            assert_eq!(metadata["server"], server);
-            assert_eq!(metadata["subject"], "alice");
-            assert_eq!(metadata["scopes"], serde_json::json!(["repo:acme/heddle"]));
-            assert!(metadata["expires_at"].as_str().is_some());
-            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(&token)
-                .expect("exported token is a Biscuit");
+            let child_signer =
+                Ed25519Signer::from_pem(&loaded.proof_key_pem).expect("parse child key");
+            let parsed = biscuit_auth::UnverifiedBiscuit::from_base64(loaded.token.as_bytes())
+                .expect("token is a Biscuit");
             assert!(
                 parsed
                     .print_block_source(1)
-                    .expect("exported child block")
+                    .expect("child block")
                     .contains(&hex::encode(child_signer.public_key())),
-                "the exported token must bind the key exported beside it"
+                "the token must bind the key packaged alongside it"
             );
 
             let error = cmd_auth_derive_agent(
@@ -2108,40 +1991,11 @@ mod tests {
                 vec!["repo:acme/heddle".to_string()],
                 vec!["Push".to_string()],
                 None,
-                Some(&export_dir),
+                Some(&out),
             )
-            .expect_err("an existing bundle must not be replaced piecemeal");
+            .expect_err("an existing credential file must not be overwritten");
             assert!(error.to_string().contains("already exists"));
-            assert_eq!(
-                std::fs::read(export_dir.join("token")).expect("re-read original token"),
-                token,
-                "a refused replacement must leave the completed bundle unchanged"
-            );
         });
-    }
-
-    #[test]
-    fn publishing_agent_bundle_syncs_the_parent_after_rename_and_reports_sync_failure() {
-        let temp = tempfile::tempdir().expect("tempdir");
-        let parent = temp.path();
-        let staging = parent.join(".agent.tmp");
-        let destination = parent.join("agent");
-        std::fs::create_dir(&staging).expect("create staging directory");
-        std::fs::write(staging.join("token"), b"token").expect("write staged token");
-
-        let error =
-            publish_agent_bundle_with_sync(&staging, &destination, parent, |synced_parent| {
-                assert_eq!(synced_parent, parent);
-                assert!(
-                    destination.join("token").is_file(),
-                    "the completed rename must precede the parent sync"
-                );
-                Err(std::io::Error::other("injected parent sync failure"))
-            })
-            .expect_err("a parent sync failure must not be reported as success");
-
-        assert!(error.to_string().contains("syncing agent bundle parent"));
-        assert!(format!("{error:#}").contains("injected parent sync failure"));
     }
 
     #[test]
@@ -2223,20 +2077,95 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn headless_login_requires_an_explicit_server() {
+    async fn login_with_missing_credential_file_fails_closed() {
         let error = cmd_auth(
             &TextCtx,
             AuthCommand::Login {
                 server: None,
                 open_browser: false,
-                token: Some("token".to_string()),
-                key_file: Some(std::path::PathBuf::from("device.pem")),
+                credential: Some(std::path::PathBuf::from("/definitely/not/here.hcred")),
             },
         )
         .await
-        .expect_err("headless install without --server must fail closed");
+        .expect_err("a missing credential file must fail");
+        assert!(error.to_string().contains("opening credential file"));
+    }
 
-        assert!(error.to_string().contains("--server is required"));
+    #[tokio::test]
+    async fn login_with_device_credential_file_installs_and_links_identity() {
+        // `with_isolated_home` guards a process-global env mutation; run the
+        // async install on the current thread inside that guard.
+        let temp = tempfile::TempDir::new().expect("temp home");
+        let _guard = credentials::lock_test_env();
+        let prev_home = std::env::var_os("HOME");
+        let prev_heddle_home = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("HEDDLE_HOME");
+        }
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let server = "grpc.device";
+            let signer = Ed25519Signer::generate().expect("device key");
+            let expires_at = chrono::Utc::now() + chrono::Duration::hours(2);
+            let token = biscuit_auth::Biscuit::builder()
+                .fact(r#"user("alice")"#)
+                .expect("user fact")
+                .fact(r#"credential_id("root-credential")"#)
+                .expect("credential fact")
+                .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+                .expect("device PoP fact")
+                .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
+                .expect("expiry fact")
+                .check(format!("check if time($now), $now < {}", expires_at.to_rfc3339()).as_str())
+                .expect("expiry check")
+                .build(&biscuit_auth::KeyPair::new())
+                .expect("build device token")
+                .to_base64()
+                .expect("encode device token");
+            let path = repo::identity::heddle_home_dir().join("device.hcred");
+            credential_file::write_credential_file(
+                &path,
+                &VerifiedCredential {
+                    server: server.to_string(),
+                    kind: CredentialKind::Device,
+                    subject: "alice".to_string(),
+                    token,
+                    proof_key_pem: signer.to_pem().expect("device PEM"),
+                    expires_at: Some(expires_at.to_rfc3339()),
+                    credential_id: Some("root-credential".to_string()),
+                    provenance: None,
+                },
+            )
+            .expect("write device .hcred");
+
+            let subject = install_credential_file(&path).expect("install device credential");
+            assert_eq!(subject, "alice");
+
+            let stored = credentials::get_server_credential(server)
+                .expect("load stored")
+                .expect("credential stored under the file's server");
+            assert_eq!(stored.subject, "alice");
+            assert_eq!(stored.credential_id.as_deref(), Some("root-credential"));
+            assert!(
+                repo::identity::device_identity_path().exists(),
+                "a device-kind credential registers the host signing identity",
+            );
+        }));
+
+        unsafe {
+            match prev_home {
+                Some(value) => std::env::set_var("HOME", value),
+                None => std::env::remove_var("HOME"),
+            }
+            match prev_heddle_home {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
     }
 
     /// On a successful logout, both the credential and the matching device

--- a/crates/client/src/auth_requests.rs
+++ b/crates/client/src/auth_requests.rs
@@ -5,8 +5,10 @@ pub enum AuthCommand {
     Login {
         server: Option<String>,
         open_browser: bool,
-        token: Option<String>,
-        key_file: Option<std::path::PathBuf>,
+        /// Install a verified `.hcred` credential file without a browser.
+        /// The server comes from the file. Mutually exclusive with the
+        /// browser flags.
+        credential: Option<std::path::PathBuf>,
     },
     Logout {
         server: Option<String>,
@@ -24,15 +26,16 @@ pub enum AuthCommand {
         /// Expands to a curated `--allow` set; a combined explicit `--allow`
         /// may only narrow it.
         template: Option<crate::device_flow::AgentTemplate>,
+        /// Write a single `<name>.hcred` credential file to this path instead
+        /// of installing the child into the keystore.
         out: Option<std::path::PathBuf>,
     },
     CreateServiceToken {
         name: String,
         namespace: String,
         server: Option<String>,
-        /// Optional path for the private-key PEM (default: under heddle home).
-        key_out: Option<String>,
-        /// Include private key material in stdout / JSON.
-        show_secrets: bool,
+        /// Path for the `.hcred` credential file
+        /// (default: `~/.heddle/service-accounts/<name>.hcred`).
+        out: Option<std::path::PathBuf>,
     },
 }

--- a/crates/client/src/credential_file.rs
+++ b/crates/client/src/credential_file.rs
@@ -1,0 +1,516 @@
+//! Single-file `.hcred` credential artifact.
+//!
+//! A `.hcred` file collapses the two coupled artifacts a non-browser Heddle
+//! credential used to require — a biscuit `token` and its device-key PEM —
+//! into one self-verifying JSON object. It is packaging only: the token and
+//! proof key the server validates are unchanged, and so is the offline,
+//! no-server-round-trip property of `derive-agent`.
+//!
+//! # Trust boundary
+//!
+//! There is exactly ONE verifying load chokepoint, [`load_credential_file`].
+//! It never trusts the file's self-reported `subject`/`expires_at` for
+//! authorization: it re-derives the effective proof key and subject from the
+//! token bytes (the same walk the hosted server performs) and rejects any file
+//! whose `proof_key_pem` or `subject` disagrees, or whose token has already
+//! expired. The `provenance` block is audit-only and is NEVER consulted for
+//! enforcement.
+//!
+//! # Secret handling
+//!
+//! [`VerifiedCredential`] is the in-memory shape. It has a MANUAL [`Debug`]
+//! impl that redacts `token`/`proof_key_pem` and deliberately derives no
+//! [`serde::Serialize`], so the secret material cannot leak into logs,
+//! tracing, or `--output json`. Serialization to disk goes through the private
+//! [`OnDiskCredential`] serde mirror, reachable only via
+//! [`write_credential_file`].
+
+use std::{
+    fmt,
+    fs::File,
+    io::Read,
+    path::Path,
+};
+
+use anyhow::{Context, Result, bail};
+use chrono::Utc;
+use crypto::{Ed25519Signer, Signer};
+use serde::{Deserialize, Serialize};
+
+/// Stable magic string in every `.hcred` file.
+const CREDENTIAL_FORMAT: &str = "heddle-credential";
+/// Only on-disk schema version this build reads and writes.
+const CREDENTIAL_VERSION: u32 = 1;
+
+/// The role a `.hcred` credential plays. Audit/provenance metadata only — the
+/// server enforces authority from the token, not this label.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CredentialKind {
+    /// An offline-derived, TTL/operation/scope-limited child credential.
+    Agent,
+    /// A namespace-scoped service-account credential for CI/automation.
+    Service,
+    /// An operator-provisioned, device-bound bootstrap credential.
+    Device,
+}
+
+/// Audit-only provenance recorded beside a derived credential. NEVER trusted
+/// for enforcement — the token's own attenuation blocks are the authority.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct CredentialProvenance {
+    /// The `--template` preset a derived agent was built from, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub template: Option<String>,
+    /// Declared resource scopes (`repo:org/name`, `namespace:org`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scopes: Option<Vec<String>>,
+    /// The exact operation ceiling recorded in the token's attenuation block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub allowed_operations: Option<Vec<String>>,
+    /// The agent id recorded in the delegation chain.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<String>,
+}
+
+impl CredentialProvenance {
+    /// Whether this provenance carries any recorded field.
+    fn is_empty(&self) -> bool {
+        self.template.is_none()
+            && self.scopes.is_none()
+            && self.allowed_operations.is_none()
+            && self.agent_id.is_none()
+    }
+}
+
+/// A cryptographically verified credential, in memory.
+///
+/// Obtained ONLY from [`load_credential_file`] (which re-verifies against the
+/// token) or constructed by a writer that just minted the token/key. The
+/// `token` and `proof_key_pem` fields are secrets — this type intentionally
+/// does not implement [`serde::Serialize`] and redacts them in [`Debug`].
+pub struct VerifiedCredential {
+    /// Server address the credential authenticates against.
+    pub server: String,
+    /// Credential role (audit only).
+    pub kind: CredentialKind,
+    /// Authenticated subject, re-derived from the token on load.
+    pub subject: String,
+    /// Base64 biscuit token. Secret.
+    pub token: String,
+    /// PEM of the Ed25519 proof key bound to `token`. Secret.
+    pub proof_key_pem: String,
+    /// Effective RFC 3339 expiry, re-computed from the token on load. `None`
+    /// for tokens the server never expires.
+    pub expires_at: Option<String>,
+    /// Authority credential id, when the token carries one (used for rotation).
+    pub credential_id: Option<String>,
+    /// Audit-only provenance. Never trusted for enforcement.
+    pub provenance: Option<CredentialProvenance>,
+}
+
+impl fmt::Debug for VerifiedCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VerifiedCredential")
+            .field("server", &self.server)
+            .field("kind", &self.kind)
+            .field("subject", &self.subject)
+            .field("token", &"<redacted>")
+            .field("proof_key_pem", &"<redacted>")
+            .field("expires_at", &self.expires_at)
+            .field("credential_id", &self.credential_id)
+            .field("provenance", &self.provenance)
+            .finish()
+    }
+}
+
+impl VerifiedCredential {
+    /// Map into the keystore's [`ServerCredential`] shape so a loaded `.hcred`
+    /// round-trips through `credentials.toml`.
+    pub fn into_server_credential(self) -> crate::credentials::ServerCredential {
+        crate::credentials::ServerCredential {
+            token: self.token,
+            subject: self.subject,
+            device_id: None,
+            credential_id: self.credential_id,
+            private_key_pem: Some(self.proof_key_pem),
+            expires_at: self.expires_at,
+        }
+    }
+}
+
+/// Private on-disk serde mirror. The only path that serializes the secret
+/// fields — kept separate from [`VerifiedCredential`] so those secrets can
+/// never be emitted through an accidental `Serialize` on the in-memory type.
+#[derive(Serialize, Deserialize)]
+struct OnDiskCredential {
+    format: String,
+    version: u32,
+    server: String,
+    kind: CredentialKind,
+    subject: String,
+    token: String,
+    proof_key_pem: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    /// Always emitted (as `null` when absent) so the schema is stable.
+    #[serde(default)]
+    credential_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provenance: Option<CredentialProvenance>,
+}
+
+/// Write `credential` to `path` as a `0600` `.hcred` file via the atomic
+/// secret writer. Refuses to overwrite an existing path (mirroring the old
+/// bundle's dir-exists guard) so a writer never clobbers another credential.
+pub fn write_credential_file(path: &Path, credential: &VerifiedCredential) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(_) => bail!(
+            "credential destination {} already exists; choose a new --out path",
+            path.display()
+        ),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("checking credential destination {}", path.display()));
+        }
+    }
+
+    if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
+        objects::fs_atomic::create_private_dir_all(parent)
+            .with_context(|| format!("creating credential parent {}", parent.display()))?;
+    }
+
+    let provenance = credential
+        .provenance
+        .as_ref()
+        .filter(|provenance| !provenance.is_empty())
+        .cloned();
+    let on_disk = OnDiskCredential {
+        format: CREDENTIAL_FORMAT.to_string(),
+        version: CREDENTIAL_VERSION,
+        server: credential.server.clone(),
+        kind: credential.kind,
+        subject: credential.subject.clone(),
+        token: credential.token.clone(),
+        proof_key_pem: credential.proof_key_pem.clone(),
+        expires_at: credential.expires_at.clone(),
+        credential_id: credential.credential_id.clone(),
+        provenance,
+    };
+
+    let mut bytes = serde_json::to_vec_pretty(&on_disk).context("serializing credential file")?;
+    bytes.push(b'\n');
+    objects::fs_atomic::write_file_atomic_secret(path, &bytes)
+        .with_context(|| format!("writing credential file {}", path.display()))?;
+    Ok(())
+}
+
+/// Load and cryptographically verify a `.hcred` file — the single trusted
+/// entry point for on-disk credentials.
+///
+/// Verification steps (all fail-closed):
+/// 1. `format`/`version` match this build;
+/// 2. a fail-closed permissions/ownership check (Unix): the file must be a
+///    regular file (a symlink to a non-file target is refused) and must not be
+///    group/other-accessible;
+/// 3. the token's effective proof key equals `proof_key_pem`'s public key;
+/// 4. the token's authenticated subject equals `subject`;
+/// 5. the effective expiry re-computed from the token is not already past
+///    (the file's `expires_at` is only a hint and is replaced by the
+///    re-computed value).
+pub fn load_credential_file(path: &Path) -> Result<VerifiedCredential> {
+    // Open through the fail-closed security gate and read from the SAME handle
+    // so the permission check and the read observe one inode (no TOCTOU).
+    let mut file = open_credential_file_checked(path)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .with_context(|| format!("reading credential file {}", path.display()))?;
+
+    let on_disk: OnDiskCredential = serde_json::from_str(&contents)
+        .with_context(|| format!("parsing credential file {}", path.display()))?;
+    if on_disk.format != CREDENTIAL_FORMAT {
+        bail!(
+            "{} is not a Heddle credential file (format {:?}, expected {CREDENTIAL_FORMAT:?})",
+            path.display(),
+            on_disk.format
+        );
+    }
+    if on_disk.version != CREDENTIAL_VERSION {
+        bail!(
+            "credential file {} has unsupported version {} (this build reads version {CREDENTIAL_VERSION})",
+            path.display(),
+            on_disk.version
+        );
+    }
+
+    // Re-derive the ground truth from the token bytes — never trust the file's
+    // self-reported identity for authorization.
+    let metadata = crate::auth_cmd::headless_token_metadata(&on_disk.token)
+        .with_context(|| format!("verifying token in credential file {}", path.display()))?;
+
+    let signer = Ed25519Signer::from_pem(&on_disk.proof_key_pem)
+        .map_err(|error| anyhow::anyhow!("credential proof key is not a valid Ed25519 PEM: {error}"))?;
+    let proof_public_key_hex = hex::encode(signer.public_key());
+    if !metadata
+        .proof_public_key_hex
+        .eq_ignore_ascii_case(&proof_public_key_hex)
+    {
+        bail!(
+            "credential file {} proof key does not match the token's effective proof key",
+            path.display()
+        );
+    }
+
+    if on_disk.subject != metadata.subject {
+        bail!(
+            "credential file {} claims subject {:?} but the token authenticates {:?}",
+            path.display(),
+            on_disk.subject,
+            metadata.subject
+        );
+    }
+
+    // Effective expiry comes from the token, not the file. Reject if past.
+    if let Some(expires_at) = metadata.expires_at.as_deref() {
+        let parsed = chrono::DateTime::parse_from_rfc3339(expires_at)
+            .with_context(|| format!("parsing token expiry {expires_at}"))?
+            .with_timezone(&Utc);
+        if parsed <= Utc::now() {
+            bail!(
+                "credential file {} is expired (token expired at {expires_at})",
+                path.display()
+            );
+        }
+    }
+
+    Ok(VerifiedCredential {
+        server: on_disk.server,
+        kind: on_disk.kind,
+        subject: metadata.subject,
+        token: on_disk.token,
+        proof_key_pem: on_disk.proof_key_pem,
+        expires_at: metadata.expires_at,
+        // Prefer the file's explicit credential id; fall back to the one the
+        // token carries so a device credential keeps its rotation anchor.
+        credential_id: on_disk.credential_id.or(metadata.credential_id),
+        provenance: on_disk.provenance,
+    })
+}
+
+/// Open a credential file behind a fail-closed security gate.
+///
+/// Follows the path to its target (so a k8s-style symlinked secret mount still
+/// works) but rejects a symlink to a NON-file target, and — on Unix — rejects
+/// any file the group or others can access. The check runs against the opened
+/// handle's metadata so the permission verdict and the later read see the same
+/// inode.
+fn open_credential_file_checked(path: &Path) -> Result<File> {
+    let file = File::open(path)
+        .with_context(|| format!("opening credential file {}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .with_context(|| format!("inspecting credential file {}", path.display()))?;
+    if !metadata.is_file() {
+        bail!(
+            "credential file {} is not a regular file (refusing a symlink to a non-file target)",
+            path.display()
+        );
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = metadata.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            bail!(
+                "credential file {} is group/other-accessible (mode {mode:o}); run `chmod 600 {}` to restrict it to your user",
+                path.display(),
+                path.display()
+            );
+        }
+    }
+    Ok(file)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use biscuit_auth::KeyPair;
+
+    /// Mint a device-bound authority token whose effective PoP key is `signer`.
+    fn mint_token(subject: &str, signer: &Ed25519Signer, ttl: chrono::Duration) -> String {
+        let expires_at = Utc::now() + ttl;
+        biscuit_auth::Biscuit::builder()
+            .fact(format!("user({})", quote(subject)).as_str())
+            .expect("user fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("device PoP fact")
+            .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
+            .expect("expiry fact")
+            .check(format!("check if time($now), $now < {}", expires_at.to_rfc3339()).as_str())
+            .expect("expiry check")
+            .build(&KeyPair::new())
+            .expect("build token")
+            .to_base64()
+            .expect("encode token")
+    }
+
+    fn quote(s: &str) -> String {
+        format!("\"{s}\"")
+    }
+
+    fn sample_verified() -> (VerifiedCredential, Ed25519Signer) {
+        let signer = Ed25519Signer::generate().expect("proof key");
+        let token = mint_token("alice", &signer, chrono::Duration::hours(2));
+        let proof_key_pem = signer.to_pem().expect("proof PEM");
+        (
+            VerifiedCredential {
+                server: "grpc.heddle.test".to_string(),
+                kind: CredentialKind::Agent,
+                subject: "alice".to_string(),
+                token,
+                proof_key_pem,
+                expires_at: Some((Utc::now() + chrono::Duration::hours(2)).to_rfc3339()),
+                credential_id: None,
+                provenance: Some(CredentialProvenance {
+                    template: Some("reviewer".to_string()),
+                    scopes: Some(vec!["repo:acme/heddle".to_string()]),
+                    allowed_operations: Some(vec!["GetState".to_string()]),
+                    agent_id: Some("agent-1".to_string()),
+                }),
+            },
+            signer,
+        )
+    }
+
+    #[test]
+    fn round_trips_write_then_load() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (credential, _signer) = sample_verified();
+        write_credential_file(&path, &credential).expect("write");
+
+        let loaded = load_credential_file(&path).expect("load");
+        assert_eq!(loaded.server, "grpc.heddle.test");
+        assert_eq!(loaded.subject, "alice");
+        assert_eq!(loaded.kind, CredentialKind::Agent);
+        assert_eq!(loaded.token, credential.token);
+        assert_eq!(loaded.proof_key_pem, credential.proof_key_pem);
+        assert!(loaded.expires_at.is_some(), "expiry re-derived from token");
+        let provenance = loaded.provenance.expect("provenance preserved");
+        assert_eq!(provenance.template.as_deref(), Some("reviewer"));
+        assert_eq!(provenance.agent_id.as_deref(), Some("agent-1"));
+    }
+
+    #[test]
+    fn refuses_to_overwrite_existing_path() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (credential, _signer) = sample_verified();
+        write_credential_file(&path, &credential).expect("first write");
+        let error = write_credential_file(&path, &credential).expect_err("second write refused");
+        assert!(error.to_string().contains("already exists"));
+    }
+
+    #[test]
+    fn debug_redacts_secret_material() {
+        let (credential, _signer) = sample_verified();
+        let rendered = format!("{credential:?}");
+        assert!(rendered.contains("<redacted>"));
+        assert!(
+            !rendered.contains(&credential.token),
+            "token must never appear in Debug output"
+        );
+        assert!(
+            !rendered.contains("BEGIN PRIVATE KEY"),
+            "proof key PEM must never appear in Debug output"
+        );
+    }
+
+    #[test]
+    fn rejects_tampered_proof_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (mut credential, _signer) = sample_verified();
+        // Swap in a mismatched proof key: no longer binds the token.
+        let attacker = Ed25519Signer::generate().expect("attacker key");
+        credential.proof_key_pem = attacker.to_pem().expect("attacker PEM");
+        write_credential_file(&path, &credential).expect("write");
+        let error = load_credential_file(&path).expect_err("mismatched key must be rejected");
+        assert!(error.to_string().contains("proof key does not match"));
+    }
+
+    #[test]
+    fn rejects_wrong_subject() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (mut credential, _signer) = sample_verified();
+        credential.subject = "mallory".to_string();
+        write_credential_file(&path, &credential).expect("write");
+        let error = load_credential_file(&path).expect_err("wrong subject must be rejected");
+        assert!(error.to_string().contains("authenticates"));
+    }
+
+    #[test]
+    fn rejects_expired_token() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let signer = Ed25519Signer::generate().expect("proof key");
+        let token = mint_token("alice", &signer, chrono::Duration::hours(-1));
+        let credential = VerifiedCredential {
+            server: "grpc.heddle.test".to_string(),
+            kind: CredentialKind::Agent,
+            subject: "alice".to_string(),
+            token,
+            proof_key_pem: signer.to_pem().expect("proof PEM"),
+            expires_at: None,
+            credential_id: None,
+            provenance: None,
+        };
+        write_credential_file(&path, &credential).expect("write");
+        let error = load_credential_file(&path).expect_err("expired token must be rejected");
+        assert!(error.to_string().contains("expired"));
+    }
+
+    #[test]
+    fn rejects_bad_format() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (credential, _signer) = sample_verified();
+        write_credential_file(&path, &credential).expect("write");
+        let contents = std::fs::read_to_string(&path).expect("read");
+        let tampered = contents.replace("heddle-credential", "not-a-credential");
+        std::fs::write(&path, tampered).expect("rewrite");
+        let error = load_credential_file(&path).expect_err("bad format must be rejected");
+        assert!(error.to_string().contains("not a Heddle credential file"));
+    }
+
+    #[test]
+    fn rejects_bad_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (credential, _signer) = sample_verified();
+        write_credential_file(&path, &credential).expect("write");
+        let contents = std::fs::read_to_string(&path).expect("read");
+        let tampered = contents.replace("\"version\": 1", "\"version\": 2");
+        std::fs::write(&path, tampered).expect("rewrite");
+        let error = load_credential_file(&path).expect_err("bad version must be rejected");
+        assert!(error.to_string().contains("unsupported version"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_group_readable_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (credential, _signer) = sample_verified();
+        write_credential_file(&path, &credential).expect("write");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640))
+            .expect("loosen perms");
+        let error = load_credential_file(&path).expect_err("group-readable file must be rejected");
+        let message = error.to_string();
+        assert!(message.contains("group/other-accessible"));
+        assert!(message.contains("chmod 600"));
+    }
+}

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -535,8 +535,6 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             let signer = Ed25519Signer::generate().expect("device key");
             let private_key_pem = signer.to_pem().expect("device PEM");
-            let key_path = home.path().join("bootstrap-key.pem");
-            std::fs::write(&key_path, &private_key_pem).expect("write bootstrap key");
 
             let subject = "headless-agent";
             let credential_id = "cred-headless";
@@ -560,8 +558,22 @@ mod tests {
                 .expect("encode fixture biscuit");
             let server = "127.0.0.1:8421";
 
-            auth_cmd::install_headless_credential(server, &token, &key_path)
-                .expect("headless credential install");
+            let root_hcred = home.path().join("root.hcred");
+            crate::credential_file::write_credential_file(
+                &root_hcred,
+                &crate::credential_file::VerifiedCredential {
+                    server: server.to_string(),
+                    kind: crate::credential_file::CredentialKind::Device,
+                    subject: subject.to_string(),
+                    token: token.clone(),
+                    proof_key_pem: private_key_pem.clone(),
+                    expires_at: Some(expires_at.to_rfc3339()),
+                    credential_id: Some(credential_id.to_string()),
+                    provenance: None,
+                },
+            )
+            .expect("write root .hcred");
+            auth_cmd::install_credential_file(&root_hcred).expect("headless credential install");
 
             let stored = credentials::get_server_credential(server)
                 .expect("read credentials")
@@ -613,10 +625,22 @@ mod tests {
             .expect("derive child token");
 
             let child_private_key_pem = child_signer.to_pem().expect("child PEM");
-            let child_key_path = home.path().join("child-key.pem");
-            std::fs::write(&child_key_path, &child_private_key_pem)
-                .expect("write child key for install");
-            auth_cmd::install_headless_credential(server, &child_token, &child_key_path)
+            let child_hcred = home.path().join("child.hcred");
+            crate::credential_file::write_credential_file(
+                &child_hcred,
+                &crate::credential_file::VerifiedCredential {
+                    server: server.to_string(),
+                    kind: crate::credential_file::CredentialKind::Agent,
+                    subject: subject.to_string(),
+                    token: child_token.clone(),
+                    proof_key_pem: child_private_key_pem.clone(),
+                    expires_at: Some((chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339()),
+                    credential_id: None,
+                    provenance: None,
+                },
+            )
+            .expect("write child .hcred");
+            auth_cmd::install_credential_file(&child_hcred)
                 .expect("install derived child credential");
 
             let stored_child = credentials::get_server_credential(server)

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod auth_cmd;
 pub mod auth_requests;
+pub mod credential_file;
 pub mod credentials;
 pub mod device_flow;
 pub mod grpc_hosted;

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1908,12 +1908,15 @@ no operation allowlist. When the server is unreachable, `reachable` is `false`,
   "output_kind": "auth_create_service_token",
   "name": "github-ci-main",
   "namespace": "heddle/platform",
-  "scope": "namespace:heddle/platform",
-  "token": "heddle_sa_...",
-  "private_key_pem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "scope": "repo:heddle/platform/*",
+  "credential_path": "/home/ci/.heddle/service-accounts/github-ci-main.hcred",
   "expires_in_days": 30
 }
 ```
+
+The token and proof key are written into the single `.hcred` file at
+`credential_path` (mode `0600`); they never appear on stdout or in this
+contract.
 
 ---
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -5870,12 +5870,15 @@ no operation allowlist. When the server is unreachable, `reachable` is `false`,
   "output_kind": "auth_create_service_token",
   "name": "github-ci-main",
   "namespace": "heddle/platform",
-  "scope": "namespace:heddle/platform",
-  "token": "heddle_sa_...",
-  "private_key_pem": "-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----\n",
+  "scope": "repo:heddle/platform/*",
+  "credential_path": "/home/ci/.heddle/service-accounts/github-ci-main.hcred",
   "expires_in_days": 30
 }
 ```
+
+The token and proof key are written into the single `.hcred` file at
+`credential_path` (mode `0600`); they never appear on stdout or in this
+contract.
 
 ---
 


### PR DESCRIPTION
Closes #1063.

## What

Collapse the **transport** for every non-browser Heddle credential from two coupled artifacts (a biscuit `token` + its device-key PEM, moved as a 3-file bundle or a `token`+`--key-file` pair) into one self-verifying `.hcred` JSON file. This is **packaging only** — the token and proof key the server validates are unchanged, and the PoP / `heddle-req-sig-v1` signing model plus the offline (no-server-round-trip) property of `derive-agent` are preserved. Runtime resolver / `HostedSession` / `HEDDLE_CREDENTIAL` are untouched (that is #1064).

## New module `crates/client/src/credential_file.rs`

- Versioned JSON (`format:"heddle-credential"`, `version:1`) with `server`/`kind`/`subject`/`token`/`proof_key_pem`/`expires_at?`/`credential_id`/`provenance?`.
- **One** verifying load chokepoint `load_credential_file`: checks format/version; re-derives the effective proof key and authenticated subject from the token bytes and rejects any mismatch; recomputes effective expiry from the token (the file value is a hint) and rejects if expired; fail-closed Unix perms check (precise `chmod 600 <path>` message) that also refuses a symlink to a non-file target — read through the opened handle to avoid TOCTOU.
- `write_credential_file` — 0600 atomic via `write_file_atomic_secret`, refuses to overwrite an existing path.
- `VerifiedCredential` has a **manual secret-redacting `Debug`** and **no derived `Serialize`**; a separate private `OnDiskCredential` serde mirror is the only path that serializes the secret fields. `provenance` is audit-only, never trusted for enforcement.
- Maps both ways: `VerifiedCredential -> ServerCredential` (install) and writer-built `VerifiedCredential -> .hcred`.

## Rewired commands (delete + replace, no back-compat shims)

- `auth login`: add `--credential <path.hcred>` (server comes from the file; `conflicts_with` the browser flags), **delete** `--token` / `--key-file`; the verify+store logic now folds through the shared verified struct.
- `auth derive-agent`: `--out` becomes a single `<name>.hcred` file; **deleted** `write_agent_bundle`/`publish_agent_bundle*` and the separate `metadata.json`/`device-key.pem` writes. Metadata folds into `provenance`. Offline crypto + `--template`/`--allow`/`--scope` unchanged; no-`--out` still installs to the keystore.
- `auth create-service-token`: add `--out <FILE.hcred>` (default `~/.heddle/service-accounts/<name>.hcred`); **deleted** `--key-out` / `--show-secrets` and every secret on stdout/JSON. Prints only path + scope + expiry; JSON carries `credential_path`.
- Updated `.agents/agent-attenuation.md`, `docs/json-schemas.md`, regenerated npm TS/JSON bindings and `docs/llms-full.txt`.

## Verification (foreground, verbatim)

- `cargo build -p heddle-cli -p heddle-client` → `Finished` (clean).
- `cargo clippy -p heddle-cli -p heddle-client --all-targets -- -D warnings` → `Finished`, no warnings from this code.
- `cargo test -p heddle-client --lib credential_file` → `ok. 12 passed; 0 failed` (round-trip, tampered-key, wrong-subject, expired, bad format/version, group-readable rejected, Debug redaction, missing-file, device-install+link).
- `cargo test -p heddle-client --lib` → `ok. 171 passed; 0 failed`.
- `cargo test -p heddle-cli --lib` → `ok. 627 passed; 0 failed`.
- `bash scripts/gen-ts-types.sh` → regenerated; `cargo test -p heddle-cli --test ts_types_in_sync --test tier_coverage --test auth_login` → all `ok` (`ts_types`/`json` in sync, tier coverage, credential login routes to verifying load).
- `cargo test -p heddle-cli --test cli_integration -- output_kind ... doctor_schemas` → all `ok` (output_kind invariants incl. `doc_samples_match_runtime`, doctor-schema doc sync).
- `cargo test -p heddle-cli --no-fail-fast` → only 3 failures, all the documented CLAUDECODE env flakes that pass in clean CI (`oss_cli_polish::agent_presence_explain_json_detects_harness_without_active_presence`, `multi_agent_worktrees::actor_presence::start_path_inherits_codex_probe_identity_into_actor_metadata`, `multi_agent_worktrees::e2e::agent_capture_and_ready_require_authenticated_writer_authority` — the last asserts `openai/gpt-5.3-codex` but the in-session harness probe reads `CLAUDECODE`). None touch credential packaging or the auth commands.

## Design deviations

- **Symlink handling**: the design said "reject if it's a symlink to an unexpected target." With no notion of an "expected" target and k8s-style symlinked secret mounts a real headless case, `open_credential_file_checked` follows the path but validates the **opened handle's** metadata — rejecting a symlink to a non-file target and (Unix) any group/other-accessible mode — which is TOCTOU-safe and covers the intent.
- **`load_credential_file` credential_id**: prefers the file's explicit `credential_id`, falling back to the one the token carries, so a `device` credential keeps its rotation anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1066"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787106575&installation_id=132405951&pr_number=1066&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1066&signature=5bc7a7b071cbcdc03b0c9313491a3839125dc710a3614d7b5a109715917180b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->