### PR TITLE
feat: content-addressed merkle semantic index (#1067)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_semantic.rs
+++ b/crates/cli/src/cli/cli_args/commands_semantic.rs
@@ -46,6 +46,18 @@ pub enum SemanticCommands {
         #[arg(long)]
         include_actors: bool,
     },
+    /// Backfill the content-addressed merkle semantic index over history.
+    ///
+    /// Native captures already index eagerly; this backfills states that
+    /// predate the index (notably git-lane imports). Runs oldest-first and
+    /// is restartable — rerun after an interruption and it resumes.
+    Index {
+        /// Recompute every state's index, superseding any existing one
+        /// (e.g. after a grammar or extractor upgrade). Without this, only
+        /// states missing an index are computed.
+        #[arg(long)]
+        all: bool,
+    },
 }
 
 /// What dimension to group events on. Mirrors

--- a/crates/cli/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli/src/cli/commands/command_catalog/mod.rs
@@ -2479,6 +2479,19 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["semantic", "hot"],
         opaque_schemas(READ_JSON, &["semantic hot"]),
     ),
+    // `semantic index` backfills the merkle semantic index, attaching a
+    // SemanticIndex sidecar to states that lack one. Metadata mutation, text
+    // progress output, no op-id (idempotent + restartable).
+    entry(
+        &["semantic", "index"],
+        CommandContract {
+            supports_json: false,
+            supports_op_id: false,
+            json_kind: "none",
+            writes_metadata: true,
+            ..MUTATION_BASE
+        },
+    ),
     entry(&["shell"], category(READ_TEXT, "repo")),
     entry(&["shell", "init"], READ_TEXT),
     entry(&["shell", "completion"], READ_TEXT),
@@ -4610,6 +4623,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         #[cfg(feature = "semantic")]
         Commands::Semantic { command } => match command {
             SemanticCommands::Hot { .. } => vec!["semantic", "hot"],
+            SemanticCommands::Index { .. } => vec!["semantic", "index"],
         },
         Commands::Daemon { command } => match command {
             DaemonCommands::Serve => vec!["daemon", "serve"],

--- a/crates/cli/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli/src/cli/commands/command_catalog/tests.rs
@@ -340,6 +340,7 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["schemas"], &["schemas"]),
     #[cfg(feature = "semantic")]
     sample(&["semantic", "hot"], &["semantic", "hot"]),
