### PR TITLE
feat(semantic): Zig language support in the semantic parser (#1068)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -160,7 +160,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2118,6 +2118,7 @@ dependencies = [
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
+ "tree-sitter-zig",
 ]
 
 [[package]]
@@ -2511,7 +2512,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2849,7 +2850,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3436,7 +3437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -3471,7 +3472,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -3932,7 +3933,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4688,7 +4689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5042,10 +5043,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5650,6 +5651,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-zig"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab11fc124851b0db4dd5e55983bbd9631192e93238389dcd44521715e5d53e28"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5997,7 +6008,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ tree-sitter-javascript = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
+tree-sitter-zig = "1.1.2"
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 walkdir = "2"
 windows-sys = "0.61"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,11 @@ tree-sitter-javascript = "0.25"
 tree-sitter-python = "0.25"
 tree-sitter-rust = "0.24"
 tree-sitter-typescript = "0.23"
-tree-sitter-zig = "1.1.2"
+# Exact pin: unlike the 0.x grammars (where caret pins the minor), a caret on
+# this >=1.0 crate would admit 1.2+, changing parse trees without matching the
+# `@1.1` version recorded in semantic_index.rs — so a `cargo update` could drift
+# `semantic_hash` with no version-bust. Bump this and the recorded version together.
+tree-sitter-zig = "=1.1.2"
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 walkdir = "2"
 windows-sys = "0.61"

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -65,8 +65,14 @@ zstd = ["objects/zstd", "wire/zstd"]
 # Symbol resolution. The implementation lives in `semantic`;
 # enabling the feature here pulls in the dep with the parsers our
 # resolver supports. `semantic`'s `common-languages` covers Rust,
-# Python, JS, TS; `lang-go` adds Go.
-tree-sitter-symbols = ["dep:semantic", "semantic/lang-go", "dep:state_review"]
+# Python, JS, TS; `lang-go` adds Go; `lang-zig` adds Zig (ghostty and
+# other Zig-heavy git-lane imports).
+tree-sitter-symbols = [
+    "dep:semantic",
+    "semantic/lang-go",
+    "semantic/lang-zig",
+    "dep:state_review",
+]
 # Alias so that `--workspace --features semantic` (used by the
 # Coverage CI job) resolves cleanly across all crates.  The dep is
 # declared with the `dep:` prefix, so Cargo does not auto-create an

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -1115,6 +1115,49 @@ mod tests {
         );
     }
 
+    /// heddle#1068: a `.zig` blob must index to a real File node (not the
+    /// `Opaque` fallback), and reformatting it must leave the whole-tree
+    /// `semantic_digest` stable — the ghostty git-lane import guarantee.
+    #[test]
+    fn zig_file_indexes_to_real_node_and_reformat_is_digest_stable() {
+        let (temp, repo) = repo();
+        let tight = "pub fn add(a: i32, b: i32) i32 { return a + b; }\ntest \"add\" { _ = add(1, 2); }\n";
+        let loose = "pub fn add(a: i32,   b: i32) i32 {\n    // sum\n    return a + b;\n}\n\ntest \"add\" {\n    _ = add(1, 2);\n}\n";
+
+        let a = snapshot(&repo, &temp, "math.zig", tight);
+        let ra = repo.semantic_index(&a).unwrap().unwrap();
+
+        // Real File node — not Opaque (which resolves to None here).
+        let node_hash = repo
+            .resolve_file_node(&ra, "math.zig")
+            .unwrap()
+            .expect("zig file must index to a real File node, not Opaque");
+        let file = repo.load_semantic_file(&node_hash).unwrap();
+        assert_eq!(file.language, "zig");
+        assert!(
+            file.symbols.iter().any(|s| s.name == "add"),
+            "fn add must be a symbol: {:?}",
+            file.symbols
+        );
+        assert!(
+            file.symbols.iter().any(|s| s.name == "test:\"add\""),
+            "test block must be a symbol: {:?}",
+            file.symbols
+        );
+
+        let b = snapshot(&repo, &temp, "math.zig", loose);
+        let rb = repo.semantic_index(&b).unwrap().unwrap();
+        assert_ne!(ra.tree, rb.tree, "reformat must move the storage hash");
+        assert_eq!(
+            ra.semantic_digest, rb.semantic_digest,
+            "reformatting a Zig file must NOT change the semantic_digest"
+        );
+        assert!(
+            !repo.semantic_changed(&a, &b, "").unwrap(),
+            "semantic_changed must prune a pure Zig reformat"
+        );
+    }
+
     /// GOLDEN: a one-token change to a single function yields exactly one
     /// SymbolDelta, for that symbol, with both old and new hashes present.
     #[test]

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -16,7 +16,7 @@ name = "semantic"
 [features]
 default = ["common-languages"]
 common-languages = ["lang-rust", "lang-python", "lang-javascript", "lang-typescript"]
