### PR TITLE
refactor(objects): move object source traits down to break the object/store cycle (phase B0)

### DIFF
--- a/crates/objects/src/object/mod.rs
+++ b/crates/objects/src/object/mod.rs
@@ -19,6 +19,7 @@ mod risk_signal;
 mod semantic_change;
 mod semantic_index;
 mod session;
+mod source;
 mod spool_id;
 mod staleness_core;
 mod state_attachment;
@@ -64,6 +65,9 @@ pub use semantic_index::{
     compute_file_scaffold_hash, compute_file_semantic_digest, compute_symbol_semantic_hash,
 };
 pub use session::{Session, SessionSegment, generate_session_id};
+#[cfg(feature = "async-source")]
+pub use source::AsyncObjectSource;
+pub use source::ObjectSource;
 pub use spool_id::{SpoolId, SpoolIdParseError};
 pub use staleness_core::{
     StalenessStatus, annotation_status_for_source,

--- a/crates/objects/src/object/source.rs
+++ b/crates/objects/src/object/source.rs
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Read-only object source traits for graph walkers.
 
-use super::Result;
-use crate::{
-    object::{Blob, ContentHash, State, StateId, Tree},
-    store::ObjectStore,
-};
+use crate::error::Result;
 
-/// Read-only subset of [`ObjectStore`] needed by object graph walkers.
+use super::{Blob, ContentHash, State, StateId, Tree};
+
+/// Read-only object access needed by object graph walkers.
 pub trait ObjectSource {
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>>;
     fn get_state(&self, id: &StateId) -> Result<Option<State>>;
@@ -18,28 +16,6 @@ pub trait ObjectSource {
         Ok(self
             .get_blob(hash)?
             .map(|blob| bytes::Bytes::from(blob.into_content())))
-    }
-}
-
-impl<S: ObjectStore + ?Sized> ObjectSource for S {
-    #[inline]
-    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
-        ObjectStore::get_tree(self, hash)
-    }
-
-    #[inline]
-    fn get_state(&self, id: &StateId) -> Result<Option<State>> {
-        ObjectStore::get_state(self, id)
-    }
-
-    #[inline]
-    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
-        ObjectStore::get_blob(self, hash)
-    }
-
-    #[inline]
-    fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
-        ObjectStore::get_blob_bytes(self, hash)
     }
 }
 

--- a/crates/objects/src/object/tree_diff.rs
+++ b/crates/objects/src/object/tree_diff.rs
@@ -6,13 +6,9 @@
 
 use std::ops::ControlFlow;
 
-use super::FileChangeSet;
 #[cfg(feature = "async-source")]
