### PR TITLE
Harden release pipelines and repository security controls

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -121,7 +121,7 @@ jobs:
       # job entirely on no-op merges.
       has_publishes: ${{ steps.classify.outputs.has_publishes }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history isn't needed (we don't walk it), but we DO
           # need the commit to be a real commit object so we can
@@ -294,17 +294,9 @@ jobs:
     if: needs.validate-publish.outputs.has_publishes == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
-    env:
-      # The env var name (CARGO_REGISTRY_TOKEN) is cargo's documented
-      # name and is what `cargo publish` reads at runtime — it must
-      # stay exactly this. The GitHub Actions secret name
-      # (CRATES_IO_API_KEY) is independent: it's the label under repo
-      # Settings → Secrets and variables → Actions. The strict asserter
-      # verifies both halves of this mapping — any rename on either
-      # side would silently break authentication.
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
+    environment: release
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Pin to the SHA validate-publish verified, NOT
           # refs/heads/main. main is mutable; a force-push between
@@ -313,35 +305,27 @@ jobs:
           # as release.yml.
           ref: ${{ needs.validate-publish.outputs.commit_sha }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: publish-crates
           cache-on-failure: true
 
-      - name: Assert CARGO_REGISTRY_TOKEN is present
-        shell: bash
-        run: |
-          set -euo pipefail
-          # We deliberately check at the FIRST credentialed step (not
-          # in validate-publish) so the validation pass still runs and
-          # surfaces what *would have* been published, even if the
-          # secret isn't configured yet. That gives the operator a
-          # punch list to act on. If the validation pass shipped
-          # without a publish attempt, it'd be silent.
-          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
-            echo "::error::CARGO_REGISTRY_TOKEN env var is empty — the CRATES_IO_API_KEY secret is unset or the mapping in publish-crates.yml is wrong. Add CRATES_IO_API_KEY under repo Settings → Secrets and variables → Actions, then re-run."
-            exit 1
-          fi
-          echo "ok: CARGO_REGISTRY_TOKEN is present (length=${#CARGO_REGISTRY_TOKEN})"
-
       - name: Publish each crate (idempotent, retry on 5xx)
         shell: bash
         env:
+          # Keep the crates.io credential scoped to the only step that
+          # needs it. Checkout, toolchain, and cache actions never receive it.
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_API_KEY }}
           TO_PUBLISH: ${{ needs.validate-publish.outputs.to_publish }}
         run: |
           set -euo pipefail
