### PR TITLE
feat(client): discover and pin descriptor trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "asn1-rs"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
+dependencies = [
+ "asn1-rs-derive",
+ "asn1-rs-impl",
+ "displaydoc",
+ "nom",
+ "num-traits",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "asn1-rs-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "synstructure",
+]
+
+[[package]]
+name = "asn1-rs-impl"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,7 +497,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -466,6 +505,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -1196,6 +1244,20 @@ dependencies = [
  "const-oid 0.10.2",
  "pem-rfc7468 1.0.0",
  "zeroize",
+]
+
+[[package]]
+name = "der-parser"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
+dependencies = [
+ "asn1-rs",
+ "displaydoc",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
 ]
 
 [[package]]
@@ -2255,6 +2317,7 @@ dependencies = [
  "prost-reflect",
  "prost-types 0.14.1",
  "rand 0.10.2",
+ "rcgen",
  "reqwest",
  "rustls",
  "serde",
@@ -4035,6 +4098,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4059,6 +4132,15 @@ checksum = "a652d9771a63711fd3c3deb670acfbe5c30a4072e664d7a3bf5a9e1056ac72c3"
 dependencies = [
  "arrayvec",
  "itoa",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -4189,6 +4271,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oid-registry"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
+dependencies = [
+ "asn1-rs",
 ]
 
 [[package]]
@@ -4383,6 +4474,16 @@ checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
  "digest 0.11.3",
  "hmac 0.13.0",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
 ]
 
 [[package]]
@@ -4763,7 +4864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
- "bit-vec",
+ "bit-vec 0.8.0",
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
@@ -5173,6 +5274,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5382,6 +5497,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rusticata-macros"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -8155,6 +8279,34 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "x509-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d43b0f71ce057da06bc0851b23ee24f3f86190b07203dd8f567d0b706a185202"
+dependencies = [
+ "asn1-rs",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
 ]
 
 [[package]]

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -11835,6 +11835,84 @@
       "title": "AuthStatusSchema",
       "type": "object"
     },
