### PR TITLE
feat(client): HEDDLE_CREDENTIAL auto-discovery + retire token/config auth mechanisms (#1064)

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -154,15 +154,11 @@ pub struct UserLoggingConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UserRemoteConfig {
     #[serde(default)]
-    pub token: Option<String>,
-    #[serde(default)]
     pub tls_enabled: bool,
     #[serde(default)]
     pub tls_domain_name: Option<String>,
     #[serde(default)]
     pub tls_ca_certificate_path: Option<PathBuf>,
-    #[serde(default)]
-    pub auth_proof_key_pem_path: Option<PathBuf>,
     /// Allow cleartext connections to non-loopback hosts without TLS.
     /// Prefer enabling TLS; this is an explicit opt-in for lab/VPN testing.
     #[serde(default)]
@@ -398,21 +394,6 @@ impl UserConfig {
         });
     }
 
-    pub fn remote_token(&self) -> anyhow::Result<Option<AuthToken>> {
-        match env::var("HEDDLE_REMOTE_TOKEN") {
-            Ok(token) if !token.is_empty() => Ok(Some(AuthToken::new(token, "env"))),
-            Ok(_) | Err(env::VarError::NotPresent) => Ok(self
-                .remote
-                .token
-                .clone()
-                .map(|token| AuthToken::new(token, "user-config"))),
-            Err(err @ env::VarError::NotUnicode(_)) => Err(security_config_error(
-                "HEDDLE_REMOTE_TOKEN",
-                format!("read environment value: {err}"),
-            )),
-        }
-    }
-
     pub fn command_auto_capture_enabled(&self) -> anyhow::Result<bool> {
         let mut mode = self.capture.auto;
         match env::var("HEDDLE_AUTO_CAPTURE") {
@@ -430,14 +411,14 @@ impl UserConfig {
         Ok(matches!(mode, UserAutoCaptureMode::Command))
     }
 
+    /// Build the validated TLS/auth client config. The bearer token is supplied
+    /// by the caller (resolved through the single `HEDDLE_CREDENTIAL` → keystore
+    /// precedence in the client crate); this method no longer reads any token
+    /// from env or user config.
     pub fn heddle_client_config(
         &self,
-        token_override: Option<AuthToken>,
+        token: Option<AuthToken>,
     ) -> anyhow::Result<ClientConfig> {
-        let token = match token_override {
-            Some(token) => Some(token),
-            None => self.remote_token()?,
-        };
         let mut config = token
             .map(|token| ClientConfig::default().with_token(token))
             .unwrap_or_default();
@@ -454,10 +435,6 @@ impl UserConfig {
         if let Some(path) = &self.remote.tls_ca_certificate_path {
             let pem = read_security_config_file("remote.tls_ca_certificate_path", path)?;
             config = config.with_tls_ca_certificate_pem(pem);
-        }
-        if let Some(path) = &self.remote.auth_proof_key_pem_path {
-            let pem = read_security_config_file("remote.auth_proof_key_pem_path", path)?;
-            config = config.with_auth_proof_key_pem(pem);
         }
 
         if env_bool("HEDDLE_REMOTE_TLS")? {
@@ -603,7 +580,6 @@ mod tests {
 
     static TEST_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
     const REMOTE_ENV_KEYS: &[&str] = &[
-        "HEDDLE_REMOTE_TOKEN",
         "HEDDLE_REMOTE_TLS",
         "HEDDLE_REMOTE_TLS_DOMAIN",
         "HEDDLE_REMOTE_TLS_CA_CERT",
@@ -758,13 +734,10 @@ mod tests {
         let dir = unique_temp_path("heddle-user-config-valid-security");
         fs::create_dir_all(&dir).expect("create temp dir");
         let ca_path = dir.join("ca.pem");
-        let key_path = dir.join("proof-key.pem");
         fs::write(&ca_path, "test ca pem").expect("write ca pem");
-        fs::write(&key_path, "test key pem").expect("write key pem");
         let user = UserConfig {
             remote: UserRemoteConfig {
                 tls_ca_certificate_path: Some(ca_path),
-                auth_proof_key_pem_path: Some(key_path),
                 ..UserRemoteConfig::default()
             },
             ..UserConfig::default()
@@ -779,7 +752,6 @@ mod tests {
             config.tls_ca_certificate_pem.as_deref(),
             Some("test ca pem")
         );
-        assert_eq!(config.auth_proof_key_pem.as_deref(), Some("test key pem"));
 
         fs::remove_dir_all(dir).expect("remove temp dir");
     }
@@ -803,27 +775,6 @@ mod tests {
 
         assert!(message.contains("fatal TLS/auth configuration error"));
         assert!(message.contains("remote.tls_ca_certificate_path"));
-    }
-
-    #[test]
-    fn heddle_client_config_missing_auth_proof_key_path_fails_closed() {
-        let _env = RemoteEnvGuard::clean();
-        let missing = unique_temp_path("heddle-user-config-missing-key").join("proof-key.pem");
-        let user = UserConfig {
-            remote: UserRemoteConfig {
-                auth_proof_key_pem_path: Some(missing),
-                ..UserRemoteConfig::default()
-            },
-            ..UserConfig::default()
-        };
-
-        let err = user
-            .heddle_client_config(None)
-            .expect_err("missing configured proof key path must fail closed");
-        let message = err.to_string();
-
-        assert!(message.contains("fatal TLS/auth configuration error"));
-        assert!(message.contains("remote.auth_proof_key_pem_path"));
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1502,7 +1502,7 @@ async fn clone_network(
     endpoint_spec: String,
 ) -> Result<()> {
     use crate::{
-        client::{HostedAuthMode, HostedSession},
+        client::HostedSession,
         config::UserConfig,
     };
 
@@ -1524,9 +1524,7 @@ async fn clone_network(
     // filesystem/repo mutation such as `create_dir_all`, `Repository::init`,
     // state writes, or ref publishes. A rejected security config must leave
     // no partial on-disk artifact.
-    let session =
-        HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
-            .with_allow_insecure(*insecure);
+    let session = HostedSession::build(&user_config, server_key)?.with_allow_insecure(*insecure);
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
 
     let json_output = should_output_json(cli, None);
@@ -1712,7 +1710,7 @@ async fn clone_monorepo(
     endpoint_spec: String,
 ) -> Result<()> {
     use crate::{
-        client::{HostedAuthMode, HostedSession},
+        client::HostedSession,
         config::UserConfig,
     };
 
@@ -1728,8 +1726,7 @@ async fn clone_monorepo(
     // Security config validation must pass before any irreversible filesystem
     // mutation, exactly as `clone_network` does.
     let session =
-        HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
-            .with_allow_insecure(options.insecure);
+        HostedSession::build(&user_config, server_key)?.with_allow_insecure(options.insecure);
 
     let json_output = should_output_json(cli, None);
     let mut client = session.connect(addr).await?;

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -58,7 +58,7 @@ use crate::cli::progress_render::clear_line;
 #[cfg(feature = "client")]
 use crate::client::HostedGrpcClient;
 #[cfg(feature = "client")]
-use crate::client::{HostedAuthMode, HostedSession};
+use crate::client::HostedSession;
 #[cfg(feature = "client")]
 use crate::remote::Remote;
 use crate::{
@@ -354,8 +354,6 @@ pub async fn cmd_push(
         }
     }
 
-    #[cfg(not(feature = "client"))]
-    let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
     let (target, server_key) = resolve_push_target_with_key(&repo, remote.as_deref())?;
     #[cfg(not(feature = "client"))]
@@ -368,10 +366,7 @@ pub async fn cmd_push(
     let network_session = if matches!(target, RemoteTarget::Network { .. }) {
         let allow_insecure =
             insecure || cli_shared::remote_allows_insecure(&repo, remote.as_deref());
-        Some(
-            HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
-                .with_allow_insecure(allow_insecure),
-        )
+        Some(HostedSession::build(&user_config, server_key)?.with_allow_insecure(allow_insecure))
     } else {
         None
     };
@@ -380,7 +375,7 @@ pub async fn cmd_push(
     // local state — matching the prevalidation the `client` build runs above.
     #[cfg(not(feature = "client"))]
     if matches!(target, RemoteTarget::Network { .. }) {
-        user_config.heddle_client_config(token.clone())?;
+        user_config.heddle_client_config(None)?;
     }
 
     // `--all-threads` fans out over every pushable thread (heddle#838);

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -428,7 +428,7 @@ pub async fn cmd_push(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, token, single_state_id, insecure);
+            let _ = (addr, repo_path, single_state_id, insecure);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("push"));
         }

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 #[cfg(feature = "client")]
-use heddle_client::grpc_hosted::{HostedAuthMode, PullMaterialization};
+use heddle_client::grpc_hosted::PullMaterialization;
 #[cfg(feature = "client")]
 use heddle_core::{
     HostedPullResult, HostedPullResultFields, format_connected_to,
@@ -271,8 +271,6 @@ pub async fn cmd_pull(
     }
 
     let user_config = UserConfig::load_default()?;
-    #[cfg(not(feature = "client"))]
-    let token = user_config.remote_token()?;
     #[cfg(feature = "client")]
     let (target, server_key) = resolve_remote_with_key(&repo, plan.remote.as_deref())?;
     #[cfg(not(feature = "client"))]
@@ -311,7 +309,7 @@ pub async fn cmd_pull(
             )
             .await?;
             #[cfg(not(feature = "client"))]
-            let _ = (addr, repo_path, token, insecure);
+            let _ = (addr, repo_path, insecure);
             #[cfg(not(feature = "client"))]
             anyhow::bail!(RecoveryAdvice::network_feature_unavailable("pull"));
         }
@@ -1006,7 +1004,6 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
         options.addr,
         options.user_config,
         options.server_key,
-        HostedAuthMode::CredentialFallback,
         options.insecure,
     )
     .await?

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -38,8 +38,6 @@ use super::{
     next_action::{NextActionValidationContext, write_command_json},
     verification_health::{action_template, action_templates, repository_setup_guidance},
 };
-#[cfg(feature = "client")]
-use crate::config::UserConfig;
 use crate::{
     cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
     perf::{ProfileField, ProfileMode, emit_profile, profile_enabled, profile_mode},
@@ -1498,7 +1496,9 @@ impl HostedPresenceWatch {
             return None;
         }
 
-        let token = UserConfig::load_default().ok()?.remote_token().ok()??;
+        let token = crate::client::resolve_hosted_credential(Some(upstream))
+            .ok()?
+            .token?;
         let mut request = normalize_presence_ws_url(upstream)
             .ok()?
             .into_client_request()

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -37,7 +37,7 @@ use crate::{
         },
         should_output_json,
     },
-    client::{HostedAuthMode, HostedGrpcClient},
+    client::HostedGrpcClient,
     config::UserConfig,
     remote::{RemoteTarget, resolve_remote_with_key},
 };
@@ -124,17 +124,11 @@ async fn open_heddle_client(
     };
 
     let user_config = UserConfig::load_default()?;
-    // Authenticated thread-workflow RPCs are proof-of-possession gated, so use
-    // CredentialFallback (resolves the credential store's proof key) rather
-    // than a token-only ConfigToken session.
-    let client = HostedGrpcClient::open_session(
-        addr,
-        &user_config,
-        server_key,
-        HostedAuthMode::CredentialFallback,
-    )
-    .await?
-    .with_human_signature_callback(crate::client::cli_human_signature_callback());
+    // Authenticated thread-workflow RPCs are proof-of-possession gated; the
+    // single resolver attaches the credential's proof key.
+    let client = HostedGrpcClient::open_session(addr, &user_config, server_key)
+        .await?
+        .with_human_signature_callback(crate::client::cli_human_signature_callback());
     Ok((client, repo_path))
 }
 

--- a/crates/cli/src/client/mod.rs
+++ b/crates/cli/src/client/mod.rs
@@ -16,7 +16,10 @@ pub mod local_sync;
 
 pub use cli_shared::ClientConfig;
 #[cfg(feature = "client")]
-pub use heddle_client::{HostedAuthMode, HostedGrpcClient, HostedSession};
+pub use heddle_client::{
+    CredentialSource, HostedGrpcClient, HostedSession, ResolvedHostedCredential,
+    resolve_active_bearer, resolve_hosted_credential,
+};
 #[cfg(feature = "client")]
 pub use human_signature::cli_human_signature_callback;
 #[cfg(unix)]

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -953,7 +953,7 @@ impl HarnessBridgeRuntime {
             .transcript_mode
             .unwrap_or(self.user_config.harness.transcript);
         let env_hints = merged_env_hints(&params.env_hints);
-        let token_claims = user_config_token_claims(&self.user_config);
+        let token_claims = active_token_claims();
         let current_session = SessionManager::new(self.repo.root()).get_current_session()?;
         let current_segment = current_session
             .as_ref()
@@ -1990,7 +1990,7 @@ fn resolve_identity(
         .as_ref()
         .and_then(|session| session.current_segment());
     let token_claims = if user_config.harness.auto_infer {
-        user_config_token_claims(user_config)
+        active_token_claims()
     } else {
         None
     };
@@ -2310,12 +2310,22 @@ fn decode_token_claims(token: &str) -> Option<TokenClaims> {
     serde_json::from_slice(&decoded).ok()
 }
 
-fn user_config_token_claims(user_config: &UserConfig) -> Option<TokenClaims> {
-    user_config
-        .remote_token()
-        .ok()
-        .flatten()
-        .and_then(|token| decode_token_claims(&token.id))
+/// Decode the claims of the locally active bearer token, if any, resolved
+/// through the single credential precedence (`HEDDLE_CREDENTIAL` → keystore).
+/// Best-effort session-identity inference; returns `None` when unauthenticated
+/// or built without the `client` feature.
+fn active_token_claims() -> Option<TokenClaims> {
+    #[cfg(feature = "client")]
+    {
+        crate::client::resolve_active_bearer()
+            .ok()
+            .flatten()
+            .and_then(|token| decode_token_claims(&token.id))
+    }
+    #[cfg(not(feature = "client"))]
+    {
+        None
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -52,6 +52,9 @@ struct AuthStatusOutput {
     output_kind: &'static str,
     server: String,
     authenticated: bool,
+    /// Credential origin: `env:<path>` when `HEDDLE_CREDENTIAL` is set,
+    /// `keystore` for a stored credential, `none` when unauthenticated.
+    source: String,
     proof_key_available: bool,
     subject: Option<String>,
     credential_id: Option<String>,
@@ -697,11 +700,16 @@ fn cmd_auth_logout(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
 /// Show current authentication status.
 fn cmd_auth_status(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     let server = resolve_server(server)?;
-    let output = auth_status_output(&server, credentials::get_server_credential(&server)?);
+    // Report through the SAME precedence the runtime authenticates with, so
+    // `auth status` reflects what a hosted op would actually use — including a
+    // `HEDDLE_CREDENTIAL` that overrides the keystore.
+    let resolved = crate::grpc_hosted::resolve_hosted_credential(Some(&server))?;
+    let output = auth_status_output(&server, &resolved);
     if ctx.should_output_json(None) {
         println!("{}", serde_json::to_string(&output)?);
     } else if output.authenticated {
         println!("Server:        {server}");
+        println!("Source:        {}", output.source);
         println!(
             "Subject:       {}",
             output.subject.as_deref().unwrap_or_default()
@@ -731,35 +739,40 @@ fn cmd_auth_status(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn auth_status_output(server: &str, credential: Option<ServerCredential>) -> AuthStatusOutput {
-    match credential {
-        Some(credential) => {
-            let proof_key_available = credential
-                .private_key_pem
-                .as_deref()
-                .is_some_and(|pem| Ed25519Signer::from_pem(pem).is_ok());
-            AuthStatusOutput {
-                output_kind: "auth_status",
-                server: server.to_string(),
-                authenticated: true,
-                proof_key_available,
-                subject: Some(credential.subject),
-                credential_id: credential.credential_id,
-                expires_at: credential.expires_at,
-                recommended_action: (!proof_key_available)
-                    .then(|| format!("heddle auth login --server {server}")),
-            }
+fn auth_status_output(
+    server: &str,
+    resolved: &crate::grpc_hosted::ResolvedHostedCredential,
+) -> AuthStatusOutput {
+    let source = resolved.source.label();
+    if resolved.token.is_some() {
+        let proof_key_available = resolved
+            .proof_key_pem
+            .as_deref()
+            .is_some_and(|pem| Ed25519Signer::from_pem(pem).is_ok());
+        AuthStatusOutput {
+            output_kind: "auth_status",
+            server: server.to_string(),
+            authenticated: true,
+            source,
+            proof_key_available,
+            subject: resolved.subject.clone(),
+            credential_id: resolved.credential_id.clone(),
+            expires_at: resolved.expires_at.clone(),
+            recommended_action: (!proof_key_available)
+                .then(|| format!("heddle auth login --server {server}")),
         }
-        None => AuthStatusOutput {
+    } else {
+        AuthStatusOutput {
             output_kind: "auth_status",
             server: server.to_string(),
             authenticated: false,
+            source,
             proof_key_available: false,
             subject: None,
             credential_id: None,
             expires_at: None,
             recommended_action: Some(format!("heddle auth login --server {server}")),
-        },
+        }
     }
 }
 
@@ -2064,9 +2077,20 @@ mod tests {
 
     #[test]
     fn auth_status_qualifies_a_credential_without_a_proof_key() {
-        let output = auth_status_output("grpc.S", Some(sample_credential()));
+        let credential = sample_credential();
+        let resolved = crate::grpc_hosted::ResolvedHostedCredential {
+            token: Some(wire::AuthToken::new(credential.token, "credential-store")),
+            proof_key_pem: credential.private_key_pem,
+            renewable: None,
+            subject: Some(credential.subject),
+            credential_id: credential.credential_id,
+            expires_at: credential.expires_at,
+            source: crate::grpc_hosted::CredentialSource::Keystore,
+        };
+        let output = auth_status_output("grpc.S", &resolved);
 
         assert!(output.authenticated);
+        assert_eq!(output.source, "keystore");
         assert!(!output.proof_key_available);
         assert!(
             output

--- a/crates/client/src/credential_file.rs
+++ b/crates/client/src/credential_file.rs
@@ -41,6 +41,10 @@ use serde::{Deserialize, Serialize};
 const CREDENTIAL_FORMAT: &str = "heddle-credential";
 /// Only on-disk schema version this build reads and writes.
 const CREDENTIAL_VERSION: u32 = 1;
+/// Upper bound on a `.hcred` file read. A credential file is tiny (a token,
+/// a PEM, and a little metadata); this cap keeps a planted huge file at a
+/// `--credential` / `HEDDLE_CREDENTIAL` path from ballooning memory on load.
+const MAX_CREDENTIAL_FILE_BYTES: u64 = 64 * 1024;
 
 /// The role a `.hcred` credential plays. Audit/provenance metadata only — the
 /// server enforces authority from the token, not this label.
@@ -222,10 +226,22 @@ pub fn write_credential_file(path: &Path, credential: &VerifiedCredential) -> Re
 pub fn load_credential_file(path: &Path) -> Result<VerifiedCredential> {
     // Open through the fail-closed security gate and read from the SAME handle
     // so the permission check and the read observe one inode (no TOCTOU).
-    let mut file = open_credential_file_checked(path)?;
+    let file = open_credential_file_checked(path)?;
+    // Cap the read: a `.hcred` is tiny, so reading one byte past the cap and
+    // finding content there means the file is oversized — reject rather than
+    // OOM on a planted huge file.
     let mut contents = String::new();
-    file.read_to_string(&mut contents)
+    let mut limited = file.take(MAX_CREDENTIAL_FILE_BYTES + 1);
+    limited
+        .read_to_string(&mut contents)
         .with_context(|| format!("reading credential file {}", path.display()))?;
+    if contents.len() as u64 > MAX_CREDENTIAL_FILE_BYTES {
+        bail!(
+            "credential file {} exceeds the {} KiB size cap; a credential file is tiny — refusing to load a suspiciously large file",
+            path.display(),
+            MAX_CREDENTIAL_FILE_BYTES / 1024,
+        );
+    }
 
     let on_disk: OnDiskCredential = serde_json::from_str(&contents)
         .with_context(|| format!("parsing credential file {}", path.display()))?;
@@ -241,6 +257,15 @@ pub fn load_credential_file(path: &Path) -> Result<VerifiedCredential> {
             "credential file {} has unsupported version {} (this build reads version {CREDENTIAL_VERSION})",
             path.display(),
             on_disk.version
+        );
+    }
+    // The `server` field reaches terminal output (`auth status`, error
+    // messages, the server-mismatch diagnostic). Reject control characters /
+    // newlines so a crafted `.hcred` can't inject escape sequences there.
+    if on_disk.server.chars().any(|c| c.is_control()) {
+        bail!(
+            "credential file {} has a server field containing control characters",
+            path.display()
         );
     }
 
@@ -496,6 +521,42 @@ mod tests {
         std::fs::write(&path, tampered).expect("rewrite");
         let error = load_credential_file(&path).expect_err("bad version must be rejected");
         assert!(error.to_string().contains("unsupported version"));
+    }
+
+    #[test]
+    fn rejects_oversized_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        // A file past the 64 KiB cap is rejected before any parse/verify.
+        let bloat = "x".repeat((MAX_CREDENTIAL_FILE_BYTES as usize) + 1);
+        std::fs::write(&path, bloat).expect("write oversized file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+                .expect("tighten perms");
+        }
+        let error = load_credential_file(&path).expect_err("oversized file must be rejected");
+        assert!(
+            error.to_string().contains("size cap"),
+            "unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn rejects_control_chars_in_server_field() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("agent.hcred");
+        let (mut credential, _signer) = sample_verified();
+        // A bell control character in `server` would reach terminal output.
+        credential.server = "grpc.heddle\u{0007}.test".to_string();
+        write_credential_file(&path, &credential).expect("write");
+        let error =
+            load_credential_file(&path).expect_err("control chars in server must be rejected");
+        assert!(
+            error.to_string().contains("control characters"),
+            "unexpected error: {error}"
+        );
     }
 
     #[cfg(unix)]

--- a/crates/client/src/grpc_hosted/hydration.rs
+++ b/crates/client/src/grpc_hosted/hydration.rs
@@ -12,7 +12,7 @@ use objects::{
 use repo::{BlobHydrator, Repository};
 use wire::ProtocolError;
 
-use super::{HostedAuthMode, HostedGrpcClient, HostedSession};
+use super::{HostedGrpcClient, HostedSession};
 
 /// Default hosted lazy-hydration deadline.
 ///
@@ -228,12 +228,13 @@ impl HydrationBridge {
         // Build + validate the session config on this thread so a rejected
         // TLS/auth config surfaces synchronously, before the worker thread is
         // spawned. The worker connects + rotates through `session.connect`.
-        let session = HostedSession::build(&user_config, None, HostedAuthMode::ConfigToken)
-            .map_err(|err| {
+        let session = HostedSession::build(&user_config, Some(endpoint.to_string())).map_err(
+            |err| {
                 HeddleError::Config(format!(
                     "lazy hosted hydrator: load TLS/auth client config: {err}"
                 ))
-            })?;
+            },
+        )?;
 
         // Build the worker thread first so the bridge can store the
         // tx side immediately. The worker's runtime + client are
@@ -1059,8 +1060,7 @@ mod connect_path_tests {
     fn lazy_hosted_connect_opens_session_through_rotating_seam() {
         let source = include_str!("hydration.rs");
         assert!(
-            source
-                .contains("HostedSession::build(&user_config, None, HostedAuthMode::ConfigToken)"),
+            source.contains("HostedSession::build(&user_config, Some(endpoint.to_string()))"),
             "hydration.rs must build its session through the shared HostedSession seam",
         );
         assert!(

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -618,7 +618,10 @@ impl HostedGrpcClient {
 pub use collaboration::{HostedDiscussion, HostedDiscussionTurn};
 pub use hydration::{LazyHostedHydrator, PullMaterialization, register_hosted_factory};
 pub use monorepo::{MonorepoCloneOp, MonorepoClonePlan, SkippedChild};
-pub use session::{HostedAuthMode, HostedSession};
+pub use session::{
+    CredentialSource, HostedSession, ResolvedHostedCredential, resolve_active_bearer,
+    resolve_hosted_credential,
+};
 pub use sync::HostedRefEntry;
 
 #[cfg(test)]

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -104,7 +104,18 @@ impl std::fmt::Debug for ResolvedHostedCredential {
 /// (the `.hcred` JSON object) and never contains a newline.
 fn heddle_credential_env_path() -> Result<Option<PathBuf>> {
     match std::env::var(HEDDLE_CREDENTIAL_ENV) {
-        Ok(value) if !value.is_empty() => {
+        Ok(value) => {
+            if value.is_empty() {
+                // Fail closed rather than fall through to the keystore: a set-but-empty
+                // value is almost always a failed shell expansion (e.g.
+                // `export HEDDLE_CREDENTIAL=$UNSET`), and silently authenticating as
+                // the stored (human) identity is exactly the confusion this resolver
+                // exists to prevent.
+                anyhow::bail!(
+                    "HEDDLE_CREDENTIAL is set but empty; unset it to use the stored \
+                     credential, or point it at a .hcred file"
+                );
+            }
             if value.starts_with('{') || value.contains('\n') {
                 anyhow::bail!(
                     "HEDDLE_CREDENTIAL takes a file path, not credential contents"
@@ -112,7 +123,7 @@ fn heddle_credential_env_path() -> Result<Option<PathBuf>> {
             }
             Ok(Some(PathBuf::from(value)))
         }
-        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotPresent) => Ok(None),
         Err(err @ std::env::VarError::NotUnicode(_)) => {
             anyhow::bail!("HEDDLE_CREDENTIAL is not valid UTF-8: {err}")
         }

--- a/crates/client/src/grpc_hosted/session.rs
+++ b/crates/client/src/grpc_hosted/session.rs
@@ -7,8 +7,21 @@
 //! then rotate only an eligible stored authority credential. This module owns
 //! that assembly so the command modules choose only intent + remote and call
 //! one seam.
+//!
+//! # Single credential resolution order
+//!
+//! [`resolve_hosted_credential`] is the ONE precedence every hosted entry
+//! point follows:
+//!
+//! 1. `HEDDLE_CREDENTIAL=<path>` — a path to a `.hcred`. When set it is
+//!    AUTHORITATIVE: an unreadable / expired / verify-failed / server-mismatch
+//!    file is a hard error, never a silent fall-through to the keystore (a
+//!    silent fallback would let an agent push as the human). Loaded through the
+//!    verifying [`crate::credential_file::load_credential_file`] chokepoint.
+//! 2. The per-server keystore entry (`resolve_credential_for_server`).
+//! 3. Unauthenticated.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::{Context, Result};
 use cli_shared::{ClientConfig, UserConfig};
@@ -21,15 +34,161 @@ use crate::{
     grpc_hosted::{HostedGrpcClient, RenewableAuthorityCredential},
 };
 
-/// How a hosted session resolves its auth token.
-pub enum HostedAuthMode {
-    /// Use only the token from env/user config (`remote_token`). Used by
-    /// fetch, support, approval, and lazy hydration.
-    ConfigToken,
-    /// Use the config token, falling back to the per-server credential store
-    /// (and its proof key) when no config token is present. Used by push and
-    /// pull.
-    CredentialFallback,
+/// Environment variable naming a `.hcred` path the runtime authenticates with.
+const HEDDLE_CREDENTIAL_ENV: &str = "HEDDLE_CREDENTIAL";
+
+/// Where a resolved hosted credential originated. Reported by `auth status`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CredentialSource {
+    /// The `.hcred` at `HEDDLE_CREDENTIAL=<path>`.
+    Env(PathBuf),
+    /// The per-server entry in the keystore (`credentials.toml`).
+    Keystore,
+    /// No credential resolved for this server.
+    Unauthenticated,
+}
+
+impl CredentialSource {
+    /// Stable label for the `auth status` `source` field.
+    pub fn label(&self) -> String {
+        match self {
+            CredentialSource::Env(path) => format!("env:{}", path.display()),
+            CredentialSource::Keystore => "keystore".to_string(),
+            CredentialSource::Unauthenticated => "none".to_string(),
+        }
+    }
+}
+
+/// A credential resolved by the single hosted-auth precedence. Fully describes
+/// the selected bearer so callers never re-read env/keystore themselves.
+pub struct ResolvedHostedCredential {
+    /// Bearer token, absent when unauthenticated.
+    pub token: Option<AuthToken>,
+    /// Device proof key PEM bound to `token`, when the source carries one.
+    pub proof_key_pem: Option<String>,
+    /// Renewal binding — populated ONLY for a keystore authority credential.
+    /// An env `.hcred` is never renewed (we cannot rewrite the pointed-at file
+    /// and must not touch the keystore on its behalf). Crate-internal: the
+    /// renewal type is module-private and only [`HostedSession::build`]
+    /// consumes it.
+    pub(crate) renewable: Option<RenewableAuthorityCredential>,
+    /// Authenticated subject.
+    pub subject: Option<String>,
+    /// Authority credential id, when present (rotation anchor).
+    pub credential_id: Option<String>,
+    /// RFC 3339 expiry, when the credential carries one.
+    pub expires_at: Option<String>,
+    /// Which mechanism produced this credential.
+    pub source: CredentialSource,
+}
+
+impl std::fmt::Debug for ResolvedHostedCredential {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Redact the secret bearer + proof key so a resolved credential can
+        // never leak them into logs, tracing, or a test panic message.
+        f.debug_struct("ResolvedHostedCredential")
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("proof_key_pem", &self.proof_key_pem.as_ref().map(|_| "<redacted>"))
+            .field("renewable", &self.renewable.is_some())
+            .field("subject", &self.subject)
+            .field("credential_id", &self.credential_id)
+            .field("expires_at", &self.expires_at)
+            .field("source", &self.source)
+            .finish()
+    }
+}
+
+/// Read + validate `HEDDLE_CREDENTIAL`. Returns the `.hcred` path when the
+/// variable is set to a non-empty value. Guards against a caller passing
+/// credential *contents* instead of a path — a path never starts with `{`
+/// (the `.hcred` JSON object) and never contains a newline.
+fn heddle_credential_env_path() -> Result<Option<PathBuf>> {
+    match std::env::var(HEDDLE_CREDENTIAL_ENV) {
+        Ok(value) if !value.is_empty() => {
+            if value.starts_with('{') || value.contains('\n') {
+                anyhow::bail!(
+                    "HEDDLE_CREDENTIAL takes a file path, not credential contents"
+                );
+            }
+            Ok(Some(PathBuf::from(value)))
+        }
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(err @ std::env::VarError::NotUnicode(_)) => {
+            anyhow::bail!("HEDDLE_CREDENTIAL is not valid UTF-8: {err}")
+        }
+    }
+}
+
+/// Resolve the hosted credential for `server_key` following the single
+/// precedence order documented on this module.
+///
+/// `HEDDLE_CREDENTIAL`, when set, is authoritative: any failure to load, verify,
+/// or match it to `server_key` is a hard error rather than a silent fall-through
+/// to the keystore.
+pub fn resolve_hosted_credential(server_key: Option<&str>) -> Result<ResolvedHostedCredential> {
+    if let Some(path) = heddle_credential_env_path()? {
+        let verified = crate::credential_file::load_credential_file(&path)
+            .with_context(|| format!("loading HEDDLE_CREDENTIAL {}", path.display()))?;
+        if let Some(target) = server_key
+            && !server_keys_match(&verified.server, target)
+        {
+            anyhow::bail!(
+                "HEDDLE_CREDENTIAL {} authenticates server {:?}, but this operation targets {:?}; \
+                 point HEDDLE_CREDENTIAL at a credential minted for {}",
+                path.display(),
+                verified.server,
+                target,
+                target,
+            );
+        }
+        return Ok(ResolvedHostedCredential {
+            token: Some(AuthToken::new(verified.token, "hcred-env")),
+            proof_key_pem: Some(verified.proof_key_pem),
+            renewable: None,
+            subject: Some(verified.subject),
+            credential_id: verified.credential_id,
+            expires_at: verified.expires_at,
+            source: CredentialSource::Env(path),
+        });
+    }
+
+    if let Some(key) = server_key {
+        // Propagate a malformed credentials.toml instead of swallowing it: a
+        // parse error here used to fall through to an unauthenticated request,
+        // which the server rejects with an opaque "missing authorization
+        // metadata" — hiding the real cause. A *missing* file returns Ok(None)
+        // and falls through to unauthenticated cleanly.
+        if let Some(cred) = credentials::resolve_credential_for_server(key)? {
+            let renewable = RenewableAuthorityCredential::from_stored(&cred);
+            return Ok(ResolvedHostedCredential {
+                token: Some(AuthToken::new(cred.token, "credential-store")),
+                proof_key_pem: cred.private_key_pem,
+                renewable,
+                subject: Some(cred.subject),
+                credential_id: cred.credential_id,
+                expires_at: cred.expires_at,
+                source: CredentialSource::Keystore,
+            });
+        }
+    }
+
+    Ok(ResolvedHostedCredential {
+        token: None,
+        proof_key_pem: None,
+        renewable: None,
+        subject: None,
+        credential_id: None,
+        expires_at: None,
+        source: CredentialSource::Unauthenticated,
+    })
+}
+
+/// Resolve the locally active bearer token, if any, using the default server
+/// for keystore lookup. For read/display paths that need the active token
+/// without a specific target remote. Still honors `HEDDLE_CREDENTIAL` first.
+pub fn resolve_active_bearer() -> Result<Option<AuthToken>> {
+    let server = credentials::default_server()?;
+    Ok(resolve_hosted_credential(server.as_deref())?.token)
 }
 
 /// A validated, connectable hosted-session configuration.
@@ -72,55 +231,19 @@ impl HostedSession {
     }
 
     /// Resolve auth + build the validated client config for a hosted session.
-    /// Owns credential-store fallback (per `mode`), server-key attachment, and
-    /// proof-key attachment from either a credential or the matching shared
-    /// same-host device identity — the assembly the command modules used to
-    /// hand-roll.
-    pub fn build(
-        user_config: &UserConfig,
-        server_key: Option<String>,
-        mode: HostedAuthMode,
-    ) -> Result<Self> {
-        let (
+    /// Runs the single [`resolve_hosted_credential`] precedence
+    /// (`HEDDLE_CREDENTIAL` → keystore → unauthenticated), server-key
+    /// attachment, and proof-key attachment from either the resolved credential
+    /// or the matching shared same-host device identity — the assembly the
+    /// command modules used to hand-roll.
+    pub fn build(user_config: &UserConfig, server_key: Option<String>) -> Result<Self> {
+        let ResolvedHostedCredential {
             token,
-            mut credential_proof_key,
-            renewable_authority_credential,
-            stored_credential_subject,
-        ) = match mode {
-            HostedAuthMode::ConfigToken => (user_config.remote_token()?, None, None, None),
-            HostedAuthMode::CredentialFallback => {
-                let mut token = user_config.remote_token()?;
-                let mut credential_proof_key = None;
-                let mut renewable_authority_credential = None;
-                let mut stored_credential_subject = None;
-                if token.is_none()
-                    && let Some(ref key) = server_key
-                {
-                    // Propagate a malformed credentials.toml instead of
-                    // swallowing it: a parse error here (e.g. a missing
-                    // `subject` field) used to fall through to an
-                    // unauthenticated request, which the server rejects with
-                    // the opaque "missing authorization metadata" — hiding the
-                    // real cause. The `?` surfaces the underlying
-                    // "parsing <path>: <toml error>" so the user can fix the
-                    // file. A *missing* file still returns Ok(None) and falls
-                    // back cleanly.
-                    if let Some(cred) = credentials::resolve_credential_for_server(key)? {
-                        renewable_authority_credential =
-                            RenewableAuthorityCredential::from_stored(&cred);
-                        stored_credential_subject = Some(cred.subject.clone());
-                        token = Some(AuthToken::new(cred.token, "credential-store"));
-                        credential_proof_key = cred.private_key_pem;
-                    }
-                }
-                (
-                    token,
-                    credential_proof_key,
-                    renewable_authority_credential,
-                    stored_credential_subject,
-                )
-            }
-        };
+            proof_key_pem: mut credential_proof_key,
+            renewable: renewable_authority_credential,
+            subject: resolved_credential_subject,
+            ..
+        } = resolve_hosted_credential(server_key.as_deref())?;
 
         if credential_proof_key.is_none()
             && let Some(ref key) = server_key
@@ -146,12 +269,12 @@ impl HostedSession {
             })?;
             let subject = crate::device_flow::authenticated_subject(&token.id)
                 .context("reading the hosted bearer token's authenticated principal")?;
-            if stored_credential_subject
+            if resolved_credential_subject
                 .as_deref()
-                .is_some_and(|stored| stored != subject.as_str())
+                .is_some_and(|resolved| resolved != subject.as_str())
             {
                 anyhow::bail!(
-                    "stored credential subject does not match the bearer token's authenticated principal"
+                    "resolved credential subject does not match the bearer token's authenticated principal"
                 );
             }
             config = config.with_authenticated_principal(format!("principal:{subject}"));
@@ -270,9 +393,8 @@ impl HostedGrpcClient {
         addr: SocketAddr,
         user_config: &UserConfig,
         server_key: Option<String>,
-        mode: HostedAuthMode,
     ) -> Result<Self> {
-        Self::open_session_with_insecure(addr, user_config, server_key, mode, false).await
+        Self::open_session_with_insecure(addr, user_config, server_key, false).await
     }
 
     /// Like [`open_session`], but allows cleartext to non-loopback when
@@ -281,10 +403,9 @@ impl HostedGrpcClient {
         addr: SocketAddr,
         user_config: &UserConfig,
         server_key: Option<String>,
-        mode: HostedAuthMode,
         allow_insecure: bool,
     ) -> Result<Self> {
-        Ok(HostedSession::build(user_config, server_key, mode)?
+        Ok(HostedSession::build(user_config, server_key)?
             .with_allow_insecure(allow_insecure)
             .connect(addr)
             .await?)
@@ -302,7 +423,7 @@ mod tests {
     use biscuit_auth::{Biscuit, KeyPair};
     use crypto::{Ed25519Signer, Signer};
 
-    use super::{validated_authenticated_principal, validated_stored_proof_key};
+    use super::{HostedSession, validated_authenticated_principal, validated_stored_proof_key};
     use crate::credentials;
 
     fn proof_bound_credential(signer: &Ed25519Signer) -> credentials::ServerCredential {
@@ -380,27 +501,171 @@ mod tests {
         );
     }
 
-    #[test]
-    fn explicit_derived_token_cannot_rotate_from_a_nearly_expired_stored_parent() {
-        use biscuit_auth::{Biscuit, KeyPair};
-        use crypto::{Ed25519Signer, Signer};
+    /// Mint a device-authority token whose effective PoP key is `signer`.
+    fn mint_authority_token(subject: &str, signer: &Ed25519Signer) -> String {
+        biscuit_auth::Biscuit::builder()
+            .fact(format!("user(\"{subject}\")").as_str())
+            .expect("user fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("proof key fact")
+            .build(&biscuit_auth::KeyPair::new())
+            .expect("mint token")
+            .to_base64()
+            .expect("encode token")
+    }
 
-        use super::{HostedAuthMode, HostedSession};
-        use crate::credentials;
+    /// Write a verifiable `.hcred` at `path` for `server`, minting a fresh
+    /// device token bound to a fresh proof key.
+    fn write_sample_hcred(path: &std::path::Path, server: &str, subject: &str) {
+        let signer = Ed25519Signer::generate().expect("proof key");
+        let token = mint_authority_token(subject, &signer);
+        crate::credential_file::write_credential_file(
+            path,
+            &crate::credential_file::VerifiedCredential {
+                server: server.to_string(),
+                kind: crate::credential_file::CredentialKind::Device,
+                subject: subject.to_string(),
+                token,
+                proof_key_pem: signer.to_pem().expect("proof PEM"),
+                expires_at: None,
+                credential_id: None,
+                provenance: None,
+            },
+        )
+        .expect("write sample .hcred");
+    }
 
-        let _guard = credentials::lock_test_env();
+    /// Run `f` with `HEDDLE_HOME` at a fresh temp dir and `HEDDLE_CREDENTIAL`
+    /// cleared, restoring both afterward. Serialized via the credentials lock.
+    fn with_isolated_env<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = crate::credentials::lock_test_env();
         let home = tempfile::TempDir::new().expect("temp Heddle home");
         let previous_home = std::env::var_os("HEDDLE_HOME");
-        let previous_remote_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
+        let previous_credential = std::env::var_os("HEDDLE_CREDENTIAL");
         unsafe {
             std::env::set_var("HEDDLE_HOME", home.path());
-            std::env::remove_var("HEDDLE_REMOTE_TOKEN");
+            std::env::remove_var("HEDDLE_CREDENTIAL");
         }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(home.path())));
+        unsafe {
+            match previous_home {
+                Some(path) => std::env::set_var("HEDDLE_HOME", path),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+            match previous_credential {
+                Some(path) => std::env::set_var("HEDDLE_CREDENTIAL", path),
+                None => std::env::remove_var("HEDDLE_CREDENTIAL"),
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
 
-        let result = std::panic::catch_unwind(|| {
+    #[test]
+    fn env_credential_resolves_and_reports_env_source() {
+        use super::{CredentialSource, resolve_hosted_credential};
+        with_isolated_env(|home| {
+            let path = home.join("agent.hcred");
+            write_sample_hcred(&path, "grpc.heddle.test", "alice");
+            unsafe { std::env::set_var("HEDDLE_CREDENTIAL", &path) };
+
+            let resolved =
+                resolve_hosted_credential(Some("grpc.heddle.test")).expect("resolve env credential");
+            assert!(resolved.token.is_some(), "env credential is authoritative");
+            assert!(resolved.proof_key_pem.is_some(), "env .hcred carries its key");
+            assert!(
+                resolved.renewable.is_none(),
+                "an env credential is never renewed"
+            );
+            assert_eq!(resolved.subject.as_deref(), Some("alice"));
+            assert_eq!(resolved.source, CredentialSource::Env(path));
+        });
+    }
+
+    #[test]
+    fn env_credential_inline_contents_are_rejected() {
+        use super::resolve_hosted_credential;
+        with_isolated_env(|_home| {
+            unsafe {
+                std::env::set_var("HEDDLE_CREDENTIAL", "{\"format\":\"heddle-credential\"}");
+            }
+            let error = resolve_hosted_credential(Some("grpc.heddle.test"))
+                .expect_err("inline contents must be rejected");
+            assert!(
+                error.to_string().contains("takes a file path"),
+                "unexpected error: {error}"
+            );
+        });
+    }
+
+    #[test]
+    fn env_credential_server_mismatch_is_a_hard_error_with_no_keystore_fallback() {
+        use super::resolve_hosted_credential;
+        with_isolated_env(|home| {
+            // A perfectly good keystore credential exists for the target
+            // server. It must NOT be used to paper over a mismatched
+            // HEDDLE_CREDENTIAL — silent fallback would let an agent push as
+            // the human.
+            credentials::store_server_credential(
+                "grpc.target.test",
+                credentials::ServerCredential {
+                    token: "keystore-token".to_string(),
+                    subject: "human".to_string(),
+                    device_id: None,
+                    credential_id: None,
+                    private_key_pem: None,
+                    expires_at: None,
+                },
+            )
+            .expect("seed keystore");
+
+            let path = home.join("other.hcred");
+            write_sample_hcred(&path, "grpc.other.test", "agent");
+            unsafe { std::env::set_var("HEDDLE_CREDENTIAL", &path) };
+
+            let error = resolve_hosted_credential(Some("grpc.target.test"))
+                .expect_err("server mismatch must be a hard error");
+            let message = error.to_string();
+            assert!(message.contains("grpc.other.test"), "message: {message}");
+            assert!(message.contains("grpc.target.test"), "message: {message}");
+        });
+    }
+
+    #[test]
+    fn env_credential_unreadable_is_a_hard_error_with_no_keystore_fallback() {
+        use super::resolve_hosted_credential;
+        with_isolated_env(|home| {
+            credentials::store_server_credential(
+                "grpc.target.test",
+                credentials::ServerCredential {
+                    token: "keystore-token".to_string(),
+                    subject: "human".to_string(),
+                    device_id: None,
+                    credential_id: None,
+                    private_key_pem: None,
+                    expires_at: None,
+                },
+            )
+            .expect("seed keystore");
+
+            let missing = home.join("does-not-exist.hcred");
+            unsafe { std::env::set_var("HEDDLE_CREDENTIAL", &missing) };
+
+            resolve_hosted_credential(Some("grpc.target.test"))
+                .expect_err("an unreadable HEDDLE_CREDENTIAL must never fall back to the keystore");
+        });
+    }
+
+    #[test]
+    fn env_credential_is_authoritative_and_not_renewable_over_a_stored_parent() {
+        use crypto::{Ed25519Signer, Signer};
+
+        with_isolated_env(|home| {
             let parent_signer = Ed25519Signer::generate().expect("parent proof key");
             let expires_at = chrono::Utc::now() + chrono::Duration::minutes(5);
-            let parent_token = Biscuit::builder()
+            let parent_token = biscuit_auth::Biscuit::builder()
                 .fact(r#"user("alice")"#)
                 .expect("user fact")
                 .fact(r#"credential_id("cred-parent")"#)
@@ -415,7 +680,7 @@ mod tests {
                 .expect("proof key fact")
                 .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
                 .expect("expiry fact")
-                .build(&KeyPair::new())
+                .build(&biscuit_auth::KeyPair::new())
                 .expect("mint parent")
                 .to_base64()
                 .expect("encode parent");
@@ -435,6 +700,26 @@ mod tests {
             credentials::store_server_credential(server, stored_parent)
                 .expect("store nearly expired parent");
 
+            // Without HEDDLE_CREDENTIAL, the keystore parent is the active,
+            // renewable authority.
+            let stored_session =
+                HostedSession::build(&cli_shared::UserConfig::default(), Some(server.to_string()))
+                    .expect("build stored-parent session");
+            assert_eq!(
+                stored_session
+                    .config
+                    .token
+                    .as_ref()
+                    .map(|token| token.id.as_str()),
+                Some(parent_token.as_str())
+            );
+            assert!(
+                stored_session.renewable_authority_credential.is_some(),
+                "the exact stored authority token is renewable"
+            );
+
+            // The same child, handed to the runtime as a HEDDLE_CREDENTIAL
+            // .hcred, overrides the keystore and is never renewed.
             let child_signer = Ed25519Signer::generate().expect("child proof key");
             let child_token = crate::device_flow::attenuate_for_agent(
                 &parent_token,
@@ -449,33 +734,28 @@ mod tests {
                 child_signer.public_key(),
             )
             .expect("derive explicit child");
-
-            let stored_session = HostedSession::build(
-                &cli_shared::UserConfig::default(),
-                Some(server.to_string()),
-                HostedAuthMode::CredentialFallback,
+            let child_hcred = home.join("child.hcred");
+            crate::credential_file::write_credential_file(
+                &child_hcred,
+                &crate::credential_file::VerifiedCredential {
+                    server: server.to_string(),
+                    kind: crate::credential_file::CredentialKind::Agent,
+                    subject: "alice".to_string(),
+                    token: child_token.clone(),
+                    proof_key_pem: child_signer.to_pem().expect("child PEM"),
+                    expires_at: Some(
+                        (chrono::Utc::now() + chrono::Duration::minutes(3)).to_rfc3339(),
+                    ),
+                    credential_id: None,
+                    provenance: None,
+                },
             )
-            .expect("build stored-parent session");
-            assert_eq!(
-                stored_session
-                    .config
-                    .token
-                    .as_ref()
-                    .map(|token| token.id.as_str()),
-                Some(parent_token.as_str())
-            );
-            assert!(
-                stored_session.renewable_authority_credential.is_some(),
-                "the exact stored authority token is renewable"
-            );
+            .expect("write child .hcred");
 
-            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
-            let explicit_child_session = HostedSession::build(
-                &cli_shared::UserConfig::default(),
-                Some(server.to_string()),
-                HostedAuthMode::CredentialFallback,
-            )
-            .expect("build explicit-child session");
+            unsafe { std::env::set_var("HEDDLE_CREDENTIAL", &child_hcred) };
+            let explicit_child_session =
+                HostedSession::build(&cli_shared::UserConfig::default(), Some(server.to_string()))
+                    .expect("build explicit-child session");
             assert_eq!(
                 explicit_child_session
                     .config
@@ -483,82 +763,58 @@ mod tests {
                     .as_ref()
                     .map(|token| token.id.as_str()),
                 Some(child_token.as_str()),
-                "the explicit child remains the active bearer"
+                "HEDDLE_CREDENTIAL is authoritative over the keystore"
             );
             assert!(
                 explicit_child_session
                     .renewable_authority_credential
                     .is_none(),
-                "an explicit derived bearer must not borrow the stored parent's renewal identity"
+                "an env-supplied credential must not borrow the stored parent's renewal identity"
             );
         });
-
-        unsafe {
-            match previous_home {
-                Some(path) => std::env::set_var("HEDDLE_HOME", path),
-                None => std::env::remove_var("HEDDLE_HOME"),
-            }
-            match previous_remote_token {
-                Some(token) => std::env::set_var("HEDDLE_REMOTE_TOKEN", token),
-                None => std::env::remove_var("HEDDLE_REMOTE_TOKEN"),
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
     }
 
     #[tokio::test]
-    async fn token_only_derived_child_does_not_fall_back_to_the_parent_device_key() {
-        use biscuit_auth::{Biscuit, KeyPair};
+    async fn token_only_stored_child_does_not_borrow_the_host_device_key() {
         use crypto::{Ed25519Signer, Signer};
         use grpc::heddle::api::v1alpha1::{
             collaboration_service_client::CollaborationServiceClient,
-            state_review_service_client::StateReviewServiceClient,
             identity_service_client::IdentityServiceClient,
             registry_service_client::RegistryServiceClient,
             repo_sync_service_client::RepoSyncServiceClient,
             repository_service_client::RepositoryServiceClient,
+            state_review_service_client::StateReviewServiceClient,
             workflow_service_client::WorkflowServiceClient,
         };
         use tonic::{Request, metadata::MetadataValue, transport::Endpoint};
 
-        use super::{HostedAuthMode, HostedSession};
-        use crate::{auth_cmd, credentials, grpc_hosted::HostedGrpcClient};
+        use crate::{auth_cmd, grpc_hosted::HostedGrpcClient};
 
-        let _guard = credentials::lock_test_env();
-        let home = tempfile::TempDir::new().expect("temp Heddle home");
-        let previous_home = std::env::var_os("HEDDLE_HOME");
-        let previous_remote_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
-        unsafe { std::env::set_var("HEDDLE_HOME", home.path()) };
-
-        let result = std::panic::catch_unwind(|| {
+        with_isolated_env(|home| {
             let signer = Ed25519Signer::generate().expect("device key");
             let private_key_pem = signer.to_pem().expect("device PEM");
 
             let subject = "headless-agent";
             let credential_id = "cred-headless";
             let expires_at = chrono::Utc::now() + chrono::Duration::days(30);
-            let user_fact = format!("user(\"{subject}\")");
-            let credential_fact = format!("credential_id(\"{credential_id}\")");
-            let expiry_fact = format!("expires_at({})", expires_at.to_rfc3339());
-            let pop_fact = format!("device_pop_key(\"{}\")", hex::encode(signer.public_key()));
-            let token = Biscuit::builder()
-                .fact(user_fact.as_str())
+            let token = biscuit_auth::Biscuit::builder()
+                .fact(format!("user(\"{subject}\")").as_str())
                 .expect("user fact")
-                .fact(credential_fact.as_str())
+                .fact(format!("credential_id(\"{credential_id}\")").as_str())
                 .expect("credential fact")
-                .fact(expiry_fact.as_str())
+                .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
                 .expect("expiry fact")
-                .fact(pop_fact.as_str())
+                .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
                 .expect("PoP key fact")
-                .build(&KeyPair::new())
+                .build(&biscuit_auth::KeyPair::new())
                 .expect("mint fixture biscuit")
                 .to_base64()
                 .expect("encode fixture biscuit");
             let server = "127.0.0.1:8421";
 
-            let root_hcred = home.path().join("root.hcred");
+            // Install the root device credential: the keystore gets the token
+            // AND its device key, and the shared device identity is linked.
+            let root_hcred = home.join("root.hcred");
             crate::credential_file::write_credential_file(
                 &root_hcred,
                 &crate::credential_file::VerifiedCredential {
@@ -575,40 +831,25 @@ mod tests {
             .expect("write root .hcred");
             auth_cmd::install_credential_file(&root_hcred).expect("headless credential install");
 
-            let stored = credentials::get_server_credential(server)
-                .expect("read credentials")
-                .expect("stored credential");
-            assert_eq!(stored.subject, subject);
-            assert_eq!(stored.credential_id.as_deref(), Some(credential_id));
-            assert_eq!(
-                stored.private_key_pem.as_deref(),
-                Some(private_key_pem.as_str())
-            );
-            assert!(stored.expires_at.is_some());
-            let credential_file = std::fs::read_to_string(credentials::credentials_path())
-                .expect("read installed credential file");
-            assert!(credential_file.contains("private_key_pem ="));
-            assert!(!credential_file.contains("\nprivate_key ="));
-
             let identity = repo::identity::load_device(&repo::identity::device_identity_path())
                 .expect("load device identity")
                 .expect("linked device identity");
             assert_eq!(identity.public_key, hex::encode(signer.public_key()));
             assert_eq!(identity.server, server);
 
-            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &token) };
-            let root_session = HostedSession::build(
-                &cli_shared::UserConfig::default(),
-                Some(server.to_string()),
-                HostedAuthMode::ConfigToken,
-            )
-            .expect("build root same-host session");
+            // The stored root credential resolves its own proof key directly.
+            let root_session =
+                HostedSession::build(&cli_shared::UserConfig::default(), Some(server.to_string()))
+                    .expect("build root session");
             assert_eq!(
                 root_session.config.auth_proof_key_pem.as_deref(),
                 Some(private_key_pem.as_str()),
-                "a root token still resolves its matching same-host device key"
+                "a stored root credential resolves its bound device key"
             );
 
+            // Now replace the keystore entry with a TOKEN-ONLY derived child
+            // (no proof key of its own). Its PoP key differs from the host
+            // device identity, so it must NOT borrow the ancestor device key.
             let child_signer = Ed25519Signer::generate().expect("child PoP key");
             let child_token = crate::device_flow::attenuate_for_agent(
                 &token,
@@ -623,58 +864,28 @@ mod tests {
                 child_signer.public_key(),
             )
             .expect("derive child token");
-
-            let child_private_key_pem = child_signer.to_pem().expect("child PEM");
-            let child_hcred = home.path().join("child.hcred");
-            crate::credential_file::write_credential_file(
-                &child_hcred,
-                &crate::credential_file::VerifiedCredential {
-                    server: server.to_string(),
-                    kind: crate::credential_file::CredentialKind::Agent,
-                    subject: subject.to_string(),
+            credentials::store_server_credential(
+                server,
+                credentials::ServerCredential {
                     token: child_token.clone(),
-                    proof_key_pem: child_private_key_pem.clone(),
-                    expires_at: Some((chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339()),
+                    subject: subject.to_string(),
+                    device_id: None,
                     credential_id: None,
-                    provenance: None,
+                    private_key_pem: None,
+                    expires_at: Some((chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339()),
                 },
             )
-            .expect("write child .hcred");
-            auth_cmd::install_credential_file(&child_hcred)
-                .expect("install derived child credential");
+            .expect("store token-only child");
 
-            let stored_child = credentials::get_server_credential(server)
-                .expect("read installed child credential")
-                .expect("installed child credential");
-            assert_eq!(
-                stored_child.private_key_pem.as_deref(),
-                Some(child_private_key_pem.as_str()),
-                "the per-server child credential must retain its matching child key"
-            );
-            let preserved_identity =
-                repo::identity::load_device(&repo::identity::device_identity_path())
-                    .expect("reload shared device identity")
-                    .expect("shared root identity remains installed");
-            assert_eq!(
-                preserved_identity.public_key,
-                hex::encode(signer.public_key()),
-                "installing a derived child must not replace the host-wide root identity"
-            );
-            assert_eq!(preserved_identity.private_key_pem, private_key_pem);
-
-            unsafe { std::env::set_var("HEDDLE_REMOTE_TOKEN", &child_token) };
-
-            let session = HostedSession::build(
-                &cli_shared::UserConfig::default(),
-                Some(server.to_string()),
-                HostedAuthMode::ConfigToken,
-            )
-            .expect("build hosted session from token-only same-host handoff");
+            let session =
+                HostedSession::build(&cli_shared::UserConfig::default(), Some(server.to_string()))
+                    .expect("build token-only child session");
             let config = session.config;
             assert!(
                 config.auth_proof_key_pem.is_none(),
                 "a token-only child must not silently sign with its ancestor device key"
             );
+
             let channel = Endpoint::from_static("http://127.0.0.1:1").connect_lazy();
             let client = HostedGrpcClient {
                 inner: RepoSyncServiceClient::new(channel.clone())
@@ -711,19 +922,5 @@ mod tests {
             assert!(metadata.get(crypto::pop::HDR_PROOF_NONCE).is_none());
             assert!(metadata.get(crypto::pop::HDR_PROOF).is_none());
         });
-
-        unsafe {
-            match previous_home {
-                Some(path) => std::env::set_var("HEDDLE_HOME", path),
-                None => std::env::remove_var("HEDDLE_HOME"),
-            }
-            match previous_remote_token {
-                Some(token) => std::env::set_var("HEDDLE_REMOTE_TOKEN", token),
-                None => std::env::remove_var("HEDDLE_REMOTE_TOKEN"),
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
     }
 }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -23,7 +23,8 @@ pub use auth_requests::AuthCommand;
 // same path the cli used internally pre-move.
 pub use device_flow as auth;
 pub use grpc_hosted::{
-    HostedAuthMode, HostedGrpcClient, HostedSession,
+    CredentialSource, HostedGrpcClient, HostedSession, ResolvedHostedCredential,
+    resolve_active_bearer, resolve_hosted_credential,
     request_signing::{HumanSignatureCallback, HumanSignatureRequest, WebAuthnAssertion},
 };
 pub use presence::{

--- a/crates/client/src/presence.rs
+++ b/crates/client/src/presence.rs
@@ -1,9 +1,10 @@
 //! Local-agent presence publisher (Track B).
 //!
 //! Runs in the foreground: reads the configured hosted upstream + namespace
-//! from `.heddle/config.toml`, resolves a bearer token from the user config or
-//! `HEDDLE_REMOTE_TOKEN`, opens a WebSocket to `<upstream>/presence/ws`, and
-//! streams `agent_start` → periodic `agent_heartbeat` → `agent_done` events.
+//! from `.heddle/config.toml`, resolves a bearer token through the single
+//! credential precedence (`HEDDLE_CREDENTIAL` → keystore), opens a WebSocket to
+//! `<upstream>/presence/ws`, and streams `agent_start` → periodic
+//! `agent_heartbeat` → `agent_done` events.
 //!
 //! This module is gated on the `client` feature because the WebSocket
 //! client (and therefore `tokio-tungstenite`) is only pulled in for hosted
@@ -43,8 +44,6 @@ use tokio_tungstenite::{
 };
 use tracing::{debug, info, warn};
 use weft_client_shim::CliContext;
-
-use crate::credentials;
 
 /// Local mirror of `weft_server::presence::hub::PresenceEvent`.
 ///
@@ -201,16 +200,13 @@ pub fn resolve_publisher_config(
         return Ok(None);
     };
 
-    let (token, credential_subject) = if let Some(token) = user_config.remote_token()? {
-        (token.id, None)
-    } else {
-        let stored_credential = credentials::resolve_credential_for_server(upstream)
-            .with_context(|| format!("loading stored credential for {upstream}"))?;
-        if let Some(credential) = stored_credential {
-            (credential.token, Some(credential.subject))
-        } else {
+    let resolved = crate::grpc_hosted::resolve_hosted_credential(Some(upstream))
+        .with_context(|| format!("resolving credential for {upstream}"))?;
+    let (token, credential_subject) = match resolved.token {
+        Some(token) => (token.id, resolved.subject),
+        None => {
             return Err(anyhow!(
-                "no remote token available — set HEDDLE_REMOTE_TOKEN or run `heddle auth login`"
+                "no credential available — set HEDDLE_CREDENTIAL=<path.hcred> or run `heddle auth login`"
             ));
         }
     };
@@ -624,14 +620,45 @@ mod tests {
 
     use cli_shared::config::UserPrincipalConfig;
 
-    fn user_with_token_and_principal() -> UserConfig {
-        let mut user = UserConfig::default();
-        user.remote.token = Some("opaque-token".into());
-        user.principal = Some(UserPrincipalConfig {
-            name: "Alice".into(),
-            email: "alice@example.com".into(),
-        });
-        user
+    fn user_with_principal() -> UserConfig {
+        UserConfig {
+            principal: Some(UserPrincipalConfig {
+                name: "Alice".into(),
+                email: "alice@example.com".into(),
+            }),
+            ..UserConfig::default()
+        }
+    }
+
+    /// Run `f` with `HOME` pointed at a fresh temp dir and `HEDDLE_HOME` /
+    /// `HEDDLE_CREDENTIAL` cleared, so credential resolution sees only what the
+    /// test seeds into the keystore. Restores the prior env afterward.
+    fn with_isolated_credential_env<T>(f: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = crate::credentials::lock_test_env();
+        let temp = tempfile::TempDir::new().unwrap();
+        let saved: Vec<(&str, Option<std::ffi::OsString>)> =
+            ["HOME", "HEDDLE_HOME", "HEDDLE_CREDENTIAL"]
+                .iter()
+                .map(|k| (*k, std::env::var_os(k)))
+                .collect();
+        unsafe {
+            std::env::set_var("HOME", temp.path());
+            std::env::remove_var("HEDDLE_HOME");
+            std::env::remove_var("HEDDLE_CREDENTIAL");
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| f(temp.path())));
+        unsafe {
+            for (key, value) in saved {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
     }
 
     #[test]
@@ -643,7 +670,7 @@ mod tests {
         let result = resolve_publisher_config(
             &hosted,
             &make_agent("agent-1"),
-            &user_with_token_and_principal(),
+            &user_with_principal(),
             Duration::from_secs(15),
         )
         .unwrap();
@@ -659,7 +686,7 @@ mod tests {
         let result = resolve_publisher_config(
             &hosted,
             &make_agent("agent-1"),
-            &user_with_token_and_principal(),
+            &user_with_principal(),
             Duration::from_secs(15),
         )
         .unwrap();
@@ -668,70 +695,39 @@ mod tests {
 
     #[test]
     fn resolves_subject_from_principal_when_token_is_opaque() {
-        let hosted = HostedConfig {
-            upstream_url: Some("https://heddle.example.com".into()),
-            namespace: Some("heddle/core".into()),
-        };
-        let config = resolve_publisher_config(
-            &hosted,
-            &make_agent("agent-1"),
-            &user_with_token_and_principal(),
-            Duration::from_secs(15),
-        )
-        .unwrap()
-        .expect("config should resolve");
-        assert_eq!(config.subject, "alice@example.com");
-        assert_eq!(config.namespace, "heddle/core");
-        assert_eq!(config.ws_url, "wss://heddle.example.com/presence/ws");
-    }
+        with_isolated_credential_env(|_home| {
+            // Seed a keystore credential for the upstream so a token resolves;
+            // the published subject still prefers the configured principal.
+            crate::credentials::store_server_credential(
+                "https://heddle.example.com",
+                crate::credentials::ServerCredential {
+                    token: "opaque-token".into(),
+                    subject: "keystore-subject".into(),
+                    device_id: None,
+                    credential_id: None,
+                    private_key_pem: None,
+                    expires_at: None,
+                },
+            )
+            .expect("seed keystore credential");
 
-    #[test]
-    fn env_token_skips_malformed_credential_store() {
-        let _guard = crate::credentials::lock_test_env();
-        let temp = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var_os("HOME");
-        let original_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
-        unsafe {
-            std::env::set_var("HOME", temp.path());
-            std::env::set_var("HEDDLE_REMOTE_TOKEN", "env-token");
-        }
-        std::fs::create_dir_all(temp.path().join(".heddle")).unwrap();
-        std::fs::write(
-            temp.path().join(".heddle/credentials.toml"),
-            "this is not valid toml =",
-        )
-        .unwrap();
-
-        let hosted = HostedConfig {
-            upstream_url: Some("https://heddle.example.com".into()),
-            namespace: Some("heddle/core".into()),
-        };
-        let config = resolve_publisher_config(
-            &hosted,
-            &make_agent("agent-1"),
-            &UserConfig {
-                remote: Default::default(),
-                principal: user_with_token_and_principal().principal,
-                ..Default::default()
-            },
-            Duration::from_secs(15),
-        )
-        .unwrap()
-        .expect("config should resolve from env token");
-
-        unsafe {
-            if let Some(home) = original_home {
-                std::env::set_var("HOME", home);
-            } else {
-                std::env::remove_var("HOME");
-            }
-            if let Some(token) = original_token {
-                std::env::set_var("HEDDLE_REMOTE_TOKEN", token);
-            } else {
-                std::env::remove_var("HEDDLE_REMOTE_TOKEN");
-            }
-        }
-        assert_eq!(config.token, "env-token");
+            let hosted = HostedConfig {
+                upstream_url: Some("https://heddle.example.com".into()),
+                namespace: Some("heddle/core".into()),
+            };
+            let config = resolve_publisher_config(
+                &hosted,
+                &make_agent("agent-1"),
+                &user_with_principal(),
+                Duration::from_secs(15),
+            )
+            .unwrap()
+            .expect("config should resolve");
+            assert_eq!(config.token, "opaque-token");
+            assert_eq!(config.subject, "alice@example.com");
+            assert_eq!(config.namespace, "heddle/core");
+            assert_eq!(config.ws_url, "wss://heddle.example.com/presence/ws");
+        });
     }
 
     #[test]
@@ -755,49 +751,26 @@ mod tests {
     }
 
     #[test]
-    fn errors_on_missing_token() {
-        // Isolate the env so an ambient `HEDDLE_REMOTE_TOKEN` (common in
-        // dev shells that source a `.env` for the hosted services) can't
-        // satisfy `user_config.remote_token()` and flip the error path
-        // to "could not derive subject from principal config" instead of
-        // the "no remote token available" message this test pins. The
-        // sibling tests use the same lock + save/restore dance.
-        let _guard = crate::credentials::lock_test_env();
-        let temp = tempfile::TempDir::new().unwrap();
-        let original_home = std::env::var_os("HOME");
-        let original_token = std::env::var_os("HEDDLE_REMOTE_TOKEN");
-        unsafe {
-            std::env::set_var("HOME", temp.path());
-            std::env::remove_var("HEDDLE_REMOTE_TOKEN");
-        }
+    fn errors_when_no_credential_available() {
+        // Isolate the env so neither an ambient `HEDDLE_CREDENTIAL` nor a
+        // real keystore can satisfy resolution: with an empty keystore and no
+        // env credential, the publisher must surface the setup error.
+        let msg = with_isolated_credential_env(|_home| {
+            let hosted = HostedConfig {
+                upstream_url: Some("https://heddle.example.com".into()),
+                namespace: Some("heddle/core".into()),
+            };
+            let err = resolve_publisher_config(
+                &hosted,
+                &make_agent("agent-1"),
+                &UserConfig::default(),
+                Duration::from_secs(15),
+            )
+            .unwrap_err();
+            format!("{err}")
+        });
 
-        let hosted = HostedConfig {
-            upstream_url: Some("https://heddle.example.com".into()),
-            namespace: Some("heddle/core".into()),
-        };
-        let user = UserConfig::default();
-        let err = resolve_publisher_config(
-            &hosted,
-            &make_agent("agent-1"),
-            &user,
-            Duration::from_secs(15),
-        )
-        .unwrap_err();
-        let msg = format!("{err}");
-
-        unsafe {
-            if let Some(home) = original_home {
-                std::env::set_var("HOME", home);
-            } else {
-                std::env::remove_var("HOME");
-            }
-            if let Some(token) = original_token {
-                std::env::set_var("HEDDLE_REMOTE_TOKEN", token);
-            } else {
-                std::env::remove_var("HEDDLE_REMOTE_TOKEN");
-            }
-        }
-
-        assert!(msg.contains("remote token"), "unexpected err: {msg}");
+        assert!(msg.contains("no credential available"), "unexpected err: {msg}");
+        assert!(msg.contains("HEDDLE_CREDENTIAL"), "unexpected err: {msg}");
     }
 }

--- a/crates/client/src/support.rs
+++ b/crates/client/src/support.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
 use crate::{
-    grpc_hosted::{HostedAuthMode, HostedGrpcClient, helpers::repository_ref_path},
+    grpc_hosted::{HostedGrpcClient, helpers::repository_ref_path},
     support_requests::{SupportCommand, SupportGrant, SupportList, SupportRevoke},
 };
 
@@ -143,8 +143,7 @@ async fn open_client(repo: &Repository, remote: &str) -> Result<HostedGrpcClient
         }
     };
     let user_config = UserConfig::load_default()?;
-    HostedGrpcClient::open_session(addr, &user_config, server_key, HostedAuthMode::ConfigToken)
-        .await
+    HostedGrpcClient::open_session(addr, &user_config, server_key).await
 }
 
 /// Parse a TTL string like `"24h"`, `"30m"`, `"4d"`, or a bare number

--- a/docs/WIRE_PROTOCOL.md
+++ b/docs/WIRE_PROTOCOL.md
@@ -24,8 +24,8 @@ The wire protocol is fully implemented and tested. All core VCS commands are ope
 Environment-based local testing:
 
 - `hosted` owns the server runtime and reads server config from its server config file or `HEDDLE_SERVER_*` overrides.
-- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for remote auth and TLS profiles.
-- `HEDDLE_REMOTE_TOKEN=<token-id>` provides the token id used by `heddle push`/`heddle pull`.
+- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
+- Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
 
 ## Hosted Admin Operations
@@ -101,13 +101,16 @@ heddle push origin main
 heddle pull origin --thread main --local-thread main
 ```
 
-With token auth (local dev):
+With credential auth (local dev):
 
 ```bash
 export HEDDLE_SERVER_REQUIRE_AUTH=1
 export HEDDLE_SERVER_TOKEN=devtoken
 
-export HEDDLE_REMOTE_TOKEN=devtoken
+# Authenticate the client either by logging in (writes the keystore) …
+heddle auth login --server 127.0.0.1:8421
+# … or by pointing the runtime at a .hcred credential file:
+export HEDDLE_CREDENTIAL=/path/to/agent.hcred
 heddle push origin main
 heddle pull origin --thread main --local-thread main
 ```

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -3246,8 +3246,8 @@ The wire protocol is fully implemented and tested. All core VCS commands are ope
 Environment-based local testing:
 
 - `hosted` owns the server runtime and reads server config from its server config file or `HEDDLE_SERVER_*` overrides.
-- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for remote auth and TLS profiles.
-- `HEDDLE_REMOTE_TOKEN=<token-id>` provides the token id used by `heddle push`/`heddle pull`.
+- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
+- Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
 
 ## Hosted Admin Operations
@@ -3323,13 +3323,16 @@ heddle push origin main
 heddle pull origin --thread main --local-thread main
 ```
 
-With token auth (local dev):
+With credential auth (local dev):
 
 ```bash
 export HEDDLE_SERVER_REQUIRE_AUTH=1
 export HEDDLE_SERVER_TOKEN=devtoken
 
-export HEDDLE_REMOTE_TOKEN=devtoken
+# Authenticate the client either by logging in (writes the keystore) …
+heddle auth login --server 127.0.0.1:8421
+# … or by pointing the runtime at a .hcred credential file:
+export HEDDLE_CREDENTIAL=/path/to/agent.hcred
 heddle push origin main
 heddle pull origin --thread main --local-thread main
 ```

--- a/scripts/smoke-hosted-release.sh
+++ b/scripts/smoke-hosted-release.sh
@@ -5,8 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 HEDDLE_BIN="${HEDDLE_BIN:-$ROOT/target/debug/heddle}"
 HEDDLE_RUNTIME_PATH="${HEDDLE_RUNTIME_PATH-}"
-HEDDLE_REMOTE_PROOF_KEY_PEM="${HEDDLE_REMOTE_PROOF_KEY_PEM-}"
-HEDDLE_REMOTE_PROOF_KEY_PEM_PATH="${HEDDLE_REMOTE_PROOF_KEY_PEM_PATH-}"
 WEFT_ADDR="${WEFT_ADDR:-}"
 HEDDLE_SMOKE_REMOTE="${HEDDLE_SMOKE_REMOTE:-}"
 ARTIFACT_ROOT="${HEDDLE_SMOKE_ARTIFACT_ROOT:-$ROOT/target/smoke-hosted-release}"
@@ -36,23 +34,11 @@ require_command() {
 
 require_command python3
 [[ -x "$HEDDLE_BIN" ]] || fail "HEDDLE_BIN is not executable: $HEDDLE_BIN"
-[[ -n "${HEDDLE_REMOTE_TOKEN:-}" ]] || fail "HEDDLE_REMOTE_TOKEN is required"
-
-if [[ -z "${HEDDLE_CONFIG:-}" && ( -n "$HEDDLE_REMOTE_PROOF_KEY_PEM" || -n "$HEDDLE_REMOTE_PROOF_KEY_PEM_PATH" ) ]]; then
-  cfg_dir="$WORK_ROOT/user-config"
-  mkdir -p "$cfg_dir"
-  if [[ -n "$HEDDLE_REMOTE_PROOF_KEY_PEM" ]]; then
-    HEDDLE_REMOTE_PROOF_KEY_PEM_PATH="$cfg_dir/auth-proof-key.pem"
-    printf '%s\n' "$HEDDLE_REMOTE_PROOF_KEY_PEM" > "$HEDDLE_REMOTE_PROOF_KEY_PEM_PATH"
-    chmod 600 "$HEDDLE_REMOTE_PROOF_KEY_PEM_PATH"
-  fi
-  cat > "$cfg_dir/config.toml" <<EOF
-[remote]
-auth_proof_key_pem_path = '$HEDDLE_REMOTE_PROOF_KEY_PEM_PATH'
-EOF
-  chmod 600 "$cfg_dir/config.toml"
-  export HEDDLE_CONFIG="$cfg_dir/config.toml"
-fi
+# The client authenticates through a single `.hcred` credential file (which
+# carries the token AND its proof key). Point the runtime at it — no separate
+# token/proof-key env vars or user-config plumbing.
+[[ -n "${HEDDLE_CREDENTIAL:-}" ]] || fail "HEDDLE_CREDENTIAL (path to a .hcred) is required"
+[[ -r "$HEDDLE_CREDENTIAL" ]] || fail "HEDDLE_CREDENTIAL is not readable: $HEDDLE_CREDENTIAL"
 
 if [[ -z "$HEDDLE_SMOKE_REMOTE" ]]; then
   [[ -n "$WEFT_ADDR" ]] || fail "set WEFT_ADDR or HEDDLE_SMOKE_REMOTE"


### PR DESCRIPTION
Closes #1064.

Makes `HEDDLE_CREDENTIAL` **live** and collapses hosted credential resolution to one precedence used by every hosted entry point, retires the three parallel env/config token mechanisms, and folds in the three non-blocking #1063 follow-ups.

## Single credential resolution order (everywhere)
New `resolve_hosted_credential(server_key)` in the client crate is the one seam. Precedence:

1. **`HEDDLE_CREDENTIAL=<path>`** — a path to a `.hcred`, **authoritative**. A value starting with `{` or containing a newline is rejected (`takes a file path, not credential contents`). An unreadable / expired / verify-failed / **server-mismatched** file is a **hard error**, never a silent fall-through to the keystore (silent fallback = an agent pushing as the human). Loaded via the existing verifying `load_credential_file` chokepoint.
2. The per-server **keystore** entry.
3. **Unauthenticated.**

`HostedSession::build`, `presence`, `auth status`, lazy hydration, and the read/display token paths all route through it. `HostedAuthMode` (`ConfigToken` vs `CredentialFallback`) collapses away; `build`/`open_session`/`open_session_with_insecure` lose the mode param.

## Deleted (pre-1.0, no shims)
- `HEDDLE_REMOTE_TOKEN` env var and every reader.
- `UserConfig::remote_token()`, the `remote.token` config field, and the `remote.auth_proof_key_pem_path` field + all plumbing (`heddle_client_config` no longer reads any token from env/config).

Grep confirms no lingering reader of `HEDDLE_REMOTE_TOKEN` / `remote.token` / `auth_proof_key_pem_path` / `HostedAuthMode` remains.

## Surface
- `auth status` reports the credential **source**: `env:<path>` when `HEDDLE_CREDENTIAL` is set, else `keystore` (new `source` field in text + JSON).
- An agent now authenticates by `export HEDDLE_CREDENTIAL=/path/agent.hcred` — no `heddle auth login`. The `create-service-token` printed guidance is now live end-to-end.

## Folded-in #1063 follow-ups
1. **64 KiB size cap** on the `.hcred` read in `credential_file.rs` (planted-huge-file OOM guard).
2. **Control-char validation** on the `.hcred` `server` field (it reaches terminal output).
3. Making `HEDDLE_CREDENTIAL` live closes the loop Fable flagged (the previously dead printed instruction).

Docs (`WIRE_PROTOCOL.md`) and `scripts/smoke-hosted-release.sh` updated to the `.hcred` model.

## Verification (verbatim)
- `cargo build -p heddle-client -p heddle-cli` — clean (exit 0).
- `cargo clippy -p heddle-client -p heddle-cli --all-targets -- -D warnings` — clean (`CLIPPY_EXIT=0`).
- `cargo test -p heddle-client --lib` — `test result: ok. 176 passed; 0 failed`. Includes the 10 new tests: env resolves + reports `env:<path>` source, inline-content guard, server-mismatch hard error (no keystore fallback), unreadable hard error (no fallback), env authoritative + non-renewable over a stored parent, token-only stored child does not borrow the host device key, presence resolves subject/errors-when-none, `.hcred` size-cap + control-char rejection.
- `cargo test -p heddle-cli --no-fail-fast` — all failures are known/confirmed flakes, each passing in isolation:
  - `agent_presence_explain_json_detects_harness_without_active_presence` — CLAUDECODE flake (detected the running `claude-opus-4-8` agent instead of the `gpt-5.3-codex` fixture).
  - `multi_agent_worktrees::actor_presence::start_path_inherits_codex_probe_identity_into_actor_metadata`, `multi_agent_worktrees::e2e::agent_capture_and_ready_require_authenticated_writer_authority` — the two known harness-probe flakes.
  - `doctor_schemas_reports_runtime_and_documented_coverage`, `fsck::test_fsck_reports_corrupted_blob`, `shallow_clone::test_partial_clone_copies_fewer_objects_than_full` — all **pass in isolation** (parallel-load contamination under 93%-full disk); auth-independent, and the doctor unit coverage tests pass, confirming no documented-vs-runtime drift from the field removals.
- End-to-end against the built `heddle` binary:
  - `HEDDLE_CREDENTIAL='{...}'` → `Error: HEDDLE_CREDENTIAL takes a file path, not credential contents`.
  - `HEDDLE_CREDENTIAL=/nonexistent/agent.hcred` → hard error `loading HEDDLE_CREDENTIAL ...: No such file or directory` (no keystore fallback).
  - `HEDDLE_CREDENTIAL=$'/a\n/b'` → same file-path guard error.
  - Unauthenticated JSON `auth status` emits `"source": "none"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787112293&installation_id=132405951&pr_number=1072&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1072&signature=5d919df26c33ba57256fc8e029e5c67b8404de7cedab5dbd3c1c129af0767ebf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->