### PR TITLE
test(cli): de-flake test_snapshot_many_small_files (hard 1s CI budget)

### DIFF
--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -145,11 +145,38 @@ fn test_snapshot_many_small_files() {
     let profile = measure_snapshot_profile(1_000);
     print_snapshot_profile("repository snapshot 1000 files", &profile);
 
+    // The *functional* fast-path guarantee (one `.pack` + one `.idx`, no loose
+    // blobs) is guarded deterministically by
+    // `put_blobs_packed_writes_a_single_packfile_no_loose_blobs` in
+    // `crates/objects/src/store/fs/fs_tests.rs`. This test is a *timing* smoke.
+    //
+    // A hard sub-second wall-clock budget flakes on loaded shared CI runners:
+    // debug builds land ~150 ms locally, but a busy runner can drift past 1 s
+    // with no regression (observed 1.14 s). So enforce the tight budget only
+    // under `HEDDLE_PERF_ASSERT=1` (a dedicated perf job or local
+    // benchmarking); otherwise keep the measurement advisory behind a generous
+    // catastrophe ceiling that only an order-of-magnitude regression or a hang
+    // would trip. The measurement is always printed above for observability.
+    let (budget, context) = if perf_assert_enabled() {
+        (Duration::from_secs(1), "the HEDDLE_PERF_ASSERT=1 budget")
+    } else {
+        (
+            Duration::from_secs(10),
+            "the advisory ceiling (set HEDDLE_PERF_ASSERT=1 to enforce the 1s budget)",
+        )
+    };
     assert!(
-        profile.snapshot_total < Duration::from_secs(1),
-        "Snapshot of 1000 files should take less than 1 second, took {:?}",
-        profile.snapshot_total
+        profile.snapshot_total < budget,
+        "Snapshot of 1000 files took {:?}, exceeding {context} of {budget:?}",
+        profile.snapshot_total,
     );
+}
+
+/// Whether the wall-clock perf budgets in this suite are enforced. Off by
+/// default so shared-runner jitter can't spuriously fail unrelated PRs; a
+/// dedicated perf job (or a local run) sets `HEDDLE_PERF_ASSERT=1`.
+fn perf_assert_enabled() -> bool {
+    std::env::var_os("HEDDLE_PERF_ASSERT").is_some_and(|v| v == "1" || v == "true")
 }
 
 /// Test handling of large individual files.


### PR DESCRIPTION
`crates/cli/tests/performance.rs` `test_snapshot_many_small_files` asserted `snapshot_total < 1s`, a hard wall-clock budget that flakes on loaded shared CI runners (observed **1.14s** vs. typical ~150ms in debug) and spuriously reds unrelated PRs.

## Fix
- The **functional** fast-path guarantee (one `.pack` + one `.idx`, no loose blobs) is already covered deterministically by `put_blobs_packed_writes_a_single_packfile_no_loose_blobs` (`crates/objects/src/store/fs/fs_tests.rs`), so this test is purely a **timing smoke**.
- Enforce the tight **1s** budget only when `HEDDLE_PERF_ASSERT=1` (a dedicated perf job or local benchmarking); default CI keeps the measurement printed and asserts a generous **10s** catastrophe ceiling (still trips a hang / order-of-magnitude regression).
- Functional correctness assertions unchanged; only the timing threshold is gated.

Verified green in both modes (advisory default + `HEDDLE_PERF_ASSERT=1`). Pre-existing flake, not caused by any current PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787114839&installation_id=132405951&pr_number=1075&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1075&signature=2c486c1c4abfcc2ad50441f5f5025ab9ea1beaad861fd9466909138ed525098c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->