### PR TITLE
test(cli): add non-empty floor assertions to source-scanning lints (phase A0)

### DIFF
--- a/crates/cli/src/cli/cli_args/commands_args.rs
+++ b/crates/cli/src/cli/cli_args/commands_args.rs
@@ -651,7 +651,7 @@ pub struct UndoArgs {
 }
 
 /// User-facing `--workspace` flag values. Vocabulary is the same as
-/// [`crate::cli::commands::repo::ThreadMode`] (and the on-wire
+/// [`repo::ThreadMode`] (and the on-wire
 /// `thread.mode` JSON field) so a single name carries through the
 /// CLI, the daemon, and the thread record on disk. See
 /// `docs/design/clonefile-threads.md` for the rationale.

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -408,6 +408,26 @@ fn recovery_phrase_allowed(rel: &Path, phrase: &str) -> bool {
 }
 
 fn walk_rust_files(dir: &Path, visit: &mut dyn FnMut(&Path)) {
+    const MIN_SCANNED_RUST_FILES: usize = 80;
+    assert!(
+        dir.is_dir(),
+        "advice_lint scan root missing at {}",
+        dir.display()
+    );
+    let mut files_scanned = 0usize;
+    walk_rust_files_inner(dir, &mut |path| {
+        files_scanned += 1;
+        visit(path);
+    });
+    assert!(
+        files_scanned >= MIN_SCANNED_RUST_FILES,
+        "advice_lint scanned only {files_scanned} files (floor {MIN_SCANNED_RUST_FILES}) — \
+         did a crate-split move CLI sources out of this scan root? Update the scan root, do not \
+         lower this floor."
+    );
+}
+
+fn walk_rust_files_inner(dir: &Path, visit: &mut dyn FnMut(&Path)) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -418,7 +438,7 @@ fn walk_rust_files(dir: &Path, visit: &mut dyn FnMut(&Path)) {
             continue;
         }
         if path.is_dir() {
-            walk_rust_files(&path, visit);
+            walk_rust_files_inner(&path, visit);
         } else if path.extension().and_then(|ext| ext.to_str()) == Some("rs") {
             visit(&path);
         }