-extended-languages = ["lang-c", "lang-cpp", "lang-go", "lang-java"]
+extended-languages = ["lang-c", "lang-cpp", "lang-go", "lang-java", "lang-zig"]
 lang-rust = ["dep:tree-sitter-rust"]
 lang-python = ["dep:tree-sitter-python"]
 lang-javascript = ["dep:tree-sitter-javascript"]
@@ -25,6 +25,7 @@ lang-go = ["dep:tree-sitter-go"]
 lang-c = ["dep:tree-sitter-c"]
 lang-cpp = ["dep:tree-sitter-cpp"]
 lang-java = ["dep:tree-sitter-java"]
+lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
@@ -40,6 +41,7 @@ tree-sitter-javascript = { workspace = true, optional = true }
 tree-sitter-python = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
+tree-sitter-zig = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion = "0.8"

--- a/crates/semantic/src/analysis/analysis_tests.rs
+++ b/crates/semantic/src/analysis/analysis_tests.rs
@@ -264,6 +264,29 @@ fn test_detect_signature_change() {
     );
 }
 
+/// heddle#1068: a parameter change on a Zig `fn` must surface as a
+/// `SignatureChanged` semantic-diff event (drives risk signals for ghostty).
+#[cfg(feature = "lang-zig")]
+#[test]
+fn test_detect_zig_signature_change() {
+    let old = "pub fn process(x: i32) i32 { return x + 1; }\n";
+    let new = "pub fn process(x: i32, y: i32) i32 { return x + y; }\n";
+    let changes = detect_function_changes(
+        std::path::Path::new("main.zig"),
+        std::path::Path::new("main.zig"),
+        old,
+        new,
+        SimilarityMethod::Lines,
+    );
+    let has_sig_change = changes
+        .iter()
+        .any(|c| matches!(c, SemanticChange::SignatureChanged { name, .. } if name == "process"));
+    assert!(
+        has_sig_change,
+        "Expected SignatureChanged for Zig 'process', got: {changes:?}"
+    );
+}
+
 #[test]
 fn test_detect_multiple_function_deletions() {
     let old = "fn a() { 1 }\nfn b() { 2 }\nfn c() { 3 }\n";

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -223,6 +223,10 @@ pub(super) fn rules_for(language: Language) -> Option<&'static dyn LanguageRules
         Language::Go => Some(&GoRules),
         Language::C | Language::Cpp => Some(&CppRules),
         Language::Java => Some(&JavaRules),
+        // Zig has no semantic merge-driver rules yet — fall back to the
+        // default line-level merge. Symbol taxonomy, function events, and the
+        // semantic index (heddle#1068) do not depend on this path.
+        Language::Zig => None,
         Language::Unknown => None,
     }
 }
@@ -1803,7 +1807,8 @@ mod tests {
                 Language::C => true,
                 Language::Cpp => true,
                 Language::Java => false,
-                Language::Unknown => continue,
+                // Zig has no merge-driver rules (falls back to line merge).
+                Language::Zig | Language::Unknown => continue,
             };
             let rules = rules_for(lang).expect("non-unknown language has rules");
             assert_eq!(

--- a/crates/semantic/src/parser/parser_language.rs
+++ b/crates/semantic/src/parser/parser_language.rs
@@ -12,6 +12,7 @@ pub enum Language {
     C,
     Cpp,
     Java,
+    Zig,
     Unknown,
 }
 
@@ -27,6 +28,7 @@ impl Language {
             Some("c") | Some("h") => Language::C,
             Some("cpp") | Some("cc") | Some("hpp") | Some("cxx") => Language::Cpp,
             Some("java") => Language::Java,
+            Some("zig") => Language::Zig,
             _ => Language::Unknown,
         }
     }
