### PR TITLE
fix(audit): record paste advisory exception

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -30,4 +30,10 @@ ignore = [
     # writes SVGs). Remove when pprof/inferno bump quick-xml. (Mirrors deny.toml.)
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+
+    # Accepted 2026-07-27: paste is an unmaintained compile-time proc macro,
+    # pulled transitively by Iroh's netlink discovery stack. No vulnerability
+    # is reported. Remove when netlink-packet-core drops it.
+    # https://github.com/HeddleCo/heddle/issues/1124
+    "RUSTSEC-2024-0436",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -50,10 +50,12 @@ ignore = [
     # proc-macro-error2 upstream.
     { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 unmaintained; transitive build-time proc-macro via biscuit-quote → biscuit-auth 6.0; no runtime exposure, no CVE. Remove when biscuit-auth drops it." },
 
-    # paste 1.0.15: unmaintained (RUSTSEC-2024-0436). Pulled transitively by
-    # Iroh's netlink discovery stack through netlink-packet-core. `paste` is a
-    # compile-time proc macro with no runtime attack surface, and the advisory
-    # does not report a vulnerability. Remove when netlink-packet-core drops it.
+    # Accepted 2026-07-27: paste 1.0.15 is unmaintained
+    # (RUSTSEC-2024-0436). Pulled transitively by Iroh's netlink discovery
+    # stack through netlink-packet-core. `paste` is a compile-time proc macro
+    # with no runtime attack surface, and the advisory does not report a
+    # vulnerability. Remove when netlink-packet-core drops it.
+    # https://github.com/HeddleCo/heddle/issues/1124
     { id = "RUSTSEC-2024-0436", reason = "paste unmaintained; transitive compile-time proc macro via Iroh netlink discovery; no runtime exposure and no vulnerability. Remove when netlink-packet-core drops it." },
 
     # quick-xml 0.26.0: unbounded namespace-declaration allocation in `NsReader`


### PR DESCRIPTION
Closes HeddleCo/heddle#1124

`netlink-packet-core` 0.8.1 is the latest release and still requires `paste`, through Iroh netlink discovery. Record the unavoidable unmaintained advisory as a dated, single-ID exception in both audit policy files, with the issue link and removal condition.

## Test evidence

```text
$ cargo audit --deny warnings
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1169 security advisories
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (755 crate dependencies)
$ echo $?
0
```

```text
$ cargo tree -i paste --locked
paste v1.0.15 (proc-macro)
└── netlink-packet-core v0.8.1
    ├── netdev v0.45.0
    │   └── netwatch v0.19.1
    │       └── iroh v1.0.2 (https://github.com/n0-computer/iroh.git?rev=cc876c75e53171dfcaf2e5fa0b81a417904694ba#cc876c75)
    │           └── heddle-client v0.10.4
    ├── netlink-packet-route v0.31.0
    ├── netlink-proto v0.12.1
    └── netwatch v0.19.1
```

```text
$ cargo deny check advisories
warning[advisory-not-detected]: advisory was not encountered
  RUSTSEC-2023-0071: no crate matched advisory criteria
advisories ok
```

```text
$ cargo build --workspace --locked
Finished `dev` profile [unoptimized + debuginfo] target(s) in 46.24s
```

```text
$ cargo test --workspace --locked
test result: FAILED. 194 passed; 673 failed; 19 ignored; 0 measured; 0 filtered out
```

The full test command is host-blocked rather than change-blocked: the required disk-backed `TMPDIR=/home/heddleco/tmpbig` sits below `/home/heddleco/.heddle`, so temporary CLI test repositories discover that unrelated parent repository and fail with `Error: repository not found at /home/heddleco`. The configured shared target is read-only in this worktree, and `/tmp` is explicitly prohibited due to its RAM quota. The workspace build and both audit gates pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787755655&installation_model_id=21489&pr_number=1126&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1126&signature=b5b1c38701b0768daae742357d6bd6eb36e6f3d88311ba0554fd59716a8497e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->