--- a/crates/cli/tests/agent_api_schema.rs
+++ b/crates/cli/tests/agent_api_schema.rs
@@ -15,6 +15,13 @@ use std::path::PathBuf;
 #[test]
 fn agent_api_schema_matches_committed_snapshot() {
     let actual = cli::cli::commands::agent_api_schema();
+    let discovered_items = actual.as_object().map_or(0, serde_json::Map::len);
+    assert!(
+        discovered_items >= 4,
+        "agent_api_schema discovered only {discovered_items} top-level schema items (floor 4) — \
+         did a crate-split disconnect the agent API registry? Update the discovery root, do not \
+         lower this floor."
+    );
     let actual_pretty = serde_json::to_string_pretty(&actual).unwrap();
 
     let snapshot_path = snapshot_path();

--- a/crates/cli/tests/cli_integration/output_mode_no_auto.rs
+++ b/crates/cli/tests/cli_integration/output_mode_no_auto.rs
@@ -514,8 +514,25 @@ fn output_mode_auto_variant_is_absent_from_source() {
         .expect("crates dir")
         .join("repo")
         .join("src");
-    for root in [cli_src, repo_src] {
-        for entry in walkdir(&root) {
+    for (root, floor) in [(cli_src, 80usize), (repo_src, 40usize)] {
+        assert!(
+            root.is_dir(),
+            "output_mode_no_auto scan root missing at {}",
+            root.display()
+        );
+        let entries = walkdir(&root);
+        let rust_files = entries
+            .iter()
+            .filter(|entry| entry.extension().and_then(|ext| ext.to_str()) == Some("rs"))
+            .count();
+        assert!(
+            rust_files >= floor,
+            "output_mode_no_auto scanned only {rust_files} Rust files under {} (floor {floor}) — \
+             did a crate-split move sources out of this scan root? Update the scan root, do not \
+             lower this floor.",
+            root.display()
+        );
+        for entry in entries {
             if entry.extension().and_then(|ext| ext.to_str()) != Some("rs") {
                 continue;
             }

--- a/crates/cli/tests/git_process_lint.rs
+++ b/crates/cli/tests/git_process_lint.rs
@@ -26,9 +26,19 @@ struct SpawnSite {
 fn runtime_git_process_spawns_match_reviewed_allowlist() {
     let workspace = workspace_root();
     let mut sites = Vec::new();
+    let mut files_scanned = 0usize;
     for dir in default_cli_runtime_source_dirs(&workspace) {
-        walk_rust_files(&dir, &mut |path| scan_file(&workspace, path, &mut sites));
+        walk_rust_files(&dir, &mut |path| {
+            files_scanned += 1;
+            scan_file(&workspace, path, &mut sites);
+        });
     }
+    assert!(
+        files_scanned >= 300,
+        "git_process_lint scanned only {files_scanned} Rust files (floor 300) — did a \
+         crate-split move runtime sources out of the configured scan roots? Update the scan \
+         roots, do not lower this floor."
+    );
 
     let allowed: BTreeMap<(&str, &str), &str> = ALLOWED_GIT_SPAWNS
         .iter()
@@ -88,6 +98,12 @@ fn git_engine_dependency_is_sley_not_gix() {
 
     let mut manifests = Vec::new();
     collect_manifest_files(&workspace, &mut manifests);
+    assert!(
+        manifests.len() >= 10,
+        "git_process_lint discovered only {} Cargo manifests (floor 10) — update the workspace \
+         scan root, do not lower this floor.",
+        manifests.len()
+    );
     let mut direct_gix_mentions = Vec::new();
     for manifest in manifests {
         let rel = manifest

--- a/crates/cli/tests/render_lint.rs
+++ b/crates/cli/tests/render_lint.rs
@@ -64,6 +64,7 @@ use std::{
 // `query.rs` now returns a `QueryReport` from `heddle_core` and routes
 // human/JSON output through `cli/render/query.rs`.
 const RENDER_VIOLATION_BASELINE: usize = 840;
+const MIN_SCANNED_RUST_FILES: usize = 50;
 
 #[test]
 fn cli_commands_render_via_render_or_write_functions() {
@@ -78,8 +79,10 @@ fn cli_commands_render_via_render_or_write_functions() {
     );
 
     let mut total = 0usize;
+    let mut files_scanned = 0usize;
     let mut by_file: Vec<(PathBuf, usize)> = Vec::new();
     walk_rust_files(&commands_dir, &mut |path| {
+        files_scanned += 1;
         let source = match fs::read_to_string(path) {
             Ok(s) => s,
             Err(_) => return,
@@ -90,6 +93,17 @@ fn cli_commands_render_via_render_or_write_functions() {
             total += count;
         }
     });
+
+    eprintln!(
+        "render_lint: current count = {total} (baseline = {RENDER_VIOLATION_BASELINE}); \
+         files scanned = {files_scanned}"
+    );
+    assert!(
+        files_scanned >= MIN_SCANNED_RUST_FILES,
+        "render_lint scanned only {files_scanned} files (floor {MIN_SCANNED_RUST_FILES}) — \
+         did a crate-split move commands out of this scan root? Update the scan root, do not \
+         lower this floor."
+    );
 
     if total > RENDER_VIOLATION_BASELINE {
         // Sort offenders descending so the largest baselines surface

--- a/crates/cli/tests/ts_types_in_sync.rs
+++ b/crates/cli/tests/ts_types_in_sync.rs
@@ -30,9 +30,23 @@ mod full_feature {
             .expect("clients/npm/generated exists")
     }
 
+    fn assert_generated_set_has_floor(generated_json: &str) {
+        const MIN_GENERATED_VERBS: usize = 75;
+        let generated: serde_json::Value =
+            serde_json::from_str(generated_json).expect("generated schema JSON should parse");
+        let discovered_verbs = generated["verbs"].as_object().map_or(0, serde_json::Map::len);
+        assert!(
+            discovered_verbs >= MIN_GENERATED_VERBS,
+            "ts_types_in_sync discovered only {discovered_verbs} generated verbs (floor \
+             {MIN_GENERATED_VERBS}) — did a crate-split disconnect the command catalog? Update \
+             the discovery root, do not lower this floor."
+        );
+    }
+
     #[test]
     fn generated_typescript_is_in_sync() {
         let generated = cli::ts_codegen::generate();
+        assert_generated_set_has_floor(&generated.json);
         let path = generated_dir().join("heddle-schemas.ts");
         let on_disk = std::fs::read_to_string(&path).expect("read heddle-schemas.ts");
         assert_eq!(
@@ -46,6 +60,7 @@ mod full_feature {
     #[test]
     fn generated_json_is_in_sync() {
         let generated = cli::ts_codegen::generate();
+        assert_generated_set_has_floor(&generated.json);
         let path = generated_dir().join("heddle-schemas.json");
         let on_disk = std::fs::read_to_string(&path).expect("read heddle-schemas.json");
         assert_eq!(

--- a/crates/cli/tests/typed_error_lint.rs
+++ b/crates/cli/tests/typed_error_lint.rs
@@ -44,13 +44,21 @@ use std::{fs, path::Path};
 /// new untyped site is a future Priya-style "run heddle status" dead
 /// end.
 const MAX_UNTYPED_ANYHOW_SITES: usize = 157;
+const MIN_SCANNED_RUST_FILES: usize = 50;
 
 #[test]
 fn untyped_error_sites_do_not_regress() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli/commands");
+    assert!(
+        root.is_dir(),
+        "typed_error_lint scan root missing at {}",
+        root.display()
+    );
     let mut count = 0usize;
+    let mut files_scanned = 0usize;
     let mut sites = Vec::new();
     walk_rs_files(&root, &mut |path, contents| {
+        files_scanned += 1;
         for (line_no, line) in contents.lines().enumerate() {
             if is_untyped_error_site(line) {
                 count += 1;
@@ -60,7 +68,16 @@ fn untyped_error_sites_do_not_regress() {
         }
     });
 
-    eprintln!("typed_error_lint: current count = {count} (max = {MAX_UNTYPED_ANYHOW_SITES})");
+    eprintln!(
+        "typed_error_lint: current count = {count} (max = {MAX_UNTYPED_ANYHOW_SITES}); \
+         files scanned = {files_scanned}"
+    );
+    assert!(
+        files_scanned >= MIN_SCANNED_RUST_FILES,
+        "typed_error_lint scanned only {files_scanned} files (floor {MIN_SCANNED_RUST_FILES}) — \
+         did a crate-split move commands out of this scan root? Update the scan root, do not \
+         lower this floor."
+    );
     assert!(
         count <= MAX_UNTYPED_ANYHOW_SITES,
         "untyped anyhow/bail sites in cli/commands regressed: count={count} \
@@ -93,8 +110,15 @@ fn untyped_error_sites_do_not_regress() {
 #[test]
 fn argv_action_command_siblings_are_forbidden() {
     let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli/commands");
+    assert!(
+        root.is_dir(),
+        "typed_error_lint scan root missing at {}",
+        root.display()
+    );
+    let mut files_scanned = 0usize;
     let mut sites = Vec::new();
     walk_rs_files(&root, &mut |path, contents| {
+        files_scanned += 1;
         for (line_no, line) in contents.lines().enumerate() {
             if let Some(ident) = forbidden_argv_sibling(line) {
                 let rel = path.strip_prefix(&root).unwrap_or(path);
@@ -103,6 +127,12 @@ fn argv_action_command_siblings_are_forbidden() {
         }
     });
 
+    assert!(
+        files_scanned >= MIN_SCANNED_RUST_FILES,
+        "typed_error_lint scanned only {files_scanned} files (floor {MIN_SCANNED_RUST_FILES}) — \
+         did a crate-split move commands out of this scan root? Update the scan root, do not \
+         lower this floor."
+    );
     assert!(
         sites.is_empty(),
         "the `_argv` null-sibling trap was re-introduced (HeddleCo/heddle#254): a \


### PR DESCRIPTION
Phase **A0** of the crate-split tracked in #1100. Prep only — **no new crate, no source file moved.**

## Why

Later phases move source out of `crates/cli/src/...`. 15 test files in `crates/cli/tests/` scan source via `env!("CARGO_MANIFEST_DIR")`. Two of them are *ratcheted baselines* — `render_lint.rs` (`RENDER_VIOLATION_BASELINE = 840`) and `typed_error_lint.rs` (`MAX_UNTYPED_ANYHOW_SITES = 157`) — which get **easier** to satisfy as files leave their scan root. The failure is silent in the worst way: CI goes green while coverage drops.

This adds floors on **files scanned** (not on violations found, which are legitimately allowed to fall), so a phase that shrinks a scan root fails loudly instead of passing vacuously.

## Proof of catch

Pointing both ratchets at a real directory containing 2 `.rs` files (so the `is_dir` guard passes and only the floor can fire):

```
render_lint.rs:98      render_lint scanned only 2 files (floor 50) — did a crate-split move
                       commands out of this scan root? Update the scan root, do not lower this floor.
typed_error_lint.rs:75  typed_error_lint scanned only 2 files (floor 50) — ...
typed_error_lint.rs:130 typed_error_lint scanned only 2 files (floor 50) — ...
```

**Without these floors all three tests PASS in that state** — 2 files yields 0 violations, so `0 <= 840`, `0 <= 157` and `sites.is_empty()` are all satisfied. That is the regression this phase exists to make impossible.

## Floors added (7)

| Test | Floor |
|---|---|
| `render_lint.rs` | ≥50 Rust files scanned |
| `typed_error_lint.rs` | scan-root `is_dir` + ≥50 Rust files (both tests) |
| `advice_lint.rs` | scan-root `is_dir` + ≥80 Rust files |
| `git_process_lint.rs` | ≥300 Rust files, ≥10 manifests |
| `agent_api_schema.rs` | ≥4 top-level schema items |
| `ts_types_in_sync.rs` | ≥75 generated verbs |
| `cli_integration/output_mode_no_auto.rs` | ≥80 CLI / ≥40 repo Rust files |

Floors are set well below current values so they are floors, not second ratchets (e.g. render/typed-error scan 103 files today; floor 50).

**8 skipped deliberately** — `tier_coverage.rs` and `op_id_coverage.rs` already assert their discovered sets are non-empty; `commit_conformance.rs`, `roundtrip_fidelity.rs`, `realworld_git.rs`, `output_kind_invariant.rs`, `oss_cli_polish.rs`, `git_projection_engine_integration.rs` locate one required file and already fail if it is absent — no recursively discovered set to floor.

## Pre-split reference values (recorded for later phases)

| Metric | Value |
|---|---|
| `RENDER_VIOLATION_BASELINE` | 840 (actual violations today: **656**) |
| `MAX_UNTYPED_ANYHOW_SITES` | 157 (actual sites today: **155**) |
| Files scanned by each ratchet | 103 |

Per the ratchet policy on #1100, a later phase that moves files out of these scan roots must re-measure these **downward** in the same PR.

## Also

Fixes a stale intra-doc link at `commands_args.rs:654` pointing at `crate::cli::commands::repo::ThreadMode`, a module that does not exist. Now targets `repo::ThreadMode` (re-exported at `crates/repo/src/lib.rs:175`); verified resolving under `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links"`. **No baseline was changed** — neither ratchet, and not `cli-dep-count-baseline.json` (see erratum 1 on #1100).

## Verification

All run independently of the implementing agent:

- `cargo build --locked --workspace` (default features — CI's first step) — pass
- `cargo build --locked --workspace --all-features` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- `cargo test --workspace` — pass
- touched lint tests (`render_lint`, `typed_error_lint`, `advice_lint`, `git_process_lint`, `agent_api_schema`, `ts_types_in_sync`) — 19 passed, 0 failed
- `bash scripts/check-no-silent-default-tree-load.sh` — pass, 649 files scanned
- `bash scripts/check-cli-dep-count.sh` — pass, 360 external deps, ceiling 360 (unchanged)
- proof-of-catch reproduced independently, then reverted; worktree clean

Closes nothing; unblocks phases A1–A5 on #1100.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1101"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787600964&installation_model_id=21489&pr_number=1101&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1101&signature=34767fcd5bb432266f9a56869f2a3349e5f4d91d1e770cf31f55bb986c2998e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->