### PR TITLE
fix(harness): match harness program by basename, not path substring

### DIFF
--- a/crates/cli/src/harness/probe/claude_code.rs
+++ b/crates/cli/src/harness/probe/claude_code.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
+use heddle_core::HarnessKind;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, attribution_env_hint, csv_paths, parse_u64,
+    argv_matches_harness, argv_value, attribution_env_hint, csv_paths, parse_u64,
 };
 
 pub(crate) struct ClaudeCodeProbe;
@@ -18,11 +19,7 @@ impl HarnessActorProbe for ClaudeCodeProbe {
             || input.probe_metadata.contains_key("session_id")
             || input.probe_metadata.contains_key("agent_id")
             || input.env_hints.contains_key("CLAUDECODE")
-            || input
-                .argv
-                .as_ref()
-                .and_then(|argv| argv.first())
-                .is_some_and(|program| program.to_ascii_lowercase().contains("claude"))
+            || argv_matches_harness(input, HarnessKind::ClaudeCode)
     }
 
     fn probe(&self, input: &HarnessProbeInput) -> Result<HarnessProbeResult> {

--- a/crates/cli/src/harness/probe/codex.rs
+++ b/crates/cli/src/harness/probe/codex.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
+use heddle_core::HarnessKind;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, attribution_env_hint, csv_paths, parse_u64,
+    argv_matches_harness, argv_value, attribution_env_hint, csv_paths, parse_u64,
 };
 
 pub(crate) struct CodexProbe;