@@ -57,6 +59,8 @@ impl Language {
             Language::Cpp => Some(tree_sitter_cpp::LANGUAGE.into()),
             #[cfg(feature = "lang-java")]
             Language::Java => Some(tree_sitter_java::LANGUAGE.into()),
+            #[cfg(feature = "lang-zig")]
+            Language::Zig => Some(tree_sitter_zig::LANGUAGE.into()),
             _ => None,
         }
     }

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -25,6 +25,10 @@ fn test_language_from_path() {
         Language::Python
     );
     assert_eq!(
+        Language::from_path(std::path::Path::new("foo.zig")),
+        Language::Zig
+    );
+    assert_eq!(
         Language::from_path(std::path::Path::new("foo.txt")),
         Language::Unknown
     );

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -110,7 +110,10 @@ impl SyntaxIndex {
                         });
                     }
                 }
-                Language::C | Language::Cpp | Language::Unknown => {}
+                // Zig has no top-level import statement node — `@import` is a
+                // builtin call bound in a `variable_declaration`, so there is
+                // no dedicated import kind to collect here.
+                Language::C | Language::Cpp | Language::Zig | Language::Unknown => {}
             }
         }
 
@@ -199,6 +202,7 @@ pub(super) fn is_function_kind(kind: &str, language: Language) -> bool {
         Language::Go => kind == "function_declaration" || kind == "method_declaration",
         Language::C | Language::Cpp => kind == "function_definition",
         Language::Java => kind == "method_declaration" || kind == "constructor_declaration",
+        Language::Zig => kind == "function_declaration",
         Language::Unknown => false,
     }
 }

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -48,6 +48,7 @@ pub fn language_name(language: Language) -> &'static str {
         Language::C => "c",
         Language::Cpp => "cpp",
         Language::Java => "java",
+        Language::Zig => "zig",
         Language::Unknown => "unknown",
     }
 }
@@ -64,6 +65,7 @@ pub fn grammar_version(language: Language) -> &'static str {
         Language::C => "tree-sitter-c@0.24",
         Language::Cpp => "tree-sitter-cpp@0.23",
         Language::Java => "tree-sitter-java@0.23",
+        Language::Zig => "tree-sitter-zig@1.1",
         Language::Unknown => "none",
     }
 }
@@ -81,6 +83,7 @@ pub fn grammar_version_by_name(name: &str) -> Option<&'static str> {
         "c" => Language::C,
         "cpp" => Language::Cpp,
         "java" => Language::Java,
+        "zig" => Language::Zig,
         _ => return None,
     };
     Some(grammar_version(language))
