### PR TITLE
Fix auth repository scope and ancestor discovery

### DIFF
--- a/crates/cli/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli/src/cli/commands/command_catalog/mod.rs
@@ -1048,6 +1048,13 @@ const fn surface(contract: CommandContract, surface: &'static str) -> CommandCon
     }
 }
 
+const fn user_scoped(contract: CommandContract) -> CommandContract {
+    CommandContract {
+        targets_current_repository: false,
+        ..contract
+    }
+}
+
 /// Assign the `heddle help advanced` area group for a native-surface
 /// advanced root command (heddle#652). See [`advanced_help_groups`] for
 /// the recognized ids and their display titles.
@@ -1421,16 +1428,19 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(&["auth"], category(feature_gated(GROUP, "client"), "repo")),
+    entry(
+        &["auth"],
+        category(feature_gated(user_scoped(GROUP), "client"), "repo"),
+    ),
     entry(
         &["auth", "login"],
-        feature_gated(NETWORK_CONFIG_MUTATION_TEXT, "client"),
+        feature_gated(user_scoped(NETWORK_CONFIG_MUTATION_TEXT), "client"),
     ),
     entry(
         &["auth", "logout"],
         feature_gated(
             json_discriminators(
-                documented_schemas(CONFIG_MUTATION_NO_OP_ID, &["auth logout"]),
+                documented_schemas(user_scoped(CONFIG_MUTATION_NO_OP_ID), &["auth logout"]),
                 &[json_discriminator(
                     Some("auth logout"),
                     "output_kind",
@@ -1444,7 +1454,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["auth", "status"],
         feature_gated(
             json_discriminators(
-                documented_schemas(READ_JSON, &["auth status"]),
+                documented_schemas(user_scoped(READ_JSON), &["auth status"]),
                 &[json_discriminator(
                     Some("auth status"),
                     "output_kind",
@@ -1456,14 +1466,14 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(
         &["auth", "derive-agent"],
-        feature_gated(CONFIG_MUTATION_TEXT, "client"),
+        feature_gated(user_scoped(CONFIG_MUTATION_TEXT), "client"),
     ),
     entry(
         &["auth", "create-service-token"],
         feature_gated(
             json_discriminators(
                 documented_schemas(
-                    NETWORK_METADATA_MUTATION_NO_OP_ID,
+                    user_scoped(NETWORK_METADATA_MUTATION_NO_OP_ID),
                     &["auth create-service-token"],
                 ),
                 &[json_discriminator(

--- a/crates/cli/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli/src/cli/commands/command_catalog/tests.rs
@@ -1400,6 +1400,25 @@ fn credential_and_trust_effect_sets_are_config_scoped() {
 }
 
 #[test]
+fn auth_commands_are_user_scoped() {
+    for path in [
+        &["auth", "login"][..],
+        &["auth", "logout"],
+        &["auth", "status"],
+        &["auth", "derive-agent"],
+        &["auth", "create-service-token"],
+    ] {
+        let contract = raw_command_contract_for_path(path.iter().copied())
+            .unwrap_or_else(|| panic!("missing command contract for `{}`", path.join(" ")));
+        assert!(
+            !contract.targets_current_repository,
+            "`{}` must not discover or recover a repository",
+            path.join(" "),
+        );
+    }
+}
+
+#[test]
 fn fsck_observation_has_no_side_effects() {
     assert_command_effects(&["fsck"], &[CommandSideEffect::ObserveOnly]);
     let contract = raw_command_contract_for_path(["fsck"]).expect("fsck contract");

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -778,6 +778,12 @@ impl Repository {
             let heddle_path = dir.join(".heddle");
 
             if heddle_path.is_dir() {
+                let pointer_path = heddle_path.join("objectstore");
+                let objects_dir = heddle_path.join("objects");
+                if !pointer_path.is_file() && !objects_dir.is_dir() {
+                    return Err(HeddleError::RepositoryNotFound(dir.to_path_buf()));
+                }
+
                 if let Some(git_root) = discovered_git_root.as_ref()
                     && git_root != dir
                     && git_root.starts_with(dir)
@@ -787,8 +793,6 @@ impl Repository {
                     Self::bootstrap_git_overlay(git_root)?;
                     return Self::open(git_root);
                 }
-                let pointer_path = heddle_path.join("objectstore");
-                let objects_dir = heddle_path.join("objects");
 
                 if pointer_path.is_file() {
                     // Worktree mode: pointer dir at <dir>/.heddle/, shared
@@ -916,9 +920,6 @@ impl Repository {
                     }
                     return Ok(repo);
                 }
-
-                // .heddle/ exists but is neither a worktree pointer nor a
-                // main repo. Treat as not-found and continue walking parents.
             }
 
             current = dir.parent();

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -397,6 +397,28 @@ fn test_open_finds_repo() {
 }
 
 #[test]
+fn test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root() {
+    let temp_dir = TempDir::new().unwrap();
+    let bogus_root = temp_dir.path().canonicalize().unwrap();
+    fs::create_dir_all(bogus_root.join(".heddle/bootstrap-op-id")).unwrap();
+    let nested = bogus_root.join("projects/demo");
+    fs::create_dir_all(&nested).unwrap();
+
+    let error = match Repository::open(&nested) {
+        Ok(_) => panic!("bogus .heddle metadata must not be accepted as a repository"),
+        Err(error) => error,
+    };
+
+    match error {
+        HeddleError::RepositoryNotFound(path) => assert_eq!(
+            path, bogus_root,
+            "the error must identify the ancestor containing bogus .heddle metadata",
+        ),
+        other => panic!("expected repository-not-found for bogus metadata, got {other}"),
+    }
+}
+
+#[test]
 fn test_snapshot_creates_state() {
     let (temp_dir, repo) = create_test_repo();
     let initial_head = repo.head().unwrap().expect("init should seed main state");


### PR DESCRIPTION
## Summary
- classify every `heddle auth` subcommand as user-scoped so auth startup never discovers or recovers a repository
- reject `.heddle` ancestors that have neither main-repository storage nor a worktree pointer, reporting the matched ancestor path
- preserve legitimate ancestor discovery; audit follow-ups noted for `whoami` and `integration install --scope user`

## Closes
Closes HeddleCo/heddle#1106

## Test evidence

Baseline reproduction with `/tmp/heddle-1106-home.7VTElG/.heddle/bootstrap-op-id` present and cwd `/tmp/heddle-1106-home.7VTElG/projects/demo`:

```text
$ heddle auth login --server http://127.0.0.1:1
Error: io error: Read-only file system (os error 30)
EXIT_CODE=1
```

This sandbox injects a protected `/tmp/.git`, so the unwanted repository startup reached that ancestor before rendering the usual repository-not-found error.

After the fix, with the same bogus directory still present:

```text
$ heddle auth login --server http://127.0.0.1:1
Error: failed to connect to http://127.0.0.1:1: transport error
LOGIN_EXIT_CODE=74

$ heddle --output json auth logout --server http://127.0.0.1:1
{"output_kind":"auth_logout","server":"http://127.0.0.1:1","removed":true,"device_identity_removed":false}
```

`login` now reaches auth transport rather than repository startup, and the config-only auth operation completes successfully.

Bogus-ancestor diagnostics now name the matched ancestor, not the cwd:

```text
$ heddle --output json capture -m test
Error: repository not found at /tmp/heddle-1106-home.7VTElG
CAPTURE_EXIT_CODE=1
MATCHED_ANCESTOR=/tmp/heddle-1106-home.7VTElG
INVOCATION_CWD=/tmp/heddle-1106-home.7VTElG/projects/demo
```

Focused positive cases:

```text
$ cargo test --locked -p heddle-cli --lib auth_commands_are_user_scoped -- --nocapture
test cli::commands::command_catalog::tests::auth_commands_are_user_scoped ... ok
test result: ok. 1 passed; 0 failed

$ cargo test --locked -p heddle-repo --lib test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root -- --nocapture
test repository::repository_tests::test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root ... ok
test result: ok. 1 passed; 0 failed

$ cargo test --locked -p heddle-repo --lib test_open_finds_repo -- --nocapture
test repository::repository_tests::test_open_finds_repo ... ok
test result: ok. 1 passed; 0 failed
```

Independent mutation check — auth classification reverted while discovery validation remained:

```text
$ cargo test --locked -p heddle-cli --lib auth_commands_are_user_scoped -- --nocapture
`auth login` must not discover or recover a repository
test cli::commands::command_catalog::tests::auth_commands_are_user_scoped ... FAILED
test result: FAILED. 0 passed; 1 failed
```

Independent mutation check — discovery validation reverted while auth classification remained:

```text
$ cargo test --locked -p heddle-repo --lib test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root -- --nocapture
expected repository-not-found for bogus metadata, got io error: Read-only file system (os error 30)
test repository::repository_tests::test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root ... FAILED
test result: FAILED. 0 passed; 1 failed
```

CI's affected-package selector produced:

```text
-p heddle-cli -p heddle-cli-shared -p heddle-repo -p heddle-wire -p heddle-daemon -p heddle-client -p weft-client-shim -p heddle-core -p heddle-git-projection -p heddle-ingest -p heddle-mount
```

CI quality invocations:

```text
$ cargo build --locked <affected packages> --tests --bin heddle --bin heddle-fuse-worker
Finished `dev` profile ... exit 0

$ cargo clippy --locked <affected packages> --lib --bins --tests --examples -- -D warnings
Finished `dev` profile ... exit 0

$ cargo test --locked <affected packages>
All selected unit, integration, and doc tests passed; exit 0.
```

The local test invocation used a process-local `LD_PRELOAD` shim that hides only the sandbox-injected, empty `/tmp/.git`; without it, 494 unrelated tempdir tests discover the protected sandbox mount and fail with `EROFS`. Real `.git` directories within each test tempdir remained visible.

Additional CI commands passed:

```text
cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd
cargo check --locked -p heddle-repo --no-default-features --features native,zstd
cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd
cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd
python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v
bash scripts/check-default-cli-contracts.sh
cargo test --locked -p heddle-cli --test cli_integration fault_injection:: -- --ignored --test-threads=1 --nocapture
cargo test --locked -p heddle-repo --test timeline_materialize_fault -- --ignored --test-threads=1 --nocapture
```

FUSE smoke could not run locally because this sandbox does not expose `/dev/fuse`; the PR CI runner owns that gate.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787616452&installation_model_id=21489&pr_number=1107&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1107&signature=25874baf8f1ea562872a0175ac6474b256e91a539139d12cf574c91b45135376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->