@@ -20,11 +21,7 @@ impl HarnessActorProbe for CodexProbe {
             || input.env_hints.contains_key("CODEX_SANDBOX")
             || input.env_hints.contains_key("CODEX_THREAD_ID")
             || input.env_hints.contains_key("CODEX_CI")
-            || input
-                .argv
-                .as_ref()
-                .and_then(|argv| argv.first())
-                .is_some_and(|program| program.to_ascii_lowercase().contains("codex"))
+            || argv_matches_harness(input, HarnessKind::Codex)
     }
 
     fn probe(&self, input: &HarnessProbeInput) -> Result<HarnessProbeResult> {

--- a/crates/cli/src/harness/probe/mod.rs
+++ b/crates/cli/src/harness/probe/mod.rs
@@ -2,7 +2,7 @@
 use std::collections::BTreeMap;
 
 use anyhow::Result;
-use heddle_core::decide_harness_probe;
+use heddle_core::{HarnessKind, decide_harness_probe, detect_harness_kind};
 use wire::{TranscriptAttachmentRef, UsageTotals};
 
 use crate::attribution::clean_attribution_value;
@@ -167,6 +167,15 @@ pub(crate) fn argv_value(argv: &[String], flag: &str) -> Option<String> {
     None
 }
 
+pub(crate) fn argv_matches_harness(input: &HarnessProbeInput, expected: HarnessKind) -> bool {
+    let program = input
+        .argv
+        .as_ref()
+        .and_then(|argv| argv.first())
+        .map(String::as_str);
+    detect_harness_kind(program, &BTreeMap::new()) == expected
+}
+
 pub(crate) fn csv_paths(value: Option<&String>) -> Vec<String> {
     value
         .map(|raw| {
@@ -313,6 +322,46 @@ mod tests {
         assert_eq!(result.harness.as_deref(), Some("claude-code"));
         assert_eq!(result.provider.as_deref(), Some("anthropic"));
         assert_eq!(result.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
+    #[test]
+    fn claude_code_probe_matches_only_claude_program_names() {
+        let input = |program: &str| HarnessProbeInput {
+            argv: Some(vec![program.to_string()]),
+            ..HarnessProbeInput::default()
+        };
+
+        assert!(!ClaudeCodeProbe.matches(&input(
+            "/home/u/dev/.claude/worktrees/x/target/debug/heddle"
+        )));
+        assert!(ClaudeCodeProbe.matches(&input("/usr/bin/claude")));
+        assert!(ClaudeCodeProbe.matches(&input("claude-code")));
+    }
+
+    #[test]
+    fn codex_probe_matches_only_codex_program_name() {
+        let input = |program: &str| HarnessProbeInput {
+            argv: Some(vec![program.to_string()]),
+            ..HarnessProbeInput::default()
+        };
+
+        assert!(!CodexProbe.matches(&input("/home/u/dev/codex/worktrees/x/target/debug/heddle")));
+        assert!(CodexProbe.matches(&input("/usr/bin/codex")));
+        assert!(CodexProbe.matches(&input("codex")));
+    }
+
+    #[test]
+    fn opencode_probe_matches_only_opencode_program_name() {
+        let input = |program: &str| HarnessProbeInput {
+            argv: Some(vec![program.to_string()]),
+            ..HarnessProbeInput::default()
+        };
+
+        assert!(!OpenCodeProbe.matches(&input(
+            "/home/u/dev/opencode/worktrees/x/target/debug/heddle"
+        )));
+        assert!(OpenCodeProbe.matches(&input("/usr/bin/opencode")));
+        assert!(OpenCodeProbe.matches(&input("opencode")));
     }
 
     #[test]

--- a/crates/cli/src/harness/probe/opencode.rs
+++ b/crates/cli/src/harness/probe/opencode.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use anyhow::Result;
+use heddle_core::HarnessKind;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
-    argv_value, attribution_env_hint, csv_paths, parse_u64,
+    argv_matches_harness, argv_value, attribution_env_hint, csv_paths, parse_u64,
 };
 
 pub(crate) struct OpenCodeProbe;
@@ -17,11 +18,7 @@ impl HarnessActorProbe for OpenCodeProbe {
         input.explicit_harness.as_deref() == Some(self.harness_name())
             || input.probe_metadata.contains_key("session_id")
             || input.env_hints.contains_key("OPENCODE_CLIENT")
-            || input
-                .argv
-                .as_ref()
-                .and_then(|argv| argv.first())
-                .is_some_and(|program| program.to_ascii_lowercase().contains("opencode"))
+            || argv_matches_harness(input, HarnessKind::OpenCode)
     }
 
     fn probe(&self, input: &HarnessProbeInput) -> Result<HarnessProbeResult> {

--- a/crates/core/src/harness_policy.rs
+++ b/crates/core/src/harness_policy.rs
@@ -11,6 +11,7 @@
 //! the returned decision.
 
 use std::collections::BTreeMap;
+use std::path::Path;
 
 // ---------------------------------------------------------------------------
 // Harness kind / fingerprint
@@ -92,22 +93,27 @@ pub fn detect_harness_kind(
     program: Option<&str>,
     env_hints: &BTreeMap<String, String>,
 ) -> HarnessKind {
-    let program = program.map(|p| p.to_ascii_lowercase()).unwrap_or_default();
+    let program = program
+        .and_then(|program| Path::new(program).file_name())
+        .and_then(|name| name.to_str())
+        .map(str::to_ascii_lowercase)
+        .unwrap_or_default();
+    let program = program.strip_suffix(".exe").unwrap_or(&program);
 
-    if program.contains("claude")
+    if matches!(program, "claude" | "claude-code")
         || env_hints.contains_key("CLAUDECODE")
         || env_hints.contains_key("CLAUDE_CODE")
     {
         HarnessKind::ClaudeCode
-    } else if program.contains("codex")
+    } else if program == "codex"
         || env_hints.contains_key("CODEX_SANDBOX")
         || env_hints.contains_key("CODEX_THREAD_ID")
         || env_hints.contains_key("CODEX_CI")
     {
         HarnessKind::Codex
-    } else if program.contains("opencode") || env_hints.contains_key("OPENCODE_CLIENT") {
+    } else if program == "opencode" || env_hints.contains_key("OPENCODE_CLIENT") {
         HarnessKind::OpenCode
-    } else if program.contains("aider") {
+    } else if program == "aider" {
         HarnessKind::Aider
     } else {
         HarnessKind::Unknown
@@ -604,6 +610,39 @@ mod tests {
         assert_eq!(
             detect_harness_kind(Some("bash"), &BTreeMap::new()),
             HarnessKind::Unknown
+        );
+    }
+
+    #[test]
+    fn detect_harness_kind_matches_program_file_name_only() {
+        let no_env = BTreeMap::new();
+
+        assert_eq!(
+            detect_harness_kind(
+                Some("/home/u/dev/.claude/worktrees/x/target/debug/heddle"),
+                &no_env,
+            ),
+            HarnessKind::Unknown
+        );
+        assert_eq!(
+            detect_harness_kind(Some("/usr/bin/claude"), &no_env),
+            HarnessKind::ClaudeCode
+        );
+        assert_eq!(
+            detect_harness_kind(Some("claude-code"), &no_env),
+            HarnessKind::ClaudeCode
+        );
+        assert_eq!(
+            detect_harness_kind(Some("/home/u/dev/codex/target/debug/heddle"), &no_env),
+            HarnessKind::Unknown
+        );
+        assert_eq!(
+            detect_harness_kind(Some("/usr/bin/codex"), &no_env),
+            HarnessKind::Codex
+        );
+        assert_eq!(
+            detect_harness_kind(Some("CODEX.EXE"), &no_env),
+            HarnessKind::Codex
         );
     }
 


### PR DESCRIPTION
Closes #1114.

## The bug

Harness detection matched the harness name as a **substring of the whole argv[0] path**, so any checkout whose path contained `claude`, `codex` or `opencode` was misdetected as running under that harness — regardless of what actually invoked the binary.

For Claude Code that then supplies `provider = "anthropic"` (`claude_code.rs:56` → `agent_cmd.rs:429` → the capture's `ActorPresence`), which **silently overrides an explicit `HEDDLE_AGENT_PROVIDER`**, producing incoherent pairs like `anthropic/gpt-5.3-codex`.

## Four sites, in two crates

The issue as originally filed named only the first of these. That was wrong, and a fix limited to it changed nothing observable — the failure actually comes from the probe layer:

| Site | Was |
|---|---|
| `crates/core/src/harness_policy.rs` | `program.contains("claude")` / `"codex"` / `"opencode"` / `"aider"` |
| `crates/cli/src/harness/probe/claude_code.rs:25` | `program.to_ascii_lowercase().contains("claude")` |
| `crates/cli/src/harness/probe/codex.rs:27` | `…contains("codex")` |
| `crates/cli/src/harness/probe/opencode.rs:24` | `…contains("opencode")` |

All four now take the **file name** of argv[0], strip `.exe`, lowercase, and compare against exact names (`claude`/`claude-code`, `codex`, `opencode`, `aider`). The three probes reuse `heddle_core::detect_harness_kind` so the normalisation lives in one place and a fifth copy cannot drift.

**Explicit env signals are untouched** — `CLAUDECODE`, `CODEX_SANDBOX`, `OPENCODE_CLIENT` and the probe-metadata keys still match first and still take priority. Those are the reliable path; only the argv *fallback* changed.

## Proof — controlled, same environment on both sides

Running `multi_agent_worktrees::e2e::agent_capture_and_ready_require_authenticated_writer_authority` from a checkout under `.claude/worktrees/`, with the ambient Claude Code env signals removed so argv is the only signal:

| Branch | Result |
|---|---|
| `main` (unfixed) | **FAILED** — `"agent":"anthropic/gpt-5.3-codex"` |
| this branch | **passed** |

The only variable between those runs is the code.

> Worth recording why that framing matters: this repo's dev worktrees live under `.claude/worktrees/`, **and** a real Claude Code session exports `CLAUDECODE=1`. In such a session the probe matches on the explicit env signal and detects Claude Code *correctly* — so the test fails there both before and after this change, and that environment cannot distinguish a working fix from a broken one. Earlier verification attempts on this issue were confounded exactly that way. The env must be neutralised for the argv path to be observable.

## Tests

Probe-level regression test per harness: a program path like `/home/u/dev/.claude/worktrees/x/target/debug/heddle` must **not** match, while `/usr/bin/claude` and `claude-code` must. Same shape for `codex` and `opencode`. Equivalent tests added in `harness_policy.rs`. Existing probe tests (`probe/mod.rs` ~235-360) and `detect_harness_kind_from_env_and_program` unchanged and passing.

## Out of scope, deliberately

Whether an explicit `HEDDLE_AGENT_PROVIDER` *should* beat a correctly-inferred harness default is a separate design question — the precedence is documented on purpose at `harness_policy.rs` (~line 134). This PR fixes misdetection only; it does not touch precedence. My view is that explicit user intent should win, but that is a behaviour change deserving its own discussion.

## Verification

- `cargo build --locked --workspace` — pass
- `cargo build --locked --workspace --all-features` — pass
- `cargo clippy --workspace --all-targets -- -D warnings` — pass
- focused probe tests — 11 passed, 0 failed
- the controlled before/after above, run independently of the implementing agent

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787756051&installation_model_id=21489&pr_number=1127&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1127&signature=ec524081c02b793d778c902cc6ae423ab82fd94624cf1200d6c3f195e3ddbd6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->