### PR TITLE
feat(bridge): detect concurrent git-side branch updates via FailedRefExportReason

### DIFF
--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -182,13 +182,20 @@ fn print_failed_ref_exports(stats: &ExportStats) {
         return;
     }
     println!(
-        "{} {} left as Git has them (heddle did not overwrite them)",
+        "{} {} diverged; left untouched (heddle did not overwrite)",
         style::warn_marker(),
         style::count(stats.failed_refs.len(), "ref"),
     );
     for (name, reason) in &stats.failed_refs {
         println!("  {}: {reason}", style::bold(name));
     }
+}
+
+/// `"1 ref"` / `"2 refs"` without terminal styling -- this text also lands in
+/// JSON error envelopes and logs, where `style::count`'s escapes do not belong.
+fn plain_count(value: usize, noun: &str) -> String {
+    let suffix = if value == 1 { "" } else { "s" };
+    format!("{value} {noun}{suffix}")
 }
 
 /// The error that makes a partially-failed export exit non-zero, or `None`
@@ -206,9 +213,10 @@ fn failed_ref_export_error(stats: &ExportStats) -> Option<anyhow::Error> {
         .iter()
         .map(|(name, _)| name.as_str())
         .collect();
+    let exported = stats.branches.len() + stats.tags.len();
     Some(anyhow!(
-        "exported {} refs, {} diverged (concurrent git-side update): {}",
-        stats.branches.len() + stats.tags.len(),
+        "exported {}, {} diverged (concurrent git-side update): {}",
+        plain_count(exported, "ref"),
         stats.failed_refs.len(),
         names.join(", "),
     ))

--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -11,8 +11,11 @@ use heddle_core::git_projection_io_plan::{
     ExportedRefSummaryFact, export_commits_summary, exported_refs_summary,
 };
 use heddle_git_projection::{
-    GitProjection, git_core::clone_url_to_bare, git_export::export_all,
-    git_ingest::import_git_history, git_util::ExportedRef,
+    GitProjection,
+    git_core::clone_url_to_bare,
+    git_export::export_all,
+    git_ingest::import_git_history,
+    git_util::{ExportStats, ExportedRef},
 };
 use ingest::{ImportOptions, LossyImportEntry};
 use objects::object::{StateId, ThreadName};
@@ -166,6 +169,49 @@ fn exported_refs_summary_for_cli(refs: &[ExportedRef]) -> String {
         })
         .collect();
     exported_refs_summary(&facts)
+}
+
+/// Print the refs an export could NOT publish, one per line with the reason.
+/// No-op for a clean export.
+///
+/// Rendered ALONGSIDE the exported-refs lines, never instead of them
+/// (heddle#261): a partial export still did real work, and an operator who
+/// sees only the failure cannot tell what state the mirror is now in.
+fn print_failed_ref_exports(stats: &ExportStats) {
+    if stats.failed_refs.is_empty() {
+        return;
+    }
+    println!(
+        "{} {} left as Git has them (heddle did not overwrite them)",
+        style::warn_marker(),
+        style::count(stats.failed_refs.len(), "ref"),
+    );
+    for (name, reason) in &stats.failed_refs {
+        println!("  {}: {reason}", style::bold(name));
+    }
+}
+
+/// The error that makes a partially-failed export exit non-zero, or `None`
+/// when every ref was published.
+///
+/// The export itself returns `Ok` -- it deliberately completes every ref it
+/// can before reporting -- so the non-zero exit is applied here, at the command
+/// boundary, once the whole picture is known.
+fn failed_ref_export_error(stats: &ExportStats) -> Option<anyhow::Error> {
+    if stats.failed_refs.is_empty() {
+        return None;
+    }
+    let names: Vec<&str> = stats
+        .failed_refs
+        .iter()
+        .map(|(name, _)| name.as_str())
+        .collect();
+    Some(anyhow!(
+        "exported {} refs, {} diverged (concurrent git-side update): {}",
+        stats.branches.len() + stats.tags.len(),
+        stats.failed_refs.len(),
+        names.join(", "),
+    ))
 }
 
 /// JSON projection of exported refs: `[{"name":..,"tip":<full sha>}]`.