@@ -333,5 +336,74 @@ mod tests {
     #[test]
     fn unsupported_language_is_none() {
         assert!(extract_semantic_file(b"whatever", Language::Unknown).is_none());
+    }
+
+    // ── Zig (heddle#1068) ────────────────────────────────────────────────
+
+    /// A `.zig` blob must extract a real file node — symbols with per-symbol
+    /// `semantic_hash`es — not the `Opaque` fallback that `Language::Unknown`
+    /// produced before Zig support.
+    #[cfg(feature = "lang-zig")]
+    #[test]
+    fn zig_blob_extracts_real_symbols_with_hashes() {
+        let src = "pub const Point = struct {\n    x: f64,\n    pub fn dist(self: Point) f64 { return self.x; }\n};\n\ntest \"works\" { _ = 1; }\n";
+        let extracted =
+            extract_semantic_file(src.as_bytes(), Language::Zig).expect("zig parses to a real node");
+        assert_eq!(language_name(extracted.language), "zig");
+
+        let by_name = |n: &str| extracted.symbols.iter().find(|s| s.name == n);
+        let point = by_name("Point").expect("Point type extracted");
+        assert_eq!(point.kind, SymbolKindTag::Type);
+        let dist = by_name("dist").expect("method extracted");
+        assert_eq!(dist.kind, SymbolKindTag::Function);
+        assert_eq!(dist.container_path, vec!["Point".to_string()]);
+        let test = by_name("test:\"works\"").expect("test block extracted");
+        assert_eq!(test.kind, SymbolKindTag::Function);
+
+        // Every symbol carries a non-degenerate per-symbol semantic_hash.
+        assert!(
+            extracted
+                .symbols
+                .iter()
+                .all(|s| s.semantic_hash != ContentHash::compute(b"")),
+            "symbols must carry real semantic hashes"
+        );
+    }
+
+    /// Reformatting a Zig file — whitespace + comments only — must leave the
+    /// file node's `semantic_digest` (and every symbol hash + the scaffold)
+    /// byte-identical.
+    #[cfg(feature = "lang-zig")]
+    #[test]
+    fn zig_reformat_leaves_semantic_digest_stable() {
+        use objects::object::SemanticFileNode;
+
+        let tight = "const std = @import(\"std\");\npub fn add(a: i32, b: i32) i32 { return a + b; }\npub const Point = struct { x: f64, pub fn dist(self: Point) f64 { return self.x; } };\n";
+        let loose = "const std = @import(\"std\");\n\n// a comment\npub fn add(a: i32,   b: i32) i32 {\n    return a + b;\n}\n\npub const Point = struct {\n    // fields\n    x: f64,\n    pub fn dist(self: Point) f64 {\n        return self.x;\n    }\n};\n";
+
+        let ea = extract_semantic_file(tight.as_bytes(), Language::Zig).expect("tight parses");
+        let eb = extract_semantic_file(loose.as_bytes(), Language::Zig).expect("loose parses");
+
+        assert_eq!(
+            ea.scaffold_hash, eb.scaffold_hash,
+            "scaffold must be reformat/comment stable"
+        );
+
+        let node = |e: &ExtractedFile, src: &str| {
+            SemanticFileNode::new(
+                language_name(e.language),
+                grammar_version(e.language),
+                EXTRACTOR_VERSION,
+                ContentHash::compute(src.as_bytes()),
+                e.scaffold_hash,
+                e.symbols.clone(),
+            )
+        };
+        // The source blobs differ, but the reformat-stable digest must not.
+        assert_eq!(
+            node(&ea, tight).semantic_digest,
+            node(&eb, loose).semantic_digest,
+            "reformatting must not perturb the file semantic_digest"
+        );
     }
 }

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -34,7 +34,12 @@ use crate::{
 /// (non-definition file content), and mod-qualified `container_path`. Bumped so
 /// any same-version-but-old-layout nodes written by a pre-fix branch checkout
 /// are treated as stale and recomputed rather than digest-compared.
-pub const EXTRACTOR_VERSION: u32 = 2;
+///
+/// v3: Zig extraction added. `parent_is_reusable` only validates grammars
+/// *present* in the parent's map, so a pre-Zig index (no `"zig"` entry) would
+/// otherwise carry `.zig` files forward as `Opaque` indefinitely. The bump
+/// forces those to recompute so imported Zig repos gain granularity.
+pub const EXTRACTOR_VERSION: u32 = 3;
 
 /// Stable lowercase language name recorded in file nodes and the root's
 /// grammar map.

--- a/crates/semantic/src/symbol_resolver.rs
+++ b/crates/semantic/src/symbol_resolver.rs
@@ -333,10 +333,12 @@ pub(crate) fn visit_definitions<'tree>(
             }
             "lexical_declaration" | "variable_declaration" => {
                 let mut cursor = node.walk();
+                let mut saw_declarator = false;
                 for child in node.children(&mut cursor) {
                     if child.kind() == "variable_declarator"
                         && let Some(name_node) = child.child_by_field_name("name")
                     {
+                        saw_declarator = true;
                         let name = node_text(&name_node, source).to_string();
                         if name.is_empty() {
                             continue;
@@ -361,6 +363,37 @@ pub(crate) fn visit_definitions<'tree>(
                             });
                         }
                     }
+                }
+                // ── Zig ──────────────────────────────────────────
+                // Zig reuses `variable_declaration` for both declarations and
+                // locals, and has no `variable_declarator`: the binding name is
+                // a direct `identifier` child. `const Name = struct|union|
+                // enum|opaque {…}` is Zig's container-as-value idiom, whose
+                // members we walk under `[Name]`; a bare `const`/`var` binding
+                // at container scope is a `ConstDecl`.
+                if kind == "variable_declaration" && !saw_declarator {
+                    descended_with_new_parent =
+                        zig_visit_variable_declaration(node, source, current_parent, emit, &mut stack);
+                }
+            }
+            "test_declaration" => {
+                // Zig `test "name" {…}` / `test Name {…}` → a `Function` named
+                // `test:"name"` / `test:Name` so risk-signal test-reachability
+                // treats them as tests.
+                let mut cursor = node.walk();
+                let test_name = node.children(&mut cursor).find_map(|c| match c.kind() {
+                    "string" | "identifier" => Some(format!("test:{}", node_text(&c, source))),
+                    _ => None,
+                });
+                if let Some(name) = test_name {
+                    emit(DefinitionSite {
+                        node,
+                        name,
+                        kind: DefinitionKind::Function,
+                        parent_name: current_parent.map(String::from),
+                        start_line: node.start_position().row as u32 + 1,
+                        end_line: node.end_position().row as u32 + 1,
+                    });
                 }
             }
 
