### PR TITLE
fix(git-projection): stop clobbering foreign pushes on mirror branches

### DIFF
--- a/crates/cli/tests/cli_integration/git_projection_commands.rs
+++ b/crates/cli/tests/cli_integration/git_projection_commands.rs
@@ -590,6 +590,104 @@ fn test_cli_export_git_writes_bare_repo() {
     assert!(find_reference(&dest_repo, "refs/heads/main").is_ok());
 }
 
+/// heddle#1096 -- an ordinary Git-side commit pushed onto a Heddle-managed
+/// mirror branch is foreign: Heddle never published that OID under the ref name.
+/// Export must report the divergence and leave the foreign tip untouched, not
+/// misclassify it as a now-embargoed tip and force-rewind it.
+#[test]
+fn test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence() {
+    let source = TempDir::new().unwrap();
+    let dest_holder = TempDir::new().unwrap();
+    let dest = dest_holder.path().join("export");
+
+    init_colocated_git_repo(source.path());
+    std::fs::write(source.path().join("file.txt"), "heddle tip\n").unwrap();
+    git_commit_all_in(source.path(), "Heddle tip");
+    init_direct_git_overlay(source.path());
+    std::fs::write(source.path().join("file.txt"), "Heddle projection tip\n").unwrap();
+    heddle(
+        &["capture", "-m", "Heddle projection tip"],
+        Some(source.path()),
+    )
+    .expect("capture projection tip");
+
+    let first = heddle_output(
+        &["export", "git", "--destination", dest.to_str().unwrap()],
+        Some(source.path()),
+    )
+    .expect("first export");
+    assert!(
+        first.status.success(),
+        "first export must succeed: stdout={} stderr={}",
+        String::from_utf8_lossy(&first.stdout),
+        String::from_utf8_lossy(&first.stderr),
+    );
+
+    let mirror = open_git(source.path().join(".heddle/git")).expect("open bridge mirror");
+    let heddle_tip = find_reference(&mirror, "refs/heads/main")
+        .expect("main after first export")
+        .peel_to_id()
+        .expect("peel Heddle tip");
+    let tree = mirror
+        .read_commit(&heddle_tip)
+        .expect("read Heddle tip")
+        .tree;
+    let foreign_tip = git_commit_with_tree(
+        &mirror,
+        Some("refs/heads/main"),
+        tree,
+        "foreign push",
+        &[heddle_tip],
+    );
+
+    let second = heddle_output(
+        &["export", "git", "--destination", dest.to_str().unwrap()],
+        Some(source.path()),
+    )
+    .expect("second export");
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    let mirror_tip_after = find_reference(&mirror, "refs/heads/main")
+        .expect("main after second export")
+        .peel_to_id()
+        .expect("peel mirror tip after second export");
+
+    let mut violations = Vec::new();
+    if mirror_tip_after != foreign_tip {
+        violations.push(format!(
+            "foreign tip was clobbered: expected {foreign_tip}, found {mirror_tip_after}"
+        ));
+    }
+    if second.status.code() != Some(74) {
+        violations.push(format!(
+            "second export must exit non-zero (74), got {:?}",
+            second.status.code()
+        ));
+    }
+    if !stdout.contains("[warn] 1 ref diverged; left untouched (heddle did not overwrite)") {
+        violations.push("stdout did not report one untouched diverged ref".to_string());
+    }
+    let expected_reason = format!(
+        "refs/heads/main: modified concurrently in git: found {foreign_tip}, heddle was publishing {heddle_tip}"
+    );
+    if !stdout.contains(&expected_reason) {
+        violations.push(format!(
+            "stdout did not classify the foreign tip as concurrent modification: expected `{expected_reason}`"
+        ));
+    }
+    if !stderr.contains("exported 0 refs, 1 diverged (concurrent git-side update): refs/heads/main")
+    {
+        violations.push("stderr did not summarize the diverged ref".to_string());
+    }
+
+    assert!(
+        violations.is_empty(),
+        "{}\nstatus={:?}\nstdout={stdout}\nstderr={stderr}",
+        violations.join("\n"),
+        second.status.code(),
+    );
+}
+
 #[test]
 fn test_cli_import_git_from_external_repo() {
     let heddle_repo_dir = TempDir::new().unwrap();

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -10,7 +10,7 @@ use objects::{
 };
 use repo::{AudienceTier, Repository as HeddleRepository, visible};
 use sley::{
-    CommitObject, EntryKind, GitObjectType, ObjectId, RefPrecondition, ReferenceTarget,
+    CommitObject, EntryKind, GitObjectType, ObjectId, ReferenceTarget,
     Repository as SleyRepository, Signature, plumbing::sley_object::EncodedObject,
 };
 use tracing::debug;
@@ -20,12 +20,12 @@ use crate::{
         GitProjection, GitProjectionError, GitProjectionResult, LocalGitIdentity, SyncMapping,
         copy_reachable_objects, count_exported_commits, delete_reference_if_present,
         git_config_identity_with_global_fallback, git_err, principal_is_default_unknown,
-        read_or_seed_mirror_managed_refs, set_reference, write_mirror_managed_refs,
+        read_or_seed_mirror_managed_refs, write_mirror_managed_refs,
     },
     git_notes,
     git_reconstruct::{commit_object_id, reconstruct_commit_bytes, write_commit_object},
     git_residual::ResidualStore,
-    git_sync::{sync_marker_to_tag, sync_track_to_branch},
+    git_sync::{force_rewind_track_to_branch, sync_marker_to_tag, sync_track_to_branch},
     git_util::{ExportStats, ExportedRef, FailedRefExportReason},
 };
 
