### PR TITLE
H3: push attachments via the sidecar lane, keep the push pack forgery-sealed (heddle#1082)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1662,9 +1662,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-api"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b57f45d4ba96435f7c027ce96d0f02c1dcf85702e13fe59bf9df577b3e5f45c1"
+checksum = "a42c0b7c4952bf0d07b335fb1e7904115b33edf565204bba17c3ccd7724b6265"
 dependencies = [
  "bytes",
  "hex",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -40,7 +40,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
-api = { package = "heddle-api", version = "=0.1.3", features = ["client"] }
+api = { package = "heddle-api", version = "=0.1.4", features = ["client"] }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-core = { path = "../core", version = "0.10", default-features = false }
 heddle-format = { path = "../format", version = "0.10" }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -37,7 +37,7 @@ uuid.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
-grpc = { package = "heddle-api", version = "=0.1.3", features = ["client"] }
+grpc = { package = "heddle-api", version = "=0.1.4", features = ["client"] }
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.10" }
@@ -45,7 +45,7 @@ repo = { path = "../repo", package = "heddle-repo", version = "0.10", default-fe
 weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.10" }
 
 [dev-dependencies]
-grpc = { package = "heddle-api", version = "=0.1.3", features = ["client", "server", "reflection"] }
+grpc = { package = "heddle-api", version = "=0.1.4", features = ["client", "server", "reflection"] }
 prost-reflect.workspace = true
 tempfile.workspace = true
 

--- a/crates/client/src/grpc_hosted/helpers.rs
+++ b/crates/client/src/grpc_hosted/helpers.rs
@@ -50,7 +50,7 @@ impl HostedTransportPolicy {
 
 /// Map a heddle [`StateAttachmentKind`] onto its proto counterpart. Exhaustive
 /// by construction: adding a kind forces an arm here.
-fn attachment_kind_to_proto(kind: StateAttachmentKind) -> ProtoStateAttachmentKind {
+pub(super) fn attachment_kind_to_proto(kind: StateAttachmentKind) -> ProtoStateAttachmentKind {
     match kind {
         StateAttachmentKind::Context => ProtoStateAttachmentKind::Context,
         StateAttachmentKind::RiskSignals => ProtoStateAttachmentKind::RiskSignals,

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -13,7 +13,8 @@ use grpc::heddle::api::v1alpha1::{
     GitObjectId as ProtoGitObjectId, GitPackTransfer, GitRefKind as GrpcGitRefKind,
     GitRefUpdateTransfer, ListRefsRequest, ObjectAvailabilityStatus, ObjectDescriptor, PackChunk,
     PackStreamKind, PartialFetchStatus, PullClientFrame, PullRequest, PullServerFrame,
-    PushClientFrame, PushRequest, PushServerFrame, RedactionTransfer, StateVisibilityTransfer,
+    PushClientFrame, PushRequest, PushServerFrame, RedactionTransfer, StateAttachmentTransfer,
+    StateVisibilityTransfer,
     StreamOpeningProof, ThreadConfidenceSummary, ThreadIntegrationPolicy, ThreadMetadata,
     ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects, git_lane_transfer,
     pull_client_frame, pull_server_frame, push_client_frame, push_server_frame,
@@ -1447,37 +1448,36 @@ fn sidecar_push_message(
 /// carry the byte-identical attachment record plus its descriptor kind so the
 /// server can reconstruct and verify it per-kind at finalize (weft W3).
 ///
-/// The on-wire carrier is a pending heddle-api addition: 0.1.3 ships only
-/// `ObjectDescriptor.attachment_kind` (H2), not a `StateAttachmentTransfer`
-/// `PushClientFrame` variant. Until that frame lands together with the weft
-/// accept chokepoint (W3, heddle#1082), this arm assembles the payload and then
-/// fails closed rather than smuggling the record through a frame that means
-/// something else. Deployed servers report attachments "present" on push, so
-/// this arm is unreachable in practice today; the forgery seal (excluding the
-/// record from the push pack) is already in force upstream at the push
-/// partition site.
+/// The carrier is the `StateAttachmentTransfer` `PushClientFrame` variant
+/// (heddle-api 0.1.4): it carries the state id, the attachment id, the
+/// descriptor kind, and the byte-identical attachment record object so the
+/// server can reconstruct and verify it per-kind at finalize (weft W3). The
+/// receiver re-checks that the carried kind agrees with the decoded body (kind
+/// is a pure projection of the record).
 fn state_attachment_push_message(
     repo: &Repository,
     info: wire::ObjectInfo,
-    _client_operation_id: &str,
+    client_operation_id: &str,
 ) -> Result<PushClientFrame, ProtocolError> {
-    let wire::ObjectId::StateAttachment { id, kind, .. } = &info.id else {
+    // Assemble the byte-identical record (rmp-encoded, the same encoding the
+    // pack/pull path uses) before consuming `info.id` for the frame fields.
+    let record = wire::load_object_data(repo.store(), &info.id, ObjectType::StateAttachment)?;
+    let wire::ObjectId::StateAttachment { state, id, kind } = info.id else {
         return Err(ProtocolError::InvalidState(
             "wanted StateAttachment must be keyed by ObjectId::StateAttachment".to_string(),
         ));
     };
-    // Assemble exactly what the server needs to reconstruct + verify the record:
-    // the byte-identical attachment record (rmp-encoded, the same encoding the
-    // pack/pull path uses) keyed by `(state, id, kind)`. The descriptor kind is
-    // a pure projection of the record body; the receiver re-checks that they
-    // agree at finalize (weft W3).
-    let record = wire::load_object_data(repo.store(), &info.id, ObjectType::StateAttachment)?;
-    Err(ProtocolError::InvalidState(format!(
-        "state attachment {id} ({kind:?}, {} record bytes) is ready for the \
-         sidecar lane, but heddle-api 0.1.3 has no StateAttachmentTransfer push \
-         frame; the sidecar send lands with weft W3 (heddle#1082)",
-        record.data.len()
-    )))
+    Ok(PushClientFrame {
+        frame: Some(push_client_frame::Frame::StateAttachment(
+            StateAttachmentTransfer {
+                state_id: super::helpers::proto_state_id(state),
+                attachment_id: id.as_hash().to_hex(),
+                attachment_kind: super::helpers::attachment_kind_to_proto(kind) as i32,
+                attachment_object: record.data,
+            },
+        )),
+        client_operation_id: client_operation_id.to_string(),
+    })
 }
 
 fn state_visibility_push_message(
@@ -4245,23 +4245,32 @@ mod tests {
         assert!(attachment.obj_type.packable_for_pull());
     }
 
-    /// The sidecar arm assembles the byte-identical attachment record (proving
-    /// the frame will carry enough to reconstruct it server-side) and then
-    /// fails closed pending the heddle-api `StateAttachmentTransfer` frame
-    /// (lands with weft W3, heddle#1082).
+    /// The sidecar arm emits a `StateAttachmentTransfer` frame carrying the
+    /// state id, attachment id, descriptor kind, and the byte-identical record
+    /// object so the server can reconstruct + verify it per-kind (weft W3).
     #[test]
-    fn state_attachment_push_message_assembles_record_and_defers_frame() {
+    fn state_attachment_push_message_emits_transfer_frame() {
+        use grpc::heddle::api::v1alpha1::StateAttachmentKind as ProtoStateAttachmentKind;
+
         let (dir, repo) = temp_repo();
-        std::fs::write(dir.path().join("README.md"), "hi\n").unwrap();
+        std::fs::write(dir.path().join("lib.rs"), "pub fn f() {}\n").unwrap();
         let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
 
-        let risk_blob = repo
+        // Build a minimal valid SemanticIndex attachment.
+        let (node, node_digest) = objects::object::SemanticTreeNode::new(Vec::new());
+        let node_hash = repo
             .store()
-            .put_blob(&Blob::from("risk signals"))
-            .expect("put risk blob");
+            .put_blob(&Blob::new(node.encode().unwrap()))
+            .expect("put semantic tree node");
+        let root =
+            objects::object::SemanticIndexRoot::new(1, Default::default(), node_hash, node_digest);
+        let root_hash = repo
+            .store()
+            .put_blob(&Blob::new(root.encode().unwrap()))
+            .expect("put semantic index root");
         let attachment = objects::object::StateAttachment {
             state_id: state.state_id,
-            body: objects::object::StateAttachmentBody::RiskSignals(risk_blob),
+            body: objects::object::StateAttachmentBody::SemanticIndex(root_hash),
             attribution: Attribution::human(Principal::new("H3 Tester", "h3@example.com")),
             created_at: Utc::now(),
             supersedes: None,
@@ -4279,19 +4288,47 @@ mod tests {
             delta_base: None,
         };
 
-        let err = sidecar_push_message(&repo, info, "op-1")
-            .expect_err("attachment sidecar frame is not yet available");
-        let ProtocolError::InvalidState(message) = err else {
-            panic!("expected InvalidState, got {err:?}");
+        let frame = sidecar_push_message(&repo, info, "op-1").expect("emit attachment sidecar frame");
+        assert_eq!(frame.client_operation_id, "op-1");
+        let Some(push_client_frame::Frame::StateAttachment(transfer)) = frame.frame else {
+            panic!("expected a StateAttachmentTransfer frame, got {:?}", frame.frame);
         };
-        assert!(
-            message.contains("StateAttachmentTransfer"),
-            "error must name the pending api frame: {message}"
+        assert_eq!(
+            transfer.state_id,
+            crate::grpc_hosted::helpers::proto_state_id(state.state_id),
+            "frame must carry the attachment's state id",
+        );
+        assert_eq!(
+            transfer.attachment_id,
+            attachment.id().as_hash().to_hex(),
+            "frame must carry the attachment id",
+        );
+        assert_eq!(
+            transfer.attachment_kind,
+            ProtoStateAttachmentKind::SemanticIndex as i32,
+            "frame must carry the descriptor kind",
         );
         assert!(
-            message.contains("record bytes"),
-            "error must confirm the record was assembled: {message}"
+            !transfer.attachment_object.is_empty(),
+            "frame must carry the serialized attachment record",
         );
+        // The carried object bytes are exactly the canonical record encoding
+        // the pack/pull path uses (so the server reconstructs the same record).
+        let canonical = wire::load_object_data(
+            repo.store(),
+            &ObjectId::StateAttachment {
+                state: state.state_id,
+                id: attachment.id(),
+                kind: attachment.body.kind(),
+            },
+            ObjectType::StateAttachment,
+        )
+        .expect("load canonical attachment record");
+        assert_eq!(transfer.attachment_object, canonical.data);
+
+        // Pull direction is unchanged: the record stays packable server->client.
+        assert!(ObjectType::StateAttachment.packable_for_pull());
+        assert!(!ObjectType::StateAttachment.packable_for_push());
     }
 
     #[test]

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -544,11 +544,24 @@ impl HostedGrpcClient {
 
         let wanted_plan = RepositoryTransferPlan::from_object_infos(wanted_infos, git_lane_intent);
 
-        if !wanted_plan.partitions.packable_objects.is_empty() {
+        // H3 (heddle#1082): keep the push pack forgery-sealed. `StateAttachment`
+        // records are content-addressed and ride the pull pack server->client
+        // unchanged, but a deployed server rejects any pack-carried attachment
+        // as a forgery guard (weft#549). Split them out of the pack partition
+        // by push-packability and route them onto the out-of-pack sidecar lane
+        // (the same lane as Redaction / StateVisibility), where the server
+        // verifies them per-kind at finalize.
+        let (pack_objects, push_sidecar_objects): (Vec<_>, Vec<_>) = wanted_plan
+            .partitions
+            .packable_objects
+            .into_iter()
+            .partition(|info| info.obj_type.packable_for_push());
+
+        if !pack_objects.is_empty() {
             send_native_pack_streaming_messages(
                 &tx,
                 repo,
-                &wanted_plan.partitions.packable_objects,
+                &pack_objects,
                 PushWireIdentities {
                     transfer_id: &transfer_id,
                     client_operation_id: operation_id.as_str(),
@@ -560,7 +573,12 @@ impl HostedGrpcClient {
             .await?;
         }
 
-        for info in wanted_plan.partitions.sidecar_objects {
+        for info in wanted_plan
+            .partitions
+            .sidecar_objects
+            .into_iter()
+            .chain(push_sidecar_objects)
+        {
             let message = sidecar_push_message(repo, info, operation_id.as_str())?;
             tx.send(message).await.map_err(|_| {
                 ProtocolError::InvalidState("push stream closed unexpectedly".to_string())
@@ -1410,10 +1428,56 @@ fn sidecar_push_message(
         ObjectType::StateVisibility => {
             state_visibility_push_message(repo, info, client_operation_id)
         }
+        ObjectType::StateAttachment => {
+            state_attachment_push_message(repo, info, client_operation_id)
+        }
         obj_type => Err(ProtocolError::InvalidState(format!(
             "{obj_type:?} is not an out-of-pack sidecar object"
         ))),
     }
+}
+
+/// Out-of-pack **push** transport for a `StateAttachment` record (H3,
+/// heddle#1082).
+///
+/// Attachments are content-addressed and ride the pull pack server->client
+/// unchanged, but a deployed server rejects any pack-carried attachment as a
+/// forgery guard (weft#549). On push they therefore travel the sidecar lane
+/// (the same lane as `Redaction` / `StateVisibility`). The sidecar frame must
+/// carry the byte-identical attachment record plus its descriptor kind so the
+/// server can reconstruct and verify it per-kind at finalize (weft W3).
+///
+/// The on-wire carrier is a pending heddle-api addition: 0.1.3 ships only
+/// `ObjectDescriptor.attachment_kind` (H2), not a `StateAttachmentTransfer`
+/// `PushClientFrame` variant. Until that frame lands together with the weft
+/// accept chokepoint (W3, heddle#1082), this arm assembles the payload and then
+/// fails closed rather than smuggling the record through a frame that means
+/// something else. Deployed servers report attachments "present" on push, so
+/// this arm is unreachable in practice today; the forgery seal (excluding the
+/// record from the push pack) is already in force upstream at the push
+/// partition site.
+fn state_attachment_push_message(
+    repo: &Repository,
+    info: wire::ObjectInfo,
+    _client_operation_id: &str,
+) -> Result<PushClientFrame, ProtocolError> {
+    let wire::ObjectId::StateAttachment { id, kind, .. } = &info.id else {
+        return Err(ProtocolError::InvalidState(
+            "wanted StateAttachment must be keyed by ObjectId::StateAttachment".to_string(),
+        ));
+    };
+    // Assemble exactly what the server needs to reconstruct + verify the record:
+    // the byte-identical attachment record (rmp-encoded, the same encoding the
+    // pack/pull path uses) keyed by `(state, id, kind)`. The descriptor kind is
+    // a pure projection of the record body; the receiver re-checks that they
+    // agree at finalize (weft W3).
+    let record = wire::load_object_data(repo.store(), &info.id, ObjectType::StateAttachment)?;
+    Err(ProtocolError::InvalidState(format!(
+        "state attachment {id} ({kind:?}, {} record bytes) is ready for the \
+         sidecar lane, but heddle-api 0.1.3 has no StateAttachmentTransfer push \
+         frame; the sidecar send lands with weft W3 (heddle#1082)",
+        record.data.len()
+    )))
 }
 
 fn state_visibility_push_message(
@@ -4110,6 +4174,124 @@ mod tests {
                 "{obj_type:?} is excluded from native packs but missing from the out-of-pack transfer partition"
             );
         }
+    }
+
+    fn state_attachment_info(state: StateId) -> ObjectInfo {
+        ObjectInfo {
+            id: ObjectId::StateAttachment {
+                state,
+                id: objects::object::StateAttachmentId::from_hash(ContentHash::from_bytes(
+                    [5u8; 32],
+                )),
+                kind: objects::object::StateAttachmentKind::SemanticIndex,
+            },
+            obj_type: ObjectType::StateAttachment,
+            size: 0,
+            delta_base: None,
+        }
+    }
+
+    /// H3 (heddle#1082): on push the attachment record is split out of the pack
+    /// partition and routed to the sidecar lane, while the pull partition keeps
+    /// carrying it in the pack exactly as before.
+    #[test]
+    fn state_attachment_pushes_via_sidecar_lane_but_pulls_in_pack() {
+        let state = StateId::from_bytes([9u8; 32]);
+        let attachment = state_attachment_info(state);
+
+        // The wire plan is built with pull/general semantics, so the record
+        // lands in `packable_objects` (proving pull carriage is unchanged).
+        let plan = RepositoryTransferPlan::from_object_infos(
+            vec![
+                state_info(state),
+                state_visibility_info(state),
+                attachment.clone(),
+            ],
+            GitLaneTransferIntent::HeddleObjectsOnly,
+        );
+        assert!(
+            plan.partitions
+                .packable_objects
+                .iter()
+                .any(|info| info.obj_type == ObjectType::StateAttachment),
+            "pull plan must keep the attachment record in the pack partition"
+        );
+
+        // The push send site re-partitions `packable_objects` by
+        // push-packability: the attachment moves to the sidecar side, the
+        // state stays in the pack side.
+        let (pack_objects, push_sidecar_objects): (Vec<_>, Vec<_>) = plan
+            .partitions
+            .packable_objects
+            .into_iter()
+            .partition(|info| info.obj_type.packable_for_push());
+        assert!(
+            pack_objects.iter().all(|info| info.obj_type != ObjectType::StateAttachment),
+            "attachment record must never ride the push pack"
+        );
+        assert!(
+            pack_objects.iter().any(|info| info.obj_type == ObjectType::State),
+            "ordinary content-addressed objects still ride the push pack"
+        );
+        assert!(
+            push_sidecar_objects
+                .iter()
+                .any(|info| info.obj_type == ObjectType::StateAttachment),
+            "attachment record must be routed to the sidecar lane on push"
+        );
+
+        // Direction predicates agree with the routing.
+        assert!(!attachment.obj_type.packable_for_push());
+        assert!(attachment.obj_type.packable_for_pull());
+    }
+
+    /// The sidecar arm assembles the byte-identical attachment record (proving
+    /// the frame will carry enough to reconstruct it server-side) and then
+    /// fails closed pending the heddle-api `StateAttachmentTransfer` frame
+    /// (lands with weft W3, heddle#1082).
+    #[test]
+    fn state_attachment_push_message_assembles_record_and_defers_frame() {
+        let (dir, repo) = temp_repo();
+        std::fs::write(dir.path().join("README.md"), "hi\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+
+        let risk_blob = repo
+            .store()
+            .put_blob(&Blob::from("risk signals"))
+            .expect("put risk blob");
+        let attachment = objects::object::StateAttachment {
+            state_id: state.state_id,
+            body: objects::object::StateAttachmentBody::RiskSignals(risk_blob),
+            attribution: Attribution::human(Principal::new("H3 Tester", "h3@example.com")),
+            created_at: Utc::now(),
+            supersedes: None,
+        };
+        repo.put_state_attachment(&attachment).unwrap();
+
+        let info = ObjectInfo {
+            id: ObjectId::StateAttachment {
+                state: state.state_id,
+                id: attachment.id(),
+                kind: attachment.body.kind(),
+            },
+            obj_type: ObjectType::StateAttachment,
+            size: 0,
+            delta_base: None,
+        };
+
+        let err = sidecar_push_message(&repo, info, "op-1")
+            .expect_err("attachment sidecar frame is not yet available");
+        let ProtocolError::InvalidState(message) = err else {
+            panic!("expected InvalidState, got {err:?}");
+        };
+        assert!(
+            message.contains("StateAttachmentTransfer"),
+            "error must name the pending api frame: {message}"
+        );
+        assert!(
+            message.contains("record bytes"),
+            "error must confirm the record was assembled: {message}"
+        );
     }
 
     #[test]

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
-api = { package = "heddle-api", version = "=0.1.3", features = ["server"] }
+api = { package = "heddle-api", version = "=0.1.4", features = ["server"] }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -109,8 +109,41 @@ impl ObjectType {
         }
     }
 
+    /// Whether this object type can ride the content-addressed native pack in
+    /// general (the historical, direction-agnostic predicate). Sidecar records
+    /// (`Redaction`, `StateVisibility`) live outside `.heddle/objects/` and can
+    /// never be packed; everything else can.
+    ///
+    /// Prefer [`ObjectType::packable_for_push`] /
+    /// [`ObjectType::packable_for_pull`] at transfer sites: packability is
+    /// direction-dependent for `StateAttachment` (see those methods). This
+    /// method retains the pull/general semantics so pack construction,
+    /// have-set, and local-copy planners are unchanged.
     pub fn packable(self) -> bool {
         !matches!(self, ObjectType::Redaction | ObjectType::StateVisibility)
+    }
+
+    /// Whether this object type may ride the client→server **push** pack.
+    ///
+    /// `StateAttachment` is deliberately excluded on push even though it is a
+    /// content-addressed object: a deployed server rejects any pack-carried
+    /// attachment as a forgery-prevention measure (weft#549). Pushed
+    /// attachments must instead ride the out-of-pack **sidecar** lane (the same
+    /// lane as `Redaction`/`StateVisibility`), where the server can verify them
+    /// per-kind at finalize while the pack itself stays forgery-sealed. Every
+    /// other type keeps its [`ObjectType::packable`] answer.
+    pub fn packable_for_push(self) -> bool {
+        self.packable() && !matches!(self, ObjectType::StateAttachment)
+    }
+
+    /// Whether this object type may ride the server→client **pull/clone** pack.
+    ///
+    /// Identical to [`ObjectType::packable`]: attachments are carried in the
+    /// pull pack exactly as today. The push/pull split exists solely so the
+    /// push direction can exclude `StateAttachment` without disturbing the
+    /// working pull carriage.
+    pub fn packable_for_pull(self) -> bool {
+        self.packable()
     }
 
     pub fn pack_object_type(self) -> Result<PackObjectType> {
@@ -1710,5 +1743,127 @@ mod tests {
                 "plan closure must include state metadata blob {metadata_hash}"
             );
         }
+    }
+
+    /// The push/pull packability split routes `StateAttachment` off the push
+    /// pack (weft#549 forgery seal) while leaving pull carriage and every other
+    /// type untouched.
+    #[test]
+    fn packable_predicates_split_state_attachment_by_direction() {
+        // Sidecar records are never packable in either direction.
+        for sidecar in [ObjectType::Redaction, ObjectType::StateVisibility] {
+            assert!(!sidecar.packable_for_push(), "{sidecar:?} push");
+            assert!(!sidecar.packable_for_pull(), "{sidecar:?} pull");
+        }
+        // Content-addressed objects ride the pack in both directions.
+        for packable in [
+            ObjectType::Blob,
+            ObjectType::Tree,
+            ObjectType::State,
+            ObjectType::Action,
+        ] {
+            assert!(packable.packable_for_push(), "{packable:?} push");
+            assert!(packable.packable_for_pull(), "{packable:?} pull");
+        }
+        // The attachment record: excluded from the push pack, kept on pull.
+        assert!(!ObjectType::StateAttachment.packable_for_push());
+        assert!(ObjectType::StateAttachment.packable_for_pull());
+    }
+
+    /// A pushed state's semantic-index attachment RECORD must be excluded from
+    /// the push pack (it rides the sidecar lane) while its semantic-index
+    /// content blobs still ride the pack in both directions, and the same
+    /// record stays packable server->client on pull.
+    #[test]
+    fn semantic_index_attachment_excluded_from_push_pack_but_kept_for_pull() {
+        use std::collections::BTreeMap;
+
+        use objects::object::{SemanticIndexRoot, SemanticTreeNode};
+
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("README.md"), "hello\n").unwrap();
+        let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+
+        // Minimal valid semantic-index fixture: an empty tree node under a root.
+        let (node, node_digest) = SemanticTreeNode::new(Vec::new());
+        let node_hash = repo
+            .store()
+            .put_blob(&Blob::new(node.encode().unwrap()))
+            .expect("put semantic tree node");
+        let root = SemanticIndexRoot::new(1, BTreeMap::new(), node_hash, node_digest);
+        let root_hash = repo
+            .store()
+            .put_blob(&Blob::new(root.encode().unwrap()))
+            .expect("put semantic index root");
+        repo.put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::SemanticIndex(root_hash),
+            attribution: test_attribution(),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .unwrap();
+
+        let plan = enumerate_state_closure_plan_with_options(
+            repo.store(),
+            state.state_id,
+            StateClosureOptions::default(),
+        )
+        .unwrap();
+
+        // Every StateAttachment record (at least the semantic index authored
+        // above) is push-excluded and pull-included.
+        let attachments: Vec<_> = plan
+            .iter()
+            .filter(|p| p.obj_type == ObjectType::StateAttachment)
+            .collect();
+        assert!(
+            !attachments.is_empty(),
+            "closure must contain the semantic-index attachment record"
+        );
+        for attachment in &attachments {
+            assert!(matches!(attachment.id, ObjectId::StateAttachment { .. }));
+            // Push: excluded from the pack (sidecar lane). Pull: kept in pack.
+            assert!(
+                !attachment.obj_type.packable_for_push(),
+                "attachment record must be excluded from the push pack"
+            );
+            assert!(
+                attachment.obj_type.packable_for_pull(),
+                "attachment record must stay in the pull pack"
+            );
+        }
+
+        // The semantic-index CONTENT blobs are ordinary content-addressed
+        // objects and still ride the pack in both directions — only the
+        // attachment record is sidecar'd on push.
+        for content in [root_hash, node_hash] {
+            let obj = plan
+                .iter()
+                .find(|p| p.id == ObjectId::Hash(content))
+                .unwrap_or_else(|| panic!("semantic content blob {content} in closure"));
+            assert_eq!(obj.obj_type, ObjectType::Blob);
+            assert!(obj.obj_type.packable_for_push());
+            assert!(obj.obj_type.packable_for_pull());
+        }
+
+        // Partitioning the plan by push-packability puts the record on the
+        // sidecar side and never in the pack side.
+        let (push_pack, push_sidecar): (Vec<_>, Vec<_>) = plan
+            .iter()
+            .partition(|p| p.obj_type.packable_for_push());
+        assert!(
+            push_sidecar
+                .iter()
+                .any(|p| p.obj_type == ObjectType::StateAttachment),
+            "attachment record routed to the push sidecar partition"
+        );
+        assert!(
+            !push_pack
+                .iter()
+                .any(|p| p.obj_type == ObjectType::StateAttachment),
+            "attachment record must not be in the push pack partition"
+        );
     }
 }


### PR DESCRIPTION
Closes #1082. Part of the wire attachment-distribution design (Fable §D, client half). Depends on H2 (#1085); blocks weft W3 (weft#660).

## Problem
On **push**, `ObjectType::packable()` puts `StateAttachment` objects into the content-addressed push pack. A deployed server rejects any pack-carried attachment as an anti-forgery measure (weft#549). We want attachments to ride the out-of-pack **sidecar lane** (the same lane as Redaction / StateVisibility) so the push pack stays forgery-sealed and the server can verify attachments per-kind at finalize.

## Change (heddle client only — weft untouched)
Mechanism: **direction-split predicate + push call-site partition**.

- **wire** (`object_graph.rs`): add `ObjectType::packable_for_push()` (`StateAttachment` → **false**) and `packable_for_pull()` (== `packable()`, attachments kept). `packable()` itself is **unchanged**, so pull carriage, native-pack construction, have-set computation, and local-copy planning are all untouched.
- **client push** (`grpc_hosted/sync.rs`): re-partition the wanted pack objects by `packable_for_push` at the send site — `StateAttachment` records move onto the sidecar loop, every other content-addressed object still rides the pack.
- **`sidecar_push_message`**: add a `StateAttachment` arm that assembles the byte-identical attachment record (via `wire::load_object_data`) so the frame will carry enough to reconstruct + verify it per-kind server-side.

## Pull direction unchanged
Attachments still travel server→client in the **pull/clone pack exactly as today** (`packable_for_pull() == true`). The split exists solely so the push direction can exclude the record without disturbing the working pull carriage. Tests assert both directions.

## Follow-up prerequisite (api frame)
The on-wire carrier frame is a **pending heddle-api addition**: 0.1.3 ships only `ObjectDescriptor.attachment_kind` (H2), **not** a `StateAttachmentTransfer` `PushClientFrame` variant. Until that frame lands together with the weft accept chokepoint (W3, weft#660), the sidecar arm assembles the record and then **fails closed** rather than smuggle it through a mismatched frame. Deployed servers report attachments "present" on push, so this arm is unreachable in practice today — the forgery seal (excluding the record from the push pack) is already in force at the partition site.

## Tests
- `packable_predicates_split_state_attachment_by_direction` — predicate matrix.
- `semantic_index_attachment_excluded_from_push_pack_but_kept_for_pull` — an authored SemanticIndex attachment record is push-excluded / pull-included; its semantic-index content blobs still ride the pack both ways.
- `state_attachment_pushes_via_sidecar_lane_but_pulls_in_pack` — push call-site partition routing.
- `state_attachment_push_message_assembles_record_and_defers_frame` — sidecar arm assembles the record and defers on the pending frame.

`cargo build/clippy/test -p heddle-wire -p heddle-client` (+ `heddle-cli` build) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1086"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787158662&installation_model_id=21489&pr_number=1086&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1086&signature=7132b8c54e30614b106bce2364e388ecdc83e61a6593713b6f355cb179f87558"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->