### PR TITLE
release: bump heddle 0.10.3 → 0.10.4 (publish attachment-distribution crates)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1679,7 +1679,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "heddle-objects",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-client"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "futures",
@@ -1873,7 +1873,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "libc",
@@ -1886,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1936,7 +1936,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -1948,7 +1948,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1979,7 +1979,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "base32",
@@ -2011,7 +2011,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-refs"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "criterion",
@@ -2053,7 +2053,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2083,14 +2083,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2123,7 +2123,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.10.3"
+version = "0.10.4"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "0.10.3",
+  "schemaVersion": "0.10.4",
   "verbs": {
     "abort": {
       "$defs": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -3,7 +3,7 @@
 // (`heddle schemas <verb>` / `crates/cli/src/cli/commands/schemas.rs`).
 // Regenerate with `scripts/gen-ts-types.sh`; a drift test keeps it in sync.
 
-export const HEDDLE_SCHEMA_VERSION = "0.10.3" as const;
+export const HEDDLE_SCHEMA_VERSION = "0.10.4" as const;
 
 export interface AbortSchema {
   action: string;


### PR DESCRIPTION
Crate-only publish. Bumps the workspace version `0.10.3` → `0.10.4` so merging auto-publishes the attachment-distribution crates (objects/wire/client/repo etc. — A1/H1/H2/H3) via `publish-crates.yml`, for **weft** to consume.

## Changes
- `[workspace.package] version` `0.10.3` → `0.10.4` (root `Cargo.toml`). No crate hardcodes its version and there are no `=0.10.3` inter-crate pins, so nothing else needed bumping.
- `Cargo.lock` — all 22 `heddle-*` / `weft-client-shim` entries → `0.10.4`.
- Regenerated npm ts_types/JSON schema via `scripts/gen-ts-types.sh` (embeds `HEDDLE_SCHEMA_VERSION` / `schemaVersion` — the `ts_types_in_sync` drift gate fails if stale, which bit #1079). Diff is version-only.

No code logic changed.

## Do NOT tag
This is a **crate-only** publish. Do **NOT** create a `v0.10.4` binary release tag until weft is redeployed (wire-compat gate) — the binary release is intentionally deferred.

## Verification (local, foreground)
- `cargo build --locked --workspace` — clean.
- `cargo test --locked -p heddle-cli --features git-overlay,native,semantic,zstd --test ts_types_in_sync` — 2 passed.
- Grep-confirmed no stray `0.10.3` in any `Cargo.toml` / `Cargo.lock` / generated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1087"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787161829&installation_model_id=21489&pr_number=1087&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1087&signature=634919e2c21ff9f7a20cd1b99c231a51a6ad913d3bc27cfe731899f25a72e5d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->