+    sample(&["semantic", "index"], &["semantic", "index"]),
     sample(
         &["agent", "provenance", "begin"],
         &[

--- a/crates/cli/src/cli/commands/semantic_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_cmd.rs
@@ -43,7 +43,22 @@ pub fn cmd_semantic(cli: &Cli, command: SemanticCommands) -> Result<()> {
             top,
             include_actors,
         ),
+        SemanticCommands::Index { all } => cmd_semantic_index(cli, all),
     }
+}
+
+/// Backfill the merkle semantic index across history (`heddle semantic index`).
+fn cmd_semantic_index(cli: &Cli, all: bool) -> Result<()> {
+    let repo = cli.open_repo()?;
+    let indexed = repo
+        .backfill_semantic_index(all)
+        .context("backfilling semantic index")?;
+    if all {
+        println!("Recomputed the semantic index for {indexed} state(s).");
+    } else {
+        println!("Indexed {indexed} state(s) that were missing a semantic index.");
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -414,6 +414,10 @@ mod fsck {
         // payload after its 8-byte magic+version header — the read
         // path will surface a hash mismatch, decompression error, or
         // structural failure. Fsck accepts any of those signals.
+        // Capture can install more than one pack (source blobs plus sidecar
+        // packs such as the semantic index). Corrupt every pack large enough
+        // to scramble so the source-object pack — the one fsck walks — is
+        // always hit, independent of read_dir order.
         let packs_dir = temp.path().join(".heddle/packs");
         let mut corrupted = false;
         for entry in fs::read_dir(&packs_dir).unwrap().filter_map(Result::ok) {
@@ -422,18 +426,15 @@ mod fsck {
                 continue;
             }
             let mut bytes = fs::read(&path).unwrap();
-            assert!(
-                bytes.len() > 32,
-                "pack {:?} too small to corrupt safely",
-                path
-            );
+            if bytes.len() <= 32 {
+                continue;
+            }
             let end = bytes.len().min(48);
             for b in &mut bytes[16..end] {
                 *b ^= 0xFF;
             }
             fs::write(&path, bytes).unwrap();
             corrupted = true;
-            break;
         }
         assert!(corrupted, "should have found a pack file to corrupt");
 

--- a/crates/cli/tests/production_features/shallow_clone.rs
+++ b/crates/cli/tests/production_features/shallow_clone.rs
@@ -171,12 +171,13 @@ fn test_partial_clone_copies_fewer_objects_than_full() {
         "partial clone must copy fewer objects than a full clone: shallow={shallow_objects}, full={full_objects}"
     );
     // The shallow clone's cost is bounded by the depth window, not the
-    // history length: tip + immediate parents only. A generous ceiling
-    // (well under the full count for a 25-commit history) pins that the
-    // depth boundary actually truncates the walk.
+    // history length: tip + immediate parents, plus the tip state's attached
+    // merkle semantic-index nodes (root + tree + file nodes). A generous
+    // ceiling (well under the full count for a 25-commit history) pins that
+    // the depth boundary actually truncates the walk.
     assert!(
-        shallow_objects <= 12,
-        "depth-1 clone should copy only the tip + immediate parents, got {shallow_objects} objects"
+        shallow_objects <= 24,
+        "depth-1 clone should copy only the tip + immediate parents (plus the tip's semantic index), got {shallow_objects} objects"
     );
 
     for path in [&full_path, &shallow_path] {

--- a/crates/objects/src/error.rs
+++ b/crates/objects/src/error.rs
@@ -254,6 +254,12 @@ impl From<rmp_serde::decode::Error> for HeddleError {
     }
 }
 
+impl From<crate::object::SemanticIndexError> for HeddleError {
+    fn from(e: crate::object::SemanticIndexError) -> Self {
+        HeddleError::InvalidObject(e.to_string())
+    }
+}
+
 impl From<toml::de::Error> for HeddleError {
     fn from(e: toml::de::Error) -> Self {
         HeddleError::Config(e.to_string())

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -17,6 +17,7 @@ mod operation_id;
 mod redaction;
 mod risk_signal;
 mod semantic_change;
+mod semantic_index;
 mod session;
 mod spool_id;
 mod staleness_core;
@@ -57,6 +58,11 @@ pub use risk_signal::{
     SignalAnchor,
 };
 pub use semantic_change::{ChangeImportance, ModificationKind, SemanticChange};
+pub use semantic_index::{
+    SemanticEntryKind, SemanticFileNode, SemanticIndexError, SemanticIndexRoot, SemanticTreeEntry,
+    SemanticTreeNode, SymbolEntry, SymbolKindTag, compute_dir_semantic_digest,
+    compute_file_semantic_digest, compute_symbol_semantic_hash,
+};
 pub use session::{Session, SessionSegment, generate_session_id};
 pub use spool_id::{SpoolId, SpoolIdParseError};
 pub use staleness_core::{

--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -61,7 +61,7 @@ pub use semantic_change::{ChangeImportance, ModificationKind, SemanticChange};
 pub use semantic_index::{
     SemanticEntryKind, SemanticFileNode, SemanticIndexError, SemanticIndexRoot, SemanticTreeEntry,
     SemanticTreeNode, SymbolEntry, SymbolKindTag, compute_dir_semantic_digest,
-    compute_file_semantic_digest, compute_symbol_semantic_hash,
+    compute_file_scaffold_hash, compute_file_semantic_digest, compute_symbol_semantic_hash,
 };
 pub use session::{Session, SessionSegment, generate_session_id};
 pub use spool_id::{SpoolId, SpoolIdParseError};

--- a/crates/objects/src/object/semantic_index.rs
+++ b/crates/objects/src/object/semantic_index.rs
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Content-addressed merkle semantic index (heddle#1067).
+//!
+//! A parallel merkle DAG over the source tree that stores *semantic* facts —
+//! the symbols a file defines and a normalization-stable fingerprint of each —
+//! rather than raw bytes. It mirrors the blob/tree/state DAG so semantic data
+//! over all of history costs about as much to maintain as the source history
+//! itself, and queries short-circuit on hash equality without re-parsing.
+//!
+//! ## The two-hash crux
+//!
+//! Every node carries two identities:
+//!
+//! - Its **storage hash** — the content-address of the encoded node blob. This
+//!   changes whenever the node bytes change, including when a symbol's span
+//!   moves under a reformat. It is the object-store key.
+//! - Its **`semantic_digest`** — a fingerprint computed over the *meaning* of
+//!   the node with spans deliberately excluded. Reformatting a file (which
+//!   moves every span) leaves the `semantic_digest` untouched, so a top-down
+//!   digest compare prunes reformatted-but-semantically-identical subtrees
+//!   with zero re-parse.
+//!
+//! The digest byte layouts (`hd-sem-sym-v1`, `hd-sem-file-v1`, `hd-sem-dir-v1`)
+//! are the canonical, cross-language-reproducible definitions. A verifier in
+//! any language that reproduces these byte streams computes byte-identical
+//! digests.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::ContentHash;
+
+/// Coarse symbol classification carried by the index. Mirrors the
+/// `semantic::symbol_resolver::DefinitionKind` taxonomy so types, traits,
+/// enums, modules and the rest are first-class in the index — not just
+/// functions.
+///
+/// The `snake_case` serde spelling is the durable wire form; the [`tag_byte`]
+/// value is the durable *hashing* form and must never be renumbered (doing so
+/// would silently change every `semantic_hash`/`semantic_digest`).
+///
+/// [`tag_byte`]: SymbolKindTag::tag_byte
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolKindTag {
+    /// Function / method / free function body.
+    Function,
+    /// Struct or record type definition.
+    Type,
+    /// Enum definition.
+    Enum,
+    /// Trait declaration (Rust).
+    Trait,
+    /// Class declaration (Python / JS / TS / Java / C++).
+    Class,
+    /// Interface declaration (TS / Java / Go).
+    Interface,
+    /// Type alias (`type Foo = ...`).
+    TypeAlias,
+    /// Constant or static at module scope.
+    Const,
+    /// Module / namespace.
+    Module,
+    /// Parseable but unclassified definition.
+    Other,
+}
+
+impl SymbolKindTag {
+    /// Stable single-byte tag used in the canonical digest byte streams.
+    /// NEVER renumber — the values are baked into every stored digest.
+    pub fn tag_byte(self) -> u8 {
+        match self {
+            SymbolKindTag::Function => 1,
+            SymbolKindTag::Type => 2,
+            SymbolKindTag::Enum => 3,
+            SymbolKindTag::Trait => 4,
+            SymbolKindTag::Class => 5,
+            SymbolKindTag::Interface => 6,
+            SymbolKindTag::TypeAlias => 7,
+            SymbolKindTag::Const => 8,
+            SymbolKindTag::Module => 9,
+            SymbolKindTag::Other => 10,
+        }
+    }
+}
+
+/// The kind of a [`SemanticTreeEntry`]'s target.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticEntryKind {
+    /// A subdirectory — `node` is a [`SemanticTreeNode`].
+    Dir,
+    /// A parsed source file — `node` is a [`SemanticFileNode`].
+    File,
+    /// Unsupported language, parse failure, or over-budget file. Carries no
+    /// semantic node: `node` and `semantic_digest` both equal the raw source
+    /// blob hash, so a content change to an opaque file still perturbs the
+    /// digest chain.
+    Opaque,
+}
+
+impl SemanticEntryKind {
+    /// Stable single-byte tag used in the canonical dir-digest byte stream.
+    pub fn tag_byte(self) -> u8 {
+        match self {
+            SemanticEntryKind::Dir => 1,
+            SemanticEntryKind::File => 2,
+            SemanticEntryKind::Opaque => 3,
+        }
+    }
+}
+
+/// One symbol defined in a source file.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SymbolEntry {
+    /// Bare symbol name as it appears in the AST.
+    pub name: String,
+    /// Coarse classification.
+    pub kind: SymbolKindTag,
+    /// Enclosing scope path (impl block, class, module, ...), outermost first.
+    pub container_path: Vec<String>,
+    /// Normalization-stable fingerprint of the symbol's definition — a pure
+    /// function of `(bytes, grammar, extractor_version)` that is invariant
+    /// under reformatting and comment edits. See [`compute_symbol_semantic_hash`].
+    pub semantic_hash: ContentHash,
+    /// `(start_line, end_line)`, 1-indexed inclusive. PROVENANCE ONLY — the
+    /// span is deliberately excluded from every digest so a reformat that moves
+    /// the symbol leaves the fingerprint stable.
+    pub span: (u32, u32),
+}
+
+impl SymbolEntry {
+    /// Canonical address spelling: `container::path::name`, or just `name`
+    /// when the symbol is at file scope.
+    pub fn address(&self) -> String {
+        if self.container_path.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}::{}", self.container_path.join("::"), self.name)
+        }
+    }
+
+    /// Sort key: `(container_path, name, kind, span.0)`.
+    fn sort_key(&self) -> (&[String], &str, u8, u32) {
+        (
+            &self.container_path,
+            self.name.as_str(),
+            self.kind.tag_byte(),
+            self.span.0,
+        )
+    }
+}
+
+/// Compute a symbol's normalization-stable `semantic_hash`.
+///
+/// Canonical layout `hd-sem-sym-v1`:
+/// `kind_tag ‖ 0x00 ‖ token_stream`.
+///
+/// `token_stream` is produced by a DFS in document order over the symbol's
+/// definition node, skipping comment-kind subtrees, emitting for each remaining
+/// leaf `u32-LE(byte_len) ‖ exact source bytes`. Length-prefixed rather than
+/// space-joined so token boundaries are unambiguous. Callers assemble the
+/// stream (they hold the tree); this owns the framing.
+pub fn compute_symbol_semantic_hash(kind: SymbolKindTag, token_stream: &[u8]) -> ContentHash {
+    let mut buf = Vec::with_capacity(2 + token_stream.len());
+    buf.push(kind.tag_byte());
+    buf.push(0x00);
+    buf.extend_from_slice(token_stream);
+    ContentHash::compute_typed("hd-sem-sym-v1", &buf)
+}
+
+/// Compute a file node's `semantic_digest` over its (already sorted) symbols.
+///
+/// Canonical layout `hd-sem-file-v1`, per symbol:
+/// `u32-LE-len-prefixed(container_path joined by "::") ‖ name ‖ kind_tag ‖ semantic_hash`.
+/// Spans are EXCLUDED — that is what makes the digest reformat-stable.
+pub fn compute_file_semantic_digest(symbols: &[SymbolEntry]) -> ContentHash {
+    let mut buf = Vec::new();
+    for symbol in symbols {
+        let joined = symbol.container_path.join("::");
+        buf.extend_from_slice(&(joined.len() as u32).to_le_bytes());
+        buf.extend_from_slice(joined.as_bytes());
+        buf.extend_from_slice(symbol.name.as_bytes());
+        buf.push(symbol.kind.tag_byte());
+        buf.extend_from_slice(symbol.semantic_hash.as_bytes());
+    }
+    ContentHash::compute_typed("hd-sem-file-v1", &buf)
+}
+
+/// Compute a directory node's `semantic_digest` over its entries.
+///
+/// Canonical layout `hd-sem-dir-v1`, per entry:
+/// `name ‖ kind_tag ‖ child semantic_digest`.
+pub fn compute_dir_semantic_digest(entries: &[SemanticTreeEntry]) -> ContentHash {
+    let mut buf = Vec::new();
+    for entry in entries {
+        buf.extend_from_slice(entry.name.as_bytes());
+        buf.push(entry.kind.tag_byte());
+        buf.extend_from_slice(entry.semantic_digest.as_bytes());
+    }
+    ContentHash::compute_typed("hd-sem-dir-v1", &buf)
+}
+
+/// The per-file semantic node: the symbols a source blob defines plus the
+/// reformat-stable digest over them.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticFileNode {
+    pub format_version: u8,
+    pub language: String,
+    pub grammar_version: String,
+    pub extractor_version: u32,
+    /// Content hash of the raw source blob this node was extracted from.
+    pub source_blob: ContentHash,
+    /// Symbols sorted by `(container_path, name, kind, span.0)`.
+    pub symbols: Vec<SymbolEntry>,
+    /// Reformat-stable digest — see [`compute_file_semantic_digest`].
+    pub semantic_digest: ContentHash,
+}
+
+impl SemanticFileNode {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    /// Build a node, sorting the symbols canonically and computing the digest.
+    pub fn new(
+        language: impl Into<String>,
+        grammar_version: impl Into<String>,
+        extractor_version: u32,
+        source_blob: ContentHash,
+        mut symbols: Vec<SymbolEntry>,
+    ) -> Self {
+        symbols.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
+        let semantic_digest = compute_file_semantic_digest(&symbols);
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            language: language.into(),
+            grammar_version: grammar_version.into(),
+            extractor_version,
+            source_blob,
+            symbols,
+            semantic_digest,
+        }
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {
+        rmp_serde::to_vec_named(self).map_err(|err| SemanticIndexError::Encoding(err.to_string()))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, SemanticIndexError> {
+        let node: Self =
+            rmp_serde::from_slice(bytes).map_err(|err| SemanticIndexError::Encoding(err.to_string()))?;
+        if node.format_version != Self::FORMAT_VERSION {
+            return Err(SemanticIndexError::UnsupportedVersion(node.format_version));
+        }
+        Ok(node)
+    }
+
+    /// Find a symbol by its canonical address (`container::name`).
+    pub fn symbol_by_address(&self, address: &str) -> Option<&SymbolEntry> {
+        self.symbols.iter().find(|s| s.address() == address)
+    }
+}
+
+/// One child edge of a [`SemanticTreeNode`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticTreeEntry {
+    pub name: String,
+    pub kind: SemanticEntryKind,
+    /// Storage hash of the child node (a [`SemanticFileNode`] or
+    /// [`SemanticTreeNode`] blob), or — for [`SemanticEntryKind::Opaque`] — the
+    /// raw source blob hash.
+    pub node: ContentHash,
+    /// The child's `semantic_digest` (its reformat-stable identity).
+    pub semantic_digest: ContentHash,
+}
+
+/// A semantic directory node mirroring a source [`Tree`](super::Tree).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticTreeNode {
+    pub format_version: u8,
+    /// Entries sorted by `name` (mirrors the source tree's ordering).
+    pub entries: Vec<SemanticTreeEntry>,
+}
+
+impl SemanticTreeNode {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    /// Build a node, sorting entries by name and computing the dir digest,
+    /// which is returned alongside the node.
+    pub fn new(mut entries: Vec<SemanticTreeEntry>) -> (Self, ContentHash) {
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        let digest = compute_dir_semantic_digest(&entries);
+        (
+            Self {
+                format_version: Self::FORMAT_VERSION,
+                entries,
+            },
+            digest,
+        )
+    }
+
+    /// The node's reformat-stable digest.
+    pub fn semantic_digest(&self) -> ContentHash {
+        compute_dir_semantic_digest(&self.entries)
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {
+        rmp_serde::to_vec_named(self).map_err(|err| SemanticIndexError::Encoding(err.to_string()))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, SemanticIndexError> {
+        let node: Self =
+            rmp_serde::from_slice(bytes).map_err(|err| SemanticIndexError::Encoding(err.to_string()))?;
+        if node.format_version != Self::FORMAT_VERSION {
+            return Err(SemanticIndexError::UnsupportedVersion(node.format_version));
+        }
+        Ok(node)
+    }
+
+    pub fn get(&self, name: &str) -> Option<&SemanticTreeEntry> {
+        self.entries
+            .binary_search_by(|e| e.name.as_str().cmp(name))
+            .ok()
+            .map(|i| &self.entries[i])
+    }
+}
+
+/// Root of a state's semantic index. Attached to a state via
+/// `StateAttachmentBody::SemanticIndex`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SemanticIndexRoot {
+    pub format_version: u8,
+    pub extractor_version: u32,
+    /// Language → grammar version, for every language present in the tree.
+    pub grammars: BTreeMap<String, String>,
+    /// Storage hash of the top [`SemanticTreeNode`].
+    pub tree: ContentHash,
+    /// The top tree node's `semantic_digest` — the whole-tree fingerprint.
+    pub semantic_digest: ContentHash,
+}
+
+impl SemanticIndexRoot {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    pub fn new(
+        extractor_version: u32,
+        grammars: BTreeMap<String, String>,
+        tree: ContentHash,
+        semantic_digest: ContentHash,
+    ) -> Self {
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            extractor_version,
+            grammars,
+            tree,
+            semantic_digest,
+        }
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {
+        rmp_serde::to_vec_named(self).map_err(|err| SemanticIndexError::Encoding(err.to_string()))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, SemanticIndexError> {
+        let root: Self =
+            rmp_serde::from_slice(bytes).map_err(|err| SemanticIndexError::Encoding(err.to_string()))?;
+        if root.format_version != Self::FORMAT_VERSION {
+            return Err(SemanticIndexError::UnsupportedVersion(root.format_version));
+        }
+        Ok(root)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SemanticIndexError {
+    #[error("unsupported semantic index node version {0}")]
+    UnsupportedVersion(u8),
+    #[error("semantic index node encoding error: {0}")]
+    Encoding(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(seed: u8) -> ContentHash {
+        ContentHash::from_bytes([seed; 32])
+    }
+
+    fn sym(name: &str, container: &[&str], kind: SymbolKindTag, span: (u32, u32)) -> SymbolEntry {
+        SymbolEntry {
+            name: name.to_string(),
+            kind,
+            container_path: container.iter().map(|s| s.to_string()).collect(),
+            semantic_hash: ContentHash::compute(name.as_bytes()),
+            span,
+        }
+    }
+
+    #[test]
+    fn file_digest_excludes_span() {
+        let a = SemanticFileNode::new(
+            "rust",
+            "0.24",
+            1,
+            h(1),
+            vec![sym("foo", &[], SymbolKindTag::Function, (10, 20))],
+        );
+        // Same symbol, moved by a reformat (span shifted).
+        let b = SemanticFileNode::new(
+            "rust",
+            "0.24",
+            1,
+            h(1),
+            vec![sym("foo", &[], SymbolKindTag::Function, (99, 120))],
+        );
+        assert_eq!(
+            a.semantic_digest, b.semantic_digest,
+            "span must not affect the file semantic_digest"
+        );
+    }
+
+    #[test]
+    fn file_digest_changes_on_symbol_hash_change() {
+        let mut s = sym("foo", &[], SymbolKindTag::Function, (1, 2));
+        let d1 = compute_file_semantic_digest(std::slice::from_ref(&s));
+        s.semantic_hash = ContentHash::compute(b"different-body");
+        let d2 = compute_file_semantic_digest(std::slice::from_ref(&s));
+        assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn symbol_hash_stable_and_kind_sensitive() {
+        let ts = b"some token stream";
+        let a = compute_symbol_semantic_hash(SymbolKindTag::Function, ts);
+        let b = compute_symbol_semantic_hash(SymbolKindTag::Function, ts);
+        assert_eq!(a, b);
+        let c = compute_symbol_semantic_hash(SymbolKindTag::Type, ts);
+        assert_ne!(a, c, "kind participates in the symbol hash");
+    }
+
+    #[test]
+    fn symbols_sorted_canonically() {
+        let node = SemanticFileNode::new(
+            "rust",
+            "0.24",
+            1,
+            h(1),
+            vec![
+                sym("zed", &[], SymbolKindTag::Function, (1, 1)),
+                sym("abe", &["Impl"], SymbolKindTag::Function, (2, 2)),
+                sym("abe", &[], SymbolKindTag::Function, (3, 3)),
+            ],
+        );
+        let names: Vec<_> = node.symbols.iter().map(|s| s.address()).collect();
+        assert_eq!(names, vec!["abe", "zed", "Impl::abe"]);
+    }
+
+    #[test]
+    fn dir_digest_stable_and_roundtrip() {
+        let e = SemanticTreeEntry {
+            name: "a.rs".to_string(),
+            kind: SemanticEntryKind::File,
+            node: h(5),
+            semantic_digest: h(6),
+        };
+        let (node, digest) = SemanticTreeNode::new(vec![e.clone()]);
+        assert_eq!(node.semantic_digest(), digest);
+        let bytes = node.encode().unwrap();
+        assert_eq!(SemanticTreeNode::decode(&bytes).unwrap(), node);
+    }
+
+    #[test]
+    fn address_spelling() {
+        assert_eq!(sym("foo", &[], SymbolKindTag::Function, (0, 0)).address(), "foo");
+        assert_eq!(
+            sym("open", &["Repository"], SymbolKindTag::Function, (0, 0)).address(),
+            "Repository::open"
+        );
+    }
+}

--- a/crates/objects/src/object/semantic_index.rs
+++ b/crates/objects/src/object/semantic_index.rs
@@ -170,36 +170,63 @@ pub fn compute_symbol_semantic_hash(kind: SymbolKindTag, token_stream: &[u8]) ->
     ContentHash::compute_typed("hd-sem-sym-v1", &buf)
 }
 
-/// Compute a file node's `semantic_digest` over its (already sorted) symbols.
+/// Hash the file's *scaffold*: the residual non-definition top-level token
+/// stream (every leaf under the file root not covered by an extracted symbol's
+/// span). This is what binds `use`-decl swaps, `impl Trait` headers, attribute
+/// edits, `macro_rules!` bodies and definition-free files (re-export-only libs,
+/// top-level statements) into the file digest — semantic content that lives
+/// *outside* any extracted symbol.
 ///
-/// Canonical layout `hd-sem-file-v1`, per symbol:
-/// `u32-LE-len-prefixed(container_path joined by "::") ‖ name ‖ kind_tag ‖ semantic_hash`.
-/// Spans are EXCLUDED — that is what makes the digest reformat-stable.
-pub fn compute_file_semantic_digest(symbols: &[SymbolEntry]) -> ContentHash {
+/// Canonical layout `hd-sem-scaffold-v1`: the length-prefixed leaf token stream
+/// (same framing as a symbol hash's token stream), comments excluded.
+pub fn compute_file_scaffold_hash(token_stream: &[u8]) -> ContentHash {
+    ContentHash::compute_typed("hd-sem-scaffold-v1", token_stream)
+}
+
+/// Compute a file node's `semantic_digest` over its scaffold and (already
+/// sorted) symbols — so the digest covers ALL of a file's semantic content,
+/// not just its extracted definitions.
+///
+/// Canonical layout `hd-sem-file-v2`: `scaffold_hash`, then per symbol
+/// `u32-LE(container element count) ‖ (u32-LE-len ‖ bytes)* ‖ u32-LE(name len) ‖
+/// name ‖ kind_tag ‖ semantic_hash`. Every variable-length field is
+/// length-framed (no record-boundary ambiguity; `["a::b"]` no longer aliases
+/// `["a","b"]`). Spans are EXCLUDED — that is what makes the digest
+/// reformat-stable.
+pub fn compute_file_semantic_digest(
+    scaffold_hash: ContentHash,
+    symbols: &[SymbolEntry],
+) -> ContentHash {
     let mut buf = Vec::new();
+    buf.extend_from_slice(scaffold_hash.as_bytes());
     for symbol in symbols {
-        let joined = symbol.container_path.join("::");
-        buf.extend_from_slice(&(joined.len() as u32).to_le_bytes());
-        buf.extend_from_slice(joined.as_bytes());
+        buf.extend_from_slice(&(symbol.container_path.len() as u32).to_le_bytes());
+        for segment in &symbol.container_path {
+            buf.extend_from_slice(&(segment.len() as u32).to_le_bytes());
+            buf.extend_from_slice(segment.as_bytes());
+        }
+        buf.extend_from_slice(&(symbol.name.len() as u32).to_le_bytes());
         buf.extend_from_slice(symbol.name.as_bytes());
         buf.push(symbol.kind.tag_byte());
         buf.extend_from_slice(symbol.semantic_hash.as_bytes());
     }
-    ContentHash::compute_typed("hd-sem-file-v1", &buf)
+    ContentHash::compute_typed("hd-sem-file-v2", &buf)
 }
 
 /// Compute a directory node's `semantic_digest` over its entries.
 ///
-/// Canonical layout `hd-sem-dir-v1`, per entry:
-/// `name ‖ kind_tag ‖ child semantic_digest`.
+/// Canonical layout `hd-sem-dir-v2`, per entry:
+/// `u32-LE(name len) ‖ name ‖ kind_tag ‖ child semantic_digest`. The name is
+/// length-framed so entry boundaries are unambiguous.
 pub fn compute_dir_semantic_digest(entries: &[SemanticTreeEntry]) -> ContentHash {
     let mut buf = Vec::new();
     for entry in entries {
+        buf.extend_from_slice(&(entry.name.len() as u32).to_le_bytes());
         buf.extend_from_slice(entry.name.as_bytes());
         buf.push(entry.kind.tag_byte());
         buf.extend_from_slice(entry.semantic_digest.as_bytes());
     }
-    ContentHash::compute_typed("hd-sem-dir-v1", &buf)
+    ContentHash::compute_typed("hd-sem-dir-v2", &buf)
 }
 
 /// The per-file semantic node: the symbols a source blob defines plus the
@@ -212,6 +239,10 @@ pub struct SemanticFileNode {
     pub extractor_version: u32,
     /// Content hash of the raw source blob this node was extracted from.
     pub source_blob: ContentHash,
+    /// Hash of the file's residual non-definition token stream — see
+    /// [`compute_file_scaffold_hash`]. Binds semantic content that lives outside
+    /// any extracted symbol into the file digest.
+    pub scaffold_hash: ContentHash,
     /// Symbols sorted by `(container_path, name, kind, span.0)`.
     pub symbols: Vec<SymbolEntry>,
     /// Reformat-stable digest — see [`compute_file_semantic_digest`].
@@ -221,22 +252,25 @@ pub struct SemanticFileNode {
 impl SemanticFileNode {
     pub const FORMAT_VERSION: u8 = 1;
 
-    /// Build a node, sorting the symbols canonically and computing the digest.
+    /// Build a node, sorting the symbols canonically and computing the digest
+    /// over the scaffold plus the symbols.
     pub fn new(
         language: impl Into<String>,
         grammar_version: impl Into<String>,
         extractor_version: u32,
         source_blob: ContentHash,
+        scaffold_hash: ContentHash,
         mut symbols: Vec<SymbolEntry>,
     ) -> Self {
         symbols.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
-        let semantic_digest = compute_file_semantic_digest(&symbols);
+        let semantic_digest = compute_file_semantic_digest(scaffold_hash, &symbols);
         Self {
             format_version: Self::FORMAT_VERSION,
             language: language.into(),
             grammar_version: grammar_version.into(),
             extractor_version,
             source_blob,
+            scaffold_hash,
             symbols,
             semantic_digest,
         }
@@ -404,6 +438,7 @@ mod tests {
             "0.24",
             1,
             h(1),
+            h(0),
             vec![sym("foo", &[], SymbolKindTag::Function, (10, 20))],
         );
         // Same symbol, moved by a reformat (span shifted).
@@ -412,6 +447,7 @@ mod tests {
             "0.24",
             1,
             h(1),
+            h(0),
             vec![sym("foo", &[], SymbolKindTag::Function, (99, 120))],
         );
         assert_eq!(
@@ -423,10 +459,33 @@ mod tests {
     #[test]
     fn file_digest_changes_on_symbol_hash_change() {
         let mut s = sym("foo", &[], SymbolKindTag::Function, (1, 2));
-        let d1 = compute_file_semantic_digest(std::slice::from_ref(&s));
+        let d1 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s));
         s.semantic_hash = ContentHash::compute(b"different-body");
-        let d2 = compute_file_semantic_digest(std::slice::from_ref(&s));
+        let d2 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s));
         assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn file_digest_changes_on_scaffold_change() {
+        let syms = [sym("foo", &[], SymbolKindTag::Function, (1, 2))];
+        let d1 = compute_file_semantic_digest(compute_file_scaffold_hash(b"use a;"), &syms);
+        let d2 = compute_file_semantic_digest(compute_file_scaffold_hash(b"use b;"), &syms);
+        assert_ne!(
+            d1, d2,
+            "scaffold (non-definition top-level tokens) must affect the file digest"
+        );
+    }
+
+    #[test]
+    fn file_digest_framing_is_unambiguous() {
+        // `["a::b"]` must NOT collide with `["a","b"]` (per-element framing),
+        // and a name boundary shift must not alias across symbols.
+        let one = sym("f", &["a::b"], SymbolKindTag::Function, (0, 0));
+        let two = sym("f", &["a", "b"], SymbolKindTag::Function, (0, 0));
+        assert_ne!(
+            compute_file_semantic_digest(h(0), &[one]),
+            compute_file_semantic_digest(h(0), &[two]),
+        );
     }
 
     #[test]
@@ -446,6 +505,7 @@ mod tests {
             "0.24",
             1,
             h(1),
+            h(0),
             vec![
                 sym("zed", &[], SymbolKindTag::Function, (1, 1)),
                 sym("abe", &["Impl"], SymbolKindTag::Function, (2, 2)),

--- a/crates/objects/src/object/state_attachment.rs
+++ b/crates/objects/src/object/state_attachment.rs
@@ -32,6 +32,8 @@ pub enum StateAttachmentBody {
     ReviewSignatures(ContentHash),
     Discussions(ContentHash),
     StructuredConflicts(ContentHash),
+    /// Content hash of the state's `SemanticIndexRoot` blob (heddle#1067).
+    SemanticIndex(ContentHash),
     Signature(StateSignature),
 }
 

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -41,6 +41,10 @@ mod repository_redaction;
 #[path = "repository_resolve_for_command.rs"]
 mod repository_resolve_for_command;
 #[cfg(feature = "tree-sitter-symbols")]
+mod repository_semantic_index;
+#[cfg(feature = "tree-sitter-symbols")]
+pub use repository_semantic_index::{ParentIndex, SemanticIndexBuilder, SymbolDelta};
+#[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
 mod repository_state_visibility;
 mod revision_address;

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -25,9 +25,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use objects::{
     object::{
-        Blob, ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot,
-        SemanticTreeEntry, SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry,
-        SymbolKindTag, Tree, TreeEntryTarget,
+        ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot, SemanticTreeEntry,
+        SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry, SymbolKindTag, Tree,
+        TreeEntryTarget,
     },
     store::ObjectStore,
 };
@@ -79,6 +79,9 @@ pub struct SemanticIndexBuilder<'store, S: ObjectStore> {
     /// Languages encountered while building, seeded from the parent root so
     /// pruned subtrees' grammars are not lost.
     grammars: BTreeMap<String, String>,
+    /// Node blobs written this build, flushed as one pack at the end so a
+    /// snapshot never regresses to N loose per-node fsyncs.
+    pending: Vec<(ContentHash, Vec<u8>)>,
     /// Number of source blobs actually parsed this build.
     pub parse_count: usize,
 }
@@ -90,6 +93,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             extractor_version,
             file_memo: HashMap::new(),
             grammars: BTreeMap::new(),
+            pending: Vec::new(),
             parse_count: 0,
         }
     }
@@ -113,7 +117,12 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             node_hash,
             digest,
         );
-        let root_hash = self.put_node(&root.encode()?)?;
+        let root_hash = self.put_node(root.encode()?);
+        // Flush every node blob as a single pack — the same hot path the
+        // snapshot uses for source blobs, so capture stays fsync-cheap and
+        // leaves nothing loose behind.
+        self.store
+            .put_blobs_packed(std::mem::take(&mut self.pending))?;
         Ok((root, root_hash))
     }
 
@@ -154,7 +163,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             });
         }
         let (node, digest) = SemanticTreeNode::new(entries);
-        let node_hash = self.put_node(&node.encode()?)?;
+        let node_hash = self.put_node(node.encode()?);
         Ok((node_hash, digest))
     }
 
@@ -299,7 +308,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             extracted.symbols,
         );
         let digest = node.semantic_digest;
-        let node_hash = self.put_node(&node.encode()?)?;
+        let node_hash = self.put_node(node.encode()?);
         Ok(BuiltEntry {
             kind: SemanticEntryKind::File,
             node: node_hash,
@@ -307,8 +316,12 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         })
     }
 
-    fn put_node(&self, bytes: &[u8]) -> Result<ContentHash> {
-        self.store.put_blob(&Blob::new(bytes.to_vec()))
+    /// Queue an encoded node blob for the end-of-build pack flush, returning its
+    /// content hash (identical to what `put_blob` would assign).
+    fn put_node(&mut self, bytes: Vec<u8>) -> ContentHash {
+        let hash = ContentHash::compute_typed("blob", &bytes);
+        self.pending.push((hash, bytes));
+        hash
     }
 }
 
@@ -852,7 +865,7 @@ fn join_path(prefix: &str, name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{Attribution, Principal, TreeEntry};
+    use objects::object::{Attribution, Blob, Principal, TreeEntry};
     use tempfile::TempDir;
 
     use super::*;

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -1,0 +1,1034 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Assembly, capture wiring, backfill and query primitives for the merkle
+//! semantic index (heddle#1067).
+//!
+//! The node types and canonical digest layouts live in `objects`; the AST
+//! extraction lives in `semantic`. This layer mirrors the source blob/tree DAG
+//! into a parallel semantic DAG stored as ordinary content-addressed blobs, and
+//! attaches its root to a state via `StateAttachmentBody::SemanticIndex`.
+//!
+//! ## Cheap-to-maintain
+//!
+//! [`SemanticIndexBuilder`] parses only *changed* source blobs: it reuses a
+//! parent index's node wholesale wherever the source subtree hash is unchanged
+//! (assembly is O(changed-path)), and memoizes per source-blob so a blob shared
+//! across paths — or across the reformat of a sibling — is parsed at most once.
+//!
+//! ## Never-fail capture
+//!
+//! Capture swallows-with-warn exactly like `compute_and_persist_signals`; a
+//! parser hiccup must never fail a snapshot.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::{BTreeMap, HashMap};
+
+use objects::{
+    object::{
+        Blob, ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot,
+        SemanticTreeEntry, SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry,
+        SymbolKindTag, Tree, TreeEntryTarget,
+    },
+    store::ObjectStore,
+};
+use semantic::{
+    parser::Language,
+    semantic_index::{EXTRACTOR_VERSION, extract_semantic_file, grammar_version, language_name},
+};
+use tracing::warn;
+
+use crate::{Repository, Result, StateAttachmentKind};
+
+/// Source files above this size are recorded as `Opaque` rather than parsed —
+/// generated/vendored blobs dominate parse cost and rarely carry review-worthy
+/// symbols.
+const SEMANTIC_FILE_BUDGET_BYTES: usize = 1 << 20;
+
+/// A single-symbol delta between two states, produced by [`Repository::semantic_diff_symbols`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolDelta {
+    /// File path + canonical symbol address (`container::name`).
+    pub anchor: SymbolAnchor,
+    pub kind: SymbolKindTag,
+    /// Fingerprint on the `a` side, `None` if the symbol did not exist there.
+    pub old_hash: Option<ContentHash>,
+    /// Fingerprint on the `b` side, `None` if the symbol does not exist there.
+    pub new_hash: Option<ContentHash>,
+}
+
+/// What a built subtree resolved to: the storage hash of the node blob (or the
+/// raw source blob, for opaque entries) plus its reformat-stable digest.
+#[derive(Clone, Copy)]
+struct BuiltEntry {
+    kind: SemanticEntryKind,
+    node: ContentHash,
+    semantic_digest: ContentHash,
+}
+
+/// Builds a semantic index over a source tree, reusing a parent index where the
+/// source is unchanged and memoizing per source-blob so each unique blob is
+/// parsed at most once. `parse_count` is exposed for tests that assert the
+/// prune-without-reparse invariant.
+pub struct SemanticIndexBuilder<'store, S: ObjectStore> {
+    store: &'store S,
+    extractor_version: u32,
+    /// Per-build memo: source blob hash → its file/opaque entry. A blob that
+    /// appears at several paths (or is the unchanged sibling of a reformat) is
+    /// parsed once.
+    file_memo: HashMap<ContentHash, BuiltEntry>,
+    /// Languages encountered while building, seeded from the parent root so
+    /// pruned subtrees' grammars are not lost.
+    grammars: BTreeMap<String, String>,
+    /// Number of source blobs actually parsed this build.
+    pub parse_count: usize,
+}
+
+impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
+    pub fn new(store: &'store S, extractor_version: u32) -> Self {
+        Self {
+            store,
+            extractor_version,
+            file_memo: HashMap::new(),
+            grammars: BTreeMap::new(),
+            parse_count: 0,
+        }
+    }
+
+    /// Build the index for `tree`, optionally reusing `parent` (its source tree
+    /// + semantic index root) for unchanged-subtree pruning. Returns the
+    /// persisted [`SemanticIndexRoot`] and its storage hash.
+    pub fn build_root(
+        &mut self,
+        tree: &Tree,
+        parent: Option<&ParentIndex>,
+    ) -> Result<(SemanticIndexRoot, ContentHash)> {
+        if let Some(parent) = parent {
+            self.grammars = parent.root.grammars.clone();
+        }
+        let parent_ctx = parent.map(|p| (&p.source_tree, &p.semantic_tree));
+        let (node_hash, digest) = self.build_tree(tree, parent_ctx)?;
+        let root = SemanticIndexRoot::new(
+            self.extractor_version,
+            std::mem::take(&mut self.grammars),
+            node_hash,
+            digest,
+        );
+        let root_hash = self.put_node(&root.encode()?)?;
+        Ok((root, root_hash))
+    }
+
+    fn build_tree(
+        &mut self,
+        tree: &Tree,
+        parent: Option<(&Tree, &SemanticTreeNode)>,
+    ) -> Result<(ContentHash, ContentHash)> {
+        let mut entries = Vec::with_capacity(tree.len());
+        for entry in tree.entries() {
+            let name = entry.name();
+            let built = match entry.target() {
+                TreeEntryTarget::Tree { hash } => {
+                    self.build_dir(name, *hash, parent)?
+                }
+                TreeEntryTarget::Blob { hash, .. } => self.build_file(name, *hash, parent)?,
+                TreeEntryTarget::Symlink { hash } => BuiltEntry {
+                    kind: SemanticEntryKind::Opaque,
+                    node: *hash,
+                    semantic_digest: *hash,
+                },
+                // Git submodule / native child-spool edges have no source blob
+                // in this store; fingerprint them by their stable target bytes.
+                TreeEntryTarget::Gitlink { .. } | TreeEntryTarget::Spoollink { .. } => {
+                    let digest = opaque_edge_digest(entry.target());
+                    BuiltEntry {
+                        kind: SemanticEntryKind::Opaque,
+                        node: digest,
+                        semantic_digest: digest,
+                    }
+                }
+            };
+            entries.push(SemanticTreeEntry {
+                name: name.to_string(),
+                kind: built.kind,
+                node: built.node,
+                semantic_digest: built.semantic_digest,
+            });
+        }
+        let (node, digest) = SemanticTreeNode::new(entries);
+        let node_hash = self.put_node(&node.encode()?)?;
+        Ok((node_hash, digest))
+    }
+
+    fn build_dir(
+        &mut self,
+        name: &str,
+        source_hash: ContentHash,
+        parent: Option<(&Tree, &SemanticTreeNode)>,
+    ) -> Result<BuiltEntry> {
+        // Unchanged-subtree prune: same-named source dir with the same hash and
+        // a matching parent semantic entry ⇒ reuse wholesale, no recurse, no
+        // parse.
+        if let Some((parent_source, parent_sem)) = parent
+            && let Some(parent_entry) = parent_source.get(name)
+            && parent_entry.tree_hash() == Some(source_hash)
+            && let Some(sem_entry) = parent_sem.get(name)
+            && sem_entry.kind == SemanticEntryKind::Dir
+        {
+            return Ok(BuiltEntry {
+                kind: SemanticEntryKind::Dir,
+                node: sem_entry.node,
+                semantic_digest: sem_entry.semantic_digest,
+            });
+        }
+
+        let source_tree = self
+            .store
+            .get_tree(&source_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("tree {source_hash}")))?;
+
+        // Descend with the matching parent subtree as the reuse basis, if any.
+        let child_parent = self.child_parent_ctx(name, parent)?;
+        let child_parent_ref = child_parent
+            .as_ref()
+            .map(|(t, n)| (t, n));
+        let (node, digest) = self.build_tree(&source_tree, child_parent_ref)?;
+        Ok(BuiltEntry {
+            kind: SemanticEntryKind::Dir,
+            node,
+            semantic_digest: digest,
+        })
+    }
+
+    /// Load the parent source subtree + parent semantic subtree for `name`, to
+    /// serve as the reuse basis when recursing into a changed directory.
+    fn child_parent_ctx(
+        &self,
+        name: &str,
+        parent: Option<(&Tree, &SemanticTreeNode)>,
+    ) -> Result<Option<(Tree, SemanticTreeNode)>> {
+        let Some((parent_source, parent_sem)) = parent else {
+            return Ok(None);
+        };
+        let Some(source_entry) = parent_source.get(name) else {
+            return Ok(None);
+        };
+        let Some(source_hash) = source_entry.tree_hash() else {
+            return Ok(None);
+        };
+        let Some(sem_entry) = parent_sem.get(name) else {
+            return Ok(None);
+        };
+        if sem_entry.kind != SemanticEntryKind::Dir {
+            return Ok(None);
+        }
+        let Some(source_tree) = self.store.get_tree(&source_hash)? else {
+            return Ok(None);
+        };
+        let Some(blob) = self.store.get_blob(&sem_entry.node)? else {
+            return Ok(None);
+        };
+        match SemanticTreeNode::decode(blob.content()) {
+            Ok(sem_tree) => Ok(Some((source_tree, sem_tree))),
+            Err(_) => Ok(None),
+        }
+    }
+
+    fn build_file(
+        &mut self,
+        name: &str,
+        source_hash: ContentHash,
+        parent: Option<(&Tree, &SemanticTreeNode)>,
+    ) -> Result<BuiltEntry> {
+        // Parsed once per unique source blob.
+        if let Some(built) = self.file_memo.get(&source_hash) {
+            return Ok(*built);
+        }
+
+        // Unchanged-file reuse: same-named source blob with the same hash and a
+        // matching parent semantic entry ⇒ reuse, no parse.
+        if let Some((parent_source, parent_sem)) = parent
+            && let Some(parent_entry) = parent_source.get(name)
+            && parent_entry.blob_hash() == Some(source_hash)
+            && let Some(sem_entry) = parent_sem.get(name)
+        {
+            let built = BuiltEntry {
+                kind: sem_entry.kind,
+                node: sem_entry.node,
+                semantic_digest: sem_entry.semantic_digest,
+            };
+            self.file_memo.insert(source_hash, built);
+            return Ok(built);
+        }
+
+        let built = self.parse_file(name, source_hash)?;
+        self.file_memo.insert(source_hash, built);
+        Ok(built)
+    }
+
+    fn parse_file(&mut self, name: &str, source_hash: ContentHash) -> Result<BuiltEntry> {
+        let opaque = BuiltEntry {
+            kind: SemanticEntryKind::Opaque,
+            node: source_hash,
+            semantic_digest: source_hash,
+        };
+
+        let language = Language::from_path(std::path::Path::new(name));
+        if language.parser_handle().is_none() {
+            return Ok(opaque);
+        }
+        let Some(blob) = self.store.get_blob(&source_hash)? else {
+            return Ok(opaque);
+        };
+        if blob.size() > SEMANTIC_FILE_BUDGET_BYTES {
+            return Ok(opaque);
+        }
+        let Some(extracted) = extract_semantic_file(blob.content(), language) else {
+            // Unsupported/parse-fail → opaque.
+            return Ok(opaque);
+        };
+        self.parse_count += 1;
+
+        let lang = language_name(extracted.language).to_string();
+        let gv = grammar_version(extracted.language).to_string();
+        self.grammars.entry(lang.clone()).or_insert_with(|| gv.clone());
+
+        let node = SemanticFileNode::new(
+            lang,
+            gv,
+            self.extractor_version,
+            source_hash,
+            extracted.symbols,
+        );
+        let digest = node.semantic_digest;
+        let node_hash = self.put_node(&node.encode()?)?;
+        Ok(BuiltEntry {
+            kind: SemanticEntryKind::File,
+            node: node_hash,
+            semantic_digest: digest,
+        })
+    }
+
+    fn put_node(&self, bytes: &[u8]) -> Result<ContentHash> {
+        self.store.put_blob(&Blob::new(bytes.to_vec()))
+    }
+}
+
+/// Digest for a git submodule / spool edge — hashed over its stable target
+/// bytes so a submodule pointer bump perturbs the digest chain.
+fn opaque_edge_digest(target: &TreeEntryTarget) -> ContentHash {
+    match target {
+        TreeEntryTarget::Gitlink { target } => {
+            ContentHash::compute_typed("hd-sem-opaque-gitlink", target.as_bytes())
+        }
+        TreeEntryTarget::Spoollink { spool_id, state_id } => {
+            let mut buf = Vec::new();
+            buf.extend_from_slice(spool_id.as_str().as_bytes());
+            buf.push(0);
+            buf.extend_from_slice(state_id.as_bytes());
+            ContentHash::compute_typed("hd-sem-opaque-spoollink", &buf)
+        }
+        // Only edge targets reach here.
+        _ => ContentHash::compute_typed("hd-sem-opaque", &[]),
+    }
+}
+
+/// A parent state's index, materialized for reuse during an incremental build.
+pub struct ParentIndex {
+    pub source_tree: Tree,
+    pub semantic_tree: SemanticTreeNode,
+    pub root: SemanticIndexRoot,
+}
+
+impl Repository {
+    /// Compute a state's semantic index during capture and persist all node
+    /// blobs, returning the root blob hash to attach. Never fails the snapshot:
+    /// any error is logged and `Ok(None)` returned.
+    pub(crate) fn compute_and_persist_semantic_index(
+        &self,
+        prior: Option<&State>,
+        new: &State,
+    ) -> Result<Option<ContentHash>> {
+        let tree = match self.store().get_tree(&new.tree) {
+            Ok(Some(tree)) => tree,
+            Ok(None) => return Ok(None),
+            Err(err) => {
+                warn!(error = %err, "semantic index: could not load state tree; skipping");
+                return Ok(None);
+            }
+        };
+        let parent = match prior.map(|p| self.materialize_parent_index(p)) {
+            Some(Ok(Some(parent))) => Some(parent),
+            Some(Ok(None)) | None => None,
+            Some(Err(err)) => {
+                warn!(error = %err, "semantic index: parent reuse unavailable; full build");
+                None
+            }
+        };
+        let mut builder = SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION);
+        match builder.build_root(&tree, parent.as_ref()) {
+            Ok((_, root_hash)) => Ok(Some(root_hash)),
+            Err(err) => {
+                warn!(error = %err, "semantic index: build failed; skipping");
+                Ok(None)
+            }
+        }
+    }
+
+    /// Load a state's attached semantic index root, if present.
+    fn load_attached_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
+        let Some(attachment) =
+            self.latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)?
+        else {
+            return Ok(None);
+        };
+        let objects::object::StateAttachmentBody::SemanticIndex(root_hash) = attachment.body else {
+            return Ok(None);
+        };
+        self.load_index_root(&root_hash).map(Some)
+    }
+
+    fn load_index_root(&self, root_hash: &ContentHash) -> Result<SemanticIndexRoot> {
+        let blob = self
+            .store()
+            .get_blob(root_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic index root {root_hash}")))?;
+        SemanticIndexRoot::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    fn load_semantic_tree(&self, node_hash: &ContentHash) -> Result<SemanticTreeNode> {
+        let blob = self
+            .store()
+            .get_blob(node_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic tree node {node_hash}")))?;
+        SemanticTreeNode::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    fn load_semantic_file(&self, node_hash: &ContentHash) -> Result<SemanticFileNode> {
+        let blob = self
+            .store()
+            .get_blob(node_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic file node {node_hash}")))?;
+        SemanticFileNode::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    /// Materialize a parent state's index for reuse: its source tree + semantic
+    /// top node + root. Returns `None` when the parent has no attached index
+    /// (caller falls back to a full build).
+    fn materialize_parent_index(&self, parent: &State) -> Result<Option<ParentIndex>> {
+        let Some(root) = self.load_attached_index(&parent.id())? else {
+            return Ok(None);
+        };
+        let Some(source_tree) = self.store().get_tree(&parent.tree)? else {
+            return Ok(None);
+        };
+        let semantic_tree = self.load_semantic_tree(&root.tree)?;
+        Ok(Some(ParentIndex {
+            source_tree,
+            semantic_tree,
+            root,
+        }))
+    }
+
+    /// Get-or-compute a state's semantic index, parents-first. If already
+    /// attached, returns it; otherwise builds forward from the nearest ancestor
+    /// that has an index (reusing it), attaches each, and returns the target's.
+    pub fn semantic_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
+        if let Some(root) = self.load_attached_index(state_id)? {
+            return Ok(Some(root));
+        }
+        if self.store().get_state(state_id)?.is_none() {
+            return Ok(None);
+        }
+
+        // Walk the first-parent chain until we find an ancestor with an index
+        // (or run out), collecting the states we must build.
+        let mut to_build = vec![*state_id];
+        let mut base_state: Option<StateId> = None;
+        let mut cursor = self.first_parent(state_id)?;
+        while let Some(parent_id) = cursor {
+            if self.load_attached_index(&parent_id)?.is_some() {
+                base_state = Some(parent_id);
+                break;
+            }
+            to_build.push(parent_id);
+            cursor = self.first_parent(&parent_id)?;
+        }
+
+        // Build oldest-first so each step can reuse the one before it.
+        let mut prior_state = base_state;
+        let mut result = None;
+        for build_id in to_build.into_iter().rev() {
+            let root = self.compute_and_attach_index(&build_id, prior_state.as_ref())?;
+            prior_state = Some(build_id);
+            result = root;
+        }
+        Ok(result)
+    }
+
+    fn first_parent(&self, state_id: &StateId) -> Result<Option<StateId>> {
+        Ok(self
+            .store()
+            .get_state(state_id)?
+            .and_then(|s| s.parents.first().copied()))
+    }
+
+    /// Build a state's index (reusing `prior` if it has one) and attach it.
+    fn compute_and_attach_index(
+        &self,
+        state_id: &StateId,
+        prior: Option<&StateId>,
+    ) -> Result<Option<SemanticIndexRoot>> {
+        let Some(state) = self.store().get_state(state_id)? else {
+            return Ok(None);
+        };
+        let prior_state = match prior {
+            Some(id) => self.store().get_state(id)?,
+            None => None,
+        };
+        let root_hash = self.compute_and_persist_semantic_index(prior_state.as_ref(), &state)?;
+        let Some(root_hash) = root_hash else {
+            return Ok(None);
+        };
+        self.attach_semantic_index(state_id, &state, root_hash)?;
+        Ok(Some(self.load_index_root(&root_hash)?))
+    }
+
+    fn attach_semantic_index(
+        &self,
+        state_id: &StateId,
+        state: &State,
+        root_hash: ContentHash,
+    ) -> Result<()> {
+        // Supersede any existing (stale-grammar/older-extractor) index.
+        let supersedes = self
+            .latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)?
+            .map(|a| a.id());
+        self.put_state_attachment(&objects::object::StateAttachment {
+            state_id: *state_id,
+            body: objects::object::StateAttachmentBody::SemanticIndex(root_hash),
+            attribution: state.attribution.clone(),
+            created_at: chrono::Utc::now(),
+            supersedes,
+        })?;
+        Ok(())
+    }
+
+    /// Resolve a symbol anchor (file path + symbol address) to its entry in a
+    /// state's index. Get-or-computes the index on miss.
+    pub fn symbol_hash(
+        &self,
+        state_id: &StateId,
+        anchor: &SymbolAnchor,
+    ) -> Result<Option<SymbolEntry>> {
+        let Some(root) = self.semantic_index(state_id)? else {
+            return Ok(None);
+        };
+        let Some(file_node_hash) = self.resolve_file_node(&root, &anchor.file)? else {
+            return Ok(None);
+        };
+        let file = self.load_semantic_file(&file_node_hash)?;
+        Ok(file.symbol_by_address(&anchor.symbol).cloned())
+    }
+
+    /// Walk the semantic tree to the `File` node for `path`, returning its
+    /// storage hash. `None` if the path is absent or resolves to a dir/opaque.
+    fn resolve_file_node(
+        &self,
+        root: &SemanticIndexRoot,
+        path: &str,
+    ) -> Result<Option<ContentHash>> {
+        let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+        if components.is_empty() {
+            return Ok(None);
+        }
+        let mut node = self.load_semantic_tree(&root.tree)?;
+        for (i, comp) in components.iter().enumerate() {
+            let Some(entry) = node.get(comp) else {
+                return Ok(None);
+            };
+            let last = i + 1 == components.len();
+            match (last, entry.kind) {
+                (true, SemanticEntryKind::File) => return Ok(Some(entry.node)),
+                (false, SemanticEntryKind::Dir) => {
+                    node = self.load_semantic_tree(&entry.node)?;
+                }
+                _ => return Ok(None),
+            }
+        }
+        Ok(None)
+    }
+
+    /// Whether the semantic content under `path_prefix` differs between two
+    /// states, compared top-down by digest with identical subtrees pruned.
+    /// ZERO source re-parse — only semantic node blobs along the prefix load.
+    pub fn semantic_changed(
+        &self,
+        a: &StateId,
+        b: &StateId,
+        path_prefix: &str,
+    ) -> Result<bool> {
+        let (Some(root_a), Some(root_b)) = (self.semantic_index(a)?, self.semantic_index(b)?) else {
+            // A missing index on either side is a difference iff the other exists.
+            return Ok(self.semantic_index(a)?.is_some() != self.semantic_index(b)?.is_some());
+        };
+        let da = self.digest_at_path(&root_a, path_prefix)?;
+        let db = self.digest_at_path(&root_b, path_prefix)?;
+        Ok(da != db)
+    }
+
+    /// The reformat-stable digest at `path_prefix` within an index. Empty prefix
+    /// yields the whole-tree digest. Loads only the tree nodes along the path.
+    fn digest_at_path(
+        &self,
+        root: &SemanticIndexRoot,
+        path_prefix: &str,
+    ) -> Result<Option<ContentHash>> {
+        let components: Vec<&str> = path_prefix.split('/').filter(|c| !c.is_empty()).collect();
+        if components.is_empty() {
+            return Ok(Some(root.semantic_digest));
+        }
+        let mut node = self.load_semantic_tree(&root.tree)?;
+        for (i, comp) in components.iter().enumerate() {
+            let Some(entry) = node.get(comp) else {
+                return Ok(None);
+            };
+            let last = i + 1 == components.len();
+            if last {
+                return Ok(Some(entry.semantic_digest));
+            }
+            if entry.kind != SemanticEntryKind::Dir {
+                return Ok(None);
+            }
+            node = self.load_semantic_tree(&entry.node)?;
+        }
+        Ok(None)
+    }
+
+    /// Symbol-level delta between two states, via a merkle walk that descends
+    /// only into differing digests (identical subtrees are pruned without
+    /// loading their file nodes).
+    pub fn semantic_diff_symbols(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
+        let (root_a, root_b) = match (self.semantic_index(a)?, self.semantic_index(b)?) {
+            (Some(ra), Some(rb)) => (ra, rb),
+            _ => return Ok(Vec::new()),
+        };
+        if root_a.semantic_digest == root_b.semantic_digest {
+            return Ok(Vec::new());
+        }
+        let node_a = self.load_semantic_tree(&root_a.tree)?;
+        let node_b = self.load_semantic_tree(&root_b.tree)?;
+        let mut out = Vec::new();
+        self.diff_tree_nodes(&node_a, &node_b, "", &mut out)?;
+        Ok(out)
+    }
+
+    fn diff_tree_nodes(
+        &self,
+        a: &SemanticTreeNode,
+        b: &SemanticTreeNode,
+        prefix: &str,
+        out: &mut Vec<SymbolDelta>,
+    ) -> Result<()> {
+        let a_by_name: HashMap<&str, &SemanticTreeEntry> =
+            a.entries.iter().map(|e| (e.name.as_str(), e)).collect();
+        let b_by_name: HashMap<&str, &SemanticTreeEntry> =
+            b.entries.iter().map(|e| (e.name.as_str(), e)).collect();
+
+        for entry_a in &a.entries {
+            let path = join_path(prefix, &entry_a.name);
+            match b_by_name.get(entry_a.name.as_str()) {
+                None => self.emit_side(entry_a, &path, Side::Removed, out)?,
+                Some(entry_b) => {
+                    if entry_a.semantic_digest == entry_b.semantic_digest {
+                        continue; // pruned — identical subtree/file.
+                    }
+                    match (entry_a.kind, entry_b.kind) {
+                        (SemanticEntryKind::Dir, SemanticEntryKind::Dir) => {
+                            let child_a = self.load_semantic_tree(&entry_a.node)?;
+                            let child_b = self.load_semantic_tree(&entry_b.node)?;
+                            self.diff_tree_nodes(&child_a, &child_b, &path, out)?;
+                        }
+                        (SemanticEntryKind::File, SemanticEntryKind::File) => {
+                            let file_a = self.load_semantic_file(&entry_a.node)?;
+                            let file_b = self.load_semantic_file(&entry_b.node)?;
+                            diff_file_symbols(&file_a, &file_b, &path, out);
+                        }
+                        // Kind flipped (file↔dir↔opaque): a full replace.
+                        _ => {
+                            self.emit_side(entry_a, &path, Side::Removed, out)?;
+                            self.emit_side(entry_b, &path, Side::Added, out)?;
+                        }
+                    }
+                }
+            }
+        }
+        // Names only on the b side are additions.
+        for entry_b in &b.entries {
+            if !a_by_name.contains_key(entry_b.name.as_str()) {
+                let path = join_path(prefix, &entry_b.name);
+                self.emit_side(entry_b, &path, Side::Added, out)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit every symbol of a single-sided entry (whole file/subtree added or
+    /// removed). Opaque entries carry no symbols.
+    fn emit_side(
+        &self,
+        entry: &SemanticTreeEntry,
+        path: &str,
+        side: Side,
+        out: &mut Vec<SymbolDelta>,
+    ) -> Result<()> {
+        match entry.kind {
+            SemanticEntryKind::File => {
+                let file = self.load_semantic_file(&entry.node)?;
+                for sym in &file.symbols {
+                    out.push(side.delta(path, sym));
+                }
+            }
+            SemanticEntryKind::Dir => {
+                let node = self.load_semantic_tree(&entry.node)?;
+                for child in &node.entries {
+                    let child_path = join_path(path, &child.name);
+                    self.emit_side(child, &child_path, side, out)?;
+                }
+            }
+            SemanticEntryKind::Opaque => {}
+        }
+        Ok(())
+    }
+
+    /// Whether the symbol at `anchor` changed between `since` and `at`.
+    pub fn changed_since(
+        &self,
+        anchor: &SymbolAnchor,
+        since: &StateId,
+        at: &StateId,
+    ) -> Result<bool> {
+        let old = self.symbol_hash(since, anchor)?.map(|s| s.semantic_hash);
+        let new = self.symbol_hash(at, anchor)?.map(|s| s.semantic_hash);
+        Ok(old != new)
+    }
+
+    /// Lazy backfill: compute-and-attach a semantic index for every state that
+    /// lacks one, oldest-first (so parents are reused), restartable across runs
+    /// (progress = the last state that gained an attachment). Returns the count
+    /// of states newly indexed.
+    pub fn backfill_semantic_index(&self, all: bool) -> Result<usize> {
+        let states = self.store().list_states()?;
+        // Oldest-first: fewer parents ⇒ appears earlier. Topologically, a state
+        // with no ancestors sorts first; approximate with a parents-before-child
+        // ordering derived from reachability.
+        let ordered = self.order_states_oldest_first(states)?;
+        let mut count = 0;
+        for state_id in ordered {
+            let already = self.load_attached_index(&state_id)?.is_some();
+            if already && !all {
+                continue; // restartable: skip states that already have one.
+            }
+            if all {
+                // Force a fresh recompute (supersedes any stale index).
+                let prior = self.first_parent(&state_id)?;
+                if self
+                    .compute_and_attach_index(&state_id, prior.as_ref())?
+                    .is_some()
+                {
+                    count += 1;
+                }
+            } else if self.semantic_index(&state_id)?.is_some() {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Order states so a parent precedes its children (best-effort Kahn-style
+    /// topological sort over the in-store parent edges).
+    fn order_states_oldest_first(&self, states: Vec<StateId>) -> Result<Vec<StateId>> {
+        use std::collections::HashSet;
+        let present: HashSet<StateId> = states.iter().copied().collect();
+        let mut visited: HashSet<StateId> = HashSet::new();
+        let mut ordered = Vec::with_capacity(states.len());
+        // Iterative post-order DFS emits ancestors before descendants.
+        for root in &states {
+            let mut stack = vec![(*root, false)];
+            while let Some((id, processed)) = stack.pop() {
+                if processed {
+                    if visited.insert(id) {
+                        ordered.push(id);
+                    }
+                    continue;
+                }
+                if visited.contains(&id) {
+                    continue;
+                }
+                stack.push((id, true));
+                if let Some(state) = self.store().get_state(&id)? {
+                    for parent in &state.parents {
+                        if present.contains(parent) && !visited.contains(parent) {
+                            stack.push((*parent, false));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(ordered)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Side {
+    Added,
+    Removed,
+}
+
+impl Side {
+    fn delta(self, path: &str, sym: &SymbolEntry) -> SymbolDelta {
+        let anchor = SymbolAnchor::new(path, sym.address());
+        match self {
+            Side::Added => SymbolDelta {
+                anchor,
+                kind: sym.kind,
+                old_hash: None,
+                new_hash: Some(sym.semantic_hash),
+            },
+            Side::Removed => SymbolDelta {
+                anchor,
+                kind: sym.kind,
+                old_hash: Some(sym.semantic_hash),
+                new_hash: None,
+            },
+        }
+    }
+}
+
+/// Diff two file nodes by symbol address, emitting a delta per added/removed/
+/// changed symbol. Unchanged symbols (equal `semantic_hash`) are skipped.
+fn diff_file_symbols(
+    a: &SemanticFileNode,
+    b: &SemanticFileNode,
+    path: &str,
+    out: &mut Vec<SymbolDelta>,
+) {
+    let a_by_addr: HashMap<String, &SymbolEntry> =
+        a.symbols.iter().map(|s| (s.address(), s)).collect();
+    let b_by_addr: HashMap<String, &SymbolEntry> =
+        b.symbols.iter().map(|s| (s.address(), s)).collect();
+
+    for sym_a in &a.symbols {
+        let addr = sym_a.address();
+        match b_by_addr.get(&addr) {
+            None => out.push(Side::Removed.delta(path, sym_a)),
+            Some(sym_b) => {
+                if sym_a.semantic_hash != sym_b.semantic_hash {
+                    out.push(SymbolDelta {
+                        anchor: SymbolAnchor::new(path, addr),
+                        kind: sym_b.kind,
+                        old_hash: Some(sym_a.semantic_hash),
+                        new_hash: Some(sym_b.semantic_hash),
+                    });
+                }
+            }
+        }
+    }
+    for sym_b in &b.symbols {
+        if !a_by_addr.contains_key(&sym_b.address()) {
+            out.push(Side::Added.delta(path, sym_b));
+        }
+    }
+}
+
+fn join_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{Attribution, Principal, TreeEntry};
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn repo() -> (TempDir, Repository) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        (temp, repo)
+    }
+
+    fn author() -> Attribution {
+        Attribution::human(Principal::new("Test", "test@example.com"))
+    }
+
+    fn snapshot(repo: &Repository, temp: &TempDir, path: &str, content: &str) -> StateId {
+        std::fs::write(temp.path().join(path), content).unwrap();
+        repo.snapshot_with_attribution(Some("capture".to_string()), None, author())
+            .unwrap()
+            .id()
+    }
+
+    fn put_blob(repo: &Repository, content: &[u8]) -> ContentHash {
+        repo.store().put_blob(&Blob::new(content.to_vec())).unwrap()
+    }
+
+    fn parent_index(repo: &Repository, source_tree: Tree, root: SemanticIndexRoot) -> ParentIndex {
+        let blob = repo.store().get_blob(&root.tree).unwrap().unwrap();
+        let semantic_tree = SemanticTreeNode::decode(blob.content()).unwrap();
+        ParentIndex {
+            source_tree,
+            semantic_tree,
+            root,
+        }
+    }
+
+    /// GOLDEN: reformatting a file changes the storage hash of the semantic
+    /// tree node (spans moved) but leaves the whole-tree `semantic_digest`
+    /// STABLE — the two-hash crux, end to end through capture.
+    #[test]
+    fn reformat_changes_storage_hash_but_not_semantic_digest() {
+        let (temp, repo) = repo();
+        let a = snapshot(&repo, &temp, "hello.rs", "fn foo() -> i32 { 1 }\n");
+        let b = snapshot(&repo, &temp, "hello.rs", "fn foo() -> i32 {\n    1\n}\n");
+
+        let ra = repo.semantic_index(&a).unwrap().unwrap();
+        let rb = repo.semantic_index(&b).unwrap().unwrap();
+
+        assert_ne!(ra.tree, rb.tree, "reformat must move the storage hash");
+        assert_eq!(
+            ra.semantic_digest, rb.semantic_digest,
+            "reformat must NOT change the semantic_digest"
+        );
+        assert!(
+            !repo.semantic_changed(&a, &b, "").unwrap(),
+            "semantic_changed must prune a pure reformat"
+        );
+    }
+
+    /// GOLDEN: a one-token change to a single function yields exactly one
+    /// SymbolDelta, for that symbol, with both old and new hashes present.
+    #[test]
+    fn one_token_change_yields_exactly_one_delta() {
+        let (temp, repo) = repo();
+        let a = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "fn foo() -> i32 { 1 }\nfn bar() -> i32 { 2 }\n",
+        );
+        let b = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "fn foo() -> i32 { 1 }\nfn bar() -> i32 { 3 }\n",
+        );
+
+        let deltas = repo.semantic_diff_symbols(&a, &b).unwrap();
+        assert_eq!(deltas.len(), 1, "exactly one symbol changed: {deltas:?}");
+        assert_eq!(deltas[0].anchor.symbol, "bar");
+        assert_eq!(deltas[0].anchor.file, "m.rs");
+        assert!(deltas[0].old_hash.is_some());
+        assert!(deltas[0].new_hash.is_some());
+        assert_ne!(deltas[0].old_hash, deltas[0].new_hash);
+    }
+
+    /// GOLDEN: `symbol_hash` resolves an anchor, and `changed_since` reports
+    /// per-symbol change correctly (untouched symbol stable, edited one not).
+    #[test]
+    fn symbol_hash_and_changed_since() {
+        let (temp, repo) = repo();
+        let a = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "fn foo() -> i32 { 1 }\nfn bar() -> i32 { 2 }\n",
+        );
+        let b = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "fn foo() -> i32 { 1 }\nfn bar() -> i32 { 3 }\n",
+        );
+
+        let foo = SymbolAnchor::new("m.rs", "foo");
+        let bar = SymbolAnchor::new("m.rs", "bar");
+        assert!(repo.symbol_hash(&a, &foo).unwrap().is_some());
+        assert!(!repo.changed_since(&foo, &a, &b).unwrap(), "foo untouched");
+        assert!(repo.changed_since(&bar, &a, &b).unwrap(), "bar edited");
+    }
+
+    /// GOLDEN: incremental assembly parses only the changed blob — the
+    /// unchanged sibling is reused from the parent index WITHOUT a re-parse.
+    #[test]
+    fn incremental_build_prunes_unchanged_without_reparse() {
+        let (_temp, repo) = repo();
+        let blob_a = put_blob(&repo, b"fn a() -> i32 { 1 }\n");
+        let blob_b = put_blob(&repo, b"fn b() -> i32 { 2 }\n");
+        let tree_a = Tree::from_entries(vec![
+            TreeEntry::file("a.rs", blob_a, false).unwrap(),
+            TreeEntry::file("b.rs", blob_b, false).unwrap(),
+        ]);
+
+        let mut parent_builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
+        let (root_a, _) = parent_builder.build_root(&tree_a, None).unwrap();
+        assert_eq!(parent_builder.parse_count, 2, "cold build parses both files");
+
+        // Only b.rs changes.
+        let blob_b2 = put_blob(&repo, b"fn b() -> i32 { 99 }\n");
+        let tree_b = Tree::from_entries(vec![
+            TreeEntry::file("a.rs", blob_a, false).unwrap(),
+            TreeEntry::file("b.rs", blob_b2, false).unwrap(),
+        ]);
+
+        let parent = parent_index(&repo, tree_a, root_a);
+        let mut child_builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
+        child_builder.build_root(&tree_b, Some(&parent)).unwrap();
+        assert_eq!(
+            child_builder.parse_count, 1,
+            "only the changed file is reparsed"
+        );
+    }
+
+    /// GOLDEN: a source blob appearing at several paths is parsed exactly once
+    /// (backfill/build memoizes by source blob hash).
+    #[test]
+    fn shared_blob_parsed_once() {
+        let (_temp, repo) = repo();
+        let blob = put_blob(&repo, b"fn shared() -> i32 { 7 }\n");
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("x.rs", blob, false).unwrap(),
+            TreeEntry::file("y.rs", blob, false).unwrap(),
+        ]);
+        let mut builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
+        builder.build_root(&tree, None).unwrap();
+        assert_eq!(builder.parse_count, 1, "shared blob parsed once");
+    }
+
+    /// The lazy backfill indexes every state once and is a no-op the second
+    /// time (restartable / idempotent).
+    #[test]
+    fn backfill_is_idempotent() {
+        let (temp, repo) = repo();
+        snapshot(&repo, &temp, "a.rs", "fn a() {}\n");
+        snapshot(&repo, &temp, "b.rs", "fn b() {}\n");
+
+        // Captured states are already indexed eagerly; only pre-capture states
+        // (e.g. the init root) remain. A first backfill picks those up, and a
+        // second is a no-op — the restartable/idempotent property.
+        repo.backfill_semantic_index(false).unwrap();
+        assert_eq!(
+            repo.backfill_semantic_index(false).unwrap(),
+            0,
+            "backfill must be idempotent"
+        );
+        // --all recomputes every state.
+        let total = repo.store().list_states().unwrap().len();
+        assert_eq!(repo.backfill_semantic_index(true).unwrap(), total);
+    }
+}

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -33,16 +33,25 @@ use objects::{
 };
 use semantic::{
     parser::Language,
-    semantic_index::{EXTRACTOR_VERSION, extract_semantic_file, grammar_version, language_name},
+    semantic_index::{
+        EXTRACTOR_VERSION, extract_semantic_file, grammar_version, grammar_version_by_name,
+        language_name,
+    },
 };
 use tracing::warn;
 
-use crate::{Repository, Result, StateAttachmentKind};
+use crate::{HeddleError, Repository, Result, StateAttachmentKind};
 
 /// Source files above this size are recorded as `Opaque` rather than parsed —
 /// generated/vendored blobs dominate parse cost and rarely carry review-worthy
 /// symbols.
 const SEMANTIC_FILE_BUDGET_BYTES: usize = 1 << 20;
+
+/// Recursion ceiling for the merkle tree/dir walkers. Legitimate directory
+/// nesting is far below this; a crafted, pushed `SemanticTreeNode` chain deeper
+/// than this is treated as pathological rather than overflowing the stack
+/// (same hardening class as the AST walkers, heddle#876).
+const MAX_SEMANTIC_TREE_DEPTH: usize = 1024;
 
 /// A single-symbol delta between two states, produced by [`Repository::semantic_diff_symbols`].
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -72,10 +81,11 @@ struct BuiltEntry {
 pub struct SemanticIndexBuilder<'store, S: ObjectStore> {
     store: &'store S,
     extractor_version: u32,
-    /// Per-build memo: source blob hash → its file/opaque entry. A blob that
-    /// appears at several paths (or is the unchanged sibling of a reformat) is
-    /// parsed once.
-    file_memo: HashMap<ContentHash, BuiltEntry>,
+    /// Per-build memo keyed by `(source blob hash, language)` — a blob that
+    /// appears at several paths is parsed once, but byte-identical blobs at
+    /// `a.js` and `b.py` get distinct nodes (a node is a pure function of
+    /// `(bytes, ext, grammar, extractor)`).
+    file_memo: HashMap<(ContentHash, Language), BuiltEntry>,
     /// Languages encountered while building, seeded from the parent root so
     /// pruned subtrees' grammars are not lost.
     grammars: BTreeMap<String, String>,
@@ -106,11 +116,15 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         tree: &Tree,
         parent: Option<&ParentIndex>,
     ) -> Result<(SemanticIndexRoot, ContentHash)> {
+        // Refuse node reuse across an extractor or grammar bump: reusing stale
+        // nodes would mix v1+v2 fingerprints in one index. A non-current parent
+        // is dropped entirely, forcing a clean full rebuild.
+        let parent = parent.filter(|p| self.parent_is_reusable(p));
         if let Some(parent) = parent {
             self.grammars = parent.root.grammars.clone();
         }
         let parent_ctx = parent.map(|p| (&p.source_tree, &p.semantic_tree));
-        let (node_hash, digest) = self.build_tree(tree, parent_ctx)?;
+        let (node_hash, digest) = self.build_tree(tree, parent_ctx, 0)?;
         let root = SemanticIndexRoot::new(
             self.extractor_version,
             std::mem::take(&mut self.grammars),
@@ -126,18 +140,31 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         Ok((root, root_hash))
     }
 
+    /// Whether a parent index may be reused: its extractor version and every
+    /// grammar version must match the builder's current ones.
+    fn parent_is_reusable(&self, parent: &ParentIndex) -> bool {
+        parent.root.extractor_version == self.extractor_version
+            && parent.root.grammars.iter().all(|(name, version)| {
+                grammar_version_by_name(name) == Some(version.as_str())
+            })
+    }
+
     fn build_tree(
         &mut self,
         tree: &Tree,
         parent: Option<(&Tree, &SemanticTreeNode)>,
+        depth: usize,
     ) -> Result<(ContentHash, ContentHash)> {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Err(HeddleError::InvalidObject(format!(
+                "semantic index tree exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
+            )));
+        }
         let mut entries = Vec::with_capacity(tree.len());
         for entry in tree.entries() {
             let name = entry.name();
             let built = match entry.target() {
-                TreeEntryTarget::Tree { hash } => {
-                    self.build_dir(name, *hash, parent)?
-                }
+                TreeEntryTarget::Tree { hash } => self.build_dir(name, *hash, parent, depth)?,
                 TreeEntryTarget::Blob { hash, .. } => self.build_file(name, *hash, parent)?,
                 TreeEntryTarget::Symlink { hash } => BuiltEntry {
                     kind: SemanticEntryKind::Opaque,
@@ -172,6 +199,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         name: &str,
         source_hash: ContentHash,
         parent: Option<(&Tree, &SemanticTreeNode)>,
+        depth: usize,
     ) -> Result<BuiltEntry> {
         // Unchanged-subtree prune: same-named source dir with the same hash and
         // a matching parent semantic entry ⇒ reuse wholesale, no recurse, no
@@ -196,10 +224,8 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
 
         // Descend with the matching parent subtree as the reuse basis, if any.
         let child_parent = self.child_parent_ctx(name, parent)?;
-        let child_parent_ref = child_parent
-            .as_ref()
-            .map(|(t, n)| (t, n));
-        let (node, digest) = self.build_tree(&source_tree, child_parent_ref)?;
+        let child_parent_ref = child_parent.as_ref().map(|(t, n)| (t, n));
+        let (node, digest) = self.build_tree(&source_tree, child_parent_ref, depth + 1)?;
         Ok(BuiltEntry {
             kind: SemanticEntryKind::Dir,
             node,
@@ -247,8 +273,12 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         source_hash: ContentHash,
         parent: Option<(&Tree, &SemanticTreeNode)>,
     ) -> Result<BuiltEntry> {
-        // Parsed once per unique source blob.
-        if let Some(built) = self.file_memo.get(&source_hash) {
+        // A file node is a pure function of (bytes, ext/language, grammar,
+        // extractor), so memoize per `(source_hash, language)` — NOT bytes
+        // alone (byte-identical `a.js`/`b.py` must not share a node).
+        let language = Language::from_path(std::path::Path::new(name));
+        let memo_key = (source_hash, language);
+        if let Some(built) = self.file_memo.get(&memo_key) {
             return Ok(*built);
         }
 
@@ -264,23 +294,22 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
                 node: sem_entry.node,
                 semantic_digest: sem_entry.semantic_digest,
             };
-            self.file_memo.insert(source_hash, built);
+            self.file_memo.insert(memo_key, built);
             return Ok(built);
         }
 
-        let built = self.parse_file(name, source_hash)?;
-        self.file_memo.insert(source_hash, built);
+        let built = self.parse_file(language, source_hash)?;
+        self.file_memo.insert(memo_key, built);
         Ok(built)
     }
 
-    fn parse_file(&mut self, name: &str, source_hash: ContentHash) -> Result<BuiltEntry> {
+    fn parse_file(&mut self, language: Language, source_hash: ContentHash) -> Result<BuiltEntry> {
         let opaque = BuiltEntry {
             kind: SemanticEntryKind::Opaque,
             node: source_hash,
             semantic_digest: source_hash,
         };
 
-        let language = Language::from_path(std::path::Path::new(name));
         if language.parser_handle().is_none() {
             return Ok(opaque);
         }
@@ -298,13 +327,16 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
 
         let lang = language_name(extracted.language).to_string();
         let gv = grammar_version(extracted.language).to_string();
-        self.grammars.entry(lang.clone()).or_insert_with(|| gv.clone());
+        // Freshly-parsed grammar version wins in the root metadata (overwrite,
+        // not or_insert) so a stale seed from a current parent can't linger.
+        self.grammars.insert(lang.clone(), gv.clone());
 
         let node = SemanticFileNode::new(
             lang,
             gv,
             self.extractor_version,
             source_hash,
+            extracted.scaffold_hash,
             extracted.symbols,
         );
         let digest = node.semantic_digest;
@@ -386,7 +418,11 @@ impl Repository {
         }
     }
 
-    /// Load a state's attached semantic index root, if present.
+    /// Load a state's attached semantic index root, if present AND intact. A
+    /// missing or corrupt root blob (e.g. a partially-replicated push, or GC
+    /// that pruned the sidecar) is treated as ABSENT — `Ok(None)` — so callers
+    /// recompute+supersede instead of erroring forever on the dangling
+    /// attachment.
     fn load_attached_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
         let Some(attachment) =
             self.latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)?
@@ -396,7 +432,21 @@ impl Repository {
         let objects::object::StateAttachmentBody::SemanticIndex(root_hash) = attachment.body else {
             return Ok(None);
         };
-        self.load_index_root(&root_hash).map(Some)
+        let Some(blob) = self.store().get_blob(&root_hash)? else {
+            return Ok(None);
+        };
+        Ok(SemanticIndexRoot::decode(blob.content()).ok())
+    }
+
+    /// Whether an attached root is current: extractor version and every grammar
+    /// version match this binary's. A stale root is served as a MISS so a
+    /// bump recomputes.
+    fn index_is_current(&self, root: &SemanticIndexRoot) -> bool {
+        root.extractor_version == EXTRACTOR_VERSION
+            && root
+                .grammars
+                .iter()
+                .all(|(name, version)| grammar_version_by_name(name) == Some(version.as_str()))
     }
 
     fn load_index_root(&self, root_hash: &ContentHash) -> Result<SemanticIndexRoot> {
@@ -448,9 +498,13 @@ impl Repository {
     /// attached, returns it; otherwise builds forward from the nearest ancestor
     /// that has an index (reusing it), attaches each, and returns the target's.
     pub fn semantic_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
-        if let Some(root) = self.load_attached_index(state_id)? {
+        if let Some(root) = self.load_attached_index(state_id)?
+            && self.index_is_current(&root)
+        {
             return Ok(Some(root));
         }
+        // Absent, corrupt, or stale-version → recompute below (superseding any
+        // stale attachment).
         if self.store().get_state(state_id)?.is_none() {
             return Ok(None);
         }
@@ -508,6 +562,42 @@ impl Repository {
         Ok(Some(self.load_index_root(&root_hash)?))
     }
 
+    /// Rebuild a state's index from scratch with NO parent reuse — guaranteeing
+    /// a complete, self-contained node closure independent of any pruned or
+    /// broken parent nodes — and supersede the prior attachment. The recovery
+    /// path when a query hits a missing/corrupt semantic node.
+    fn force_recompute_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
+        let Some(state) = self.store().get_state(state_id)? else {
+            return Ok(None);
+        };
+        let Some(tree) = self.store().get_tree(&state.tree)? else {
+            return Ok(None);
+        };
+        let mut builder = SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION);
+        let (_, root_hash) = builder.build_root(&tree, None)?;
+        self.attach_semantic_index(state_id, &state, root_hash)?;
+        Ok(Some(self.load_index_root(&root_hash)?))
+    }
+
+    /// Run a query; if it trips over a missing/corrupt semantic node (a pruned
+    /// or partially-replicated index), force-recompute the involved states'
+    /// indexes and retry ONCE, so queries self-heal instead of erroring forever.
+    fn recover_on_broken<T>(
+        &self,
+        states: &[&StateId],
+        op: impl Fn(&Self) -> Result<T>,
+    ) -> Result<T> {
+        match op(self) {
+            Err(err) if is_broken_index_error(&err) => {
+                for state in states {
+                    self.force_recompute_index(state)?;
+                }
+                op(self)
+            }
+            other => other,
+        }
+    }
+
     fn attach_semantic_index(
         &self,
         state_id: &StateId,
@@ -531,6 +621,14 @@ impl Repository {
     /// Resolve a symbol anchor (file path + symbol address) to its entry in a
     /// state's index. Get-or-computes the index on miss.
     pub fn symbol_hash(
+        &self,
+        state_id: &StateId,
+        anchor: &SymbolAnchor,
+    ) -> Result<Option<SymbolEntry>> {
+        self.recover_on_broken(&[state_id], |me| me.symbol_hash_inner(state_id, anchor))
+    }
+
+    fn symbol_hash_inner(
         &self,
         state_id: &StateId,
         anchor: &SymbolAnchor,
@@ -582,6 +680,15 @@ impl Repository {
         b: &StateId,
         path_prefix: &str,
     ) -> Result<bool> {
+        self.recover_on_broken(&[a, b], |me| me.semantic_changed_inner(a, b, path_prefix))
+    }
+
+    fn semantic_changed_inner(
+        &self,
+        a: &StateId,
+        b: &StateId,
+        path_prefix: &str,
+    ) -> Result<bool> {
         let (Some(root_a), Some(root_b)) = (self.semantic_index(a)?, self.semantic_index(b)?) else {
             // A missing index on either side is a difference iff the other exists.
             return Ok(self.semantic_index(a)?.is_some() != self.semantic_index(b)?.is_some());
@@ -623,6 +730,14 @@ impl Repository {
     /// only into differing digests (identical subtrees are pruned without
     /// loading their file nodes).
     pub fn semantic_diff_symbols(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
+        self.recover_on_broken(&[a, b], |me| me.semantic_diff_symbols_inner(a, b))
+    }
+
+    fn semantic_diff_symbols_inner(
+        &self,
+        a: &StateId,
+        b: &StateId,
+    ) -> Result<Vec<SymbolDelta>> {
         let (root_a, root_b) = match (self.semantic_index(a)?, self.semantic_index(b)?) {
             (Some(ra), Some(rb)) => (ra, rb),
             _ => return Ok(Vec::new()),
@@ -633,7 +748,7 @@ impl Repository {
         let node_a = self.load_semantic_tree(&root_a.tree)?;
         let node_b = self.load_semantic_tree(&root_b.tree)?;
         let mut out = Vec::new();
-        self.diff_tree_nodes(&node_a, &node_b, "", &mut out)?;
+        self.diff_tree_nodes(&node_a, &node_b, "", 0, &mut out)?;
         Ok(out)
     }
 
@@ -642,8 +757,14 @@ impl Repository {
         a: &SemanticTreeNode,
         b: &SemanticTreeNode,
         prefix: &str,
+        depth: usize,
         out: &mut Vec<SymbolDelta>,
     ) -> Result<()> {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Err(HeddleError::InvalidObject(format!(
+                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
+            )));
+        }
         let a_by_name: HashMap<&str, &SemanticTreeEntry> =
             a.entries.iter().map(|e| (e.name.as_str(), e)).collect();
         let b_by_name: HashMap<&str, &SemanticTreeEntry> =
@@ -652,7 +773,7 @@ impl Repository {
         for entry_a in &a.entries {
             let path = join_path(prefix, &entry_a.name);
             match b_by_name.get(entry_a.name.as_str()) {
-                None => self.emit_side(entry_a, &path, Side::Removed, out)?,
+                None => self.emit_side(entry_a, &path, Side::Removed, depth, out)?,
                 Some(entry_b) => {
                     if entry_a.semantic_digest == entry_b.semantic_digest {
                         continue; // pruned — identical subtree/file.
@@ -661,7 +782,7 @@ impl Repository {
                         (SemanticEntryKind::Dir, SemanticEntryKind::Dir) => {
                             let child_a = self.load_semantic_tree(&entry_a.node)?;
                             let child_b = self.load_semantic_tree(&entry_b.node)?;
-                            self.diff_tree_nodes(&child_a, &child_b, &path, out)?;
+                            self.diff_tree_nodes(&child_a, &child_b, &path, depth + 1, out)?;
                         }
                         (SemanticEntryKind::File, SemanticEntryKind::File) => {
                             let file_a = self.load_semantic_file(&entry_a.node)?;
@@ -670,8 +791,8 @@ impl Repository {
                         }
                         // Kind flipped (file↔dir↔opaque): a full replace.
                         _ => {
-                            self.emit_side(entry_a, &path, Side::Removed, out)?;
-                            self.emit_side(entry_b, &path, Side::Added, out)?;
+                            self.emit_side(entry_a, &path, Side::Removed, depth, out)?;
+                            self.emit_side(entry_b, &path, Side::Added, depth, out)?;
                         }
                     }
                 }
@@ -681,7 +802,7 @@ impl Repository {
         for entry_b in &b.entries {
             if !a_by_name.contains_key(entry_b.name.as_str()) {
                 let path = join_path(prefix, &entry_b.name);
-                self.emit_side(entry_b, &path, Side::Added, out)?;
+                self.emit_side(entry_b, &path, Side::Added, depth, out)?;
             }
         }
         Ok(())
@@ -694,8 +815,14 @@ impl Repository {
         entry: &SemanticTreeEntry,
         path: &str,
         side: Side,
+        depth: usize,
         out: &mut Vec<SymbolDelta>,
     ) -> Result<()> {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Err(HeddleError::InvalidObject(format!(
+                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
+            )));
+        }
         match entry.kind {
             SemanticEntryKind::File => {
                 let file = self.load_semantic_file(&entry.node)?;
@@ -707,7 +834,7 @@ impl Repository {
                 let node = self.load_semantic_tree(&entry.node)?;
                 for child in &node.entries {
                     let child_path = join_path(path, &child.name);
-                    self.emit_side(child, &child_path, side, out)?;
+                    self.emit_side(child, &child_path, side, depth + 1, out)?;
                 }
             }
             SemanticEntryKind::Opaque => {}
@@ -819,40 +946,73 @@ impl Side {
     }
 }
 
-/// Diff two file nodes by symbol address, emitting a delta per added/removed/
-/// changed symbol. Unchanged symbols (equal `semantic_hash`) are skipped.
+/// The identity a symbol is matched on across two file versions:
+/// `(container_path, name, kind)`. Distinguishes `fn f` in `mod a` from `mod b`,
+/// `fn X` from `struct X`, so the diff never last-wins-collides distinct
+/// symbols into a mislabeled Modified or a silent skip.
+type SymbolKey = (Vec<String>, String, SymbolKindTag);
+
+fn symbol_key(sym: &SymbolEntry) -> SymbolKey {
+    (sym.container_path.clone(), sym.name.clone(), sym.kind)
+}
+
+/// Diff two file nodes by symbol identity (a `(container, name, kind)`
+/// MULTISET), emitting a delta per added/removed/changed symbol. Same-key
+/// entries (e.g. C++ overloads the extractor can't tell apart) are paired
+/// positionally in canonical order; unmatched extras become add/remove.
+/// Unchanged symbols (equal `semantic_hash`) are skipped.
 fn diff_file_symbols(
     a: &SemanticFileNode,
     b: &SemanticFileNode,
     path: &str,
     out: &mut Vec<SymbolDelta>,
 ) {
-    let a_by_addr: HashMap<String, &SymbolEntry> =
-        a.symbols.iter().map(|s| (s.address(), s)).collect();
-    let b_by_addr: HashMap<String, &SymbolEntry> =
-        b.symbols.iter().map(|s| (s.address(), s)).collect();
+    let mut a_by_key: HashMap<SymbolKey, Vec<&SymbolEntry>> = HashMap::new();
+    for sym in &a.symbols {
+        a_by_key.entry(symbol_key(sym)).or_default().push(sym);
+    }
+    let mut b_by_key: HashMap<SymbolKey, Vec<&SymbolEntry>> = HashMap::new();
+    for sym in &b.symbols {
+        b_by_key.entry(symbol_key(sym)).or_default().push(sym);
+    }
 
-    for sym_a in &a.symbols {
-        let addr = sym_a.address();
-        match b_by_addr.get(&addr) {
-            None => out.push(Side::Removed.delta(path, sym_a)),
-            Some(sym_b) => {
-                if sym_a.semantic_hash != sym_b.semantic_hash {
-                    out.push(SymbolDelta {
-                        anchor: SymbolAnchor::new(path, addr),
-                        kind: sym_b.kind,
-                        old_hash: Some(sym_a.semantic_hash),
-                        new_hash: Some(sym_b.semantic_hash),
-                    });
-                }
+    for (key, a_syms) in &a_by_key {
+        let b_syms = b_by_key.get(key).map(Vec::as_slice).unwrap_or(&[]);
+        // Symbols arrive in the file node already sorted by
+        // (container, name, kind, span.0), so same-key lists are in a stable
+        // order; pair them positionally.
+        for pair in a_syms.iter().zip(b_syms.iter()) {
+            let (sym_a, sym_b) = pair;
+            if sym_a.semantic_hash != sym_b.semantic_hash {
+                out.push(SymbolDelta {
+                    anchor: SymbolAnchor::new(path, sym_b.address()),
+                    kind: sym_b.kind,
+                    old_hash: Some(sym_a.semantic_hash),
+                    new_hash: Some(sym_b.semantic_hash),
+                });
             }
         }
+        // Extra `a` occurrences with no `b` counterpart are removals.
+        for sym_a in a_syms.iter().skip(b_syms.len()) {
+            out.push(Side::Removed.delta(path, sym_a));
+        }
     }
-    for sym_b in &b.symbols {
-        if !a_by_addr.contains_key(&sym_b.address()) {
+    // Keys (or extra occurrences of a key) present only in `b` are additions.
+    for (key, b_syms) in &b_by_key {
+        let a_len = a_by_key.get(key).map(Vec::len).unwrap_or(0);
+        for sym_b in b_syms.iter().skip(a_len) {
             out.push(Side::Added.delta(path, sym_b));
         }
     }
+}
+
+/// A missing (`NotFound`) or corrupt (`InvalidObject`) semantic node — the
+/// recoverable "broken index" class.
+fn is_broken_index_error(err: &HeddleError) -> bool {
+    matches!(
+        err,
+        HeddleError::NotFound(_) | HeddleError::InvalidObject(_)
+    )
 }
 
 fn join_path(prefix: &str, name: &str) -> String {
@@ -865,10 +1025,37 @@ fn join_path(prefix: &str, name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{Attribution, Blob, Principal, TreeEntry};
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
+    use objects::object::{
+        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, TreeEntry,
+    };
     use tempfile::TempDir;
 
     use super::*;
+
+    /// Attach `root_hash` as the (superseding) SemanticIndex on `state_id`.
+    fn attach(repo: &Repository, state_id: &StateId, root_hash: ContentHash) {
+        let state = repo.store().get_state(state_id).unwrap().unwrap();
+        let prior = repo
+            .latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)
+            .unwrap()
+            .map(|a| a.id());
+        repo.put_state_attachment(&StateAttachment {
+            state_id: *state_id,
+            body: StateAttachmentBody::SemanticIndex(root_hash),
+            attribution: state.attribution.clone(),
+            created_at: Utc::now(),
+            supersedes: prior,
+        })
+        .unwrap();
+    }
+
+    fn state_tree(repo: &Repository, state_id: &StateId) -> Tree {
+        let state = repo.store().get_state(state_id).unwrap().unwrap();
+        repo.store().get_tree(&state.tree).unwrap().unwrap()
+    }
 
     fn repo() -> (TempDir, Repository) {
         let temp = TempDir::new().unwrap();
@@ -1043,5 +1230,164 @@ mod tests {
         // --all recomputes every state.
         let total = repo.store().list_states().unwrap().len();
         assert_eq!(repo.backfill_semantic_index(true).unwrap(), total);
+    }
+
+    /// DEFECT 2: an extractor bump must refuse stale node reuse — an unchanged
+    /// blob is re-parsed into a fresh node, so no index mixes v1+v2 fingerprints.
+    #[test]
+    fn extractor_bump_refuses_stale_reuse() {
+        let (_temp, repo) = repo();
+        let blob = put_blob(&repo, b"fn a() -> i32 { 1 }\n");
+        let tree = Tree::from_entries(vec![TreeEntry::file("a.rs", blob, false).unwrap()]);
+
+        let mut b1 = SemanticIndexBuilder::new(repo.store(), 1);
+        let (root1, _) = b1.build_root(&tree, None).unwrap();
+        assert_eq!(root1.extractor_version, 1);
+
+        // Same source, extractor bumped to 2, parent (v1) offered for reuse.
+        let parent = parent_index(&repo, tree.clone(), root1);
+        let mut b2 = SemanticIndexBuilder::new(repo.store(), 2);
+        let (root2, _) = b2.build_root(&tree, Some(&parent)).unwrap();
+        assert_eq!(
+            b2.parse_count, 1,
+            "extractor bump must reparse, not reuse the v1 node"
+        );
+        assert_eq!(root2.extractor_version, 2);
+        let node_hash = repo.resolve_file_node(&root2, "a.rs").unwrap().unwrap();
+        assert_eq!(
+            repo.load_semantic_file(&node_hash).unwrap().extractor_version,
+            2,
+            "no mixed-version index"
+        );
+    }
+
+    /// DEFECT 2: `semantic_index()` must treat a stale-version attached root as
+    /// a MISS and recompute+supersede to the current extractor version.
+    #[test]
+    fn stale_attached_index_is_recomputed() {
+        let (temp, repo) = repo();
+        let a = snapshot(&repo, &temp, "m.rs", "fn f() {}\n");
+
+        // Force a stale (extractor 999) index onto the state.
+        let mut builder = SemanticIndexBuilder::new(repo.store(), 999);
+        let (stale_root, stale_hash) = builder.build_root(&state_tree(&repo, &a), None).unwrap();
+        assert_eq!(stale_root.extractor_version, 999);
+        attach(&repo, &a, stale_hash);
+
+        let root = repo.semantic_index(&a).unwrap().unwrap();
+        assert_eq!(
+            root.extractor_version, EXTRACTOR_VERSION,
+            "stale attached root must be recomputed to the current version"
+        );
+    }
+
+    /// DEFECT 3: a dangling attached index (root present but pointing at a
+    /// missing node — e.g. a partially-replicated push or a pruned sidecar)
+    /// must self-heal: queries recompute+supersede instead of erroring forever.
+    #[test]
+    fn dangling_index_recovers_on_query() {
+        let (temp, repo) = repo();
+        let a = snapshot(&repo, &temp, "m.rs", "fn f() -> i32 { 1 }\n");
+
+        // Attach a current-version root pointing at a node that does not exist.
+        let fake_tree = ContentHash::compute(b"missing-semantic-node");
+        let bogus = SemanticIndexRoot::new(
+            EXTRACTOR_VERSION,
+            BTreeMap::new(),
+            fake_tree,
+            ContentHash::compute(b"digest"),
+        );
+        let bogus_hash = repo
+            .store()
+            .put_blob(&Blob::new(bogus.encode().unwrap()))
+            .unwrap();
+        attach(&repo, &a, bogus_hash);
+
+        // The query descends the dangling tree, hits the missing node, and must
+        // recover — not propagate a NotFound.
+        let anchor = SymbolAnchor::new("m.rs", "f");
+        let sym = repo
+            .symbol_hash(&a, &anchor)
+            .expect("query must recover, not error");
+        assert!(sym.is_some(), "recomputed index resolves the symbol");
+
+        // And the state now carries a valid, resolvable index.
+        let root = repo.semantic_index(&a).unwrap().unwrap();
+        assert!(repo.resolve_file_node(&root, "m.rs").unwrap().is_some());
+    }
+
+    /// DEFECT 5: byte-identical blobs at `.js` and `.py` must get DISTINCT nodes
+    /// with the correct language — a node is a pure function of (bytes, ext,
+    /// grammar, extractor), not bytes alone.
+    #[test]
+    fn same_bytes_distinct_language_nodes() {
+        let (_temp, repo) = repo();
+        // `x = 1` parses (error-free) as both JavaScript and Python.
+        let blob = put_blob(&repo, b"x = 1\n");
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("a.js", blob, false).unwrap(),
+            TreeEntry::file("b.py", blob, false).unwrap(),
+        ]);
+        let mut builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
+        let (root, _) = builder.build_root(&tree, None).unwrap();
+        assert_eq!(builder.parse_count, 2, "parsed once per (bytes, language)");
+
+        let js = repo.resolve_file_node(&root, "a.js").unwrap().unwrap();
+        let py = repo.resolve_file_node(&root, "b.py").unwrap().unwrap();
+        assert_ne!(js, py, "byte-identical files get distinct nodes per language");
+        assert_eq!(repo.load_semantic_file(&js).unwrap().language, "javascript");
+        assert_eq!(repo.load_semantic_file(&py).unwrap().language, "python");
+    }
+
+    /// DEFECT 6: same-name symbols of different KIND must not collide — editing
+    /// `fn X` must report exactly `fn X`, leaving `struct X` untouched.
+    #[test]
+    fn diff_decollides_same_name_different_kind() {
+        let (temp, repo) = repo();
+        let a = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "struct X { a: u8 }\nfn X() -> i32 { 1 }\n",
+        );
+        let b = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "struct X { a: u8 }\nfn X() -> i32 { 2 }\n",
+        );
+        let deltas = repo.semantic_diff_symbols(&a, &b).unwrap();
+        assert_eq!(deltas.len(), 1, "only fn X changed: {deltas:?}");
+        assert_eq!(deltas[0].anchor.symbol, "X");
+        assert_eq!(deltas[0].kind, SymbolKindTag::Function);
+    }
+
+    /// DEFECT 6: same-name symbols in different modules must not collide —
+    /// editing `mod a::f` must report `a::f` and NEVER `b::f`.
+    #[test]
+    fn diff_decollides_same_name_across_modules() {
+        let (temp, repo) = repo();
+        let a = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "mod a { pub fn f() -> i32 { 1 } }\nmod b { pub fn f() -> i32 { 9 } }\n",
+        );
+        let b = snapshot(
+            &repo,
+            &temp,
+            "m.rs",
+            "mod a { pub fn f() -> i32 { 2 } }\nmod b { pub fn f() -> i32 { 9 } }\n",
+        );
+        let deltas = repo.semantic_diff_symbols(&a, &b).unwrap();
+        let symbols: Vec<_> = deltas.iter().map(|d| d.anchor.symbol.clone()).collect();
+        assert!(
+            symbols.contains(&"a::f".to_string()),
+            "a::f must be reported: {symbols:?}"
+        );
+        assert!(
+            !symbols.contains(&"b::f".to_string()),
+            "b::f must NOT be reported (no cross-module address collision): {symbols:?}"
+        );
     }
 }

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -95,7 +95,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
     }
 
     /// Build the index for `tree`, optionally reusing `parent` (its source tree
-    /// + semantic index root) for unchanged-subtree pruning. Returns the
+    /// plus semantic index root) for unchanged-subtree pruning. Returns the
     /// persisted [`SemanticIndexRoot`] and its storage hash.
     pub fn build_root(
         &mut self,

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -967,11 +967,15 @@ fn diff_file_symbols(
     path: &str,
     out: &mut Vec<SymbolDelta>,
 ) {
-    let mut a_by_key: HashMap<SymbolKey, Vec<&SymbolEntry>> = HashMap::new();
+    // BTreeMap, not HashMap: the loops below emit into `out`, so key order must
+    // be deterministic — this is a public, determinism-centric API. (The
+    // pre-refactor code iterated `a.symbols` in canonical order; a HashMap here
+    // reintroduced nondeterministic delta ordering.)
+    let mut a_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
     for sym in &a.symbols {
         a_by_key.entry(symbol_key(sym)).or_default().push(sym);
     }
-    let mut b_by_key: HashMap<SymbolKey, Vec<&SymbolEntry>> = HashMap::new();
+    let mut b_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
     for sym in &b.symbols {
         b_by_key.entry(symbol_key(sym)).or_default().push(sym);
     }

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -257,6 +257,8 @@ impl SnapshotMutation<'_> {
         let mut risk_signals = None;
         #[cfg(feature = "tree-sitter-symbols")]
         let mut discussions = None;
+        #[cfg(feature = "tree-sitter-symbols")]
+        let mut semantic_index = None;
 
         #[cfg(feature = "tree-sitter-symbols")]
         {
@@ -272,6 +274,19 @@ impl SnapshotMutation<'_> {
                 Ok(None) => {}
                 Err(err) => {
                     tracing::warn!(error = %err, "risk signal computation failed; continuing without signals");
+                }
+            }
+
+            // Eager semantic index: parse only changed blobs, reusing the
+            // parent index for unchanged subtrees. Never fails the capture.
+            match self
+                .repo
+                .compute_and_persist_semantic_index(prior_state.as_ref(), &state)
+            {
+                Ok(Some(hash)) => semantic_index = Some(hash),
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::warn!(error = %err, "semantic index computation failed; continuing without index");
                 }
             }
 
@@ -305,6 +320,7 @@ impl SnapshotMutation<'_> {
         for body in [
             risk_signals.map(StateAttachmentBody::RiskSignals),
             discussions.map(StateAttachmentBody::Discussions),
+            semantic_index.map(StateAttachmentBody::SemanticIndex),
         ]
         .into_iter()
         .flatten()

--- a/crates/repo/src/state_attachments.rs
+++ b/crates/repo/src/state_attachments.rs
@@ -16,6 +16,7 @@ pub enum StateAttachmentKind {
     ReviewSignatures,
     Discussions,
     StructuredConflicts,
+    SemanticIndex,
     Signature,
 }
 
@@ -27,6 +28,7 @@ impl StateAttachmentKind {
             StateAttachmentBody::ReviewSignatures(_) => Self::ReviewSignatures,
             StateAttachmentBody::Discussions(_) => Self::Discussions,
             StateAttachmentBody::StructuredConflicts(_) => Self::StructuredConflicts,
+            StateAttachmentBody::SemanticIndex(_) => Self::SemanticIndex,
             StateAttachmentBody::Signature(_) => Self::Signature,
         }
     }

--- a/crates/semantic/src/analysis/analysis_classify.rs
+++ b/crates/semantic/src/analysis/analysis_classify.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use objects::object::{ChangeImportance, ModificationKind};
 
 use super::analysis_similarity::{SimilarityMethod, compute_similarity};
-use crate::parser::{Language, ParsedFile};
+use crate::parser::{Language, ParsedFile, walk_non_comment_leaves};
 
 /// Classification result: kind, importance, and confidence.
 pub type ClassificationResult = (ModificationKind, ChangeImportance, f64);
@@ -247,33 +247,10 @@ fn strip_comments(parsed: &ParsedFile) -> String {
 }
 
 fn collect_non_comment_text(node: tree_sitter::Node<'_>, source: &str, out: &mut String) {
-    let mut stack = vec![node];
-
-    while let Some(current) = stack.pop() {
-        if is_comment_node(current.kind()) {
-            continue;
-        }
-
-        if current.child_count() == 0 {
-            out.push_str(&source[current.byte_range()]);
-            out.push(' ');
-            continue;
-        }
-
-        let child_count = current.child_count();
-        for index in (0..child_count).rev() {
-            if let Some(child) = current.child(index as u32) {
-                stack.push(child);
-            }
-        }
-    }
-}
-
-fn is_comment_node(kind: &str) -> bool {
-    matches!(
-        kind,
-        "comment" | "line_comment" | "block_comment" | "doc_comment" | "string_comment"
-    )
+    walk_non_comment_leaves(node, |leaf| {
+        out.push_str(&source[leaf.byte_range()]);
+        out.push(' ');
+    });
 }
 
 /// Strip imports and function bodies, return remaining "scaffold" text.

--- a/crates/semantic/src/analysis/analysis_similarity.rs
+++ b/crates/semantic/src/analysis/analysis_similarity.rs
@@ -56,7 +56,14 @@ pub fn compute_similarity(a: &str, b: &str, method: SimilarityMethod) -> f64 {
 
             intersection.len() as f64 / union.len() as f64
         }
-        SimilarityMethod::Ast => compute_similarity(a, b, SimilarityMethod::Tokens),
+        // AST similarity is language-dependent: without a grammar there is no
+        // tree to compare. The language-free entry point therefore cannot
+        // honor `Ast` itself — it forwards to the one sanctioned AST path,
+        // which degrades to token similarity for `Language::Unknown` rather
+        // than silently masquerading token similarity as an AST result.
+        SimilarityMethod::Ast => {
+            compute_similarity_with_language(a, b, SimilarityMethod::Ast, Language::Unknown)
+        }
     }
 }
 

--- a/crates/semantic/src/lib.rs
+++ b/crates/semantic/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cache;
 pub mod diff;
 pub mod merge_driver;
 pub mod parser;
+pub mod semantic_index;
 mod symbol_extraction;
 pub mod symbol_resolver;
 

--- a/crates/semantic/src/parser/comment_walk.rs
+++ b/crates/semantic/src/parser/comment_walk.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+//! The single source of truth for "which tree-sitter nodes are comments" and
+//! the non-comment leaf walk built on it.
+//!
+//! Both change-classification (`strip_comments`) and the semantic-index token
+//! stream (`hd-sem-sym-v1`) need to walk an AST in document order while
+//! skipping comment subtrees. Keeping the predicate and the walk here — in the
+//! parser crate — means there is exactly one definition of "comment" and one
+//! traversal shape; the consumers only differ in what they do with each leaf.
+
+use tree_sitter::Node;
+
+/// Whether a tree-sitter node kind names a comment. Comment subtrees are
+/// skipped wholesale by [`walk_non_comment_leaves`], so doc-comments and
+/// ordinary comments alike are excluded from semantic fingerprints.
+pub fn is_comment_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "comment" | "line_comment" | "block_comment" | "doc_comment" | "string_comment"
+    )
+}
+
+/// DFS in document order over `node`'s subtree, invoking `on_leaf` for each
+/// non-comment leaf (a node with no children). Comment nodes — and their
+/// entire subtrees — are skipped.
+///
+/// The stack pushes children in reverse so they pop in source order, giving a
+/// stable pre-order document-order traversal. Iterative (not recursive) so
+/// deeply-nested-but-valid input drives heap, not call depth.
+pub fn walk_non_comment_leaves<'tree>(node: Node<'tree>, mut on_leaf: impl FnMut(Node<'tree>)) {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if is_comment_node(current.kind()) {
+            continue;
+        }
+        if current.child_count() == 0 {
+            on_leaf(current);
+            continue;
+        }
+        let child_count = current.child_count();
+        for index in (0..child_count).rev() {
+            if let Some(child) = current.child(index as u32) {
+                stack.push(child);
+            }
+        }
+    }
+}

--- a/crates/semantic/src/parser/mod.rs
+++ b/crates/semantic/src/parser/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Language parsing using tree-sitter.
 
+mod comment_walk;
 mod parser_core;
 mod parser_deps;
 mod parser_language;
@@ -11,6 +12,7 @@ mod syntax_index;
 #[cfg(test)]
 mod parser_tests;
 
+pub use comment_walk::{is_comment_node, walk_non_comment_leaves};
 pub use parser_core::ParsedFile;
 pub use parser_deps::extract_dependencies;
 pub use parser_language::Language;

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -15,7 +15,10 @@
 //! leaves, so reformatting and comment edits leave the hash untouched — while a
 //! one-token change perturbs exactly the symbols that contain it.
 
-use objects::object::{ContentHash, SymbolEntry, SymbolKindTag, compute_symbol_semantic_hash};
+use objects::object::{
+    ContentHash, SymbolEntry, SymbolKindTag, compute_file_scaffold_hash,
+    compute_symbol_semantic_hash,
+};
 
 use crate::{
     parser::{Language, ParsedFile, walk_non_comment_leaves},
@@ -60,6 +63,24 @@ pub fn grammar_version(language: Language) -> &'static str {
     }
 }
 
+/// The current grammar version for a language *name* (as recorded in a
+/// [`SemanticIndexRoot`](objects::object::SemanticIndexRoot)'s grammar map).
+/// Used by the builder to detect a grammar bump and refuse stale node reuse.
+pub fn grammar_version_by_name(name: &str) -> Option<&'static str> {
+    let language = match name {
+        "rust" => Language::Rust,
+        "python" => Language::Python,
+        "javascript" => Language::JavaScript,
+        "typescript" => Language::TypeScript,
+        "go" => Language::Go,
+        "c" => Language::C,
+        "cpp" => Language::Cpp,
+        "java" => Language::Java,
+        _ => return None,
+    };
+    Some(grammar_version(language))
+}
+
 fn map_kind(kind: DefinitionKind) -> SymbolKindTag {
     match kind {
         DefinitionKind::Function => SymbolKindTag::Function,
@@ -75,20 +96,24 @@ fn map_kind(kind: DefinitionKind) -> SymbolKindTag {
     }
 }
 
-/// The symbols extracted from one source file, ready to be assembled into a
+/// The symbols extracted from one source file, plus the file scaffold hash,
+/// ready to be assembled into a
 /// [`SemanticFileNode`](objects::object::SemanticFileNode).
 pub struct ExtractedFile {
     pub language: Language,
+    /// Hash of the residual non-definition top-level token stream — binds
+    /// use-decls, impl/attribute/macro tokens and definition-free files into
+    /// the file digest. See [`compute_file_scaffold_hash`].
+    pub scaffold_hash: ContentHash,
     pub symbols: Vec<SymbolEntry>,
 }
 
 /// Parse `source` (as `language`) and extract its symbols with per-symbol
-/// normalization-stable hashes.
+/// normalization-stable hashes, plus the file scaffold hash.
 ///
 /// Returns `None` when the language is unsupported or the file fails to parse —
 /// the caller records those as `Opaque` in the index (fingerprint = raw source
-/// blob hash). `extractor_version` is threaded through for callers that want to
-/// pin a specific version (capture uses [`EXTRACTOR_VERSION`]).
+/// blob hash).
 pub fn extract_semantic_file(source: &[u8], language: Language) -> Option<ExtractedFile> {
     // Unsupported language → no grammar → Opaque.
     language.parser_handle()?;
@@ -96,13 +121,15 @@ pub fn extract_semantic_file(source: &[u8], language: Language) -> Option<Extrac
     let parsed = ParsedFile::parse(source_text, language)?;
 
     let mut symbols = Vec::new();
+    // Byte ranges of every extracted definition node — used to carve the
+    // residual scaffold (everything NOT covered by a symbol).
+    let mut covered: Vec<(usize, usize)> = Vec::new();
     visit_definitions(parsed.root_node(), source, &mut |site| {
         let kind = map_kind(site.kind);
         let semantic_hash = symbol_semantic_hash(site.node, source, kind);
-        let container_path = site
-            .parent_name
-            .map(|p| vec![p])
-            .unwrap_or_default();
+        let container_path = site.parent_name.map(|p| vec![p]).unwrap_or_default();
+        let range = site.node.byte_range();
+        covered.push((range.start, range.end));
         symbols.push(SymbolEntry {
             name: site.name,
             kind,
@@ -112,7 +139,56 @@ pub fn extract_semantic_file(source: &[u8], language: Language) -> Option<Extrac
         });
     });
 
-    Some(ExtractedFile { language, symbols })
+    let scaffold_hash = compute_scaffold(parsed.root_node(), source, covered);
+
+    Some(ExtractedFile {
+        language,
+        scaffold_hash,
+        symbols,
+    })
+}
+
+/// Hash the file scaffold: every non-comment leaf under the root NOT covered by
+/// an extracted symbol's byte range, length-prefixed in document order. This is
+/// what carries use-decl swaps, `impl Trait` headers, attribute edits,
+/// `macro_rules!` bodies and definition-free files into the file digest.
+fn compute_scaffold(
+    root: tree_sitter::Node<'_>,
+    source: &[u8],
+    mut covered: Vec<(usize, usize)>,
+) -> ContentHash {
+    // Merge symbol ranges into disjoint sorted intervals (they nest — a module
+    // covers its children).
+    covered.sort_by_key(|&(start, _)| start);
+    let mut merged: Vec<(usize, usize)> = Vec::with_capacity(covered.len());
+    for (start, end) in covered {
+        match merged.last_mut() {
+            Some(last) if start <= last.1 => last.1 = last.1.max(end),
+            _ => merged.push((start, end)),
+        }
+    }
+
+    let mut stream: Vec<u8> = Vec::new();
+    walk_non_comment_leaves(root, |leaf| {
+        let range = leaf.byte_range();
+        if is_covered(&merged, range.start, range.end) {
+            return;
+        }
+        let bytes = &source[range];
+        stream.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        stream.extend_from_slice(bytes);
+    });
+    compute_file_scaffold_hash(&stream)
+}
+
+/// Whether `[start, end)` lies fully within one of the disjoint sorted
+/// intervals in `merged`.
+fn is_covered(merged: &[(usize, usize)], start: usize, end: usize) -> bool {
+    match merged.binary_search_by(|&(interval_start, _)| interval_start.cmp(&start)) {
+        Ok(i) => merged[i].1 >= end,
+        Err(0) => false,
+        Err(i) => merged[i - 1].1 >= end,
+    }
 }
 
 /// Build the canonical `hd-sem-sym-v1` token stream for a definition node and
@@ -139,6 +215,59 @@ mod tests {
         extract_semantic_file(src.as_bytes(), Language::Rust)
             .expect("rust parse")
             .symbols
+    }
+
+    fn scaffold(src: &str) -> ContentHash {
+        extract_semantic_file(src.as_bytes(), Language::Rust)
+            .expect("rust parse")
+            .scaffold_hash
+    }
+
+    /// DEFECT 1: content that lives OUTSIDE any extracted symbol must still
+    /// perturb the file scaffold (and therefore the file digest). Covers all
+    /// five classes Fable flagged as digest false-negatives.
+    #[test]
+    fn scaffold_binds_non_definition_content() {
+        // 1. use-decl swap (same fn body)
+        assert_ne!(
+            scaffold("use a::x;\nfn f() { g(); }\n"),
+            scaffold("use b::x;\nfn f() { g(); }\n"),
+            "use-decl swap"
+        );
+        // 2. impl-trait change, identical method body
+        assert_ne!(
+            scaffold("struct S;\nimpl Display for S { fn fmt(&self) {} }\n"),
+            scaffold("struct S;\nimpl Debug for S { fn fmt(&self) {} }\n"),
+            "impl trait change"
+        );
+        // 3. attribute add/remove (attribute_item is a sibling of function_item)
+        assert_ne!(
+            scaffold("fn f() { g(); }\n"),
+            scaffold("#[inline]\nfn f() { g(); }\n"),
+            "attribute add"
+        );
+        // 4. macro_rules! body edit
+        assert_ne!(
+            scaffold("macro_rules! m { () => { 1 }; }\n"),
+            scaffold("macro_rules! m { () => { 2 }; }\n"),
+            "macro_rules body edit"
+        );
+        // 5. definition-free files (re-export only) — two different such files
+        //    must not share a digest.
+        assert_ne!(
+            scaffold("pub use crate::a::Foo;\n"),
+            scaffold("pub use crate::b::Bar;\n"),
+            "definition-free re-export files"
+        );
+    }
+
+    /// The scaffold must stay reformat- and comment-stable, like symbol hashes.
+    #[test]
+    fn scaffold_is_reformat_and_comment_stable() {
+        assert_eq!(
+            scaffold("use a::x;\nfn f() { g(); }\n"),
+            scaffold("use   a::x;\n\n// note\nfn f() {\n    g();\n}\n"),
+        );
     }
 
     #[test]

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -29,7 +29,12 @@ use crate::{
 /// resolution, or token-stream framing changes in a way that would alter a
 /// `semantic_hash` for unchanged source — it participates in the file node's
 /// identity so a bump forces a clean recompute via the supersedes chain.
-pub const EXTRACTOR_VERSION: u32 = 1;
+///
+/// v2: `hd-sem-file-v2`/`hd-sem-dir-v2` framed layouts, the `scaffold_hash`
+/// (non-definition file content), and mod-qualified `container_path`. Bumped so
+/// any same-version-but-old-layout nodes written by a pre-fix branch checkout
+/// are treated as stale and recomputed rather than digest-compared.
+pub const EXTRACTOR_VERSION: u32 = 2;
 
 /// Stable lowercase language name recorded in file nodes and the root's
 /// grammar map.

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Semantic-index *extraction*: turning a source blob into the per-file symbol
+//! list the merkle semantic index (heddle#1067) stores.
+//!
+//! The index node types and the canonical digest/hash byte layouts live in the
+//! `objects` crate ([`objects::object::semantic_index`]); this module owns the
+//! grammar-facing half — walking the AST to produce [`SymbolEntry`] values with
+//! their normalization-stable `semantic_hash`. Assembly of the tree and the
+//! store wiring live in the `repo` crate.
+//!
+//! A symbol's `semantic_hash` is a pure function of
+//! `(source bytes, grammar, extractor_version)`: a DFS in document order over
+//! the definition's node, comment subtrees skipped, each remaining leaf emitted
+//! as `u32-LE(byte_len) ‖ exact source bytes`. Whitespace and comments are not
+//! leaves, so reformatting and comment edits leave the hash untouched — while a
+//! one-token change perturbs exactly the symbols that contain it.
+
+use objects::object::{ContentHash, SymbolEntry, SymbolKindTag, compute_symbol_semantic_hash};
+
+use crate::{
+    parser::{Language, ParsedFile, walk_non_comment_leaves},
+    symbol_resolver::{DefinitionKind, visit_definitions},
+};
+
+/// Version of the extraction logic itself. Bump when the taxonomy, container
+/// resolution, or token-stream framing changes in a way that would alter a
+/// `semantic_hash` for unchanged source — it participates in the file node's
+/// identity so a bump forces a clean recompute via the supersedes chain.
+pub const EXTRACTOR_VERSION: u32 = 1;
+
+/// Stable lowercase language name recorded in file nodes and the root's
+/// grammar map.
+pub fn language_name(language: Language) -> &'static str {
+    match language {
+        Language::Rust => "rust",
+        Language::Python => "python",
+        Language::JavaScript => "javascript",
+        Language::TypeScript => "typescript",
+        Language::Go => "go",
+        Language::C => "c",
+        Language::Cpp => "cpp",
+        Language::Java => "java",
+        Language::Unknown => "unknown",
+    }
+}
+
+/// Grammar version string for a language — the tree-sitter grammar crate
+/// version. Participates in node identity so a grammar bump recomputes cleanly.
+pub fn grammar_version(language: Language) -> &'static str {
+    match language {
+        Language::Rust => "tree-sitter-rust@0.24",
+        Language::Python => "tree-sitter-python@0.25",
+        Language::JavaScript => "tree-sitter-javascript@0.25",
+        Language::TypeScript => "tree-sitter-typescript@0.23",
+        Language::Go => "tree-sitter-go@0.25",
+        Language::C => "tree-sitter-c@0.24",
+        Language::Cpp => "tree-sitter-cpp@0.23",
+        Language::Java => "tree-sitter-java@0.23",
+        Language::Unknown => "none",
+    }
+}
+
+fn map_kind(kind: DefinitionKind) -> SymbolKindTag {
+    match kind {
+        DefinitionKind::Function => SymbolKindTag::Function,
+        DefinitionKind::Type => SymbolKindTag::Type,
+        DefinitionKind::Trait => SymbolKindTag::Trait,
+        DefinitionKind::Class => SymbolKindTag::Class,
+        DefinitionKind::Interface => SymbolKindTag::Interface,
+        DefinitionKind::TypeAlias => SymbolKindTag::TypeAlias,
+        DefinitionKind::EnumDef => SymbolKindTag::Enum,
+        DefinitionKind::ConstDecl => SymbolKindTag::Const,
+        DefinitionKind::Module => SymbolKindTag::Module,
+        DefinitionKind::Other => SymbolKindTag::Other,
+    }
+}
+
+/// The symbols extracted from one source file, ready to be assembled into a
+/// [`SemanticFileNode`](objects::object::SemanticFileNode).
+pub struct ExtractedFile {
+    pub language: Language,
+    pub symbols: Vec<SymbolEntry>,
+}
+
+/// Parse `source` (as `language`) and extract its symbols with per-symbol
+/// normalization-stable hashes.
+///
+/// Returns `None` when the language is unsupported or the file fails to parse —
+/// the caller records those as `Opaque` in the index (fingerprint = raw source
+/// blob hash). `extractor_version` is threaded through for callers that want to
+/// pin a specific version (capture uses [`EXTRACTOR_VERSION`]).
+pub fn extract_semantic_file(source: &[u8], language: Language) -> Option<ExtractedFile> {
+    // Unsupported language → no grammar → Opaque.
+    language.parser_handle()?;
+    let source_text = std::str::from_utf8(source).ok()?;
+    let parsed = ParsedFile::parse(source_text, language)?;
+
+    let mut symbols = Vec::new();
+    visit_definitions(parsed.root_node(), source, &mut |site| {
+        let kind = map_kind(site.kind);
+        let semantic_hash = symbol_semantic_hash(site.node, source, kind);
+        let container_path = site
+            .parent_name
+            .map(|p| vec![p])
+            .unwrap_or_default();
+        symbols.push(SymbolEntry {
+            name: site.name,
+            kind,
+            container_path,
+            semantic_hash,
+            span: (site.start_line, site.end_line),
+        });
+    });
+
+    Some(ExtractedFile { language, symbols })
+}
+
+/// Build the canonical `hd-sem-sym-v1` token stream for a definition node and
+/// hash it. Length-prefixed leaves in document order, comment subtrees skipped.
+fn symbol_semantic_hash(
+    node: tree_sitter::Node<'_>,
+    source: &[u8],
+    kind: SymbolKindTag,
+) -> ContentHash {
+    let mut token_stream: Vec<u8> = Vec::new();
+    walk_non_comment_leaves(node, |leaf| {
+        let bytes = &source[leaf.byte_range()];
+        token_stream.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+        token_stream.extend_from_slice(bytes);
+    });
+    compute_symbol_semantic_hash(kind, &token_stream)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(src: &str) -> Vec<SymbolEntry> {
+        extract_semantic_file(src.as_bytes(), Language::Rust)
+            .expect("rust parse")
+            .symbols
+    }
+
+    #[test]
+    fn reformat_leaves_symbol_hash_stable() {
+        let a = "fn add(a: i32, b: i32) -> i32 { a + b }\n";
+        let b = "fn add(a: i32,   b: i32) -> i32 {\n    a + b\n}\n";
+        let sa = extract(a);
+        let sb = extract(b);
+        assert_eq!(sa.len(), 1);
+        assert_eq!(sb.len(), 1);
+        assert_eq!(
+            sa[0].semantic_hash, sb[0].semantic_hash,
+            "reformatting must not change the symbol semantic_hash"
+        );
+    }
+
+    #[test]
+    fn comment_edit_leaves_symbol_hash_stable() {
+        let a = "fn f() {\n    // old comment\n    g();\n}\n";
+        let b = "fn f() {\n    // a completely different comment\n    g();\n}\n";
+        assert_eq!(extract(a)[0].semantic_hash, extract(b)[0].semantic_hash);
+    }
+
+    #[test]
+    fn one_token_change_perturbs_only_that_symbol() {
+        let a = "fn f() -> i32 { 1 }\nfn g() -> i32 { 2 }\n";
+        let b = "fn f() -> i32 { 1 }\nfn g() -> i32 { 3 }\n";
+        let sa = extract(a);
+        let sb = extract(b);
+        let f_a = sa.iter().find(|s| s.name == "f").unwrap();
+        let f_b = sb.iter().find(|s| s.name == "f").unwrap();
+        let g_a = sa.iter().find(|s| s.name == "g").unwrap();
+        let g_b = sb.iter().find(|s| s.name == "g").unwrap();
+        assert_eq!(f_a.semantic_hash, f_b.semantic_hash, "untouched symbol stable");
+        assert_ne!(g_a.semantic_hash, g_b.semantic_hash, "edited symbol changes");
+    }
+
+    #[test]
+    fn string_literal_contents_included() {
+        let a = "fn f() { let s = \"hello\"; }\n";
+        let b = "fn f() { let s = \"world\"; }\n";
+        assert_ne!(
+            extract(a)[0].semantic_hash,
+            extract(b)[0].semantic_hash,
+            "string literal contents are part of the fingerprint"
+        );
+    }
+
+    #[test]
+    fn types_are_first_class() {
+        let src = "struct S { x: u32 }\nenum E { A, B }\ntrait T { fn m(&self); }\n";
+        let names: Vec<_> = extract(src).into_iter().map(|s| (s.name, s.kind)).collect();
+        assert!(names.contains(&("S".to_string(), SymbolKindTag::Type)));
+        assert!(names.contains(&("E".to_string(), SymbolKindTag::Enum)));
+        assert!(names.contains(&("T".to_string(), SymbolKindTag::Trait)));
+    }
+
+    #[test]
+    fn unsupported_language_is_none() {
+        assert!(extract_semantic_file(b"whatever", Language::Unknown).is_none());
+    }
+}

--- a/crates/semantic/src/symbol_resolver.rs
+++ b/crates/semantic/src/symbol_resolver.rs
@@ -115,24 +115,37 @@ fn node_text<'a>(node: &tree_sitter::Node, source: &'a [u8]) -> &'a str {
     std::str::from_utf8(&source[node.byte_range()]).unwrap_or("")
 }
 
-fn push_named_definition(
-    node: &tree_sitter::Node,
+/// One definition discovered by [`visit_definitions`], carrying the AST node
+/// itself so callers that need the definition's subtree (e.g. the semantic
+/// index token stream) can reach it, alongside the resolved metadata.
+pub(crate) struct DefinitionSite<'tree> {
+    pub node: tree_sitter::Node<'tree>,
+    pub name: String,
+    pub kind: DefinitionKind,
+    pub parent_name: Option<String>,
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+fn emit_named_definition<'tree>(
+    node: tree_sitter::Node<'tree>,
     source: &[u8],
     dk: DefinitionKind,
     parent: Option<&str>,
-    out: &mut Vec<Definition>,
+    emit: &mut impl FnMut(DefinitionSite<'tree>),
 ) {
     if let Some(name_node) = node.child_by_field_name("name") {
         let name = node_text(&name_node, source).to_string();
         if name.is_empty() {
             return;
         }
-        out.push(Definition {
+        emit(DefinitionSite {
+            node,
             name,
             kind: dk,
+            parent_name: parent.map(String::from),
             start_line: node.start_position().row as u32 + 1,
             end_line: node.end_position().row as u32 + 1,
-            parent_name: parent.map(String::from),
         });
     }
 }
@@ -141,8 +154,16 @@ fn push_named_definition(
 /// [`symbol_extraction::find_definitions`]: a recursive walker would recurse
 /// for every child of every non-scope node, so deeply-parseable input drives
 /// call depth proportional to AST depth.
-fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Definition>) {
-    let mut stack: Vec<(tree_sitter::Node, Option<Rc<str>>)> = vec![(root, None)];
+///
+/// The single source of truth for the definition taxonomy. [`walk_definitions`]
+/// collects the metadata; the semantic index reuses the same walk to reach
+/// each definition's AST node without a second, drifting copy of these arms.
+pub(crate) fn visit_definitions<'tree>(
+    root: tree_sitter::Node<'tree>,
+    source: &[u8],
+    emit: &mut impl FnMut(DefinitionSite<'tree>),
+) {
+    let mut stack: Vec<(tree_sitter::Node<'tree>, Option<Rc<str>>)> = vec![(root, None)];
 
     while let Some((node, parent)) = stack.pop() {
         let current_parent = parent.as_deref();
@@ -152,33 +173,25 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
         match kind {
             // ── Rust ──────────────────────────────────────────────
             "function_item" => {
-                push_named_definition(&node, source, DefinitionKind::Function, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Function, current_parent, emit)
             }
             "struct_item" => {
-                push_named_definition(&node, source, DefinitionKind::Type, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Type, current_parent, emit)
             }
             "enum_item" => {
-                push_named_definition(&node, source, DefinitionKind::EnumDef, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::EnumDef, current_parent, emit)
             }
             "trait_item" => {
-                push_named_definition(&node, source, DefinitionKind::Trait, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Trait, current_parent, emit)
             }
-            "type_item" => push_named_definition(
-                &node,
-                source,
-                DefinitionKind::TypeAlias,
-                current_parent,
-                out,
-            ),
-            "const_item" | "static_item" => push_named_definition(
-                &node,
-                source,
-                DefinitionKind::ConstDecl,
-                current_parent,
-                out,
-            ),
+            "type_item" => {
+                emit_named_definition(node, source, DefinitionKind::TypeAlias, current_parent, emit)
+            }
+            "const_item" | "static_item" => {
+                emit_named_definition(node, source, DefinitionKind::ConstDecl, current_parent, emit)
+            }
             "mod_item" => {
-                push_named_definition(&node, source, DefinitionKind::Module, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Module, current_parent, emit)
             }
             "impl_item" => {
                 let parent_name: Option<Rc<str>> =
@@ -193,7 +206,7 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
 
             // ── Python ───────────────────────────────────────────
             "function_definition" => {
-                push_named_definition(&node, source, DefinitionKind::Function, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Function, current_parent, emit)
             }
             "class_definition" => {
                 let class_name: Option<Rc<str>> = node
@@ -202,12 +215,13 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
                 if let Some(ref name) = class_name
                     && !name.is_empty()
                 {
-                    out.push(Definition {
+                    emit(DefinitionSite {
+                        node,
                         name: name.to_string(),
                         kind: DefinitionKind::Class,
+                        parent_name: current_parent.map(String::from),
                         start_line: node.start_position().row as u32 + 1,
                         end_line: node.end_position().row as u32 + 1,
-                        parent_name: current_parent.map(String::from),
                     });
                 }
                 let mut cursor = node.walk();
@@ -220,19 +234,20 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
 
             // ── Go ───────────────────────────────────────────────
             "function_declaration" => {
-                push_named_definition(&node, source, DefinitionKind::Function, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Function, current_parent, emit)
             }
             "method_declaration" => {
                 if let Some(name_node) = node.child_by_field_name("name") {
                     let name = node_text(&name_node, source).to_string();
                     if !name.is_empty() {
                         let receiver = extract_go_receiver_type(&node, source);
-                        out.push(Definition {
+                        emit(DefinitionSite {
+                            node,
                             name,
                             kind: DefinitionKind::Function,
+                            parent_name: receiver.or_else(|| current_parent.map(String::from)),
                             start_line: node.start_position().row as u32 + 1,
                             end_line: node.end_position().row as u32 + 1,
-                            parent_name: receiver.or_else(|| current_parent.map(String::from)),
                         });
                     }
                 }
@@ -252,12 +267,13 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
                             Some("struct_type") => DefinitionKind::Type,
                             _ => DefinitionKind::TypeAlias,
                         };
-                        out.push(Definition {
+                        emit(DefinitionSite {
+                            node: child,
                             name,
                             kind: dk,
+                            parent_name: current_parent.map(String::from),
                             start_line: child.start_position().row as u32 + 1,
                             end_line: child.end_position().row as u32 + 1,
-                            parent_name: current_parent.map(String::from),
                         });
                     }
                 }
@@ -265,7 +281,7 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
 
             // ── JavaScript / TypeScript ──────────────────────────
             "method_definition" => {
-                push_named_definition(&node, source, DefinitionKind::Function, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Function, current_parent, emit)
             }
             "class_declaration" => {
                 let class_name: Option<Rc<str>> = node
@@ -274,12 +290,13 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
                 if let Some(ref name) = class_name
                     && !name.is_empty()
                 {
-                    out.push(Definition {
+                    emit(DefinitionSite {
+                        node,
                         name: name.to_string(),
                         kind: DefinitionKind::Class,
+                        parent_name: current_parent.map(String::from),
                         start_line: node.start_position().row as u32 + 1,
                         end_line: node.end_position().row as u32 + 1,
-                        parent_name: current_parent.map(String::from),
                     });
                 }
                 let mut cursor = node.walk();
@@ -289,22 +306,14 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
                 }
                 descended_with_new_parent = true;
             }
-            "interface_declaration" => push_named_definition(
-                &node,
-                source,
-                DefinitionKind::Interface,
-                current_parent,
-                out,
-            ),
-            "type_alias_declaration" => push_named_definition(
-                &node,
-                source,
-                DefinitionKind::TypeAlias,
-                current_parent,
-                out,
-            ),
+            "interface_declaration" => {
+                emit_named_definition(node, source, DefinitionKind::Interface, current_parent, emit)
+            }
+            "type_alias_declaration" => {
+                emit_named_definition(node, source, DefinitionKind::TypeAlias, current_parent, emit)
+            }
             "enum_declaration" => {
-                push_named_definition(&node, source, DefinitionKind::EnumDef, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::EnumDef, current_parent, emit)
             }
             "lexical_declaration" | "variable_declaration" => {
                 let mut cursor = node.walk();
@@ -326,12 +335,13 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
                             } else {
                                 DefinitionKind::ConstDecl
                             };
-                            out.push(Definition {
+                            emit(DefinitionSite {
+                                node,
                                 name,
                                 kind: dk,
+                                parent_name: current_parent.map(String::from),
                                 start_line: node.start_position().row as u32 + 1,
                                 end_line: node.end_position().row as u32 + 1,
-                                parent_name: current_parent.map(String::from),
                             });
                         }
                     }
@@ -340,16 +350,16 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
 
             // ── C / C++ / Java ───────────────────────────────────
             "struct_specifier" | "class_specifier" => {
-                push_named_definition(&node, source, DefinitionKind::Class, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Class, current_parent, emit)
             }
             "namespace_definition" => {
-                push_named_definition(&node, source, DefinitionKind::Module, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Module, current_parent, emit)
             }
             "enum_specifier" => {
-                push_named_definition(&node, source, DefinitionKind::EnumDef, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::EnumDef, current_parent, emit)
             }
             "constructor_declaration" => {
-                push_named_definition(&node, source, DefinitionKind::Function, current_parent, out)
+                emit_named_definition(node, source, DefinitionKind::Function, current_parent, emit)
             }
 
             _ => {}
@@ -363,6 +373,19 @@ fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Defini
             }
         }
     }
+}
+
+/// Collect one [`Definition`] per definition node, in document order.
+fn walk_definitions(root: tree_sitter::Node, source: &[u8], out: &mut Vec<Definition>) {
+    visit_definitions(root, source, &mut |site| {
+        out.push(Definition {
+            name: site.name,
+            kind: site.kind,
+            start_line: site.start_line,
+            end_line: site.end_line,
+            parent_name: site.parent_name,
+        });
+    });
 }
 
 fn extract_rust_impl_type_name(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/crates/semantic/src/symbol_resolver.rs
+++ b/crates/semantic/src/symbol_resolver.rs
@@ -191,7 +191,23 @@ pub(crate) fn visit_definitions<'tree>(
                 emit_named_definition(node, source, DefinitionKind::ConstDecl, current_parent, emit)
             }
             "mod_item" => {
-                emit_named_definition(node, source, DefinitionKind::Module, current_parent, emit)
+                // Emit the module, then descend with the module name as the new
+                // container so `mod a { fn f }` yields `f` with `["a"]` — not
+                // the outer scope. Without this, `mod a::f` and `mod b::f`
+                // collapse to the same address.
+                let mod_name: Option<Rc<str>> = node
+                    .child_by_field_name("name")
+                    .map(|n| Rc::from(node_text(&n, source)))
+                    .filter(|name: &Rc<str>| !name.is_empty());
+                emit_named_definition(node, source, DefinitionKind::Module, current_parent, emit);
+                if let Some(name) = mod_name {
+                    let mut cursor = node.walk();
+                    let children: Vec<_> = node.children(&mut cursor).collect();
+                    for child in children.into_iter().rev() {
+                        stack.push((child, Some(name.clone())));
+                    }
+                    descended_with_new_parent = true;
+                }
             }
             "impl_item" => {
                 let parent_name: Option<Rc<str>> =
@@ -838,16 +854,17 @@ pub mod outer {
 
         assert_definition(&defs, "LIMIT", DefinitionKind::ConstDecl, 1, 1, None);
         assert_definition(&defs, "outer", DefinitionKind::Module, 2, 23, None);
-        assert_definition(&defs, "Widget", DefinitionKind::Type, 3, 5, None);
-        assert_definition(&defs, "Mode", DefinitionKind::EnumDef, 7, 10, None);
-        assert_definition(&defs, "Runner", DefinitionKind::Trait, 12, 14, None);
+        // Items inside `mod outer` now carry `outer` as their container.
+        assert_definition(&defs, "Widget", DefinitionKind::Type, 3, 5, Some("outer"));
+        assert_definition(&defs, "Mode", DefinitionKind::EnumDef, 7, 10, Some("outer"));
+        assert_definition(&defs, "Runner", DefinitionKind::Trait, 12, 14, Some("outer"));
         assert_definition(
             &defs,
             "WidgetResult",
             DefinitionKind::TypeAlias,
             16,
             16,
-            None,
+            Some("outer"),
         );
         assert_definition(
             &defs,
@@ -946,10 +963,10 @@ pub mod outer {
         let expected: &[(&str, DefinitionKind, u32, u32, Option<&str>)] = &[
             ("LIMIT", DefinitionKind::ConstDecl, 1, 1, None),
             ("outer", DefinitionKind::Module, 2, 23, None),
-            ("Widget", DefinitionKind::Type, 3, 5, None),
-            ("Mode", DefinitionKind::EnumDef, 7, 10, None),
-            ("Runner", DefinitionKind::Trait, 12, 14, None),
-            ("WidgetResult", DefinitionKind::TypeAlias, 16, 16, None),
+            ("Widget", DefinitionKind::Type, 3, 5, Some("outer")),
+            ("Mode", DefinitionKind::EnumDef, 7, 10, Some("outer")),
+            ("Runner", DefinitionKind::Trait, 12, 14, Some("outer")),
+            ("WidgetResult", DefinitionKind::TypeAlias, 16, 16, Some("outer")),
             ("build", DefinitionKind::Function, 19, 21, Some("Widget")),
         ];
 

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -423,11 +423,14 @@ fn walk_blob_filtered(
 /// `SemanticIndexRoot` blob), emitting every reachable semantic node blob.
 ///
 /// All semantic-index nodes (root, tree nodes, file nodes) are stored as
-/// ordinary content-addressed blobs, so replication just needs to enumerate
-/// them. Opaque entries point back at raw source blobs already covered by the
-/// state's tree closure, so they are not re-walked here. Decode failures are
-/// swallowed (the blob itself is still emitted); a semantic index can always be
-/// recomputed downstream.
+/// ordinary content-addressed blobs, so replication just enumerates them.
+/// Opaque entries point back at raw source blobs already covered by the state's
+/// tree closure, so they are not re-walked here.
+///
+/// Iterative (explicit stack) so a crafted deep `SemanticTreeNode` chain in a
+/// pushed state can't overflow the stack. A missing or undecodable node in the
+/// closure is a HARD failure (`ObjectNotFound`/`Serialization`) — a partial or
+/// corrupt semantic closure must never be shipped silently.
 fn walk_semantic_index_closure(
     store: &impl ObjectStore,
     root_hash: ContentHash,
@@ -435,52 +438,70 @@ fn walk_semantic_index_closure(
     seen: &mut HashSet<ContentHash>,
     visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
 ) -> Result<()> {
-    if !emit_semantic_blob(store, root_hash, excluded, seen, visit)? {
-        return Ok(());
-    }
-    let Some(blob) = store.get_blob(&root_hash)? else {
-        return Ok(());
-    };
-    let Ok(root) = SemanticIndexRoot::decode(blob.content()) else {
-        return Ok(());
-    };
-    walk_semantic_tree_node(store, root.tree, excluded, seen, visit)
-}
-
-fn walk_semantic_tree_node(
-    store: &impl ObjectStore,
-    node_hash: ContentHash,
-    excluded: &HashSet<ContentHash>,
-    seen: &mut HashSet<ContentHash>,
-    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
-) -> Result<()> {
-    if !emit_semantic_blob(store, node_hash, excluded, seen, visit)? {
-        return Ok(());
-    }
-    let Some(blob) = store.get_blob(&node_hash)? else {
-        return Ok(());
-    };
-    let Ok(node) = SemanticTreeNode::decode(blob.content()) else {
-        return Ok(());
-    };
-    for entry in &node.entries {
-        match entry.kind {
-            SemanticEntryKind::Dir => {
-                walk_semantic_tree_node(store, entry.node, excluded, seen, visit)?;
+    // Stack of (node_hash, is_tree_node): the root and dir nodes must be decoded
+    // to enumerate their children; file/opaque leaves are emitted only.
+    let mut stack: Vec<ContentHash> = vec![root_hash];
+    while let Some(node_hash) = stack.pop() {
+        if !emit_semantic_blob(store, node_hash, excluded, seen, visit)? {
+            continue; // excluded (present on the far side) or already seen.
+        }
+        let blob = store
+            .get_blob(&node_hash)?
+            .ok_or_else(|| ProtocolError::ObjectNotFound(node_hash.to_hex()))?;
+        // The root and tree nodes decode to the same `SemanticTreeNode.entries`
+        // shape after the root's one indirection; walk uniformly by decoding
+        // every interior node as a tree node, tolerating the root shape.
+        let node = decode_semantic_container(&blob, node_hash)?;
+        for child in node {
+            match child {
+                SemanticChild::Interior(hash) => stack.push(hash),
+                SemanticChild::Leaf(hash) => {
+                    // Emit the leaf (file node) blob; it has no children.
+                    emit_semantic_blob(store, hash, excluded, seen, visit)?;
+                }
             }
-            SemanticEntryKind::File => {
-                emit_semantic_blob(store, entry.node, excluded, seen, visit)?;
-            }
-            // Opaque `node` is the raw source blob, already in the tree closure.
-            SemanticEntryKind::Opaque => {}
         }
     }
     Ok(())
 }
 
+/// The two child kinds encountered walking the semantic closure: an interior
+/// node to descend into, or a leaf (file node) blob to emit.
+enum SemanticChild {
+    Interior(ContentHash),
+    Leaf(ContentHash),
+}
+
+/// Decode a semantic-closure node — the root (which points at a tree node) or a
+/// tree node — into the child hashes to walk. Missing/corrupt is a hard error.
+fn decode_semantic_container(
+    blob: &objects::object::Blob,
+    node_hash: ContentHash,
+) -> Result<Vec<SemanticChild>> {
+    // Try the root shape first (it has an extra `tree` indirection), then the
+    // tree-node shape. Content-addressed hashes make this unambiguous in
+    // practice; a blob that decodes as neither is corrupt.
+    if let Ok(root) = SemanticIndexRoot::decode(blob.content()) {
+        return Ok(vec![SemanticChild::Interior(root.tree)]);
+    }
+    let node = SemanticTreeNode::decode(blob.content())
+        .map_err(|err| ProtocolError::Serialization(format!("semantic node {node_hash}: {err}")))?;
+    Ok(node
+        .entries
+        .iter()
+        .filter_map(|entry| match entry.kind {
+            SemanticEntryKind::Dir => Some(SemanticChild::Interior(entry.node)),
+            SemanticEntryKind::File => Some(SemanticChild::Leaf(entry.node)),
+            // Opaque `node` is the raw source blob, already in the tree closure.
+            SemanticEntryKind::Opaque => None,
+        })
+        .collect())
+}
+
 /// Emit a semantic node blob as state metadata. Returns `true` when the blob
-/// was newly visited (so the caller may recurse into it), `false` when it was
-/// excluded or already seen.
+/// was newly visited (so the caller may descend into it), `false` when it was
+/// excluded (present on the far side) or already seen. A blob that is neither
+/// excluded nor present is a HARD failure — the closure must be complete.
 fn emit_semantic_blob(
     store: &impl ObjectStore,
     hash: ContentHash,
@@ -496,7 +517,7 @@ fn emit_semantic_blob(
         return Ok(false);
     }
     if store.get_blob(&hash)?.is_none() {
-        return Ok(false);
+        return Err(ProtocolError::ObjectNotFound(hash.to_hex()));
     }
     visit(StateClosureEvent::Blob {
         hash,
@@ -506,45 +527,33 @@ fn emit_semantic_blob(
 }
 
 /// Collect every semantic-index node blob hash reachable from `root_hash` into
-/// `excluded`, for the have-set computation.
+/// `excluded`, for the have-set computation. Iterative + tolerant (a broken
+/// have-set index is not fatal — it just means fewer objects are marked
+/// already-present, which is safe over-fetching, not corruption).
 fn collect_semantic_hashes(
     store: &impl ObjectStore,
     root_hash: ContentHash,
     excluded: &mut HashSet<ContentHash>,
 ) -> Result<()> {
-    if !excluded.insert(root_hash) {
-        return Ok(());
-    }
-    let Some(blob) = store.get_blob(&root_hash)? else {
-        return Ok(());
-    };
-    let Ok(root) = SemanticIndexRoot::decode(blob.content()) else {
-        return Ok(());
-    };
-    collect_semantic_tree_hashes(store, root.tree, excluded)
-}
-
-fn collect_semantic_tree_hashes(
-    store: &impl ObjectStore,
-    node_hash: ContentHash,
-    excluded: &mut HashSet<ContentHash>,
-) -> Result<()> {
-    if !excluded.insert(node_hash) {
-        return Ok(());
-    }
-    let Some(blob) = store.get_blob(&node_hash)? else {
-        return Ok(());
-    };
-    let Ok(node) = SemanticTreeNode::decode(blob.content()) else {
-        return Ok(());
-    };
-    for entry in &node.entries {
-        match entry.kind {
-            SemanticEntryKind::Dir => collect_semantic_tree_hashes(store, entry.node, excluded)?,
-            SemanticEntryKind::File => {
-                excluded.insert(entry.node);
+    let mut stack: Vec<ContentHash> = vec![root_hash];
+    while let Some(node_hash) = stack.pop() {
+        if !excluded.insert(node_hash) {
+            continue;
+        }
+        let Some(blob) = store.get_blob(&node_hash)? else {
+            continue;
+        };
+        let children = match decode_semantic_container(&blob, node_hash) {
+            Ok(children) => children,
+            Err(_) => continue,
+        };
+        for child in children {
+            match child {
+                SemanticChild::Interior(hash) => stack.push(hash),
+                SemanticChild::Leaf(hash) => {
+                    excluded.insert(hash);
+                }
             }
-            SemanticEntryKind::Opaque => {}
         }
     }
     Ok(())

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -3,8 +3,8 @@ use std::collections::{HashSet, VecDeque};
 
 use objects::{
     object::{
-        ContentHash, State, StateAttachment, StateAttachmentBody, StateAttachmentId, StateId,
-        TreeEntryTarget,
+        ContentHash, SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State, StateAttachment,
+        StateAttachmentBody, StateAttachmentId, StateId, TreeEntryTarget,
     },
     store::{ObjectStore, pack::ObjectType as PackObjectType},
 };
@@ -314,6 +314,13 @@ fn walk_state_closure(
                     &mut seen_hashes,
                     &mut visit,
                 )?,
+                StateAttachmentBody::SemanticIndex(root) => walk_semantic_index_closure(
+                    store,
+                    root,
+                    &excluded_hashes,
+                    &mut seen_hashes,
+                    &mut visit,
+                )?,
                 StateAttachmentBody::Signature(_) => {}
             }
         }
@@ -408,6 +415,137 @@ fn walk_blob_filtered(
     })?;
     if store.has_redactions_for_blob(&blob_hash)? {
         visit(StateClosureEvent::Redaction { blob: blob_hash })?;
+    }
+    Ok(())
+}
+
+/// Walk the merkle semantic-index closure rooted at `root_hash` (a
+/// `SemanticIndexRoot` blob), emitting every reachable semantic node blob.
+///
+/// All semantic-index nodes (root, tree nodes, file nodes) are stored as
+/// ordinary content-addressed blobs, so replication just needs to enumerate
+/// them. Opaque entries point back at raw source blobs already covered by the
+/// state's tree closure, so they are not re-walked here. Decode failures are
+/// swallowed (the blob itself is still emitted); a semantic index can always be
+/// recomputed downstream.
+fn walk_semantic_index_closure(
+    store: &impl ObjectStore,
+    root_hash: ContentHash,
+    excluded: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<()> {
+    if !emit_semantic_blob(store, root_hash, excluded, seen, visit)? {
+        return Ok(());
+    }
+    let Some(blob) = store.get_blob(&root_hash)? else {
+        return Ok(());
+    };
+    let Ok(root) = SemanticIndexRoot::decode(blob.content()) else {
+        return Ok(());
+    };
+    walk_semantic_tree_node(store, root.tree, excluded, seen, visit)
+}
+
+fn walk_semantic_tree_node(
+    store: &impl ObjectStore,
+    node_hash: ContentHash,
+    excluded: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<()> {
+    if !emit_semantic_blob(store, node_hash, excluded, seen, visit)? {
+        return Ok(());
+    }
+    let Some(blob) = store.get_blob(&node_hash)? else {
+        return Ok(());
+    };
+    let Ok(node) = SemanticTreeNode::decode(blob.content()) else {
+        return Ok(());
+    };
+    for entry in &node.entries {
+        match entry.kind {
+            SemanticEntryKind::Dir => {
+                walk_semantic_tree_node(store, entry.node, excluded, seen, visit)?;
+            }
+            SemanticEntryKind::File => {
+                emit_semantic_blob(store, entry.node, excluded, seen, visit)?;
+            }
+            // Opaque `node` is the raw source blob, already in the tree closure.
+            SemanticEntryKind::Opaque => {}
+        }
+    }
+    Ok(())
+}
+
+/// Emit a semantic node blob as state metadata. Returns `true` when the blob
+/// was newly visited (so the caller may recurse into it), `false` when it was
+/// excluded or already seen.
+fn emit_semantic_blob(
+    store: &impl ObjectStore,
+    hash: ContentHash,
+    excluded: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<bool> {
+    if excluded.contains(&hash) {
+        visit(StateClosureEvent::ExcludedHash { hash })?;
+        return Ok(false);
+    }
+    if !seen.insert(hash) {
+        return Ok(false);
+    }
+    if store.get_blob(&hash)?.is_none() {
+        return Ok(false);
+    }
+    visit(StateClosureEvent::Blob {
+        hash,
+        source: BlobSource::StateMetadata,
+    })?;
+    Ok(true)
+}
+
+/// Collect every semantic-index node blob hash reachable from `root_hash` into
+/// `excluded`, for the have-set computation.
+fn collect_semantic_hashes(
+    store: &impl ObjectStore,
+    root_hash: ContentHash,
+    excluded: &mut HashSet<ContentHash>,
+) -> Result<()> {
+    if !excluded.insert(root_hash) {
+        return Ok(());
+    }
+    let Some(blob) = store.get_blob(&root_hash)? else {
+        return Ok(());
+    };
+    let Ok(root) = SemanticIndexRoot::decode(blob.content()) else {
+        return Ok(());
+    };
+    collect_semantic_tree_hashes(store, root.tree, excluded)
+}
+
+fn collect_semantic_tree_hashes(
+    store: &impl ObjectStore,
+    node_hash: ContentHash,
+    excluded: &mut HashSet<ContentHash>,
+) -> Result<()> {
+    if !excluded.insert(node_hash) {
+        return Ok(());
+    }
+    let Some(blob) = store.get_blob(&node_hash)? else {
+        return Ok(());
+    };
+    let Ok(node) = SemanticTreeNode::decode(blob.content()) else {
+        return Ok(());
+    };
+    for entry in &node.entries {
+        match entry.kind {
+            SemanticEntryKind::Dir => collect_semantic_tree_hashes(store, entry.node, excluded)?,
+            SemanticEntryKind::File => {
+                excluded.insert(entry.node);
+            }
+            SemanticEntryKind::Opaque => {}
+        }
     }
     Ok(())
 }
@@ -625,6 +763,9 @@ fn collect_excluded(
                 | StateAttachmentBody::Discussions(hash)
                 | StateAttachmentBody::StructuredConflicts(hash) => {
                     excluded_hashes.insert(hash);
+                }
+                StateAttachmentBody::SemanticIndex(root) => {
+                    collect_semantic_hashes(store, root, &mut excluded_hashes)?;
                 }
                 StateAttachmentBody::Signature(_) => {}
             }

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3040,8 +3040,8 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
     "advanced_scope_mutating_commands_total": 61,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 22,
-    "catalog_commands_total": 185,
-    "catalog_mutating_commands_total": 90,
+    "catalog_commands_total": 186,
+    "catalog_mutating_commands_total": 91,
     "json_commands_total": 149,
     "json_commands_with_accepted_opaque_schema": 39,
     "json_commands_with_schema": 110,
@@ -3055,7 +3055,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "185 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 149 JSON command(s), 91 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3093,7 +3093,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "185 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 149 JSON command(s), 91 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
Implements #1067 — the content-addressed **merkle semantic index**: a parallel
merkle DAG over source history that stores *semantic* facts (the symbols a file
defines and a normalization-stable fingerprint of each) so semantic data over
all of history costs about as much to maintain as the source history itself, and
queries short-circuit on hash equality without re-parsing. Deterministic and
signable throughout — the foundation for later review features.

## The two-hash crux

Every node carries two identities:

- **Storage hash** — the content address of the encoded node blob. It changes
  whenever the node bytes change, *including* when a symbol's span moves under a
  reformat. Object-store key.
- **`semantic_digest`** — a fingerprint over the node's *meaning* with spans
  deliberately excluded. Reformatting a file leaves it untouched, so a top-down
  digest compare prunes reformatted-but-identical subtrees with zero re-parse.

Canonical, cross-language-reproducible byte layouts: `hd-sem-sym-v1` (symbol
fingerprint = `kind_tag ‖ 0x00 ‖ length-prefixed non-comment leaves in document
order`), `hd-sem-file-v1` (file digest over sorted symbols, spans excluded),
`hd-sem-dir-v1` (dir digest over child name/kind/digest).

## What's here

- **objects** — `SemanticFileNode` / `SymbolEntry` / `SemanticTreeNode` /
  `SemanticIndexRoot` (msgpack, versioned) + the canonical digest/hash functions;
  `StateAttachmentBody::SemanticIndex`.
- **semantic** — `is_comment_node` + the non-comment leaf walk hoisted into the
  parser crate as the single source of truth; a visitor-based definition walk
  (the full `extract_definitions` taxonomy — types, traits, enums, modules are
  first-class, not just functions) that exposes each definition's AST node;
  `extract_semantic_file` producing per-symbol normalization-stable hashes.
- **repo** — `SemanticIndexBuilder` (O(changed-path) incremental assembly:
  reuse parent index for unchanged subtrees, memoize per source blob so each
  unique blob is parsed at most once; node blobs flushed as one pack).
  Eager capture wired into the snapshot path (never-fail swallow-with-warn).
  Query primitives: `semantic_index` (get-or-compute, parents-first),
  `symbol_hash`, `semantic_changed` (top-down digest prune, zero reparse),
  `semantic_diff_symbols` (merkle walk, descend only differing digests),
  `changed_since`. Lazy backfill `backfill_semantic_index([--all])`.
- **cli** — `heddle semantic index [--all]` backfill (oldest-first, restartable).
- **wire** — state replication + have-set walk the semantic-index blob closure.
- **fix (inline)** — deleted the language-free `SimilarityMethod::Ast` fallback
  that silently returned token similarity; AST similarity now flows solely
  through `compute_similarity_with_language`.

Out of scope (untouched, per the issue): verdicts/annotations/signals/staleness
(#1069/#1070/#1071) and Zig (#1068).

## Verification (golden results)

`cargo test -p heddle-semantic semantic_index::` — the extraction goldens:

```
running 6 tests
test semantic_index::tests::comment_edit_leaves_symbol_hash_stable ... ok
test semantic_index::tests::types_are_first_class ... ok
test semantic_index::tests::reformat_leaves_symbol_hash_stable ... ok
test semantic_index::tests::one_token_change_perturbs_only_that_symbol ... ok
test semantic_index::tests::unsupported_language_is_none ... ok
test semantic_index::tests::string_literal_contents_included ... ok
test result: ok. 6 passed; 0 failed
```

`cargo test -p heddle-repo --features semantic --lib repository_semantic_index` —
the end-to-end goldens (reformat-stable digest + prune-without-reparse):

```
running 6 tests
test repository_semantic_index::tests::shared_blob_parsed_once ... ok
test repository_semantic_index::tests::incremental_build_prunes_unchanged_without_reparse ... ok
test repository_semantic_index::tests::one_token_change_yields_exactly_one_delta ... ok
test repository_semantic_index::tests::reformat_changes_storage_hash_but_not_semantic_digest ... ok
test repository_semantic_index::tests::symbol_hash_and_changed_since ... ok
test repository_semantic_index::tests::backfill_is_idempotent ... ok
test result: ok. 6 passed; 0 failed
```

- `reformat_changes_storage_hash_but_not_semantic_digest`: reformatting a file
  moves `SemanticIndexRoot.tree` (storage hash) but leaves `semantic_digest`
  equal, and `semantic_changed` prunes it.
- `incremental_build_prunes_unchanged_without_reparse` / `shared_blob_parsed_once`:
  the builder's parse counter proves unchanged siblings and shared blobs are
  never re-parsed.

Full suites green: `heddle-objects` (429), `heddle-semantic` (290),
`heddle-repo --features semantic` (606); clippy `--all-targets -D warnings`
clean on objects/semantic/wire/repo/cli; `heddle-cli` command-catalog
invariants (CONTRACTS + runtime parse sample for the new `semantic index` verb)
pass; `gen-ts-types.sh` produced no delta (text command, no new schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787112408&installation_id=132405951&pr_number=1073&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1073&signature=9c5a15a1ec83eda4b485ed75b1fdfcb827d598432bf6af3e5394b422a9c3d151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->