### PR TITLE
ci(publish): validate that dependencies of publishable crates are themselves publishable

### DIFF
--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -336,11 +336,12 @@ elif [[ -z "$toml_module" ]]; then
   echo "skip: tomllib (Python 3.11+) and tomli both unavailable; consumer-version check skipped"
 else
   ok "toml parser available ($toml_module)"
-  consumer_report=$(TOML_MODULE="$toml_module" python3 - <<'PY'
+  consumer_report=$(TOML_MODULE="$toml_module" python3 - "$WF" <<'PY'
 import glob
 import importlib
 import os
 import re
+import sys
 tomllib = importlib.import_module(os.environ["TOML_MODULE"])
 
 with open("Cargo.toml", "rb") as f:
@@ -356,6 +357,7 @@ errors = []
 oks = []
 
 by_name = {}      # crate name → current version string
+toml_by_name = {}
 publishable = set()
 for cm, toml in crates:
     pkg = toml.get("package", {})
@@ -366,12 +368,96 @@ for cm, toml in crates:
     if not name or not isinstance(version, str):
         continue
     by_name[name] = version
+    toml_by_name[name] = toml
     # `publish` unset defaults to true (publishable). A non-empty list
     # restricts the registries but is still publishable. `false` /
     # empty list / explicit False means not publishable.
     pub = pkg.get("publish")
     if pub is None or pub is True or (isinstance(pub, list) and len(pub) > 0):
         publishable.add(name)
+
+
+workflow_lines = open(sys.argv[1], encoding="utf-8").read().splitlines()
+publish_list = []
+in_publish_list = False
+for line in workflow_lines:
+    if line == "  PUBLISHABLE_CRATES: |":
+        in_publish_list = True
+        continue
+    if in_publish_list:
+        if line.startswith("    "):
+            crate_name = line.strip()
+            if crate_name:
+                publish_list.append(crate_name)
+            continue
+        break
+
+publish_positions = {name: i for i, name in enumerate(publish_list)}
+if not publish_list:
+    errors.append("could not parse PUBLISHABLE_CRATES from workflow")
+elif len(publish_positions) != len(publish_list):
+    errors.append("PUBLISHABLE_CRATES contains a duplicate crate name")
+else:
+    dependency_pairs = 0
+    order_pairs = 0
+    # Versioned dev-dependencies are errors as well: they do not block
+    # `cargo publish` itself, but their path is stripped from the published
+    # manifest, so downstream source/test use must resolve them from the
+    # registry. They do not constrain publish order because Cargo does not
+    # resolve them while packaging/publishing the consumer.
+    for consumer in publish_list:
+        consumer_toml = toml_by_name.get(consumer)
+        if consumer_toml is None:
+            errors.append(
+                f"PUBLISHABLE_CRATES lists {consumer}, but no workspace package has that name"
+            )
+            continue
+
+        tables = []
+        for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+            if isinstance(consumer_toml.get(table_name), dict):
+                tables.append((table_name, consumer_toml[table_name]))
+        for _target, target_toml in (consumer_toml.get("target", {}) or {}).items():
+            if not isinstance(target_toml, dict):
+                continue
+            for table_name in ("dependencies", "dev-dependencies", "build-dependencies"):
+                if isinstance(target_toml.get(table_name), dict):
+                    tables.append((table_name, target_toml[table_name]))
+
+        for table_name, deps in tables:
+            for dep_key, dep_val in deps.items():
+                if not isinstance(dep_val, dict):
+                    continue
+                if not isinstance(dep_val.get("path"), str) or not isinstance(
+                    dep_val.get("version"), str
+                ):
+                    continue
+                dependency = dep_val.get("package") or dep_key
+                dependency_pairs += 1
+                if dependency not in publish_positions:
+                    errors.append(
+                        f"publishable crate {consumer} depends on {dependency}, "
+                        f"which is not in PUBLISHABLE_CRATES"
+                    )
+                    continue
+                if table_name == "dev-dependencies":
+                    continue
+                order_pairs += 1
+                if publish_positions[dependency] >= publish_positions[consumer]:
+                    errors.append(
+                        f"PUBLISHABLE_CRATES order invalid: {consumer} depends on "
+                        f"{dependency}, which must appear earlier"
+                    )
+
+    if not errors:
+        oks.append(
+            f"publishable crates have publishable versioned path dependencies "
+            f"({dependency_pairs} dependency pairs)"
+        )
+        oks.append(
+            f"PUBLISHABLE_CRATES is topologically ordered "
+            f"({order_pairs} publish-order dependency pairs)"
+        )
 
 
 def parse_ver_full(s):


### PR DESCRIPTION
Closes #1116.

## The gap

`scripts/check-publish-pipeline.sh` validated version **compatibility** between workspace consumers and publishable crates, but never that a `PUBLISHABLE_CRATES` entry's own versioned dependencies are on that list. That is silent until release, then surfaces as a failed `cargo publish`.

It nearly shipped: the #1100 crate split added six crates, and both `heddle-objects` and `heddle-cli` (both publishable) grew hard `version = "0.10"` dependencies on them. `cargo publish` resolves versioned deps from crates.io, so publishing either would have failed. **The gate passed throughout** — a human caught it, which is exactly the failure mode a gate exists to prevent.

## What this adds

1. **Dependency-publishability check** — for each `PUBLISHABLE_CRATES` entry, walks `[dependencies]`, `[dev-dependencies]`, `[build-dependencies]` and target-specific tables; any entry with **both** a `path` and a `version` must resolve (honouring `package = "…"` renames) to a crate that is also listed.
2. **Topological-order check** — the publish job consumes the list sequentially via `while IFS= read -r crate`, so a dependency appearing *after* its consumer fails at publish time. That ordering was maintained by hand until now.

Dev-dependencies are required to be publishable (published manifests must resolve them for downstream testing) but do **not** constrain publish order, since Cargo does not resolve them while publishing. Reuses the script's existing `tomllib` parsing and `ok:`/`err:` conventions — no new dependencies.

## Proof of catch — verified independently, not just reported

A gate that only passes is worthless, so it was tested against the bug it exists to catch. Removing `heddle-object-model` from `PUBLISHABLE_CRATES`:

```
::error::publishable crate heddle-fs-prims depends on heddle-object-model, which is not in PUBLISHABLE_CRATES
::error::publishable crate heddle-pack depends on heddle-object-model, which is not in PUBLISHABLE_CRATES
::error::publishable crate heddle-objects depends on heddle-object-model, which is not in PUBLISHABLE_CRATES
publish-pipeline check FAILED
```

exit 1, then restored. And for ordering, moving an entry after its consumer:

```
::error::PUBLISHABLE_CRATES order invalid: heddle-objects depends on heddle-object-model, which must appear earlier
```

I re-ran the first mutation myself rather than accepting the report — it names **all three** affected consumers, not just the one requested.

## Verification

- `bash scripts/check-publish-pipeline.sh` — **passes** on the correct list; 114 dependency pairs and 110 publish-order pairs checked across 28 publishable crates
- `bash scripts/check-release-pipeline.sh` — passes
- `bash -n scripts/check-publish-pipeline.sh`, `git diff --check` — pass

Cargo build/test/clippy gates were **deliberately skipped and are not claimed** — this changes only a shell script, no Rust source.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787675946&installation_model_id=21489&pr_number=1120&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1120&signature=a8a204f100f9adea540f245b7d4d2d8c08b817f5a14a9b98468b3a6d25a8e84e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->