@@ -715,10 +715,12 @@ fn export_scoped(
     // the mirror, and stays in the managed record so the push still copies it. The
     // desired head target is the maximal served ancestor-or-self of the thread tip
     // (`frontier_git_oid`, via `project_desired_refs`). The existing tip is
-    // classified against the whole-mirror served-OID set, so a still-served tip
-    // fast-forwards, an embargoed tip force-rewinds to its served ancestor, and a
-    // whole-line-embargoed head is deleted. A scoped export reconciles every current
-    // thread but MATERIALIZES (creates) only the one it was scoped to.
+    // classified against the whole-mirror served-OID set and the name-keyed
+    // ownership record, so a still-served tip fast-forwards, Heddle's exact
+    // embargoed tip force-rewinds to its served ancestor, a foreign unserved tip
+    // is preserved+reported, and a whole-line-embargoed head is deleted. A scoped
+    // export reconciles every current thread but MATERIALIZES (creates) only the
+    // one it was scoped to.
     for track_name in &threads {
         if bridge
             .heddle_repo
@@ -733,10 +735,12 @@ fn export_scoped(
         let in_scope = thread.is_none() || thread == Some(track_name.as_str());
         let desired_oid = desired.get(&branch_ref).copied();
         let existing_oid = branch_tip_oid(&repo, &branch_ref);
+        let managed_oid = managed_record.get(&branch_ref).copied();
         match reconcile_ref(
             ReconcileNs::Head,
             desired_oid,
             existing_oid,
+            managed_oid,
             in_scope,
             /* marker_served_unminted */ false,
             &served_oids,
@@ -763,13 +767,8 @@ fn export_scoped(
             }
             ReconcileOp::ForceRewind => {
                 let git_oid = desired_oid.expect("ForceRewind implies a desired target");
-                match set_reference(
-                    &repo,
-                    &branch_ref,
-                    git_oid,
-                    RefPrecondition::Any,
-                    "heddle: retract embargoed thread frontier",
-                ) {
+                let expected_old = existing_oid.expect("ForceRewind implies an existing owned tip");
+                match force_rewind_track_to_branch(&repo, track_name, expected_old, git_oid) {
                     Ok(()) => {
                         managed_record.insert(branch_ref.clone(), git_oid);
                         stats.threads_synced += 1;
@@ -782,6 +781,15 @@ fn export_scoped(
                         .failed_refs
                         .push((branch_ref.clone(), failed_set_reason(err))),
                 }
+            }
+            ReconcileOp::Diverged => {
+                stats.failed_refs.push((
+                    branch_ref.clone(),
+                    FailedRefExportReason::ModifiedConcurrentlyInGit {
+                        found: existing_oid.expect("Diverged implies an existing tip"),
+                        intended: desired_oid.expect("Diverged implies a desired target"),
+                    },
+                ));
             }
             ReconcileOp::Delete => match delete_reference_if_present(&repo, &branch_ref) {
                 Ok(()) => {
@@ -854,6 +862,7 @@ fn export_scoped(
             ReconcileNs::Tag,
             desired_oid,
             existing_oid,
+            managed_record.get(&tag_ref).copied(),
             in_scope,
             marker_served_unminted,
             &served_oids,
@@ -884,8 +893,11 @@ fn export_scoped(
             },
             // PRESERVE keeps the existing served tag (still managed → stays in the
             // record); SKIP is a no-op. A tag is free-move and never force-rewinds
-            // (ForceRewind is unreachable for `ReconcileNs::Tag`).
-            ReconcileOp::Preserve | ReconcileOp::Skip | ReconcileOp::ForceRewind => {}
+            // (ForceRewind and Diverged are unreachable for `ReconcileNs::Tag`).
+            ReconcileOp::Preserve
+            | ReconcileOp::Skip
+            | ReconcileOp::ForceRewind
+            | ReconcileOp::Diverged => {}
         }
     }
 
@@ -923,9 +935,9 @@ enum ReconcileNs {
 }
 
 /// The op the mirror reconcile applies to a single ref. The SINGLE decision the
-/// head and tag reconciles share (heddle#316): a foreign ref never reaches here
-/// (the iteration set is current threads/markers ∪ heddle-managed names), so every
-/// arm acts on a ref heddle owns.
+/// head and tag reconciles share (heddle#316). A foreign ref can collide with a
+/// current thread/marker name and therefore reach this decision; the name-keyed
+/// managed tip distinguishes an owned embargo rewind from that collision.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReconcileOp {
     /// Nothing to do — a scoped export declining to materialize an out-of-scope
@@ -937,6 +949,9 @@ enum ReconcileOp {
     /// Force-set a head to the desired target past the fast-forward guard — the
     /// embargo retract that rewinds an embargoed tip to its served ancestor.
     ForceRewind,
+    /// Preserve an unserved head whose current tip does not equal the OID Heddle
+    /// last recorded writing under this name, and report the Git-side divergence.
+    Diverged,
     /// Keep an existing served tag whose marker target is served-but-unminted this
     /// run (r18). A later all-thread export re-mints and advances it.
     Preserve,
@@ -991,13 +1006,16 @@ fn failed_delete_reason(err: GitProjectionError) -> FailedRefExportReason {
 /// brand-new one the caller did not ask for. `marker_served_unminted` is set only
 /// for a tag whose live marker target is served but was not minted this run — the
 /// sole axis that, combined with `existing_served`, splits r18-PRESERVE from
-/// r19-DELETE. `served_oids` is the whole-mirror served-OID set classifying the
-/// existing tip (NOT this run's purge drop-set, which omits a prior-run /
-/// out-of-scope embargo).
+/// r19-DELETE. `managed_oid` is the tip Heddle last recorded writing under this
+/// exact ref name; exact equality with an unserved head authorizes the embargo
+/// force, while a mismatch is foreign Git-side divergence. `served_oids` is the
+/// whole-mirror served-OID set classifying the existing tip (NOT this run's purge
+/// drop-set, which omits a prior-run / out-of-scope embargo).
 fn reconcile_ref(
     ns: ReconcileNs,
     desired_oid: Option<ObjectId>,
     existing_oid: Option<ObjectId>,
+    managed_oid: Option<ObjectId>,
     in_scope: bool,
     marker_served_unminted: bool,
     served_oids: &HashSet<ObjectId>,
@@ -1014,12 +1032,16 @@ fn reconcile_ref(
         // Create a fresh ref at the served target.
         (Some(_), None) => ReconcileOp::Write,
         // Head with an existing tip: a still-served tip fast-forwards (r17 FF guard
-        // applies); an embargoed tip is force-rewound to its served ancestor.
+        // applies); an unserved tip is force-rewound only when it is exactly the
+        // tip Heddle last published under this name. Any other unserved tip came
+        // from Git and is preserved+reported as divergence.
         (Some(_), Some(_)) if ns == ReconcileNs::Head => {
             if existing_served {
                 ReconcileOp::Write
-            } else {
+            } else if managed_oid == existing_oid {
                 ReconcileOp::ForceRewind
+            } else {
+                ReconcileOp::Diverged
             }
         }
         // Tag with an existing tip: free-move force-retarget to the served target.

--- a/crates/git-projection/src/git_sync.rs
+++ b/crates/git-projection/src/git_sync.rs
@@ -174,6 +174,29 @@ pub fn sync_track_to_branch(
     )
 }
 
+/// Force-rewind a Heddle-owned mirror branch to an embargo-lagged frontier.
+///
+/// The force bypasses the fast-forward guard, but never the ref transaction's
+/// compare-and-swap: `expected_old` is the exact tip Heddle's managed-ref record
+/// says it last published. A Git-side writer that moves the ref after reconcile
+/// classification loses this CAS and is reported through [`set_ref`]'s
+/// [`FailedRefExportReason`] classifier instead of being overwritten.
+pub(crate) fn force_rewind_track_to_branch(
+    repo: &SleyRepository,
+    track_name: &str,
+    expected_old: SleyObjectId,
+    git_oid: SleyObjectId,
+) -> GitProjectionResult<()> {
+    let branch_ref = format!("refs/heads/{track_name}");
+    set_ref(
+        repo,
+        &branch_ref,
+        git_oid,
+        RefPrecondition::MustExistAndMatch(ReferenceTarget::Direct(expected_old)),
+        "heddle: retract embargoed thread frontier",
+    )
+}
+
 /// Sync a Heddle marker to a Git tag.
 pub fn sync_marker_to_tag(
     repo: &SleyRepository,


### PR DESCRIPTION
## Summary

- `reconcile_ref` treated **every** unserved existing head tip as a now-embargoed Heddle tip and force-set it with `RefPrecondition::Any`. An ordinary Git-side `git push` onto a mirror branch whose name collides with a Heddle thread was therefore silently overwritten — data loss with no report.
- The existing tip is now classified against the **name-keyed managed-ref record** as well as the served-OID set: a still-served tip fast-forwards, a tip that *exactly equals* what Heddle last published under that name force-rewinds (the embargo retract), and any other unserved tip is foreign — preserved and reported as the new `ReconcileOp::Diverged`.
- Force-rewind now goes through `force_rewind_track_to_branch`, which keeps the fast-forward bypass but swaps `RefPrecondition::Any` for `MustExistAndMatch(expected_old)`. A Git-side writer that moves the ref between reconcile classification and the write loses the compare-and-swap and is reported through the existing `FailedRefExportReason` classifier rather than overwritten.

The split is deliberately asymmetric in the safe direction: embargo enforcement still force-rewinds Heddle's own tips (exact OID equality), while anything Heddle cannot prove it wrote is left alone and surfaced.

Closes HeddleCo/heddle#1096

> **The red commit for this change was lost and could not be reconstructed.** This branch was
> authored in a sandboxed session with no network access; the session reported a red commit
> `3e2516af` and fix `81979264` as "temporary history", but neither object survived the sandbox
> failure and neither is recoverable from any bundle, patch, or reflog on the dev box. What
> remained was an uncommitted working tree of 3 modified files. That tree was reviewed and
> committed as a single commit here, so this PR has **no red-commit SHA to cite**. The new test
> was instead confirmed to be a genuine regression test by review of its construction (it builds a
> real foreign commit on the mirror branch and asserts the tip is unchanged, the exit code is 74,
> and the divergence is reported) — but it was never observed failing against the unfixed code.

## Test evidence

New regression test — an ordinary Git-side commit pushed onto a Heddle-managed mirror branch:

```text
$ cargo test -p heddle-cli --test cli_integration test_cli_export_git_preserves_foreign_mirror_push -- --nocapture
test git_projection_commands::test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 885 filtered out; finished in 0.23s
```

```text
$ cargo test -p heddle-git-projection
test result: ok. 57 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.01s

$ cargo test -p heddle-cli --test git_projection_engine_integration
test result: ok. 96 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 5.22s
```

```text
$ cargo clippy --workspace --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.31s
clippy exit: 0

$ cargo build --workspace
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.64s
build exit: 0
```

### Baseline comparison for the 3 failing `git_projection_commands` tests

The full `git_projection_commands` suite reports 3 failures on this branch. They are **pre-existing
and environmental**, not caused by this change — the identical failure set occurs on `main`
(`3a79b351`), single-threaded, in the same worktree:

| | passed | failed | failing tests |
|---|---|---|---|
| `main` @ `3a79b351` | 10 | 3 | `test_cli_bridge_git_init_leaf_removed`, `test_cli_export_git_and_clone_roundtrip`, `test_cli_export_git_writes_bare_repo` |
| this branch | 11 | 3 | *the same three* (the +1 pass is the new test) |

Cause, identical on both sides:

```text
Error: configuration error: failed to inspect Git worktree status at '/tmp/.tmptAktCN':
io error: Permission denied (os error 13)
```

That is the known dev-box `/tmp` worktree-status condition, not a projection regression.

Formatting: `rustfmt +nightly --edition 2024 --check` is clean on all three touched files.

## Reviewer notes — two residual gaps this change does not close

1. **The seed run still adopts everything.** `read_or_seed_mirror_managed_refs` falls back to
   `collect_ref_updates(mirror_repo)` when no managed-ref record exists yet, so on that first run
   `managed_oid == existing_oid` for *every* ref present — including a foreign one already pushed.
   A foreign tip that predates the record can therefore still be force-rewound on the seed run.
   This is pre-existing seeding behaviour and a narrow window, but it is the one path where the new
   guard does not engage.
2. **Tags are unchanged.** The `ReconcileNs::Tag` arm still free-move force-retargets any existing
   tip; `Diverged` is unreachable there by construction. A foreign tag colliding with a marker name
   is still overwritten. Less severe than head clobber (the tag object survives in the object store,
   only the ref moves) and out of scope for this issue, but it is the same class.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787586203&installation_model_id=21489&pr_number=1099&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1099&signature=006484d8a49111798c7f6580c3eaac0399b2acf1ab306e3425c8da7647a9b788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->