+    "auth trust replace": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "canonical_server": {
+          "type": "string"
+        },
+        "fingerprint": {
+          "description": "SHA-256 fingerprint of the raw descriptor public key.",
+          "type": "string"
+        },
+        "key_id": {
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "auth_trust_replace"
+          ],
+          "type": "string"
+        },
+        "public_key": {
+          "description": "The 64-character lowercase-hex descriptor public key.",
+          "type": "string"
+        },
+        "source": {
+          "description": "`explicit` or `automatic`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "canonical_server",
+        "source",
+        "key_id",
+        "public_key",
+        "fingerprint"
+      ],
+      "title": "AuthTrustSchema",
+      "type": "object"
+    },
+    "auth trust show": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "canonical_server": {
+          "type": "string"
+        },
+        "fingerprint": {
+          "description": "SHA-256 fingerprint of the raw descriptor public key.",
+          "type": "string"
+        },
+        "key_id": {
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "auth_trust_show"
+          ],
+          "type": "string"
+        },
+        "public_key": {
+          "description": "The 64-character lowercase-hex descriptor public key.",
+          "type": "string"
+        },
+        "source": {
+          "description": "`explicit` or `automatic`.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "canonical_server",
+        "source",
+        "key_id",
+        "public_key",
+        "fingerprint"
+      ],
+      "title": "AuthTrustSchema",
+      "type": "object"
+    },
     "capture": {
       "$defs": {
         "ActionTemplateSchema": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -425,6 +425,30 @@ export interface AuthStatusSchema {
   subject?: string | null;
 }
 
+export interface AuthTrustReplaceSchema {
+  canonical_server: string;
+  /** SHA-256 fingerprint of the raw descriptor public key. */
+  fingerprint: string;
+  key_id: string;
+  output_kind: "auth_trust_replace";
+  /** The 64-character lowercase-hex descriptor public key. */
+  public_key: string;
+  /** `explicit` or `automatic`. */
+  source: string;
+}
+
+export interface AuthTrustShowSchema {
+  canonical_server: string;
+  /** SHA-256 fingerprint of the raw descriptor public key. */
+  fingerprint: string;
+  key_id: string;
+  output_kind: "auth_trust_show";
+  /** The 64-character lowercase-hex descriptor public key. */
+  public_key: string;
+  /** `explicit` or `automatic`. */
+  source: string;
+}
+
 export interface AvailableGitRefSchema {
   git_commit: string;
   name: string;
@@ -3239,6 +3263,8 @@ export interface HeddleVerbOutputs {
   "auth create-service-token": AuthCreateServiceTokenSchema;
   "auth logout": AuthLogoutSchema;
   "auth status": AuthStatusSchema;
+  "auth trust replace": AuthTrustReplaceSchema;
+  "auth trust show": AuthTrustShowSchema;
   capture: CaptureSchema;
   clone: CloneSchema;
   collapse: CollapseSchema;
@@ -3399,6 +3425,8 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "auth create-service-token",
   "auth logout",
   "auth status",
+  "auth trust replace",
+  "auth trust show",
   "capture",
   "clone",
   "collapse",

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Hosted-client command arguments.
 
-use clap::{Subcommand, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum};
 
 /// Preset operation ceilings for `heddle auth derive-agent`.
 ///
@@ -72,6 +72,12 @@ pub enum AuthCommands {
         server: Option<String>,
     },
 
+    /// Inspect or explicitly replace descriptor-signing trust
+    Trust {
+        #[command(subcommand)]
+        command: AuthTrustCommands,
+    },
+
     /// Derive a scoped, short-lived agent token offline
     DeriveAgent {
         /// Server whose stored credential is the parent.
@@ -124,6 +130,37 @@ pub enum AuthCommands {
     },
 }
 
+#[derive(Subcommand, Clone, Debug)]
+pub enum AuthTrustCommands {
+    /// Show the descriptor trust controlling a server connection
+    Show(AuthTrustShowArgs),
+    /// Atomically replace an automatic descriptor trust pin
+    Replace(AuthTrustReplaceArgs),
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct AuthTrustShowArgs {
+    /// Heddle server authority
+    #[arg(long)]
+    pub server: String,
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct AuthTrustReplaceArgs {
+    /// Heddle server authority
+    #[arg(long)]
+    pub server: String,
+    /// Current descriptor public key required for compare-and-swap
+    #[arg(long, value_name = "64_HEX")]
+    pub expect_current_public_key: String,
+    /// New descriptor key id confirmed out of band
+    #[arg(long)]
+    pub key_id: String,
+    /// New descriptor public key confirmed out of band
+    #[arg(long, value_name = "64_HEX")]
+    pub public_key: String,
+}
+
 impl From<AuthCommands> for heddle_client::AuthCommand {
     fn from(command: AuthCommands) -> Self {
         match command {
@@ -138,6 +175,23 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
             },
             AuthCommands::Logout { server } => heddle_client::AuthCommand::Logout { server },
             AuthCommands::Status { server } => heddle_client::AuthCommand::Status { server },
+            AuthCommands::Trust { command } => heddle_client::AuthCommand::Trust {
+                command: match command {
+                    AuthTrustCommands::Show(args) => {
+                        heddle_client::auth_requests::AuthTrustCommand::Show {
+                            server: args.server,
+                        }
+                    }
+                    AuthTrustCommands::Replace(args) => {
+                        heddle_client::auth_requests::AuthTrustCommand::Replace {
+                            server: args.server,
+                            expected_current_public_key: args.expect_current_public_key,
+                            key_id: args.key_id,
+                            public_key: args.public_key,
+                        }
+                    }
+                },
+            },
             AuthCommands::DeriveAgent {
                 server,
                 agent_id,
@@ -174,7 +228,42 @@ impl From<AuthCommands> for heddle_client::AuthCommand {
 mod tests {
     use clap::Parser;
 
-    use crate::cli::{AuthCommands, Cli, Commands};
+    use crate::cli::{AuthCommands, AuthTrustCommands, Cli, Commands};
+
+    #[test]
+    fn trust_replace_parses_compare_and_swap_inputs() {
+        let old_key = "11".repeat(32);
+        let new_key = "22".repeat(32);
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "auth",
+            "trust",
+            "replace",
+            "--server",
+            "api.example",
+            "--expect-current-public-key",
+            &old_key,
+            "--key-id",
+            "next-key",
+            "--public-key",
+            &new_key,
+        ])
+        .expect("trust replacement parses");
+
+        let Commands::Auth {
+            command:
+                AuthCommands::Trust {
+                    command: AuthTrustCommands::Replace(args),
+                },
+        } = cli.command
+        else {
+            panic!("expected auth trust replace");
+        };
+        assert_eq!(args.server, "api.example");
+        assert_eq!(args.expect_current_public_key, old_key);
+        assert_eq!(args.key_id, "next-key");
+        assert_eq!(args.public_key, new_key);
+    }
 
     #[test]
     fn login_parses_credential_path() {

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -49,7 +49,7 @@ pub use commands_args::{
     TimelineTargetArgs, TryArgs, UndoArgs, WatchArgs, WorkspaceModeArg,
 };
 #[cfg(feature = "client")]
-pub use commands_client::AuthCommands;
+pub use commands_client::{AuthCommands, AuthTrustCommands};
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]
 pub use commands_context::ContextReasonCommands;

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1437,6 +1437,41 @@ const CONTRACTS: &[CommandContractEntry] = &[
         ),
     ),
     entry(
+        &["auth", "trust"],
+        category(feature_gated(user_scoped(GROUP), "client"), "repo"),
+    ),
+    entry(
+        &["auth", "trust", "show"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(user_scoped(READ_JSON), &["auth trust show"]),
+                &[json_discriminator(
+                    Some("auth trust show"),
+                    "output_kind",
+                    "auth_trust_show",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["auth", "trust", "replace"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(
+                    user_scoped(CONFIG_MUTATION_NO_OP_ID),
+                    &["auth trust replace"],
+                ),
+                &[json_discriminator(
+                    Some("auth trust replace"),
+                    "output_kind",
+                    "auth_trust_replace",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
         &["auth", "derive-agent"],
         feature_gated(user_scoped(CONFIG_MUTATION_TEXT), "client"),
     ),
@@ -4571,6 +4606,10 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             AuthCommands::Login { .. } => vec!["auth", "login"],
             AuthCommands::Logout { .. } => vec!["auth", "logout"],
             AuthCommands::Status { .. } => vec!["auth", "status"],
+            AuthCommands::Trust { command } => match command {
+                crate::cli::AuthTrustCommands::Show(_) => vec!["auth", "trust", "show"],
+                crate::cli::AuthTrustCommands::Replace(_) => vec!["auth", "trust", "replace"],
+            },
             AuthCommands::DeriveAgent { .. } => vec!["auth", "derive-agent"],
             AuthCommands::CreateServiceToken { .. } => vec!["auth", "create-service-token"],
         },

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -125,6 +125,28 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["auth", "status"], &["auth", "status"]),
     #[cfg(feature = "client")]
     sample(
+        &["auth", "trust", "show"],
+        &["auth", "trust", "show", "--server", "api.heddle.test"],
+    ),
+    #[cfg(feature = "client")]
+    sample(
+        &["auth", "trust", "replace"],
+        &[
+            "auth",
+            "trust",
+            "replace",
+            "--server",
+            "api.heddle.test",
+            "--expect-current-public-key",
+            "1111111111111111111111111111111111111111111111111111111111111111",
+            "--key-id",
+            "next-key",
+            "--public-key",
+            "2222222222222222222222222222222222222222222222222222222222222222",
+        ],
+    ),
+    #[cfg(feature = "client")]
+    sample(
         &["auth", "derive-agent"],
         &[
             "auth",
@@ -1612,6 +1634,10 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "agent presence complete",
             "auth logout",
             "auth status",
+            // heddle#1130: descriptor-trust inspection and explicit
+            // compare-and-swap replacement emit stable trust records.
+            "auth trust show",
+            "auth trust replace",
             "auth create-service-token",
             // heddle whoami (H6, weft#642): the machine-readable
             // acting-identity verb emits `output_kind: "whoami"`, so it

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -142,6 +142,7 @@ schema_registry! {
     (&["agent fanout plan", "agent fanout start"], AgentFanoutSchema),
     (&["auth logout"], AuthLogoutSchema),
     (&["auth status"], AuthStatusSchema),
+    (&["auth trust show", "auth trust replace"], AuthTrustSchema),
     (&["whoami"], WhoamiSchema),
     (&["auth create-service-token"], AuthCreateServiceTokenSchema),
     (&["agent provenance begin", "agent provenance end", "agent provenance show"], AgentProvenanceEnvelopeSchema),
@@ -716,6 +717,19 @@ pub struct AuthStatusSchema {
     pub credential_id: Option<String>,
     pub expires_at: Option<String>,
     pub recommended_action: Option<String>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct AuthTrustSchema {
+    pub output_kind: String,
+    pub canonical_server: String,
+    /// `explicit` or `automatic`.
+    pub source: String,
+    pub key_id: String,
+    /// The 64-character lowercase-hex descriptor public key.
+    pub public_key: String,
+    /// SHA-256 fingerprint of the raw descriptor public key.
+    pub fingerprint: String,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -817,7 +817,7 @@ mod tests {
     }
 
     #[test]
-    fn heddle_client_config_rejects_partial_descriptor_trust() {
+    fn heddle_client_config_rejects_key_only_environment_descriptor_trust() {
         let env = RemoteEnvGuard::clean();
         env.set("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID", "weft-current");
 
@@ -830,6 +830,70 @@ mod tests {
                 .to_string()
                 .contains("both non-empty descriptor trust")
         );
+        assert!(error.to_string().contains("ambiguous security posture"));
+    }
+
+    #[test]
+    fn heddle_client_config_rejects_public_key_only_environment_descriptor_trust() {
+        let env = RemoteEnvGuard::clean();
+        env.set(
+            "HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY",
+            hex::encode([17; 32]),
+        );
+
+        let error = UserConfig::default()
+            .heddle_client_config(None)
+            .expect_err("partial descriptor trust must fail closed");
+
+        assert!(
+            error
+                .to_string()
+                .contains("both non-empty descriptor trust")
+        );
+        assert!(error.to_string().contains("ambiguous security posture"));
+    }
+
+    #[test]
+    fn heddle_client_config_rejects_key_only_file_descriptor_trust() {
+        let _env = RemoteEnvGuard::clean();
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                iroh_descriptor_key_id: Some("weft-current".to_string()),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+
+        let error = user
+            .heddle_client_config(None)
+            .expect_err("partial descriptor trust must fail closed");
+
+        assert!(error.to_string().contains("both descriptor trust fields"));
+        assert!(error.to_string().contains("ambiguous security posture"));
+    }
+
+    #[test]
+    fn heddle_client_config_rejects_public_key_only_file_descriptor_trust() {
+        let _env = RemoteEnvGuard::clean();
+        let dir = unique_temp_path("heddle-user-config-partial-descriptor");
+        fs::create_dir_all(&dir).expect("create temp dir");
+        let public_key_path = dir.join("descriptor-public-key");
+        fs::write(&public_key_path, hex::encode([17; 32])).expect("write descriptor public key");
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                iroh_descriptor_public_key_path: Some(public_key_path),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+
+        let error = user
+            .heddle_client_config(None)
+            .expect_err("partial descriptor trust must fail closed");
+
+        assert!(error.to_string().contains("both descriptor trust fields"));
+        assert!(error.to_string().contains("ambiguous security posture"));
+        fs::remove_dir_all(dir).expect("remove temp dir");
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -72,6 +72,8 @@ const SWEPT: &[&str] = &[
     "agent presence complete",
     "auth logout",
     "auth status",
+    "auth trust show",
+    "auth trust replace",
     "auth create-service-token",
     "revert",
     "redact apply",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -51,6 +51,7 @@ weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim",
 
 [dev-dependencies]
 prost-reflect.workspace = true
+rcgen = "0.14.8"
 tempfile.workspace = true
 
 [lib]

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -16,7 +16,7 @@ use sha2::{Digest, Sha256};
 use weft_client_shim::{CliContext, HostedRecoveryAdvice};
 
 use crate::{
-    auth_requests::AuthCommand,
+    auth_requests::{AuthCommand, AuthTrustCommand},
     credential_file::{self, CredentialKind, CredentialProvenance, VerifiedCredential},
     credentials,
     credentials::ServerCredential,
@@ -60,6 +60,16 @@ struct AuthStatusOutput {
 }
 
 #[derive(Serialize)]
+struct AuthTrustOutput {
+    output_kind: &'static str,
+    canonical_server: String,
+    source: crate::hosted::DescriptorTrustSource,
+    key_id: String,
+    public_key: String,
+    fingerprint: String,
+}
+
+#[derive(Serialize)]
 struct ServiceTokenOutput {
     output_kind: &'static str,
     name: String,
@@ -96,6 +106,7 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
         },
         AuthCommand::Logout { server } => cmd_auth_logout(ctx, server.as_deref()),
         AuthCommand::Status { server } => cmd_auth_status(ctx, server.as_deref()),
+        AuthCommand::Trust { command } => cmd_auth_trust(ctx, command),
         AuthCommand::DeriveAgent {
             server,
             agent_id,
@@ -122,6 +133,82 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             cmd_create_service_token(ctx, server.as_deref(), name, namespace, out.as_deref()).await
         }
     }
+}
+
+fn cmd_auth_trust(ctx: &dyn CliContext, command: AuthTrustCommand) -> Result<()> {
+    match command {
+        AuthTrustCommand::Show { server } => {
+            let config = UserConfig::load_default()?.heddle_client_config(None)?;
+            let explicit = config
+                .descriptor_key_id
+                .as_deref()
+                .zip(config.descriptor_public_key.as_ref());
+            let report = crate::hosted::trust_report(&server, explicit)?;
+            emit_auth_trust(
+                ctx,
+                AuthTrustOutput {
+                    output_kind: "auth_trust_show",
+                    canonical_server: report.canonical_server,
+                    source: report.source,
+                    key_id: report.key_id,
+                    public_key: report.public_key,
+                    fingerprint: report.fingerprint,
+                },
+            )
+        }
+        AuthTrustCommand::Replace {
+            server,
+            expected_current_public_key,
+            key_id,
+            public_key,
+        } => {
+            let config = UserConfig::load_default()?.heddle_client_config(None)?;
+            if config.descriptor_key_id.is_some() || config.descriptor_public_key.is_some() {
+                bail!(
+                    "descriptor trust replacement refused: explicit descriptor trust controls this \
+                     connection; update both explicit values together"
+                );
+            }
+            let canonical_server = crate::hosted::canonical_server_authority(&server)?;
+            let record = crate::hosted::replace_descriptor_trust(
+                &canonical_server,
+                &expected_current_public_key,
+                &key_id,
+                &public_key,
+            )?;
+            let fingerprint = record.fingerprint()?;
+            emit_auth_trust(
+                ctx,
+                AuthTrustOutput {
+                    output_kind: "auth_trust_replace",
+                    canonical_server,
+                    source: crate::hosted::DescriptorTrustSource::Automatic,
+                    key_id: record.key_id,
+                    public_key: record.public_key,
+                    fingerprint,
+                },
+            )
+        }
+    }
+}
+
+fn emit_auth_trust(ctx: &dyn CliContext, output: AuthTrustOutput) -> Result<()> {
+    if ctx.should_output_json(None) {
+        println!("{}", serde_json::to_string(&output)?);
+    } else {
+        println!("Server:                {}", output.canonical_server);
+        println!(
+            "Source:                {}",
+            match output.source {
+                crate::hosted::DescriptorTrustSource::Explicit => "explicit",
+                crate::hosted::DescriptorTrustSource::Automatic => "automatic",
+            }
+        );
+        println!("Descriptor key id:     {}", output.key_id);
+        println!("Descriptor public key: {}", output.public_key);
+        println!("Fingerprint:           {}", output.fingerprint);
+    }
+    Ok(())
 }
 
 /// Derive an offline child credential with a fresh PoP key, then either install
@@ -1524,6 +1611,60 @@ mod tests {
         }
     }
 
+    #[test]
+    fn trust_replace_refuses_active_explicit_config_without_mutating_the_pin() {
+        with_isolated_home(|| {
+            let server = "https://api.example";
+            crate::hosted::insert_verified_pin(server, "old-id", &[0x11; 32])
+                .expect("initial automatic pin");
+            let before =
+                std::fs::read(crate::hosted::descriptor_trust_path()).expect("read pin store");
+            let previous_key_id = std::env::var_os("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID");
+            let previous_public_key = std::env::var_os("HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY");
+
+            unsafe {
+                std::env::set_var("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID", "explicit-id");
+                std::env::set_var(
+                    "HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY",
+                    hex::encode([0x33; 32]),
+                );
+            }
+            let result = cmd_auth_trust(
+                &TextCtx,
+                AuthTrustCommand::Replace {
+                    server: server.to_string(),
+                    expected_current_public_key: hex::encode([0x11; 32]),
+                    key_id: "new-id".to_string(),
+                    public_key: hex::encode([0x22; 32]),
+                },
+            );
+            unsafe {
+                match previous_key_id {
+                    Some(value) => std::env::set_var("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID", value),
+                    None => std::env::remove_var("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID"),
+                }
+                match previous_public_key {
+                    Some(value) => {
+                        std::env::set_var("HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY", value)
+                    }
+                    None => std::env::remove_var("HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY"),
+                }
+            }
+
+            let error = result.expect_err("explicit trust must control replacement");
+            assert!(
+                error
+                    .to_string()
+                    .contains("update both explicit values together")
+            );
+            assert_eq!(
+                std::fs::read(crate::hosted::descriptor_trust_path())
+                    .expect("read unchanged pin store"),
+                before
+            );
+        });
+    }
+
     /// Run `f` with `HOME` pointed at a fresh temp dir and `HEDDLE_HOME` cleared,
     /// so the credential store and device identity both resolve under
     /// `<temp>/.heddle`. Serialised with the credential store's env tests.
@@ -1923,6 +2064,10 @@ mod tests {
 
             let subject = install_credential_file(&path).expect("install device credential");
             assert_eq!(subject, "alice");
+            assert!(
+                !crate::hosted::descriptor_trust_path().exists(),
+                ".hcred installation must stay offline and must not create descriptor trust",
+            );
 
             let stored = credentials::get_server_credential(server)
                 .expect("load stored")

--- a/crates/client/src/auth_requests.rs
+++ b/crates/client/src/auth_requests.rs
@@ -16,6 +16,9 @@ pub enum AuthCommand {
     Status {
         server: Option<String>,
     },
+    Trust {
+        command: AuthTrustCommand,
+    },
     DeriveAgent {
         server: String,
         agent_id: Option<String>,
@@ -37,5 +40,18 @@ pub enum AuthCommand {
         /// Path for the `.hcred` credential file
         /// (default: `~/.heddle/service-accounts/<name>.hcred`).
         out: Option<std::path::PathBuf>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub enum AuthTrustCommand {
+    Show {
+        server: String,
+    },
+    Replace {
+        server: String,
+        expected_current_public_key: String,
+        key_id: String,
+        public_key: String,
     },
 }

--- a/crates/client/src/hosted/bootstrap.rs
+++ b/crates/client/src/hosted/bootstrap.rs
@@ -14,13 +14,24 @@ use crypto::Ed25519Signer;
 use iroh::{EndpointAddr, EndpointId, RelayUrl};
 use prost::Message;
 use reqwest::{
-    Client,
-    header::{HOST, HeaderValue},
+    Client, StatusCode,
+    header::{CONTENT_TYPE, HOST, HeaderValue},
+    redirect::Policy,
 };
+use serde::Deserialize;
 
 use super::{HostedError, Result};
 
 const MAX_DESCRIPTOR_BYTES: usize = 64 * 1024;
+const MAX_DESCRIPTOR_KEY_DOCUMENT_BYTES: usize = 4 * 1024;
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescriptorKeyDocument {
+    pub version: u32,
+    pub key_id: String,
+    pub public_key: String,
+}
 
 /// Trusted descriptor-signing keys, keyed independently from Iroh endpoint and
 /// hosted capability identities.
@@ -160,6 +171,14 @@ pub async fn fetch_endpoint_descriptor(
     keys: &DescriptorKeyring,
     config: &ClientConfig,
 ) -> Result<VerifiedEndpointDescriptor> {
+    let signed = fetch_signed_endpoint_descriptor(url, config).await?;
+    keys.verify(&signed, now_unix_millis()?)
+}
+
+pub async fn fetch_signed_endpoint_descriptor(
+    url: &str,
+    config: &ClientConfig,
+) -> Result<SignedEndpointDescriptor> {
     if !url.starts_with("https://") {
         return Err(HostedError::InvalidDescriptor(
             "endpoint descriptor URL must use HTTPS".to_string(),
@@ -170,30 +189,70 @@ pub async fn fetch_endpoint_descriptor(
     if let Some(host_header) = host_header {
         request = request.header(HOST, host_header);
     }
-    let response = request.send().await?.error_for_status()?;
-    if response
-        .content_length()
-        .is_some_and(|length| length > MAX_DESCRIPTOR_BYTES as u64)
-    {
+    let response = request.send().await?;
+    if response.status() != StatusCode::OK {
+        return Err(HostedError::InvalidDescriptor(format!(
+            "endpoint descriptor request returned HTTP {}",
+            response.status()
+        )));
+    }
+    let body = bounded_response_body(response, MAX_DESCRIPTOR_BYTES, "endpoint descriptor").await?;
+    Ok(SignedEndpointDescriptor::decode(body.as_slice())?)
+}
+
+pub async fn fetch_descriptor_key_document(
+    url: &str,
+    config: &ClientConfig,
+) -> Result<DescriptorKeyDocument> {
+    if !url.starts_with("https://") {
         return Err(HostedError::InvalidDescriptor(
-            "endpoint descriptor is oversized".to_string(),
+            "descriptor trust URL must use HTTPS".to_string(),
         ));
     }
-    let body = response.bytes().await?;
-    if body.len() > MAX_DESCRIPTOR_BYTES {
+    let (client, request_url, host_header) = bootstrap_http_client(url, config).await?;
+    let mut request = client.get(request_url);
+    if let Some(host_header) = host_header {
+        request = request.header(HOST, host_header);
+    }
+    let response = request.send().await?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(HostedError::DescriptorTrustUnavailable);
+    }
+    if response.status() != StatusCode::OK {
+        return Err(HostedError::InvalidDescriptor(format!(
+            "descriptor trust request returned HTTP {}",
+            response.status()
+        )));
+    }
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(';').next())
+        .map(str::trim);
+    if !content_type.is_some_and(|value| value.eq_ignore_ascii_case("application/json")) {
         return Err(HostedError::InvalidDescriptor(
-            "endpoint descriptor is oversized".to_string(),
+            "descriptor trust response must use application/json".to_string(),
         ));
     }
-    let signed = SignedEndpointDescriptor::decode(body)?;
-    keys.verify(&signed, now_unix_millis()?)
+    let body = bounded_response_body(
+        response,
+        MAX_DESCRIPTOR_KEY_DOCUMENT_BYTES,
+        "descriptor trust response",
+    )
+    .await?;
+    serde_json::from_slice(&body).map_err(|error| {
+        HostedError::InvalidDescriptor(format!("descriptor trust response is malformed: {error}"))
+    })
 }
 
 async fn bootstrap_http_client(
     url: &str,
     config: &ClientConfig,
 ) -> Result<(Client, reqwest::Url, Option<HeaderValue>)> {
-    let mut builder = Client::builder().timeout(Duration::from_secs(config.timeout_secs.max(1)));
+    let mut builder = Client::builder()
+        .timeout(Duration::from_secs(config.timeout_secs.max(1)))
+        .redirect(Policy::none());
     if let Some(ca_pem) = config.tls_ca_certificate_pem.as_deref() {
         let certificates = reqwest::Certificate::from_pem_bundle(ca_pem.as_bytes())?;
         if certificates.is_empty() {
@@ -209,6 +268,31 @@ async fn bootstrap_http_client(
         builder = builder.resolve_to_addrs(&server_name, &addresses);
     }
     Ok((builder.build()?, target.url, target.host_header))
+}
+
+async fn bounded_response_body(
+    mut response: reqwest::Response,
+    limit: usize,
+    label: &str,
+) -> Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > limit as u64)
+    {
+        return Err(HostedError::InvalidDescriptor(format!(
+            "{label} is oversized"
+        )));
+    }
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if body.len().saturating_add(chunk.len()) > limit {
+            return Err(HostedError::InvalidDescriptor(format!(
+                "{label} is oversized"
+            )));
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
 }
 
 struct BootstrapTarget {

--- a/crates/client/src/hosted/descriptor_trust.rs
+++ b/crates/client/src/hosted/descriptor_trust.rs
@@ -1,0 +1,520 @@
+//! Per-server descriptor-signing trust continuity.
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result, bail};
+use objects::{
+    fs_atomic::{create_private_dir_all, write_file_atomic_secret},
+    lock::RepoLock,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const STORE_VERSION: u32 = 1;
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DescriptorTrustRecord {
+    pub key_id: String,
+    pub public_key: String,
+    pub first_verified_unix_millis: i64,
+}
+
+impl DescriptorTrustRecord {
+    pub fn public_key_bytes(&self) -> Result<[u8; 32]> {
+        parse_descriptor_public_key(&self.public_key)
+    }
+
+    pub fn fingerprint(&self) -> Result<String> {
+        Ok(descriptor_public_key_fingerprint(&self.public_key_bytes()?))
+    }
+
+    fn validate(&self) -> Result<()> {
+        validate_key_id(&self.key_id)?;
+        self.public_key_bytes()?;
+        if self.first_verified_unix_millis < 0 {
+            bail!("descriptor trust record has an invalid first verification time");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct DescriptorTrustStore {
+    version: u32,
+    #[serde(default)]
+    servers: BTreeMap<String, DescriptorTrustRecord>,
+}
+
+impl Default for DescriptorTrustStore {
+    fn default() -> Self {
+        Self {
+            version: STORE_VERSION,
+            servers: BTreeMap::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DescriptorTrustSource {
+    Explicit,
+    Automatic,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct DescriptorTrustReport {
+    pub canonical_server: String,
+    pub source: DescriptorTrustSource,
+    pub key_id: String,
+    pub public_key: String,
+    pub fingerprint: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PinInsertOutcome {
+    Created,
+    AlreadyPresent,
+}
+
+pub fn descriptor_trust_path() -> PathBuf {
+    repo::identity::heddle_home_dir().join("descriptor-trust.toml")
+}
+
+pub fn canonical_server_authority(server: &str) -> Result<String> {
+    let candidate = if let Some(authority) = server.strip_prefix("heddle://") {
+        format!("https://{authority}")
+    } else if server.starts_with("https://") {
+        server.to_string()
+    } else if server.contains("://") {
+        bail!("native hosted bootstrap requires an HTTPS server authority");
+    } else {
+        format!("https://{server}")
+    };
+    let mut url = reqwest::Url::parse(&candidate)
+        .context("native hosted bootstrap requires a valid HTTPS server authority")?;
+    if url.scheme() != "https" {
+        bail!("native hosted bootstrap requires an HTTPS server authority");
+    }
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.host_str().is_none()
+        || !matches!(url.path(), "" | "/")
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        bail!(
+            "native hosted bootstrap requires an HTTPS server authority without userinfo, path, query, or fragment"
+        );
+    }
+    url.set_path("");
+    if url.port() == Some(443) {
+        url.set_port(None)
+            .map_err(|_| anyhow::anyhow!("invalid HTTPS server port"))?;
+    }
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
+pub fn validate_descriptor_pair(key_id: &str, public_key: &str) -> Result<[u8; 32]> {
+    validate_key_id(key_id)?;
+    parse_descriptor_public_key(public_key)
+}
+
+pub fn parse_descriptor_public_key(public_key: &str) -> Result<[u8; 32]> {
+    if public_key.len() != 64
+        || !public_key
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("descriptor public key must be exactly 64 lowercase hexadecimal characters");
+    }
+    let decoded = hex::decode(public_key).context("decoding descriptor public key")?;
+    decoded
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("descriptor public key must decode to exactly 32 bytes"))
+}
+
+pub fn descriptor_public_key_fingerprint(public_key: &[u8; 32]) -> String {
+    format!("sha256:{}", hex::encode(Sha256::digest(public_key)))
+}
+
+pub fn load_automatic_pin(canonical_server: &str) -> Result<Option<DescriptorTrustRecord>> {
+    let store = load_store()?;
+    Ok(store.servers.get(canonical_server).cloned())
+}
+
+pub fn insert_verified_pin(
+    canonical_server: &str,
+    key_id: &str,
+    public_key: &[u8; 32],
+) -> Result<PinInsertOutcome> {
+    let path = descriptor_trust_path();
+    prepare_store_directory(&path)?;
+    let _guard = RepoLock::at(lock_path(&path))
+        .write()
+        .context("locking descriptor trust store")?;
+    let mut store = load_store_from(&path)?;
+    let candidate_key = hex::encode(public_key);
+    if let Some(current) = store.servers.get(canonical_server) {
+        if current.key_id == key_id && current.public_key == candidate_key {
+            return Ok(PinInsertOutcome::AlreadyPresent);
+        }
+        bail!("{}", pin_change_message(canonical_server, current, key_id)?);
+    }
+    let record = DescriptorTrustRecord {
+        key_id: key_id.to_string(),
+        public_key: candidate_key,
+        first_verified_unix_millis: now_unix_millis()?,
+    };
+    record.validate()?;
+    store.servers.insert(canonical_server.to_string(), record);
+    save_store_to(&path, &store)?;
+    Ok(PinInsertOutcome::Created)
+}
+
+pub fn replace_descriptor_trust(
+    canonical_server: &str,
+    expected_current_public_key: &str,
+    new_key_id: &str,
+    new_public_key: &str,
+) -> Result<DescriptorTrustRecord> {
+    let expected = parse_descriptor_public_key(expected_current_public_key)?;
+    let new_key = validate_descriptor_pair(new_key_id, new_public_key)?;
+    let path = descriptor_trust_path();
+    prepare_store_directory(&path)?;
+    let _guard = RepoLock::at(lock_path(&path))
+        .write()
+        .context("locking descriptor trust store")?;
+    let mut store = load_store_from(&path)?;
+    let current = store.servers.get(canonical_server).ok_or_else(|| {
+        anyhow::anyhow!("no automatic descriptor trust pin exists for {canonical_server}")
+    })?;
+    if current.public_key_bytes()? != expected {
+        bail!(
+            "descriptor trust replacement refused for {canonical_server}: \
+             --expect-current-public-key does not match the current descriptor public key"
+        );
+    }
+    let replacement = DescriptorTrustRecord {
+        key_id: new_key_id.to_string(),
+        public_key: hex::encode(new_key),
+        first_verified_unix_millis: now_unix_millis()?,
+    };
+    store
+        .servers
+        .insert(canonical_server.to_string(), replacement.clone());
+    save_store_to(&path, &store)?;
+    Ok(replacement)
+}
+
+pub fn trust_report(
+    server: &str,
+    explicit: Option<(&str, &[u8; 32])>,
+) -> Result<DescriptorTrustReport> {
+    let canonical_server = canonical_server_authority(server)?;
+    let (source, key_id, public_key) = match explicit {
+        Some((key_id, public_key)) => (
+            DescriptorTrustSource::Explicit,
+            key_id.to_string(),
+            hex::encode(public_key),
+        ),
+        None => {
+            let record = load_automatic_pin(&canonical_server)?.ok_or_else(|| {
+                anyhow::anyhow!("no descriptor trust is configured for {canonical_server}")
+            })?;
+            (
+                DescriptorTrustSource::Automatic,
+                record.key_id,
+                record.public_key,
+            )
+        }
+    };
+    let public_key_bytes = parse_descriptor_public_key(&public_key)?;
+    Ok(DescriptorTrustReport {
+        canonical_server,
+        source,
+        key_id,
+        public_key,
+        fingerprint: descriptor_public_key_fingerprint(&public_key_bytes),
+    })
+}
+
+pub fn pin_change_message(
+    canonical_server: &str,
+    current: &DescriptorTrustRecord,
+    observed_key_id: &str,
+) -> Result<String> {
+    Ok(format!(
+        "descriptor trust changed for {canonical_server}: pinned key id `{}` \
+         with descriptor public key fingerprint {}; observed descriptor key id `{observed_key_id}`. \
+         Automatic re-pinning was refused; verify the new descriptor public key out of band, then run \
+         `heddle auth trust replace --server {canonical_server} \
+         --expect-current-public-key {} --key-id <new-id> --public-key <64-hex>`",
+        current.key_id,
+        current.fingerprint()?,
+        current.public_key,
+    ))
+}
+
+fn validate_key_id(key_id: &str) -> Result<()> {
+    if key_id.trim().is_empty() {
+        bail!("descriptor key id must not be empty");
+    }
+    Ok(())
+}
+
+fn load_store() -> Result<DescriptorTrustStore> {
+    load_store_from(&descriptor_trust_path())
+}
+
+fn load_store_from(path: &Path) -> Result<DescriptorTrustStore> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(DescriptorTrustStore::default());
+        }
+        Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
+    };
+    let store: DescriptorTrustStore =
+        toml::from_str(&contents).with_context(|| format!("parsing {}", path.display()))?;
+    if store.version != STORE_VERSION {
+        bail!(
+            "unsupported descriptor trust store version {} in {}",
+            store.version,
+            path.display()
+        );
+    }
+    for (server, record) in &store.servers {
+        if canonical_server_authority(server)? != *server {
+            bail!("descriptor trust store contains non-canonical server authority `{server}`");
+        }
+        record
+            .validate()
+            .with_context(|| format!("validating descriptor trust for {server}"))?;
+    }
+    Ok(store)
+}
+
+fn save_store_to(path: &Path, store: &DescriptorTrustStore) -> Result<()> {
+    let contents = toml::to_string_pretty(store).context("serializing descriptor trust store")?;
+    write_file_atomic_secret(path, contents.as_bytes())
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+fn prepare_store_directory(path: &Path) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("descriptor trust store path has no parent"))?;
+    create_private_dir_all(parent)
+        .with_context(|| format!("creating descriptor trust directory {}", parent.display()))
+}
+
+fn lock_path(path: &Path) -> PathBuf {
+    path.with_extension("toml.lock")
+}
+
+fn now_unix_millis() -> Result<i64> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("system clock is before Unix epoch")?
+        .as_millis();
+    i64::try_from(millis).context("system clock exceeds supported Unix time")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        panic::{AssertUnwindSafe, catch_unwind},
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use super::*;
+
+    fn with_isolated_home<T>(test: impl FnOnce(&std::path::Path) -> T) -> T {
+        let _guard = crate::credentials::lock_test_env();
+        let home = tempfile::TempDir::new().expect("temporary Heddle home");
+        let previous = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", home.path());
+        }
+        let result = catch_unwind(AssertUnwindSafe(|| test(home.path())));
+        unsafe {
+            match previous {
+                Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                None => std::env::remove_var("HEDDLE_HOME"),
+            }
+        }
+        match result {
+            Ok(value) => value,
+            Err(payload) => std::panic::resume_unwind(payload),
+        }
+    }
+
+    #[test]
+    fn canonical_aliases_share_default_port_and_non_default_ports_do_not() {
+        for alias in [
+            "API.Example",
+            "https://api.example",
+            "heddle://api.example:443",
+        ] {
+            assert_eq!(
+                canonical_server_authority(alias).unwrap(),
+                "https://api.example"
+            );
+        }
+        assert_eq!(
+            canonical_server_authority("api.example:8421").unwrap(),
+            "https://api.example:8421"
+        );
+        assert_eq!(
+            canonical_server_authority("[2001:db8::1]:443").unwrap(),
+            "https://[2001:db8::1]"
+        );
+    }
+
+    #[test]
+    fn canonical_authority_rejects_ambiguous_url_components() {
+        for invalid in [
+            "http://api.example",
+            "https://user@api.example",
+            "https://api.example/path",
+            "https://api.example?query",
+            "https://api.example#fragment",
+        ] {
+            assert!(canonical_server_authority(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn store_is_fail_closed_and_replacement_is_compare_and_swap() {
+        with_isolated_home(|_| {
+            let server = "https://api.example";
+            let old = [0x11; 32];
+            let new = [0x22; 32];
+            insert_verified_pin(server, "old-id", &old).unwrap();
+            let before = fs::read(descriptor_trust_path()).unwrap();
+
+            assert!(
+                replace_descriptor_trust(
+                    server,
+                    &hex::encode([0x33; 32]),
+                    "new-id",
+                    &hex::encode(new)
+                )
+                .is_err()
+            );
+            assert_eq!(fs::read(descriptor_trust_path()).unwrap(), before);
+            assert!(
+                replace_descriptor_trust(server, &hex::encode(old), "", &hex::encode(new)).is_err()
+            );
+            assert_eq!(fs::read(descriptor_trust_path()).unwrap(), before);
+
+            let replacement =
+                replace_descriptor_trust(server, &hex::encode(old), "new-id", &hex::encode(new))
+                    .unwrap();
+            assert_eq!(replacement.key_id, "new-id");
+            assert_eq!(replacement.public_key, hex::encode(new));
+
+            fs::write(descriptor_trust_path(), "not valid toml").unwrap();
+            assert!(load_automatic_pin(server).is_err());
+        });
+    }
+
+    #[test]
+    fn same_pair_concurrent_first_contact_converges() {
+        with_isolated_home(|_| {
+            let barrier = Arc::new(Barrier::new(2));
+            let handles = (0..2)
+                .map(|_| {
+                    let barrier = Arc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        insert_verified_pin("https://api.example", "same-id", &[0x44; 32])
+                    })
+                })
+                .collect::<Vec<_>>();
+            let outcomes = handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap().unwrap())
+                .collect::<Vec<_>>();
+            assert!(outcomes.contains(&PinInsertOutcome::Created));
+            assert!(outcomes.contains(&PinInsertOutcome::AlreadyPresent));
+            assert_eq!(
+                load_automatic_pin("https://api.example")
+                    .unwrap()
+                    .unwrap()
+                    .public_key,
+                hex::encode([0x44; 32])
+            );
+        });
+    }
+
+    #[test]
+    fn different_pair_concurrent_first_contact_preserves_the_winner() {
+        with_isolated_home(|_| {
+            let barrier = Arc::new(Barrier::new(2));
+            let handles = [(0x55, "key-a"), (0x66, "key-b")]
+                .into_iter()
+                .map(|(byte, key_id)| {
+                    let barrier = Arc::clone(&barrier);
+                    thread::spawn(move || {
+                        barrier.wait();
+                        (
+                            byte,
+                            insert_verified_pin("https://api.example", key_id, &[byte; 32]),
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            let outcomes = handles
+                .into_iter()
+                .map(|handle| handle.join().unwrap())
+                .collect::<Vec<_>>();
+            assert_eq!(
+                outcomes.iter().filter(|(_, result)| result.is_ok()).count(),
+                1
+            );
+            assert_eq!(
+                outcomes
+                    .iter()
+                    .filter(|(_, result)| result.is_err())
+                    .count(),
+                1
+            );
+            let winner = outcomes
+                .iter()
+                .find_map(|(byte, result)| result.is_ok().then_some(*byte))
+                .unwrap();
+            assert_eq!(
+                load_automatic_pin("https://api.example")
+                    .unwrap()
+                    .unwrap()
+                    .public_key,
+                hex::encode([winner; 32])
+            );
+        });
+    }
+
+    #[test]
+    fn report_distinguishes_explicit_and_automatic_trust() {
+        with_isolated_home(|_| {
+            insert_verified_pin("https://api.example", "automatic-id", &[0x77; 32]).unwrap();
+            let automatic = trust_report("heddle://API.example:443", None).unwrap();
+            assert_eq!(automatic.source, DescriptorTrustSource::Automatic);
+            assert_eq!(automatic.key_id, "automatic-id");
+
+            let explicit_key = [0x88; 32];
+            let explicit =
+                trust_report("api.example", Some(("explicit-id", &explicit_key))).unwrap();
+            assert_eq!(explicit.source, DescriptorTrustSource::Explicit);
+            assert_eq!(explicit.public_key, hex::encode(explicit_key));
+        });
+    }
+}

--- a/crates/client/src/hosted/descriptor_trust_acceptance.rs
+++ b/crates/client/src/hosted/descriptor_trust_acceptance.rs
@@ -1,0 +1,377 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    fs,
+    panic::{AssertUnwindSafe, catch_unwind},
+    time::Duration,
+};
+
+use api::{
+    HOSTED_ALPN_V1,
+    heddle::api::v1alpha1::{EndpointDescriptor, SignedEndpointDescriptor},
+    signing::endpoint_descriptor_bytes,
+};
+use crypto::{Ed25519Signer, Signer};
+use futures::FutureExt;
+use prost::Message;
+
+use super::{
+    descriptor_trust::load_automatic_pin,
+    resolver::resolve_and_verify_endpoint_descriptor,
+    test_https::{TestHttpsServer, TestResponse},
+};
+
+const KEY_PATH: &str = "/.well-known/heddle/iroh-descriptor-key";
+const DESCRIPTOR_PATH: &str = "/.well-known/heddle/iroh-endpoint";
+
+#[tokio::test]
+async fn clean_first_contact_pins_after_verification_and_reuses_without_discovery() {
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = server_with_pair("first-key", &signer, 2);
+        let config = trusted_config(&server);
+
+        resolve_and_verify_endpoint_descriptor(server.authority(), &config)
+            .await
+            .unwrap();
+        let pin = load_automatic_pin(server.authority()).unwrap().unwrap();
+        assert_eq!(pin.key_id, "first-key");
+        assert_eq!(pin.public_key, hex::encode(signer.public_key()));
+        assert_eq!(server.requests(), [KEY_PATH, DESCRIPTOR_PATH]);
+
+        resolve_and_verify_endpoint_descriptor(server.authority(), &config)
+            .await
+            .unwrap();
+        assert_eq!(
+            server.requests(),
+            [KEY_PATH, DESCRIPTOR_PATH, DESCRIPTOR_PATH]
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn tls_authenticates_first_contact_and_configured_ca_allows_it() {
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = server_with_pair("tls-key", &signer, 1);
+        let untrusted_error =
+            resolve_and_verify_endpoint_descriptor(server.authority(), &Default::default())
+                .await
+                .unwrap_err();
+        assert!(untrusted_error.to_string().contains("HTTPS request failed"));
+        assert!(load_automatic_pin(server.authority()).unwrap().is_none());
+
+        resolve_and_verify_endpoint_descriptor(server.authority(), &trusted_config(&server))
+            .await
+            .unwrap();
+        assert!(load_automatic_pin(server.authority()).unwrap().is_some());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn invalid_key_documents_and_unverified_candidates_never_pin() {
+    let cases = [
+        ("malformed", TestResponse::json(b"{".to_vec())),
+        ("oversized", TestResponse::json(vec![b'x'; 4 * 1024 + 1])),
+        (
+            "wrong-version",
+            TestResponse::json(key_document(2, "key", &[1; 32])),
+        ),
+        (
+            "empty-id",
+            TestResponse::json(key_document(1, "", &[1; 32])),
+        ),
+        (
+            "bad-hex",
+            TestResponse::json(br#"{"version":1,"key_id":"key","public_key":"zz"}"#.to_vec()),
+        ),
+        (
+            "wrong-length",
+            TestResponse::json(key_document(1, "key", &[1; 31])),
+        ),
+        ("non-200", TestResponse::status(500)),
+        (
+            "redirect",
+            TestResponse::redirect("https://example.invalid/key"),
+        ),
+    ];
+    for (name, response) in cases {
+        with_isolated_home_async(|_| async move {
+            let server = TestHttpsServer::start(HashMap::from([(
+                KEY_PATH.to_string(),
+                VecDeque::from([response]),
+            )]));
+            let result = resolve_and_verify_endpoint_descriptor(
+                server.authority(),
+                &trusted_config(&server),
+            )
+            .await;
+            assert!(result.is_err(), "{name} unexpectedly succeeded");
+            assert!(
+                load_automatic_pin(server.authority()).unwrap().is_none(),
+                "{name} wrote a pin"
+            );
+            assert_eq!(server.requests(), [KEY_PATH], "{name}");
+        })
+        .await;
+    }
+
+    with_isolated_home_async(|_| async {
+        let candidate = Ed25519Signer::generate().unwrap();
+        let descriptor_signer = Ed25519Signer::generate().unwrap();
+        let server = TestHttpsServer::start(routes_for_pair(
+            "candidate",
+            &candidate,
+            &descriptor_signer,
+            1,
+        ));
+        assert!(
+            resolve_and_verify_endpoint_descriptor(server.authority(), &trusted_config(&server))
+                .await
+                .is_err()
+        );
+        assert!(load_automatic_pin(server.authority()).unwrap().is_none());
+        assert_eq!(server.requests(), [KEY_PATH, DESCRIPTOR_PATH]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn pin_change_refuses_new_id_and_reused_id_without_state_mutation() {
+    for reuse_id in [false, true] {
+        with_isolated_home_async(|_| async move {
+            let first = Ed25519Signer::generate().unwrap();
+            let changed = Ed25519Signer::generate().unwrap();
+            let changed_id = if reuse_id { "stable-id" } else { "new-id" };
+            let server = TestHttpsServer::start(HashMap::from([
+                (
+                    KEY_PATH.to_string(),
+                    VecDeque::from([TestResponse::json(key_document(
+                        1,
+                        "stable-id",
+                        first.public_key(),
+                    ))]),
+                ),
+                (
+                    DESCRIPTOR_PATH.to_string(),
+                    VecDeque::from([
+                        TestResponse::protobuf(signed_descriptor("stable-id", &first)),
+                        TestResponse::protobuf(signed_descriptor(changed_id, &changed)),
+                    ]),
+                ),
+            ]));
+            let config = trusted_config(&server);
+            resolve_and_verify_endpoint_descriptor(server.authority(), &config)
+                .await
+                .unwrap();
+            let before = fs::read(super::descriptor_trust_path()).unwrap();
+
+            let error = tokio::time::timeout(
+                Duration::from_secs(1),
+                super::HostedClient::connect_server(server.authority(), &config),
+            )
+            .await
+            .expect("pin change must fail before an Iroh dial can stall")
+            .unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("Automatic re-pinning was refused")
+            );
+            assert_eq!(fs::read(super::descriptor_trust_path()).unwrap(), before);
+            assert_eq!(
+                server.requests(),
+                [KEY_PATH, DESCRIPTOR_PATH, DESCRIPTOR_PATH]
+            );
+        })
+        .await;
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn trust_store_write_failure_prevents_iroh_and_iroh_failure_keeps_pin() {
+    use std::os::unix::fs::PermissionsExt;
+
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = server_with_pair("write-key", &signer, 1);
+        let home = repo::identity::heddle_home_dir();
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o500)).unwrap();
+        let result =
+            super::HostedClient::connect_server(server.authority(), &trusted_config(&server)).await;
+        fs::set_permissions(&home, fs::Permissions::from_mode(0o700)).unwrap();
+
+        let error = result.expect_err("pin persistence must fail before Iroh");
+        assert!(
+            error.to_string().contains("locking descriptor trust store")
+                || error.to_string().contains("Permission denied")
+        );
+        assert!(!super::descriptor_trust_path().exists());
+        assert!(!crate::credentials::credentials_path().exists());
+        assert_eq!(server.requests(), [KEY_PATH, DESCRIPTOR_PATH]);
+    })
+    .await;
+
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = server_with_pair("dial-key", &signer, 1);
+        let result = tokio::time::timeout(
+            Duration::from_millis(500),
+            super::HostedClient::connect_server(server.authority(), &trusted_config(&server)),
+        )
+        .await;
+        assert!(
+            result.is_err() || result.unwrap().is_err(),
+            "the unreachable Iroh endpoint must not connect"
+        );
+        let pin = load_automatic_pin(server.authority()).unwrap().unwrap();
+        assert_eq!(pin.key_id, "dial-key");
+        assert!(!crate::credentials::credentials_path().exists());
+        assert_eq!(server.requests(), [KEY_PATH, DESCRIPTOR_PATH]);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn explicit_pair_skips_discovery_and_old_server_failure_is_actionable() {
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = TestHttpsServer::start(HashMap::from([(
+            DESCRIPTOR_PATH.to_string(),
+            VecDeque::from([TestResponse::protobuf(signed_descriptor(
+                "explicit-id",
+                &signer,
+            ))]),
+        )]));
+        let public_key: [u8; 32] = signer.public_key().try_into().unwrap();
+        let config = trusted_config(&server).with_descriptor_trust("explicit-id", public_key);
+        resolve_and_verify_endpoint_descriptor(server.authority(), &config)
+            .await
+            .unwrap();
+        assert_eq!(server.requests(), [DESCRIPTOR_PATH]);
+        assert!(!super::descriptor_trust_path().exists());
+    })
+    .await;
+
+    with_isolated_home_async(|_| async {
+        let server = TestHttpsServer::start(HashMap::new());
+        let error =
+            resolve_and_verify_endpoint_descriptor(server.authority(), &trusted_config(&server))
+                .await
+                .unwrap_err();
+        assert!(error.to_string().contains(
+            "server does not publish descriptor trust; configure both values or upgrade the server"
+        ));
+        assert!(!super::descriptor_trust_path().exists());
+    })
+    .await;
+}
+
+fn server_with_pair(
+    key_id: &str,
+    signer: &Ed25519Signer,
+    descriptor_count: usize,
+) -> TestHttpsServer {
+    TestHttpsServer::start(routes_for_pair(key_id, signer, signer, descriptor_count))
+}
+
+fn routes_for_pair(
+    key_id: &str,
+    published_signer: &Ed25519Signer,
+    descriptor_signer: &Ed25519Signer,
+    descriptor_count: usize,
+) -> HashMap<String, VecDeque<TestResponse>> {
+    HashMap::from([
+        (
+            KEY_PATH.to_string(),
+            VecDeque::from([TestResponse::json(key_document(
+                1,
+                key_id,
+                published_signer.public_key(),
+            ))]),
+        ),
+        (
+            DESCRIPTOR_PATH.to_string(),
+            (0..descriptor_count)
+                .map(|_| TestResponse::protobuf(signed_descriptor(key_id, descriptor_signer)))
+                .collect(),
+        ),
+    ])
+}
+
+fn key_document(version: u32, key_id: &str, public_key: &[u8]) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::json!({
+        "version": version,
+        "key_id": key_id,
+        "public_key": hex::encode(public_key),
+    }))
+    .unwrap()
+}
+
+fn signed_descriptor(key_id: &str, signer: &Ed25519Signer) -> Vec<u8> {
+    let now = chrono::Utc::now().timestamp_millis();
+    let descriptor = EndpointDescriptor {
+        version: 1,
+        endpoint_id: hex::encode([9; 32]),
+        relay_urls: Vec::new(),
+        direct_addresses: vec!["127.0.0.1:9".to_string()],
+        supported_alpns: vec![HOSTED_ALPN_V1.to_vec()],
+        issued_at_unix_millis: now - 1_000,
+        expires_at_unix_millis: now + 60_000,
+        rotation: None,
+    };
+    SignedEndpointDescriptor {
+        signature: signer
+            .sign(&endpoint_descriptor_bytes(&descriptor))
+            .unwrap(),
+        descriptor: Some(descriptor),
+        key_id: key_id.to_string(),
+    }
+    .encode_to_vec()
+}
+
+fn trusted_config(server: &TestHttpsServer) -> cli_shared::ClientConfig {
+    cli_shared::ClientConfig::default()
+        .with_tls_ca_certificate_pem(server.certificate_pem().to_string())
+}
+
+// HEDDLE_HOME is process-global, so this test helper deliberately holds the
+// repository's shared environment lock across each async scenario.
+#[allow(clippy::await_holding_lock)]
+async fn with_isolated_home_async<F, Fut, T>(test: F) -> T
+where
+    F: FnOnce(&std::path::Path) -> Fut,
+    Fut: Future<Output = T>,
+{
+    let _guard = crate::credentials::lock_test_env();
+    let home = tempfile::TempDir::new().unwrap();
+    let previous = std::env::var_os("HEDDLE_HOME");
+    unsafe {
+        std::env::set_var("HEDDLE_HOME", home.path());
+    }
+    let future = catch_unwind(AssertUnwindSafe(|| test(home.path())));
+    let output = match future {
+        Ok(future) => match AssertUnwindSafe(future).catch_unwind().await {
+            Ok(output) => output,
+            Err(payload) => {
+                unsafe {
+                    match previous.clone() {
+                        Some(value) => std::env::set_var("HEDDLE_HOME", value),
+                        None => std::env::remove_var("HEDDLE_HOME"),
+                    }
+                }
+                std::panic::resume_unwind(payload)
+            }
+        },
+        Err(payload) => std::panic::resume_unwind(payload),
+    };
+    unsafe {
+        match previous {
+            Some(value) => std::env::set_var("HEDDLE_HOME", value),
+            None => std::env::remove_var("HEDDLE_HOME"),
+        }
+    }
+    output
+}

--- a/crates/client/src/hosted/error.rs
+++ b/crates/client/src/hosted/error.rs
@@ -3,6 +3,10 @@ use api::heddle::api::v1alpha1::{CallFailure, ErrorDetail};
 /// Failure returned by the native hosted-call module.
 #[derive(Debug, thiserror::Error)]
 pub enum HostedError {
+    #[error("server does not publish descriptor trust")]
+    DescriptorTrustUnavailable,
+    #[error("{0}")]
+    DescriptorTrust(String),
     #[error("hosted endpoint descriptor is invalid: {0}")]
     InvalidDescriptor(String),
     #[error("hosted endpoint descriptor signature is invalid")]

--- a/crates/client/src/hosted/mod.rs
+++ b/crates/client/src/hosted/mod.rs
@@ -10,6 +10,7 @@ mod connection;
 mod content;
 mod context;
 mod credential;
+mod descriptor_trust;
 mod error;
 pub(crate) mod helpers;
 mod human;
@@ -17,15 +18,24 @@ mod hydration;
 mod methods;
 pub mod monorepo;
 pub(crate) mod operation_id;
+mod resolver;
 mod session;
 mod state_review;
 mod sync;
+#[cfg(test)]
+mod test_https;
 mod user;
+
+#[cfg(test)]
+mod descriptor_trust_acceptance;
 
 use std::sync::Arc;
 
 use api::heddle::api::v1alpha1::CallContext;
-pub use bootstrap::{DescriptorKeyring, VerifiedEndpointDescriptor, fetch_endpoint_descriptor};
+pub use bootstrap::{
+    DescriptorKeyDocument, DescriptorKeyring, VerifiedEndpointDescriptor,
+    fetch_descriptor_key_document, fetch_endpoint_descriptor, fetch_signed_endpoint_descriptor,
+};
 pub use call::{BidirectionalRequestStream, BidirectionalStream, ServerStream, ServerStreamItem};
 use cli_shared::ClientConfig;
 pub use collaboration::{HostedDiscussion, HostedDiscussionTurn};
@@ -35,6 +45,13 @@ pub use credential::{
     CredentialSource, ResolvedHostedCredential, resolve_active_bearer, resolve_hosted_credential,
 };
 use crypto::{Ed25519Signer, Signer as _};
+#[cfg(test)]
+pub(crate) use descriptor_trust::insert_verified_pin;
+pub use descriptor_trust::{
+    DescriptorTrustRecord, DescriptorTrustReport, DescriptorTrustSource,
+    canonical_server_authority, descriptor_public_key_fingerprint, descriptor_trust_path,
+    replace_descriptor_trust, trust_report,
+};
 pub use error::HostedError;
 pub use human::{HumanSignatureCallback, HumanSignatureRequest, WebAuthnAssertion};
 pub use hydration::{LazyHostedHydrator, register_hosted_factory};

--- a/crates/client/src/hosted/resolver.rs
+++ b/crates/client/src/hosted/resolver.rs
@@ -1,0 +1,149 @@
+//! Shared descriptor-trust resolution for every native hosted entry point.
+
+use cli_shared::ClientConfig;
+
+use super::{
+    DescriptorKeyring, HostedError, Result, VerifiedEndpointDescriptor,
+    descriptor_trust::{
+        PinInsertOutcome, canonical_server_authority, insert_verified_pin, load_automatic_pin,
+        pin_change_message, validate_descriptor_pair,
+    },
+    fetch_descriptor_key_document, fetch_signed_endpoint_descriptor,
+};
+
+pub(super) async fn resolve_and_verify_endpoint_descriptor(
+    server: &str,
+    config: &ClientConfig,
+) -> Result<VerifiedEndpointDescriptor> {
+    let canonical_server = canonical_server_authority(server)
+        .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?;
+    match (
+        config.descriptor_key_id.as_deref(),
+        config.descriptor_public_key.as_ref(),
+    ) {
+        (Some(key_id), Some(public_key)) => {
+            let mut keys = DescriptorKeyring::default();
+            keys.insert(key_id, *public_key, i64::MIN, i64::MAX)?;
+            let signed =
+                fetch_signed_endpoint_descriptor(&descriptor_url(&canonical_server), config)
+                    .await?;
+            keys.verify(&signed, now_unix_millis()?)
+        }
+        (Some(_), None) | (None, Some(_)) => Err(HostedError::DescriptorTrust(
+            "ambiguous security posture: both descriptor trust fields are required".to_string(),
+        )),
+        (None, None) => resolve_automatic_descriptor_trust(&canonical_server, config).await,
+    }
+}
+
+async fn resolve_automatic_descriptor_trust(
+    canonical_server: &str,
+    config: &ClientConfig,
+) -> Result<VerifiedEndpointDescriptor> {
+    if let Some(pin) = load_automatic_pin(canonical_server)
+        .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?
+    {
+        let signed =
+            fetch_signed_endpoint_descriptor(&descriptor_url(canonical_server), config).await?;
+        if signed.key_id != pin.key_id {
+            return Err(HostedError::DescriptorTrust(
+                pin_change_message(canonical_server, &pin, &signed.key_id)
+                    .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?,
+            ));
+        }
+        let mut keys = DescriptorKeyring::default();
+        keys.insert(
+            &pin.key_id,
+            pin.public_key_bytes()
+                .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?,
+            i64::MIN,
+            i64::MAX,
+        )?;
+        return match keys.verify(&signed, now_unix_millis()?) {
+            Err(HostedError::InvalidDescriptorSignature) => Err(HostedError::DescriptorTrust(
+                pin_change_message(canonical_server, &pin, &signed.key_id)
+                    .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?,
+            )),
+            result => result,
+        };
+    }
+
+    let document =
+        match fetch_descriptor_key_document(&descriptor_key_url(canonical_server), config).await {
+            Err(HostedError::DescriptorTrustUnavailable) => {
+                return Err(HostedError::DescriptorTrust(format!(
+                    "server does not publish descriptor trust; configure both values or upgrade \
+                     the server (canonical server: {canonical_server})"
+                )));
+            }
+            result => result?,
+        };
+    if document.version != 1 {
+        return Err(HostedError::InvalidDescriptor(format!(
+            "unsupported descriptor trust document version {}",
+            document.version
+        )));
+    }
+    let public_key = validate_descriptor_pair(&document.key_id, &document.public_key)
+        .map_err(|error| HostedError::InvalidDescriptor(error.to_string()))?;
+    let mut keys = DescriptorKeyring::default();
+    keys.insert(&document.key_id, public_key, i64::MIN, i64::MAX)?;
+    let signed =
+        fetch_signed_endpoint_descriptor(&descriptor_url(canonical_server), config).await?;
+    let verified = keys.verify(&signed, now_unix_millis()?)?;
+    let outcome = insert_verified_pin(canonical_server, &document.key_id, &public_key)
+        .map_err(|error| HostedError::DescriptorTrust(error.to_string()))?;
+    if outcome == PinInsertOutcome::Created {
+        eprintln!("Pinned descriptor trust for {canonical_server}.");
+        eprintln!("Descriptor key id: {}", document.key_id);
+        eprintln!("Descriptor public key: {}", document.public_key);
+    }
+    Ok(verified)
+}
+
+fn descriptor_url(canonical_server: &str) -> String {
+    format!("{canonical_server}/.well-known/heddle/iroh-endpoint")
+}
+
+fn descriptor_key_url(canonical_server: &str) -> String {
+    format!("{canonical_server}/.well-known/heddle/iroh-descriptor-key")
+}
+
+fn now_unix_millis() -> Result<i64> {
+    let millis = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(HostedError::transport)?
+        .as_millis();
+    i64::try_from(millis).map_err(HostedError::transport)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{descriptor_key_url, descriptor_url};
+
+    #[test]
+    fn descriptor_bootstrap_is_https_and_well_known() {
+        assert_eq!(
+            descriptor_url("https://weft.example:8421"),
+            "https://weft.example:8421/.well-known/heddle/iroh-endpoint"
+        );
+        assert_eq!(
+            descriptor_key_url("https://weft.example:8421"),
+            "https://weft.example:8421/.well-known/heddle/iroh-descriptor-key"
+        );
+    }
+
+    #[tokio::test]
+    async fn half_config_refuses_before_network_io() {
+        let error = super::resolve_and_verify_endpoint_descriptor(
+            "weft.example:8421",
+            &cli_shared::ClientConfig {
+                descriptor_key_id: Some("key-1".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(error.to_string().contains("ambiguous security posture"));
+    }
+}

--- a/crates/client/src/hosted/session.rs
+++ b/crates/client/src/hosted/session.rs
@@ -8,8 +8,8 @@ use crypto::{Ed25519Signer, Signer};
 use wire::{AuthToken, ProtocolError};
 
 use super::{
-    DescriptorKeyring, HostedClient, RenewableAuthorityCredential, credential::server_keys_match,
-    fetch_endpoint_descriptor, resolve_hosted_credential,
+    HostedClient, RenewableAuthorityCredential, credential::server_keys_match,
+    resolve_hosted_credential, resolver::resolve_and_verify_endpoint_descriptor,
 };
 use crate::credentials;
 
@@ -116,26 +116,13 @@ impl HostedSession {
     }
 
     pub async fn connect(&self, fallback_addr: SocketAddr) -> Result<HostedClient, ProtocolError> {
-        let key_id = self.config.descriptor_key_id.as_deref().ok_or_else(|| {
-            ProtocolError::InvalidState(
-                "native hosted transport requires a trusted descriptor key id".to_string(),
-            )
-        })?;
-        let public_key = self.config.descriptor_public_key.ok_or_else(|| {
-            ProtocolError::InvalidState(
-                "native hosted transport requires a trusted descriptor public key".to_string(),
-            )
-        })?;
-        let mut keys = DescriptorKeyring::default();
-        keys.insert(key_id, public_key, i64::MIN, i64::MAX)
-            .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
         let server = self
             .config
             .server_key
             .as_deref()
             .map(str::to_string)
             .unwrap_or_else(|| fallback_addr.to_string());
-        let descriptor = fetch_endpoint_descriptor(&descriptor_url(&server)?, &keys, &self.config)
+        let descriptor = resolve_and_verify_endpoint_descriptor(&server, &self.config)
             .await
             .map_err(|error| ProtocolError::Remote(error.to_string()))?;
         let mut client = HostedClient::connect_with_config(&descriptor, &self.config)
@@ -156,15 +143,7 @@ impl HostedClient {
     /// verification and Iroh address selection remain inside the hosted-call
     /// module instead of being repeated by each caller.
     pub async fn connect_server(server: &str, config: &ClientConfig) -> Result<Self> {
-        let key_id = config.descriptor_key_id.as_deref().ok_or_else(|| {
-            anyhow::anyhow!("native hosted transport requires a trusted descriptor key id")
-        })?;
-        let public_key = config.descriptor_public_key.ok_or_else(|| {
-            anyhow::anyhow!("native hosted transport requires a trusted descriptor public key")
-        })?;
-        let mut keys = DescriptorKeyring::default();
-        keys.insert(key_id, public_key, i64::MIN, i64::MAX)?;
-        let descriptor = fetch_endpoint_descriptor(&descriptor_url(server)?, &keys, config).await?;
+        let descriptor = resolve_and_verify_endpoint_descriptor(server, config).await?;
         Ok(Self::connect_with_config(&descriptor, config).await?)
     }
 
@@ -189,22 +168,6 @@ impl HostedClient {
             .connect(addr)
             .await?)
     }
-}
-
-fn descriptor_url(server: &str) -> Result<String, ProtocolError> {
-    let authority = server
-        .strip_prefix("https://")
-        .or_else(|| server.strip_prefix("heddle://"))
-        .unwrap_or(server)
-        .trim_end_matches('/');
-    if server.starts_with("http://") || authority.is_empty() || authority.contains('/') {
-        return Err(ProtocolError::InvalidState(
-            "native hosted bootstrap requires an HTTPS server authority".to_string(),
-        ));
-    }
-    Ok(format!(
-        "https://{authority}/.well-known/heddle/iroh-endpoint"
-    ))
 }
 
 fn validated_authenticated_principal(credential: &credentials::ServerCredential) -> Result<String> {
@@ -250,29 +213,4 @@ fn shared_device_proof_key(server_key: &str, token: &str) -> Result<Option<Strin
         return Ok(None);
     }
     Ok(Some(identity.private_key_pem))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::descriptor_url;
-
-    #[test]
-    fn descriptor_bootstrap_is_https_and_well_known() {
-        assert_eq!(
-            descriptor_url("heddle://weft.example:8421").unwrap(),
-            "https://weft.example:8421/.well-known/heddle/iroh-endpoint"
-        );
-        assert!(descriptor_url("http://weft.example:8421").is_err());
-    }
-
-    #[tokio::test]
-    async fn connect_server_requires_a_descriptor_trust_root_before_network_io() {
-        let error = crate::hosted::HostedClient::connect_server(
-            "weft.example:8421",
-            &cli_shared::ClientConfig::default(),
-        )
-        .await
-        .unwrap_err();
-        assert!(error.to_string().contains("trusted descriptor key id"));
-    }
 }

--- a/crates/client/src/hosted/test_https.rs
+++ b/crates/client/src/hosted/test_https.rs
@@ -1,0 +1,206 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+use rustls::{
+    ServerConfig, ServerConnection, StreamOwned,
+    pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+};
+
+#[derive(Clone)]
+pub(super) struct TestResponse {
+    status: u16,
+    content_type: Option<&'static str>,
+    location: Option<String>,
+    body: Vec<u8>,
+}
+
+impl TestResponse {
+    pub(super) fn json(body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            status: 200,
+            content_type: Some("application/json"),
+            location: None,
+            body: body.into(),
+        }
+    }
+
+    pub(super) fn protobuf(body: impl Into<Vec<u8>>) -> Self {
+        Self {
+            status: 200,
+            content_type: Some("application/protobuf"),
+            location: None,
+            body: body.into(),
+        }
+    }
+
+    pub(super) fn status(status: u16) -> Self {
+        Self {
+            status,
+            content_type: None,
+            location: None,
+            body: Vec::new(),
+        }
+    }
+
+    pub(super) fn redirect(location: impl Into<String>) -> Self {
+        Self {
+            status: 302,
+            content_type: None,
+            location: Some(location.into()),
+            body: Vec::new(),
+        }
+    }
+}
+
+pub(super) struct TestHttpsServer {
+    authority: String,
+    certificate_pem: String,
+    requests: Arc<Mutex<Vec<String>>>,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl TestHttpsServer {
+    pub(super) fn start(routes: HashMap<String, VecDeque<TestResponse>>) -> Self {
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(vec!["127.0.0.1".to_string()])
+                .expect("generate test TLS certificate");
+        let certificate_pem = cert.pem();
+        let private_key =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+        let tls = Arc::new(
+            ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert.der().clone()], private_key)
+                .expect("test TLS server config"),
+        );
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind test HTTPS server");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking test HTTPS listener");
+        let authority = format!("https://{}", listener.local_addr().unwrap());
+        let requests = Arc::new(Mutex::new(Vec::new()));
+        let thread_requests = Arc::clone(&requests);
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let routes = Arc::new(Mutex::new(routes));
+        let thread = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        serve_connection(
+                            stream,
+                            Arc::clone(&tls),
+                            Arc::clone(&routes),
+                            Arc::clone(&thread_requests),
+                        );
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => panic!("test HTTPS accept failed: {error}"),
+                }
+            }
+        });
+        Self {
+            authority,
+            certificate_pem,
+            requests,
+            stop,
+            thread: Some(thread),
+        }
+    }
+
+    pub(super) fn authority(&self) -> &str {
+        &self.authority
+    }
+
+    pub(super) fn certificate_pem(&self) -> &str {
+        &self.certificate_pem
+    }
+
+    pub(super) fn requests(&self) -> Vec<String> {
+        self.requests.lock().unwrap().clone()
+    }
+}
+
+impl Drop for TestHttpsServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve_connection(
+    stream: TcpStream,
+    tls: Arc<ServerConfig>,
+    routes: Arc<Mutex<HashMap<String, VecDeque<TestResponse>>>>,
+    requests: Arc<Mutex<Vec<String>>>,
+) {
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("test HTTPS read timeout");
+    let connection = ServerConnection::new(tls).expect("test TLS connection");
+    let mut stream = StreamOwned::new(connection, stream);
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        let count = match stream.read(&mut chunk) {
+            Ok(count) => count,
+            Err(_) => return,
+        };
+        if count == 0 {
+            return;
+        }
+        request.extend_from_slice(&chunk[..count]);
+    }
+    let request_line = String::from_utf8_lossy(&request);
+    let path = request_line
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .unwrap_or("/")
+        .to_string();
+    requests.lock().unwrap().push(path.clone());
+    let response = routes
+        .lock()
+        .unwrap()
+        .get_mut(&path)
+        .and_then(VecDeque::pop_front)
+        .unwrap_or_else(|| TestResponse::status(404));
+    let reason = match response.status {
+        200 => "OK",
+        302 => "Found",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        _ => "Test Status",
+    };
+    let mut headers = format!(
+        "HTTP/1.1 {} {reason}\r\nContent-Length: {}\r\nConnection: close\r\n",
+        response.status,
+        response.body.len()
+    );
+    if let Some(content_type) = response.content_type {
+        headers.push_str(&format!("Content-Type: {content_type}\r\n"));
+    }
+    if let Some(location) = response.location {
+        headers.push_str(&format!("Location: {location}\r\n"));
+    }
+    headers.push_str("\r\n");
+    let _ = stream
+        .write_all(headers.as_bytes())
+        .and_then(|_| stream.write_all(&response.body))
+        .and_then(|_| stream.flush());
+}

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1854,6 +1854,36 @@ the same ready envelope.
 
 ---
 
+## `heddle auth trust show --output json`
+
+```json
+{
+  "output_kind": "auth_trust_show",
+  "canonical_server": "https://api.heddle.sh",
+  "source": "automatic",
+  "key_id": "production-2026-01",
+  "public_key": "7c5eb1d4f7c09c8981789c759b1445676336afe9c88d08f57d02893df9ea23c4",
+  "fingerprint": "sha256:f31c0dbdb183e33f2366f5daa71273d3444006c0143e0f8d65e0745478c14b48"
+}
+```
+
+---
+
+## `heddle auth trust replace --output json`
+
+```json
+{
+  "output_kind": "auth_trust_replace",
+  "canonical_server": "https://api.heddle.sh",
+  "source": "automatic",
+  "key_id": "production-2026-02",
+  "public_key": "280c37c667a6334f69e878f90588d8813bb44fc88333757b3e2d6b1e79bdab01",
+  "fingerprint": "sha256:06d1aac7c406aa1cd62280ae9948af0fd2d42ac10ba5c8c0b3a7840d9deb7275"
+}
+```
+
+---
+
 ## `heddle whoami --output json`
 
 ```json
@@ -3039,26 +3069,26 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust remove",
       "redact purge apply"
     ],
-    "advanced_scope_json_commands_total": 106,
+    "advanced_scope_json_commands_total": 108,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 61,
+    "advanced_scope_mutating_commands_total": 62,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 22,
-    "catalog_commands_total": 183,
-    "catalog_mutating_commands_total": 89,
-    "json_commands_total": 146,
+    "catalog_commands_total": 186,
+    "catalog_mutating_commands_total": 90,
+    "json_commands_total": 148,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 107,
+    "json_commands_with_schema": 109,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 85,
+    "json_mutating_commands_total": 86,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 85,
+    "mutating_commands_total": 86,
     "mutating_commands_with_accepted_opaque_schema": 22,
-    "mutating_commands_with_schema": 63,
+    "mutating_commands_with_schema": 64,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "183 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3096,7 +3126,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "183 command(s), 146 JSON command(s), 89 mutating command(s), 85 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true


### PR DESCRIPTION
## Summary

- Discover descriptor-signing trust over authenticated HTTPS on first contact, verify the signed descriptor, then atomically pin the exact server/key pair before Iroh traffic.
- Preserve explicit-pair precedence and the half-config gate, refuse pin changes without state mutation, and add compare-and-swap `auth trust show` / `auth trust replace` surfaces.
- Cover canonical aliases, strict candidate parsing, TLS authentication, pin reuse/change, persistence boundaries, concurrent first contact, old servers, credential-file behavior, and CLI/schema contracts.

## Closes

Closes HeddleCo/heddle#1130

## Test evidence

- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-issue-1130-target cargo test -p heddle-cli --test cli_integration output_kind_invariant::every_json_emitting_verb_is_classified -- --exact` — 1 passed; both new verbs are in `SWEPT` with `output_kind` discriminators.
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-issue-1130-target cargo test --locked -p heddle-cli --features git-overlay,native,semantic,zstd --test ts_types_in_sync` — 2 passed after regenerating the NPM schemas.
- GitHub Actions on `4bfd9825b50e15b53bccc9e53fe78f9e69d1aabe` — 19 successful, 4 skipped, 0 failed; [Rust Tests / Quality](https://github.com/HeddleCo/heddle/actions/runs/30380064643/job/90345508169) passed in 17m32s.
- The previously reported client/contract/shared/args suites remain green: client 132 passed, CLI contract 123 passed, CLI shared 25 passed, CLI args 16 passed.

### Acceptance test 14 — passed

Ran current weft `main` at `4f7888ee` (publisher PR #852, including the CA:FALSE TLS leaf fix at `87fcd198`) with the current Heddle checkout. Because host port 8421 was occupied, compose project `heddle1130` used an external `-f /home/scratch/issue-1130-compose.override.yml` whose port lists use `!override`; the tested equivalent URL was `https://127.0.0.1:18421`. The repository's `docker-compose.yml` was not edited.

The fresh client home was `/home/scratch/heddle1130-home`. Its only out-of-band trust input was the stack's **public TLS certificate** through `tls_ca_certificate_path`. `HEDDLE_SERVER_IROH_DESCRIPTOR_SIGNING_KEY`, `HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID`, and `HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY` were explicitly unset for the client commands. The test never read weft's descriptor-signing private key or `dev-secrets.env`. Device authorization was completed directly in the isolated test stack's Postgres fixture using the pending client's public key; no descriptor-signing material was involved.

Login transcript (exit 0):

```text
$ env -u HEDDLE_SERVER_IROH_DESCRIPTOR_SIGNING_KEY \
      -u HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID \
      -u HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY \
      HEDDLE_HOME=/home/scratch/heddle1130-home \
      HEDDLE_CONFIG=/home/scratch/heddle1130-user-config.toml \
      heddle auth login --server https://127.0.0.1:18421
Pinned descriptor trust for https://127.0.0.1:18421.
Descriptor key id: weft-local-dev
Descriptor public key: 0b71d20d788e1242fceba986ddaa015b8c2ed86cfc60bc1df395b9a9c3a4d667

Open this URL to authorize:
  http://localhost:5173/auth/device

Enter code: JCBUXHZT

Waiting for authorization...
Authenticated as acceptance-1130. Credentials saved.
```

Pinned state before restart:

```json
{"output_kind":"auth_trust_show","canonical_server":"https://127.0.0.1:18421","source":"automatic","key_id":"weft-local-dev","public_key":"0b71d20d788e1242fceba986ddaa015b8c2ed86cfc60bc1df395b9a9c3a4d667","fingerprint":"sha256:d739f548f73da523e183b88e4050bff3524d463b8dc8f76105da4fda258477e0"}
```

Restart and persistence proof:

```text
$ docker compose ... restart weft
$ # wait for healthy, then fetch the public discovery document again
published_key_same_after_restart: yes
pin_sha_before: f2d1f3cfa42fdbaf0ca439ca8faa170f0edb748e8527684cc38d0d7600bcde48
pin_sha_after:  f2d1f3cfa42fdbaf0ca439ca8faa170f0edb748e8527684cc38d0d7600bcde48
pin_unchanged: yes

$ heddle whoami --server https://127.0.0.1:18421 --output json
{"output_kind":"whoami","server":"https://127.0.0.1:18421","authenticated":true,"reachable":true,"token_kind":"root","identity":{"subject":"acceptance-1130","device_id":"dev-acceptance-1130","amr":["device_code"]}}
```

The CLI emitted a non-fatal Iroh endpoint-drop warning after the successful login/whoami commands; both commands exited 0 and the networked post-restart identity check succeeded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787846865&installation_model_id=21489&pr_number=1131&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1131&signature=c6983c943653ebfe44f715060bd43ae329b24da546385f7487071dca4080989c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
