### PR TITLE
ci(release): make standalone-CLI spctl assessment advisory (fixes v0.10.3 macOS release)

### DIFF
--- a/scripts/build-macos-cask-artifact.sh
+++ b/scripts/build-macos-cask-artifact.sh
@@ -168,9 +168,19 @@ xcrun notarytool submit "$STANDALONE_NOTARY_ZIP" \
   --key-id "$NOTARY_KEY_ID" \
   --issuer "$NOTARY_ISSUER_ID" \
   --wait
+# Notarization is gated authoritatively above by `notarytool submit --wait`
+# (non-zero exit on any status other than Accepted) plus `codesign --verify`.
+# `spctl --assess -t execute` does NOT meaningfully assess *standalone* CLI
+# Mach-O binaries: Gatekeeper reports "the code is valid but does not seem to be
+# an app" for a bare executable regardless of notarization, and its exit code
+# flips across macOS runner-image updates (it passed pre-0.10.3, then began
+# failing exit 3 on the same validly-notarized binaries). Run it for diagnostics
+# only; never gate the release on it.
 for target in aarch64-apple-darwin x86_64-apple-darwin; do
-  spctl -a -vvv -t execute "$REPO_ROOT/target/$target/release/heddle"
-  spctl -a -vvv -t execute "$REPO_ROOT/target/$target/release/heddle-fsmonitor-worker"
+  spctl -a -vvv -t execute "$REPO_ROOT/target/$target/release/heddle" \
+    || echo "note: spctl -t execute is advisory for standalone CLI binaries (see comment above)"
+  spctl -a -vvv -t execute "$REPO_ROOT/target/$target/release/heddle-fsmonitor-worker" \
+    || echo "note: spctl -t execute is advisory for standalone CLI binaries (see comment above)"
 done
 rm -rf "$STANDALONE_NOTARY_DIR"
 


### PR DESCRIPTION
## Problem
The v0.10.3 release (`release.yml` run 29747203762) failed **deterministically** on the macOS cask job — twice. The binary is fine: it's codesigned, and `notarytool submit --wait` returned **status: Accepted**. It dies only on the belt-and-suspenders `spctl -a -vvv -t execute` check on the *standalone* CLI binaries (`scripts/build-macos-cask-artifact.sh:172-173`), which returns `rejected (the code is valid but does not seem to be an app)` / exit 3.

`spctl --assess -t execute` is designed to assess **application bundles**; Gatekeeper reports "does not seem to be an app" for a bare Mach-O executable regardless of notarization, and its exit code shifted across a macOS runner-image bump (this step passed pre-0.10.3). It is not a meaningful notarization signal for a CLI tool.

Because `publish release` and `publish package manifests` (homebrew/scoop/apt) both `needs: build-macos-cask`, this one over-strict check blocked the **entire** release.

## Fix
Make the two standalone-binary `spctl -t execute` calls **advisory** (run for diagnostics, don't gate the release). Notarization remains gated authoritatively by `notarytool submit --wait` (fails on any non-Accepted status) + `codesign --verify --strict`. The app-bundle (`-t install`) and DMG (`-t open`) assessments are unchanged — those are correct for their artifact types.

## Re-release
After merge, v0.10.3 is re-released by moving the tag to this commit (nothing published under v0.10.3 yet — all downstream jobs gate on the macOS cask job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787152655&installation_id=132405951&pr_number=1083&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1083&signature=cf8b2d35f02bfcf42d7c12ed7df1ba787c0b17853c408c69b53c730748b74f16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->