### PR TITLE
refactor(objects): own snapshot pack seam

### DIFF
--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -17,10 +17,7 @@ use super::{
 use crate::{
     fs_atomic::sync_directory,
     object::{Blob, ContentHash, State, StateId, Tree},
-    store::{
-        Result,
-        pack::{PackManager, PackObjectId},
-    },
+    store::{Result, SnapshotPackManager, pack::PackObjectId},
 };
 
 const RECENT_BLOB_CACHE_CAPACITY: usize = 2_048;
@@ -234,7 +231,7 @@ where
 pub struct FsStore {
     pub(super) root: PathBuf,
     pub(super) compression: CompressionConfig,
-    pack_manager: RwLock<PackManager>,
+    pack_manager: RwLock<SnapshotPackManager>,
     pub(super) recent_blobs: RwLock<RecentObjectCache<ContentHash, Blob>>,
     pub(super) recent_trees: RwLock<RecentObjectCache<ContentHash, Tree>>,
     pub(super) recent_states: RwLock<RecentObjectCache<StateId, State>>,
@@ -280,7 +277,7 @@ impl FsStore {
     /// The path should be the `.heddle` directory.
     pub fn new(root: impl AsRef<Path>) -> Self {
         let root = root.as_ref().to_path_buf();
-        let pack_manager = PackManager::new(packs_dir(&root));
+        let pack_manager = SnapshotPackManager::new(packs_dir(&root));
         Self {
             root,
             compression: CompressionConfig::default(),
@@ -307,7 +304,7 @@ impl FsStore {
     /// Create a new filesystem store with custom compression settings.
     pub fn with_compression(root: impl AsRef<Path>, compression: CompressionConfig) -> Self {
         let root = root.as_ref().to_path_buf();
-        let pack_manager = PackManager::new(packs_dir(&root));
+        let pack_manager = SnapshotPackManager::new(packs_dir(&root));
         Self {
             root,
             compression,
@@ -452,7 +449,7 @@ impl FsStore {
     }
 
     /// Get the pack manager for pack operations.
-    pub fn pack_manager(&self) -> &RwLock<PackManager> {
+    pub fn pack_manager(&self) -> &RwLock<SnapshotPackManager> {
         &self.pack_manager
     }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -43,6 +43,8 @@ pub use liveness::{
 pub use memory::InMemoryStore;
 pub use pack::{PackBuilder, PackObjectId, PackReader, PackStats, StreamingPackBuilder, SyncData};
 pub use shallow::ShallowInfo;
+#[doc(hidden)]
+pub use snapshot_commit::SnapshotPackManager;
 #[cfg(feature = "async-source")]
 pub use source::AsyncObjectSource;
 pub use source::ObjectSource;

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -16,6 +16,7 @@ pub mod liveness;
 pub mod memory;
 pub use heddle_pack::store::pack;
 pub mod shallow;
+mod snapshot_commit;
 pub mod source;
 pub mod store_compliance;
 pub mod writer_lease;

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -1,5 +1,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{ops::Deref, path::PathBuf};
+
+use super::{Result, pack::PackManager};
+
+/// Objects-owned seam around the format-only pack manager.
+///
+/// Snapshot commit decoding and indexing can live here without making
+/// `heddle-pack` depend on objects-owned types or serializers.
+#[doc(hidden)]
+pub struct SnapshotPackManager {
+    format: PackManager,
+}
+
+impl SnapshotPackManager {
+    /// Open the format manager for `packs_dir`.
+    pub fn new(packs_dir: PathBuf) -> Self {
+        Self {
+            format: PackManager::new(packs_dir),
+        }
+    }
+
+    /// Reload pack-format state and any objects-owned indexes layered on it.
+    pub fn reload(&mut self) -> Result<()> {
+        self.format.reload()
+    }
+
+    /// Reload both layers when a complete pack/index pair appeared on disk.
+    pub fn reload_if_disk_grew(&mut self) -> Result<bool> {
+        self.format.reload_if_disk_grew()
+    }
+}
+
+impl Deref for SnapshotPackManager {
+    type Target = PackManager;
+
+    fn deref(&self) -> &Self::Target {
+        &self.format
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use heddle_format::compression::CompressionConfig;
+    use tempfile::TempDir;
+
+    use super::SnapshotPackManager;
+    use crate::{
+        object::ContentHash,
+        store::pack::{ObjectType, PackBuilder, PackManager},
+    };
+
+    #[test]
+    fn objects_owned_pack_wrapper_preserves_pack_bytes_and_reads() {
+        let temp = TempDir::new().unwrap();
+        let packs_dir = temp.path().join("packs");
+        fs::create_dir_all(&packs_dir).unwrap();
+
+        let payload = b"issue-1122-pack-snapshot-seam".to_vec();
+        let hash = ContentHash::compute(&payload);
+        let mut builder = PackBuilder::new(CompressionConfig::disabled());
+        builder.add(hash, ObjectType::Blob, payload.clone());
+        let (pack_data, index_data, _) = builder.build().unwrap();
+
+        assert_eq!(
+            blake3::hash(&pack_data).to_hex().as_str(),
+            "332afc6e60a35973800c50e7599bcb41ed055b730d41acfc7f9f1cd574408ccd",
+            "pack bytes must match the pre-refactor main baseline"
+        );
+        assert_eq!(
+            blake3::hash(&index_data).to_hex().as_str(),
+            "5baf8125e8db75055da475cc41f4bcc6ec90d0452c266adf3ebc440cce38b32b",
+            "index bytes must match the pre-refactor main baseline"
+        );
+
+        let pack_path = packs_dir.join("fixture.pack");
+        let index_path = packs_dir.join("fixture.idx");
+        fs::write(&pack_path, &pack_data).unwrap();
+        fs::write(&index_path, &index_data).unwrap();
+
+        let format_manager = PackManager::new(packs_dir.clone());
+        let mut snapshot_manager = SnapshotPackManager::new(packs_dir);
+        assert_eq!(
+            snapshot_manager.get_hashed_object(&hash).unwrap(),
+            format_manager.get_hashed_object(&hash).unwrap()
+        );
+        assert_eq!(
+            snapshot_manager.get_hashed_object(&hash).unwrap(),
+            Some((ObjectType::Blob, payload))
+        );
+
+        snapshot_manager.reload().unwrap();
+        assert_eq!(fs::read(pack_path).unwrap(), pack_data);
+        assert_eq!(fs::read(index_path).unwrap(), index_data);
+    }
+}

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -16,6 +16,9 @@ use crate::{
     },
 };
 
+/// Format-only coordinator for loaded pack and index files.
+///
+/// Object-domain indexes belong in a wrapper owned by the consuming crate.
 pub struct PackManager {
     packs_dir: PathBuf,
     packs: Vec<CachedPack>,


### PR DESCRIPTION
## Summary

- Keep `heddle-pack::PackManager` format-only and document the downward-only boundary.
- Store an objects-owned `SnapshotPackManager` wrapper in `FsStore`, with explicit mutating reload methods so snapshot indexes can be added above the format layer.
- Pin pre-refactor pack/index byte hashes and compare wrapped reads with the raw format manager.

## Closes

Closes HeddleCo/heddle#1122

## Test evidence

- `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker` — passed in 1m03s.
- `cargo test --locked -p heddle-pack --features zstd` — 72 passed.
- `cargo test --locked -p heddle-objects --all-features` — 162 unit tests and 1 integration test passed; 1 doctest ignored.
- `cargo test --locked -p heddle-cli --lib` — 463 passed.
- `cargo clippy --locked -p heddle-pack -p heddle-objects --all-targets --all-features -- -D warnings` — passed.
- Byte identity against unmodified `origin/main`: pack BLAKE3 `332afc6e60a35973800c50e7599bcb41ed055b730d41acfc7f9f1cd574408ccd`; index BLAKE3 `5baf8125e8db75055da475cc41f4bcc6ec90d0452c266adf3ebc440cce38b32b`. The committed test pins both and confirms wrapped/raw reads return the same object bytes.
- Mandatory negative case: temporarily importing `heddle_objects::store::SnapshotPackManager` from `heddle-pack` made `cargo check --locked -p heddle-pack` fail with `E0433` (unlinked crate). Temporarily adding the path dependency made Cargo fail with `cyclic package dependency` on `heddle-objects -> heddle-pack -> heddle-objects`. Both mutations were removed. No separate dependency scanner was added because rustc and the Cargo cycle check already enforce both routes more strongly.
- `cargo test --locked --workspace` was run exactly and completed the CLI integration binary with 376 passed, 494 failed, and 19 ignored. All observed failures share the managed sandbox mount `/tmp/.git` (`tmpfs`, read-only) and fail repository initialization with `Read-only file system (os error 30)`; the same environment limitation is documented on #1119. A non-CLI follow-up likewise reached two `heddle-core` temp-repository tests before the same ancestor-marker failure. The attributable pack/object and CLI library suites above are green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1123"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787712920&installation_model_id=21489&pr_number=1123&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1123&signature=fdec153b4da32146719e903308c054f7c4210e78b0c4bf3bf52d6458d67c38ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->