@@ -437,6 +470,99 @@ fn extract_go_receiver_type(node: &tree_sitter::Node, source: &[u8]) -> Option<S
         }
     }
     None
+}
+
+/// Zig container scopes whose direct `variable_declaration` children are
+/// declarations rather than function-body locals: the file root and the four
+/// container-type bodies. Used to gate bare `const`/`var` bindings so a
+/// function's local variables don't each become a symbol.
+fn is_zig_container_scope(kind: &str) -> bool {
+    matches!(
+        kind,
+        "source_file"
+            | "struct_declaration"
+            | "union_declaration"
+            | "enum_declaration"
+            | "opaque_declaration"
+    )
+}
+
+/// Map a Zig container-declaration node kind to its symbol taxonomy kind.
+/// `struct`/`union`/`opaque` are `Type`; `enum` is `EnumDef`.
+fn zig_container_kind(kind: &str) -> Option<DefinitionKind> {
+    match kind {
+        "struct_declaration" | "union_declaration" | "opaque_declaration" => {
+            Some(DefinitionKind::Type)
+        }
+        "enum_declaration" => Some(DefinitionKind::EnumDef),
+        _ => None,
+    }
+}
+
+/// Handle a Zig `variable_declaration` (no `variable_declarator`). Returns
+/// `true` when it descended into a container body with a new `container_path`
+/// parent (so the caller skips the default same-parent descent).
+///
+/// `const Name = struct|union|enum|opaque {…}` emits `Name` with the matching
+/// kind and walks the container's members under `[Name]`. A bare `const`/`var`
+/// binding at container scope emits a `ConstDecl`; inside a function body it is
+/// a local and is skipped.
+fn zig_visit_variable_declaration<'tree>(
+    node: tree_sitter::Node<'tree>,
+    source: &[u8],
+    current_parent: Option<&str>,
+    emit: &mut impl FnMut(DefinitionSite<'tree>),
+    stack: &mut Vec<(tree_sitter::Node<'tree>, Option<Rc<str>>)>,
+) -> bool {
+    let mut cursor = node.walk();
+    let children: Vec<tree_sitter::Node<'tree>> = node.children(&mut cursor).collect();
+
+    // Binding name = first direct `identifier` child (it precedes `=`; a value
+    // identifier like `const A = B;` comes after and is never first).
+    let Some(name) = children
+        .iter()
+        .find(|c| c.kind() == "identifier")
+        .map(|c| node_text(c, source).to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        return false;
+    };
+
+    if let Some(container) = children.iter().find(|c| zig_container_kind(c.kind()).is_some()) {
+        let dk = zig_container_kind(container.kind()).expect("checked by find");
+        emit(DefinitionSite {
+            node,
+            name: name.clone(),
+            kind: dk,
+            parent_name: current_parent.map(String::from),
+            start_line: node.start_position().row as u32 + 1,
+            end_line: node.end_position().row as u32 + 1,
+        });
+        let child_parent: Rc<str> = Rc::from(name.as_str());
+        let mut member_cursor = container.walk();
+        let members: Vec<_> = container.children(&mut member_cursor).collect();
+        for member in members.into_iter().rev() {
+            stack.push((member, Some(child_parent.clone())));
+        }
+        return true;
+    }
+
+    // Bare binding: a declaration only at container scope; otherwise a local.
+    let at_container_scope = node
+        .parent()
+        .map(|p| is_zig_container_scope(p.kind()))
+        .unwrap_or(false);
+    if at_container_scope {
+        emit(DefinitionSite {
+            node,
+            name,
+            kind: DefinitionKind::ConstDecl,
+            parent_name: current_parent.map(String::from),
+            start_line: node.start_position().row as u32 + 1,
+            end_line: node.end_position().row as u32 + 1,
+        });
+    }
+    false
 }
 
 /// Resolve a symbol name to a line range in source code.
@@ -1010,6 +1136,75 @@ pub mod outer {
             defs.iter().any(|d| d.name == "target"),
             "deep target fn must be returned, not silently dropped; got {defs:?}"
         );
+    }
+
+    /// heddle#1068: Zig's container-as-value idiom, `fn`/`test` blocks, and
+    /// `const`/`var` bindings map onto the shared taxonomy — and function-body
+    /// locals (Zig reuses `const`/`var` for locals) must NOT leak as symbols.
+    #[cfg(feature = "lang-zig")]
+    #[test]
+    fn extract_definitions_reports_zig_taxonomy_parents_and_ranges() {
+        let source = br#"const std = @import("std");
+
+pub const MAX: usize = 100;
+var counter: u32 = 0;
+
+pub fn add(a: i32, b: i32) i32 {
+    const local = 1;
+    return a + b + local;
+}
+
+pub const Point = struct {
+    x: f64,
+    pub fn dist(self: Point) f64 {
+        const scale = 2.0;
+        return self.x * scale;
+    }
+};
+
+const Color = enum { red, green };
+
+const Shape = union(enum) { circle: f64 };
+
+const Handle = opaque {
+    pub fn get() void {}
+};
+
+test "addition works" {
+    const r = add(1, 2);
+    _ = r;
+}
+"#;
+
+        let defs = extract_definitions(source, Path::new("sample.zig")).unwrap();
+
+        assert_definition(&defs, "std", DefinitionKind::ConstDecl, 1, 1, None);
+        assert_definition(&defs, "MAX", DefinitionKind::ConstDecl, 3, 3, None);
+        assert_definition(&defs, "counter", DefinitionKind::ConstDecl, 4, 4, None);
+        assert_definition(&defs, "add", DefinitionKind::Function, 6, 9, None);
+        assert_definition(&defs, "Point", DefinitionKind::Type, 11, 17, None);
+        assert_definition(&defs, "dist", DefinitionKind::Function, 13, 16, Some("Point"));
+        assert_definition(&defs, "Color", DefinitionKind::EnumDef, 19, 19, None);
+        assert_definition(&defs, "Shape", DefinitionKind::Type, 21, 21, None);
+        assert_definition(&defs, "Handle", DefinitionKind::Type, 23, 25, None);
+        assert_definition(&defs, "get", DefinitionKind::Function, 24, 24, Some("Handle"));
+        assert_definition(
+            &defs,
+            "test:\"addition works\"",
+            DefinitionKind::Function,
+            27,
+            30,
+            None,
+        );
+
+        // Function-body / method-body / test-body locals must never surface as
+        // symbols — they are `variable_declaration`s at non-container scope.
+        for leaked in ["local", "scale", "r"] {
+            assert!(
+                !defs.iter().any(|d| d.name == leaked),
+                "local {leaked:?} leaked as a symbol: {defs:?}"
+            );
+        }
     }
 
     fn assert_definition(

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -128,6 +128,9 @@ fn is_test_function(name: &str, lang: Language) -> bool {
             name.starts_with("test") || name.starts_with("it") || name.starts_with("describe")
         }
         Language::Go => name.starts_with("Test"),
+        // Zig `test "…"` / `test Name` blocks are extracted as functions named
+        // `test:"…"` / `test:Name` by the symbol resolver.
+        Language::Zig => name.starts_with("test:"),
         _ => false,
     }
 }


