### PR TITLE
H1: lift StateAttachmentKind into objects (heddle#1080)

### DIFF
--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -69,7 +69,9 @@ pub use staleness_core::{
     StalenessStatus, annotation_status_for_source,
     annotation_status_for_source_with_symbol_resolver, extract_line_range, resolve_current_symbol,
 };
-pub use state_attachment::{StateAttachment, StateAttachmentBody, StateAttachmentId};
+pub use state_attachment::{
+    StateAttachment, StateAttachmentBody, StateAttachmentId, StateAttachmentKind,
+};
 pub use state_attribution::{Agent, Attribution, Principal};
 pub use state_context::{
     Annotation, AnnotationKind, AnnotationRevision, AnnotationScope, AnnotationStatus, ContextBlob,

--- a/crates/objects/src/object/state_attachment.rs
+++ b/crates/objects/src/object/state_attachment.rs
@@ -37,6 +37,41 @@ pub enum StateAttachmentBody {
     Signature(StateSignature),
 }
 
+/// The kind of a [`StateAttachmentBody`], with the payload projected away.
+///
+/// Kind is a pure function of the record: [`StateAttachmentBody::kind`] maps a
+/// body to its kind with no I/O and no ambiguity. This is the primitive that
+/// currency (last-attachment-of-a-kind) and supersession (same-kind guard) are
+/// expressed in terms of, and that the wire layer threads through
+/// `wire::ObjectId` (heddle#1080, Fable §B(1)).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum StateAttachmentKind {
+    Context,
+    RiskSignals,
+    ReviewSignatures,
+    Discussions,
+    StructuredConflicts,
+    SemanticIndex,
+    Signature,
+}
+
+impl StateAttachmentBody {
+    /// The [`StateAttachmentKind`] of this body — a pure projection that
+    /// discards the payload. Exhaustive by construction: adding a body variant
+    /// forces a matching kind arm here.
+    pub fn kind(&self) -> StateAttachmentKind {
+        match self {
+            StateAttachmentBody::Context(_) => StateAttachmentKind::Context,
+            StateAttachmentBody::RiskSignals(_) => StateAttachmentKind::RiskSignals,
+            StateAttachmentBody::ReviewSignatures(_) => StateAttachmentKind::ReviewSignatures,
+            StateAttachmentBody::Discussions(_) => StateAttachmentKind::Discussions,
+            StateAttachmentBody::StructuredConflicts(_) => StateAttachmentKind::StructuredConflicts,
+            StateAttachmentBody::SemanticIndex(_) => StateAttachmentKind::SemanticIndex,
+            StateAttachmentBody::Signature(_) => StateAttachmentKind::Signature,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct StateAttachment {
     pub state_id: StateId,

--- a/crates/repo/src/state_attachments.rs
+++ b/crates/repo/src/state_attachments.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use objects::{
-    object::{StateAttachment, StateAttachmentBody, StateAttachmentId, StateId},
+    object::{StateAttachment, StateAttachmentId, StateId},
     store::ObjectStore,
 };
 use oplog::OpLogBackend;
@@ -9,30 +9,10 @@ use refs::RefBackend;
 
 use crate::{HeddleError, Repository, Result};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StateAttachmentKind {
-    Context,
-    RiskSignals,
-    ReviewSignatures,
-    Discussions,
-    StructuredConflicts,
-    SemanticIndex,
-    Signature,
-}
-
-impl StateAttachmentKind {
-    fn of(body: &StateAttachmentBody) -> Self {
-        match body {
-            StateAttachmentBody::Context(_) => Self::Context,
-            StateAttachmentBody::RiskSignals(_) => Self::RiskSignals,
-            StateAttachmentBody::ReviewSignatures(_) => Self::ReviewSignatures,
-            StateAttachmentBody::Discussions(_) => Self::Discussions,
-            StateAttachmentBody::StructuredConflicts(_) => Self::StructuredConflicts,
-            StateAttachmentBody::SemanticIndex(_) => Self::SemanticIndex,
-            StateAttachmentBody::Signature(_) => Self::Signature,
-        }
-    }
-}
+/// The kind of a state attachment, re-exported from the `objects` crate where
+/// it lives as a first-class projection of `StateAttachmentBody` (heddle#1080).
+/// Derive kind from a body with `body.kind()`.
+pub use objects::object::StateAttachmentKind;
 
 impl<R, O, S> Repository<R, O, S>
 where
@@ -49,7 +29,7 @@ where
             let prior = self
                 .get_state_attachment(&attachment.state_id, &prior_id)?
                 .ok_or_else(|| HeddleError::NotFound(format!("state attachment {prior_id}")))?;
-            if StateAttachmentKind::of(&prior.body) != StateAttachmentKind::of(&attachment.body) {
+            if prior.body.kind() != attachment.body.kind() {
                 return Err(HeddleError::InvalidObject(
                     "state attachment can only supersede the same attachment kind".to_string(),
                 ));
@@ -93,7 +73,7 @@ where
         let attachments: Vec<_> = self
             .list_state_attachments(state_id)?
             .into_iter()
-            .filter(|attachment| StateAttachmentKind::of(&attachment.body) == kind)
+            .filter(|attachment| attachment.body.kind() == kind)
             .collect();
         let superseded: std::collections::HashSet<_> = attachments
             .iter()
@@ -109,7 +89,7 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::{Duration, Utc};
-    use objects::object::{Attribution, ContentHash, Principal, StateAttachment};
+    use objects::object::{Attribution, ContentHash, Principal, StateAttachment, StateAttachmentBody};
     use tempfile::TempDir;
 
     use super::*;


### PR DESCRIPTION
Implements **H1 (heddle#1080)**: lift attachment body-kind into the `objects` crate as a first-class property. See Fable §B(1).

## What changed
- **`crates/objects/src/object/state_attachment.rs`**: add `pub enum StateAttachmentKind` — a `#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]` C-like enum, one payload-free variant per `StateAttachmentBody` variant (`Context, RiskSignals, ReviewSignatures, Discussions, StructuredConflicts, SemanticIndex, Signature`). Add `impl StateAttachmentBody { pub fn kind(&self) -> StateAttachmentKind }` — an exhaustive match (no `_ =>`); adding a body variant now forces a matching kind arm.
- **`crates/objects/src/object/mod.rs`**: export `StateAttachmentKind`.
- **`crates/repo/src/state_attachments.rs`**: delete the hand-rolled duplicate `StateAttachmentKind` enum + its `StateAttachmentKind::of(body)` mapping; re-export `objects::object::StateAttachmentKind` instead. Route the two supersession / currency call sites through `body.kind()`. All workspace consumers keep using `repo::StateAttachmentKind` unchanged.

There is now **exactly one** definition of the kind enum in the workspace (in `objects`). Kind is a pure function of the record — the primitive H2 threads through `wire::ObjectId`.

Grepped the workspace: the only hand-rolled kind-mapping was the repo `::of`. Other `StateAttachmentBody::` matches destructure the payload (extract the hash), not derive a kind, so they are untouched. weft was not touched (separate repo).

## Verification (local)
- `cargo build -p heddle-objects -p heddle-repo -p heddle-cli` — clean (exit 0).
- `cargo clippy -p heddle-objects -p heddle-repo` — clean, no warnings (exit 0).
- `cargo test -p heddle-objects -p heddle-repo` — 593 passed, 0 failed across 5 test binaries (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787154672&installation_model_id=21489&pr_number=1084&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1084&signature=ad4a6efc2888f7f2c1aab5b0a4cb9cdc860ca836f33460668df6ae3c07d70c6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->