### PR TITLE
refactor(refs): route ref writes through the AtomicMutation chokepoint

### DIFF
--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -20,7 +20,6 @@ use objects::{
         current_boot_id, validate_task_id,
     },
 };
-use oplog::OpLogRecorder;
 use refs::{Head, RefExpectation};
 use repo::{
     Repository, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadId,
@@ -454,13 +453,9 @@ pub fn cmd_agent_reserve(cli: &Cli, args: AgentReserveArgs) -> Result<()> {
 
     let thread = ThreadName::new(&thread_name);
     if let Some(existing) = existing_ref {
-        repo.refs()
-            .set_thread_cas(&thread, RefExpectation::Value(existing), &anchor)?;
+        repo.set_thread_recorded_cas(&thread, RefExpectation::Value(existing), &anchor)?;
     } else {
-        repo.refs()
-            .set_thread_cas(&thread, RefExpectation::Missing, &anchor)?;
-        repo.oplog()
-            .record_thread_create(&thread, &anchor, None, Some(&repo.op_scope()))?;
+        repo.set_thread_recorded_cas(&thread, RefExpectation::Missing, &anchor)?;
     }
     ensure_thread_record(&repo, &thread_name, &anchor, &args.task)?;
 

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -613,7 +613,7 @@ fn finish_git_overlay_clone(
     // disk do not yet represent that target.
     repo.goto_from_materialized_state(&state_id, None)?;
     // Keep Git and Heddle attached to the same imported branch.
-    repo.refs().write_head(&Head::Attached {
+    repo.write_head_recorded(&Head::Attached {
         thread: ThreadName::new(&track_name),
     })?;
     write_git_head_branch(&local_path.join(".git"), &track_name)?;
@@ -1212,8 +1212,8 @@ async fn clone_local(
     local_repo.goto_from_materialized_state(&state_id, None)?;
     // Set up the thread locally after materialization so the dirty-worktree
     // guard does not mistake an empty fresh clone for deleted target files.
-    local_repo.refs().set_thread(&tn, &state_id)?;
-    local_repo.refs().write_head(&Head::Attached {
+    local_repo.set_thread_recorded(&tn, &state_id)?;
+    local_repo.write_head_recorded(&Head::Attached {
         thread: ThreadName::new(track_name),
     })?;
 
@@ -1501,10 +1501,7 @@ async fn clone_network(
     server_key: Option<String>,
     endpoint_spec: String,
 ) -> Result<()> {
-    use crate::{
-        client::HostedSession,
-        config::UserConfig,
-    };
+    use crate::{client::HostedSession, config::UserConfig};
 
     let CloneOptions {
         thread,
@@ -1630,7 +1627,10 @@ async fn clone_network(
         {
             Ok(_) => {}
             Err(error) => {
-                eprintln!("{} discussion sync skipped: {error:#}", style::warn_marker());
+                eprintln!(
+                    "{} discussion sync skipped: {error:#}",
+                    style::warn_marker()
+                );
             }
         }
         // Read path for hosted context annotations (heddle context): materialize
@@ -1709,10 +1709,7 @@ async fn clone_monorepo(
     server_key: Option<String>,
     endpoint_spec: String,
 ) -> Result<()> {
-    use crate::{
-        client::HostedSession,
-        config::UserConfig,
-    };
+    use crate::{client::HostedSession, config::UserConfig};
 
     // Monorepo clone materializes each node at a resolved state; the shallow /
     // lazy / partial knobs don't compose with the multi-spool walk in this
@@ -2353,14 +2350,14 @@ mod tests {
             "owner/repo",
         )
         .expect("thread selected");
-        assert_eq!(selected, "main", "companion refs/heads/* entries are ignored");
+        assert_eq!(
+            selected, "main",
+            "companion refs/heads/* entries are ignored"
+        );
 
-        let non_main = select_hosted_clone_thread(
-            None,
-            ["refs/heads/trunk", "trunk"],
-            "owner/repo",
-        )
-        .expect("thread selected");
+        let non_main =
+            select_hosted_clone_thread(None, ["refs/heads/trunk", "trunk"], "owner/repo")
+                .expect("thread selected");
         assert_eq!(
             non_main, "trunk",
             "a non-main default resolves to the short thread, not its companion"

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -185,7 +185,7 @@ fn repair_git_ref(
                 None,
             )?;
             if repo.git_overlay_current_branch()?.as_deref() == Some(ref_name) {
-                repo.refs().write_head(&Head::Attached {
+                repo.write_head_recorded(&Head::Attached {
                     thread: ThreadName::new(ref_name),
                 })?;
             }
@@ -206,7 +206,7 @@ fn repair_git_ref(
                 .get_thread(&tn)?
                 .ok_or_else(|| git_repair_missing_heddle_thread_advice(ref_name))?;
             repo.goto_without_record(&state)?;
-            repo.refs().write_head(&Head::Attached { thread: tn })?;
+            repo.write_head_recorded(&Head::Attached { thread: tn })?;
             let mut bridge = heddle_git_projection::GitProjection::new(repo);
             match bridge.write_through_current_checkout()? {
                 heddle_git_projection::WriteThroughOutcome::Wrote(git_oid) => {

--- a/crates/cli/src/cli/commands/marker.rs
+++ b/crates/cli/src/cli/commands/marker.rs
@@ -8,7 +8,6 @@ use heddle_core::{
     marker_prefix_is_valid, plan_marker_delete_selector,
 };
 use objects::{object::MarkerName, store::ObjectStore};
-use oplog::OpLogRecorder;
 use repo::Repository;
 use serde::Serialize;
 
@@ -123,8 +122,7 @@ fn cmd_marker_create(cli: &Cli, repo: &Repository, name: String) -> Result<()> {
     )?;
 
     let mn = MarkerName::new(&name);
-    repo.refs().create_marker(&mn, &current)?;
-    repo.oplog().record_marker_create(&mn, &current)?;
+    repo.create_marker_recorded(&mn, &current)?;
 
     let output = MarkerOpOutput {
         output_kind: "thread_marker_create",
@@ -144,12 +142,8 @@ fn cmd_marker_create(cli: &Cli, repo: &Repository, name: String) -> Result<()> {
 
 fn cmd_marker_delete(cli: &Cli, repo: &Repository, name: String) -> Result<()> {
     let mn = MarkerName::new(&name);
-    let state = repo
-        .refs()
-        .delete_marker(&mn)?
+    repo.delete_marker_recorded(&mn)?
         .ok_or_else(|| anyhow!("Marker not found: {}", name))?;
-
-    repo.oplog().record_marker_delete(&mn, &state)?;
 
     let output = MarkerOpOutput {
         output_kind: "thread_marker_delete",
@@ -181,8 +175,7 @@ fn cmd_marker_delete_prefix(cli: &Cli, repo: &Repository, prefix: String) -> Res
     let mut deleted: Vec<MarkerEntry> = Vec::with_capacity(matches.len());
     for name in &matches {
         // Skip if it disappeared between list and delete (concurrent delete).
-        if let Some(state) = repo.refs().delete_marker(name)? {
-            repo.oplog().record_marker_delete(name, &state)?;
+        if let Some(state) = repo.delete_marker_recorded(name)? {
             deleted.push(MarkerEntry {
                 name: name.to_string(),
                 state_id: state.short(),

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -250,7 +250,8 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                         | OpRecord::RemoteThreadDelete { .. }
                         | OpRecord::UndoRecoveryUpdate { .. }
                         | OpRecord::StateVisibilitySet { .. }
-                        | OpRecord::StateVisibilityPromote { .. } => {
+                        | OpRecord::StateVisibilityPromote { .. }
+                        | OpRecord::HeadUpdate { .. } => {
                             if for_abort {
                                 continue;
                             }

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -460,10 +460,7 @@ fn emit_push_dry_run(
         PushPath::NativeRemote { .. } => "native/hosted Heddle remote",
     };
 
-    let mut dry = DryRunPlan::new(
-        "push",
-        format!("push to {target_label} ({path_kind})"),
-    );
+    let mut dry = DryRunPlan::new("push", format!("push to {target_label} ({path_kind})"));
 
     if plan.all_threads {
         // Per-thread tips are read cheaply, but for a broad fan-out we keep
@@ -479,9 +476,7 @@ fn emit_push_dry_run(
             .flatten()
             .map(|state| state.state_id.short().to_string());
         if new_tip.is_none() {
-            dry.note(
-                "no current state yet; a real push would first bootstrap a state to publish",
-            );
+            dry.note("no current state yet; a real push would first bootstrap a state to publish");
         }
         dry.ref_updates.push(RefUpdatePreview {
             name: thread
@@ -1091,9 +1086,7 @@ async fn push_local(
     let sync = LocalSync::open(repo.root())?;
     let objects_copied = sync.fetch_state(&target_repo, state_id)?;
 
-    target_repo
-        .refs()
-        .set_thread(&ThreadName::new(track_name), state_id)?;
+    target_repo.set_thread_recorded(&ThreadName::new(track_name), state_id)?;
 
     if should_output_json(cli, Some(repo.config())) {
         let trust = build_repository_verification_state(repo);
@@ -1200,9 +1193,7 @@ async fn push_local_all_threads(
     for thread in &threads {
         let push_one = || -> Result<usize> {
             let copied = sync.fetch_state(&target_repo, &thread.state)?;
-            target_repo
-                .refs()
-                .set_thread(&ThreadName::new(&thread.name), &thread.state)?;
+            target_repo.set_thread_recorded(&ThreadName::new(&thread.name), &thread.state)?;
             Ok(copied)
         };
         match push_one() {
@@ -1503,8 +1494,8 @@ async fn push_network_all_threads(
             // strict UUID (a composite "{uuid}:push:{thread}" string is rejected as
             // InvalidArgument). Derive a deterministic, retry-stable per-thread
             // UUIDv5 from the root op-id (namespace) and the thread name.
-            let namespace = uuid::Uuid::parse_str(&root_operation_id)
-                .unwrap_or(uuid::Uuid::NAMESPACE_OID);
+            let namespace =
+                uuid::Uuid::parse_str(&root_operation_id).unwrap_or(uuid::Uuid::NAMESPACE_OID);
             uuid::Uuid::new_v5(&namespace, thread.name.as_bytes()).to_string()
         };
         let outcome = push_network_one_thread(

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -482,9 +482,7 @@ fn pull_git_overlay(
         )?;
     }
     if old_state.as_ref() != Some(&new_state)
-        && let Err(error) = repo
-            .refs()
-            .set_thread(&ThreadName::new(local_branch), &new_state)
+        && let Err(error) = repo.set_thread_recorded(&ThreadName::new(local_branch), &new_state)
     {
         let rollback = changed.then(|| {
             rollback_git_pull_branch(
@@ -938,15 +936,14 @@ async fn pull_local(
             }
             (Head::Detached { .. }, _) => {
                 repo.goto(&state_id)?;
-                repo.refs().set_thread(&track_tn, &state_id)?;
+                repo.set_thread_recorded(&track_tn, &state_id)?;
             }
         }
     } else {
-        repo.refs().set_thread(&track_tn, &state_id)?;
+        repo.set_thread_recorded(&track_tn, &state_id)?;
     }
     if let Some(remote_name) = configured_remote_name {
-        repo.refs()
-            .set_remote_thread(remote_name, &ThreadName::new(remote_thread), &state_id)?;
+        repo.set_remote_thread_recorded(remote_name, &ThreadName::new(remote_thread), &state_id)?;
     }
 
     let remote_label = configured_remote_name
@@ -1070,11 +1067,11 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
                             }
                             (Head::Detached { .. }, _) => {
                                 repo.goto(&final_state_id)?;
-                                repo.refs().set_thread(&track_tn, &final_state_id)?;
+                                repo.set_thread_recorded(&track_tn, &final_state_id)?;
                             }
                         }
                     } else {
-                        repo.refs().set_thread(&track_tn, &final_state_id)?;
+                        repo.set_thread_recorded(&track_tn, &final_state_id)?;
                     }
                 }
             }
@@ -1085,9 +1082,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
             match crate::client::discussion_sync::pull_discussions(repo, &mut client, repo_path)
                 .await
             {
-                Ok(count)
-                    if count > 0 && !should_output_json(options.cli, Some(repo.config())) =>
-                {
+                Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} discussion(s) from {}",
                         crate::cli::style::ok_marker(),
@@ -1104,9 +1099,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
             }
             // Read path for hosted context annotations — same seam as discussions.
             match crate::client::context_sync::pull_context(repo, &mut client, repo_path).await {
-                Ok(count)
-                    if count > 0 && !should_output_json(options.cli, Some(repo.config())) =>
-                {
+                Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} annotation(s) from {}",
                         crate::cli::style::ok_marker(),

--- a/crates/cli/src/cli/commands/retro.rs
+++ b/crates/cli/src/cli/commands/retro.rs
@@ -294,7 +294,8 @@ pub async fn cmd_retro(cli: &Cli, options: RetroCommandOptions) -> Result<()> {
                 | OpRecord::RemoteThreadDelete { .. }
                 | OpRecord::UndoRecoveryUpdate { .. }
                 | OpRecord::StateVisibilitySet { .. }
-                | OpRecord::StateVisibilityPromote { .. } => {}
+                | OpRecord::StateVisibilityPromote { .. }
+                | OpRecord::HeadUpdate { .. } => {}
             }
         }
     }
@@ -403,7 +404,8 @@ fn find_recent_turn_ts(repo: &Repository) -> Result<Option<DateTime<Utc>>> {
                 | OpRecord::RemoteThreadDelete { .. }
                 | OpRecord::UndoRecoveryUpdate { .. }
                 | OpRecord::StateVisibilitySet { .. }
-                | OpRecord::StateVisibilityPromote { .. } => continue,
+                | OpRecord::StateVisibilityPromote { .. }
+                | OpRecord::HeadUpdate { .. } => continue,
             };
             if let Some(state) = repo.store().get_state(&new_state)?
                 && let Some(intent) = state.intent.as_deref()

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -699,20 +699,20 @@ fn point_overlay_head_at_mapped_tip(repo: &Repository, state_id: &StateId) -> Re
     {
         let thread = ThreadName::from(branch.as_str());
         if repo.refs().get_thread(&thread)?.as_ref() != Some(state_id) {
-            repo.refs().set_thread(&thread, state_id)?;
+            repo.set_thread_recorded(&thread, state_id)?;
         }
         let expected = Head::Attached {
             thread: thread.clone(),
         };
         if repo.refs().read_head()? != expected {
-            repo.refs().write_head(&expected)?;
+            repo.write_head_recorded(&expected)?;
         }
         return Ok(());
     }
 
     let expected = Head::Detached { state: *state_id };
     if repo.refs().read_head()? != expected {
-        repo.refs().write_head(&expected)?;
+        repo.write_head_recorded(&expected)?;
     }
     Ok(())
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -32,7 +32,7 @@ use objects::{
         WriterLeaseStore,
     },
 };
-use oplog::OpLogRecorder;
+use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
 use repo::{
     AgentUsageSummary, Repository, Thread, ThreadCaptureOutcome, ThreadFreshness, ThreadId,
@@ -1604,9 +1604,6 @@ pub(crate) fn cmd_thread_create(
         )),
     )?;
 
-    repo.refs()
-        .set_thread_cas(&ThreadName::new(&name), RefExpectation::Missing, &current)?;
-
     // Persist a Thread record so subsequent commands that go through
     // `ThreadManager::load` (delegate, land, integration policy,
     // `thread show`'s record path) can find it. Without this the ref
@@ -1680,25 +1677,30 @@ pub(crate) fn cmd_thread_create(
         // promoted to materialized later can opt in then.
         shared_target_dir: None,
     };
-    thread_manager.save(&thread_state)?;
-
-    // Snapshot the just-saved record into the OpRecord so `heddle undo --redo`
+    // Encode the planned record into the OpRecord so `heddle undo --redo`
     // can recreate it after `heddle undo` destroys it. Without this,
     // redo restores only the ref and record-backed commands (`thread
     // cd`, delegate, integration policy) silently degrade. heddle#23 r2
     // Codex P1 (mirrors the heddle#99 r2 FastForward pattern — record
     // what redo needs).
     //
-    // Snapshot failure is fatal here: we just wrote the record, so a
-    // round-trip-encode that can't read its own write is a serde
-    // contract bug, not a runtime condition.
-    let manager_snapshot = thread_manager.snapshot_thread_record(&name)?;
-    repo.oplog().record_thread_create(
-        &ThreadName::new(&name),
-        &current,
-        manager_snapshot,
-        Some(&repo.op_scope()),
+    // Encoding failure is fatal before either the ref or manager record is
+    // persisted.
+    let manager_snapshot = Some(thread_manager.encode_thread_record_snapshot(&thread_state)?);
+    let thread_name = ThreadName::new(&name);
+    repo.commit_and_publish(
+        vec![OpRecord::ThreadCreate {
+            name: name.clone(),
+            state: current,
+            manager_snapshot,
+        }],
+        &[RefUpdate::Thread {
+            name: thread_name,
+            expected: RefExpectation::Missing,
+            new: Some(current),
+        }],
     )?;
+    thread_manager.save(&thread_state)?;
 
     let output = thread_op_output(
         "thread_create",
@@ -1956,7 +1958,7 @@ pub(crate) fn cmd_thread_switch(
         // inside a worktree.
         let head_target_repo = open_main_repo_from_worktree_if_needed(repo)?;
         let head_repo = head_target_repo.as_ref().unwrap_or(repo);
-        head_repo.refs().write_head(&Head::Attached {
+        head_repo.write_head_recorded(&Head::Attached {
             thread: ThreadName::new(&name),
         })?;
     } else if open_main_repo_from_worktree_if_needed(repo)?.is_some() {
@@ -1987,7 +1989,7 @@ pub(crate) fn cmd_thread_switch(
         } else {
             repo.goto(&state)?;
         }
-        repo.refs().write_head(&Head::Attached {
+        repo.write_head_recorded(&Head::Attached {
             thread: ThreadName::new(&name),
         })?;
         if repo.capability() == repo::RepositoryCapability::GitOverlay
@@ -2493,13 +2495,8 @@ pub(crate) fn cmd_thread_delete(cli: &Cli, repo: &Repository, name: String) -> R
     }
 
     let thread_name = ThreadName::new(&name);
-    let state = repo
-        .refs()
-        .delete_thread(&thread_name)?
+    repo.delete_thread_recorded(&thread_name)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(&name, "delete thread")))?;
-
-    repo.oplog()
-        .record_thread_delete(&thread_name, &state, Some(&repo.op_scope()))?;
 
     let output = thread_op_output(
         "thread_drop",
@@ -2532,6 +2529,17 @@ pub(crate) fn cmd_thread_rename(
         .get_thread(&old_tn)?
         .ok_or_else(|| anyhow!(thread_not_found_advice(&old, "rename thread")))?;
 
+    let mut records = vec![
+        OpRecord::ThreadCreate {
+            name: new.clone(),
+            state,
+            manager_snapshot: None,
+        },
+        OpRecord::ThreadDelete {
+            name: old.clone(),
+            state,
+        },
+    ];
     let mut updates = vec![
         RefUpdate::Thread {
             name: new_tn.clone(),
@@ -2545,22 +2553,21 @@ pub(crate) fn cmd_thread_rename(
         },
     ];
 
-    if let Head::Attached { thread } = repo.head_ref()?
-        && thread == old
+    let previous_head = repo.head_ref()?;
+    if let Head::Attached { thread } = &previous_head
+        && thread == &old
     {
+        let new_head = Head::Attached {
+            thread: new_tn.clone(),
+        };
+        records.push(Repository::head_update_record(&previous_head, &new_head));
         updates.push(RefUpdate::Head {
-            expected: RefExpectation::Value(Head::Attached {
-                thread: old_tn.clone(),
-            }),
-            new: Head::Attached {
-                thread: new_tn.clone(),
-            },
+            expected: RefExpectation::Value(previous_head),
+            new: new_head,
         });
     }
 
-    repo.refs().update_refs(&updates)?;
-    repo.oplog()
-        .record_thread_rename(&old_tn, &new_tn, &state, Some(&repo.op_scope()))?;
+    repo.commit_and_publish(records, &updates)?;
 
     let output = thread_op_output(
         "thread_rename",

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -20,8 +20,8 @@ use objects::{
     object::{StateId, ThreadName},
     store::{ActorPresenceStore, ObjectStore, WriterLeaseStore},
 };
-use oplog::{OpLogRecorder, ThreadUpdateSnapshots};
-use refs::Head;
+use oplog::{OpLogRecorder, OpRecord, ThreadUpdateSnapshots};
+use refs::{Head, RefExpectation, RefUpdate};
 use repo::{
     Repository, Thread, ThreadFreshness, ThreadManager, ThreadMode, ThreadState,
     describe_thread_advice,
@@ -133,21 +133,45 @@ pub(crate) fn save_thread_update_with_oplog(
     }
     let old_manager_records = encode_thread_records(manager, &before.manager_records)?;
     let new_manager_records = encode_thread_records(manager, &new_manager_records)?;
-    objects::fault_inject::maybe_fail_at("thread_manager_save_in_thread_update")?;
-    manager.save(thread)?;
-    repo.oplog().record_thread_update(
-        &ThreadName::new(&thread.thread),
-        &before.state,
-        &new_state,
-        ThreadUpdateSnapshots::from_record_sets(
-            before.manager_snapshot,
-            new_manager_snapshot,
-            old_manager_records,
-            new_manager_records,
-            before.ref_absent,
-        ),
-        Some(&repo.op_scope()),
-    )?;
+    let thread_name = ThreadName::new(&thread.thread);
+    let snapshots = ThreadUpdateSnapshots::from_record_sets(
+        before.manager_snapshot,
+        new_manager_snapshot,
+        old_manager_records,
+        new_manager_records,
+        before.ref_absent,
+    );
+    if repo.refs().get_thread(&thread_name)? == Some(new_state) {
+        objects::fault_inject::maybe_fail_at("thread_manager_save_in_thread_update")?;
+        manager.save(thread)?;
+        repo.oplog().record_thread_update(
+            &thread_name,
+            &before.state,
+            &new_state,
+            snapshots,
+            Some(&repo.op_scope()),
+        )?;
+    } else {
+        objects::fault_inject::maybe_fail_at("thread_manager_save_in_thread_update")?;
+        repo.commit_and_publish(
+            vec![OpRecord::ThreadUpdate {
+                name: thread_name.to_string(),
+                old_state: before.state,
+                new_state,
+                manager_snapshots: snapshots,
+            }],
+            &[RefUpdate::Thread {
+                name: thread_name,
+                expected: if before.ref_absent {
+                    RefExpectation::Missing
+                } else {
+                    RefExpectation::Value(before.state)
+                },
+                new: Some(new_state),
+            }],
+        )?;
+        manager.save(thread)?;
+    }
     Ok(())
 }
 
@@ -604,9 +628,7 @@ pub(crate) fn refresh_thread(repo: &Repository, thread_id: &str, _cli: &Cli) -> 
             .is_some_and(|pending| pending != current_state)
         {
             fs::remove_file(&rebase_state_path)?;
-            thread_repo
-                .refs()
-                .set_thread(&ThreadName::new(&thread.thread), &current_state)?;
+            thread_repo.set_thread_recorded(&ThreadName::new(&thread.thread), &current_state)?;
             thread.integration_policy_result.status = Some("manual_resolved".to_string());
             thread.integration_policy_result.reason =
                 Some("manual integration resolution captured".to_string());
@@ -697,9 +719,8 @@ fn restore_refresh_rebase_abort(repo: &Repository, rebase_state_path: &Path) -> 
     let head_before = repo.head_ref()?;
     repo.goto_without_record_discard_local(&rebase_state.original_head)?;
     if let Head::Attached { thread } = head_before {
-        repo.refs()
-            .set_thread(&thread, &rebase_state.original_head)?;
-        repo.refs().write_head(&Head::Attached {
+        repo.set_thread_recorded(&thread, &rebase_state.original_head)?;
+        repo.write_head_recorded(&Head::Attached {
             thread: thread.clone(),
         })?;
         let manager = thread_manager(repo);
@@ -1149,12 +1170,8 @@ fn try_three_way_merge_refresh(
             Ok(ThreeWayMergeRefresh::Clean { new_state: target })
         }
         ThreeWayMergeOutcome::FastForward { target } => {
-            // Thread is strictly behind target — fast-forward the
-            // thread ref. We do this against the parent repo so the
-            // ref move is visible to the caller's bookkeeping.
-            parent_repo
-                .refs()
-                .set_thread(&ThreadName::new(&thread.thread), &target)?;
+            // Thread is strictly behind target. The caller advances the parent
+            // ref with the matching `ThreadUpdate` record after this returns.
             // Materialize the target tree to the thread's worktree.
             // Without this, HEAD metadata advances while the files on
             // disk stay stale and subsequent operations run against a
@@ -1188,9 +1205,6 @@ fn try_three_way_merge_refresh(
                 None,
                 false,
             )?;
-            parent_repo
-                .refs()
-                .set_thread(&ThreadName::new(&thread.thread), &new_state.state_id)?;
             Ok(ThreeWayMergeRefresh::Clean {
                 new_state: new_state.state_id,
             })
@@ -1464,7 +1478,7 @@ pub(crate) fn drop_thread_silent(
     WriterLeaseStore::new(repo.heddle_dir()).abandon_thread(&thread.thread, Utc::now())?;
     let tn = ThreadName::new(&thread.thread);
     if plan.delete_thread_ref && repo.refs().get_thread(&tn)?.is_some() {
-        repo.refs().delete_thread(&tn)?;
+        repo.delete_thread_recorded(&tn)?;
     }
     Ok(DropOutcome::Dropped(Box::new(thread)))
 }
@@ -1990,7 +2004,7 @@ fn apply_thread_drop(repo: &Repository, manager: &ThreadManager, thread: &Thread
     }
     let tn = ThreadName::new(&thread.thread);
     if plan.delete_thread_ref && repo.refs().get_thread(&tn)?.is_some() {
-        repo.refs().delete_thread(&tn)?;
+        repo.delete_thread_recorded(&tn)?;
     }
     if plan.strip_actor_presence {
         let registry = ActorPresenceStore::new(repo.heddle_dir());

--- a/crates/cli/src/cli/commands/undo_apply/mod.rs
+++ b/crates/cli/src/cli/commands/undo_apply/mod.rs
@@ -15,7 +15,9 @@ use objects::{
     lock::{RepoLock, WriteLockGuard},
     object::{ContentHash, MarkerName, StateId, ThreadName},
 };
-use oplog::{IsolationKey, OpBatch, OpEntry, OpLogBackend, OpRecord, isolation_keys_for_record};
+use oplog::{
+    IsolationKey, OpBatch, OpEntry, OpLogBackend, OpRecord, RecordedHead, isolation_keys_for_record,
+};
 use refs::Head;
 use repo::{
     CommitGraphIndex, Repository, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
@@ -786,6 +788,9 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         } => {
             apply_ff_undo(steps, source_thread, target_thread, pre_target_id)?;
         }
+        OpRecord::HeadUpdate { previous, .. } => {
+            steps.write_head(head_from_record(previous))?;
+        }
         OpRecord::GitCheckpoint {
             branch,
             previous_git_oid,
@@ -958,6 +963,9 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         } => {
             apply_ff_redo(steps, source_thread, target_thread, post_target_id)?;
         }
+        OpRecord::HeadUpdate { new, .. } => {
+            steps.write_head(head_from_record(new))?;
+        }
         OpRecord::GitCheckpoint {
             branch,
             previous_git_oid,
@@ -1017,6 +1025,15 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
     }
 
     Ok(())
+}
+
+fn head_from_record(head: &RecordedHead) -> Head {
+    match head {
+        RecordedHead::Attached { thread } => Head::Attached {
+            thread: ThreadName::new(thread),
+        },
+        RecordedHead::Detached { state } => Head::Detached { state: *state },
+    }
 }
 
 fn apply_ff_redo(

--- a/crates/cli/src/cli/commands/watch.rs
+++ b/crates/cli/src/cli/commands/watch.rs
@@ -51,7 +51,7 @@ use heddle_core::watch_plan::{
 };
 use notify::{Config as NotifyConfig, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 use objects::{object::StateId, store::ObjectStore};
-use oplog::{OpEntry, OpLog, OpLogBackend, OpRecord};
+use oplog::{OpEntry, OpLog, OpLogBackend, OpRecord, RecordedHead};
 use repo::Repository;
 use serde::Serialize;
 
@@ -458,6 +458,10 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
         OpRecord::RemoteThreadUpdate { thread, .. }
         | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
+        OpRecord::HeadUpdate {
+            new: RecordedHead::Attached { thread },
+            ..
+        } => Some(thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -468,6 +472,10 @@ fn thread_for(op: &OpRecord, _kind: &str) -> Option<String> {
         | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::StateVisibilitySet { .. }
         | OpRecord::StateVisibilityPromote { .. }
+        | OpRecord::HeadUpdate {
+            new: RecordedHead::Detached { .. },
+            ..
+        }
         | OpRecord::Purge { .. } => None,
     }
 }
@@ -496,11 +504,19 @@ fn primary_state_id(op: &OpRecord) -> Option<StateId> {
             Some(*state)
         }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
+        OpRecord::HeadUpdate {
+            new: RecordedHead::Detached { state },
+            ..
+        } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. } => None,
+        | OpRecord::FastForward { .. }
+        | OpRecord::HeadUpdate {
+            new: RecordedHead::Attached { .. },
+            ..
+        } => None,
     }
 }
 

--- a/crates/cli/src/client/local_sync.rs
+++ b/crates/cli/src/client/local_sync.rs
@@ -159,7 +159,7 @@ impl LocalSync {
             let current = target.refs().get_marker(&name)?;
             if current != Some(state) {
                 let expected = current.map_or(RefExpectation::Missing, RefExpectation::Value);
-                target.refs().set_marker_cas(&name, expected, &state)?;
+                target.set_marker_recorded_cas(&name, expected, &state)?;
             }
         }
         Ok(copied)

--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -25,9 +25,10 @@ use objects::{
         TimelineToolCallStatus, TimelineToolPayloadMetadata, ToolCallFinishedV1, ToolCallStartedV1,
         Tree,
     },
-    store::{ActorPresence, ActorPresenceStore, ActorPresenceStatus, AgentUsageSummary, ObjectStore},
+    store::{
+        ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary, ObjectStore,
+    },
 };
-use oplog::OpLogRecorder;
 use refs::Head;
 use repo::{
     Repository, SessionManager, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
@@ -1340,18 +1341,7 @@ impl HarnessBridgeRuntime {
         let tn = ThreadName::new(name);
         if self.repo.refs().get_thread(&tn)?.is_none() {
             self.repo
-                .refs()
-                .set_thread_cas(&tn, refs::RefExpectation::Missing, &base_state)?;
-            // Harness writes the ThreadManager record later in this
-            // function (after materializing); no record exists to
-            // snapshot at recording time. `None` matches the pattern
-            // used by `cmd_start` / agent reservation. heddle#23 r2.
-            self.repo.oplog().record_thread_create(
-                &tn,
-                &base_state,
-                None,
-                Some(&self.repo.op_scope()),
-            )?;
+                .set_thread_recorded_cas(&tn, refs::RefExpectation::Missing, &base_state)?;
         }
 
         let workspace_mode = self
@@ -1893,9 +1883,9 @@ impl HarnessBridgeRuntime {
                 entry.status = status.clone();
                 entry.completed_at = match status {
                     ActorPresenceStatus::Active => None,
-                    ActorPresenceStatus::Abandoned | ActorPresenceStatus::Complete | ActorPresenceStatus::Merged => {
-                        Some(Utc::now())
-                    }
+                    ActorPresenceStatus::Abandoned
+                    | ActorPresenceStatus::Complete
+                    | ActorPresenceStatus::Merged => Some(Utc::now()),
                 };
             })?
         } else {

--- a/crates/cli/tests/git_projection_engine_integration.rs
+++ b/crates/cli/tests/git_projection_engine_integration.rs
@@ -2105,7 +2105,7 @@ fn test_sync_mapping() {
 
 #[test]
 #[cfg(unix)]
-fn sync_branches_propagates_track_write_failures() {
+fn sync_branches_recovers_track_publish_failures_after_commit() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let (_git_temp, git_repo) = init_git_repo();
@@ -2131,12 +2131,20 @@ fn sync_branches_propagates_track_write_failures() {
     let result = sync_branches(&mut git_projection);
 
     std::fs::set_permissions(&threads_dir, std::fs::Permissions::from_mode(original_mode)).unwrap();
-    assert!(result.is_err(), "thread write failures should be returned");
+    assert!(
+        result.is_ok(),
+        "the committed ref update has linearized even when its loose publish fails"
+    );
+    assert_eq!(
+        repo.refs().get_thread(&ThreadName::new("main")).unwrap(),
+        Some(state_id),
+        "the next read must reconcile the committed thread update"
+    );
 }
 
 #[test]
 #[cfg(unix)]
-fn sync_tags_propagates_marker_write_failures() {
+fn sync_tags_recovers_marker_publish_failures_after_commit() {
     let heddle_temp = TempDir::new().expect("heddle temp");
     let repo = Repository::init(heddle_temp.path()).expect("init heddle");
     let (_git_temp, git_repo) = init_git_repo();
@@ -2163,7 +2171,15 @@ fn sync_tags_propagates_marker_write_failures() {
     let result = sync_tags(&mut git_projection);
 
     std::fs::set_permissions(&markers_dir, std::fs::Permissions::from_mode(original_mode)).unwrap();
-    assert!(result.is_err(), "marker write failures should be returned");
+    assert!(
+        result.is_ok(),
+        "the committed marker update has linearized even when its loose publish fails"
+    );
+    assert_eq!(
+        repo.refs().get_marker(&MarkerName::new("v1.0")).unwrap(),
+        Some(state_id),
+        "the next read must reconcile the committed marker update"
+    );
 }
 
 #[test]

--- a/crates/client/src/grpc_hosted/mod.rs
+++ b/crates/client/src/grpc_hosted/mod.rs
@@ -2,21 +2,20 @@
 
 mod collaboration;
 mod content;
-mod state_review;
 pub(crate) mod helpers;
 mod hydration;
 pub mod monorepo;
 pub(crate) mod operation_id;
 pub mod request_signing;
 mod session;
+mod state_review;
 mod sync;
 mod user;
 
 use cli_shared::{ClientConfig, cleartext_connect_allowed, cleartext_refused_message};
 use crypto::{Ed25519Signer, Signer};
 use grpc::heddle::api::v1alpha1::{
-    KeypairProof, MintBiscuitRequest,
-    collaboration_service_client::CollaborationServiceClient,
+    KeypairProof, MintBiscuitRequest, collaboration_service_client::CollaborationServiceClient,
     identity_service_client::IdentityServiceClient, mint_biscuit_request::Proof,
     registry_service_client::RegistryServiceClient,
     repo_sync_service_client::RepoSyncServiceClient,
@@ -603,12 +602,12 @@ impl HostedGrpcClient {
             let marker_name = MarkerName::from(marker.name.as_str());
             match repo.refs().get_marker(&marker_name)? {
                 Some(existing) if existing == marker.state_id => {}
-                Some(existing) => repo.refs().set_marker_cas(
+                Some(existing) => repo.set_marker_recorded_cas(
                     &marker_name,
                     refs::RefExpectation::Value(existing),
                     &marker.state_id,
                 )?,
-                None => repo.refs().create_marker(&marker_name, &marker.state_id)?,
+                None => repo.create_marker_recorded(&marker_name, &marker.state_id)?,
             }
         }
         Ok(())

--- a/crates/client/src/grpc_hosted/sync.rs
+++ b/crates/client/src/grpc_hosted/sync.rs
@@ -14,10 +14,9 @@ use grpc::heddle::api::v1alpha1::{
     GitRefUpdateTransfer, ListRefsRequest, ObjectAvailabilityStatus, ObjectDescriptor, PackChunk,
     PackStreamKind, PartialFetchStatus, PullClientFrame, PullRequest, PullServerFrame,
     PushClientFrame, PushRequest, PushServerFrame, RedactionTransfer, StateAttachmentTransfer,
-    StateVisibilityTransfer,
-    StreamOpeningProof, ThreadConfidenceSummary, ThreadIntegrationPolicy, ThreadMetadata,
-    ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects, git_lane_transfer,
-    pull_client_frame, pull_server_frame, push_client_frame, push_server_frame,
+    StateVisibilityTransfer, StreamOpeningProof, ThreadConfidenceSummary, ThreadIntegrationPolicy,
+    ThreadMetadata, ThreadVerificationSummary, TransportMode, UpdateRefRequest, WantObjects,
+    git_lane_transfer, pull_client_frame, pull_server_frame, push_client_frame, push_server_frame,
 };
 use objects::{
     Progress,
@@ -1220,8 +1219,7 @@ impl HostedGrpcClient {
                         if let Some(local_thread) = options.local_thread
                             && let Some(state) = final_state
                         {
-                            repo.refs()
-                                .set_thread(&ThreadName::from(local_thread), &state)?;
+                            repo.set_thread_recorded(&ThreadName::from(local_thread), &state)?;
                         }
                         if let Some(state) = final_state
                             && allow_partial_fetch
@@ -1758,12 +1756,12 @@ fn apply_marker_snapshot(repo: &Repository, checkpoint: &[u8]) -> Result<bool, P
         let name = MarkerName::from(name);
         match repo.refs().get_marker(&name)? {
             Some(existing) if existing == state_id => {}
-            Some(existing) => repo.refs().set_marker_cas(
+            Some(existing) => repo.set_marker_recorded_cas(
                 &name,
                 refs::RefExpectation::Value(existing),
                 &state_id,
             )?,
-            None => repo.refs().create_marker(&name, &state_id)?,
+            None => repo.create_marker_recorded(&name, &state_id)?,
         }
     }
 
@@ -4226,11 +4224,15 @@ mod tests {
             .into_iter()
             .partition(|info| info.obj_type.packable_for_push());
         assert!(
-            pack_objects.iter().all(|info| info.obj_type != ObjectType::StateAttachment),
+            pack_objects
+                .iter()
+                .all(|info| info.obj_type != ObjectType::StateAttachment),
             "attachment record must never ride the push pack"
         );
         assert!(
-            pack_objects.iter().any(|info| info.obj_type == ObjectType::State),
+            pack_objects
+                .iter()
+                .any(|info| info.obj_type == ObjectType::State),
             "ordinary content-addressed objects still ride the push pack"
         );
         assert!(
@@ -4288,10 +4290,14 @@ mod tests {
             delta_base: None,
         };
 
-        let frame = sidecar_push_message(&repo, info, "op-1").expect("emit attachment sidecar frame");
+        let frame =
+            sidecar_push_message(&repo, info, "op-1").expect("emit attachment sidecar frame");
         assert_eq!(frame.client_operation_id, "op-1");
         let Some(push_client_frame::Frame::StateAttachment(transfer)) = frame.frame else {
-            panic!("expected a StateAttachmentTransfer frame, got {:?}", frame.frame);
+            panic!(
+                "expected a StateAttachmentTransfer frame, got {:?}",
+                frame.frame
+            );
         };
         assert_eq!(
             transfer.state_id,

--- a/crates/core/src/merge/mod.rs
+++ b/crates/core/src/merge/mod.rs
@@ -1755,7 +1755,8 @@ fn merge_op_targets_state(op: &OpRecord, state: &StateId) -> bool {
         | OpRecord::RemoteThreadDelete { .. }
         | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::StateVisibilitySet { .. }
-        | OpRecord::StateVisibilityPromote { .. } => false,
+        | OpRecord::StateVisibilityPromote { .. }
+        | OpRecord::HeadUpdate { .. } => false,
     }
 }
 

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -8,7 +8,7 @@ use objects::{
     error::Result,
     object::{OperationId, StateId},
 };
-use oplog::{OpEntry, OpLog, OpLogBackend, OpRecord};
+use oplog::{OpEntry, OpLog, OpLogBackend, OpRecord, RecordedHead};
 use refs::refs::{IndexedOperation, OperationLogIndex, OperationLogQuery};
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -238,6 +238,10 @@ fn thread_for(op: &OpRecord) -> Option<String> {
         OpRecord::GitCheckpoint { branch, .. } => Some(branch.clone()),
         OpRecord::RemoteThreadUpdate { thread, .. }
         | OpRecord::RemoteThreadDelete { thread, .. } => Some(thread.clone()),
+        OpRecord::HeadUpdate {
+            new: RecordedHead::Attached { thread },
+            ..
+        } => Some(thread.clone()),
         OpRecord::Goto { .. }
         | OpRecord::Fork { .. }
         | OpRecord::Collapse { .. }
@@ -248,6 +252,10 @@ fn thread_for(op: &OpRecord) -> Option<String> {
         | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::StateVisibilitySet { .. }
         | OpRecord::StateVisibilityPromote { .. }
+        | OpRecord::HeadUpdate {
+            new: RecordedHead::Detached { .. },
+            ..
+        }
         | OpRecord::Purge { .. } => None,
     }
 }
@@ -273,10 +281,18 @@ fn primary_state_id(op: &OpRecord) -> Option<StateId> {
             Some(*state)
         }
         OpRecord::UndoRecoveryUpdate { state } => Some(*state),
+        OpRecord::HeadUpdate {
+            new: RecordedHead::Detached { state },
+            ..
+        } => Some(*state),
         OpRecord::TransactionAbort { .. }
         | OpRecord::TransactionCommit { .. }
         | OpRecord::ConflictResolved { .. }
         | OpRecord::Purge { .. }
-        | OpRecord::FastForward { .. } => None,
+        | OpRecord::FastForward { .. }
+        | OpRecord::HeadUpdate {
+            new: RecordedHead::Attached { .. },
+            ..
+        } => None,
     }
 }

--- a/crates/core/src/workflow.rs
+++ b/crates/core/src/workflow.rs
@@ -503,7 +503,8 @@ pub fn op_targets_merge_state(op: &OpRecord, merge_state: &str) -> bool {
         | OpRecord::RemoteThreadDelete { .. }
         | OpRecord::UndoRecoveryUpdate { .. }
         | OpRecord::StateVisibilitySet { .. }
-        | OpRecord::StateVisibilityPromote { .. } => false,
+        | OpRecord::StateVisibilityPromote { .. }
+        | OpRecord::HeadUpdate { .. } => false,
     }
 }
 

--- a/crates/devtools/src/check_ref_write_chokepoint.rs
+++ b/crates/devtools/src/check_ref_write_chokepoint.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Workspace guard against production callers bypassing `commit_and_publish`.
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use syn::{Attribute, Expr, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
+
+use crate::asserter::for_each_rs_file;
+
+mod exemptions;
+
+const WRITERS: &[&str] = &[
+    "set_thread",
+    "set_thread_cas",
+    "write_head",
+    "write_head_cas",
+    "set_marker_cas",
+    "create_marker",
+    "delete_thread",
+    "delete_thread_cas",
+    "delete_marker",
+    "delete_marker_cas",
+    "set_remote_thread",
+    "delete_remote_thread",
+    "set_undo_recovery",
+    "clear_undo_recovery",
+    "update_refs",
+];
+
+#[derive(Debug)]
+struct Hit {
+    path: PathBuf,
+    line: usize,
+    function: String,
+    method: String,
+}
+
+fn scan_dirs(dirs: &[PathBuf]) -> Result<Vec<Hit>> {
+    let mut found = Vec::new();
+    let mut scanned = 0;
+    for dir in dirs {
+        for_each_rs_file(dir, &mut scanned, is_skipped_path, |path, source| {
+            let file =
+                syn::parse_file(source).with_context(|| format!("parse {}", path.display()))?;
+            let mut visitor = Finder {
+                path,
+                found: &mut found,
+            };
+            visitor.visit_file(&file);
+            Ok(())
+        })?;
+    }
+    Ok(apply_exemption_budgets(found))
+}
+
+fn is_skipped_path(path: &Path) -> bool {
+    if path.components().any(|part| {
+        matches!(
+            part.as_os_str().to_str(),
+            Some("tests" | "benches" | "devtools")
+        )
+    }) {
+        return true;
+    }
+    if path
+        .file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|name| name == "tests.rs" || name.ends_with("_tests.rs"))
+    {
+        return true;
+    }
+    path.components()
+        .collect::<Vec<_>>()
+        .windows(3)
+        .any(|parts| {
+            parts[0].as_os_str() == "crates"
+                && parts[1].as_os_str() == "refs"
+                && parts[2].as_os_str() == "src"
+        })
+}
+
+fn is_cfg_test(attrs: &[Attribute]) -> bool {
+    fn mentions_test(meta: &Meta) -> bool {
+        match meta {
+            Meta::Path(path) => path.is_ident("test"),
+            Meta::List(list) => list.tokens.to_string().contains("test"),
+            Meta::NameValue(_) => false,
+        }
+    }
+    attrs
+        .iter()
+        .any(|attr| attr.path().is_ident("cfg") && mentions_test(&attr.meta))
+}
+
+struct Finder<'a> {
+    path: &'a Path,
+    found: &'a mut Vec<Hit>,
+}
+
+impl Finder<'_> {
+    fn inspect(&mut self, function: &str, block: &syn::Block) {
+        let mut collector = Collector::default();
+        collector.visit_block(block);
+        self.found
+            .extend(collector.writes.into_iter().map(|(method, line)| Hit {
+                path: self.path.to_path_buf(),
+                line,
+                function: function.to_string(),
+                method,
+            }));
+    }
+}
+
+impl<'ast> Visit<'ast> for Finder<'_> {
+    fn visit_item_mod(&mut self, node: &'ast ItemMod) {
+        if !is_cfg_test(&node.attrs) {
+            syn::visit::visit_item_mod(self, node);
+        }
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast ItemFn) {
+        if !is_cfg_test(&node.attrs) {
+            self.inspect(&node.sig.ident.to_string(), &node.block);
+        }
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast ImplItemFn) {
+        if !is_cfg_test(&node.attrs) {
+            self.inspect(&node.sig.ident.to_string(), &node.block);
+        }
+    }
+}
+
+#[derive(Default)]
+struct Collector {
+    writes: Vec<(String, usize)>,
+    refs_aliases: HashSet<String>,
+}
+
+impl Collector {
+    fn is_refs_handle(&self, expr: &Expr) -> bool {
+        let mut current = expr;
+        loop {
+            match current {
+                Expr::Field(field) => {
+                    return matches!(
+                        &field.member,
+                        syn::Member::Named(ident) if ident == "refs"
+                    );
+                }
+                Expr::MethodCall(call) => return call.method == "refs",
+                Expr::Path(path) => {
+                    return path
+                        .path
+                        .get_ident()
+                        .is_some_and(|ident| self.refs_aliases.contains(&ident.to_string()));
+                }
+                Expr::Reference(value) => current = &value.expr,
+                Expr::Try(value) => current = &value.expr,
+                Expr::Paren(value) => current = &value.expr,
+                Expr::Group(value) => current = &value.expr,
+                Expr::Await(value) => current = &value.base,
+                _ => return false,
+            }
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Collector {
+    fn visit_local(&mut self, node: &'ast syn::Local) {
+        if let Some(init) = &node.init
+            && self.is_refs_handle(&init.expr)
+            && let syn::Pat::Ident(ident) = &node.pat
+            && ident.subpat.is_none()
+        {
+            self.refs_aliases.insert(ident.ident.to_string());
+        }
+        syn::visit::visit_local(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        let method = node.method.to_string();
+        if WRITERS.contains(&method.as_str()) && self.is_refs_handle(&node.receiver) {
+            self.writes.push((method, node.method.span().start().line));
+        }
+        syn::visit::visit_expr_method_call(self, node);
+    }
+}
+
+fn apply_exemption_budgets(hits: Vec<Hit>) -> Vec<Hit> {
+    let mut used = BTreeMap::<(String, String, String), usize>::new();
+    hits.into_iter()
+        .filter(|hit| {
+            let key = (
+                path_key(&hit.path).to_string(),
+                hit.function.clone(),
+                hit.method.clone(),
+            );
+            let count = used.entry(key).or_default();
+            let budget = exemptions::budget(&hit.path, &hit.function, &hit.method);
+            *count += 1;
+            *count > budget
+        })
+        .collect()
+}
+
+fn path_key(path: &Path) -> &str {
+    exemptions::path_key(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn planted_cross_crate_bypass_is_detected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("bypass.rs"),
+            "fn bypass(&self) { self.refs.set_thread(&thread, &state).unwrap(); }",
+        )
+        .expect("write fixture");
+        let hits = scan_dirs(&[dir.path().to_path_buf()]).expect("scan fixture");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].method, "set_thread");
+    }
+
+    #[test]
+    fn production_tree_has_no_bare_ref_writes() {
+        let crates = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .expect("devtools lives under crates/")
+            .to_path_buf();
+        let hits = scan_dirs(&[crates]).expect("scan workspace");
+        let first = hits.first().map(|hit| {
+            format!(
+                "{}:{} `{}` calls `.{}(...)`",
+                hit.path.display(),
+                hit.line,
+                hit.function,
+                hit.method
+            )
+        });
+        assert!(
+            hits.is_empty(),
+            "{} bare production ref write(s) bypass commit_and_publish; first: {:?}",
+            hits.len(),
+            first
+        );
+    }
+}

--- a/crates/devtools/src/check_ref_write_chokepoint.rs
+++ b/crates/devtools/src/check_ref_write_chokepoint.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use syn::{Attribute, Expr, ImplItemFn, ItemFn, ItemMod, Meta, visit::Visit};
+use syn::{Attribute, Expr, ImplItemFn, ItemFn, ItemMod, Meta, TraitItemFn, visit::Visit};
 
 use crate::asserter::for_each_rs_file;
 
@@ -134,6 +134,14 @@ impl<'ast> Visit<'ast> for Finder<'_> {
             self.inspect(&node.sig.ident.to_string(), &node.block);
         }
     }
+
+    fn visit_trait_item_fn(&mut self, node: &'ast TraitItemFn) {
+        if !is_cfg_test(&node.attrs)
+            && let Some(block) = &node.default
+        {
+            self.inspect(&node.sig.ident.to_string(), block);
+        }
+    }
 }
 
 #[derive(Default)]
@@ -155,10 +163,9 @@ impl Collector {
                 }
                 Expr::MethodCall(call) => return call.method == "refs",
                 Expr::Path(path) => {
-                    return path
-                        .path
-                        .get_ident()
-                        .is_some_and(|ident| self.refs_aliases.contains(&ident.to_string()));
+                    return path.path.get_ident().is_some_and(|ident| {
+                        ident == "refs" || self.refs_aliases.contains(&ident.to_string())
+                    });
                 }
                 Expr::Reference(value) => current = &value.expr,
                 Expr::Try(value) => current = &value.expr,
@@ -230,6 +237,19 @@ mod tests {
         let hits = scan_dirs(&[dir.path().to_path_buf()]).expect("scan fixture");
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].method, "set_thread");
+    }
+
+    #[test]
+    fn planted_refs_parameter_bypass_is_detected() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("bypass.rs"),
+            "fn bypass(refs: &RefManager) { refs.write_head(&head).unwrap(); }",
+        )
+        .expect("write fixture");
+        let hits = scan_dirs(&[dir.path().to_path_buf()]).expect("scan fixture");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].method, "write_head");
     }
 
     #[test]

--- a/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
+++ b/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exact budgets for low-level ref writes that cannot create new operations.
+
+use std::path::Path;
+
+pub(super) fn path_key(path: &Path) -> &str {
+    const KEYS: &[&str] = &[
+        "repo/src/repository.rs",
+        "repo/src/repository_goto.rs",
+        "repo/src/repository_thread_materialize.rs",
+        "cli/src/cli/commands/undo_apply/mod.rs",
+        "cli/src/cli/commands/start_atomic.rs",
+        "cli/src/cli/commands/git_projection_io.rs",
+        "git-projection/src/git_core.rs",
+    ];
+    KEYS.iter()
+        .copied()
+        .find(|key| path.ends_with(key))
+        .unwrap_or("")
+}
+
+pub(super) fn budget(path: &Path, function: &str, method: &str) -> usize {
+    match (path_key(path), function, method) {
+        ("repo/src/repository.rs", "init_git_overlay_sidecar", "write_head") => 1,
+        ("repo/src/repository.rs", "open", "write_head") => 2,
+        ("repo/src/repository.rs", "seed_default_thread", "set_thread") => 1,
+        ("repo/src/repository_goto.rs", "fast_forward_attached_internal", "set_thread") => 1,
+        ("repo/src/repository_goto.rs", "fast_forward_attached_internal", "write_head") => 1,
+        ("repo/src/repository_goto.rs", "goto_internal", "write_head") => 1,
+        (
+            "repo/src/repository_thread_materialize.rs",
+            "cas_guarded_thread_ref_rollback",
+            "set_thread_cas",
+        ) => 1,
+        (
+            "repo/src/repository_thread_materialize.rs",
+            "cas_guarded_thread_ref_rollback",
+            "delete_thread_cas",
+        ) => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "restore_head", "write_head") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "write_head", "write_head") => 2,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "set_thread", "set_thread") => 2,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "set_thread", "delete_thread") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "delete_thread", "delete_thread") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "delete_thread", "set_thread") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "create_marker", "create_marker") => 2,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "create_marker", "delete_marker") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "delete_marker", "delete_marker") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "delete_marker", "create_marker") => 1,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "apply", "set_undo_recovery") => 2,
+        ("cli/src/cli/commands/undo_apply/mod.rs", "apply", "clear_undo_recovery") => 1,
+        ("cli/src/cli/commands/start_atomic.rs", "stage_ref", "set_thread_cas") => 2,
+        (
+            "cli/src/cli/commands/git_projection_io.rs",
+            "materialize_imported_attached_thread",
+            "set_thread",
+        ) => 2,
+        (
+            "cli/src/cli/commands/git_projection_io.rs",
+            "materialize_imported_attached_thread",
+            "write_head",
+        ) => 2,
+        ("git-projection/src/git_core.rs", "pull", "set_thread") => 2,
+        ("git-projection/src/git_core.rs", "pull", "write_head") => 2,
+        _ => 0,
+    }
+}

--- a/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
+++ b/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
@@ -22,6 +22,7 @@ pub(super) fn path_key(path: &Path) -> &str {
 pub(super) fn budget(path: &Path, function: &str, method: &str) -> usize {
     match (path_key(path), function, method) {
         ("repo/src/repository.rs", "init_git_overlay_sidecar", "write_head") => 1,
+        ("repo/src/repository.rs", "init_with_source_authority", "write_head") => 1,
         ("repo/src/repository.rs", "open", "write_head") => 2,
         ("repo/src/repository.rs", "seed_default_thread", "set_thread") => 1,
         ("repo/src/repository_goto.rs", "fast_forward_attached_internal", "set_thread") => 1,

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -7,6 +7,7 @@ mod asserter;
 mod check_atomic_ledger_encapsulation;
 mod check_no_silent_default_tree_load;
 mod check_oprecord_exhaustiveness;
+#[cfg(test)]
 mod check_ref_write_chokepoint;
 mod check_snapshot_atomicity;
 mod check_verification_owner;

--- a/crates/devtools/src/main.rs
+++ b/crates/devtools/src/main.rs
@@ -7,6 +7,7 @@ mod asserter;
 mod check_atomic_ledger_encapsulation;
 mod check_no_silent_default_tree_load;
 mod check_oprecord_exhaustiveness;
+mod check_ref_write_chokepoint;
 mod check_snapshot_atomicity;
 mod check_verification_owner;
 mod fuse_dispatch_bench;

--- a/crates/git-projection/src/git_sync.rs
+++ b/crates/git-projection/src/git_sync.rs
@@ -72,7 +72,7 @@ pub fn sync_branches(bridge: &mut GitProjection) -> GitProjectionResult<usize> {
                 });
             }
 
-            bridge.heddle_repo.refs().set_thread(&tn, &state_id)?;
+            bridge.heddle_repo.set_thread_recorded(&tn, &state_id)?;
             stats += 1;
         }
     }
@@ -113,14 +113,13 @@ pub fn sync_tags(bridge: &mut GitProjection) -> GitProjectionResult<usize> {
             match bridge.heddle_repo.refs().get_marker(&mn) {
                 Ok(Some(existing)) if existing != state_id => bridge
                     .heddle_repo
-                    .refs()
-                    .set_marker_cas(&mn, RefExpectation::Any, &state_id)?,
+                    .set_marker_recorded_cas(&mn, RefExpectation::Any, &state_id)?,
                 Ok(_) => {}
                 Err(err) => return Err(err.into()),
             }
 
             if bridge.heddle_repo.refs().get_marker(&mn)?.is_none() {
-                bridge.heddle_repo.refs().create_marker(&mn, &state_id)?;
+                bridge.heddle_repo.create_marker_recorded(&mn, &state_id)?;
             }
             stats += 1;
         }

--- a/crates/ingest/src/ref_emit.rs
+++ b/crates/ingest/src/ref_emit.rs
@@ -31,6 +31,7 @@ use objects::{
     object::{MarkerName, StateId, ThreadName, Tree},
     store::ObjectStore,
 };
+use oplog::OpRecord;
 use refs::refs::{RefBackend, RefExpectation, RefUpdate};
 use tracing::warn;
 
@@ -124,11 +125,12 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
                     // The divergence check MUST run before the batch publish:
                     // a thread import that would move a thread across divergent
                     // history fails closed here, before any ref is written.
-                    if let Some(existing) = self
+                    let existing = self
                         .refs
                         .get_thread(&thread_name)
                         .await
-                        .map_err(IngestError::from)?
+                        .map_err(IngestError::from)?;
+                    if let Some(existing) = existing
                         && self.state_remaps.get(&existing) != Some(&cid)
                         && !self.thread_can_adopt_change(&existing, &cid)?
                     {
@@ -139,7 +141,7 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
                             incoming: cid,
                         });
                     }
-                    threads.push((thread_name, cid));
+                    threads.push((thread_name, cid, existing));
                 }
                 RefNamespace::Tag => {
                     let marker_name = MarkerName::from(head.short_name.as_str());
@@ -170,14 +172,29 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
         // ref list never repeats a full name, so each (kind, short_name) pair
         // is already unique across the batch.
         let mut updates: Vec<RefUpdate> = Vec::with_capacity(threads.len() + markers.len());
+        let mut records = Vec::with_capacity(threads.len() + markers.len());
 
-        for (thread_name, cid) in threads {
+        for (thread_name, cid, existing) in threads {
+            if existing == Some(cid) {
+                stats.threads_written += 1;
+                continue;
+            }
+            records.push(match existing {
+                Some(old_state) => OpRecord::ThreadUpdate {
+                    name: thread_name.to_string(),
+                    old_state,
+                    new_state: cid,
+                    manager_snapshots: None,
+                },
+                None => OpRecord::ThreadCreate {
+                    name: thread_name.to_string(),
+                    state: cid,
+                    manager_snapshot: None,
+                },
+            });
             updates.push(RefUpdate::Thread {
                 name: thread_name,
-                // The divergence check above already validated the move; there
-                // is no concurrent writer during import, so `Any` mirrors the
-                // single-ref `set_thread` it replaces.
-                expected: RefExpectation::Any,
+                expected: existing.map_or(RefExpectation::Missing, RefExpectation::Value),
                 new: Some(cid),
             });
             stats.threads_written += 1;
@@ -185,9 +202,19 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
 
         for (marker_name, cid, existing) in markers {
             if existing != Some(cid) {
+                if let Some(old_state) = existing {
+                    records.push(OpRecord::MarkerDelete {
+                        name: marker_name.to_string(),
+                        state: old_state,
+                    });
+                }
+                records.push(OpRecord::MarkerCreate {
+                    name: marker_name.to_string(),
+                    state: cid,
+                });
                 updates.push(RefUpdate::Marker {
                     name: marker_name,
-                    expected: RefExpectation::Any,
+                    expected: existing.map_or(RefExpectation::Missing, RefExpectation::Value),
                     new: Some(cid),
                 });
             }
@@ -196,7 +223,24 @@ impl<'a, R: RefBackend, S: ObjectStore> RefEmitter<'a, R, S> {
             stats.markers_written += 1;
         }
 
-        self.refs.update_refs(&updates).map_err(IngestError::from)?;
+        let encoded_records = if self.refs.can_commit_records() {
+            records
+                .iter()
+                .map(|record| {
+                    rmp_serde::to_vec(record).map_err(|error| IngestError::Other(error.to_string()))
+                })
+                .collect::<crate::Result<Vec<_>>>()?
+        } else {
+            // Mechanical/recordless import is an explicit supported mode.
+            // It still enters through commit_and_publish for the atomic ref
+            // batch, but cannot claim an oplog invariant its backend does not
+            // provide. Configured repository backends advertise the committer
+            // and receive the exact records above.
+            Vec::new()
+        };
+        self.refs
+            .commit_and_publish(&encoded_records, &updates, None)
+            .map_err(IngestError::from)?;
 
         Ok(stats)
     }
@@ -261,18 +305,34 @@ fn change_is_ancestor<S: ObjectStore>(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use objects::{
+        error::Result as HeddleResult,
         object::{Attribution, Principal, State, StateId},
         store::{InMemoryStore, ObjectStore},
     };
-    use refs::refs::RefManager;
+    use refs::refs::{RefCommitter, RefManager};
     use tempfile::TempDir;
 
     use super::*;
 
+    struct TestCommitter;
+
+    impl RefCommitter for TestCommitter {
+        fn commit_records(
+            &self,
+            _encoded_records: &[Vec<u8>],
+            _scope: Option<&str>,
+        ) -> HeddleResult<()> {
+            Ok(())
+        }
+    }
+
     fn fresh_ref_manager() -> (TempDir, RefManager) {
         let tmp = TempDir::new().unwrap();
-        let mgr = RefManager::new(tmp.path());
+        let mgr = RefManager::new(tmp.path())
+            .with_committer(Arc::new(TestCommitter) as Arc<dyn RefCommitter>);
         mgr.init().unwrap();
         (tmp, mgr)
     }

--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -18,8 +18,8 @@ pub use oplog_core::OpLog;
 pub use oplog_recorder::{OpLogRecorder, VisibilitySidecarSnapshots};
 pub use oplog_types::{
     ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    RedactionUndoClass, ThreadUpdateSnapshots, is_transaction_commit, is_transaction_commit_for,
-    isolation_keys_for_record,
+    RecordedHead, RedactionUndoClass, ThreadUpdateSnapshots, is_transaction_commit,
+    is_transaction_commit_for, isolation_keys_for_record,
 };
 pub use packed_oplog::OplogRecoveryReport;
 #[cfg(feature = "postgres")]

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -839,7 +839,8 @@ impl PackedOpLogIndex {
                 | OpRecord::RemoteThreadDelete { .. }
                 | OpRecord::UndoRecoveryUpdate { .. }
                 | OpRecord::StateVisibilitySet { .. }
-                | OpRecord::StateVisibilityPromote { .. } => {
+                | OpRecord::StateVisibilityPromote { .. }
+                | OpRecord::HeadUpdate { .. } => {
                     return Err(HeddleError::InvalidObject(
                         "oplog transaction directory references a non-commit entry".to_string(),
                     ));

--- a/crates/refs/src/refs/pg_refs.rs
+++ b/crates/refs/src/refs/pg_refs.rs
@@ -338,7 +338,98 @@ impl CoreRefBackend for PgRefBackend {
         let pool = Arc::clone(&self.pool);
         let repo_id = self.repo_id;
         let updates = updates.to_vec();
-        self.block(async move { let mut tx = pool.begin().await.map_err(sqlx_err)?; for update in &updates { match update { RefUpdate::Thread { name, expected, new } => match (expected, new) { (_, None) => { sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = true").bind(repo_id).bind(name.as_str()).execute(&mut *tx).await.map_err(sqlx_err)?; } (RefExpectation::Missing, Some(state)) => { sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, true, $3, NOW()) ON CONFLICT DO NOTHING").bind(repo_id).bind(name.as_str()).bind(Self::id_to_bytes(state)).execute(&mut *tx).await.map_err(sqlx_err)?; } (RefExpectation::Value(old), Some(new_state)) => { sqlx::query("UPDATE refs SET state_id = $4, updated_at = NOW() WHERE repo_id = $1 AND name = $2 AND is_thread = true AND state_id = $3").bind(repo_id).bind(name.as_str()).bind(Self::id_to_bytes(old)).bind(Self::id_to_bytes(new_state)).execute(&mut *tx).await.map_err(sqlx_err)?; } (_, Some(state)) => { sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, true, $3, NOW()) ON CONFLICT (repo_id, name) DO UPDATE SET state_id = EXCLUDED.state_id, updated_at = NOW()").bind(repo_id).bind(name.as_str()).bind(Self::id_to_bytes(state)).execute(&mut *tx).await.map_err(sqlx_err)?; } }, RefUpdate::Marker { name, expected: _, new } => match new { None => { sqlx::query("DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = false").bind(repo_id).bind(name.as_str()).execute(&mut *tx).await.map_err(sqlx_err)?; } Some(state) => { sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, false, $3, NOW()) ON CONFLICT (repo_id, name) DO UPDATE SET state_id = EXCLUDED.state_id, updated_at = NOW()").bind(repo_id).bind(name.as_str()).bind(Self::id_to_bytes(state)).execute(&mut *tx).await.map_err(sqlx_err)?; } }, RefUpdate::Head { new, .. } => { let (thread, state_id): (Option<String>, Option<Vec<u8>>) = match new { Head::Attached { thread } => (Some(thread.to_string()), None), Head::Detached { state } => (None, Some(Self::id_to_bytes(state))), }; sqlx::query("INSERT INTO heads (repo_id, thread, state_id) VALUES ($1, $2, $3) ON CONFLICT (repo_id) DO UPDATE SET thread = EXCLUDED.thread, state_id = EXCLUDED.state_id").bind(repo_id).bind(thread).bind(state_id).execute(&mut *tx).await.map_err(sqlx_err)?; } } } tx.commit().await.map_err(sqlx_err)?; Ok(()) })
+        self.block(async move {
+            let mut tx = pool.begin().await.map_err(sqlx_err)?;
+            for update in &updates {
+                match update {
+                    RefUpdate::Thread {
+                        name,
+                        expected,
+                        new,
+                    } => match (expected, new) {
+                        (_, None) => {
+                            sqlx::query(
+                                "DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = true",
+                            )
+                            .bind(repo_id)
+                            .bind(name.as_str())
+                            .execute(&mut *tx)
+                            .await
+                            .map_err(sqlx_err)?;
+                        }
+                        (RefExpectation::Missing, Some(state)) => {
+                            sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, true, $3, NOW()) ON CONFLICT DO NOTHING")
+                                .bind(repo_id)
+                                .bind(name.as_str())
+                                .bind(Self::id_to_bytes(state))
+                                .execute(&mut *tx)
+                                .await
+                                .map_err(sqlx_err)?;
+                        }
+                        (RefExpectation::Value(old), Some(new_state)) => {
+                            sqlx::query("UPDATE refs SET state_id = $4, updated_at = NOW() WHERE repo_id = $1 AND name = $2 AND is_thread = true AND state_id = $3")
+                                .bind(repo_id)
+                                .bind(name.as_str())
+                                .bind(Self::id_to_bytes(old))
+                                .bind(Self::id_to_bytes(new_state))
+                                .execute(&mut *tx)
+                                .await
+                                .map_err(sqlx_err)?;
+                        }
+                        (_, Some(state)) => {
+                            sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, true, $3, NOW()) ON CONFLICT (repo_id, name) DO UPDATE SET state_id = EXCLUDED.state_id, updated_at = NOW()")
+                                .bind(repo_id)
+                                .bind(name.as_str())
+                                .bind(Self::id_to_bytes(state))
+                                .execute(&mut *tx)
+                                .await
+                                .map_err(sqlx_err)?;
+                        }
+                    },
+                    RefUpdate::Marker { name, new, .. } => match new {
+                        None => {
+                            sqlx::query(
+                                "DELETE FROM refs WHERE repo_id = $1 AND name = $2 AND is_thread = false",
+                            )
+                            .bind(repo_id)
+                            .bind(name.as_str())
+                            .execute(&mut *tx)
+                            .await
+                            .map_err(sqlx_err)?;
+                        }
+                        Some(state) => {
+                            sqlx::query("INSERT INTO refs (repo_id, name, is_thread, state_id, updated_at) VALUES ($1, $2, false, $3, NOW()) ON CONFLICT (repo_id, name) DO UPDATE SET state_id = EXCLUDED.state_id, updated_at = NOW()")
+                                .bind(repo_id)
+                                .bind(name.as_str())
+                                .bind(Self::id_to_bytes(state))
+                                .execute(&mut *tx)
+                                .await
+                                .map_err(sqlx_err)?;
+                        }
+                    },
+                    RefUpdate::Head { new, .. } => {
+                        let (thread, state_id): (Option<String>, Option<Vec<u8>>) = match new {
+                            Head::Attached { thread } => (Some(thread.to_string()), None),
+                            Head::Detached { state } => (None, Some(Self::id_to_bytes(state))),
+                        };
+                        sqlx::query("INSERT INTO heads (repo_id, thread, state_id) VALUES ($1, $2, $3) ON CONFLICT (repo_id) DO UPDATE SET thread = EXCLUDED.thread, state_id = EXCLUDED.state_id")
+                            .bind(repo_id)
+                            .bind(thread)
+                            .bind(state_id)
+                            .execute(&mut *tx)
+                            .await
+                            .map_err(sqlx_err)?;
+                    }
+                    RefUpdate::RemoteThread { .. } => {
+                        return Err(HeddleError::Conflict(
+                            "remote threading refs are not supported on the server backend".into(),
+                        ));
+                    }
+                }
+            }
+            tx.commit().await.map_err(sqlx_err)?;
+            Ok(())
+        })
     }
     async fn resolve(&self, refspec: &str) -> Result<Option<StateId>> {
         if refspec == "@" || refspec == "HEAD" {

--- a/crates/refs/src/refs/ref_backend.rs
+++ b/crates/refs/src/refs/ref_backend.rs
@@ -19,6 +19,17 @@ pub trait RefBackend: CoreRefBackend<Error = HeddleError> {
     fn list_remotes(&self) -> Result<Vec<String>>;
     fn list_remote_threads(&self, remote: &str) -> Result<Vec<ThreadName>>;
 
+    /// Whether this backend can durably commit a non-empty opaque operation
+    /// record batch at the [`commit_and_publish`](Self::commit_and_publish)
+    /// seam.
+    ///
+    /// Recordless/bootstrap backends still route ref batches through the same
+    /// chokepoint, but callers must pass an empty record batch. The default is
+    /// conservative so an unwired backend never claims it can preserve records.
+    fn can_commit_records(&self) -> bool {
+        false
+    }
+
     /// The write chokepoint (heddle#330 §2.2 r18): append the caller-supplied
     /// ref-carrying record batch (phase 4, opaque rmp-serde `OpRecord` bytes so
     /// `refs` names no `oplog` type) before publishing the atomic ref batch

--- a/crates/refs/src/refs/ref_summary_index.rs
+++ b/crates/refs/src/refs/ref_summary_index.rs
@@ -85,8 +85,7 @@ struct RefSummaryEntry {
 /// The plan already knows exactly which thread/marker changed and its new
 /// state-id, so a publish that touches `k` refs costs `O(k)` index edits +
 /// one packed-refs load — not an `O(refs)` full-dir rescan. HEAD is not part of
-/// the summary index, so HEAD plans carry no target; remote threads are never
-/// produced by `publish_ref_plans`, so they stay untouched in the index.
+/// the summary index, so HEAD plans carry no target.
 #[derive(Debug, Clone)]
 pub(super) enum SummaryDelta {
     /// Loose thread set to a new state-id (the loose file now exists on disk).
@@ -98,6 +97,14 @@ pub(super) enum SummaryDelta {
     DeleteThread { name: String },
     /// Marker removed from both loose and packed storage.
     DeleteMarker { name: String },
+    /// Remote thread set to a new state-id.
+    SetRemoteThread {
+        remote: String,
+        name: String,
+        state_id: StateId,
+    },
+    /// Remote thread removed.
+    DeleteRemoteThread { remote: String, name: String },
 }
 
 #[derive(Debug, Clone)]
@@ -259,7 +266,7 @@ impl RefSummaryIndex {
     /// recorded as `LooseAndPacked` (matching the from-storage rebuild).
     ///
     /// Entries stay sorted by name: set inserts at the sorted position (or
-    /// updates in place), delete removes. Remotes are never touched here.
+    /// updates in place), delete removes.
     fn apply_delta(&mut self, delta: &SummaryDelta, packed: &PackedRefs) {
         match delta {
             SummaryDelta::SetThread { name, state_id } => {
@@ -283,6 +290,49 @@ impl RefSummaryIndex {
             }
             SummaryDelta::DeleteMarker { name } => {
                 self.markers.retain(|entry| entry.name != *name);
+            }
+            SummaryDelta::SetRemoteThread {
+                remote,
+                name,
+                state_id,
+            } => {
+                let remote_index = match self
+                    .remotes
+                    .binary_search_by(|entry| entry.name.as_str().cmp(remote))
+                {
+                    Ok(index) => index,
+                    Err(index) => {
+                        self.remotes.insert(
+                            index,
+                            RemoteSummaryEntry {
+                                name: remote.clone(),
+                                threads: Vec::new(),
+                            },
+                        );
+                        index
+                    }
+                };
+                let threads = &mut self.remotes[remote_index].threads;
+                match threads.binary_search_by(|entry| entry.name.as_str().cmp(name)) {
+                    Ok(index) => threads[index].state_id = *state_id,
+                    Err(index) => threads.insert(
+                        index,
+                        RemoteThreadSummaryEntry {
+                            name: name.clone(),
+                            state_id: *state_id,
+                        },
+                    ),
+                }
+            }
+            SummaryDelta::DeleteRemoteThread { remote, name } => {
+                if let Ok(index) = self
+                    .remotes
+                    .binary_search_by(|entry| entry.name.as_str().cmp(remote))
+                {
+                    self.remotes[index]
+                        .threads
+                        .retain(|entry| entry.name != *name);
+                }
             }
         }
     }

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -668,7 +668,11 @@ impl RefManager {
         }
     }
 
-    fn raw_get_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<StateId>> {
+    pub(super) fn raw_get_remote_thread(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+    ) -> Result<Option<StateId>> {
         let path = self.remote_thread_path(remote, thread)?;
         self.read_state_id_at(&path, "remote thread", &format!("{}/{}", remote, thread))
     }
@@ -1166,6 +1170,10 @@ impl CoreRefBackend for RefManager {
 }
 
 impl RefBackend for RefManager {
+    fn can_commit_records(&self) -> bool {
+        self.committer.is_some()
+    }
+
     fn get_remote_thread(&self, remote: &str, thread: &ThreadName) -> Result<Option<StateId>> {
         RefManager::get_remote_thread(self, remote, thread)
     }

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -23,7 +23,7 @@ use super::{
         matches_expectation,
     },
 };
-use crate::fs_atomic::{stage_temp_files_durable, sync_directory};
+use crate::fs_atomic::{create_dir_all_durable, stage_temp_files_durable, sync_directory};
 
 enum PackedRemove {
     Thread(String),
@@ -318,6 +318,59 @@ impl RefManager {
                         summary_delta: None,
                     });
                 }
+                RefUpdate::RemoteThread {
+                    remote,
+                    thread,
+                    expected,
+                    new,
+                } => {
+                    let path = self.remote_thread_path(remote, thread)?;
+                    if !seen.insert(path.clone()) {
+                        return Err(HeddleError::Conflict(format!(
+                            "duplicate ref update for remote thread {}/{}",
+                            remote, thread
+                        )));
+                    }
+
+                    let current =
+                        match self.reconciled_value_under_lock(&LoadRequest::RemoteThread {
+                            remote: remote.clone(),
+                            thread: thread.clone(),
+                        })? {
+                            Loaded::Point(id) => id,
+                            _ => unreachable!("RemoteThread request yields Point"),
+                        };
+                    if !matches_expectation(expected, current.as_ref(), current.is_some()) {
+                        return Err(HeddleError::Conflict(format!(
+                            "remote thread {}/{} expected {}, found {}",
+                            remote,
+                            thread,
+                            describe_expectation_state_id(expected),
+                            describe_state_id(current)
+                        )));
+                    }
+
+                    let summary_delta = Some(match new {
+                        Some(state_id) => SummaryDelta::SetRemoteThread {
+                            remote: remote.clone(),
+                            name: thread.to_string(),
+                            state_id: *state_id,
+                        },
+                        None => SummaryDelta::DeleteRemoteThread {
+                            remote: remote.clone(),
+                            name: thread.to_string(),
+                        },
+                    });
+                    plans.push(RefUpdatePlan {
+                        path,
+                        new_content: new.as_ref().map(format_state_id_text),
+                        previous_content: current.as_ref().map(format_state_id_text),
+                        description: format!("remote thread {}/{}", remote, thread),
+                        temp_path: None,
+                        packed_remove: None,
+                        summary_delta,
+                    });
+                }
             }
         }
 
@@ -400,6 +453,38 @@ impl RefManager {
                         summary_delta: None,
                     });
                 }
+                RefUpdate::RemoteThread {
+                    remote,
+                    thread,
+                    new,
+                    ..
+                } => {
+                    let path = self.remote_thread_path(remote, thread)?;
+                    let current = self.raw_get_remote_thread(remote, thread)?;
+                    if current == *new {
+                        continue;
+                    }
+                    let summary_delta = Some(match new {
+                        Some(state_id) => SummaryDelta::SetRemoteThread {
+                            remote: remote.clone(),
+                            name: thread.to_string(),
+                            state_id: *state_id,
+                        },
+                        None => SummaryDelta::DeleteRemoteThread {
+                            remote: remote.clone(),
+                            name: thread.to_string(),
+                        },
+                    });
+                    plans.push(RefUpdatePlan {
+                        path,
+                        new_content: new.as_ref().map(format_state_id_text),
+                        previous_content: current.as_ref().map(format_state_id_text),
+                        description: format!("remote thread {}/{}", remote, thread),
+                        temp_path: None,
+                        packed_remove: None,
+                        summary_delta,
+                    });
+                }
             }
         }
         Ok(plans)
@@ -426,6 +511,10 @@ impl RefManager {
         let mut temp_writes: Vec<(PathBuf, Vec<u8>)> = Vec::new();
         for plan in &mut plans {
             if let Some(ref content) = plan.new_content {
+                let parent = plan.path.parent().ok_or_else(|| {
+                    HeddleError::Config(format!("invalid ref path {}", plan.path.display()))
+                })?;
+                create_dir_all_durable(parent)?;
                 let temp_path = self.alloc_temp_path(&plan.path)?;
                 temp_writes.push((temp_path.clone(), content.clone().into_bytes()));
                 plan.temp_path = Some(temp_path);

--- a/crates/refs/src/refs/types.rs
+++ b/crates/refs/src/refs/types.rs
@@ -28,4 +28,10 @@ pub enum RefUpdate {
         expected: RefExpectation<Head>,
         new: Head,
     },
+    RemoteThread {
+        remote: String,
+        thread: ThreadName,
+        expected: RefExpectation<StateId>,
+        new: Option<StateId>,
+    },
 }

--- a/crates/repo/src/atomic/reconciler.rs
+++ b/crates/repo/src/atomic/reconciler.rs
@@ -16,7 +16,7 @@ use objects::{
     error::Result,
     object::{MarkerName, StateId, ThreadName},
 };
-use oplog::{OpLog, OpRecord};
+use oplog::{OpLog, OpRecord, RecordedHead};
 use refs::{
     Head, LoadRequest, Loaded, ReconcileOutcome, RefClass, RefExpectation, RefManager,
     RefReconciler, RefUpdate,
@@ -227,6 +227,14 @@ impl Fold {
             }
             OpRecord::Goto { head, .. } => {
                 self.head = HeadFold::Republish(Head::Detached { state: *head });
+            }
+            OpRecord::HeadUpdate { new, .. } => {
+                self.head = HeadFold::Republish(match new {
+                    RecordedHead::Attached { thread } => Head::Attached {
+                        thread: ThreadName::new(thread),
+                    },
+                    RecordedHead::Detached { state } => Head::Detached { state: *state },
+                });
             }
             // Records that do not move canonical HEAD: transaction markers,
             // conflict resolution, redaction bookkeeping, and the Git-overlay

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -1441,6 +1441,7 @@ fn op_record_variant_name(record: &OpRecord) -> &'static str {
         OpRecord::UndoRecoveryUpdate { .. } => "UndoRecoveryUpdate",
         OpRecord::StateVisibilitySet { .. } => "StateVisibilitySet",
         OpRecord::StateVisibilityPromote { .. } => "StateVisibilityPromote",
+        OpRecord::HeadUpdate { .. } => "HeadUpdate",
     }
 }
 

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -32,6 +32,8 @@ mod repository_partial_fetch;
 mod repository_provenance;
 #[path = "repository_recovery.rs"]
 mod repository_recovery;
+#[path = "repository_ref_mutation.rs"]
+mod repository_ref_mutation;
 #[path = "repository_resolve.rs"]
 mod repository_resolve;
 #[path = "repository_signing.rs"]
@@ -2304,7 +2306,7 @@ impl Repository {
             ));
         }
         let thread = ThreadName::from(facet.thread_ref(main_thread).as_str());
-        self.refs.set_thread(&thread, state)
+        self.set_thread_recorded(&thread, state)
     }
 
     /// The write chokepoint (heddle#330 §2.2): commit the ref-carrying

--- a/crates/repo/src/repository_ref_mutation.rs
+++ b/crates/repo/src/repository_ref_mutation.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Recorded ref mutations routed through the atomic write chokepoint.
+
+use objects::object::MarkerName;
+use oplog::RecordedHead;
+
+use super::*;
+
+fn recorded_head(head: &Head) -> RecordedHead {
+    match head {
+        Head::Attached { thread } => RecordedHead::Attached {
+            thread: thread.to_string(),
+        },
+        Head::Detached { state } => RecordedHead::Detached { state: *state },
+    }
+}
+
+fn is_conflict(error: &HeddleError) -> bool {
+    matches!(error, HeddleError::Conflict(_))
+}
+
+impl Repository {
+    /// Build the record paired with a direct HEAD ref update.
+    pub fn head_update_record(previous: &Head, new: &Head) -> OpRecord {
+        OpRecord::HeadUpdate {
+            previous: recorded_head(previous),
+            new: recorded_head(new),
+        }
+    }
+
+    /// Set a thread ref and derive its create/update record from the
+    /// reconciled value. A concurrent unconditional writer is retried so this
+    /// preserves the original last-writer-wins behavior without recording a
+    /// stale before-image.
+    pub fn set_thread_recorded(&self, name: &ThreadName, state: &StateId) -> Result<()> {
+        loop {
+            let expected = match self.refs.get_thread(name)? {
+                Some(current) if current == *state => return Ok(()),
+                Some(current) => RefExpectation::Value(current),
+                None => RefExpectation::Missing,
+            };
+            match self.set_thread_recorded_cas(name, expected, state) {
+                Err(error) if is_conflict(&error) => continue,
+                result => return result,
+            }
+        }
+    }
+
+    /// CAS variant of [`set_thread_recorded`](Self::set_thread_recorded).
+    pub fn set_thread_recorded_cas(
+        &self,
+        name: &ThreadName,
+        expected: RefExpectation<StateId>,
+        state: &StateId,
+    ) -> Result<()> {
+        let record = match &expected {
+            RefExpectation::Missing => OpRecord::ThreadCreate {
+                name: name.to_string(),
+                state: *state,
+                manager_snapshot: None,
+            },
+            RefExpectation::Value(old_state) if old_state == state => {
+                return match self.refs.get_thread(name)? {
+                    Some(current) if current == *old_state => Ok(()),
+                    current => Err(HeddleError::Conflict(format!(
+                        "thread {} expected {}, found {}",
+                        name,
+                        old_state,
+                        current
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "missing".to_string())
+                    ))),
+                };
+            }
+            RefExpectation::Value(old_state) => OpRecord::ThreadUpdate {
+                name: name.to_string(),
+                old_state: *old_state,
+                new_state: *state,
+                manager_snapshots: None,
+            },
+            RefExpectation::Any => {
+                return self.set_thread_recorded(name, state);
+            }
+        };
+        self.commit_and_publish(
+            vec![record],
+            &[RefUpdate::Thread {
+                name: name.clone(),
+                expected,
+                new: Some(*state),
+            }],
+        )
+    }
+
+    /// Delete a thread ref, returning its prior value. A disappearing or
+    /// concurrently-updated ref is re-read before the record is constructed.
+    pub fn delete_thread_recorded(&self, name: &ThreadName) -> Result<Option<StateId>> {
+        loop {
+            let Some(current) = self.refs.get_thread(name)? else {
+                return Ok(None);
+            };
+            let result = self.commit_and_publish(
+                vec![OpRecord::ThreadDelete {
+                    name: name.to_string(),
+                    state: current,
+                }],
+                &[RefUpdate::Thread {
+                    name: name.clone(),
+                    expected: RefExpectation::Value(current),
+                    new: None,
+                }],
+            );
+            match result {
+                Ok(()) => return Ok(Some(current)),
+                Err(error) if is_conflict(&error) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Publish HEAD with an exact before/after record.
+    pub fn write_head_recorded(&self, new: &Head) -> Result<()> {
+        loop {
+            let previous = self.refs.read_head()?;
+            if previous == *new {
+                return Ok(());
+            }
+            let result = self.commit_and_publish(
+                vec![Self::head_update_record(&previous, new)],
+                &[RefUpdate::Head {
+                    expected: RefExpectation::Value(previous),
+                    new: new.clone(),
+                }],
+            );
+            match result {
+                Err(error) if is_conflict(&error) => continue,
+                result => return result,
+            }
+        }
+    }
+
+    /// Create a marker only when absent, recording the same CAS condition.
+    pub fn create_marker_recorded(&self, name: &MarkerName, state: &StateId) -> Result<()> {
+        self.commit_and_publish(
+            vec![OpRecord::MarkerCreate {
+                name: name.to_string(),
+                state: *state,
+            }],
+            &[RefUpdate::Marker {
+                name: name.clone(),
+                expected: RefExpectation::Missing,
+                new: Some(*state),
+            }],
+        )
+    }
+
+    /// CAS-update a marker with a reversible delete/create record pair.
+    pub fn set_marker_recorded_cas(
+        &self,
+        name: &MarkerName,
+        expected: RefExpectation<StateId>,
+        state: &StateId,
+    ) -> Result<()> {
+        let records = match &expected {
+            RefExpectation::Missing => vec![OpRecord::MarkerCreate {
+                name: name.to_string(),
+                state: *state,
+            }],
+            RefExpectation::Value(old_state) if old_state == state => {
+                return match self.refs.get_marker(name)? {
+                    Some(current) if current == *old_state => Ok(()),
+                    current => Err(HeddleError::Conflict(format!(
+                        "marker {} expected {}, found {}",
+                        name,
+                        old_state,
+                        current
+                            .map(|value| value.to_string())
+                            .unwrap_or_else(|| "missing".to_string())
+                    ))),
+                };
+            }
+            RefExpectation::Value(old_state) => vec![
+                OpRecord::MarkerDelete {
+                    name: name.to_string(),
+                    state: *old_state,
+                },
+                OpRecord::MarkerCreate {
+                    name: name.to_string(),
+                    state: *state,
+                },
+            ],
+            RefExpectation::Any => loop {
+                let exact = match self.refs.get_marker(name)? {
+                    Some(current) if current == *state => return Ok(()),
+                    Some(current) => RefExpectation::Value(current),
+                    None => RefExpectation::Missing,
+                };
+                match self.set_marker_recorded_cas(name, exact, state) {
+                    Err(error) if is_conflict(&error) => continue,
+                    result => return result,
+                }
+            },
+        };
+        self.commit_and_publish(
+            records,
+            &[RefUpdate::Marker {
+                name: name.clone(),
+                expected,
+                new: Some(*state),
+            }],
+        )
+    }
+
+    /// Delete a marker, returning its prior value.
+    pub fn delete_marker_recorded(&self, name: &MarkerName) -> Result<Option<StateId>> {
+        loop {
+            let Some(current) = self.refs.get_marker(name)? else {
+                return Ok(None);
+            };
+            let result = self.commit_and_publish(
+                vec![OpRecord::MarkerDelete {
+                    name: name.to_string(),
+                    state: current,
+                }],
+                &[RefUpdate::Marker {
+                    name: name.clone(),
+                    expected: RefExpectation::Value(current),
+                    new: None,
+                }],
+            );
+            match result {
+                Ok(()) => return Ok(Some(current)),
+                Err(error) if is_conflict(&error) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    /// Publish a remote-tracking thread with its reconciliation record.
+    pub fn set_remote_thread_recorded(
+        &self,
+        remote: &str,
+        thread: &ThreadName,
+        state: &StateId,
+    ) -> Result<()> {
+        loop {
+            let expected = match self.refs.get_remote_thread(remote, thread)? {
+                Some(current) if current == *state => return Ok(()),
+                Some(current) => RefExpectation::Value(current),
+                None => RefExpectation::Missing,
+            };
+            let result = self.commit_and_publish(
+                vec![OpRecord::RemoteThreadUpdate {
+                    remote: remote.to_string(),
+                    thread: thread.to_string(),
+                    state: *state,
+                }],
+                &[RefUpdate::RemoteThread {
+                    remote: remote.to_string(),
+                    thread: thread.clone(),
+                    expected,
+                    new: Some(*state),
+                }],
+            );
+            match result {
+                Err(error) if is_conflict(&error) => continue,
+                result => return result,
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn test_repo() -> (TempDir, Repository) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        (temp, repo)
+    }
+
+    #[test]
+    fn recorded_ref_helpers_publish_with_exact_records() {
+        let (_temp, repo) = test_repo();
+        let thread = ThreadName::new("feature");
+        let first = crate::test_state_id();
+        let second = crate::test_state_id();
+
+        repo.set_thread_recorded(&thread, &first).unwrap();
+        repo.set_thread_recorded(&thread, &second).unwrap();
+
+        assert_eq!(repo.refs().get_thread(&thread).unwrap(), Some(second));
+        let recent = repo.oplog().recent(8).unwrap();
+        assert!(recent.iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::ThreadCreate { name, state, .. }
+                if name == "feature" && *state == first
+        )));
+        assert!(recent.iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::ThreadUpdate {
+                name,
+                old_state,
+                new_state,
+                ..
+            } if name == "feature" && *old_state == first && *new_state == second
+        )));
+    }
+
+    #[test]
+    fn head_and_remote_updates_are_replayable_records() {
+        let (_temp, repo) = test_repo();
+        let previous = repo.refs().read_head().unwrap();
+        let detached = crate::test_state_id();
+        repo.write_head_recorded(&Head::Detached { state: detached })
+            .unwrap();
+
+        let remote_state = crate::test_state_id();
+        let remote_thread = ThreadName::new("main");
+        repo.set_remote_thread_recorded("origin", &remote_thread, &remote_state)
+            .unwrap();
+
+        assert_eq!(
+            repo.refs().read_head().unwrap(),
+            Head::Detached { state: detached }
+        );
+        assert_eq!(
+            repo.refs()
+                .get_remote_thread("origin", &remote_thread)
+                .unwrap(),
+            Some(remote_state)
+        );
+        let recent = repo.oplog().recent(8).unwrap();
+        assert!(recent.iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::HeadUpdate {
+                previous: recorded_previous,
+                new: RecordedHead::Detached { state },
+            } if recorded_previous == &recorded_head(&previous) && *state == detached
+        )));
+        assert!(recent.iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::RemoteThreadUpdate {
+                remote,
+                thread,
+                state,
+            } if remote == "origin" && thread == "main" && *state == remote_state
+        )));
+    }
+}

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -194,7 +194,8 @@ impl AtomicMutation for SnapshotMutation<'_> {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => None,
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => None,
         }) else {
             return Ok(this_run);
         };

--- a/crates/repo/src/repository_thread_materialize.rs
+++ b/crates/repo/src/repository_thread_materialize.rs
@@ -798,7 +798,7 @@ impl Repository {
         // is a real author capture that bypasses `stage_snapshot_objects`. Last
         // mutation before the write.
         self.put_authored_state(&state)?;
-        self.refs().set_thread(&thread_name, &state.id())?;
+        self.set_thread_recorded(&thread_name, &state.id())?;
 
         // 4. Rewrite the manifest to reflect the new state. `root` is
         //    the worktree being captured from — record its canonical

--- a/crates/schema/src/op_record/codec.rs
+++ b/crates/schema/src/op_record/codec.rs
@@ -13,7 +13,7 @@ use objects::{
 };
 use serde::Deserialize;
 
-use super::{OpRecord, ThreadUpdateSnapshots};
+use super::{OpRecord, RecordedHead, ThreadUpdateSnapshots};
 
 pub const CURRENT_OP_RECORD_SCHEMA_VERSION: u32 = 4;
 const CURRENT_OP_RECORD_SCHEMA_NAME: &str = "state-id-v4";
@@ -184,6 +184,10 @@ enum StrictCurrentOpRecord {
         prior_sidecar: Option<Vec<u8>>,
         #[serde(default)]
         new_sidecar: Option<Vec<u8>>,
+    },
+    HeadUpdate {
+        previous: RecordedHead,
+        new: RecordedHead,
     },
 }
 
@@ -373,6 +377,7 @@ impl StrictCurrentOpRecord {
                 prior_sidecar,
                 new_sidecar,
             },
+            Self::HeadUpdate { previous, new } => OpRecord::HeadUpdate { previous, new },
         }
     }
 }
@@ -520,6 +525,12 @@ mod tests {
                 prior_sidecar: Some(vec![4]),
                 new_sidecar: Some(vec![5]),
             },
+            OpRecord::HeadUpdate {
+                previous: RecordedHead::Detached { state: state(26) },
+                new: RecordedHead::Attached {
+                    thread: "main".into(),
+                },
+            },
         ]
     }
 
@@ -548,6 +559,7 @@ mod tests {
             OpRecord::UndoRecoveryUpdate { .. } => "UndoRecoveryUpdate",
             OpRecord::StateVisibilitySet { .. } => "StateVisibilitySet",
             OpRecord::StateVisibilityPromote { .. } => "StateVisibilityPromote",
+            OpRecord::HeadUpdate { .. } => "HeadUpdate",
         }
     }
 
@@ -605,6 +617,7 @@ mod tests {
                 "UndoRecoveryUpdate",
                 "StateVisibilitySet",
                 "StateVisibilityPromote",
+                "HeadUpdate",
             ]
         );
         for record in records {

--- a/crates/schema/src/op_record/types.rs
+++ b/crates/schema/src/op_record/types.rs
@@ -45,6 +45,16 @@ pub enum ConditionalCommitOutcome {
     },
 }
 
+/// A HEAD value captured in an operation record.
+///
+/// This mirrors the refs crate's `Head` without making the schema crate depend
+/// on the refs implementation. The repository layer owns the conversion.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RecordedHead {
+    Attached { thread: String },
+    Detached { state: StateId },
+}
+
 /// Record of an operation that can be undone.
 ///
 /// Variants must be appended at the tail. rmp-serde encodes enum variants by
@@ -325,6 +335,15 @@ pub enum OpRecord {
         #[serde(default)]
         new_sidecar: Option<Vec<u8>>,
     },
+    /// A direct HEAD publish that is not already represented by a more
+    /// specific operation such as `Snapshot`, `Fork`, `Collapse`, or `Goto`.
+    ///
+    /// Both images are recorded so reconciliation can recover a committed but
+    /// unpublished move and undo/redo can restore the exact attachment state.
+    HeadUpdate {
+        previous: RecordedHead,
+        new: RecordedHead,
+    },
 }
 
 /// True when `record` is the atomic transaction commit marker.
@@ -446,6 +465,7 @@ pub fn isolation_keys_for_record(record: &OpRecord, scope: Option<&str>) -> BTre
         OpRecord::Snapshot { thread: None, .. }
         | OpRecord::Checkpoint { thread: None, .. }
         | OpRecord::Goto { .. }
+        | OpRecord::HeadUpdate { .. }
         | OpRecord::UndoRecoveryUpdate { .. } => {
             if let Some(scope) = scope {
                 keys.insert(IsolationKey::LocalHead {
@@ -635,6 +655,12 @@ impl OpRecord {
             OpRecord::StateVisibilityPromote { state, tier, .. } => {
                 format!("promote visibility {} -> {}", state.short(), tier.as_str())
             }
+            OpRecord::HeadUpdate { new, .. } => match new {
+                RecordedHead::Attached { thread } => format!("attach HEAD to {}", thread),
+                RecordedHead::Detached { state } => {
+                    format!("detach HEAD at {}", state.short())
+                }
+            },
         }
     }
 }
@@ -708,6 +734,7 @@ op_verb_catalog! {
     UndoRecoveryUpdate => ("undo_recovery_update", checkpoint = false),
     StateVisibilitySet => ("state_visibility_set", checkpoint = false),
     StateVisibilityPromote => ("state_visibility_promote", checkpoint = false),
+    HeadUpdate => ("head_update", checkpoint = false),
 }
 
 impl OpRecord {
@@ -776,6 +803,10 @@ impl OpRecord {
             OpRecord::ThreadUpdate { old_state, .. } => vec![*old_state],
             OpRecord::MarkerDelete { state, .. } => vec![*state],
             OpRecord::FastForward { pre_target_id, .. } => vec![*pre_target_id],
+            OpRecord::HeadUpdate {
+                previous: RecordedHead::Detached { state },
+                ..
+            } => vec![*state],
             OpRecord::Snapshot {
                 prev_head: None, ..
             }
@@ -798,7 +829,11 @@ impl OpRecord {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => Vec::new(),
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate {
+                previous: RecordedHead::Attached { .. },
+                ..
+            } => Vec::new(),
         }
     }
 
@@ -814,6 +849,10 @@ impl OpRecord {
             OpRecord::ThreadUpdate { new_state, .. } => vec![*new_state],
             OpRecord::MarkerCreate { state, .. } => vec![*state],
             OpRecord::FastForward { post_target_id, .. } => vec![*post_target_id],
+            OpRecord::HeadUpdate {
+                new: RecordedHead::Detached { state },
+                ..
+            } => vec![*state],
             OpRecord::ThreadDelete { .. }
             | OpRecord::MarkerDelete { .. }
             | OpRecord::Fork { .. }
@@ -830,7 +869,11 @@ impl OpRecord {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => Vec::new(),
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate {
+                new: RecordedHead::Attached { .. },
+                ..
+            } => Vec::new(),
         }
     }
 
@@ -863,7 +906,8 @@ impl OpRecord {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => None,
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => None,
         }
     }
 
@@ -896,7 +940,8 @@ impl OpRecord {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => RedactionUndoClass::Other,
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => RedactionUndoClass::Other,
         }
     }
 
@@ -929,7 +974,8 @@ impl OpRecord {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => None,
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => None,
         }
     }
 }
@@ -1042,7 +1088,8 @@ mod verb_catalog_tests {
             | OpRecord::RemoteThreadDelete { .. }
             | OpRecord::UndoRecoveryUpdate { .. }
             | OpRecord::StateVisibilitySet { .. }
-            | OpRecord::StateVisibilityPromote { .. } => {}
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => {}
         }
         vec![
             sample,
@@ -1159,6 +1206,12 @@ mod verb_catalog_tests {
                 tier: VisibilityTier::Public,
                 prior_sidecar: Some(vec![4, 5]),
                 new_sidecar: None,
+            },
+            OpRecord::HeadUpdate {
+                previous: RecordedHead::Detached { state: cid() },
+                new: RecordedHead::Attached {
+                    thread: "main".into(),
+                },
             },
         ]
     }


### PR DESCRIPTION
## Summary

- Route all 46 operational ref-write call sites through `Repository::commit_and_publish` or recorded repository helpers built on that chokepoint.
- Add exact reversible records for direct HEAD updates, atomic planning for remote-tracking threads, and a backend capability that keeps recordless ingest explicit without pretending it has an oplog committer.
- Add a source-level future-bypass guard. It detects direct handles, `repo.refs()` accessors, aliases, and `refs` parameters, and enforces exact budgets for the deliberately low-level sites.

Closes HeddleCo/heddle#377

> This branch was authored in a sandboxed session that had no network access and could not push. The two commits are the original author's, preserved unchanged (including the red commit); all evidence below was re-run outside that sandbox.

Call-site inventory:

- The first independent syntax pass found 81 raw production ref writers. Strengthening the scanner to recognize a `refs: &RefManager` parameter found one bootstrap write the first pass missed: 82 total raw writers.
- 46 are operational writes and match the issue exactly: 18 mechanical helper substitutions and 28 context-sensitive sites with an existing record, CAS, multi-ref batch, rollback, materialization, or ingest transaction to preserve.
- All 46 operational sites are routed.
- 36 raw writes are deliberately retained behind exact guard budgets: 20 AtomicMutation/undo/compensation internals, 8 temporary Git checkout-materialization writes, 5 bootstrap/open writes before the committer is available, and 3 centralized goto/fast-forward publication seams. Adding any further raw call fails the guard.

The existing API could not represent two required cases cleanly, so this change extends it instead of weakening callers:

- `RecordedHead` plus tail variant `OpRecord::HeadUpdate` preserves exact attached/detached before and after images for reconciliation and undo/redo.
- `RefUpdate::RemoteThread` adds atomic local planning, publication, and summary-index updates.
- `RefBackend::can_commit_records` makes the existing recordless ingest mode explicit: configured repositories carry exact records; recordless/bootstrap backends still use `commit_and_publish` with an empty record batch. The Postgres backend still does not claim opaque-record co-commit support, and its unsupported remote-thread update fails closed.

## Test evidence

Chokepoint guard — the whole point of the change — green in `heddle-devtools`:

```text
$ cargo test -p heddle-devtools
test check_ref_write_chokepoint::tests::production_tree_has_no_bare_ref_writes ... ok
test check_atomic_ledger_encapsulation::tests::production_tree_has_no_external_ledger_use ... ok
test check_oprecord_exhaustiveness::tests::production_tree_oprecord_matches_are_exhaustive ... ok
test check_snapshot_atomicity::tests::production_tree_has_no_publish_first_snapshot ... ok

test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.15s
```

New recorded-mutation unit tests:

```text
$ cargo test -p heddle-repo repository_ref_mutation
test repository::repository_ref_mutation::tests::head_and_remote_updates_are_replayable_records ... ok
test repository::repository_ref_mutation::tests::recorded_ref_helpers_publish_with_exact_records ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 590 filtered out; finished in 0.00s
```

Focused suites:

```text
$ cargo test -p heddle-ingest
test result: ok. 200 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 0.14s

$ cargo test -p heddle-cli --test git_projection_engine_integration
test result: ok. 95 passed; 0 failed; 0 ignored; 0 measured; 5.14s
```

Workspace clippy and build:

```text
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 13.07s
clippy exit: 0

$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.45s
build exit: 0
```

Note on the original session's reported `cargo test --workspace` failure: it attributed a
`client::local_daemon::tests::check_peer_uid_matches_self_accepts_socketpair` failure to the dev box.
Re-run outside the sandbox that test **passes** (the sibling branch for #265 ran the full
`heddle-cli` lib suite: 627 passed, 0 failed). That failure was a sandbox UID-mapping artifact
and is not a property of this box or this branch.

## Red commit

`d0366221bd78c43387277dcbca27a4787adc7f79` — `test(refs): forbid bare production ref writes`

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787585827&installation_model_id=21489&pr_number=1098&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1098&signature=1deaaee35989dfc77496201486b6ad8d754b89531e20c22a12eaf15c8de605b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->