### PR DESCRIPTION
Closes #1068.

## Why
ghostty (a major real-world git-lane import target) is mostly Zig. Before this, `.zig` resolved to `Language::Unknown`, so those files got no symbols, no semantic-diff function events, no hot-spots, and only an `Opaque` node in the merkle semantic index (#1067). This adds a real Zig parser so ghostty's code parses.

## tree-sitter-zig version chosen: `1.1.2`
Picked because it matches the ABI of the workspace's other grammars: it declares `tree-sitter-language ^0.1` as a **normal** dependency (the shared `LanguageFn` ABI crate, resolved to 0.1.7 here) with `tree-sitter` only as a **dev** dependency — identical to `tree-sitter-c`/`-go`/`-rust`. So `tree_sitter_zig::LANGUAGE.into()` produces a `tree_sitter::Language` under the workspace's `tree-sitter` 0.26 with no ABI mismatch. Earlier 1.0.x pin `tree-sitter ^0.23`; 1.1.2 is the latest and cleanest match. Grammar version recorded as `tree-sitter-zig@1.1`.

## What
- New `lang-zig` feature (added to `extended-languages`); `tree-sitter-zig` workspace dep.
- `Language::Zig` + `.zig` in `from_path` + `parser()` under `#[cfg(feature = "lang-zig")]`; stable snake_case name `"zig"` in `language_name`/`grammar_version`/`grammar_version_by_name`.
- Extraction covers **both** the symbol taxonomy (`visit_definitions`) and the semantic-diff `FunctionDef` path (`SyntaxIndex`/`is_function_kind`):
  - `fn` → `Function` (reuses the shared `function_declaration` arm, whose `name` field Zig populates).
  - `const Name = struct|union|opaque {…}` → `Type`, `enum {…}` → `EnumDef`, with members walked under `container_path = [Name]`.
  - `test "name" {…}` → `Function` named `test:"name"` (also recognised by `test_reachability::is_test_function`).
  - top-level `const`/`var` → `ConstDecl`. Zig reuses `const`/`var` for locals, so bare bindings are gated to **container scope** (file root / struct / union / enum / opaque body) — function-body locals never leak as symbols.
  - Node kind names were verified against tree-sitter-zig's actual grammar via a parse-tree probe, not guessed (`function_declaration`, `variable_declaration`, `struct_declaration`, `enum_declaration`, `union_declaration`, `opaque_declaration`, `test_declaration`).
- Wired `semantic/lang-zig` into repo's `tree-sitter-symbols` feature so the index builder actually parses Zig during imports.

## Deferred (named in-issue + code comments, not implemented)
`comptime`-generated declarations (their tokens still land in the file scaffold hash — deterministic, just not symbol-granular), `usingnamespace`, and inline-for generated decls. The Zig merge-driver falls back to line-level merge (`rules_for` → `None`).

## Extracted-symbol test results
`extract_definitions_reports_zig_taxonomy_parents_and_ranges` (passing) on a fixture with import/const/var/fn/struct+method/enum/union/opaque+method/test asserts:

| symbol | kind | container_path |
|---|---|---|
| `std`, `MAX`, `counter` | ConstDecl | — |
| `add` | Function | — |
| `Point` | Type | — |
| `dist` | Function | `[Point]` |
| `Color` | EnumDef | — |
| `Shape` (union) | Type | — |
| `Handle` (opaque) | Type | — |
| `get` | Function | `[Handle]` |
| `test:"addition works"` | Function | — |

and asserts the body locals `local`/`scale`/`r` do **not** appear. A Zig `fn` parameter change produces a `SignatureChanged` event (`test_detect_zig_signature_change`).

## Zig blob → real index node, reformat-stable digest
- `zig_blob_extracts_real_symbols_with_hashes`: a `.zig` blob yields a real file node (language `"zig"`, symbols with non-degenerate per-symbol `semantic_hash`es), not `Opaque`.
- `zig_reformat_leaves_semantic_digest_stable` (semantic) + `zig_file_indexes_to_real_node_and_reformat_is_digest_stable` (repo, end-to-end through capture): reformatting + comment edits move the storage hash but leave the `semantic_digest` byte-identical, and `semantic_changed` prunes the reformat.

## Verification (foreground)
- `cargo build -p heddle-semantic --features lang-zig` ✅ and `--features extended-languages` ✅
- `cargo clippy -p heddle-semantic --features extended-languages --all-targets -- -D warnings` ✅ clean
- `cargo test -p heddle-semantic --features extended-languages` ✅ 303 passed
- `cargo test -p heddle-repo --features semantic` ✅ 613 passed (incl. the Zig index test)
- `cargo test -p heddle-objects --features memory-backend` ✅ 431 passed
- default `cargo build -p heddle-semantic` (no Zig) ✅ still builds

## Known limitation
Empty `opaque {}` parses with an error node in this grammar (`opaque { … }` with a body is fine), so a file containing an empty opaque marker falls back to a graceful `Opaque` index node. This is a grammar-level quirk, out of scope to fix here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787118338&installation_id=132405951&pr_number=1077&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1077&signature=f0c624d43cdc922dd4941fd7ada11d4e54c17d973237cdc9baebea4867a7cdaf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->