+
+          if [[ -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
+            echo "::error::CARGO_REGISTRY_TOKEN env var is empty — the CRATES_IO_API_KEY secret is unset or the mapping in publish-crates.yml is wrong. Add CRATES_IO_API_KEY to the approval-protected release environment, then re-run."
+            exit 1
+          fi
 
           # Pretty-print the publish plan up front so the workflow log
           # has a clean record before any side effects.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,11 @@ name: Release binaries
 # the same FSKit SDK floor.
 #
 # Signing: cosign keyless via the Sigstore public-good instance. No
-# stored secrets — the GitHub OIDC token is the trust anchor. Verifying
-# parties run `cosign verify-blob --certificate-identity-regexp ...`;
-# see RELEASING.md for the exact recipe.
+# stored secrets — the GitHub OIDC token is the trust anchor. Every
+# signing or publishing job is gated by the approval-protected `release`
+# environment before GitHub issues credentials. Verifying parties run
+# `cosign verify-blob --certificate-identity-regexp ...`; see
+# RELEASING.md for the exact recipe.
 
 on:
   push:
@@ -41,17 +43,16 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to build (vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]); or a synthetic prerelease tag when branch_dry_run is true.'
+        description: 'Existing tag to build (vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]).'
         required: true
       branch_dry_run:
-        description: 'TEMP: build from the selected branch/ref without publishing a GitHub Release.'
+        description: 'Deprecated and refused: release credentials are never exposed to branch-selected workflow code.'
         type: boolean
         required: false
         default: false
 
 permissions:
-  contents: write   # create release + upload assets
-  id-token: write   # cosign keyless OIDC
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -76,7 +77,7 @@ jobs:
       kind: ${{ steps.classify.outputs.kind }}
       publish_release: ${{ steps.classify.outputs.publish_release }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Full history is needed for both the tag→commit resolution and
           # the ancestor check against origin/main.
@@ -131,49 +132,40 @@ jobs:
             exit 1
           fi
 
-          # TEMP: branch_dry_run is for PR validation of release-only
-          # signing/notarization paths. It builds artifacts from the
-          # manually selected workflow ref, skips the GitHub Release job,
-          # and still requires a prerelease-shaped synthetic tag so asset
-          # names remain realistic. Remove once the release artifact guard
-          # has been verified in CI.
+          # A branch-selected workflow definition is not an acceptable
+          # signing boundary: it can replace this validation before asking
+          # GitHub for the Apple credentials or an OIDC token. Keep the
+          # deprecated input long enough to fail existing callers explicitly,
+          # but never build or sign from it. Approved RC dry-runs remain
+          # available by dispatching an existing prerelease tag reachable from
+          # main through the normal path below.
           if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" == "true" ]]; then
-            if [[ "$PUSH_REF" != refs/heads/* ]]; then
-              echo "::error::branch_dry_run must be dispatched from a branch ref, got: $PUSH_REF"
-              exit 1
-            fi
-            if [[ "$tag" =~ $stable_re ]]; then
-              echo "::error::branch_dry_run requires a prerelease-shaped synthetic tag (vX.Y.Z-rc.N), got stable tag '${tag}'"
-              exit 1
-            fi
-            tag_sha="$(git rev-parse HEAD)"
-            kind=prerelease
-            publish_release=false
-            echo "::notice::TEMP branch_dry_run building ${tag} from ${PUSH_REF} (${tag_sha}) without publishing a GitHub Release"
-          else
-            # 3. Reject anything that is not a real tag in this repo. This
-            #    catches workflow_dispatch with 'main', a typo, or a
-            #    deleted tag — none of which should reach the release job.
-            if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
-              echo "::error::'${tag}' is not a tag in this repository"
-              exit 1
-            fi
-
-            # 4. The pipeline only ships releases from main. A tag pointed
-            #    at a feature branch (deliberately or accidentally) must
-            #    not produce signed release assets with the heddle release
-            #    OIDC identity. The tag-push trigger does not enforce
-            #    branch ancestry on its own, so we do it here.
-            tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
-            if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
-              echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
-              exit 1
-            fi
-
-            publish_release=true
+            echo "::error::branch_dry_run is disabled: branch-selected workflow code cannot receive release signing or publishing credentials. Push an existing prerelease tag reachable from main and dispatch that tag for an approval-protected RC dry-run."
+            exit 1
           fi
 
-          if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" != "true" ]]; then
+          # 3. Reject anything that is not a real tag in this repo. This
+          #    catches workflow_dispatch with 'main', a typo, or a
+          #    deleted tag — none of which should reach the release job.
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            echo "::error::'${tag}' is not a tag in this repository"
+            exit 1
+          fi
+
+          # 4. The pipeline only ships releases from main. A tag pointed
+          #    at a feature branch (deliberately or accidentally) must
+          #    not produce signed release assets with the heddle release
+          #    OIDC identity. The tag-push trigger does not enforce
+          #    branch ancestry on its own, so we do it here.
+          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
+            echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
+            exit 1
+          fi
+
+          publish_release=true
+
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
             # Dispatch is the RC/dry-run path. Stable tags MUST go through
             # the push trigger so they cannot be retroactively downgraded:
             # softprops/action-gh-release UPDATES an existing release when
@@ -213,9 +205,12 @@ jobs:
   build:
     name: build non-mac ${{ matrix.target }}
     needs: validate-tag
-    if: ${{ github.event_name != 'workflow_dispatch' || !inputs.branch_dry_run }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -240,7 +235,7 @@ jobs:
           # absence. Re-add when cosign ships win-arm64 binaries — tracked in
           # the "re-enable aarch64-pc-windows-msvc" issue.
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Pin to the SHA validate-tag verified, not the tag ref. If the
           # tag is force-moved between validate-tag and this step, we
@@ -250,11 +245,11 @@ jobs:
           # points at.
           ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-${{ matrix.target }}
           cache-on-failure: true
@@ -304,7 +299,7 @@ jobs:
           "SUM=dist/$stage.zip.sha256"   | Out-File -Encoding ascii -Append $env:GITHUB_ENV
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign artifact (cosign keyless)
         shell: bash
@@ -319,7 +314,7 @@ jobs:
             "${ASSET}"
 
       - name: Upload build outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: heddle-${{ matrix.target }}
           path: |
@@ -335,17 +330,21 @@ jobs:
     needs: validate-tag
     runs-on: macos-26
     timeout-minutes: 120
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Same SHA pin as the CLI build job — see comment there.
           ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-macos-cask
           cache-on-failure: true
@@ -453,7 +452,7 @@ jobs:
           done
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
 
       - name: Sign macOS artifacts (cosign keyless)
         shell: bash
@@ -474,7 +473,7 @@ jobs:
           done
 
       - name: Upload macOS cask outputs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: heddle-macos-artifacts
           path: |
@@ -499,8 +498,11 @@ jobs:
     if: needs.validate-tag.outputs.publish_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    environment: release
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Keep the publication job anchored to the same validated commit as
           # the artifact builders. The release action itself uses downloaded
@@ -509,7 +511,7 @@ jobs:
           ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
       - name: Download all build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: staging
 
@@ -524,7 +526,7 @@ jobs:
           ls -la dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ needs.validate-tag.outputs.tag }}
           name: ${{ needs.validate-tag.outputs.tag }}
@@ -557,16 +559,17 @@ jobs:
     if: needs.validate-tag.outputs.kind == 'stable'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
+    environment: release
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           # Render manifests from the exact commit that produced the release.
           ref: ${{ needs.validate-tag.outputs.tag_sha }}
 
       - name: Download release build outputs
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: staging
 
@@ -619,7 +622,7 @@ jobs:
 
       - name: Generate release publisher token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.HEDDLE_RELEASE_APP_ID }}
           private-key: ${{ secrets.HEDDLE_RELEASE_APP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,15 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Changed
 
+- **Security boundaries hardened across local, hosted, and release paths.**
+  Dynamic Bash completion no longer re-evaluates ref names; recursive clone
+  mounts are confined beneath the clone root; explicit remote destinations
+  cannot be shadowed by aliases; hosted Git ref updates are staged, scoped,
+  and compare-and-set after successful pull completion; authoritative
+  redaction, visibility, and signature-attachment metadata is client-signed
+  and fail-closed; and release workflows use protected environments,
+  least-privilege credentials, and commit-pinned actions.
+
 - **Explicit source authority and direct Sley Git Overlay.** Existing Git
   checkouts keep source objects, refs, index, and worktree state in their real
   `.git`; Heddle keeps provenance and coordination metadata in `.heddle`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -433,6 +433,19 @@ passes:
   the `needs:` line; the parser confirms each downstream job
   individually.
 
+Every binary-signing or publishing job declares the `release` GitHub
+environment. Repository settings must keep that environment
+approval-protected and restrict deployments to protected release refs. The
+workflow deliberately refuses the deprecated `branch_dry_run` input: code
+selected from an arbitrary branch must never receive Apple signing secrets,
+release-app credentials, or a release OIDC identity. Approved RC dry-runs use
+an existing prerelease tag whose commit is reachable from `main`.
+
+All external actions in the binary and crates.io release workflows are pinned
+to exact commit SHAs. Version comments beside those pins are informational;
+updating an action means reviewing and replacing the SHA, not changing back to
+a mutable tag.
+
 The contract above is the contract it enforces. If you intentionally
 change the contract, update `scripts/check-release-pipeline.sh` in
 the same PR.
@@ -469,10 +482,12 @@ packages. The full cross-repository release gate is tracked in
      **publish** (Cargo.toml version isn't on crates.io yet),
      **skip** (already published — idempotent re-run), or **fail**
      (Cargo.toml downgrade — refuses).
-   - `publish` runs only when `has_publishes == 'true'`, checks out
+   - `publish` runs only when `has_publishes == 'true'`, enters the
+     approval-protected `release` environment, checks out
      the validated `commit_sha` (not `refs/heads/main` — see the
      TOCTOU note in `release.yml`), asserts the `CARGO_REGISTRY_TOKEN`
-     env var is non-empty (sourced from `secrets.CRATES_IO_API_KEY` —
+     env var is non-empty in the publish step only (sourced from
+     `secrets.CRATES_IO_API_KEY` —
      see [Token wiring](#token-wiring) below), and runs
      `cargo publish -p <crate>` for each entry in the publish set.
      "already exists" errors are treated as success (race / re-run);
@@ -504,7 +519,7 @@ the explicit list keeps the publication scope visible in diff.
 
 ### Token wiring
 
-The workflow's publish job exposes the credential to cargo via:
+The workflow's cargo-publish step exposes the credential to cargo via:
 
 ```yaml
 env:
@@ -521,8 +536,10 @@ The two names are deliberately distinct halves of the mapping:
   side would resolve to an empty string and break authentication on
   the first publish.
 
-The asserter (see below) checks both halves separately so a regression
-on either side surfaces with its own error line.
+The credential is step-scoped so checkout, toolchain, and cache actions never
+receive it. The asserter (see below) checks the mapping, scope, protected
+environment, and exact action pins so a regression surfaces with its own error
+line.
 
 To rotate the token: update the `CRATES_IO_API_KEY` secret in repo
 settings. No workflow change is needed.

--- a/crates/cli-shared/src/remote/mod.rs
+++ b/crates/cli-shared/src/remote/mod.rs
@@ -167,8 +167,16 @@ pub fn resolve_remote_with_key_and_insecure(
     repo: &Repository,
     remote_arg: Option<&str>,
 ) -> Result<(RemoteTarget, Option<String>, bool)> {
-    let cfg = RemoteConfig::open(repo)?;
+    if let Some(spec) = remote_arg
+        && RemoteTarget::is_explicit_spec(spec)
+    {
+        let target =
+            RemoteTarget::parse(spec).map_err(|_| RemoteError::InvalidUrl(spec.to_string()))?;
+        let key = credential_key_from_url(spec);
+        return Ok((target, key, false));
+    }
 
+    let cfg = RemoteConfig::open(repo)?;
     let spec = match remote_arg {
         Some(spec) => spec.to_string(),
         None => cfg
@@ -176,20 +184,6 @@ pub fn resolve_remote_with_key_and_insecure(
             .ok_or(RemoteError::NoDefaultRemote)?
             .to_string(),
     };
-
-    // Named remote first so configured `insecure` applies even when the
-    // name also happens to parse as a bare host:port.
-    if let Ok(remote) = cfg.get(&spec)
-        && let Ok(target) = RemoteTarget::parse(&remote.url)
-    {
-        let key = credential_key_from_url(&remote.url);
-        return Ok((target, key, remote.insecure));
-    }
-
-    if let Ok(target) = RemoteTarget::parse(&spec) {
-        let key = credential_key_from_url(&spec);
-        return Ok((target, key, false));
-    }
 
     let remote = cfg.get(&spec)?;
     if let Ok(target) = RemoteTarget::parse(&remote.url) {
@@ -289,6 +283,96 @@ mod tests {
         let reopened = RemoteConfig::open(&repo).expect("reopen config");
         let remote = reopened.get("origin").expect("load remote");
         assert_eq!(remote.url, "http://heddle.example:8421/repo");
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn explicit_host_port_cannot_be_shadowed_by_a_named_remote() {
+        let temp = unique_temp_dir("heddle-remote-shadow-test");
+        fs::create_dir_all(&temp).expect("create temp dir");
+        let repo = Repository::init_default(&temp).expect("init repo");
+        let mut cfg = RemoteConfig::open(&repo).expect("open config");
+        cfg.add(
+            "127.0.0.1:8421",
+            Remote {
+                url: "heddle://127.0.0.1:9999/attacker/repo".to_string(),
+                insecure: true,
+            },
+        )
+        .expect("add shadowing remote");
+
+        let (target, key, insecure) =
+            resolve_remote_with_key_and_insecure(&repo, Some("127.0.0.1:8421"))
+                .expect("resolve explicit address");
+        match target {
+            RemoteTarget::Network { addr, repo_path } => {
+                assert_eq!(addr.port(), 8421);
+                assert!(repo_path.is_none());
+            }
+            other => panic!("expected network target, got {other:?}"),
+        }
+        assert_eq!(key.as_deref(), Some("127.0.0.1:8421"));
+        assert!(
+            !insecure,
+            "an explicit address must not inherit alias policy"
+        );
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn explicit_location_does_not_consult_remote_configuration() {
+        let temp = unique_temp_dir("heddle-explicit-remote-test");
+        fs::create_dir_all(&temp).expect("create temp dir");
+        let repo = Repository::init_default(&temp).expect("init repo");
+        fs::write(repo.heddle_dir().join("remotes.toml"), b"not = [valid")
+            .expect("write malformed remote config");
+
+        let (target, _, insecure) =
+            resolve_remote_with_key_and_insecure(&repo, Some("127.0.0.1:8421"))
+                .expect("explicit address bypasses aliases");
+        assert!(
+            matches!(
+                target,
+                RemoteTarget::Network {
+                    addr,
+                    repo_path: None,
+                } if addr.port() == 8421
+            ),
+            "explicit address must be resolved independently"
+        );
+        assert!(!insecure);
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn bare_remote_name_still_uses_configured_target_and_policy() {
+        let temp = unique_temp_dir("heddle-named-remote-test");
+        fs::create_dir_all(&temp).expect("create temp dir");
+        let repo = Repository::init_default(&temp).expect("init repo");
+        let mut cfg = RemoteConfig::open(&repo).expect("open config");
+        cfg.add(
+            "origin",
+            Remote {
+                url: "heddle://127.0.0.1:9999/acme/repo".to_string(),
+                insecure: true,
+            },
+        )
+        .expect("add named remote");
+
+        let (target, key, insecure) = resolve_remote_with_key_and_insecure(&repo, Some("origin"))
+            .expect("resolve named remote");
+        match target {
+            RemoteTarget::Network { addr, repo_path } => {
+                assert_eq!(addr.port(), 9999);
+                assert_eq!(repo_path.as_deref(), Some("acme/repo"));
+            }
+            other => panic!("expected network target, got {other:?}"),
+        }
+        assert_eq!(key.as_deref(), Some("127.0.0.1:9999"));
+        assert!(insecure, "named remotes retain their configured policy");
 
         let _ = fs::remove_dir_all(temp);
     }

--- a/crates/cli-shared/src/remote/target.rs
+++ b/crates/cli-shared/src/remote/target.rs
@@ -19,6 +19,26 @@ pub enum RemoteTarget {
 }
 
 impl RemoteTarget {
+    /// Whether a CLI argument is syntactically a location rather than an alias.
+    ///
+    /// Explicit locations must be parsed before repository configuration is
+    /// consulted so an alias with the same spelling cannot redirect them.
+    pub fn is_explicit_spec(s: &str) -> bool {
+        if s.contains("://")
+            || PathBuf::from(s).is_absolute()
+            || s.starts_with("./")
+            || s.starts_with("../")
+        {
+            return true;
+        }
+
+        let authority = s.split('/').next().unwrap_or(s);
+        authority.parse::<SocketAddr>().is_ok()
+            || authority
+                .rsplit_once(':')
+                .is_some_and(|(host, port)| !host.is_empty() && port.parse::<u16>().is_ok())
+    }
+
     /// Parse from a string.
     ///
     /// Accepts:
@@ -132,6 +152,25 @@ mod tests {
                 assert_eq!(repo_path.as_deref(), Some("acme/heddle"));
             }
             other => panic!("expected network target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn explicit_specs_are_classified_without_configuration_or_dns() {
+        for spec in [
+            "heddle://example.test:8421/acme/repo",
+            "file:///tmp/repo",
+            "/tmp/repo",
+            "./repo",
+            "../repo",
+            "example.test:8421",
+            "example.test:8421/acme/repo",
+            "[::1]:8421",
+        ] {
+            assert!(RemoteTarget::is_explicit_spec(spec), "{spec:?}");
+        }
+        for alias in ["origin", "publish", "team-prod"] {
+            assert!(!RemoteTarget::is_explicit_spec(alias), "{alias:?}");
         }
     }
 }

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1756,7 +1756,7 @@ async fn clone_monorepo(
     // then pure-plan placement, work order, and per-node steps (no FS yet).
     let resolved = client.resolve_monorepo(root_path, None).await?;
     let facts = monorepo_node_facts_from_resolved(&resolved);
-    let clone_plan = plan_monorepo_clone(&facts);
+    let clone_plan = plan_monorepo_clone(&facts).map_err(|err| anyhow!(err))?;
     let exec = plan_monorepo_execution(&clone_plan, &MonorepoNodeStepOptions::default());
     // Ordering invariants (Init before Fetch, paired fetch/materialize, …)
     // before any irreversible per-node I/O.
@@ -1769,7 +1769,13 @@ async fn clone_monorepo(
 
     let total_nodes = exec.node_count();
     for (node_index, node_exec) in exec.nodes.iter().enumerate() {
-        let dest = node_exec.node.dest_path(local_path);
+        let dest = validate_monorepo_destination(local_path, &node_exec.node.rel_path)
+            .with_context(|| {
+                format!(
+                    "refusing unsafe mount path for spool '{}'",
+                    node_exec.node.spool_id
+                )
+            })?;
         execute_monorepo_node_steps(
             &mut client,
             node_exec,
@@ -1828,6 +1834,59 @@ async fn clone_monorepo(
         }
     }
     Ok(())
+}
+
+#[cfg(feature = "client")]
+fn validate_monorepo_destination(clone_root: &Path, rel_path: &Path) -> Result<PathBuf> {
+    let root_metadata = fs::symlink_metadata(clone_root)?;
+    if root_metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "monorepo clone root '{}' must not be a symlink",
+            clone_root.display()
+        );
+    }
+    let canonical_root = fs::canonicalize(clone_root)?;
+    let mut checked = canonical_root.clone();
+
+    for component in rel_path.components() {
+        let std::path::Component::Normal(name) = component else {
+            anyhow::bail!(
+                "monorepo mount path '{}' contains an unsafe component",
+                rel_path.display()
+            );
+        };
+        checked.push(name);
+        match fs::symlink_metadata(&checked) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "monorepo mount path '{}' traverses symlink '{}'",
+                    rel_path.display(),
+                    checked.display()
+                );
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                anyhow::bail!(
+                    "monorepo mount path '{}' traverses non-directory '{}'",
+                    rel_path.display(),
+                    checked.display()
+                );
+            }
+            Ok(_) => {
+                checked = fs::canonicalize(&checked)?;
+                if !checked.starts_with(&canonical_root) {
+                    anyhow::bail!(
+                        "monorepo mount path '{}' resolves outside clone root '{}'",
+                        rel_path.display(),
+                        clone_root.display()
+                    );
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    Ok(clone_root.join(rel_path))
 }
 
 /// Map a transport `MonorepoNode` tree into pure core facts (no I/O).
@@ -2427,6 +2486,36 @@ mod tests {
             cfg.get("origin").expect("origin remote").url,
             "heddle://weft.local:8421/smoke-cli/project"
         );
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn monorepo_destination_preserves_safe_nested_mounts() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("clone");
+        std::fs::create_dir_all(root.join("libs")).expect("create clone root");
+
+        let destination = validate_monorepo_destination(&root, Path::new("libs/vendor"))
+            .expect("safe nested mount");
+
+        assert_eq!(destination, root.join("libs/vendor"));
+    }
+
+    #[cfg(all(feature = "client", unix))]
+    #[test]
+    fn monorepo_destination_rejects_symlinked_mount_ancestor() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("clone");
+        let outside = temp.path().join("outside");
+        std::fs::create_dir_all(&root).expect("create clone root");
+        std::fs::create_dir_all(&outside).expect("create outside");
+        std::os::unix::fs::symlink(&outside, root.join("libs")).expect("create mount symlink");
+
+        let error = validate_monorepo_destination(&root, Path::new("libs/vendor"))
+            .expect_err("symlinked mount must fail");
+
+        assert!(error.to_string().contains("traverses symlink"));
+        assert!(!outside.join("vendor").exists());
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/completion.rs
+++ b/crates/cli/src/cli/commands/completion.rs
@@ -74,7 +74,14 @@ __heddle_dynamic_words() {
 
 __heddle_complete_from() {
     local subject="$1"
-    mapfile -t COMPREPLY < <(compgen -W "$(__heddle_dynamic_words "$subject")" -- "${COMP_WORDS[COMP_CWORD]}")
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    local candidate
+    COMPREPLY=()
+    while IFS= read -r candidate; do
+        if [[ "$candidate" == "$current"* ]]; then
+            COMPREPLY+=("$candidate")
+        fi
+    done < <(__heddle_dynamic_words "$subject")
 }
 
 __heddle_thread_value_position() {

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -766,8 +766,10 @@ fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
     // Purging is a new authoritative metadata decision. A re-signs the
     // lifecycle transition with its active client identity rather than
     // pretending the original redaction operator made that later decision.
-    // In production Tapestry distributes trusted client identities; this
-    // local-sync fixture enrolls A's public key explicitly.
+    // Hosted rollout must provision trusted client identities through the
+    // Weft/Tapestry control plane before purge sync is enabled. That
+    // distribution is not implemented in this repository; this local-sync
+    // fixture mirrors current behavior by enrolling A's public key explicitly.
     let identity_raw =
         fs::read_to_string(a.path().join(".heddle/identity.toml")).expect("read A identity");
     let identity: toml::Value = toml::from_str(&identity_raw).expect("parse A identity");

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -763,6 +763,31 @@ fn purge_apply_signed_propagates_byte_removal_to_cloned_replica() {
         Some(&b_path),
     )
     .expect("B trusts A's signing key");
+    // Purging is a new authoritative metadata decision. A re-signs the
+    // lifecycle transition with its active client identity rather than
+    // pretending the original redaction operator made that later decision.
+    // In production Tapestry distributes trusted client identities; this
+    // local-sync fixture enrolls A's public key explicitly.
+    let identity_raw =
+        fs::read_to_string(a.path().join(".heddle/identity.toml")).expect("read A identity");
+    let identity: toml::Value = toml::from_str(&identity_raw).expect("parse A identity");
+    let client_public_key = identity
+        .get("public_key")
+        .and_then(toml::Value::as_str)
+        .expect("A identity public key");
+    heddle(
+        &[
+            "redact",
+            "trust",
+            "add",
+            "--algorithm",
+            "ed25519",
+            "--public-key",
+            client_public_key,
+        ],
+        Some(&b_path),
+    )
+    .expect("B trusts A's client metadata identity");
     heddle(
         &["remote", "add", "origin", a.path().to_str().unwrap()],
         Some(&b_path),

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -1324,6 +1324,67 @@ mod completion {
         );
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn bash_dynamic_completion_never_evaluates_ref_names() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().unwrap();
+        let completion = heddle(&["shell", "completion", "bash"], Some(temp.path())).unwrap();
+        let completion_path = temp.path().join("heddle-completion.bash");
+        fs::write(&completion_path, completion).unwrap();
+
+        let marker = temp.path().join("executed");
+        let bin_dir = temp.path().join("bin");
+        fs::create_dir(&bin_dir).unwrap();
+        let fake_heddle = bin_dir.join("heddle");
+        fs::write(
+            &fake_heddle,
+            format!(
+                "#!/bin/sh\nprintf '%s\\n' 'safe' '$(printf pwned > {})'\n",
+                marker.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&fake_heddle, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let output = Command::new("bash")
+            .arg("-c")
+            .arg(
+                r#"source "$1"
+COMP_WORDS=(heddle thread show "")
+COMP_CWORD=3
+__heddle_complete_from threads
+printf '%s\n' "${COMPREPLY[@]}""#,
+            )
+            .arg("bash")
+            .arg(&completion_path)
+            .env(
+                "PATH",
+                format!(
+                    "{}:{}",
+                    bin_dir.display(),
+                    std::env::var("PATH").unwrap_or_default()
+                ),
+            )
+            .output()
+            .expect("run generated Bash completion");
+
+        assert!(
+            output.status.success(),
+            "generated completion failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("$(printf pwned >"),
+            "the malicious-looking but valid name should remain a literal completion candidate"
+        );
+        assert!(
+            !marker.exists(),
+            "dynamic completion must not evaluate candidate contents"
+        );
+    }
+
     #[test]
     fn test_completion_zsh() {
         let temp = TempDir::new().unwrap();

--- a/crates/cli/tests/production_features/state_signing.rs
+++ b/crates/cli/tests/production_features/state_signing.rs
@@ -262,7 +262,7 @@ fn test_state_signing_via_repository() {
 }
 
 #[test]
-fn test_signature_tampering_detected() {
+fn test_signature_tampering_cannot_supersede_valid_evidence() {
     use objects::object::{Attribution, Principal, Tree};
     use repo::Repository;
 
@@ -290,20 +290,22 @@ fn test_signature_tampering_detected() {
     let mut sig_bytes = hex::decode(&signature.signature).expect("decode");
     sig_bytes[0] ^= 0xff;
     signature.signature = hex::encode(&sig_bytes);
-    repo.put_state_attachment(&objects::object::StateAttachment {
-        state_id,
-        body: objects::object::StateAttachmentBody::Signature(signature),
-        attribution: state.attribution,
-        created_at: chrono::Utc::now(),
-        supersedes: Some(prior_id),
-    })
-    .unwrap();
+    let error = repo
+        .put_state_attachment(&objects::object::StateAttachment {
+            state_id,
+            body: objects::object::StateAttachmentBody::Signature(signature),
+            attribution: state.attribution,
+            created_at: chrono::Utc::now(),
+            supersedes: Some(prior_id),
+        })
+        .expect_err("signature evidence must be append-only");
+    assert!(error.to_string().contains("append-only"));
 
     let status = repo.verify_state_signature(&state_id).expect("verify");
     assert_eq!(
         status,
-        crypto::SignatureStatus::Invalid,
-        "tampered signature should be invalid"
+        crypto::SignatureStatus::Valid,
+        "rejected attachment must not suppress the valid signature"
     );
 }
 

--- a/crates/client/src/hosted/monorepo.rs
+++ b/crates/client/src/hosted/monorepo.rs
@@ -94,15 +94,31 @@ pub struct MonorepoClonePlan {
     pub skipped: Vec<SkippedChild>,
 }
 
+/// A remote edge supplied a mount that cannot be placed beneath the clone root.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MonorepoClonePlanError {
+    #[error(
+        "invalid monorepo mount name '{mount_name}' for child '{child_spool_id}': mount names must be exactly one relative path component"
+    )]
+    InvalidMountName {
+        child_spool_id: String,
+        mount_name: String,
+    },
+}
+
 impl MonorepoClonePlan {
     /// Build the plan from a resolved root `MonorepoNode`. Pure — no I/O.
-    pub fn from_resolved(root: &MonorepoNode) -> Self {
+    pub fn from_resolved(root: &MonorepoNode) -> Result<Self, MonorepoClonePlanError> {
         let mut plan = MonorepoClonePlan::default();
-        plan.walk(root, PathBuf::new());
-        plan
+        plan.walk(root, PathBuf::new())?;
+        Ok(plan)
     }
 
-    fn walk(&mut self, node: &MonorepoNode, rel_path: PathBuf) {
+    fn walk(
+        &mut self,
+        node: &MonorepoNode,
+        rel_path: PathBuf,
+    ) -> Result<(), MonorepoClonePlanError> {
         // Emit this node's clone op. An absent/malformed content_state maps to
         // `None` (empty checkout) rather than being dropped — the mount point
         // must still exist for the monorepo layout to be coherent.
@@ -117,10 +133,11 @@ impl MonorepoClonePlan {
         });
 
         for edge in &node.edges {
+            validate_mount_name(edge)?;
             let child_rel = rel_path.join(&edge.mount_name);
             match (&edge.subtree, edge.skipped) {
                 // Descended: recurse into the resolved subtree at its mount.
-                (Some(subtree), _) => self.walk(subtree, child_rel),
+                (Some(subtree), _) => self.walk(subtree, child_rel)?,
                 // Withheld: record the reason, do not descend. A missing
                 // subtree with no explicit reason is treated as unspecified
                 // rather than silently vanishing.
@@ -137,7 +154,25 @@ impl MonorepoClonePlan {
                 }
             }
         }
+        Ok(())
     }
+}
+
+fn validate_mount_name(
+    edge: &api::heddle::api::v1alpha1::MonorepoEdge,
+) -> Result<(), MonorepoClonePlanError> {
+    let mut components = Path::new(&edge.mount_name).components();
+    let is_one_normal_component =
+        matches!(components.next(), Some(std::path::Component::Normal(_)))
+            && components.next().is_none()
+            && !edge.mount_name.contains(['/', '\\']);
+    if is_one_normal_component {
+        return Ok(());
+    }
+    Err(MonorepoClonePlanError::InvalidMountName {
+        child_spool_id: edge.child_spool_id.clone(),
+        mount_name: edge.mount_name.clone(),
+    })
 }
 
 #[cfg(test)]
@@ -225,7 +260,7 @@ mod tests {
 
     #[test]
     fn planner_places_each_spool_at_its_mount_path_and_anchored_state() {
-        let plan = MonorepoClonePlan::from_resolved(&fixture_tree());
+        let plan = MonorepoClonePlan::from_resolved(&fixture_tree()).expect("plan monorepo clone");
 
         // Three descended ops in pre-order: root, child-a, grandchild.
         assert_eq!(plan.ops.len(), 3, "root + child-a + grandchild");
@@ -249,7 +284,7 @@ mod tests {
 
     #[test]
     fn planner_reports_the_skipped_child_and_does_not_clone_it() {
-        let plan = MonorepoClonePlan::from_resolved(&fixture_tree());
+        let plan = MonorepoClonePlan::from_resolved(&fixture_tree()).expect("plan monorepo clone");
 
         assert_eq!(plan.skipped.len(), 1, "exactly one withheld edge");
         let sk = &plan.skipped[0];
@@ -268,7 +303,7 @@ mod tests {
 
     #[test]
     fn dest_path_joins_root_for_children_and_returns_root_itself_for_the_root_op() {
-        let plan = MonorepoClonePlan::from_resolved(&fixture_tree());
+        let plan = MonorepoClonePlan::from_resolved(&fixture_tree()).expect("plan monorepo clone");
         let root = Path::new("/tmp/mono");
 
         assert_eq!(plan.ops[0].dest_path(root), PathBuf::from("/tmp/mono"));
@@ -289,7 +324,7 @@ mod tests {
             content_state: None,
             edges: vec![descended_edge("sub", "acme/child", 5, child)],
         };
-        let plan = MonorepoClonePlan::from_resolved(&root);
+        let plan = MonorepoClonePlan::from_resolved(&root).expect("plan monorepo clone");
 
         assert_eq!(plan.ops.len(), 2);
         assert_eq!(plan.ops[0].spool_id, "acme/root");
@@ -297,6 +332,40 @@ mod tests {
         assert_eq!(plan.ops[1].spool_id, "acme/child");
         assert_eq!(plan.ops[1].rel_path, PathBuf::from("sub"));
         assert_eq!(plan.ops[1].content_state, Some(cid(5)));
+    }
+
+    #[test]
+    fn planner_rejects_mounts_that_are_not_one_relative_component() {
+        for mount in [
+            "",
+            ".",
+            "..",
+            "../victim",
+            "/tmp/victim",
+            "libs/child",
+            r"libs\child",
+        ] {
+            let root = MonorepoNode {
+                spool_id: "acme/root".to_string(),
+                content_state: proto_cid(1),
+                edges: vec![descended_edge(
+                    mount,
+                    "acme/child",
+                    2,
+                    leaf("acme/child", 2),
+                )],
+            };
+            assert!(
+                matches!(
+                    MonorepoClonePlan::from_resolved(&root),
+                    Err(MonorepoClonePlanError::InvalidMountName {
+                        child_spool_id,
+                        mount_name,
+                    }) if child_spool_id == "acme/child" && mount_name == mount
+                ),
+                "mount {mount:?} must fail before clone I/O"
+            );
+        }
     }
 
     #[test]
@@ -311,7 +380,7 @@ mod tests {
                 content_state: proto_cid(1),
                 edges: vec![skipped_edge("m", "child", 2, reason)],
             };
-            let plan = MonorepoClonePlan::from_resolved(&root);
+            let plan = MonorepoClonePlan::from_resolved(&root).expect("plan monorepo clone");
             assert_eq!(plan.skipped.len(), 1);
             assert_eq!(plan.skipped[0].reason, reason);
             assert_eq!(plan.skipped[0].reason_label(), label);

--- a/crates/client/src/hosted/sync.rs
+++ b/crates/client/src/hosted/sync.rs
@@ -84,6 +84,13 @@ struct GitLanePushPlan {
     ref_updates: Vec<GitRefUpdateTransfer>,
 }
 
+struct StagedGitLanePull {
+    allow_ref_updates: bool,
+    initial_refs: HashMap<String, ReferenceTarget>,
+    ref_updates: Vec<GitRefUpdateTransfer>,
+    checkpoints: Vec<GitCheckpointTransfer>,
+}
+
 #[derive(Clone)]
 struct GitPackPushPlan {
     transfer_id: String,
@@ -1250,6 +1257,8 @@ impl HostedClient {
         };
         let mut git_lane_repo = None;
         let mut git_pack_state = GitPackPullInstallState::default();
+        let mut staged_git_lane =
+            StagedGitLanePull::snapshot(repo, options.target_state.is_none())?;
         let mut received = 0usize;
         while let Some(message) = next_pull_message(&mut response).await? {
             match message.frame {
@@ -1372,6 +1381,7 @@ impl HostedClient {
                         repo,
                         &mut git_lane_repo,
                         &mut git_pack_state,
+                        &mut staged_git_lane,
                         transfer,
                     )?;
                     let decode_elapsed = decode_start.elapsed();
@@ -1383,6 +1393,7 @@ impl HostedClient {
                     let final_state = super::helpers::parse_proto_state_id(complete.new_state)?;
 
                     if complete.success {
+                        apply_staged_git_lane_pull(repo, &mut git_lane_repo, &mut staged_git_lane)?;
                         if native_pack_required {
                             let store_start = Instant::now();
                             let installed_ids = if let Some(pack_spool) = pack_spool.as_mut() {
@@ -1780,10 +1791,12 @@ fn redaction_push_message(
     // receiver verifies the signature + trust list and then
     // persists these bytes verbatim.
     let bytes = repo
-        .store()
-        .get_redactions_bytes_for_blob(&blob)
+        .verified_redactions_bytes_for_wire(&blob)
         .map_err(|err| {
-            ProtocolError::InvalidState(format!("load redactions sidecar for {}: {err}", hex))
+            ProtocolError::InvalidState(format!(
+                "load verified redactions sidecar for {}: {err}",
+                hex
+            ))
         })?
         .ok_or_else(|| {
             ProtocolError::InvalidState(format!(
@@ -3411,6 +3424,7 @@ fn accept_git_lane_pull_transfer(
     repo: &Repository,
     git_repo: &mut Option<SleyRepository>,
     git_pack_state: &mut GitPackPullInstallState,
+    staged: &mut StagedGitLanePull,
     transfer: GitLaneTransfer,
 ) -> Result<(), ProtocolError> {
     if repo.capability() != RepositoryCapability::GitOverlay {
@@ -3424,10 +3438,11 @@ fn accept_git_lane_pull_transfer(
             accept_git_lane_pack(repo, git_repo, git_pack_state, pack)
         }
         Some(git_lane_transfer::Body::RefUpdate(update)) => {
-            accept_git_lane_ref_update(repo, git_repo, update)
+            stage_git_lane_ref_update(staged, update)
         }
         Some(git_lane_transfer::Body::Checkpoint(checkpoint)) => {
-            record_git_lane_checkpoint(repo, git_lane_sley_repository(repo, git_repo)?, checkpoint)
+            staged.checkpoints.push(checkpoint);
+            Ok(())
         }
         None => Err(ProtocolError::InvalidState(
             "GitLaneTransfer body is required".to_string(),
@@ -3446,45 +3461,120 @@ fn accept_git_lane_pack(
     Ok(())
 }
 
-/// Apply a server-originated Git ref update on the pull stream.
-///
-/// Pull-side ref application is unconditional: we commit the local Git ref with
-/// [`RefPrecondition::Any`] and do not compare against a prior target oid. That
-/// is deliberate and **not** symmetric with push-side compare-and-set, where the
-/// client transmits `expected_target_oid` / `expected_missing` from `ListRefs`.
-/// The pull stream is single-threaded and server-trusted — the client applies
-/// ref updates in the order the server sends them after installing the
-/// accompanying pack, so there is no concurrent local writer racing this path.
-fn accept_git_lane_ref_update(
-    repo: &Repository,
-    git_repo: &mut Option<SleyRepository>,
+impl StagedGitLanePull {
+    fn snapshot(repo: &Repository, allow_ref_updates: bool) -> Result<Self, ProtocolError> {
+        let initial_refs = if repo.capability() == RepositoryCapability::GitOverlay {
+            repo.git_overlay_sley_repository()
+                .map_err(|error| ProtocolError::InvalidState(error.to_string()))?
+                .ok_or_else(|| {
+                    ProtocolError::InvalidState(
+                        "git-overlay repository has no Git store".to_string(),
+                    )
+                })?
+                .references()
+                .list_refs()
+                .map_err(|error| {
+                    ProtocolError::InvalidState(format!(
+                        "snapshot Git refs before hosted pull: {error}"
+                    ))
+                })?
+                .into_iter()
+                .map(|reference| (reference.name, reference.target))
+                .collect()
+        } else {
+            HashMap::new()
+        };
+        Ok(Self {
+            allow_ref_updates,
+            initial_refs,
+            ref_updates: Vec::new(),
+            checkpoints: Vec::new(),
+        })
+    }
+}
+
+fn stage_git_lane_ref_update(
+    staged: &mut StagedGitLanePull,
     update: GitRefUpdateTransfer,
 ) -> Result<(), ProtocolError> {
+    if !staged.allow_ref_updates {
+        return Err(ProtocolError::InvalidState(
+            "targeted object fetch cannot mutate Git refs".to_string(),
+        ));
+    }
+    if !update.name.starts_with("refs/")
+        || !GitRefName::new(&update.name).is_hosted_mirror_content()
+    {
+        return Err(ProtocolError::InvalidState(format!(
+            "hosted pull attempted to update non-mirrored Git ref {}",
+            update.name
+        )));
+    }
+    if staged
+        .ref_updates
+        .iter()
+        .any(|existing| existing.name == update.name)
+    {
+        return Err(ProtocolError::InvalidState(format!(
+            "hosted pull sent duplicate Git ref update for {}",
+            update.name
+        )));
+    }
+    staged.ref_updates.push(update);
+    Ok(())
+}
+
+/// Apply every staged Git ref only after a successful `PullComplete`.
+///
+/// One transaction uses the pull-start ref snapshot as compare-and-set
+/// preconditions. A concurrent local ref mutation therefore aborts the whole
+/// batch instead of being overwritten by a stale hosted response.
+fn apply_staged_git_lane_pull(
+    repo: &Repository,
+    git_repo: &mut Option<SleyRepository>,
+    staged: &mut StagedGitLanePull,
+) -> Result<(), ProtocolError> {
+    if staged.ref_updates.is_empty() && staged.checkpoints.is_empty() {
+        return Ok(());
+    }
     let git_repo = git_lane_sley_repository(repo, git_repo)?;
-    let target = git_oid_from_proto(
-        git_repo,
-        "GitRefUpdateTransfer.target_oid",
-        update.target_oid.as_ref(),
-    )?;
-    git_repo.read_commit(&target).map_err(|err| {
-        ProtocolError::InvalidState(format!(
-            "Git ref {} target commit {} is not present after pack receive: {err}",
-            update.name,
-            target.to_hex()
-        ))
-    })?;
     let refs = git_repo.references();
     let mut tx = refs.transaction();
-    tx.update_to(
-        update.name.clone(),
-        ReferenceTarget::Direct(target),
-        RefPrecondition::Any,
-        None,
-    );
+    for update in &staged.ref_updates {
+        let target = git_oid_from_proto(
+            git_repo,
+            "GitRefUpdateTransfer.target_oid",
+            update.target_oid.as_ref(),
+        )?;
+        git_repo.read_commit(&target).map_err(|err| {
+            ProtocolError::InvalidState(format!(
+                "Git ref {} target commit {} is not present after pack receive: {err}",
+                update.name,
+                target.to_hex()
+            ))
+        })?;
+        let precondition = staged
+            .initial_refs
+            .get(&update.name)
+            .cloned()
+            .map(RefPrecondition::MustExistAndMatch)
+            .unwrap_or(RefPrecondition::MustNotExist);
+        tx.update_to(
+            update.name.clone(),
+            ReferenceTarget::Direct(target),
+            precondition,
+            None,
+        );
+    }
     tx.commit().map_err(|err| {
-        ProtocolError::InvalidState(format!("update Git ref {}: {err}", update.name))
+        ProtocolError::InvalidState(format!("commit staged hosted Git refs: {err}"))
     })?;
-    if let Some(checkpoint) = update.checkpoint {
+    for update in staged.ref_updates.drain(..) {
+        if let Some(checkpoint) = update.checkpoint {
+            record_git_lane_checkpoint(repo, git_repo, checkpoint)?;
+        }
+    }
+    for checkpoint in staged.checkpoints.drain(..) {
         record_git_lane_checkpoint(repo, git_repo, checkpoint)?;
     }
     Ok(())
@@ -3875,6 +3965,53 @@ fn preferred_transport_mode(
     let _ = transport;
     let _ = object_count;
     TransportMode::NativePack
+}
+
+#[cfg(test)]
+mod git_lane_pull_staging_tests {
+    use super::*;
+
+    fn update(name: &str) -> GitRefUpdateTransfer {
+        GitRefUpdateTransfer {
+            name: name.to_string(),
+            ..GitRefUpdateTransfer::default()
+        }
+    }
+
+    fn staging(allow_ref_updates: bool) -> StagedGitLanePull {
+        StagedGitLanePull {
+            allow_ref_updates,
+            initial_refs: HashMap::new(),
+            ref_updates: Vec::new(),
+            checkpoints: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn hosted_pull_stages_content_refs_but_rejects_local_only_refs() {
+        let mut staged = staging(true);
+        stage_git_lane_ref_update(&mut staged, update("refs/heads/main"))
+            .expect("content ref is mirrorable");
+        assert_eq!(staged.ref_updates.len(), 1);
+
+        let error = stage_git_lane_ref_update(&mut staged, update("refs/stash"))
+            .expect_err("remote must not mutate local-only ref");
+        assert!(error.to_string().contains("non-mirrored"));
+    }
+
+    #[test]
+    fn targeted_fetch_rejects_ref_mutation_and_duplicate_updates() {
+        let mut targeted = staging(false);
+        let error = stage_git_lane_ref_update(&mut targeted, update("refs/heads/main"))
+            .expect_err("object-only fetch cannot update refs");
+        assert!(error.to_string().contains("targeted object fetch"));
+
+        let mut full = staging(true);
+        stage_git_lane_ref_update(&mut full, update("refs/tags/v1")).unwrap();
+        let duplicate = stage_git_lane_ref_update(&mut full, update("refs/tags/v1"))
+            .expect_err("duplicate ref update must be rejected");
+        assert!(duplicate.to_string().contains("duplicate"));
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/clone_plan.rs
+++ b/crates/core/src/clone_plan.rs
@@ -747,6 +747,18 @@ pub struct MonorepoClonePlan {
     pub skipped: Vec<MonorepoSkippedChild>,
 }
 
+/// A remote monorepo edge supplied a mount that cannot be placed safely.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MonorepoClonePlanError {
+    #[error(
+        "invalid monorepo mount name '{mount_name}' for child '{child_spool_id}': mount names must be exactly one relative path component"
+    )]
+    InvalidMountName {
+        child_spool_id: String,
+        mount_name: String,
+    },
+}
+
 /// Reject `--depth` / `--lazy` / `--filter` for recursive monorepo clones.
 ///
 /// These knobs change single-spool pull semantics and do not compose across the
@@ -768,13 +780,19 @@ pub fn validate_monorepo_clone_options(
 ///
 /// Applies path anchoring and child selection rules. Does not perform hosted
 /// RPC or write to disk.
-pub fn plan_monorepo_clone(root: &MonorepoNodeFacts) -> MonorepoClonePlan {
+pub fn plan_monorepo_clone(
+    root: &MonorepoNodeFacts,
+) -> Result<MonorepoClonePlan, MonorepoClonePlanError> {
     let mut plan = MonorepoClonePlan::default();
-    walk_monorepo_node(&mut plan, root, PathBuf::new());
-    plan
+    walk_monorepo_node(&mut plan, root, PathBuf::new())?;
+    Ok(plan)
 }
 
-fn walk_monorepo_node(plan: &mut MonorepoClonePlan, node: &MonorepoNodeFacts, rel_path: PathBuf) {
+fn walk_monorepo_node(
+    plan: &mut MonorepoClonePlan,
+    node: &MonorepoNodeFacts,
+    rel_path: PathBuf,
+) -> Result<(), MonorepoClonePlanError> {
     // Always emit a node plan (including empty content) so the mount exists.
     plan.nodes.push(MonorepoNodePlan {
         spool_id: node.spool_id.clone(),
@@ -783,9 +801,10 @@ fn walk_monorepo_node(plan: &mut MonorepoClonePlan, node: &MonorepoNodeFacts, re
     });
 
     for edge in &node.edges {
+        validate_monorepo_mount_name(edge)?;
         let child_rel = rel_path.join(&edge.mount_name);
         match &edge.child {
-            Some(child) => walk_monorepo_node(plan, child, child_rel),
+            Some(child) => walk_monorepo_node(plan, child, child_rel)?,
             None => {
                 let reason = edge
                     .skip_reason
@@ -799,6 +818,22 @@ fn walk_monorepo_node(plan: &mut MonorepoClonePlan, node: &MonorepoNodeFacts, re
             }
         }
     }
+    Ok(())
+}
+
+fn validate_monorepo_mount_name(edge: &MonorepoEdgeFacts) -> Result<(), MonorepoClonePlanError> {
+    let mut components = Path::new(&edge.mount_name).components();
+    let is_one_normal_component =
+        matches!(components.next(), Some(std::path::Component::Normal(_)))
+            && components.next().is_none()
+            && !edge.mount_name.contains(['/', '\\']);
+    if is_one_normal_component {
+        return Ok(());
+    }
+    Err(MonorepoClonePlanError::InvalidMountName {
+        child_spool_id: edge.child_spool_id.clone(),
+        mount_name: edge.mount_name.clone(),
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -1650,7 +1685,7 @@ mod tests {
 
     #[test]
     fn plan_monorepo_places_nodes_at_mount_paths_in_preorder() {
-        let plan = plan_monorepo_clone(&fixture_tree());
+        let plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
 
         assert_eq!(plan.nodes.len(), 3, "root + child-a + grandchild");
 
@@ -1669,7 +1704,7 @@ mod tests {
 
     #[test]
     fn plan_monorepo_records_skipped_children_and_does_not_select_them() {
-        let plan = plan_monorepo_clone(&fixture_tree());
+        let plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
 
         assert_eq!(plan.skipped.len(), 1);
         let sk = &plan.skipped[0];
@@ -1687,7 +1722,7 @@ mod tests {
 
     #[test]
     fn monorepo_node_dest_path_joins_root() {
-        let plan = plan_monorepo_clone(&fixture_tree());
+        let plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
         let root = Path::new("/tmp/mono");
 
         assert_eq!(plan.nodes[0].dest_path(root), PathBuf::from("/tmp/mono"));
@@ -1709,7 +1744,7 @@ mod tests {
             content_state: None,
             edges: vec![selected_edge("sub", "acme/child", child)],
         };
-        let plan = plan_monorepo_clone(&root);
+        let plan = plan_monorepo_clone(&root).expect("plan monorepo clone");
 
         assert_eq!(plan.nodes.len(), 2);
         assert_eq!(plan.nodes[0].spool_id, "acme/root");
@@ -1717,6 +1752,35 @@ mod tests {
         assert_eq!(plan.nodes[1].spool_id, "acme/child");
         assert_eq!(plan.nodes[1].rel_path, PathBuf::from("sub"));
         assert_eq!(plan.nodes[1].content_state, Some(cid(5)));
+    }
+
+    #[test]
+    fn plan_monorepo_rejects_mounts_that_are_not_one_relative_component() {
+        for mount in [
+            "",
+            ".",
+            "..",
+            "../victim",
+            "/tmp/victim",
+            "libs/child",
+            r"libs\child",
+        ] {
+            let root = MonorepoNodeFacts {
+                spool_id: "acme/root".to_string(),
+                content_state: Some(cid(1)),
+                edges: vec![selected_edge(mount, "acme/child", leaf("acme/child", 2))],
+            };
+            assert!(
+                matches!(
+                    plan_monorepo_clone(&root),
+                    Err(MonorepoClonePlanError::InvalidMountName {
+                        child_spool_id,
+                        mount_name,
+                    }) if child_spool_id == "acme/child" && mount_name == mount
+                ),
+                "mount {mount:?} must fail before clone I/O"
+            );
+        }
     }
 
     #[test]
@@ -1731,7 +1795,7 @@ mod tests {
                 skip_reason: None,
             }],
         };
-        let plan = plan_monorepo_clone(&root);
+        let plan = plan_monorepo_clone(&root).expect("plan monorepo clone");
         assert_eq!(plan.skipped.len(), 1);
         assert_eq!(plan.skipped[0].reason, MonorepoEdgeSkipReason::Unspecified);
         assert_eq!(plan.skipped[0].reason_label(), "unspecified");
@@ -1761,7 +1825,7 @@ mod tests {
                 content_state: Some(cid(1)),
                 edges: vec![skipped_edge("m", "child", reason)],
             };
-            let plan = plan_monorepo_clone(&root);
+            let plan = plan_monorepo_clone(&root).expect("plan monorepo clone");
             assert_eq!(plan.skipped[0].reason_label(), label);
         }
     }
@@ -1810,7 +1874,7 @@ mod tests {
                 skip_reason: Some(MonorepoEdgeSkipReason::Unreadable),
             }],
         };
-        let plan = plan_monorepo_clone(&root);
+        let plan = plan_monorepo_clone(&root).expect("plan monorepo clone");
         assert_eq!(plan.nodes.len(), 2);
         assert!(plan.skipped.is_empty());
         assert_eq!(plan.nodes[1].spool_id, "acme/child");
@@ -1901,7 +1965,7 @@ mod tests {
 
     #[test]
     fn plan_monorepo_execution_preserves_preorder_and_skipped() {
-        let clone_plan = plan_monorepo_clone(&fixture_tree());
+        let clone_plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
         let exec = plan_monorepo_execution(&clone_plan, &MonorepoNodeStepOptions::default());
 
         assert_eq!(exec.node_count(), 3);
@@ -1944,7 +2008,7 @@ mod tests {
             content_state: None,
             edges: vec![selected_edge("sub", "acme/child", child)],
         };
-        let clone_plan = plan_monorepo_clone(&root);
+        let clone_plan = plan_monorepo_clone(&root).expect("plan monorepo clone");
         let exec = plan_monorepo_execution(&clone_plan, &MonorepoNodeStepOptions::default());
 
         assert_eq!(exec.nodes[0].node.content_state, None);
@@ -2103,7 +2167,7 @@ mod tests {
 
     #[test]
     fn validate_monorepo_execution_accepts_full_plan() {
-        let clone_plan = plan_monorepo_clone(&fixture_tree());
+        let clone_plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
         let exec = plan_monorepo_execution(&clone_plan, &MonorepoNodeStepOptions::default());
         assert!(validate_monorepo_execution(&exec).is_ok());
     }
@@ -2125,7 +2189,7 @@ mod tests {
 
     #[test]
     fn assemble_monorepo_clone_result_summary_counts_placed_and_skipped() {
-        let clone_plan = plan_monorepo_clone(&fixture_tree());
+        let clone_plan = plan_monorepo_clone(&fixture_tree()).expect("plan monorepo clone");
         let exec = plan_monorepo_execution(&clone_plan, &MonorepoNodeStepOptions::default());
         let summary = assemble_monorepo_clone_result_summary(&exec);
 
@@ -2168,7 +2232,7 @@ mod tests {
             edges: vec![],
         };
         let exec = plan_monorepo_execution(
-            &plan_monorepo_clone(&root),
+            &plan_monorepo_clone(&root).expect("plan monorepo clone"),
             &MonorepoNodeStepOptions::default(),
         );
         let summary = assemble_monorepo_clone_result_summary(&exec);

--- a/crates/core/src/fsck/tests.rs
+++ b/crates/core/src/fsck/tests.rs
@@ -44,25 +44,21 @@ fn test_check_states_thorough_rejects_invalid_signature() {
     let signer = Ed25519Signer::from_seed(&[7u8; 32]).expect("create signer");
 
     repo.store().put_state(&state).expect("put state");
-    repo.sign_state(&state.state_id, &signer)
-        .expect("sign state");
-    let prior = repo
-        .latest_state_attachment(&state.state_id, repo::StateAttachmentKind::Signature)
-        .expect("read signature attachment")
-        .expect("signature attachment");
-    let prior_id = prior.id();
-    let StateAttachmentBody::Signature(mut signature) = prior.body else {
-        panic!("expected signature attachment")
-    };
+    let mut signature = crypto::state_signature_from_signer(&state.compute_hash(), &signer)
+        .expect("sign state hash");
     signature.signature = "00".repeat(64);
-    repo.put_state_attachment(&StateAttachment {
-        state_id: state.state_id,
-        body: StateAttachmentBody::Signature(signature),
-        attribution: sample_attribution(),
-        created_at: chrono::Utc::now() + chrono::Duration::seconds(1),
-        supersedes: Some(prior_id),
-    })
-    .expect("put invalid signature attachment");
+    // Fsck validates objects that may have arrived in a pack below the
+    // Repository acceptance seam. Insert the corrupt evidence directly into
+    // storage; the public API correctly rejects signature supersession.
+    repo.store()
+        .put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::Signature(signature),
+            attribution: sample_attribution(),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .expect("install invalid packed signature attachment");
 
     let mut errors = Vec::new();
     let mut objects_checked = 0;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -94,8 +94,8 @@ pub use approval_plan::{
 pub use clone_plan::{
     AdoptPlan, AdoptPlanError, AdoptPlanOptions, CloneMode, ClonePlan, ClonePlanError,
     ClonePlanFacts, ClonePlanOptions, CloneRemoteSource, CloneSecurityPreflight,
-    MonorepoCloneJsonReport, MonorepoClonePlan, MonorepoCloneResultSummary, MonorepoEdgeFacts,
-    MonorepoEdgeSkipReason, MonorepoExecutionPlan, MonorepoExecutionProgress,
+    MonorepoCloneJsonReport, MonorepoClonePlan, MonorepoClonePlanError, MonorepoCloneResultSummary,
+    MonorepoEdgeFacts, MonorepoEdgeSkipReason, MonorepoExecutionPlan, MonorepoExecutionProgress,
     MonorepoNodeExecution, MonorepoNodeExecutionError, MonorepoNodeExecutionStep,
     MonorepoNodeFacts, MonorepoNodePlan, MonorepoNodeStepOptions, MonorepoPlacedJsonRow,
     MonorepoPlacedNodeSummary, MonorepoSkippedChild, MonorepoSkippedJsonRow, UnsupportedCloneFlag,

--- a/crates/object-model/src/object/redaction.rs
+++ b/crates/object-model/src/object/redaction.rs
@@ -22,7 +22,7 @@ use crate::object::{ContentHash, Principal, StateId, StateSignature};
 /// Stable byte prefix the signing payload begins with. Bumping this versions
 /// the payload format itself; old signatures with the old prefix continue to
 /// verify exactly as they did when written.
-pub const REDACTION_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-redact-v1\x00";
+pub const REDACTION_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-redact-v2\x00";
 
 /// A redaction declaration on a single blob in a single state.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -61,9 +61,9 @@ pub struct Redaction {
 
 impl Redaction {
     /// Build the canonical bytes a signer covers. Anything outside this
-    /// payload (e.g. `purged_at`, `signature` itself) is intentionally
-    /// excluded — purges happen after signing, and the signature can't sign
-    /// itself.
+    /// payload (the `signature` itself) is intentionally excluded because a
+    /// signature cannot sign itself. Lifecycle state, including `purged_at`,
+    /// is covered so a relay cannot forge a destructive purge transition.
     pub fn canonical_signing_payload(&self) -> Vec<u8> {
         let mut buf = Vec::with_capacity(256);
         buf.extend_from_slice(REDACTION_SIGNING_PAYLOAD_VERSION_TAG);
@@ -78,6 +78,15 @@ impl Redaction {
         buf.extend_from_slice(self.redactor.email.as_bytes());
         buf.push(0);
         buf.extend_from_slice(self.redacted_at.to_rfc3339().as_bytes());
+        buf.push(0);
+        match self.purged_at {
+            Some(purged_at) => {
+                buf.push(1);
+                buf.extend_from_slice(purged_at.to_rfc3339().as_bytes());
+            }
+            None => buf.push(0),
+        }
+        buf.push(0);
         if let Some(supersedes) = &self.supersedes {
             buf.extend_from_slice(supersedes.as_bytes());
         }
@@ -263,6 +272,7 @@ mod tests {
     #[test]
     fn mark_purged_is_idempotent_and_observable() {
         let mut r = redaction(blob_hash(), "leaked credential");
+        let before = r.canonical_signing_payload();
         let at = Utc.with_ymd_and_hms(2026, 5, 11, 0, 0, 0).unwrap();
         assert!(!r.is_purged());
         assert!(r.mark_purged(at));
@@ -271,6 +281,11 @@ mod tests {
         // without distorting the `purged_at` audit trail.
         assert!(!r.mark_purged(Utc.with_ymd_and_hms(2026, 5, 12, 0, 0, 0).unwrap()));
         assert_eq!(r.purged_at, Some(at));
+        assert_ne!(
+            before,
+            r.canonical_signing_payload(),
+            "purge lifecycle must be covered by the signed payload"
+        );
     }
 
     #[test]

--- a/crates/object-model/src/object/redaction.rs
+++ b/crates/object-model/src/object/redaction.rs
@@ -19,9 +19,10 @@ use serde::{Deserialize, Serialize};
 
 use crate::object::{ContentHash, Principal, StateId, StateSignature};
 
-/// Stable byte prefix the signing payload begins with. Bumping this versions
-/// the payload format itself; old signatures with the old prefix continue to
-/// verify exactly as they did when written.
+/// Stable byte prefix the signing payload begins with. Bumping this invalidates
+/// signatures written with an older prefix unless verification also gains
+/// explicit version dispatch. Version 2 intentionally makes a clean break from
+/// the unused version 1 format.
 pub const REDACTION_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-redact-v2\x00";
 
 /// A redaction declaration on a single blob in a single state.

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -134,7 +134,7 @@ pub use repository::{
     ContextSuggestionTier, DiffKind, GitCheckpointIntent, GitCheckpointIntentPhase,
     GitCheckpointRecord, GitImportGuidance, GitRemoteTrackingStatus, HIGH_SUGGESTION_THRESHOLD,
     HistoryQuery, HostedConfig, MAJOR_REWRITE_THRESHOLD_PCT, MEDIUM_SUGGESTION_THRESHOLD,
-    MissingBlob, OperationKind, OperationScope, OutputFormat, PackFilesInspection,
+    MetadataConfig, MissingBlob, OperationKind, OperationScope, OutputFormat, PackFilesInspection,
     PartialFetchInspection, PullPlannerCacheInspection, RedactConfig, RefCountsInspection,
     RefSummaryIndexInspection, RepoConfig, Repository, RepositoryCapability,
     RepositoryMaintenanceRunReport, RepositoryOperationStatus,

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -37,6 +37,8 @@ pub struct RepoConfig {
     pub review: ReviewConfig,
     #[serde(default)]
     pub redact: RedactConfig,
+    #[serde(default)]
+    pub metadata: MetadataConfig,
 }
 
 /// `[redact]` config section. Houses the list of operator public keys
@@ -73,6 +75,17 @@ pub struct TrustedKey {
     /// semantics. Optional; doesn't affect matching.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+/// Trust anchors for client-authored metadata received from a remote host.
+///
+/// Hosted servers relay these records but are not trusted to author them.
+/// An empty list therefore fails closed for authoritative metadata such as
+/// visibility declarations and detached signature supersession.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetadataConfig {
+    #[serde(default)]
+    pub trusted_keys: Vec<TrustedKey>,
 }
 
 /// Review-epic configuration. Houses the `[review.signals]` sub-table read by
@@ -418,6 +431,7 @@ impl Default for RepoConfig {
             hosted: HostedConfig::default(),
             review: ReviewConfig::default(),
             redact: RedactConfig::default(),
+            metadata: MetadataConfig::default(),
         }
     }
 }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -71,7 +71,8 @@ use oplog::{ConditionalCommitOutcome, IsolationPrecondition, OpLog, OpLogBackend
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
 pub use refs::{RefSummaryIndexInspection, SpoolFacet};
 pub use repo_config::{
-    HostedConfig, OutputFormat, RedactConfig, RepoConfig, RepositorySourceAuthority, TrustedKey,
+    HostedConfig, MetadataConfig, OutputFormat, RedactConfig, RepoConfig,
+    RepositorySourceAuthority, TrustedKey,
 };
 // Review-epic config types — re-exported here so the new
 // `repository_signals.rs` (and external crates wanting to construct a

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -392,9 +392,10 @@ impl Repository {
     /// `redact` before `purge`. This is the contract from the build
     /// brief: "Refuses unless a Redaction already exists on the blob."
     ///
-    /// `_purger` is recorded by the caller in the oplog `Purge` entry;
-    /// it's accepted here so the helper can be extended (e.g. to embed
-    /// the purger in a purge record) without changing the signature.
+    /// `_purger` is recorded by the caller in the oplog `Purge` entry. The
+    /// purge transition itself is re-signed by the active client identity so
+    /// receivers can independently authorize the client that made the later
+    /// destructive decision.
     pub fn purge_blob(&self, blob: &ContentHash, _purger: &Principal) -> Result<PurgeOutcome> {
         let mut redactions_blob = self.get_redactions_for_blob(blob)?;
         if redactions_blob.redactions.is_empty() {
@@ -405,6 +406,14 @@ impl Repository {
         }
         let now = Utc::now();
         let redactions_marked = redactions_blob.mark_all_purged(now);
+        if redactions_marked > 0 {
+            for redaction in &mut redactions_blob.redactions {
+                if redaction.purged_at == Some(now) {
+                    redaction.signature =
+                        Some(self.sign_client_metadata(&redaction.canonical_signing_payload())?);
+                }
+            }
+        }
         let latest_id = match redactions_blob.latest() {
             Some(latest) => Some(redaction_content_hash(latest)?),
             None => None,
@@ -533,6 +542,33 @@ impl Repository {
         }
 
         Ok(outcome)
+    }
+
+    /// Return a redaction sidecar only when every record is signed and its
+    /// lifecycle payload verifies. Push callers use this before handing bytes
+    /// to an untrusted relay, preventing unsigned or locally-tampered metadata
+    /// from entering the hosted store.
+    pub fn verified_redactions_bytes_for_wire(
+        &self,
+        blob: &ContentHash,
+    ) -> Result<Option<Vec<u8>>> {
+        let Some(bytes) = self.store().get_redactions_bytes_for_blob(blob)? else {
+            return Ok(None);
+        };
+        let redactions = RedactionsBlob::decode(&bytes)
+            .with_context(|| format!("decode outgoing redactions for blob {}", blob.short()))?;
+        for redaction in &redactions.redactions {
+            if redaction.redacted_blob != *blob {
+                anyhow::bail!(
+                    "outgoing redaction claims blob {} but is stored under {}",
+                    redaction.redacted_blob.short(),
+                    blob.short()
+                );
+            }
+            verify_redaction_signature(redaction)
+                .with_context(|| format!("verify outgoing redaction for blob {}", blob.short()))?;
+        }
+        Ok(Some(bytes))
     }
 
     /// `<heddle_dir>/redactions/` — root of the redaction store.
@@ -718,6 +754,13 @@ fn verify_wire_redaction(redaction: &Redaction, trusted_keys: &[crate::TrustedKe
             public_key: signature.public_key.clone(),
         });
     }
+    verify_redaction_signature(redaction)
+}
+
+fn verify_redaction_signature(redaction: &Redaction) -> Result<()> {
+    let Some(signature) = &redaction.signature else {
+        anyhow::bail!(WireRejection::Unsigned);
+    };
     let payload = redaction.canonical_signing_payload();
     let public_key = hex::decode(&signature.public_key)
         .with_context(|| "decode incoming redaction signature public key")?;
@@ -1242,6 +1285,29 @@ mod tests {
     }
 
     #[test]
+    fn outgoing_redactions_must_be_signed_before_hosted_transfer() {
+        let (_dir, repo) = fresh_repo();
+        repo.put_redaction(sample_redaction())
+            .expect("persist local unsigned draft");
+        let error = repo
+            .verified_redactions_bytes_for_wire(&sample_blob())
+            .expect_err("unsigned metadata must not be sent to a hosted relay");
+        assert!(error.to_string().contains("verify outgoing redaction"));
+
+        let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let (_dir, signed_repo) = fresh_repo();
+        signed_repo
+            .put_redaction(signed_sample_redaction(&signer))
+            .expect("persist signed redaction");
+        assert!(
+            signed_repo
+                .verified_redactions_bytes_for_wire(&sample_blob())
+                .expect("validate outgoing")
+                .is_some()
+        );
+    }
+
+    #[test]
     fn accept_wire_redactions_refuses_untrusted_signer_even_with_valid_signature() {
         // The codex-flagged spoof vector: an attacker mints a redaction,
         // signs it with their own key, and ships it. Signature
@@ -1313,9 +1379,8 @@ mod tests {
         let mut signed = signed_sample_redaction(&signer);
         // Sender purged before propagation: mark the record purged.
         signed.purged_at = Some(Utc.with_ymd_and_hms(2026, 5, 12, 9, 0, 0).unwrap());
-        // Re-sign over the new canonical payload (purged_at is excluded
-        // per the signing contract, so no actual change in signature
-        // bytes — but be precise about this).
+        // Re-sign over the new canonical payload: purged_at is lifecycle
+        // authority and is therefore covered by the signature.
         let payload_bytes = signed.canonical_signing_payload();
         let sig = signer.sign(&payload_bytes).unwrap();
         signed.signature = Some(objects::object::StateSignature {
@@ -1334,6 +1399,24 @@ mod tests {
         assert!(
             stored.redactions.iter().all(|r| r.is_purged()),
             "redaction must be persisted with purged_at"
+        );
+    }
+
+    #[test]
+    fn accept_wire_redactions_rejects_forged_purged_at() {
+        let signer = crypto::Ed25519Signer::generate().expect("keygen");
+        let (_dir, repo) = fresh_repo_trusting(&signer);
+        let mut signed = signed_sample_redaction(&signer);
+        signed.purged_at = Some(Utc.with_ymd_and_hms(2026, 5, 12, 9, 0, 0).unwrap());
+        let wire = RedactionsBlob::new(vec![signed]).encode().unwrap();
+
+        let err = repo
+            .accept_wire_redactions(sample_blob(), &wire)
+            .expect_err("relay-forged purge marker must be refused");
+        assert!(
+            err.chain()
+                .any(|cause| cause.to_string().contains("failed to verify")),
+            "rejection must identify signature failure: {err:#}"
         );
     }
 }

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -63,8 +63,10 @@ impl Repository {
         })
     }
 
-    /// Verify that hosted metadata was signed by a client key explicitly
-    /// trusted by this repository. The hosted service itself is only a relay.
+    /// Verify hosted metadata against this repository's temporary, manually trusted client keys.
+    /// Weft authorizes destructive and state-visibility operations but holds no signing key for
+    /// this path, so it cannot forge them. HeddleCo/weft#836 tracks replacing the manual list
+    /// with that authorization model.
     pub(crate) fn verify_trusted_client_metadata_signature(
         &self,
         payload: &[u8],

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -3,7 +3,10 @@
 
 use std::sync::Arc;
 
-use crypto::{Signer, load_signer, state_signature_from_signer, verify_state_signature_bytes};
+use crypto::{
+    Signer, load_signer, state_signature_from_signer, verify_payload_signature,
+    verify_state_signature_bytes,
+};
 use objects::{
     object::{
         SignatureStatus, State, StateAttachment, StateAttachmentBody, StateId, StateSignature,
@@ -38,6 +41,62 @@ impl Repository {
         let local = self.local_identity_path();
         let device = crate::identity::device_identity_path();
         crate::identity::resolve_signer(&local, &device).map(Arc::from)
+    }
+
+    /// Sign authoritative client-authored metadata with this repository's
+    /// active client identity. Unlike state auto-signing, metadata signing is
+    /// fail-closed because an unsigned sidecar must never become authoritative
+    /// after a hosted round trip.
+    pub(crate) fn sign_client_metadata(&self, payload: &[u8]) -> Result<StateSignature> {
+        let signer = self.signing_signer().ok_or_else(|| {
+            HeddleError::Conflict(
+                "client metadata requires a protected local signing identity".to_string(),
+            )
+        })?;
+        let signature = signer.sign(payload).map_err(|error| {
+            HeddleError::Conflict(format!("failed to sign client metadata: {error}"))
+        })?;
+        Ok(StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(signature),
+        })
+    }
+
+    /// Verify that hosted metadata was signed by a client key explicitly
+    /// trusted by this repository. The hosted service itself is only a relay.
+    pub(crate) fn verify_trusted_client_metadata_signature(
+        &self,
+        payload: &[u8],
+        signature: Option<&StateSignature>,
+    ) -> Result<()> {
+        let signature = signature.ok_or_else(|| {
+            HeddleError::InvalidObject(
+                "hosted metadata is unsigned; a trusted client signature is required".to_string(),
+            )
+        })?;
+        let trusted = self.config().metadata.trusted_keys.iter().any(|key| {
+            key.algorithm.eq_ignore_ascii_case(&signature.algorithm)
+                && key.public_key.eq_ignore_ascii_case(&signature.public_key)
+        });
+        if !trusted {
+            return Err(HeddleError::InvalidObject(format!(
+                "hosted metadata signer is not trusted ({}:{})",
+                signature.algorithm, signature.public_key
+            )));
+        }
+        let public_key = hex::decode(&signature.public_key).map_err(|error| {
+            HeddleError::InvalidObject(format!("invalid metadata public key: {error}"))
+        })?;
+        let signature_bytes = hex::decode(&signature.signature).map_err(|error| {
+            HeddleError::InvalidObject(format!("invalid metadata signature: {error}"))
+        })?;
+        verify_payload_signature(payload, &signature.algorithm, &public_key, &signature_bytes)
+            .map_err(|error| {
+                HeddleError::InvalidObject(format!(
+                    "hosted metadata signature failed verification: {error}"
+                ))
+            })
     }
 
     /// Produce a detached signature when a signing identity is available.
@@ -107,15 +166,12 @@ impl Repository {
             .ok_or(HeddleError::StateNotFound(*state_id))?;
         let signature = state_signature_from_signer(&state.compute_hash(), signer)
             .map_err(|error| HeddleError::Conflict(format!("failed to sign state: {error}")))?;
-        let supersedes = self
-            .latest_state_attachment(state_id, crate::StateAttachmentKind::Signature)?
-            .map(|attachment| attachment.id());
         self.put_state_attachment(&StateAttachment {
             state_id: *state_id,
             body: StateAttachmentBody::Signature(signature),
             attribution: state.attribution,
             created_at: chrono::Utc::now(),
-            supersedes,
+            supersedes: None,
         })?;
 
         debug!(algorithm = signer.algorithm(), "State signed successfully");
@@ -162,31 +218,28 @@ impl Repository {
             .get_state(state_id)?
             .ok_or(HeddleError::StateNotFound(*state_id))?;
 
-        let signature = self
-            .latest_state_attachment(state_id, crate::StateAttachmentKind::Signature)?
-            .and_then(|attachment| match attachment.body {
+        let signatures: Vec<_> = self
+            .list_state_attachments(state_id)?
+            .into_iter()
+            .filter_map(|attachment| match attachment.body {
                 StateAttachmentBody::Signature(signature) => Some(signature),
                 _ => None,
-            });
-
-        match &signature {
-            Some(sig) => {
-                let hash = state.compute_hash();
-                match verify_state_signature_bytes(sig, &hash) {
-                    Ok(()) => {
-                        debug!("Signature is valid");
-                        Ok(SignatureStatus::Valid)
-                    }
-                    Err(e) => {
-                        debug!(error = %e, "Signature verification error");
-                        Ok(SignatureStatus::Invalid)
-                    }
-                }
-            }
-            None => {
-                debug!("State has no signature");
-                Ok(SignatureStatus::Unsigned)
-            }
+            })
+            .collect();
+        if signatures.is_empty() {
+            debug!("State has no signature");
+            return Ok(SignatureStatus::Unsigned);
+        }
+        let hash = state.compute_hash();
+        if signatures
+            .iter()
+            .any(|signature| verify_state_signature_bytes(signature, &hash).is_ok())
+        {
+            debug!("At least one state signature is valid");
+            Ok(SignatureStatus::Valid)
+        } else {
+            debug!("No state signature verifies");
+            Ok(SignatureStatus::Invalid)
         }
     }
 
@@ -197,12 +250,19 @@ impl Repository {
         if !self.store.has_state(state_id)? {
             return Ok(None);
         }
+        let state = self
+            .store
+            .get_state(state_id)?
+            .ok_or(HeddleError::StateNotFound(*state_id))?;
+        let hash = state.compute_hash();
         Ok(self
-            .latest_state_attachment(state_id, crate::StateAttachmentKind::Signature)?
-            .and_then(|attachment| match attachment.body {
+            .list_state_attachments(state_id)?
+            .into_iter()
+            .filter_map(|attachment| match attachment.body {
                 StateAttachmentBody::Signature(signature) => Some(signature),
                 _ => None,
-            }))
+            })
+            .find(|signature| verify_state_signature_bytes(signature, &hash).is_ok()))
     }
 }
 
@@ -277,18 +337,30 @@ mod tests {
         let mut sig_bytes = hex::decode(&signature.signature).expect("decode");
         sig_bytes[0] ^= 0xff;
         signature.signature = hex::encode(&sig_bytes);
-        repo.put_state_attachment(&StateAttachment {
+        let malicious = StateAttachment {
             state_id,
             body: StateAttachmentBody::Signature(signature),
             attribution: state.attribution,
             created_at: chrono::Utc::now() + chrono::Duration::seconds(1),
             supersedes: Some(prior_id),
-        })
-        .expect("put corrupted signature attachment");
+        };
+        let err = repo
+            .put_state_attachment(&malicious)
+            .expect_err("signature evidence cannot supersede");
+        assert!(err.to_string().contains("append-only"));
 
-        // Should now be invalid
+        // A received pack can install immutable objects below the Repository
+        // acceptance seam. Even if such a sibling is present, verification
+        // considers every signature and cannot let it eclipse valid evidence.
+        let mut packed_sibling = malicious;
+        packed_sibling.supersedes = None;
+        repo.store()
+            .put_state_attachment(&packed_sibling)
+            .expect("simulate received packed sibling");
+
+        // The original valid evidence remains authoritative.
         let status = repo.verify_state_signature(&state_id).expect("verify");
-        assert_eq!(status, SignatureStatus::Invalid);
+        assert_eq!(status, SignatureStatus::Valid);
     }
 
     #[test]

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -138,7 +138,14 @@ impl Repository {
     /// `false`. This holds whether the Public put is fresh or supersedes a
     /// prior private record — no caller can leave a Public record that makes
     /// a public state read as non-public.
-    pub fn put_state_visibility(&self, record: StateVisibility) -> Result<PutVisibilityOutcome> {
+    pub fn put_state_visibility(
+        &self,
+        mut record: StateVisibility,
+    ) -> Result<PutVisibilityOutcome> {
+        if record.signature.is_none() {
+            record.signature =
+                Some(self.sign_client_metadata(&record.canonical_signing_payload())?);
+        }
         // Serialize the full read-modify-write behind the repo write lock so
         // concurrent appends on the same state can't clobber each other.
         let _lock = self
@@ -160,8 +167,12 @@ impl Repository {
     /// `declared_at` under it) and calls the locked body directly.
     pub fn put_state_visibility_if_absent(
         &self,
-        record: StateVisibility,
+        mut record: StateVisibility,
     ) -> Result<Option<PutVisibilityOutcome>> {
+        if record.signature.is_none() {
+            record.signature =
+                Some(self.sign_client_metadata(&record.canonical_signing_payload())?);
+        }
         let _lock = self
             .locker()
             .write()
@@ -189,6 +200,9 @@ impl Repository {
         &self,
         record: StateVisibility,
     ) -> Result<PutVisibilityOutcome> {
+        if record.signature.is_none() {
+            anyhow::bail!("authoritative state-visibility metadata must be client-signed");
+        }
         record
             .validate()
             .with_context(|| "validate state-visibility record before put")?;
@@ -369,6 +383,7 @@ impl Repository {
         // passes `supersedes: None`; the authoritative pointer is established
         // here so a `set` onto an existing record also extends the chain.
         record.supersedes = prior_head_id;
+        record.signature = Some(self.sign_client_metadata(&record.canonical_signing_payload())?);
 
         let state = record.state;
         let tier = record.tier.clone();
@@ -460,9 +475,10 @@ impl Repository {
 
     /// Accept a wire-transferred `StateVisibilityBlob` for a specific state.
     /// The payload must decode, every contained record must target `state`,
-    /// and each record is persisted through `put_state_visibility` so
-    /// validation and public-by-absence normalization run at the same
-    /// boundary as local writes.
+    /// every record must carry a valid signature from a configured trusted
+    /// client key. Each verified record is persisted through
+    /// `put_state_visibility` so validation and public-by-absence
+    /// normalization run at the same boundary as local writes.
     pub fn accept_wire_state_visibility(&self, state: StateId, bytes: &[u8]) -> Result<()> {
         let incoming = StateVisibilityBlob::decode(bytes).with_context(|| {
             format!(
@@ -482,6 +498,11 @@ impl Repository {
             record
                 .validate()
                 .with_context(|| "validate incoming state-visibility record")?;
+            self.verify_trusted_client_metadata_signature(
+                &record.canonical_signing_payload(),
+                record.signature.as_ref(),
+            )
+            .with_context(|| "verify incoming state-visibility signature")?;
         }
 
         for record in incoming.records {
@@ -658,7 +679,7 @@ impl Repository {
                 || "acquire repo write lock for capture-time default visibility binding",
             )?)
         };
-        let record = StateVisibility {
+        let mut record = StateVisibility {
             state: *state,
             tier: tier.clone(),
             embargo_until: None,
@@ -675,6 +696,7 @@ impl Repository {
             signature: None,
             supersedes: None,
         };
+        record.signature = Some(self.sign_client_metadata(&record.canonical_signing_payload())?);
         // Bind ONLY if the state is record-free, with the existence test and the
         // write fused into one locked critical section (heddle#317 r5). A racing
         // `visibility set` that lands between the two would otherwise be clobbered
@@ -850,6 +872,7 @@ mod tests {
     use std::{sync::Arc, thread};
 
     use chrono::{TimeZone, Utc};
+    use crypto::{Ed25519Signer, Signer};
     use objects::object::{Principal, VisibilityTier};
     use oplog::OpLogBackend;
     use tempfile::TempDir;
@@ -890,6 +913,66 @@ mod tests {
         }
     }
 
+    fn repo_trusting_metadata(signer: &dyn Signer) -> (TempDir, Repository) {
+        let dir = TempDir::new().unwrap();
+        Repository::init_default(dir.path()).unwrap();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let mut config = crate::repository::repo_config::RepoConfig::load(&config_path).unwrap();
+        config.metadata.trusted_keys.push(crate::TrustedKey {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            label: Some("test-client".to_string()),
+        });
+        config.save(&config_path).unwrap();
+        let repo = Repository::open(dir.path()).unwrap();
+        (dir, repo)
+    }
+
+    fn sign_visibility(record: &mut StateVisibility, signer: &dyn Signer) {
+        let signature = signer
+            .sign(&record.canonical_signing_payload())
+            .expect("sign visibility");
+        record.signature = Some(objects::object::StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(signature),
+        });
+    }
+
+    #[test]
+    fn wire_visibility_requires_trusted_signature_and_covers_tier() {
+        let signer = Ed25519Signer::generate().expect("keygen");
+        let (_dir, repo) = repo_trusting_metadata(&signer);
+        let state = StateId::from_bytes([4u8; 32]);
+        let mut record = sample_record(state, VisibilityTier::Internal);
+
+        let unsigned = StateVisibilityBlob::new(vec![record.clone()])
+            .encode()
+            .unwrap();
+        repo.accept_wire_state_visibility(state, &unsigned)
+            .expect_err("unsigned authoritative metadata must be rejected");
+
+        sign_visibility(&mut record, &signer);
+        let signed = StateVisibilityBlob::new(vec![record.clone()])
+            .encode()
+            .unwrap();
+        repo.accept_wire_state_visibility(state, &signed)
+            .expect("trusted signed visibility");
+
+        let tampered_state = StateId::from_bytes([5u8; 32]);
+        let mut tampered = sample_record(
+            tampered_state,
+            VisibilityTier::Private {
+                scope_label: "executives".to_string(),
+            },
+        );
+        sign_visibility(&mut tampered, &signer);
+        tampered.tier = VisibilityTier::Public;
+        let forged = StateVisibilityBlob::new(vec![tampered]).encode().unwrap();
+        repo.accept_wire_state_visibility(tampered_state, &forged)
+            .expect_err("relay must not widen signed visibility");
+    }
+
     #[test]
     fn put_then_read_back_and_has_visibility_true() {
         let (_dir, repo) = fresh_repo();
@@ -907,7 +990,13 @@ mod tests {
             .get_state_visibility_for_state(&state)
             .expect("read back");
         assert_eq!(stored.records.len(), 1);
-        assert_eq!(stored.records[0], record);
+        assert!(
+            stored.records[0].signature.is_some(),
+            "locally-authored visibility must be signed"
+        );
+        let mut unsigned_view = stored.records[0].clone();
+        unsigned_view.signature = None;
+        assert_eq!(unsigned_view, record);
         assert!(
             repo.has_visibility_for_state(&state)
                 .expect("has visibility"),
@@ -972,7 +1061,10 @@ mod tests {
         let stored = repo
             .get_state_visibility_for_state(&restricted_state)
             .expect("read valid record");
-        assert_eq!(stored.records, vec![valid]);
+        assert!(stored.records[0].signature.is_some());
+        let mut unsigned_view = stored.records[0].clone();
+        unsigned_view.signature = None;
+        assert_eq!(unsigned_view, valid);
     }
 
     #[test]
@@ -1310,8 +1402,11 @@ mod tests {
             1,
             "no spurious second record appended"
         );
+        assert!(stored.records[0].signature.is_some());
+        let mut unsigned_view = stored.records[0].clone();
+        unsigned_view.signature = None;
         assert_eq!(
-            stored.records[0], existing,
+            unsigned_view, existing,
             "bind must not overwrite the user's declared tier"
         );
 

--- a/crates/repo/src/state_attachments.rs
+++ b/crates/repo/src/state_attachments.rs
@@ -25,6 +25,12 @@ where
         }
 
         if let Some(prior_id) = attachment.supersedes {
+            if attachment.body.kind() == StateAttachmentKind::Signature {
+                return Err(HeddleError::InvalidObject(
+                    "state-signature evidence is append-only and cannot supersede another signature"
+                        .to_string(),
+                ));
+            }
             let prior = self
                 .get_state_attachment(&attachment.state_id, &prior_id)?
                 .ok_or_else(|| HeddleError::NotFound(format!("state attachment {prior_id}")))?;

--- a/scripts/check-publish-pipeline.sh
+++ b/scripts/check-publish-pipeline.sh
@@ -109,6 +109,39 @@ else
   err "$WF must expose the token as the CARGO_REGISTRY_TOKEN env var (cargo's documented name)"
 fi
 
+# The publish credential must not be inherited by checkout, toolchain, or
+# cache actions. It belongs only on the cargo-publish step, after environment
+# approval.
+publish_job_block=$(
+  awk '
+    /^  publish:/ { in_job=1; next }
+    in_job && /^  [A-Za-z0-9_-]+:/ { exit }
+    in_job { print }
+  ' "$WF"
+)
+if grep -E '^    environment:\s*release\s*$' <<<"$publish_job_block" >/dev/null; then
+  ok "publish job uses approval-protected release environment"
+else
+  err "publish job must declare environment: release"
+fi
+if grep -E '^      CARGO_REGISTRY_TOKEN:' <<<"$publish_job_block" >/dev/null; then
+  err "CARGO_REGISTRY_TOKEN must not be job-scoped"
+elif grep -E '^          CARGO_REGISTRY_TOKEN:\s*\$\{\{\s*secrets\.CRATES_IO_API_KEY\s*\}\}\s*$' <<<"$publish_job_block" >/dev/null; then
+  ok "CARGO_REGISTRY_TOKEN is scoped to the cargo publish step"
+else
+  err "cargo publish step must map secrets.CRATES_IO_API_KEY to CARGO_REGISTRY_TOKEN"
+fi
+
+while IFS= read -r action; do
+  [[ -z "$action" || "$action" == ./* ]] && continue
+  ref="${action##*@}"
+  if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+    ok "external action pinned: $action"
+  else
+    err "external action must use an exact 40-character commit SHA: $action"
+  fi
+done < <(sed -nE 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*([^[:space:]#]+).*/\2/p' "$WF")
+
 # Explicit crate list. Auto-discovery via `cargo metadata --workspace`
 # would publish whatever's currently marked publishable in Cargo.toml,
 # which is invisible at PR review time. An explicit list (env var or
@@ -259,7 +292,7 @@ else:
             "— TOCTOU on mutable main ref"
         )
 
-    if re.search(r"(?m)^      CARGO_REGISTRY_TOKEN:\s*", publish_block):
+    if re.search(r"(?m)^          CARGO_REGISTRY_TOKEN:\s*", publish_block):
         oks.append("env var key is exactly CARGO_REGISTRY_TOKEN (the name cargo reads)")
         if "secrets.CRATES_IO_API_KEY" in publish_block:
             oks.append("CARGO_REGISTRY_TOKEN wired from secrets.CRATES_IO_API_KEY")
@@ -267,8 +300,8 @@ else:
             errors.append("CARGO_REGISTRY_TOKEN env var must read from secrets.CRATES_IO_API_KEY")
     else:
         errors.append(
-            "publish job must expose CARGO_REGISTRY_TOKEN as an env var "
-            "(at job or step scope) so cargo publish can authenticate"
+            "publish job's cargo-publish step must expose CARGO_REGISTRY_TOKEN "
+            "so cargo publish can authenticate without leaking the secret to actions"
         )
 
 print("OKS:")

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -14,7 +14,9 @@
 #   - final-DMG app signature verification
 #   - stable-tag-only GitHub Packages publication for the generated
 #     TypeScript gRPC client
-#   - non-publishing branch dry-run path for release-only verification
+#   - explicit refusal of branch-selected release dry-runs
+#   - approval-protected release environment on credentialed jobs
+#   - exact commit pins for every external action
 #   - sha256 checksums
 #   - signing step
 #   - GitHub Release upload
@@ -92,12 +94,57 @@ else
 fi
 
 if grep -F 'branch_dry_run:' "$WF" >/dev/null \
-   && grep -F 'publish_release=false' "$WF" >/dev/null \
-   && grep -F "if: \${{ github.event_name != 'workflow_dispatch' || !inputs.branch_dry_run }}" "$WF" >/dev/null \
-   && grep -F "if: needs.validate-tag.outputs.publish_release == 'true'" "$WF" >/dev/null; then
-  ok "temporary branch dry-run path skips generic builds and GitHub Release publication"
+   && grep -F 'branch_dry_run is disabled:' "$WF" >/dev/null \
+   && ! grep -F 'tag_sha="$(git rev-parse HEAD)"' "$WF" >/dev/null; then
+  ok "branch-selected release dry-runs fail explicitly before credentialed jobs"
 else
-  err "temporary branch dry-run path must be explicit and must skip generic builds and GitHub Release publication"
+  err "branch_dry_run must fail explicitly; branch-selected workflow code cannot receive release credentials"
+fi
+
+# GitHub environments are the control-plane boundary that a tag's copy of
+# this workflow cannot self-approve. Every job that can sign or publish must
+# wait for the approval-protected release environment.
+for job in build build-macos-cask release publish-manifests; do
+  block=$(
+    awk -v wanted="$job" '
+      $0 == "  " wanted ":" { in_job=1; next }
+      in_job && /^  [A-Za-z0-9_-]+:/ { exit }
+      in_job { print }
+    ' "$WF"
+  )
+  if grep -E '^    environment:\s*release\s*$' <<<"$block" >/dev/null; then
+    ok "$job uses approval-protected release environment"
+  else
+    err "$job must declare environment: release before signing or publishing"
+  fi
+done
+
+# External actions execute inside credentialed release jobs. Mutable tags and
+# branches are therefore forbidden even when the repository is trusted.
+while IFS= read -r action; do
+  [[ -z "$action" || "$action" == ./* ]] && continue
+  ref="${action##*@}"
+  if [[ "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+    ok "external action pinned: $action"
+  else
+    err "external action must use an exact 40-character commit SHA: $action"
+  fi
+done < <(sed -nE 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*([^[:space:]#]+).*/\2/p' "$WF")
+
+# Least privilege: OIDC is available only to the two artifact-signing jobs,
+# and repository write permission only to the GitHub Release publisher.
+top_permissions=$(
+  awk '
+    /^permissions:/ { in_permissions=1; next }
+    in_permissions && /^[^[:space:]]/ { exit }
+    in_permissions { print }
+  ' "$WF"
+)
+if grep -E '^\s*contents:\s*read\s*$' <<<"$top_permissions" >/dev/null \
+   && ! grep -E '^\s*(contents:\s*write|id-token:\s*write)\s*$' <<<"$top_permissions" >/dev/null; then
+  ok "top-level permissions are read-only"
+else
+  err "top-level permissions must be contents: read; grant write/OIDC only to credentialed jobs"
 fi
 
 # All five active target triples (win-arm64 parked, see below).


### PR DESCRIPTION
## Summary

- Harden crate publishing and release workflows with validation checks.
- Add repository redaction, purge, signing, and state-visibility controls.
- Improve remote target handling, clone planning, hosted sync, and CLI completion.
- Add regression coverage for redaction, signing, and production security features.
- Update changelog and release documentation.

## Testing

- Added and updated CLI and production-feature integration tests.
- Added publish and release pipeline validation scripts.
- Verified the affected crates with Clippy under `-D warnings`.
- Ran all 413 `heddle-core` library tests and the signed-purge propagation regression.

## Compatibility and rollout notes

- Redaction signing payloads intentionally make a clean break from the unused `hd-redact-v1` format. Existing v1 signatures do not verify under v2. Any future payload-version change that needs compatibility must add explicit verify-side version dispatch and operator-facing migration errors.
- Purge lifecycle transitions are re-signed by the active client identity. Receivers fail closed unless that client public key is trusted.
- Automated trusted-client-key provisioning through the Weft/Tapestry control plane is not implemented by this PR. Hosted purge synchronization must remain disabled until that provisioning is delivered; current local synchronization requires explicit `heddle redact trust add` enrollment.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1129"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787799708&installation_model_id=21489&pr_number=1129&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1129&signature=ef2c7c2a772a38b43cbfcc52ab27fac7b0af2fca8d726a080cadabe720ad4d33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->