-use crate::store::AsyncObjectSource;
-use crate::{
-    object::{ContentHash, DiffKind, FileChange, Tree},
-    store::ObjectSource,
-};
+use super::AsyncObjectSource;
+use super::{ContentHash, DiffKind, FileChange, FileChangeSet, ObjectSource, Tree};
 
 struct DiffFrame {
     from: Option<Tree>,
@@ -304,10 +300,8 @@ fn child_path(prefix: &str, name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        object::{Blob, ContentHash, EntryType, Tree, TreeEntry},
-        store::{InMemoryStore, ObjectStore},
-    };
+    use crate::object::{Blob, ContentHash, EntryType, Tree, TreeEntry};
+    use crate::store::{InMemoryStore, ObjectStore};
 
     fn create_blob(store: &InMemoryStore, content: &str) -> ContentHash {
         let blob = Blob::from_slice(content.as_bytes());

--- a/crates/objects/src/object/tree_path.rs
+++ b/crates/objects/src/object/tree_path.rs
@@ -6,8 +6,10 @@ use std::{
     path::{Component, Path},
 };
 
-use super::{Blob, ContentHash, Tree, TreeEntry};
-use crate::{error::HeddleError, store::ObjectSource};
+#[cfg(feature = "async-source")]
+use super::AsyncObjectSource;
+use super::{Blob, ContentHash, ObjectSource, Tree, TreeEntry};
+use crate::error::HeddleError;
 
 /// How a tree-path walk classifies and materializes the terminal entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -108,7 +110,7 @@ pub fn resolve_tree_path<S: ObjectSource>(
 }
 
 #[cfg(feature = "async-source")]
-pub async fn resolve_tree_path_async<S: crate::store::AsyncObjectSource + ?Sized>(
+pub async fn resolve_tree_path_async<S: AsyncObjectSource + ?Sized>(
     store: &S,
     root: &ContentHash,
     path: &Path,
@@ -196,7 +198,7 @@ fn resolve_from_tree<S: ObjectSource>(
 }
 
 #[cfg(feature = "async-source")]
-async fn resolve_from_tree_async<S: crate::store::AsyncObjectSource + ?Sized>(
+async fn resolve_from_tree_async<S: AsyncObjectSource + ?Sized>(
     store: &S,
     tree: &Tree,
     segments: &[String],
@@ -273,7 +275,7 @@ fn resolve_leaf<S: ObjectSource>(
 }
 
 #[cfg(feature = "async-source")]
-async fn resolve_leaf_async<S: crate::store::AsyncObjectSource + ?Sized>(
+async fn resolve_leaf_async<S: AsyncObjectSource + ?Sized>(
     store: &S,
     entry: TreeEntry,
     policy: LeafPolicy,
@@ -353,7 +355,7 @@ fn load_subtree<S: ObjectSource>(
 }
 
 #[cfg(feature = "async-source")]
-async fn load_subtree_async<S: crate::store::AsyncObjectSource + ?Sized>(
+async fn load_subtree_async<S: AsyncObjectSource + ?Sized>(
     store: &S,
     hash: &ContentHash,
     policy: LeafPolicy,
@@ -381,10 +383,8 @@ async fn load_subtree_async<S: crate::store::AsyncObjectSource + ?Sized>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        object::{EntryType, TreeEntry},
-        store::{InMemoryStore, ObjectStore},
-    };
+    use crate::object::{EntryType, TreeEntry};
+    use crate::store::{InMemoryStore, ObjectStore};
 
     fn create_blob(store: &InMemoryStore, content: &[u8]) -> ContentHash {
         ObjectStore::put_blob(store, &Blob::from_slice(content)).unwrap()

--- a/crates/objects/src/object/tree_walk.rs
+++ b/crates/objects/src/object/tree_walk.rs
@@ -3,11 +3,9 @@
 
 use std::collections::HashSet;
 
-use crate::{
-    error::Result,
-    object::{ContentHash, Tree, TreeEntry},
-    store::ObjectSource,
-};
+use crate::error::Result;
+
+use super::{ContentHash, ObjectSource, Tree, TreeEntry};
 
 /// Events emitted while walking reachable trees for integrity checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,10 +93,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        object::{Blob, Tree, TreeEntry},
-        store::{InMemoryStore, ObjectStore},
-    };
+    use crate::object::{Blob, Tree, TreeEntry};
+    use crate::store::{InMemoryStore, ObjectStore};
 
     #[test]
     fn walk_tree_integrity_dedups_shared_subtrees() {

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -16,10 +16,12 @@ pub mod liveness;
 pub mod memory;
 pub mod pack;
 pub mod shallow;
-pub mod source;
 pub mod store_compliance;
 pub mod writer_lease;
 
+#[cfg(feature = "async-source")]
+pub use crate::object::AsyncObjectSource;
+pub use crate::object::ObjectSource;
 pub use actor_presence::{
     ActorChainNode, ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary,
     ContextQueryEntry, generate_actor_session_id,
@@ -42,9 +44,6 @@ pub use liveness::{
 pub use memory::InMemoryStore;
 pub use pack::{PackBuilder, PackObjectId, PackReader, PackStats, StreamingPackBuilder, SyncData};
 pub use shallow::ShallowInfo;
-#[cfg(feature = "async-source")]
-pub use source::AsyncObjectSource;
-pub use source::ObjectSource;
 pub use writer_lease::{
     WriterLease, WriterLeaseAuthOutcome, WriterLeaseDraft, WriterLeaseGrant,
     WriterLeaseReserveOutcome, WriterLeaseStatus, WriterLeaseStore, generate_writer_lease_id,

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -16,12 +16,10 @@ pub mod liveness;
 pub mod memory;
 pub mod pack;
 pub mod shallow;
+pub mod source;
 pub mod store_compliance;
 pub mod writer_lease;
 
-#[cfg(feature = "async-source")]
-pub use crate::object::AsyncObjectSource;
-pub use crate::object::ObjectSource;
 pub use actor_presence::{
     ActorChainNode, ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary,
     ContextQueryEntry, generate_actor_session_id,
@@ -44,6 +42,9 @@ pub use liveness::{
 pub use memory::InMemoryStore;
 pub use pack::{PackBuilder, PackObjectId, PackReader, PackStats, StreamingPackBuilder, SyncData};
 pub use shallow::ShallowInfo;
+#[cfg(feature = "async-source")]
+pub use source::AsyncObjectSource;
+pub use source::ObjectSource;
 pub use writer_lease::{
     WriterLease, WriterLeaseAuthOutcome, WriterLeaseDraft, WriterLeaseGrant,
     WriterLeaseReserveOutcome, WriterLeaseStatus, WriterLeaseStore, generate_writer_lease_id,

--- a/crates/objects/src/store/source.rs
+++ b/crates/objects/src/store/source.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Store bridges for read-only object source traits.
+
+use super::{ObjectStore, Result};
+use crate::object::{Blob, ContentHash, State, StateId, Tree};
+
+#[cfg(feature = "async-source")]
+pub use crate::object::AsyncObjectSource;
+pub use crate::object::ObjectSource;
+
+impl<S: ObjectStore + ?Sized> ObjectSource for S {
+    #[inline]
+    fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        ObjectStore::get_tree(self, hash)
+    }
+
+    #[inline]
+    fn get_state(&self, id: &StateId) -> Result<Option<State>> {
+        ObjectStore::get_state(self, id)
+    }
+
+    #[inline]
+    fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
+        ObjectStore::get_blob(self, hash)
+    }
+
+    #[inline]
+    fn get_blob_bytes(&self, hash: &ContentHash) -> Result<Option<bytes::Bytes>> {
+        ObjectStore::get_blob_bytes(self, hash)
+    }
+}


### PR DESCRIPTION
Phase **B0** of the crate-split tracked in #1100 — prep for the objects track. **No new crate, no crate boundary change.** Stacked behind Track A (#1102 → #1103 → #1104); it touches only `crates/objects/` so it does not conflict with them.

## Why

`crates/objects/src/object/` depended on `crate::store`, and `store/` depends on `object/` — a two-way cycle that blocks extracting `heddle-object-model` (phase B1).

## Scope was wider than the design said

The design's §2.3 named **only** `AsyncObjectSource` (5 references). That was wrong: the **synchronous** `ObjectSource` trait crosses the same boundary in three more files, via *grouped* imports:

```rust
use crate::{ error::Result, object::{ContentHash, Tree, TreeEntry}, store::ObjectSource };
```

The design's own verification command — `grep -rn 'crate::store' crates/objects/src/object/` — plus the audit tool used to plan this effort both missed these, because a grouped `use crate::{…}` was evaluated as a single path against its first segment. Moving only `AsyncObjectSource` would have emptied that grep **while leaving the real cycle intact**, and B1 would then have failed to compile with the cause a phase upstream.

`ObjectSource` was introduced by `f386c142` (2026-06-20), before this design's basis commit.

## What moved

Both trait *definitions* moved with `git mv` from `store/source.rs` → `object/source.rs`. They describe read-only access to object-model types, so they belong at the model layer.

- The blanket `ObjectStore` bridge **stays** in `store/source.rs`, satisfying the orphan rule at every impl site (trait from the model layer, concrete type local).
- Old paths preserved: both `store::ObjectSource` and `store::source::ObjectSource` still resolve. Zero call-site churn.
- The `async-source` gate on `AsyncObjectSource` is unchanged.

History follows:
```
$ git log --follow --oneline -- crates/objects/src/object/source.rs
63176235 refactor(objects): move object source traits down (#1100)
d8701f2e Refactor CLI around source authority and direct Sley Git Overlay (#1011)
754fd9ee Checkpoint streaming sync and auto-capture work
f386c142 seam P3a: ObjectSource sync/async read seam (tree_diff + staleness) (#763)
```

## Success criteria — verified independently

Deliberately written to grep for the **symbols**, not the module path, so it cannot pass vacuously the way the design's original command would have:

```
$ grep -rn 'store::ObjectSource\|store::AsyncObjectSource' crates/objects/src/object/
(empty)
```

The only remaining `crate::store` references are three `#[cfg(test)]` module imports of `InMemoryStore`/`ObjectStore` (`tree_diff.rs:304`, `tree_walk.rs:97`, `tree_path.rs:387`). Those are **deliberately left alone** — they are a phase-B1 concern (a model crate whose unit tests need a concrete store implies either relocating those tests or a dev-dependency edge) and restructuring them here would mix phases.

## Verification — re-run independently of the implementing agent

| Gate | Result |
|---|---|
| `cargo build --locked --workspace` (default) | pass, 0 errors |
| `cargo build --locked --workspace --all-features` | pass, 0 errors |
| `cargo clippy --workspace --all-targets -- -D warnings` | pass, 0 errors |
| `cargo test --workspace --no-fail-fast` | **95 binaries, 1 failed** (environmental) |

The single failure is the known `multi_agent_worktrees` harness test — `harness_policy.rs:122` matches `program.contains("claude")` against argv[0] and this dev worktree lives under `.claude/worktrees/`. Pre-existing; passes in CI. Detail in #1102.

No feature gate deleted, no ratchet touched (this phase does not go near `src/cli/commands`), no visibility promotions required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1108"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787617675&installation_model_id=21489&pr_number=1108&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1108&signature=38193c134d97f585bbe2a78c691f6f723f25a09c14994d70801b1e8dc21e3e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->