@@ -343,19 +389,25 @@ fn run_git_export(
 ) -> Result<()> {
     let destination = destination.ok_or_else(|| anyhow!(missing_destination_message))?;
     let stats = bridge.export_to_path(&destination)?;
+    let failure = failed_ref_export_error(&stats);
 
     if should_output_json(cli, Some(repo.config())) {
-        let out = serde_json::json!({
-            "output_kind": "export_git",
-            "states_exported": stats.states_exported,
-            "commits_total": stats.commits_total,
-            "threads_synced": stats.threads_synced,
-            "markers_synced": stats.markers_synced,
-            "branches": exported_refs_json(&stats.branches),
-            "tags": exported_refs_json(&stats.tags),
-            "destination": destination.display().to_string(),
-        });
-        println!("{out}");
+        // A partial export leaves through the error envelope below instead, so
+        // a machine consumer is never handed a success payload for a run that
+        // could not publish every ref.
+        if failure.is_none() {
+            let out = serde_json::json!({
+                "output_kind": "export_git",
+                "states_exported": stats.states_exported,
+                "commits_total": stats.commits_total,
+                "threads_synced": stats.threads_synced,
+                "markers_synced": stats.markers_synced,
+                "branches": exported_refs_json(&stats.branches),
+                "tags": exported_refs_json(&stats.tags),
+                "destination": destination.display().to_string(),
+            });
+            println!("{out}");
+        }
     } else {
         println!(
             "{} exported to {}",
@@ -377,8 +429,12 @@ fn run_git_export(
             "  {}",
             style::field("tags", &exported_refs_summary_for_cli(&stats.tags))
         );
+        print_failed_ref_exports(&stats);
     }
-    Ok(())
+    match failure {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -542,11 +598,16 @@ fn run_git_sync(
         recovery_commands: trust.recovery_commands.clone(),
         trust,
     };
+    let failure = failed_ref_export_error(&export_stats);
     if should_output_json(cli, Some(repo.config())) {
-        write_full_command_json(
-            &sync_output,
-            NextActionValidationContext::new(command_path, repo.capability()),
-        )?;
+        // See `run_git_export`: a partial run reports through the error
+        // envelope rather than a success payload.
+        if failure.is_none() {
+            write_full_command_json(
+                &sync_output,
+                NextActionValidationContext::new(command_path, repo.capability()),
+            )?;
+        }
     } else {
         println!("{} synced Git overlay", style::ok_marker());
         println!(
@@ -599,8 +660,12 @@ fn run_git_sync(
             println!();
             print_next(&sync_output.recommended_action);
         }
+        print_failed_ref_exports(&export_stats);
     }
-    Ok(())
+    match failure {
+        Some(err) => Err(err),
+        None => Ok(()),
+    }
 }
 
 #[cfg(feature = "ingest")]

--- a/crates/cli/tests/git_projection_engine_integration.rs
+++ b/crates/cli/tests/git_projection_engine_integration.rs
@@ -8320,3 +8320,201 @@ fn non_utf8_git_fidelity_is_byte_identical_across_bridge_and_ingest() {
         assert!(String::from_utf8(value.clone()).is_err());
     }
 }
+
+/// heddle#261 -- a branch that moved on the GIT side between heddle's last
+/// observation and this export must be DETECTED and REPORTED, and it must not
+/// take the rest of the export down with it.
+///
+/// The hazard: heddle is a git-overlay VCS, so the mirror's `refs/heads/*` can
+/// be moved by anything holding the repo (a `git push`, a `git branch -f`,
+/// another tool). Export projects each thread's tip onto its branch; if the
+/// branch no longer holds what heddle projected from, heddle is about to
+/// publish over a commit it never minted.
+///
+/// The defect this pins: `export_scoped` used `?` on the per-ref sync, so the
+/// FIRST diverged branch aborted the whole run -- every later ref was never
+/// attempted and the operator got one stringly error instead of a complete
+/// succeeded-vs-diverged report. The fix is continue-and-collect.
+///
+/// Setup mirrors two concurrent Git-side writers: `alpha` and `beta` are each
+/// force-moved onto the OTHER line's tip (a real commit heddle minted and still
+/// serves, so the reconcile still routes it through the ref-sync rather than
+/// treating it as an embargo retraction). Neither new tip is an ancestor of the
+/// tip heddle wants to publish, so both lose. `gamma` is untouched and its
+/// heddle thread advances, so it proves the export kept going and still did its
+/// real work.
+#[test]
+fn concurrent_git_side_branch_updates_are_all_collected_and_export_continues() {
+    use heddle_git_projection::git_util::FailedRefExportReason;
+    use objects::object::{Attribution, Principal, State};
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let put_state = |content: &[u8], parents: Vec<StateId>| -> State {
+        let store = repo.store();
+        let blob_hash = store
+            .put_blob(&Blob::from_slice(content))
+            .expect("put blob");
+        let tree_hash = store
+            .put_tree(&Tree::from_entries(vec![
+                TreeEntry::file("file.txt".to_string(), blob_hash, false).expect("tree entry"),
+            ]))
+            .expect("put tree");
+        let state = State::new(
+            tree_hash,
+            parents,
+            Attribution::human(Principal::new("Alice", "alice@example.com")),
+        );
+        store.put_state(&state).expect("put state");
+        state
+    };
+
+    // Three independent lines, one per thread.
+    let alpha_tip = put_state(b"alpha\n", Vec::new());
+    let beta_tip = put_state(b"beta\n", Vec::new());
+    let gamma_root = put_state(b"gamma root\n", Vec::new());
+    for (thread, tip) in [
+        ("alpha", alpha_tip.state_id),
+        ("beta", beta_tip.state_id),
+        ("gamma", gamma_root.state_id),
+    ] {
+        repo.refs()
+            .set_thread(&ThreadName::new(thread), &tip)
+            .expect("set thread");
+    }
+
+    // Run 1 -- publish all three branches cleanly.
+    let mut git_projection = GitProjection::new(&repo);
+    let first = export_all(&mut git_projection).expect("first export");
+    assert!(
+        first.failed_refs.is_empty(),
+        "a clean export must report no failed refs, got {:?}",
+        first.failed_refs
+    );
+    let oid_alpha = test_support::mapping(&git_projection)
+        .get_git(&alpha_tip.state_id)
+        .expect("alpha minted");
+    let oid_beta = test_support::mapping(&git_projection)
+        .get_git(&beta_tip.state_id)
+        .expect("beta minted");
+    let oid_gamma_root = test_support::mapping(&git_projection)
+        .get_git(&gamma_root.state_id)
+        .expect("gamma root minted");
+
+    // TWO concurrent Git-side writers move `alpha` and `beta` out from under
+    // heddle, each onto the other line's tip. Both targets are commits heddle
+    // minted and still serves, so the mirror reconcile classifies each existing
+    // tip as served and routes it to the ref-sync -- the same path a real
+    // concurrent push lands in.
+    {
+        let mirror = test_support::open_git_repo(&git_projection).expect("open mirror");
+        set_reference(
+            &mirror,
+            "refs/heads/alpha",
+            oid_beta,
+            RefPrecondition::Any,
+            "test: concurrent git-side push onto alpha",
+        )
+        .expect("move alpha");
+        set_reference(
+            &mirror,
+            "refs/heads/beta",
+            oid_alpha,
+            RefPrecondition::Any,
+            "test: concurrent git-side push onto beta",
+        )
+        .expect("move beta");
+    }
+
+    // `gamma` legitimately advances on the heddle side, so run 2 has real work
+    // to do on a ref nobody raced.
+    let gamma_tip = put_state(b"gamma tip\n", vec![gamma_root.state_id]);
+    repo.refs()
+        .set_thread(&ThreadName::new("gamma"), &gamma_tip.state_id)
+        .expect("advance gamma");
+
+    // Run 2 -- the export must SUCCEED as an operation while reporting both
+    // diverged refs. Halting on the first one is the bug.
+    let mut git_projection = GitProjection::new(&repo);
+    let stats = export_all(&mut git_projection)
+        .expect("export must continue past diverged refs, not abort on the first");
+
+    let mut failed: Vec<(String, FailedRefExportReason)> = stats.failed_refs.clone();
+    failed.sort_by(|a, b| a.0.cmp(&b.0));
+    let failed_names: Vec<&str> = failed.iter().map(|(name, _)| name.as_str()).collect();
+    assert_eq!(
+        failed_names,
+        vec!["refs/heads/alpha", "refs/heads/beta"],
+        "BOTH concurrently-updated refs must be reported, got {failed:?}"
+    );
+    assert_eq!(
+        failed[0].1,
+        FailedRefExportReason::ModifiedConcurrentlyInGit {
+            found: oid_beta,
+            intended: oid_alpha,
+        },
+        "alpha must name what git holds and what heddle was publishing"
+    );
+    assert_eq!(
+        failed[1].1,
+        FailedRefExportReason::ModifiedConcurrentlyInGit {
+            found: oid_alpha,
+            intended: oid_beta,
+        },
+        "beta must name what git holds and what heddle was publishing"
+    );
+
+    let oid_gamma_tip = test_support::mapping(&git_projection)
+        .get_git(&gamma_tip.state_id)
+        .expect("gamma tip minted");
+    let mirror = test_support::open_git_repo(&git_projection).expect("reopen mirror");
+    let tip_of = |name: &str| -> ObjectId {
+        mirror
+            .find_reference(name)
+            .expect("read ref")
+            .unwrap_or_else(|| panic!("{name} must still exist"))
+            .peeled_oid(&mirror)
+            .expect("peel ref")
+            .expect("ref has a commit tip")
+    };
+
+    // The unaffected ref was still exported -- the collect kept the run alive.
+    assert_eq!(
+        tip_of("refs/heads/gamma"),
+        oid_gamma_tip,
+        "an unraced branch must still be exported after other refs diverged"
+    );
+    assert!(
+        stats
+            .branches
+            .iter()
+            .any(|exported| exported.name == "gamma" && exported.tip == oid_gamma_tip),
+        "gamma must be reported as exported, got {:?}",
+        stats.branches
+    );
+    assert!(
+        !stats
+            .branches
+            .iter()
+            .any(|exported| exported.name == "alpha" || exported.name == "beta"),
+        "a ref that failed must not also be reported as exported, got {:?}",
+        stats.branches
+    );
+
+    // Detection, NOT auto-resolution: the concurrently-written tips survive
+    // untouched. Clobbering them is exactly the data loss this guards.
+    assert_eq!(
+        tip_of("refs/heads/alpha"),
+        oid_beta,
+        "a diverged branch must be left alone, not overwritten"
+    );
+    assert_eq!(
+        tip_of("refs/heads/beta"),
+        oid_alpha,
+        "a diverged branch must be left alone, not overwritten"
+    );
+    assert_ne!(
+        oid_gamma_root, oid_gamma_tip,
+        "gamma must genuinely have advanced for this test to prove anything"
+    );
+}

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -44,7 +44,7 @@ use super::{
     git_notes,
     git_reconstruct::{commit_object_id, reconstruct_commit_bytes, write_commit_object},
     git_residual::{ResidualStore, resolve_lossy_object},
-    git_util::ImportStats,
+    git_util::{FailedRefExportReason, ImportStats},
 };
 
 /// Errors specific to Git Projection and Bridge Mirror operations.
@@ -128,6 +128,19 @@ pub enum GitProjectionError {
 
     #[error("change id parse error: {0}")]
     StateIdParse(#[from] StateIdParseError),
+
+    /// A SINGLE ref could not be published, already classified against the
+    /// compare-and-swap heddle asserted (heddle#261). Distinct from the errors
+    /// above because it is per-ref and recoverable at the export level: the
+    /// export reconcile catches it, records `reason` in
+    /// [`ExportStats::failed_refs`](super::git_util::ExportStats::failed_refs),
+    /// and keeps going with the remaining refs. It still surfaces as an error
+    /// for the ref-sync callers that legitimately want to stop.
+    #[error("ref {name}: {reason}")]
+    RefExportFailed {
+        name: String,
+        reason: FailedRefExportReason,
+    },
 }
 
 /// Type alias for Git Projection and Bridge Mirror results.

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -26,7 +26,7 @@ use crate::{
     git_reconstruct::{commit_object_id, reconstruct_commit_bytes, write_commit_object},
     git_residual::ResidualStore,
     git_sync::{sync_marker_to_tag, sync_track_to_branch},
-    git_util::{ExportStats, ExportedRef},
+    git_util::{ExportStats, ExportedRef, FailedRefExportReason},
 };
 
 /// Whether `state` carries a captured original git commit to reconstruct
@@ -743,34 +743,54 @@ fn export_scoped(
         ) {
             ReconcileOp::Write => {
                 let git_oid = desired_oid.expect("Write implies a desired target");
-                sync_track_to_branch(&repo, track_name, git_oid)?;
-                managed_record.insert(branch_ref.clone(), git_oid);
-                stats.threads_synced += 1;
-                stats.branches.push(ExportedRef {
-                    name: track_name.clone(),
-                    tip: git_oid,
-                });
+                match sync_track_to_branch(&repo, track_name, git_oid) {
+                    Ok(()) => {
+                        managed_record.insert(branch_ref.clone(), git_oid);
+                        stats.threads_synced += 1;
+                        stats.branches.push(ExportedRef {
+                            name: track_name.clone(),
+                            tip: git_oid,
+                        });
+                    }
+                    // COLLECT, don't halt (heddle#261). The ref is left exactly
+                    // as Git has it and the managed record is NOT updated -- so
+                    // heddle does not claim ownership of a tip it failed to
+                    // write, and the next run re-reconciles from the real state.
+                    Err(err) => stats
+                        .failed_refs
+                        .push((branch_ref.clone(), failed_set_reason(err))),
+                }
             }
             ReconcileOp::ForceRewind => {
                 let git_oid = desired_oid.expect("ForceRewind implies a desired target");
-                set_reference(
+                match set_reference(
                     &repo,
                     &branch_ref,
                     git_oid,
                     RefPrecondition::Any,
                     "heddle: retract embargoed thread frontier",
-                )?;
-                managed_record.insert(branch_ref.clone(), git_oid);
-                stats.threads_synced += 1;
-                stats.branches.push(ExportedRef {
-                    name: track_name.clone(),
-                    tip: git_oid,
-                });
+                ) {
+                    Ok(()) => {
+                        managed_record.insert(branch_ref.clone(), git_oid);
+                        stats.threads_synced += 1;
+                        stats.branches.push(ExportedRef {
+                            name: track_name.clone(),
+                            tip: git_oid,
+                        });
+                    }
+                    Err(err) => stats
+                        .failed_refs
+                        .push((branch_ref.clone(), failed_set_reason(err))),
+                }
             }
-            ReconcileOp::Delete => {
-                delete_reference_if_present(&repo, &branch_ref)?;
-                managed_record.remove(&branch_ref);
-            }
+            ReconcileOp::Delete => match delete_reference_if_present(&repo, &branch_ref) {
+                Ok(()) => {
+                    managed_record.remove(&branch_ref);
+                }
+                Err(err) => stats
+                    .failed_refs
+                    .push((branch_ref.clone(), failed_delete_reason(err))),
+            },
             // A head has no preserve path — `frontier_git_oid` recomputes the
             // target every run, so a head is always rewound/deleted, never kept at
             // a stale tip (Preserve is unreachable for `ReconcileNs::Head`).
@@ -840,18 +860,28 @@ fn export_scoped(
         ) {
             ReconcileOp::Write => {
                 let git_oid = desired_oid.expect("Write implies a desired target");
-                sync_marker_to_tag(&repo, name, git_oid)?;
-                managed_record.insert(tag_ref.clone(), git_oid);
-                stats.markers_synced += 1;
-                stats.tags.push(ExportedRef {
-                    name: name.clone(),
-                    tip: git_oid,
-                });
+                match sync_marker_to_tag(&repo, name, git_oid) {
+                    Ok(()) => {
+                        managed_record.insert(tag_ref.clone(), git_oid);
+                        stats.markers_synced += 1;
+                        stats.tags.push(ExportedRef {
+                            name: name.clone(),
+                            tip: git_oid,
+                        });
+                    }
+                    Err(err) => stats
+                        .failed_refs
+                        .push((tag_ref.clone(), failed_set_reason(err))),
+                }
             }
-            ReconcileOp::Delete => {
-                delete_reference_if_present(&repo, &tag_ref)?;
-                managed_record.remove(&tag_ref);
-            }
+            ReconcileOp::Delete => match delete_reference_if_present(&repo, &tag_ref) {
+                Ok(()) => {
+                    managed_record.remove(&tag_ref);
+                }
+                Err(err) => stats
+                    .failed_refs
+                    .push((tag_ref.clone(), failed_delete_reason(err))),
+            },
             // PRESERVE keeps the existing served tag (still managed → stays in the
             // record); SKIP is a no-op. A tag is free-move and never force-rewinds
             // (ForceRewind is unreachable for `ReconcileNs::Tag`).
@@ -913,6 +943,42 @@ enum ReconcileOp {
     /// Delete the ref — its line/marker has no served frontier (whole-line embargo,
     /// r19 embargoed-existing tag, or a deleted marker's stale tag).
     Delete,
+}
+
+/// Map a failed ref WRITE into the export's fail-soft vocabulary (heddle#261).
+///
+/// Two shapes of the same hazard converge here. `RefExportFailed` is a lost
+/// compare-and-swap, already classified in `git_sync::set_ref` against the
+/// precondition that lost. `NonFastForwardRef` is that hazard observed one step
+/// EARLIER: the Git tip had already diverged from heddle's projection when the
+/// export read it, so the fast-forward guard rejected the update before any
+/// swap was attempted. Both mean "the branch moved on the Git side", so both
+/// report as `ModifiedConcurrentlyInGit`.
+///
+/// Anything else is NOT demonstrably another writer's doing and stays generic,
+/// so `FailedToSet` never becomes a dumping ground that inflates the race count.
+fn failed_set_reason(err: GitProjectionError) -> FailedRefExportReason {
+    match err {
+        GitProjectionError::RefExportFailed { reason, .. } => reason,
+        GitProjectionError::NonFastForwardRef { old, new, .. } => {
+            FailedRefExportReason::ModifiedConcurrentlyInGit {
+                found: old,
+                intended: new,
+            }
+        }
+        other => FailedRefExportReason::FailedToSet(other.to_string()),
+    }
+}
+
+/// The delete-side counterpart of [`failed_set_reason`]. A delete that lost its
+/// own precondition still arrives pre-classified; everything else is reported
+/// as `FailedToDelete` so the summary distinguishes "could not retract" from
+/// "could not publish".
+fn failed_delete_reason(err: GitProjectionError) -> FailedRefExportReason {
+    match err {
+        GitProjectionError::RefExportFailed { reason, .. } => reason,
+        other => FailedRefExportReason::FailedToDelete(other.to_string()),
+    }
 }
 
 /// The mirror reconcile decision — IDENTICAL in shape for heads and tags

--- a/crates/git-projection/src/git_sync.rs
+++ b/crates/git-projection/src/git_sync.rs
@@ -281,13 +281,48 @@ fn set_ref(
 /// value that actually cost heddle the swap. `found` is therefore a faithful
 /// "what is there now", not a proof of "what beat us".
 fn classify_failed_ref_write(
-    _repo: &SleyRepository,
-    _name: &str,
-    _precondition: &RefPrecondition,
-    _intended: SleyObjectId,
+    repo: &SleyRepository,
+    name: &str,
+    precondition: &RefPrecondition,
+    intended: SleyObjectId,
     err: GitProjectionError,
 ) -> FailedRefExportReason {
-    FailedRefExportReason::FailedToSet(err.to_string())
+    // The ref's RAW target, not its peeled commit: the precondition heddle
+    // asserted was against the raw value, so peeling here could call an
+    // annotated tag "unchanged" when its wrapper object was in fact replaced.
+    let current = match repo.find_reference(name) {
+        Ok(reference) => reference.map(|reference| reference.target),
+        // The ref store cannot be read back, so nothing can be asserted about
+        // another writer. Report the original failure, not a guess.
+        Err(_) => return FailedRefExportReason::FailedToSet(err.to_string()),
+    };
+
+    match (precondition, current) {
+        // heddle required a specific existing value and the ref is now gone.
+        // Only `MustExistAndMatch` can conclude this: `ExistingMustMatch` is
+        // satisfied by absence, so a missing ref there is not a lost swap.
+        (RefPrecondition::MustExistAndMatch(_), None) => {
+            FailedRefExportReason::DeletedInGit { intended }
+        }
+        // heddle required a specific existing value and Git holds another one.
+        (
+            RefPrecondition::MustExistAndMatch(expected)
+            | RefPrecondition::ExistingMustMatch(expected),
+            Some(ReferenceTarget::Direct(found)),
+        ) if *expected != ReferenceTarget::Direct(found) => {
+            FailedRefExportReason::ModifiedConcurrentlyInGit { found, intended }
+        }
+        // heddle required the ref to be absent (a create) and Git has one now:
+        // another writer created it under the same name.
+        (RefPrecondition::MustNotExist, Some(ReferenceTarget::Direct(found))) => {
+            FailedRefExportReason::ModifiedConcurrentlyInGit { found, intended }
+        }
+        // What is on disk is CONSISTENT with what heddle asserted (or is a
+        // symref, which heddle never asserts against), so the failure is not
+        // attributable to another writer -- a locked ref, an IO error, an
+        // invalid name. Reporting it as a race would be a claim we cannot back.
+        _ => FailedRefExportReason::FailedToSet(err.to_string()),
+    }
 }
 
 fn ensure_commit_update_fast_forward(

--- a/crates/git-projection/src/git_sync.rs
+++ b/crates/git-projection/src/git_sync.rs
@@ -7,8 +7,12 @@ use sley::{
     ObjectId as SleyObjectId, RefPrecondition, ReferenceTarget, Repository as SleyRepository,
 };
 
-use crate::git_core::{
-    GitProjection, GitProjectionError, GitProjectionResult, git_err, thread_is_unclaimed_bootstrap,
+use crate::{
+    git_core::{
+        GitProjection, GitProjectionError, GitProjectionResult, git_err,
+        thread_is_unclaimed_bootstrap,
+    },
+    git_util::FailedRefExportReason,
 };
 
 /// Sync Heddle threads to Git branches.
@@ -232,7 +236,7 @@ fn set_ref(
     tx.update_to(
         name,
         ReferenceTarget::Direct(oid),
-        precondition,
+        precondition.clone(),
         Some(sley::plumbing::sley_refs::ReflogEntry {
             old_oid,
             new_oid: oid,
@@ -240,7 +244,50 @@ fn set_ref(
             message: message.as_bytes().to_vec(),
         }),
     );
-    tx.commit().map_err(git_err)
+    tx.commit()
+        .map_err(|err| GitProjectionError::RefExportFailed {
+            name: name.to_string(),
+            reason: classify_failed_ref_write(repo, name, &precondition, oid, git_err(err)),
+        })
+}
+
+/// Classify a failed ref write into the export's [`FailedRefExportReason`]
+/// vocabulary by RE-READING the ref and testing what it holds against the
+/// precondition heddle asserted.
+///
+/// Classification is driven by observed state, never by the error text, so
+/// rewording sley's transaction message cannot silently reclassify a race. If
+/// the ref now contradicts `precondition`, another writer moved it and the
+/// compare-and-swap is exactly what stopped heddle from clobbering them. If it
+/// does NOT contradict, the write failed for some unrelated reason and is
+/// reported as [`FailedRefExportReason::FailedToSet`] rather than blamed on a
+/// race we cannot demonstrate.
+///
+/// WINDOW COVERED. sley re-verifies the precondition *while holding the ref
+/// lock* ("a true CAS, not a check-then-write" -- `RefPrecondition`), so any
+/// Git-side write that lands before heddle's transaction commits loses the swap
+/// and arrives here. That is the entire read-then-write window of this export,
+/// including the gap between `sync_track_to_branch`'s `find_reference` and its
+/// `set_ref`.
+///
+/// WINDOW NOT COVERED. A Git-side write that lands AFTER heddle's transaction
+/// commits: heddle's value is already in place and the later writer overwrites
+/// it. Nothing here detects that, and nothing could -- it is not a lost swap,
+/// it is a subsequent one. Nor is a `RefPrecondition::Any` write covered at all:
+/// it asserts nothing, so it cannot lose a race by construction.
+///
+/// The re-read is DIAGNOSTIC only. It reports what Git holds a moment after the
+/// failure, which a fast third writer may already have changed again from the
+/// value that actually cost heddle the swap. `found` is therefore a faithful
+/// "what is there now", not a proof of "what beat us".
+fn classify_failed_ref_write(
+    _repo: &SleyRepository,
+    _name: &str,
+    _precondition: &RefPrecondition,
+    _intended: SleyObjectId,
+    err: GitProjectionError,
+) -> FailedRefExportReason {
+    FailedRefExportReason::FailedToSet(err.to_string())
 }
 
 fn ensure_commit_update_fast_forward(
@@ -302,4 +349,138 @@ fn git_projection_identity() -> Vec<u8> {
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0);
     format!("Heddle <heddle@local> {seconds} +0000").into_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use sley::{
+        CommitObject, GitObjectType, GitTime, Signature, TreeEditor,
+        plumbing::{sley_core::ByteString, sley_object::EncodedObject},
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_signature() -> Signature {
+        let time = GitTime::new(0, 0);
+        let raw = format!("Heddle Test <heddle@test> 0 {}", time.offset_token()).into_bytes();
+        Signature {
+            name: ByteString::new(b"Heddle Test".to_vec()),
+            email: ByteString::new(b"heddle@test".to_vec()),
+            time,
+            raw,
+        }
+    }
+
+    /// A bare repo plus two unrelated commits, standing in for "heddle's tip"
+    /// and "the tip some other writer pushed".
+    fn repo_with_two_commits() -> (TempDir, SleyRepository, SleyObjectId, SleyObjectId) {
+        let temp = TempDir::new().expect("temp dir");
+        let repo = SleyRepository::init_bare(temp.path()).expect("init bare");
+        let tree = repo.write_tree(TreeEditor::new()).expect("empty tree");
+        let sig = test_signature();
+        let commit = |message: &str| {
+            let object = CommitObject {
+                tree,
+                parents: Vec::new(),
+                author: sig.to_ident_bytes(),
+                committer: sig.to_ident_bytes(),
+                encoding: None,
+                message: message.as_bytes().to_vec(),
+            };
+            repo.write_object(EncodedObject::new(GitObjectType::Commit, object.write()))
+                .expect("write commit")
+        };
+        let ours = commit("ours");
+        let theirs = commit("theirs");
+        (temp, repo, ours, theirs)
+    }
+
+    /// A LOST compare-and-swap -- the on-disk ref holds something other than
+    /// what heddle asserted -- must classify as `ModifiedConcurrentlyInGit` and
+    /// NAME the value Git actually holds. A generic `FailedToSet` here would
+    /// tell an operator nothing about what moved underneath them.
+    #[test]
+    fn lost_cas_against_a_moved_ref_reports_modified_concurrently_in_git() {
+        let (_temp, repo, ours, theirs) = repo_with_two_commits();
+        // The ref really holds `theirs`: exactly the state a concurrent
+        // Git-side branch update leaves behind.
+        set_ref(
+            &repo,
+            "refs/heads/raced",
+            theirs,
+            RefPrecondition::MustNotExist,
+            "test: concurrent git-side writer",
+        )
+        .expect("seed ref");
+
+        let reason = classify_failed_ref_write(
+            &repo,
+            "refs/heads/raced",
+            // What heddle read before it decided to write.
+            &RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(ours)),
+            ours,
+            GitProjectionError::Git("transaction failed: expected ref to match".into()),
+        );
+
+        assert_eq!(
+            reason,
+            FailedRefExportReason::ModifiedConcurrentlyInGit {
+                found: theirs,
+                intended: ours,
+            },
+            "a ref holding a value other than the asserted one is a lost race"
+        );
+    }
+
+    /// The ref VANISHING under a `MustExistAndMatch` assertion is a delete on
+    /// the Git side, not a modification. The operator needs the difference to
+    /// know whether to re-import or re-create the branch.
+    #[test]
+    fn lost_cas_against_a_deleted_ref_reports_deleted_in_git() {
+        let (_temp, repo, ours, _theirs) = repo_with_two_commits();
+
+        let reason = classify_failed_ref_write(
+            &repo,
+            "refs/heads/gone",
+            &RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(ours)),
+            ours,
+            GitProjectionError::Git("transaction failed: expected ref to match".into()),
+        );
+
+        assert_eq!(
+            reason,
+            FailedRefExportReason::DeletedInGit { intended: ours },
+            "an absent ref under a must-exist assertion was deleted in git"
+        );
+    }
+
+    /// A failure whose observed state is CONSISTENT with what heddle asserted
+    /// is not attributable to another writer, so it must stay generic. Without
+    /// this, every locked-ref or IO failure would be misreported as a race.
+    #[test]
+    fn failure_with_a_satisfied_precondition_stays_generic() {
+        let (_temp, repo, ours, _theirs) = repo_with_two_commits();
+        set_ref(
+            &repo,
+            "refs/heads/intact",
+            ours,
+            RefPrecondition::MustNotExist,
+            "test: seed",
+        )
+        .expect("seed ref");
+
+        let reason = classify_failed_ref_write(
+            &repo,
+            "refs/heads/intact",
+            &RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(ours)),
+            ours,
+            GitProjectionError::Git("could not lock ref".into()),
+        );
+
+        assert!(
+            matches!(reason, FailedRefExportReason::FailedToSet(_)),
+            "an unmoved ref is not evidence of a race, got {reason:?}"
+        );
+    }
 }

--- a/crates/git-projection/src/git_util.rs
+++ b/crates/git-projection/src/git_util.rs
@@ -128,6 +128,61 @@ pub struct ExportStats {
     pub branches: Vec<ExportedRef>,
     /// Tags written to the destination, paired with their tip commit.
     pub tags: Vec<ExportedRef>,
+    /// Refs this export could NOT publish, paired with why -- the fail-soft
+    /// counterpart of `branches`/`tags` (heddle#261). Export continues past a
+    /// failed ref and records it here rather than aborting on the first one,
+    /// so a single branch that moved on the Git side cannot mask the outcome
+    /// of every ref behind it. Keyed by FULL ref name (`refs/heads/foo`), the
+    /// same spelling the reconcile loops use. Mirrors the import side's
+    /// [`ImportStats::skipped_non_commit_refs`] reporting: the operation
+    /// succeeds at what it could do and reports the remainder, and the caller
+    /// exits non-zero when this is non-empty.
+    pub failed_refs: Vec<(String, FailedRefExportReason)>,
+}
+
+/// Why a single ref could not be published to the Git projection.
+///
+/// Every arm is a REPORT, never an attempted repair: heddle names what it found
+/// on the Git side and leaves the ref exactly as it is, for the operator to
+/// reconcile (import first, or force). Auto-resolving a ref another writer just
+/// moved is how that writer's commits get lost.
+///
+/// Variant names are heddle-native but map 1:1 onto jj's `FailedRefExportReason`
+/// (`lib/src/git.rs`), so a future port translates without re-deriving the
+/// taxonomy: `ModifiedConcurrentlyInGit` <-> jj `DeletedInJjModifiedInGit`,
+/// `DeletedInGit` <-> jj `ModifiedInJjDeletedInGit`, and `FailedToSet` /
+/// `FailedToDelete` <-> the same-named jj arms.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum FailedRefExportReason {
+    /// The Git ref does not hold the value heddle based its update on: it moved
+    /// underneath the export (a `git push`, `git branch -f`, or another tool
+    /// writing the mirror). Covers both the tip that had ALREADY diverged when
+    /// export read it and the one that changed inside the read-write window.
+    #[error("modified concurrently in git: found {found}, heddle was publishing {intended}")]
+    ModifiedConcurrentlyInGit {
+        /// What Git holds -- the value that lost heddle the compare-and-swap.
+        found: GitObjectId,
+        /// The tip heddle was publishing when it lost the race.
+        intended: GitObjectId,
+    },
+
+    /// heddle read the ref, then found it gone by the time it wrote: deleted on
+    /// the Git side mid-export.
+    #[error("deleted in git while heddle was publishing {intended}")]
+    DeletedInGit {
+        /// The tip heddle was publishing when the ref disappeared.
+        intended: GitObjectId,
+    },
+
+    /// The ref write failed for a reason that is NOT a demonstrable race -- a
+    /// locked ref, an IO error, an invalid name. Kept distinct so a lost race
+    /// is never inferred from a failure we cannot attribute to another writer.
+    #[error("failed to set: {0}")]
+    FailedToSet(String),
+
+    /// The ref delete failed, likewise for a non-race reason.
+    #[error("failed to delete: {0}")]
+    FailedToDelete(String),
 }
 
 /// A ref written to the export destination, paired with the commit it


### PR DESCRIPTION
## Summary

- `export_scoped` halted on the **first** ref it could not publish (`?` on `sync_track_to_branch` / `sync_marker_to_tag`), so one branch that moved on the Git side aborted the whole export: later refs were never attempted and the operator got a single stringly error instead of a succeeded-vs-diverged report. Export now **continues and collects** into `ExportStats::failed_refs`, keyed by full ref name.
- Adds `FailedRefExportReason` — `ModifiedConcurrentlyInGit`, `DeletedInGit`, `FailedToSet`, `FailedToDelete`. Heddle-native names, 1:1-mappable to jj's enum in `lib/src/git.rs`. All four ref-mutating sites participate (thread write, embargo force-rewind, marker write, ref delete), so every arm is genuinely produced.
- Classification is driven by **observed state, not error text**: `git_sync::classify_failed_ref_write` re-reads the ref and tests it against the precondition that lost. Rewording sley's transaction message cannot silently reclassify a race, and a failure whose observed state is consistent with what heddle asserted stays `FailedToSet` instead of inflating the race count.
- **Detection, not repair.** A diverged ref is left exactly as Git has it and is *not* recorded as heddle-managed, so heddle never claims ownership of a tip it failed to write and the next run re-reconciles from real state.
- `heddle export git` / `heddle sync git` render the diverged refs alongside the exported ones and exit non-zero.

## Closes

HeddleCo/heddle#261

## Test evidence

New integration test at the **red** commit — the export aborts on the first diverged ref and never attempts the second:

```
running 1 test
test concurrent_git_side_branch_updates_are_all_collected_and_export_continues ... FAILED

---- concurrent_git_side_branch_updates_are_all_collected_and_export_continues stdout ----
panicked at crates/cli/tests/git_projection_engine_integration.rs:8440:10:
export must continue past diverged refs, not abort on the first: NonFastForwardRef {
  name: "refs/heads/alpha",
  old: ObjectId("85a5485b042708233ce004af874966578c978882"),
  new: ObjectId("39687bb1b155b7db39010ab7407506101449f451"),
  remote_destination: false }

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 95 filtered out
```

Classifier unit tests at the **red** commit:

```
running 3 tests
test git_sync::tests::lost_cas_against_a_deleted_ref_reports_deleted_in_git ... FAILED
test git_sync::tests::lost_cas_against_a_moved_ref_reports_modified_concurrently_in_git ... FAILED
test git_sync::tests::failure_with_a_satisfied_precondition_stays_generic ... ok

assertion `left == right` failed: a ref holding a value other than the asserted one is a lost race
  left: FailedToSet("git error: transaction failed: expected ref to match")
 right: ModifiedConcurrentlyInGit { found: ObjectId("837b3a6a..."), intended: ObjectId("9943334e...") }

assertion `left == right` failed: an absent ref under a must-exist assertion was deleted in git
  left: FailedToSet("git error: transaction failed: expected ref to match")
 right: DeletedInGit { intended: ObjectId("9943334e...") }

test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 54 filtered out
```

After the fix:

```
$ cargo test -p heddle-git-projection
     Running unittests src/lib.rs (target/debug/deps/heddle_git_projection-bef37f50c5ce54d9)
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.04s

$ cargo test -p heddle-cli --test git_projection_engine_integration
test result: ok. 96 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.69s

$ cargo test -p heddle-cli --test advice_lint
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.48s
```

```
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.44s
EXIT=0

$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.72s
EXIT=0
```

End-to-end through the real CLI — a concurrent writer moves a heddle-managed mirror branch onto another served tip; export publishes what it can, reports the rest, exits non-zero:

```
=== export 2 (raced) ===
[ok] exported to /tmp/h261-.../dest
  commits: 2 total (already in sync)
  branches: 1   main 440809e
  tags: 0
[warn] 1 ref diverged; left untouched (heddle did not overwrite)
  refs/heads/beta: modified concurrently in git: found fe5b26e1c04ab4d52265bbc51e6eaa221283e373, heddle was publishing 440809e37763f19790c8ee5d1b3314392c7b0604
Error: exported 1 ref, 1 diverged (concurrent git-side update): refs/heads/beta

exit_code=74
```

The raced ref is unchanged afterwards — detect, not clobber.

### `cargo test --workspace`

Not green **on this box, on `main` as much as on this branch** — environment-blocked, not regressed. Hundreds of CLI-spawning tests across `blame`, `fsck`, `gc`, `resolve`, `undo`, `cli_integration` … fail with:

```
Error: configuration error: failed to inspect Git worktree status
at '/tmp/.tmpkr9MLT': io error: Permission denied (os error 13)
```

`/tmp` on this host holds ~1900 concurrent test temp dirs from parallel work, and the failure count tracks load. Matched `--no-fail-fast` runs:

| | failing tests |
|---|---|
| `main` | 629 |
| this branch | 587 |
| **failing here but not on `main`** | **0** |

The branch's failing set is a strict subset of `main`'s. `crates/cli/tests/git_overlay_sley_remote.rs` fails the same 4 push-transport tests on both. Every suite covering this change passes, as shown above.

## Red commit

`f6de21ca36a0f7691101255e09f6640b1873dbd8`

## Scope note — a detection gap this PR does *not* close

The issue's premise #1 ("detection already exists — `ExistingMustMatch` is already there") holds only for the ref-sync path. It predates the heddle#316 mirror reconcile, and **the more common concurrent-push case never reaches that path.**

`reconcile_ref` classifies a head whose existing tip is not in the served set as an *embargoed* tip and routes it to `ReconcileOp::ForceRewind`, which writes with `RefPrecondition::Any` — no compare-and-swap. A commit heddle never minted is by definition unserved, so an ordinary `git push` of a **new** commit onto a heddle-managed mirror branch is force-clobbered, silently, exit 0:

```
mirror main after export 1:  a9355fbbd83ccb3378858b780e01881c7cb81a51
foreign commit pushed:       ec47af5a0b763146073ff3791e96dd9e7768a6b5
=== export 2 ===
[ok] exported to /tmp/h261f-.../dest
  branches: 1   main a9355fb
exit=0
mirror main after export 2:  a9355fbbd83ccb3378858b780e01881c7cb81a51
RESULT: foreign commit CLOBBERED
```

Closing this means teaching `reconcile_ref` to distinguish *unserved because embargoed* (heddle minted it, then withdrew it — must force) from *unserved because foreign* (heddle never minted it — must not force). That changes heddle#316's embargo-retraction semantics, well outside this issue's acceptance criteria, so it is flagged here rather than folded in silently. Happy to file it as a follow-up.

What this PR **does** cover: a mirror ref moved to a commit heddle minted and still serves — caught by the fast-forward guard or by the compare-and-swap, now collected and reported per-ref instead of aborting the run.

The `classify_failed_ref_write` doc comment states the window explicitly: sley re-verifies preconditions under the ref lock (a true CAS), so any Git-side write landing *before* heddle's transaction commits is caught; one landing *after* it is not, and cannot be. The post-failure re-read is documented as diagnostic only — `found` is "what is there now", not proof of "what beat us".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787542591&installation_model_id=21489&pr_number=1095&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1095&signature=dbb290e451b220a0f63a01373c630c070873106397fa0eced202fe94032b3263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->