### PR TITLE
semantic: iterative merge-driver walks + semantic_diff_with_changes entry point (heddle#1090)

### DIFF
--- a/crates/semantic/src/diff/diff_core.rs
+++ b/crates/semantic/src/diff/diff_core.rs
@@ -193,6 +193,25 @@ pub fn semantic_diff_with_cache<S: ObjectStore + ?Sized>(
     cache: &SemanticParseCache,
 ) -> Result<SemanticDiffResult, anyhow::Error> {
     let file_changes = diff_trees(store, from_tree_hash, to_tree_hash)?;
+    semantic_diff_with_changes(
+        store,
+        from_tree_hash,
+        to_tree_hash,
+        file_changes,
+        options,
+        cache,
+    )
+}
+
+/// Perform semantic diff analysis using a pre-computed file change set.
+pub fn semantic_diff_with_changes<S: ObjectStore + ?Sized>(
+    store: &S,
+    from_tree_hash: &ContentHash,
+    to_tree_hash: &ContentHash,
+    file_changes: FileChangeSet,
+    options: &SemanticDiffOptions,
+    cache: &SemanticParseCache,
+) -> Result<SemanticDiffResult, anyhow::Error> {
     let old_loader = TreeBlobContentLoader::new(store, *from_tree_hash);
     let new_loader = TreeBlobContentLoader::new(store, *to_tree_hash);
     SemanticEngine::new(

--- a/crates/semantic/src/diff/diff_tests.rs
+++ b/crates/semantic/src/diff/diff_tests.rs
@@ -2,14 +2,14 @@
 use std::{collections::BTreeMap, path::Path, process::Command, time::Instant};
 
 use objects::{
-    object::{Blob, ContentHash, SemanticChange, Tree, TreeEntry},
+    object::{Blob, ContentHash, FileChangeSet, SemanticChange, Tree, TreeEntry},
     store::{InMemoryStore, ObjectStore},
 };
 
 use super::{
     SemanticBudget, SemanticCheckStatus, SemanticDiffOptions, SemanticFallbackReason,
     semantic_check_only, semantic_diff, semantic_diff_summary, semantic_diff_with_cache,
-    semantic_diff_worktree_with_cache,
+    semantic_diff_with_changes, semantic_diff_worktree_with_cache,
 };
 use crate::cache::SemanticParseCache;
 
@@ -494,6 +494,38 @@ fn full_diff_parse_cache_only_parses_changed_blobs() {
         stats.stores, 2,
         "semantic diff should parse only old/new changed blobs, not unchanged CAS-identical files: {stats:?}"
     );
+}
+
+#[test]
+fn full_diff_with_changes_uses_the_supplied_file_change_set() {
+    let store = InMemoryStore::new();
+    let from_tree = create_tree(
+        &store,
+        vec![(
+            "changed.rs",
+            create_blob(&store, "fn value() -> i32 { 1 }\n"),
+        )],
+    );
+    let to_tree = create_tree(
+        &store,
+        vec![(
+            "changed.rs",
+            create_blob(&store, "fn value() -> i32 { 2 }\n"),
+        )],
+    );
+
+    let result = semantic_diff_with_changes(
+        &store,
+        &from_tree,
+        &to_tree,
+        FileChangeSet::new(),
+        &SemanticDiffOptions::default(),
+        &SemanticParseCache::default(),
+    )
+    .unwrap_or_else(|err| panic!("full diff with supplied changes should succeed: {err}"));
+
+    assert!(result.file_changes.is_empty());
+    assert!(result.changes.is_empty());
 }
 
 fn assert_language_function_modified(path: &str, old: &str, new: &str, function_name: &str) {

--- a/crates/semantic/src/diff/mod.rs
+++ b/crates/semantic/src/diff/mod.rs
@@ -15,8 +15,8 @@ pub use diff_core::{
     semantic_check_only, semantic_check_only_with_cache, semantic_check_only_worktree,
     semantic_check_only_worktree_with_cache, semantic_diff, semantic_diff_summary,
     semantic_diff_summary_with_cache, semantic_diff_summary_worktree,
-    semantic_diff_summary_worktree_with_cache, semantic_diff_with_cache, semantic_diff_worktree,
-    semantic_diff_worktree_with_cache,
+    semantic_diff_summary_worktree_with_cache, semantic_diff_with_cache,
+    semantic_diff_with_changes, semantic_diff_worktree, semantic_diff_worktree_with_cache,
 };
 pub use diff_options::SemanticDiffOptions;
 pub use diff_types::{

--- a/crates/semantic/src/merge_driver/language_rules.rs
+++ b/crates/semantic/src/merge_driver/language_rules.rs
@@ -1291,34 +1291,29 @@ fn enclosing_template_param_lists(node: Node<'_>, source: &str) -> Vec<Vec<Strin
 /// recognise (e.g. parameter packs of template-template params) so
 /// the caller bails out conservatively and the enclosing
 /// `template_declaration`'s param list is dropped from matching.
-fn template_param_name(source: &str, param: Node<'_>) -> Option<String> {
+fn template_param_name(source: &str, mut param: Node<'_>) -> Option<String> {
     // Template-template parameters wrap the declared name inside a
     // trailing nested declaration node; the leading
     // `template_parameter_list` is the inner-template header (not
     // the parameter name) and must be skipped.
-    if param.kind() == "template_template_parameter_declaration" {
-        let mut cursor = param.walk();
-        let last_decl = param
-            .named_children(&mut cursor)
-            .filter(|c| {
+    while param.kind() == "template_template_parameter_declaration" {
+        param = (0..param.named_child_count())
+            .rev()
+            .filter_map(|i| u32::try_from(i).ok().and_then(|i| param.named_child(i)))
+            .find(|child| {
                 matches!(
-                    c.kind(),
+                    child.kind(),
                     "type_parameter_declaration"
                         | "variadic_type_parameter_declaration"
                         | "template_template_parameter_declaration"
                 )
-            })
-            .last();
-        return last_decl.and_then(|n| template_param_name(source, n));
+            })?;
     }
-    let mut last = None;
-    let mut cursor = param.walk();
-    for child in param.named_children(&mut cursor) {
-        if matches!(child.kind(), "identifier" | "type_identifier") {
-            last = Some(child);
-        }
-    }
-    last.map(|n| strip_whitespace(&source[n.byte_range()]))
+    (0..param.named_child_count())
+        .rev()
+        .filter_map(|i| u32::try_from(i).ok().and_then(|i| param.named_child(i)))
+        .find(|child| matches!(child.kind(), "identifier" | "type_identifier"))
+        .map(|node| strip_whitespace(&source[node.byte_range()]))
 }
 
 /// True iff every named child of `args` (a `template_argument_list`)
@@ -1360,25 +1355,17 @@ fn template_args_match_any_param_list(
 /// usage of an enclosing `class... Ts` reads as a bare parameter
 /// usage of `Ts` — matching the param-list name and letting
 /// `c_function_scope` strip the args (Codex r12 audit pre-fix A).
-fn parameter_usage_arg_name(source: &str, arg: Node<'_>) -> Option<String> {
-    if arg.kind() == "parameter_pack_expansion" {
-        let pattern = arg.child_by_field_name("pattern")?;
-        return parameter_usage_arg_name(source, pattern);
+fn parameter_usage_arg_name(source: &str, mut arg: Node<'_>) -> Option<String> {
+    while arg.kind() == "parameter_pack_expansion" {
+        arg = arg.child_by_field_name("pattern")?;
     }
     if arg.kind() != "type_descriptor" {
         return None;
     }
-    let mut cursor = arg.walk();
-    let mut only: Option<Node<'_>> = None;
-    let mut count = 0usize;
-    for child in arg.named_children(&mut cursor) {
-        count += 1;
-        only = Some(child);
-        if count > 1 {
-            return None;
-        }
+    if arg.named_child_count() != 1 {
+        return None;
     }
-    let only = only?;
+    let only = arg.named_child(0)?;
     if only.kind() != "type_identifier" {
         return None;
     }
@@ -1522,28 +1509,31 @@ fn c_name_bearing_function_declarator(declarator: Node<'_>) -> Option<Node<'_>> 
 /// silently collapse distinctions in rarer shapes (operator overloads
 /// with reference-qualifiers, structured-binding declarators, etc.).
 fn emit_c_declarator_shape(node: Node<'_>, out: &mut String) {
-    match node.kind() {
-        // Name leaves — strip across both named and abstract forms.
-        "identifier" | "field_identifier" | "type_identifier" => {}
-        "pointer_declarator" | "abstract_pointer_declarator" => out.push('*'),
-        "reference_declarator" | "abstract_reference_declarator" => out.push('&'),
-        "array_declarator" | "abstract_array_declarator" => out.push_str("[]"),
-        "function_declarator" | "abstract_function_declarator" => out.push_str("()"),
-        // Pass-through wrappers — no symbol of their own, just recurse.
-        "parenthesized_declarator" | "abstract_parenthesized_declarator" => {}
-        // Unknown shape — include verbatim so we don't lose signal.
-        k => {
-            out.push('<');
-            out.push_str(k);
-            out.push('>');
+    let mut stack = vec![node];
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            // Name leaves — strip across both named and abstract forms.
+            "identifier" | "field_identifier" | "type_identifier" => {}
+            "pointer_declarator" | "abstract_pointer_declarator" => out.push('*'),
+            "reference_declarator" | "abstract_reference_declarator" => out.push('&'),
+            "array_declarator" | "abstract_array_declarator" => out.push_str("[]"),
+            "function_declarator" | "abstract_function_declarator" => out.push_str("()"),
+            // Pass-through wrappers — no symbol of their own.
+            "parenthesized_declarator" | "abstract_parenthesized_declarator" => {}
+            // Unknown shape — include verbatim so we don't lose signal.
+            k => {
+                out.push('<');
+                out.push_str(k);
+                out.push('>');
+            }
         }
-    }
-    // Recurse into NAMED children so identifier leaves can be stripped
-    // by the leaf-clause above. Anonymous punctuation (`*`, `&`, etc.)
-    // is excluded from named-children iteration.
-    let mut cursor = node.walk();
-    for child in node.named_children(&mut cursor) {
-        emit_c_declarator_shape(child, out);
+        // Push in reverse so the LIFO worklist visits named children in
+        // the same pre-order as the former recursive implementation.
+        for i in (0..node.named_child_count()).rev() {
+            if let Some(child) = u32::try_from(i).ok().and_then(|i| node.named_child(i)) {
+                stack.push(child);
+            }
+        }
     }
 }
 
@@ -1703,6 +1693,93 @@ mod tests {
             .iter()
             .map(|r| r.kind)
             .collect()
+    }
+
+    #[cfg(feature = "lang-cpp")]
+    fn first_named_descendant<'tree>(root: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if node.kind() == kind {
+                return Some(node);
+            }
+            for i in (0..node.named_child_count()).rev() {
+                if let Some(child) = u32::try_from(i).ok().and_then(|i| node.named_child(i)) {
+                    stack.push(child);
+                }
+            }
+        }
+        None
+    }
+
+    #[cfg(feature = "lang-cpp")]
+    fn parse_cpp(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_cpp::LANGUAGE.into())
+            .expect("set C++ language");
+        parser.parse(source, None).expect("parse C++ source")
+    }
+
+    #[cfg(feature = "lang-cpp")]
+    #[test]
+    fn deeply_nested_cpp_declarators_templates_and_packs_do_not_stack_overflow() {
+        let depth = 2000usize;
+
+        let declarator_source = format!("void f(int {}value);", "*".repeat(depth));
+        let declarator_tree = parse_cpp(&declarator_source);
+        assert!(!declarator_tree.root_node().has_error());
+
+        let template_source = format!(
+            "{}class T{}> class Holder;",
+            "template<".repeat(depth + 1),
+            "> class T".repeat(depth)
+        );
+        let template_tree = parse_cpp(&template_source);
+        assert!(!template_tree.root_node().has_error());
+
+        let pack_source = format!(
+            "template<class... Ts> struct Holder; Holder<Ts{}> value;",
+            "...".repeat(depth)
+        );
+        let pack_tree = parse_cpp(&pack_source);
+        assert!(!pack_tree.root_node().has_error());
+
+        let handle = std::thread::Builder::new()
+            .stack_size(128 * 1024)
+            .spawn(move || {
+                let parameter =
+                    first_named_descendant(declarator_tree.root_node(), "parameter_declaration")
+                        .expect("deep parameter declaration");
+                let declarator = parameter
+                    .child_by_field_name("declarator")
+                    .expect("deep parameter declarator");
+                let mut shape = String::new();
+                emit_c_declarator_shape(declarator, &mut shape);
+                assert_eq!(shape, "*".repeat(depth));
+
+                let template_param = first_named_descendant(
+                    template_tree.root_node(),
+                    "template_template_parameter_declaration",
+                )
+                .expect("deep template-template parameter");
+                assert_eq!(
+                    template_param_name(&template_source, template_param).as_deref(),
+                    Some("T")
+                );
+
+                let pack =
+                    first_named_descendant(pack_tree.root_node(), "parameter_pack_expansion")
+                        .expect("deep parameter-pack expansion");
+                // Multiple consecutive expansions are parsed as a deep
+                // pack-expansion chain ending in an expression identifier,
+                // so this is intentionally not a bare type parameter usage.
+                assert_eq!(parameter_usage_arg_name(&pack_source, pack), None);
+            })
+            .expect("spawn small-stack thread");
+
+        handle
+            .join()
+            .expect("declarator, template, and parameter-pack helpers must not stack-overflow");
     }
 
     #[test]


### PR DESCRIPTION
Iterative rewrite of the last 3 merge-driver recursions (emission order byte-identical per Fable differential harness across 40+ sources incl. depth-300 nests; 2000-depth 128KB regression test) + new semantic_diff_with_changes entry point (pure insertion, existing APIs unchanged, for weft#699 dedupe). Fable APPROVE (2 non-blocking nits -> heddle#1092). Closes heddle#1090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787450107&installation_model_id=21489&pr_number=1093&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1093&signature=189c30fd77dd17bb09eb212a2a468f1915983caba96a804460033f83bc9f8d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->