### PR TITLE
H2: wire ObjectId carries attachment kind + encode/decode ObjectDescriptor.attachment_kind (heddle#1081)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,9 +1662,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-api"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461132b7b20cc2c07c90026fddc4c33e88dd1112c08f5735be6a9d3e64ed8e42"
+checksum = "b57f45d4ba96435f7c027ce96d0f02c1dcf85702e13fe59bf9df577b3e5f45c1"
 dependencies = [
  "bytes",
  "hex",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,7 +40,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
-api = { package = "heddle-api", version = "=0.1.2", features = ["client"] }
+api = { package = "heddle-api", version = "=0.1.3", features = ["client"] }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-core = { path = "../core", version = "0.10", default-features = false }
 heddle-format = { path = "../format", version = "0.10" }

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -172,7 +172,7 @@ impl LocalSync {
     ) -> Result<usize> {
         let mut pending = Vec::new();
         for object in objects {
-            let ObjectId::StateAttachment { state, id } = &object.id else {
+            let ObjectId::StateAttachment { state, id, kind: _ } = &object.id else {
                 return Err(anyhow!(
                     "transfer plan object {:?} has incompatible type {:?}",
                     object.id,

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -656,6 +656,7 @@ fn decode_native_pack(pack_data: &[u8], index_data: &[u8]) -> Vec<ObjectData> {
                     ObjectId::StateAttachment {
                         state: attachment.state_id,
                         id: attachment.id(),
+                        kind: attachment.body.kind(),
                     }
                 }
                 (PackObjectId::Hash(hash), _) => ObjectId::Hash(hash),

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -37,7 +37,7 @@ uuid.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
-grpc = { package = "heddle-api", version = "=0.1.2", features = ["client"] }
+grpc = { package = "heddle-api", version = "=0.1.3", features = ["client"] }
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
@@ -45,7 +45,7 @@ repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-fe
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.10" }
 
 [dev-dependencies]
-grpc = { package = "heddle-api", version = "=0.1.2", features = ["client", "server", "reflection"] }
+grpc = { package = "heddle-api", version = "=0.1.3", features = ["client", "server", "reflection"] }
 prost-reflect.workspace = true
 tempfile.workspace = true
 

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -4,10 +4,10 @@ use base64::Engine as _;
 use cli_shared::ClientConfig;
 use grpc::heddle::api::v1alpha1::{
     HostedGrant, HostedNamespace, HostedRepository, ObjectAvailabilityStatus, ObjectDescriptor,
-    RepositoryRef, StateId as ProtoStateId, TransferCheckpoint, TransportMode,
-    repository_ref::Reference,
+    RepositoryRef, StateAttachmentKind as ProtoStateAttachmentKind, StateId as ProtoStateId,
+    TransferCheckpoint, TransportMode, repository_ref::Reference,
 };
-use objects::object::{ContentHash, StateAttachmentId, StateId};
+use objects::object::{ContentHash, StateAttachmentId, StateAttachmentKind, StateId};
 use tonic::Status;
 use wire::{ObjectId, ObjectInfo, ObjectType, ProtocolError};
 
@@ -48,11 +48,57 @@ impl HostedTransportPolicy {
     }
 }
 
+/// Map a heddle [`StateAttachmentKind`] onto its proto counterpart. Exhaustive
+/// by construction: adding a kind forces an arm here.
+fn attachment_kind_to_proto(kind: StateAttachmentKind) -> ProtoStateAttachmentKind {
+    match kind {
+        StateAttachmentKind::Context => ProtoStateAttachmentKind::Context,
+        StateAttachmentKind::RiskSignals => ProtoStateAttachmentKind::RiskSignals,
+        StateAttachmentKind::ReviewSignatures => ProtoStateAttachmentKind::ReviewSignatures,
+        StateAttachmentKind::Discussions => ProtoStateAttachmentKind::Discussions,
+        StateAttachmentKind::StructuredConflicts => ProtoStateAttachmentKind::StructuredConflicts,
+        StateAttachmentKind::SemanticIndex => ProtoStateAttachmentKind::SemanticIndex,
+        StateAttachmentKind::Signature => ProtoStateAttachmentKind::Signature,
+    }
+}
+
+/// Map a proto attachment kind back onto its heddle counterpart. `Unspecified`
+/// carries no kind (`None`) — a descriptor for an attachment MUST name a
+/// concrete kind, so callers hard-error on `None`. Exhaustive, no `_ =>`.
+fn attachment_kind_from_proto(kind: ProtoStateAttachmentKind) -> Option<StateAttachmentKind> {
+    match kind {
+        ProtoStateAttachmentKind::Unspecified => None,
+        ProtoStateAttachmentKind::Context => Some(StateAttachmentKind::Context),
+        ProtoStateAttachmentKind::RiskSignals => Some(StateAttachmentKind::RiskSignals),
+        ProtoStateAttachmentKind::ReviewSignatures => Some(StateAttachmentKind::ReviewSignatures),
+        ProtoStateAttachmentKind::Discussions => Some(StateAttachmentKind::Discussions),
+        ProtoStateAttachmentKind::StructuredConflicts => {
+            Some(StateAttachmentKind::StructuredConflicts)
+        }
+        ProtoStateAttachmentKind::SemanticIndex => Some(StateAttachmentKind::SemanticIndex),
+        ProtoStateAttachmentKind::Signature => Some(StateAttachmentKind::Signature),
+    }
+}
+
 pub(super) fn parse_descriptor_to_info(
     descriptor: ObjectDescriptor,
 ) -> Result<ObjectInfo, ProtocolError> {
     let obj_type = parse_object_type(&descriptor.object_type)?;
-    let id = parse_object_id(&descriptor.id, obj_type)?;
+    // Resolve the carried attachment kind up front. For an attachment
+    // descriptor this MUST be a concrete kind — an `UNSPECIFIED` (or
+    // unrecognized) value is a hard error, not a silent default.
+    let attachment_kind = if obj_type == ObjectType::StateAttachment {
+        let proto_kind = ProtoStateAttachmentKind::try_from(descriptor.attachment_kind)
+            .unwrap_or(ProtoStateAttachmentKind::Unspecified);
+        Some(attachment_kind_from_proto(proto_kind).ok_or_else(|| {
+            ProtocolError::InvalidState(
+                "state attachment descriptor is missing attachment_kind (UNSPECIFIED)".to_string(),
+            )
+        })?)
+    } else {
+        None
+    };
+    let id = parse_object_id(&descriptor.id, obj_type, attachment_kind)?;
     Ok(ObjectInfo {
         id,
         obj_type,
@@ -77,6 +123,7 @@ pub(super) fn decode_blob_content(
 pub(super) fn parse_object_id(
     value: &str,
     obj_type: ObjectType,
+    attachment_kind: Option<StateAttachmentKind>,
 ) -> Result<ObjectId, ProtocolError> {
     match obj_type {
         // State and its per-state visibility sidecar are both keyed by StateId.
@@ -89,6 +136,14 @@ pub(super) fn parse_object_id(
             let (state, attachment) = value.split_once(':').ok_or_else(|| {
                 ProtocolError::InvalidState("invalid state attachment locator".to_string())
             })?;
+            // An attachment ObjectId is only constructible WITH a kind; the
+            // caller resolves it from the descriptor and hard-errors on
+            // UNSPECIFIED before reaching here.
+            let kind = attachment_kind.ok_or_else(|| {
+                ProtocolError::InvalidState(
+                    "state attachment descriptor is missing attachment_kind".to_string(),
+                )
+            })?;
             Ok(ObjectId::StateAttachment {
                 state: StateId::parse(state)
                     .map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
@@ -96,6 +151,7 @@ pub(super) fn parse_object_id(
                     ContentHash::from_hex(attachment)
                         .map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
                 ),
+                kind,
             })
         }
         ObjectType::Blob | ObjectType::Tree | ObjectType::Action | ObjectType::Redaction => {
@@ -119,17 +175,25 @@ pub(super) fn object_descriptor_with_status(
     availability_status: ObjectAvailabilityStatus,
     availability_note: impl Into<String>,
 ) -> ObjectDescriptor {
+    // Carry the attachment kind for attachment descriptors; every other
+    // object type leaves it UNSPECIFIED. Kind is carried, not keyed — the
+    // dedup key stays `(id, object_type)`.
+    let attachment_kind = match &info.id {
+        ObjectId::StateAttachment { kind, .. } => attachment_kind_to_proto(*kind),
+        ObjectId::Hash(_) | ObjectId::StateId(_) => ProtoStateAttachmentKind::Unspecified,
+    };
     ObjectDescriptor {
         id: match &info.id {
             ObjectId::Hash(hash) => hash.to_hex(),
             ObjectId::StateId(state_id) => state_id.to_string_full(),
-            ObjectId::StateAttachment { state, id } => {
+            ObjectId::StateAttachment { state, id, kind: _ } => {
                 format!("{}:{}", state.to_string_full(), id.as_hash().to_hex())
             }
         },
         object_type: object_type_name(info.obj_type).to_string(),
         availability_status: availability_status as i32,
         availability_note: availability_note.into(),
+        attachment_kind: attachment_kind as i32,
     }
 }
 
@@ -155,7 +219,7 @@ pub(super) fn descriptor_id_from_info(info: &ObjectInfo) -> (String, String) {
     let id = match &info.id {
         ObjectId::Hash(hash) => hash.to_hex(),
         ObjectId::StateId(state_id) => state_id.to_string_full(),
-        ObjectId::StateAttachment { state, id } => {
+        ObjectId::StateAttachment { state, id, kind: _ } => {
             format!("{}:{}", state.to_string_full(), id.as_hash().to_hex())
         }
     };

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -1380,7 +1380,7 @@ fn descriptor_id_from_plan(object: &PlannedObject) -> (String, String) {
     let id = match &object.id {
         wire::ObjectId::Hash(hash) => hash.to_hex(),
         wire::ObjectId::StateId(state_id) => state_id.to_string_full(),
-        wire::ObjectId::StateAttachment { state, id } => {
+        wire::ObjectId::StateAttachment { state, id, kind: _ } => {
             format!("{}:{}", state.to_string_full(), id.as_hash().to_hex())
         }
     };

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
-api = { package = "heddle-api", version = "=0.1.2", features = ["server"] }
+api = { package = "heddle-api", version = "=0.1.3", features = ["server"] }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }

--- a/crates/objects/src/object/state_attachment.rs
+++ b/crates/objects/src/object/state_attachment.rs
@@ -44,7 +44,7 @@ pub enum StateAttachmentBody {
 /// currency (last-attachment-of-a-kind) and supersession (same-kind guard) are
 /// expressed in terms of, and that the wire layer threads through
 /// `wire::ObjectId` (heddle#1080, Fable §B(1)).
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum StateAttachmentKind {
     Context,
     RiskSignals,

--- a/crates/wire/src/object_availability.rs
+++ b/crates/wire/src/object_availability.rs
@@ -19,7 +19,7 @@ pub fn has_object(store: &impl ObjectStore, info: &ObjectInfo) -> Result<bool> {
         (ObjectId::Hash(hash), ObjectType::Blob) => Ok(store.has_blob(hash)?),
         (ObjectId::Hash(hash), ObjectType::Tree) => Ok(store.has_tree(hash)?),
         (ObjectId::StateId(state_id), ObjectType::State) => Ok(store.has_state(state_id)?),
-        (ObjectId::StateAttachment { state, id }, ObjectType::StateAttachment) => {
+        (ObjectId::StateAttachment { state, id, kind: _ }, ObjectType::StateAttachment) => {
             Ok(store.get_state_attachment(state, id)?.is_some())
         }
         // Redactions are keyed by the redacted blob's hash. Two senders

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -4,7 +4,7 @@ use std::collections::{HashSet, VecDeque};
 use objects::{
     object::{
         ContentHash, SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State, StateAttachment,
-        StateAttachmentBody, StateAttachmentId, StateId, TreeEntryTarget,
+        StateAttachmentBody, StateAttachmentId, StateAttachmentKind, StateId, TreeEntryTarget,
     },
     store::{ObjectStore, pack::ObjectType as PackObjectType},
 };
@@ -19,6 +19,12 @@ pub enum ObjectId {
     StateAttachment {
         state: StateId,
         id: StateAttachmentId,
+        /// The attachment's kind, a pure projection of its body
+        /// ([`StateAttachmentBody::kind`]). Carried through the wire so
+        /// descriptors self-describe their kind; the dedup/identity key is
+        /// still `(state, id)`, and kind is coherent under `Eq`/`Hash` because
+        /// it is a deterministic function of the same record.
+        kind: StateAttachmentKind,
     },
 }
 
@@ -615,6 +621,7 @@ fn object_info_from_event(
                 id: ObjectId::StateAttachment {
                     state,
                     id: attachment.id(),
+                    kind: attachment.body.kind(),
                 },
                 obj_type: ObjectType::StateAttachment,
                 size: bytes.len() as u64,
@@ -666,6 +673,7 @@ fn planned_object_from_event(
             id: ObjectId::StateAttachment {
                 state,
                 id: attachment.id(),
+                kind: attachment.body.kind(),
             },
             obj_type: ObjectType::StateAttachment,
         })),

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -138,7 +138,7 @@ pub fn load_requested_object(store: &impl ObjectStore, req: &ObjectRequest) -> R
                 .ok_or_else(|| ProtocolError::ObjectNotFound(state_id.to_string()))?;
             (ObjectType::State, rmp_serde::to_vec_named(&state)?)
         }
-        ObjectId::StateAttachment { state, id } => {
+        ObjectId::StateAttachment { state, id, kind: _ } => {
             let attachment = store
                 .get_state_attachment(state, id)?
                 .ok_or_else(|| ProtocolError::ObjectNotFound(id.to_string()))?;
@@ -186,7 +186,7 @@ pub fn load_object_data(
         (ObjectId::StateId(state_id), ObjectType::StateVisibility) => store
             .get_state_visibility_bytes_for_state(state_id)?
             .ok_or_else(|| ProtocolError::ObjectNotFound(state_id.to_string_full()))?,
-        (ObjectId::StateAttachment { state, id }, ObjectType::StateAttachment) => {
+        (ObjectId::StateAttachment { state, id, kind: _ }, ObjectType::StateAttachment) => {
             let attachment = store
                 .get_state_attachment(state, id)?
                 .ok_or_else(|| ProtocolError::ObjectNotFound(id.to_string()))?;
@@ -234,12 +234,22 @@ pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Res
             }
             store.put_state_serialized(&data.data, *state_id)?;
         }
-        (ObjectId::StateAttachment { state, id }, ObjectType::StateAttachment) => {
+        (ObjectId::StateAttachment { state, id, kind }, ObjectType::StateAttachment) => {
             let attachment: objects::object::StateAttachment = rmp_serde::from_slice(&data.data)?;
             if attachment.state_id != *state || attachment.id() != *id {
                 return Err(ProtocolError::InvalidState(
                     "state attachment id mismatch".to_string(),
                 ));
+            }
+            // The descriptor's carried kind must agree with the decoded body's
+            // kind — kind is a pure projection of the record, so a divergence
+            // means the descriptor and the bytes disagree about what this
+            // attachment is. Refuse rather than silently trust either side.
+            let body_kind = attachment.body.kind();
+            if *kind != body_kind {
+                return Err(ProtocolError::InvalidState(format!(
+                    "state attachment kind mismatch: descriptor {kind:?}, body {body_kind:?}"
+                )));
             }
             store.put_state_attachment(&attachment)?;
         }
@@ -560,6 +570,7 @@ mod tests {
         let id = ObjectId::StateAttachment {
             state: state.id(),
             id: attachment.id(),
+            kind: attachment.body.kind(),
         };
         let data = load_object_data(&source, &id, ObjectType::StateAttachment).unwrap();
         store_received_object(&dest, &data).unwrap();


### PR DESCRIPTION
Implements **H2 (heddle#1081)** — thread the attachment body-kind through the sync wire (Fable §B(2-3)). Follows H1 (#1084), which lifted `StateAttachmentKind` into `objects`.

## Changes
- **heddle-api pin `=0.1.2` → `=0.1.3`** in `crates/cli`, `crates/client` (x2), `crates/daemon` — 0.1.3 adds `ObjectDescriptor.attachment_kind` (proto enum `StateAttachmentKind`). `Cargo.lock` updated to 0.1.3.
- **`wire::ObjectId::StateAttachment`** now carries `kind: StateAttachmentKind` — constructible only WITH a kind (no `Option`). Kind is a pure projection of the record (`body.kind()`), so `Eq`/`Hash` stay coherent; the identity/dedup key stays `(state, id)`. Every construction/match site across the workspace updated (kind sourced from `body.kind()` at construction).
- **Encode/decode `ObjectDescriptor.attachment_kind`** (`crates/client/src/grpc_hosted/helpers.rs`): `object_descriptor_with_status` emits `attachment_kind` for attachment descriptors (UNSPECIFIED otherwise); `parse_descriptor_to_info` **hard-errors** when an attachment descriptor's `attachment_kind == UNSPECIFIED`. One exhaustive two-way heddle↔proto kind map (no `_ =>`). Descriptor matching key stays `(id, object_type)` — kind is carried, not keyed.
- **Install consistency** (`crates/wire/src/object_transfer.rs`): asserts the descriptor's kind == the decoded body's `kind()`; mismatch is a hard error.
- `StateAttachmentKind` gains `Serialize`/`Deserialize` (`ObjectId` is serialized).

Does not touch weft (W2/W3).

## Verification
- `cargo build -p heddle-wire -p heddle-client -p heddle-cli -p heddle-daemon` — clean
- `cargo clippy -p heddle-wire -p heddle-client -p heddle-objects` — clean
- `cargo test -p heddle-wire` — 53 passed; `-p heddle-client` — 176 passed; `-p heddle-objects` — 433 passed
- `cargo test -p heddle-cli --test performance --no-run` — compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1085"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787156318&installation_model_id=21489&pr_number=1085&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1085&signature=a6f649e33d5e975d444f17b51c6bdf688412d9ceaae2297c0a63bef3af46b818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->