### PR TITLE
feat(repo): read-only, never-compute semantic-index query API (#1078)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "futures",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "libc",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "base32",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2083,14 +2083,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.2"
+version = "0.10.3"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.10.2",
+  "schemaVersion": "0.10.3",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.10.2" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.10.3" as const;
 
 export interface AbortSchema {
   action: string;

--- a/crates/objects/src/object/state_attachment.rs
+++ b/crates/objects/src/object/state_attachment.rs
@@ -52,3 +52,94 @@ impl StateAttachment {
         StateAttachmentId::from_hash(ContentHash::compute_typed("state-attachment", &bytes))
     }
 }
+
+#[cfg(test)]
+mod wire_compat_tests {
+    //! Cross-version decode guard for the `SemanticIndex` attachment variant
+    //! (heddle#1067 / heddle#1078).
+    //!
+    //! `StateAttachmentBody` is an externally-tagged rmp-named enum, so a
+    //! `SemanticIndex(hash)` value serializes as a one-key map keyed on the
+    //! variant name. A consumer built before the variant existed (heddle 0.10.2,
+    //! e.g. a `weft` that has not yet bumped its `heddle-objects` pin) has no
+    //! matching arm and therefore CANNOT decode such an attachment. This test
+    //! pins that hazard so the failure mode is a documented regression guard and
+    //! not a field surprise: weft must bump to `=0.10.3` before a heddle release
+    //! ships #1067.
+
+    use chrono::{DateTime, Utc};
+    use serde::Deserialize;
+
+    use super::*;
+    use crate::object::{Attribution, Principal};
+
+    /// A faithful mirror of the **0.10.2** `StateAttachmentBody`, i.e. the arm
+    /// set BEFORE `SemanticIndex` was introduced. This is exactly the shape an
+    /// older consumer's decoder would carry. The payloads exist only to shape
+    /// the decoder — they are never read.
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    enum LegacyBody {
+        Context(ContentHash),
+        RiskSignals(ContentHash),
+        ReviewSignatures(ContentHash),
+        Discussions(ContentHash),
+        StructuredConflicts(ContentHash),
+        Signature(StateSignature),
+    }
+
+    /// A 0.10.2 consumer's `StateAttachment`, structurally identical to the
+    /// current one but with the legacy (SemanticIndex-less) body enum.
+    #[derive(Debug, Deserialize)]
+    #[allow(dead_code)]
+    struct LegacyAttachment {
+        state_id: StateId,
+        body: LegacyBody,
+        attribution: Attribution,
+        created_at: DateTime<Utc>,
+        supersedes: Option<StateAttachmentId>,
+    }
+
+    fn sample(body: StateAttachmentBody) -> StateAttachment {
+        StateAttachment {
+            state_id: StateId::from_bytes([7; 32]),
+            body,
+            attribution: Attribution::human(Principal::new("Test", "test@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        }
+    }
+
+    #[test]
+    fn semantic_index_attachment_is_undecodable_by_0_10_2_consumer() {
+        let attachment = sample(StateAttachmentBody::SemanticIndex(ContentHash::compute(b"root")));
+        let bytes = rmp_serde::to_vec_named(&attachment).expect("encode");
+
+        // A current (0.10.3+) consumer round-trips it cleanly.
+        let current: StateAttachment = rmp_serde::from_slice(&bytes).expect("current decoder");
+        assert_eq!(current, attachment);
+
+        // A 0.10.2 consumer, whose decoder has no `SemanticIndex` arm, MUST
+        // reject it — this is precisely why weft has to bump before a heddle
+        // release ships the SemanticIndex attachment.
+        let legacy: Result<LegacyAttachment, _> = rmp_serde::from_slice(&bytes);
+        assert!(
+            legacy.is_err(),
+            "a 0.10.2 decoder must fail on a SemanticIndex-tagged attachment"
+        );
+    }
+
+    #[test]
+    fn known_variant_still_decodes_on_0_10_2_consumer() {
+        // Control: an attachment kind the 0.10.2 consumer DOES know still
+        // decodes with the legacy enum, so the failure above is specifically the
+        // new variant and not a framing/format mismatch.
+        let attachment = sample(StateAttachmentBody::Context(ContentHash::compute(b"ctx")));
+        let bytes = rmp_serde::to_vec_named(&attachment).expect("encode");
+        let legacy: Result<LegacyAttachment, _> = rmp_serde::from_slice(&bytes);
+        assert!(
+            legacy.is_ok(),
+            "a 0.10.2 decoder must still handle the Context variant it knows"
+        );
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -43,7 +43,12 @@ mod repository_resolve_for_command;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_semantic_index;
 #[cfg(feature = "tree-sitter-symbols")]
-pub use repository_semantic_index::{ParentIndex, SemanticIndexBuilder, SymbolDelta};
+pub use repository_semantic_index::{ParentIndex, SemanticIndexBuilder};
+/// Read-only, never-compute semantic-index query primitives. Always compiled,
+/// with no tree-sitter dependency, so a parse-free consumer can read a
+/// persisted index (heddle#1078).
+mod repository_semantic_query;
+pub use repository_semantic_query::SymbolDelta;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
 mod repository_state_visibility;

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Assembly, capture wiring, backfill and query primitives for the merkle
-//! semantic index (heddle#1067).
+//! Assembly, capture wiring and backfill for the merkle semantic index
+//! (heddle#1067) — the *compute* half, gated behind `tree-sitter-symbols`.
+//!
+//! The parse-free READ half (loading an attached index, resolving symbols,
+//! diffing two states) lives in the always-compiled
+//! [`repository_semantic_query`](crate::repository_semantic_query) module; a
+//! consumer that never parses (e.g. `weft`) links only that. This module owns
+//! everything that can *produce* index nodes: the [`SemanticIndexBuilder`],
+//! capture wiring, backfill, and the get-or-compute + self-heal `semantic_index`
+//! query family (which recomputes on a miss and therefore needs the parser).
 //!
 //! The node types and canonical digest layouts live in `objects`; the AST
 //! extraction lives in `semantic`. This layer mirrors the source blob/tree DAG
@@ -26,8 +34,7 @@ use std::collections::{BTreeMap, HashMap};
 use objects::{
     object::{
         ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot, SemanticTreeEntry,
-        SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry, SymbolKindTag, Tree,
-        TreeEntryTarget,
+        SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry, Tree, TreeEntryTarget,
     },
     store::ObjectStore,
 };
@@ -40,30 +47,13 @@ use semantic::{
 };
 use tracing::warn;
 
-use crate::{HeddleError, Repository, Result, StateAttachmentKind};
+use crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH;
+use crate::{HeddleError, Repository, Result, StateAttachmentKind, SymbolDelta};
 
 /// Source files above this size are recorded as `Opaque` rather than parsed —
 /// generated/vendored blobs dominate parse cost and rarely carry review-worthy
 /// symbols.
 const SEMANTIC_FILE_BUDGET_BYTES: usize = 1 << 20;
-
-/// Recursion ceiling for the merkle tree/dir walkers. Legitimate directory
-/// nesting is far below this; a crafted, pushed `SemanticTreeNode` chain deeper
-/// than this is treated as pathological rather than overflowing the stack
-/// (same hardening class as the AST walkers, heddle#876).
-const MAX_SEMANTIC_TREE_DEPTH: usize = 1024;
-
-/// A single-symbol delta between two states, produced by [`Repository::semantic_diff_symbols`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct SymbolDelta {
-    /// File path + canonical symbol address (`container::name`).
-    pub anchor: SymbolAnchor,
-    pub kind: SymbolKindTag,
-    /// Fingerprint on the `a` side, `None` if the symbol did not exist there.
-    pub old_hash: Option<ContentHash>,
-    /// Fingerprint on the `b` side, `None` if the symbol does not exist there.
-    pub new_hash: Option<ContentHash>,
-}
 
 /// What a built subtree resolved to: the storage hash of the node blob (or the
 /// raw source blob, for opaque entries) plus its reformat-stable digest.
@@ -418,26 +408,6 @@ impl Repository {
         }
     }
 
-    /// Load a state's attached semantic index root, if present AND intact. A
-    /// missing or corrupt root blob (e.g. a partially-replicated push, or GC
-    /// that pruned the sidecar) is treated as ABSENT — `Ok(None)` — so callers
-    /// recompute+supersede instead of erroring forever on the dangling
-    /// attachment.
-    fn load_attached_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
-        let Some(attachment) =
-            self.latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)?
-        else {
-            return Ok(None);
-        };
-        let objects::object::StateAttachmentBody::SemanticIndex(root_hash) = attachment.body else {
-            return Ok(None);
-        };
-        let Some(blob) = self.store().get_blob(&root_hash)? else {
-            return Ok(None);
-        };
-        Ok(SemanticIndexRoot::decode(blob.content()).ok())
-    }
-
     /// Whether an attached root is current: extractor version and every grammar
     /// version match this binary's. A stale root is served as a MISS so a
     /// bump recomputes.
@@ -449,38 +419,11 @@ impl Repository {
                 .all(|(name, version)| grammar_version_by_name(name) == Some(version.as_str()))
     }
 
-    fn load_index_root(&self, root_hash: &ContentHash) -> Result<SemanticIndexRoot> {
-        let blob = self
-            .store()
-            .get_blob(root_hash)?
-            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic index root {root_hash}")))?;
-        SemanticIndexRoot::decode(blob.content())
-            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
-    }
-
-    fn load_semantic_tree(&self, node_hash: &ContentHash) -> Result<SemanticTreeNode> {
-        let blob = self
-            .store()
-            .get_blob(node_hash)?
-            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic tree node {node_hash}")))?;
-        SemanticTreeNode::decode(blob.content())
-            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
-    }
-
-    fn load_semantic_file(&self, node_hash: &ContentHash) -> Result<SemanticFileNode> {
-        let blob = self
-            .store()
-            .get_blob(node_hash)?
-            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic file node {node_hash}")))?;
-        SemanticFileNode::decode(blob.content())
-            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
-    }
-
     /// Materialize a parent state's index for reuse: its source tree + semantic
     /// top node + root. Returns `None` when the parent has no attached index
     /// (caller falls back to a full build).
     fn materialize_parent_index(&self, parent: &State) -> Result<Option<ParentIndex>> {
-        let Some(root) = self.load_attached_index(&parent.id())? else {
+        let Some(root) = self.attached_semantic_index(&parent.id())? else {
             return Ok(None);
         };
         let Some(source_tree) = self.store().get_tree(&parent.tree)? else {
@@ -498,7 +441,7 @@ impl Repository {
     /// attached, returns it; otherwise builds forward from the nearest ancestor
     /// that has an index (reusing it), attaches each, and returns the target's.
     pub fn semantic_index(&self, state_id: &StateId) -> Result<Option<SemanticIndexRoot>> {
-        if let Some(root) = self.load_attached_index(state_id)?
+        if let Some(root) = self.attached_semantic_index(state_id)?
             && self.index_is_current(&root)
         {
             return Ok(Some(root));
@@ -515,7 +458,7 @@ impl Repository {
         let mut base_state: Option<StateId> = None;
         let mut cursor = self.first_parent(state_id)?;
         while let Some(parent_id) = cursor {
-            if self.load_attached_index(&parent_id)?.is_some() {
+            if self.attached_semantic_index(&parent_id)?.is_some() {
                 base_state = Some(parent_id);
                 break;
             }
@@ -643,34 +586,6 @@ impl Repository {
         Ok(file.symbol_by_address(&anchor.symbol).cloned())
     }
 
-    /// Walk the semantic tree to the `File` node for `path`, returning its
-    /// storage hash. `None` if the path is absent or resolves to a dir/opaque.
-    fn resolve_file_node(
-        &self,
-        root: &SemanticIndexRoot,
-        path: &str,
-    ) -> Result<Option<ContentHash>> {
-        let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
-        if components.is_empty() {
-            return Ok(None);
-        }
-        let mut node = self.load_semantic_tree(&root.tree)?;
-        for (i, comp) in components.iter().enumerate() {
-            let Some(entry) = node.get(comp) else {
-                return Ok(None);
-            };
-            let last = i + 1 == components.len();
-            match (last, entry.kind) {
-                (true, SemanticEntryKind::File) => return Ok(Some(entry.node)),
-                (false, SemanticEntryKind::Dir) => {
-                    node = self.load_semantic_tree(&entry.node)?;
-                }
-                _ => return Ok(None),
-            }
-        }
-        Ok(None)
-    }
-
     /// Whether the semantic content under `path_prefix` differs between two
     /// states, compared top-down by digest with identical subtrees pruned.
     /// ZERO source re-parse — only semantic node blobs along the prefix load.
@@ -696,34 +611,6 @@ impl Repository {
         let da = self.digest_at_path(&root_a, path_prefix)?;
         let db = self.digest_at_path(&root_b, path_prefix)?;
         Ok(da != db)
-    }
-
-    /// The reformat-stable digest at `path_prefix` within an index. Empty prefix
-    /// yields the whole-tree digest. Loads only the tree nodes along the path.
-    fn digest_at_path(
-        &self,
-        root: &SemanticIndexRoot,
-        path_prefix: &str,
-    ) -> Result<Option<ContentHash>> {
-        let components: Vec<&str> = path_prefix.split('/').filter(|c| !c.is_empty()).collect();
-        if components.is_empty() {
-            return Ok(Some(root.semantic_digest));
-        }
-        let mut node = self.load_semantic_tree(&root.tree)?;
-        for (i, comp) in components.iter().enumerate() {
-            let Some(entry) = node.get(comp) else {
-                return Ok(None);
-            };
-            let last = i + 1 == components.len();
-            if last {
-                return Ok(Some(entry.semantic_digest));
-            }
-            if entry.kind != SemanticEntryKind::Dir {
-                return Ok(None);
-            }
-            node = self.load_semantic_tree(&entry.node)?;
-        }
-        Ok(None)
     }
 
     /// Symbol-level delta between two states, via a merkle walk that descends
@@ -752,108 +639,6 @@ impl Repository {
         Ok(out)
     }
 
-    fn diff_tree_nodes(
-        &self,
-        a: &SemanticTreeNode,
-        b: &SemanticTreeNode,
-        prefix: &str,
-        depth: usize,
-        out: &mut Vec<SymbolDelta>,
-    ) -> Result<()> {
-        if depth > MAX_SEMANTIC_TREE_DEPTH {
-            return Err(HeddleError::InvalidObject(format!(
-                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
-            )));
-        }
-        let a_by_name: HashMap<&str, &SemanticTreeEntry> =
-            a.entries.iter().map(|e| (e.name.as_str(), e)).collect();
-        let b_by_name: HashMap<&str, &SemanticTreeEntry> =
-            b.entries.iter().map(|e| (e.name.as_str(), e)).collect();
-
-        for entry_a in &a.entries {
-            let path = join_path(prefix, &entry_a.name);
-            match b_by_name.get(entry_a.name.as_str()) {
-                None => self.emit_side(entry_a, &path, Side::Removed, depth, out)?,
-                Some(entry_b) => {
-                    if entry_a.semantic_digest == entry_b.semantic_digest {
-                        continue; // pruned — identical subtree/file.
-                    }
-                    match (entry_a.kind, entry_b.kind) {
-                        (SemanticEntryKind::Dir, SemanticEntryKind::Dir) => {
-                            let child_a = self.load_semantic_tree(&entry_a.node)?;
-                            let child_b = self.load_semantic_tree(&entry_b.node)?;
-                            self.diff_tree_nodes(&child_a, &child_b, &path, depth + 1, out)?;
-                        }
-                        (SemanticEntryKind::File, SemanticEntryKind::File) => {
-                            let file_a = self.load_semantic_file(&entry_a.node)?;
-                            let file_b = self.load_semantic_file(&entry_b.node)?;
-                            diff_file_symbols(&file_a, &file_b, &path, out);
-                        }
-                        // Kind flipped (file↔dir↔opaque): a full replace.
-                        _ => {
-                            self.emit_side(entry_a, &path, Side::Removed, depth, out)?;
-                            self.emit_side(entry_b, &path, Side::Added, depth, out)?;
-                        }
-                    }
-                }
-            }
-        }
-        // Names only on the b side are additions.
-        for entry_b in &b.entries {
-            if !a_by_name.contains_key(entry_b.name.as_str()) {
-                let path = join_path(prefix, &entry_b.name);
-                self.emit_side(entry_b, &path, Side::Added, depth, out)?;
-            }
-        }
-        Ok(())
-    }
-
-    /// Emit every symbol of a single-sided entry (whole file/subtree added or
-    /// removed). Opaque entries carry no symbols.
-    fn emit_side(
-        &self,
-        entry: &SemanticTreeEntry,
-        path: &str,
-        side: Side,
-        depth: usize,
-        out: &mut Vec<SymbolDelta>,
-    ) -> Result<()> {
-        if depth > MAX_SEMANTIC_TREE_DEPTH {
-            return Err(HeddleError::InvalidObject(format!(
-                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
-            )));
-        }
-        match entry.kind {
-            SemanticEntryKind::File => {
-                let file = self.load_semantic_file(&entry.node)?;
-                for sym in &file.symbols {
-                    out.push(side.delta(path, sym));
-                }
-            }
-            SemanticEntryKind::Dir => {
-                let node = self.load_semantic_tree(&entry.node)?;
-                for child in &node.entries {
-                    let child_path = join_path(path, &child.name);
-                    self.emit_side(child, &child_path, side, depth + 1, out)?;
-                }
-            }
-            SemanticEntryKind::Opaque => {}
-        }
-        Ok(())
-    }
-
-    /// Whether the symbol at `anchor` changed between `since` and `at`.
-    pub fn changed_since(
-        &self,
-        anchor: &SymbolAnchor,
-        since: &StateId,
-        at: &StateId,
-    ) -> Result<bool> {
-        let old = self.symbol_hash(since, anchor)?.map(|s| s.semantic_hash);
-        let new = self.symbol_hash(at, anchor)?.map(|s| s.semantic_hash);
-        Ok(old != new)
-    }
-
     /// Lazy backfill: compute-and-attach a semantic index for every state that
     /// lacks one, oldest-first (so parents are reused), restartable across runs
     /// (progress = the last state that gained an attachment). Returns the count
@@ -866,7 +651,7 @@ impl Repository {
         let ordered = self.order_states_oldest_first(states)?;
         let mut count = 0;
         for state_id in ordered {
-            let already = self.load_attached_index(&state_id)?.is_some();
+            let already = self.attached_semantic_index(&state_id)?.is_some();
             if already && !all {
                 continue; // restartable: skip states that already have one.
             }
@@ -920,96 +705,6 @@ impl Repository {
     }
 }
 
-#[derive(Clone, Copy)]
-enum Side {
-    Added,
-    Removed,
-}
-
-impl Side {
-    fn delta(self, path: &str, sym: &SymbolEntry) -> SymbolDelta {
-        let anchor = SymbolAnchor::new(path, sym.address());
-        match self {
-            Side::Added => SymbolDelta {
-                anchor,
-                kind: sym.kind,
-                old_hash: None,
-                new_hash: Some(sym.semantic_hash),
-            },
-            Side::Removed => SymbolDelta {
-                anchor,
-                kind: sym.kind,
-                old_hash: Some(sym.semantic_hash),
-                new_hash: None,
-            },
-        }
-    }
-}
-
-/// The identity a symbol is matched on across two file versions:
-/// `(container_path, name, kind)`. Distinguishes `fn f` in `mod a` from `mod b`,
-/// `fn X` from `struct X`, so the diff never last-wins-collides distinct
-/// symbols into a mislabeled Modified or a silent skip.
-type SymbolKey = (Vec<String>, String, SymbolKindTag);
-
-fn symbol_key(sym: &SymbolEntry) -> SymbolKey {
-    (sym.container_path.clone(), sym.name.clone(), sym.kind)
-}
-
-/// Diff two file nodes by symbol identity (a `(container, name, kind)`
-/// MULTISET), emitting a delta per added/removed/changed symbol. Same-key
-/// entries (e.g. C++ overloads the extractor can't tell apart) are paired
-/// positionally in canonical order; unmatched extras become add/remove.
-/// Unchanged symbols (equal `semantic_hash`) are skipped.
-fn diff_file_symbols(
-    a: &SemanticFileNode,
-    b: &SemanticFileNode,
-    path: &str,
-    out: &mut Vec<SymbolDelta>,
-) {
-    // BTreeMap, not HashMap: the loops below emit into `out`, so key order must
-    // be deterministic — this is a public, determinism-centric API. (The
-    // pre-refactor code iterated `a.symbols` in canonical order; a HashMap here
-    // reintroduced nondeterministic delta ordering.)
-    let mut a_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
-    for sym in &a.symbols {
-        a_by_key.entry(symbol_key(sym)).or_default().push(sym);
-    }
-    let mut b_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
-    for sym in &b.symbols {
-        b_by_key.entry(symbol_key(sym)).or_default().push(sym);
-    }
-
-    for (key, a_syms) in &a_by_key {
-        let b_syms = b_by_key.get(key).map(Vec::as_slice).unwrap_or(&[]);
-        // Symbols arrive in the file node already sorted by
-        // (container, name, kind, span.0), so same-key lists are in a stable
-        // order; pair them positionally.
-        for pair in a_syms.iter().zip(b_syms.iter()) {
-            let (sym_a, sym_b) = pair;
-            if sym_a.semantic_hash != sym_b.semantic_hash {
-                out.push(SymbolDelta {
-                    anchor: SymbolAnchor::new(path, sym_b.address()),
-                    kind: sym_b.kind,
-                    old_hash: Some(sym_a.semantic_hash),
-                    new_hash: Some(sym_b.semantic_hash),
-                });
-            }
-        }
-        // Extra `a` occurrences with no `b` counterpart are removals.
-        for sym_a in a_syms.iter().skip(b_syms.len()) {
-            out.push(Side::Removed.delta(path, sym_a));
-        }
-    }
-    // Keys (or extra occurrences of a key) present only in `b` are additions.
-    for (key, b_syms) in &b_by_key {
-        let a_len = a_by_key.get(key).map(Vec::len).unwrap_or(0);
-        for sym_b in b_syms.iter().skip(a_len) {
-            out.push(Side::Added.delta(path, sym_b));
-        }
-    }
-}
-
 /// A missing (`NotFound`) or corrupt (`InvalidObject`) semantic node — the
 /// recoverable "broken index" class.
 fn is_broken_index_error(err: &HeddleError) -> bool {
@@ -1019,21 +714,13 @@ fn is_broken_index_error(err: &HeddleError) -> bool {
     )
 }
 
-fn join_path(prefix: &str, name: &str) -> String {
-    if prefix.is_empty() {
-        name.to_string()
-    } else {
-        format!("{prefix}/{name}")
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
 
     use chrono::Utc;
     use objects::object::{
-        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, TreeEntry,
+        Attribution, Blob, Principal, StateAttachment, StateAttachmentBody, SymbolKindTag, TreeEntry,
     };
     use tempfile::TempDir;
 

--- a/crates/repo/src/repository_semantic_query.rs
+++ b/crates/repo/src/repository_semantic_query.rs
@@ -1,0 +1,600 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Read-only, never-compute query primitives over the merkle semantic index
+//! (heddle#1067 / heddle#1078).
+//!
+//! This module is **always compiled** — it is deliberately free of any
+//! dependency on `heddle-semantic`/tree-sitter. Every primitive here is a pure
+//! store walk over already-stored, content-addressed semantic nodes; NONE of
+//! them ever parse a source blob or recompute an index. A consumer that never
+//! parses (e.g. `weft`, which must never carry a parser) reads the persisted
+//! index through exactly these entry points.
+//!
+//! The get-or-compute / self-heal / backfill / builder machinery — everything
+//! that can *produce* index nodes — lives in `repository_semantic_index`, gated
+//! behind the `tree-sitter-symbols` feature.
+
+use std::collections::{BTreeMap, HashMap};
+
+use objects::{
+    object::{
+        ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot, SemanticTreeEntry,
+        SemanticTreeNode, StateId, SymbolAnchor, SymbolEntry, SymbolKindTag,
+    },
+    store::ObjectStore,
+};
+
+use crate::{HeddleError, Repository, Result, StateAttachmentKind};
+
+/// Recursion ceiling for the merkle tree/dir walkers. Legitimate directory
+/// nesting is far below this; a crafted, pushed `SemanticTreeNode` chain deeper
+/// than this is treated as pathological rather than overflowing the stack
+/// (same hardening class as the AST walkers, heddle#876). Shared by the
+/// (gated) builder in `repository_semantic_index`.
+pub(crate) const MAX_SEMANTIC_TREE_DEPTH: usize = 1024;
+
+/// A single-symbol delta between two states, produced by
+/// [`Repository::semantic_diff_symbols`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SymbolDelta {
+    /// File path + canonical symbol address (`container::name`).
+    pub anchor: SymbolAnchor,
+    pub kind: SymbolKindTag,
+    /// Fingerprint on the `a` side, `None` if the symbol did not exist there.
+    pub old_hash: Option<ContentHash>,
+    /// Fingerprint on the `b` side, `None` if the symbol does not exist there.
+    pub new_hash: Option<ContentHash>,
+}
+
+impl Repository {
+    /// Load a state's attached semantic index root, if present AND intact —
+    /// **never recomputing**. A missing attachment, a body of another kind, or
+    /// a missing/corrupt root blob (e.g. a partially-replicated push, or GC that
+    /// pruned the sidecar) is reported as ABSENT — `Ok(None)`.
+    ///
+    /// This is the parse-free read entry point: it only ever loads an
+    /// already-stored root. The get-or-compute behaviour (build forward from
+    /// the nearest indexed ancestor) lives in the tree-sitter-gated
+    /// [`Repository::semantic_index`](crate::Repository) and is NOT reachable
+    /// from here.
+    pub fn attached_semantic_index(
+        &self,
+        state_id: &StateId,
+    ) -> Result<Option<SemanticIndexRoot>> {
+        let Some(attachment) =
+            self.latest_state_attachment(state_id, StateAttachmentKind::SemanticIndex)?
+        else {
+            return Ok(None);
+        };
+        let objects::object::StateAttachmentBody::SemanticIndex(root_hash) = attachment.body else {
+            return Ok(None);
+        };
+        let Some(blob) = self.store().get_blob(&root_hash)? else {
+            return Ok(None);
+        };
+        Ok(SemanticIndexRoot::decode(blob.content()).ok())
+    }
+
+    /// Load the per-file semantic node for `path` in a state's attached index —
+    /// a pure store walk to the file node, then the node blob. `Ok(None)` when
+    /// the state has no attached index, or the path is absent / resolves to a
+    /// dir or opaque entry. NEVER parses.
+    pub fn semantic_file_node(
+        &self,
+        state_id: &StateId,
+        path: &str,
+    ) -> Result<Option<SemanticFileNode>> {
+        let Some(root) = self.attached_semantic_index(state_id)? else {
+            return Ok(None);
+        };
+        let Some(node_hash) = self.resolve_file_node(&root, path)? else {
+            return Ok(None);
+        };
+        Ok(Some(self.load_semantic_file(&node_hash)?))
+    }
+
+    /// Whether the symbol at `anchor` changed between `since` and `at`.
+    /// Resolves each side through whichever `symbol_hash` is compiled (the
+    /// never-compute reader without the parser, the get-or-compute reader with
+    /// it).
+    pub fn changed_since(
+        &self,
+        anchor: &SymbolAnchor,
+        since: &StateId,
+        at: &StateId,
+    ) -> Result<bool> {
+        let old = self.symbol_hash(since, anchor)?.map(|s| s.semantic_hash);
+        let new = self.symbol_hash(at, anchor)?.map(|s| s.semantic_hash);
+        Ok(old != new)
+    }
+
+    // ----- never-compute inner walks (shared) -------------------------------
+
+    /// Never-compute `symbol_hash`: resolve an anchor against the state's
+    /// ATTACHED index only. Backs the public `symbol_hash` in the parse-free
+    /// build; the tree-sitter build's `symbol_hash` is get-or-compute instead.
+    #[cfg(not(feature = "tree-sitter-symbols"))]
+    pub(crate) fn symbol_hash_readonly(
+        &self,
+        state_id: &StateId,
+        anchor: &SymbolAnchor,
+    ) -> Result<Option<SymbolEntry>> {
+        let Some(root) = self.attached_semantic_index(state_id)? else {
+            return Ok(None);
+        };
+        let Some(file_node_hash) = self.resolve_file_node(&root, &anchor.file)? else {
+            return Ok(None);
+        };
+        let file = self.load_semantic_file(&file_node_hash)?;
+        Ok(file.symbol_by_address(&anchor.symbol).cloned())
+    }
+
+    /// Never-compute `semantic_changed`: compare the reformat-stable digest at
+    /// `path_prefix` between the two states' ATTACHED indexes.
+    #[cfg(not(feature = "tree-sitter-symbols"))]
+    pub(crate) fn semantic_changed_readonly(
+        &self,
+        a: &StateId,
+        b: &StateId,
+        path_prefix: &str,
+    ) -> Result<bool> {
+        match (
+            self.attached_semantic_index(a)?,
+            self.attached_semantic_index(b)?,
+        ) {
+            (Some(root_a), Some(root_b)) => {
+                let da = self.digest_at_path(&root_a, path_prefix)?;
+                let db = self.digest_at_path(&root_b, path_prefix)?;
+                Ok(da != db)
+            }
+            // A missing index on either side is a difference iff the other exists.
+            (a_opt, b_opt) => Ok(a_opt.is_some() != b_opt.is_some()),
+        }
+    }
+
+    /// Never-compute `semantic_diff_symbols`: merkle-walk the two states'
+    /// ATTACHED indexes, descending only into differing digests.
+    #[cfg(not(feature = "tree-sitter-symbols"))]
+    pub(crate) fn semantic_diff_symbols_readonly(
+        &self,
+        a: &StateId,
+        b: &StateId,
+    ) -> Result<Vec<SymbolDelta>> {
+        let (root_a, root_b) = match (
+            self.attached_semantic_index(a)?,
+            self.attached_semantic_index(b)?,
+        ) {
+            (Some(ra), Some(rb)) => (ra, rb),
+            _ => return Ok(Vec::new()),
+        };
+        if root_a.semantic_digest == root_b.semantic_digest {
+            return Ok(Vec::new());
+        }
+        let node_a = self.load_semantic_tree(&root_a.tree)?;
+        let node_b = self.load_semantic_tree(&root_b.tree)?;
+        let mut out = Vec::new();
+        self.diff_tree_nodes(&node_a, &node_b, "", 0, &mut out)?;
+        Ok(out)
+    }
+
+    // ----- shared node loaders + walkers ------------------------------------
+
+    /// Load and decode an index root blob by hash. Used only by the (gated)
+    /// compute paths that just persisted a root and want it back as a struct;
+    /// the read paths go through [`Repository::attached_semantic_index`].
+    #[cfg(feature = "tree-sitter-symbols")]
+    pub(crate) fn load_index_root(&self, root_hash: &ContentHash) -> Result<SemanticIndexRoot> {
+        let blob = self
+            .store()
+            .get_blob(root_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic index root {root_hash}")))?;
+        SemanticIndexRoot::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    pub(crate) fn load_semantic_tree(&self, node_hash: &ContentHash) -> Result<SemanticTreeNode> {
+        let blob = self
+            .store()
+            .get_blob(node_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic tree node {node_hash}")))?;
+        SemanticTreeNode::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    pub(crate) fn load_semantic_file(&self, node_hash: &ContentHash) -> Result<SemanticFileNode> {
+        let blob = self
+            .store()
+            .get_blob(node_hash)?
+            .ok_or_else(|| crate::HeddleError::NotFound(format!("semantic file node {node_hash}")))?;
+        SemanticFileNode::decode(blob.content())
+            .map_err(|err| crate::HeddleError::InvalidObject(err.to_string()))
+    }
+
+    /// Walk the semantic tree to the `File` node for `path`, returning its
+    /// storage hash. `None` if the path is absent or resolves to a dir/opaque.
+    pub(crate) fn resolve_file_node(
+        &self,
+        root: &SemanticIndexRoot,
+        path: &str,
+    ) -> Result<Option<ContentHash>> {
+        let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+        if components.is_empty() {
+            return Ok(None);
+        }
+        let mut node = self.load_semantic_tree(&root.tree)?;
+        for (i, comp) in components.iter().enumerate() {
+            let Some(entry) = node.get(comp) else {
+                return Ok(None);
+            };
+            let last = i + 1 == components.len();
+            match (last, entry.kind) {
+                (true, SemanticEntryKind::File) => return Ok(Some(entry.node)),
+                (false, SemanticEntryKind::Dir) => {
+                    node = self.load_semantic_tree(&entry.node)?;
+                }
+                _ => return Ok(None),
+            }
+        }
+        Ok(None)
+    }
+
+    /// The reformat-stable digest at `path_prefix` within an index. Empty prefix
+    /// yields the whole-tree digest. Loads only the tree nodes along the path.
+    pub(crate) fn digest_at_path(
+        &self,
+        root: &SemanticIndexRoot,
+        path_prefix: &str,
+    ) -> Result<Option<ContentHash>> {
+        let components: Vec<&str> = path_prefix.split('/').filter(|c| !c.is_empty()).collect();
+        if components.is_empty() {
+            return Ok(Some(root.semantic_digest));
+        }
+        let mut node = self.load_semantic_tree(&root.tree)?;
+        for (i, comp) in components.iter().enumerate() {
+            let Some(entry) = node.get(comp) else {
+                return Ok(None);
+            };
+            let last = i + 1 == components.len();
+            if last {
+                return Ok(Some(entry.semantic_digest));
+            }
+            if entry.kind != SemanticEntryKind::Dir {
+                return Ok(None);
+            }
+            node = self.load_semantic_tree(&entry.node)?;
+        }
+        Ok(None)
+    }
+
+    pub(crate) fn diff_tree_nodes(
+        &self,
+        a: &SemanticTreeNode,
+        b: &SemanticTreeNode,
+        prefix: &str,
+        depth: usize,
+        out: &mut Vec<SymbolDelta>,
+    ) -> Result<()> {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Err(HeddleError::InvalidObject(format!(
+                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
+            )));
+        }
+        let a_by_name: HashMap<&str, &SemanticTreeEntry> =
+            a.entries.iter().map(|e| (e.name.as_str(), e)).collect();
+        let b_by_name: HashMap<&str, &SemanticTreeEntry> =
+            b.entries.iter().map(|e| (e.name.as_str(), e)).collect();
+
+        for entry_a in &a.entries {
+            let path = join_path(prefix, &entry_a.name);
+            match b_by_name.get(entry_a.name.as_str()) {
+                None => self.emit_side(entry_a, &path, Side::Removed, depth, out)?,
+                Some(entry_b) => {
+                    if entry_a.semantic_digest == entry_b.semantic_digest {
+                        continue; // pruned — identical subtree/file.
+                    }
+                    match (entry_a.kind, entry_b.kind) {
+                        (SemanticEntryKind::Dir, SemanticEntryKind::Dir) => {
+                            let child_a = self.load_semantic_tree(&entry_a.node)?;
+                            let child_b = self.load_semantic_tree(&entry_b.node)?;
+                            self.diff_tree_nodes(&child_a, &child_b, &path, depth + 1, out)?;
+                        }
+                        (SemanticEntryKind::File, SemanticEntryKind::File) => {
+                            let file_a = self.load_semantic_file(&entry_a.node)?;
+                            let file_b = self.load_semantic_file(&entry_b.node)?;
+                            diff_file_symbols(&file_a, &file_b, &path, out);
+                        }
+                        // Kind flipped (file↔dir↔opaque): a full replace.
+                        _ => {
+                            self.emit_side(entry_a, &path, Side::Removed, depth, out)?;
+                            self.emit_side(entry_b, &path, Side::Added, depth, out)?;
+                        }
+                    }
+                }
+            }
+        }
+        // Names only on the b side are additions.
+        for entry_b in &b.entries {
+            if !a_by_name.contains_key(entry_b.name.as_str()) {
+                let path = join_path(prefix, &entry_b.name);
+                self.emit_side(entry_b, &path, Side::Added, depth, out)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Emit every symbol of a single-sided entry (whole file/subtree added or
+    /// removed). Opaque entries carry no symbols.
+    pub(crate) fn emit_side(
+        &self,
+        entry: &SemanticTreeEntry,
+        path: &str,
+        side: Side,
+        depth: usize,
+        out: &mut Vec<SymbolDelta>,
+    ) -> Result<()> {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Err(HeddleError::InvalidObject(format!(
+                "semantic diff exceeds max depth {MAX_SEMANTIC_TREE_DEPTH}"
+            )));
+        }
+        match entry.kind {
+            SemanticEntryKind::File => {
+                let file = self.load_semantic_file(&entry.node)?;
+                for sym in &file.symbols {
+                    out.push(side.delta(path, sym));
+                }
+            }
+            SemanticEntryKind::Dir => {
+                let node = self.load_semantic_tree(&entry.node)?;
+                for child in &node.entries {
+                    let child_path = join_path(path, &child.name);
+                    self.emit_side(child, &child_path, side, depth + 1, out)?;
+                }
+            }
+            SemanticEntryKind::Opaque => {}
+        }
+        Ok(())
+    }
+}
+
+/// Never-compute public read methods, compiled when the parser is absent — the
+/// parse-free consumer's (weft's) surface. When `tree-sitter-symbols` is on,
+/// `repository_semantic_index` supplies get-or-compute + self-heal variants of
+/// these same names instead.
+#[cfg(not(feature = "tree-sitter-symbols"))]
+impl Repository {
+    /// Resolve a symbol anchor to its entry in a state's ATTACHED index.
+    pub fn symbol_hash(
+        &self,
+        state_id: &StateId,
+        anchor: &SymbolAnchor,
+    ) -> Result<Option<SymbolEntry>> {
+        self.symbol_hash_readonly(state_id, anchor)
+    }
+
+    /// Whether the semantic content under `path_prefix` differs between two
+    /// states, compared top-down by digest over their ATTACHED indexes.
+    pub fn semantic_changed(&self, a: &StateId, b: &StateId, path_prefix: &str) -> Result<bool> {
+        self.semantic_changed_readonly(a, b, path_prefix)
+    }
+
+    /// Symbol-level delta between two states' ATTACHED indexes.
+    pub fn semantic_diff_symbols(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
+        self.semantic_diff_symbols_readonly(a, b)
+    }
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum Side {
+    Added,
+    Removed,
+}
+
+impl Side {
+    fn delta(self, path: &str, sym: &SymbolEntry) -> SymbolDelta {
+        let anchor = SymbolAnchor::new(path, sym.address());
+        match self {
+            Side::Added => SymbolDelta {
+                anchor,
+                kind: sym.kind,
+                old_hash: None,
+                new_hash: Some(sym.semantic_hash),
+            },
+            Side::Removed => SymbolDelta {
+                anchor,
+                kind: sym.kind,
+                old_hash: Some(sym.semantic_hash),
+                new_hash: None,
+            },
+        }
+    }
+}
+
+/// The identity a symbol is matched on across two file versions:
+/// `(container_path, name, kind)`. Distinguishes `fn f` in `mod a` from `mod b`,
+/// `fn X` from `struct X`, so the diff never last-wins-collides distinct
+/// symbols into a mislabeled Modified or a silent skip.
+type SymbolKey = (Vec<String>, String, SymbolKindTag);
+
+fn symbol_key(sym: &SymbolEntry) -> SymbolKey {
+    (sym.container_path.clone(), sym.name.clone(), sym.kind)
+}
+
+/// Diff two file nodes by symbol identity (a `(container, name, kind)`
+/// MULTISET), emitting a delta per added/removed/changed symbol. Same-key
+/// entries (e.g. C++ overloads the extractor can't tell apart) are paired
+/// positionally in canonical order; unmatched extras become add/remove.
+/// Unchanged symbols (equal `semantic_hash`) are skipped.
+fn diff_file_symbols(
+    a: &SemanticFileNode,
+    b: &SemanticFileNode,
+    path: &str,
+    out: &mut Vec<SymbolDelta>,
+) {
+    // BTreeMap, not HashMap: the loops below emit into `out`, so key order must
+    // be deterministic — this is a public, determinism-centric API. (The
+    // pre-refactor code iterated `a.symbols` in canonical order; a HashMap here
+    // reintroduced nondeterministic delta ordering.)
+    let mut a_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
+    for sym in &a.symbols {
+        a_by_key.entry(symbol_key(sym)).or_default().push(sym);
+    }
+    let mut b_by_key: BTreeMap<SymbolKey, Vec<&SymbolEntry>> = BTreeMap::new();
+    for sym in &b.symbols {
+        b_by_key.entry(symbol_key(sym)).or_default().push(sym);
+    }
+
+    for (key, a_syms) in &a_by_key {
+        let b_syms = b_by_key.get(key).map(Vec::as_slice).unwrap_or(&[]);
+        // Symbols arrive in the file node already sorted by
+        // (container, name, kind, span.0), so same-key lists are in a stable
+        // order; pair them positionally.
+        for pair in a_syms.iter().zip(b_syms.iter()) {
+            let (sym_a, sym_b) = pair;
+            if sym_a.semantic_hash != sym_b.semantic_hash {
+                out.push(SymbolDelta {
+                    anchor: SymbolAnchor::new(path, sym_b.address()),
+                    kind: sym_b.kind,
+                    old_hash: Some(sym_a.semantic_hash),
+                    new_hash: Some(sym_b.semantic_hash),
+                });
+            }
+        }
+        // Extra `a` occurrences with no `b` counterpart are removals.
+        for sym_a in a_syms.iter().skip(b_syms.len()) {
+            out.push(Side::Removed.delta(path, sym_a));
+        }
+    }
+    // Keys (or extra occurrences of a key) present only in `b` are additions.
+    for (key, b_syms) in &b_by_key {
+        let a_len = a_by_key.get(key).map(Vec::len).unwrap_or(0);
+        for sym_b in b_syms.iter().skip(a_len) {
+            out.push(Side::Added.delta(path, sym_b));
+        }
+    }
+}
+
+fn join_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use chrono::Utc;
+    use objects::object::{
+        Attribution, Blob, Principal, State, StateAttachment, StateAttachmentBody,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn repo() -> (TempDir, Repository) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        (temp, repo)
+    }
+
+    fn author() -> Attribution {
+        Attribution::human(Principal::new("Test", "test@example.com"))
+    }
+
+    fn put_encoded(repo: &Repository, bytes: Vec<u8>) -> ContentHash {
+        repo.store().put_blob(&Blob::new(bytes)).unwrap()
+    }
+
+    /// Hand-assemble a one-file semantic index (no parser involved) and attach
+    /// its root to a freshly-put state, returning the state id and the root's
+    /// tree hash.
+    fn attach_handbuilt_index(repo: &Repository) -> (StateId, ContentHash) {
+        let sym = SymbolEntry {
+            name: "foo".to_string(),
+            kind: SymbolKindTag::Function,
+            container_path: vec![],
+            semantic_hash: ContentHash::compute(b"foo-body"),
+            span: (1, 1),
+        };
+        let file_node = SemanticFileNode::new(
+            "rust",
+            "0.24",
+            1,
+            ContentHash::compute(b"src-blob"),
+            ContentHash::compute(b"scaffold"),
+            vec![sym],
+        );
+        let file_hash = put_encoded(repo, file_node.encode().unwrap());
+        let (tree_node, tree_digest) = SemanticTreeNode::new(vec![SemanticTreeEntry {
+            name: "foo.rs".to_string(),
+            kind: SemanticEntryKind::File,
+            node: file_hash,
+            semantic_digest: file_node.semantic_digest,
+        }]);
+        let tree_hash = put_encoded(repo, tree_node.encode().unwrap());
+        let root = SemanticIndexRoot::new(1, BTreeMap::new(), tree_hash, tree_digest);
+        let root_hash = put_encoded(repo, root.encode().unwrap());
+
+        let state = State::new(ContentHash::compute(b"state-tree"), vec![], author());
+        repo.store().put_state(&state).unwrap();
+        let state_id = state.id();
+        repo.put_state_attachment(&StateAttachment {
+            state_id,
+            body: StateAttachmentBody::SemanticIndex(root_hash),
+            attribution: author(),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .unwrap();
+        (state_id, tree_hash)
+    }
+
+    /// `attached_semantic_index` returns `None` for a state with no index
+    /// attachment — and NEVER computes one (there is no parser in this build
+    /// path, and the state's tree hash is dangling).
+    #[test]
+    fn attached_semantic_index_none_without_attachment() {
+        let (_temp, repo) = repo();
+        let state = State::new(ContentHash::compute(b"no-index-tree"), vec![], author());
+        repo.store().put_state(&state).unwrap();
+        assert!(
+            repo.attached_semantic_index(&state.id()).unwrap().is_none(),
+            "a state with no attachment must read as no index, never recompute"
+        );
+    }
+
+    /// `attached_semantic_index` returns the stored root when one is attached,
+    /// and `semantic_file_node` loads a file's symbols by path — both pure
+    /// store walks, no parser.
+    #[test]
+    fn attached_index_and_file_node_load_without_parser() {
+        let (_temp, repo) = repo();
+        let (state_id, tree_hash) = attach_handbuilt_index(&repo);
+
+        let root = repo
+            .attached_semantic_index(&state_id)
+            .unwrap()
+            .expect("attached root must load");
+        assert_eq!(root.tree, tree_hash);
+
+        let file = repo
+            .semantic_file_node(&state_id, "foo.rs")
+            .unwrap()
+            .expect("file node must resolve by path");
+        assert_eq!(file.language, "rust");
+        assert!(
+            file.symbols.iter().any(|s| s.name == "foo"),
+            "hand-built symbol must be present: {:?}",
+            file.symbols
+        );
+
+        // An absent path resolves to None, never an error.
+        assert!(
+            repo.semantic_file_node(&state_id, "missing.rs")
+                .unwrap()
+                .is_none()
+        );
+    }
+}


### PR DESCRIPTION
Closes #1078.

Splits the parse-free READ half of the merkle semantic index (#1067) out of the tree-sitter-gated `repository_semantic_index` so a consumer that must never parse (weft) can read a persisted index without linking heddle-semantic/tree-sitter.

## (a) Read / never-compute split + parser-free feature set
New always-compiled `crates/repo/src/repository_semantic_query.rs` owns the pure store walks:
- `attached_semantic_index(state)` — loads the attached root ONLY; `Ok(None)` on no-attachment / missing-or-corrupt root; NEVER recomputes.
- `semantic_file_node(state, path)` — walks the tree to the file node and loads it; no parse.
- `symbol_hash`, `semantic_changed`, `semantic_diff_symbols`, `changed_since`, plus all shared node loaders / merkle-diff walkers and `SymbolDelta`.

Everything that can *produce* nodes — the `SemanticIndexBuilder`, backfill, `compute_and_persist_semantic_index`, and the get-or-compute + self-heal `semantic_index()` query family — stays behind `tree-sitter-symbols` in `repository_semantic_index`. Under the parser-free build the public `symbol_hash`/`semantic_changed`/`semantic_diff_symbols` resolve through `attached_semantic_index` (load-only); under `tree-sitter-symbols` they keep the existing get-or-compute + self-heal behaviour, so no behaviour changes and every existing golden stays green (incl. `dangling_index_recovers_on_query`).

**Parser-free feature set verified:** the heddle-repo DEFAULT features are `git-overlay, native, zstd` — tree-sitter is NOT default. `cargo build -p heddle-repo` and `cargo clippy -p heddle-repo --all-targets -- -D warnings` compile the read module with zero tree-sitter deps. New unit tests exercise it against a hand-built index (no parser): `attached_semantic_index` returns None with no attachment / the root when present, and `semantic_file_node` loads a file's symbols by path.

## (b) Cross-version decode guard
`crates/objects/src/object/state_attachment.rs` adds `wire_compat_tests`: a `StateAttachmentBody::SemanticIndex` record encoded with `rmp_serde::to_vec_named` is undecodable by a faithful simulated **0.10.2** decoder (an enum lacking the `SemanticIndex` arm), while a `Context` record still decodes. This is the regression guard documenting why weft must bump before a heddle release ships #1067.

## (c) Version bump
Workspace `0.10.2` -> `0.10.3` (inter-crate deps use caret `"0.10"`, no `=` pins to move). Publish is deferred to the coordinator — no `cargo publish`, no tag.

## Verification (foreground)
- `cargo build -p heddle-repo` (default, parser-free) + `-p heddle-objects` + `-p heddle-cli` (end-to-end) — all green.
- `cargo clippy -p heddle-repo --all-targets -- -D warnings` (default) and `--features semantic` — clean; `-p heddle-objects` clean.
- `cargo test -p heddle-repo --features semantic` — 15 semantic goldens + 2 new query tests pass; parser-free `cargo test -p heddle-repo` runs the query tests; `cargo test -p heddle-objects` — cross-version guard passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787121712&installation_id=132405951&pr_number=1079&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1079&signature=67f2037a9115f146f1f6e9cbdf511d93bd92caf7a03f91a27074e22a4fbe2fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->