### PR TITLE
feat(status): report submodule commit ids

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -28424,6 +28424,21 @@
           ],
           "type": "object"
         },
+        "SubmoduleInfo": {
+          "properties": {
+            "commit": {
+              "type": "string"
+            },
+            "path": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "commit"
+          ],
+          "type": "object"
+        },
         "VerificationCheck": {
           "properties": {
             "clean": {
@@ -28723,6 +28738,12 @@
         "storage_model": {
           "type": "string"
         },
+        "submodules": {
+          "items": {
+            "$ref": "#/$defs/SubmoduleInfo"
+          },
+          "type": "array"
+        },
         "target_thread": {
           "type": [
             "string",
@@ -28808,6 +28829,7 @@
         "is_isolated",
         "parallel_threads",
         "changes",
+        "submodules",
         "recommended_action"
       ],
       "title": "StatusSchema",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -2234,6 +2234,7 @@ export interface StatusSchema {
   session_id?: string | null;
   state?: StateInfo | null;
   storage_model: string;
+  submodules: SubmoduleInfo[];
   target_thread?: string | null;
   task?: string | null;
   thinking_level?: string | null;
@@ -2245,6 +2246,11 @@ export interface StatusSchema {
   usage_summary?: unknown;
   verification: RepositoryVerificationState;
   worktree_changed_path_count: number;
+}
+
+export interface SubmoduleInfo {
+  commit: string;
+  path: string;
 }
 
 export interface SyncGitSchema {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -730,6 +730,7 @@ fn render_long_status(output: &StatusOutput, verbose: bool) {
     render_status_details(output, verbose);
     render_status_advice(output);
     render_status_changes(output);
+    render_status_submodules(output);
     render_status_parallel(output);
     render_status_materialized(&output.materialized_threads, verbose);
 }
@@ -1385,6 +1386,22 @@ fn render_status_changes(output: &StatusOutput) {
         );
     } else if !has_changes {
         println!("{}", style::dim("No unsaved worktree changes detected"));
+    }
+}
+
+fn render_status_submodules(output: &StatusOutput) {
+    if output.submodules.is_empty() {
+        return;
+    }
+    println!();
+    println!("{}", style::bold("Submodules"));
+    for submodule in &output.submodules {
+        let short_commit = submodule.commit.get(..12).unwrap_or(&submodule.commit);
+        println!(
+            "  submodule {} @ {}",
+            submodule.path,
+            style::dim(short_commit)
+        );
     }
 }
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -338,6 +338,8 @@ mod shared_target;
 mod state_id_acceptance;
 #[path = "cli_integration/stdout_stderr_split.rs"]
 mod stdout_stderr_split;
+#[path = "cli_integration/submodule_status.rs"]
+mod submodule_status;
 #[path = "cli_integration/thread_cleanup.rs"]
 mod thread_cleanup;
 #[path = "cli_integration/thread_default_current.rs"]

--- a/crates/cli/tests/cli_integration/submodule_status.rs
+++ b/crates/cli/tests/cli_integration/submodule_status.rs
@@ -80,6 +80,10 @@ fn capture_status_snapshot(paths: &[&str]) -> SubmoduleStatusSnapshot {
     }
 
     heddle(&["init"], Some(superproject.path())).expect("initialize Heddle overlay");
+    for (path, _) in &submodules {
+        std::fs::remove_dir_all(superproject.path().join(path))
+            .expect("remove submodule checkout before status");
+    }
     let text =
         heddle(&["status", "--no-color"], Some(superproject.path())).expect("render text status");
     let json = heddle(

--- a/crates/cli/tests/cli_integration/submodule_status.rs
+++ b/crates/cli/tests/cli_integration/submodule_status.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+use super::*;
+
+struct SubmoduleStatusSnapshot {
+    text: String,
+    json: Value,
+    submodules: Vec<(String, String)>,
+}
+
+fn git(path: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .env("GIT_AUTHOR_NAME", "Heddle Test")
+        .env("GIT_AUTHOR_EMAIL", "heddle@example.com")
+        .env("GIT_COMMITTER_NAME", "Heddle Test")
+        .env("GIT_COMMITTER_EMAIL", "heddle@example.com")
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run git {args:?}: {error}"));
+    assert!(
+        output.status.success(),
+        "git {args:?} failed in {}:\nstdout: {}\nstderr: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout)
+        .expect("git output is UTF-8")
+        .trim()
+        .to_string()
+}
+
+fn init_git_repo(path: &Path) {
+    git(path, &["init", "-q", "--initial-branch=main"]);
+}
+
+fn capture_status_snapshot(paths: &[&str]) -> SubmoduleStatusSnapshot {
+    let superproject = TempDir::new().expect("superproject tempdir");
+    init_git_repo(superproject.path());
+    std::fs::write(superproject.path().join("README.md"), "superproject\n")
+        .expect("write superproject file");
+    git(superproject.path(), &["add", "README.md"]);
+    git(superproject.path(), &["commit", "-q", "-m", "base"]);
+
+    let mut sources = Vec::new();
+    let mut submodules = Vec::new();
+    for (index, path) in paths.iter().enumerate() {
+        let source = TempDir::new().expect("submodule source tempdir");
+        init_git_repo(source.path());
+        std::fs::write(
+            source.path().join("lib.txt"),
+            format!("submodule {index}\n"),
+        )
+        .expect("write submodule file");
+        git(source.path(), &["add", "lib.txt"]);
+        git(source.path(), &["commit", "-q", "-m", "submodule base"]);
+        let commit = git(source.path(), &["rev-parse", "HEAD"]);
+        git(
+            superproject.path(),
+            &[
+                "-c",
+                "protocol.file.allow=always",
+                "submodule",
+                "add",
+                "-q",
+                source.path().to_str().expect("UTF-8 source path"),
+                path,
+            ],
+        );
+        sources.push(source);
+        submodules.push(((*path).to_string(), commit));
+    }
+    if !submodules.is_empty() {
+        git(
+            superproject.path(),
+            &["commit", "-q", "-am", "add submodules"],
+        );
+    }
+
+    heddle(&["init"], Some(superproject.path())).expect("initialize Heddle overlay");
+    let text =
+        heddle(&["status", "--no-color"], Some(superproject.path())).expect("render text status");
+    let json = heddle(
+        &["status", "--output", "json", "--no-color"],
+        Some(superproject.path()),
+    )
+    .expect("render JSON status");
+
+    SubmoduleStatusSnapshot {
+        text,
+        json: serde_json::from_str(&json).expect("status JSON parses"),
+        submodules,
+    }
+}
+
+#[test]
+fn status_reports_one_submodule() {
+    let snapshot = capture_status_snapshot(&["vendor/library"]);
+    let (path, commit) = &snapshot.submodules[0];
+
+    assert!(
+        snapshot.text.contains(&format!(
+            "\nSubmodules\n  submodule {path} @ {}\n",
+            &commit[..12]
+        )),
+        "text status should contain a dedicated submodule section:\n{}",
+        snapshot.text
+    );
+    assert_eq!(
+        snapshot.json["submodules"],
+        serde_json::json!([{"path": path, "commit": commit}]),
+        "JSON status should expose the full pinned commit"
+    );
+}
+
+#[test]
+fn status_reports_multiple_submodules_in_path_order() {
+    let snapshot = capture_status_snapshot(&["vendor/zeta", "deps/alpha"]);
+    let mut expected = snapshot.submodules.clone();
+    expected.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let expected_text = format!(
+        "\nSubmodules\n{}\n",
+        expected
+            .iter()
+            .map(|(path, commit)| format!("  submodule {path} @ {}", &commit[..12]))
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+    assert!(
+        snapshot.text.contains(&expected_text),
+        "text status should sort submodules by path:\n{}",
+        snapshot.text
+    );
+    assert_eq!(
+        snapshot.json["submodules"],
+        Value::Array(
+            expected
+                .iter()
+                .map(|(path, commit)| serde_json::json!({"path": path, "commit": commit}))
+                .collect()
+        ),
+        "JSON status should sort submodules by path"
+    );
+}
+
+#[test]
+fn status_omits_text_section_and_emits_empty_json_list_without_submodules() {
+    let snapshot = capture_status_snapshot(&[]);
+
+    assert!(
+        !snapshot.text.contains("\nSubmodules\n"),
+        "text status should stay silent without submodules:\n{}",
+        snapshot.text
+    );
+    assert_eq!(
+        snapshot.json["submodules"],
+        serde_json::json!([]),
+        "JSON status should keep a stable empty submodule list"
+    );
+}

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -1596,12 +1596,12 @@ fn collect_status_submodules(
         let tree = repo.require_tree(&state.tree)?;
         collect_tree_submodules(repo, &tree, "", &mut submodules)?;
     } else if let Some(git) = repo.git_overlay_sley_repository()? {
-        let head = git.head().map_err(|error| {
+        let head = git.head_state().map_err(|error| {
             HeddleError::Config(format!(
                 "read Git HEAD while collecting submodules: {error}"
             ))
         })?;
-        if let Some(commit_oid) = head.oid {
+        if let Some(commit_oid) = head.oid() {
             let commit = git.read_commit(&commit_oid).map_err(|error| {
                 HeddleError::Config(format!(
                     "read Git commit {commit_oid} while collecting submodules: {error}"

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -15,7 +15,7 @@ use chrono::Utc;
 use objects::{
     HeddleError,
     error::Result,
-    object::{Principal, State, ThreadName},
+    object::{Principal, State, ThreadName, Tree},
     store::{ActorPresence, ActorPresenceStatus, ActorPresenceStore},
     worktree::{WorktreeStatus, build_worktree_ignore},
 };
@@ -204,6 +204,7 @@ pub struct StatusReport {
     pub state: Option<StateInfo>,
     pub git_checkpoint: Option<GitCheckpointInfo>,
     pub changes: ChangesInfo,
+    pub submodules: Vec<SubmoduleInfo>,
     #[serde(default)]
     pub materialized_threads: Vec<MaterializedThreadInfo>,
     #[serde(skip)]
@@ -1578,6 +1579,95 @@ pub struct GitCheckpointInfo {
     pub committed_at: String,
 }
 
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct SubmoduleInfo {
+    pub path: String,
+    pub commit: String,
+}
+
+fn collect_status_submodules(
+    repo: &Repository,
+    state: Option<&State>,
+) -> Result<Vec<SubmoduleInfo>> {
+    let mut submodules = Vec::new();
+    if let Some(state) = state
+        && !is_synthetic_root(state)
+    {
+        let tree = repo.require_tree(&state.tree)?;
+        collect_tree_submodules(repo, &tree, "", &mut submodules)?;
+    } else if let Some(git) = repo.git_overlay_sley_repository()? {
+        let head = git.head().map_err(|error| {
+            HeddleError::Config(format!(
+                "read Git HEAD while collecting submodules: {error}"
+            ))
+        })?;
+        if let Some(commit_oid) = head.oid {
+            let commit = git.read_commit(&commit_oid).map_err(|error| {
+                HeddleError::Config(format!(
+                    "read Git commit {commit_oid} while collecting submodules: {error}"
+                ))
+            })?;
+            collect_git_tree_submodules(&git, commit.tree, "", &mut submodules)?;
+        }
+    }
+    submodules.sort_by(|left, right| left.path.cmp(&right.path));
+    Ok(submodules)
+}
+
+fn collect_tree_submodules(
+    repo: &Repository,
+    tree: &Tree,
+    prefix: &str,
+    submodules: &mut Vec<SubmoduleInfo>,
+) -> Result<()> {
+    for entry in tree.entries() {
+        let path = format!("{prefix}{}", entry.name());
+        if let Some(target) = entry.gitlink_target() {
+            submodules.push(SubmoduleInfo {
+                path,
+                commit: target.to_string(),
+            });
+        } else if let Some(hash) = entry.tree_hash() {
+            let subtree = repo.require_tree(&hash)?;
+            collect_tree_submodules(repo, &subtree, &format!("{path}/"), submodules)?;
+        }
+    }
+    Ok(())
+}
+
+fn collect_git_tree_submodules(
+    git: &SleyRepository,
+    tree_oid: sley::ObjectId,
+    prefix: &str,
+    submodules: &mut Vec<SubmoduleInfo>,
+) -> Result<()> {
+    let tree = git.read_tree(&tree_oid).map_err(|error| {
+        HeddleError::Config(format!(
+            "read Git tree {tree_oid} while collecting submodules: {error}"
+        ))
+    })?;
+    for entry in tree.entries {
+        if !matches!(entry.mode, 0o040000 | 0o160000) {
+            continue;
+        }
+        let Ok(name) = String::from_utf8(entry.name.as_bytes().to_vec()) else {
+            continue;
+        };
+        let path = format!("{prefix}{name}");
+        match entry.mode {
+            0o040000 => {
+                collect_git_tree_submodules(git, entry.oid, &format!("{path}/"), submodules)?;
+            }
+            0o160000 => submodules.push(SubmoduleInfo {
+                path,
+                commit: entry.oid.to_string(),
+            }),
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone, Default, Serialize, JsonSchema)]
 pub struct ChangesInfo {
     pub modified: Vec<String>,
@@ -2082,6 +2172,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
             },
         }));
     }
+    let submodules = collect_status_submodules(repo, current_state.as_ref())?;
 
     let thread_summary_start = Instant::now();
     let track_name = repo.current_lane()?;
@@ -2278,6 +2369,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
         state: state_info,
         git_checkpoint,
         changes,
+        submodules,
         materialized_threads,
         profile: StatusProfile::default(),
     };
@@ -2423,6 +2515,7 @@ fn build_short_path_report(input: ShortPathInputs<'_>) -> StatusReport {
         state: None,
         git_checkpoint: None,
         changes: input.changes,
+        submodules: Vec::new(),
         materialized_threads: assess_materialized_threads(input.repo),
         profile: input.profile,
     }


### PR DESCRIPTION
## Summary

- Add a top-level `submodules` inventory to status JSON, sorted by path and carrying each full pinned commit ID.
- Render non-empty inventories in a dedicated `Submodules` section as `submodule <path> @ <12-character-commit>`, matching the groomed issue shape and existing status-section idiom.
- Walk only first-class gitlink entries in the superproject's Heddle or Git tree. The integration fixture removes the checked-out submodule directories before invoking `heddle status`, proving status does not open or descend into them.

Closes HeddleCo/heddle#265

> This branch was authored in a sandboxed session that had no network access and could not push. The commits below are the original author's, preserved unchanged; the verification in the Test evidence section was re-run outside that sandbox.

## Test evidence

Focused submodule suite:

```text
$ cargo test -p heddle-cli --test cli_integration submodule_status -- --nocapture
running 3 tests
test submodule_status::status_omits_text_section_and_emits_empty_json_list_without_submodules ... ok
test submodule_status::status_reports_one_submodule ... ok
test submodule_status::status_reports_multiple_submodules_in_path_order ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 885 filtered out; finished in 0.18s
```

Existing empty-repository status regression:

```text
$ cargo test -p heddle-cli --test cli_integration misc::test_cli_json_output -- --nocapture
running 1 test
test misc::test_cli_json_output ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 887 filtered out; finished in 0.44s
```

Workspace clippy and build:

```text
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.90s
clippy exit: 0

$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.88s
build exit: 0
```

Full `heddle-cli` lib suite — green, with no failures:

```text
$ cargo test -p heddle-cli --lib
test result: ok. 627 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.23s
```

Note: the original session reported `client::local_daemon::tests::check_peer_uid_matches_self_accepts_socketpair`
as a pre-existing dev-box failure. Re-run outside the sandbox it **passes** — that failure was a
sandbox UID-mapping artifact, not a property of this box or this branch.

## Red commit

`1df12a0f8601caf04da0c2a8af8fb678cb0aaa12` — `test(status): cover submodule inventory`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787585551&installation_model_id=21489&pr_number=1097&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1097&signature=3042916f36bcec56bae18632ad4cbe9a2a23f8afbb646f950194bffe0c0694c2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->