### PR TITLE
fix: accept HTTPS for native remotes

### DIFF
--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -1026,7 +1026,7 @@ impl RecoveryAdvice {
             format!(
                 "Refusing to {action}: remote '{remote}' is a Git remote, not a Heddle-native remote"
             ),
-            "Use a Heddle-native remote here, or clone/adopt that Git remote in a Git-overlay checkout.",
+            "For a native server, use `heddle://<host>/<repo>` to force Heddle transport, or clone/adopt this Git remote in a Git-overlay checkout.",
             format!("remote '{remote}' resolves to Git storage"),
             format!(
                 "{action} would route a Git repository through Heddle-native sync and fail after setup work"
@@ -1037,6 +1037,23 @@ impl RecoveryAdvice {
                 "heddle clone <remote> <fresh-path>".to_string(),
                 "heddle remote add <name> <url>".to_string(),
             ],
+        )
+    }
+
+    pub fn native_https_iroh_endpoint_missing(action: &str, remote: &str) -> Self {
+        Self::safety_refusal(
+            "native_https_iroh_endpoint_missing",
+            format!(
+                "Refusing to {action}: HTTPS server for remote '{remote}' does not advertise an Iroh endpoint"
+            ),
+            "Configure the server to publish `/.well-known/heddle/iroh-endpoint`, then retry. Heddle will not silently fall back to Git transport.",
+            format!(
+                "remote '{remote}' returned no Iroh endpoint descriptor at `/.well-known/heddle/iroh-endpoint`"
+            ),
+            "falling back would silently downgrade a native repository to Git transport",
+            "remote configuration, Heddle refs, Git refs, and worktree files were left unchanged",
+            "heddle help remotes",
+            vec!["heddle help remotes".to_string()],
         )
     }
 

--- a/crates/cli-shared/src/remote/mod.rs
+++ b/crates/cli-shared/src/remote/mod.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 use objects::fs_atomic::write_file_atomic;
-use repo::Repository;
+use repo::{Repository, RepositoryCapability};
 use serde::{Deserialize, Serialize};
 pub use target::RemoteTarget;
 
@@ -180,24 +180,35 @@ pub fn resolve_remote_with_key_and_insecure(
     // Named remote first so configured `insecure` applies even when the
     // name also happens to parse as a bare host:port.
     if let Ok(remote) = cfg.get(&spec)
-        && let Ok(target) = RemoteTarget::parse(&remote.url)
+        && let Ok(target) = parse_target_for_repository(repo, &remote.url)
     {
         let key = credential_key_from_url(&remote.url);
         return Ok((target, key, remote.insecure));
     }
 
-    if let Ok(target) = RemoteTarget::parse(&spec) {
+    if let Ok(target) = parse_target_for_repository(repo, &spec) {
         let key = credential_key_from_url(&spec);
         return Ok((target, key, false));
     }
 
     let remote = cfg.get(&spec)?;
-    if let Ok(target) = RemoteTarget::parse(&remote.url) {
+    if let Ok(target) = parse_target_for_repository(repo, &remote.url) {
         let key = credential_key_from_url(&remote.url);
         return Ok((target, key, remote.insecure));
     }
 
     Err(RemoteError::InvalidUrl(remote.url))
+}
+
+/// Parse a remote using the repository's source authority to interpret HTTPS.
+pub fn parse_target_for_repository(
+    repo: &Repository,
+    url: &str,
+) -> std::result::Result<RemoteTarget, String> {
+    match repo.capability() {
+        RepositoryCapability::NativeHeddle => RemoteTarget::parse_native(url),
+        RepositoryCapability::GitOverlay => RemoteTarget::parse(url),
+    }
 }
 
 /// Whether a named remote (or the default) has `insecure = true` in
@@ -289,6 +300,33 @@ mod tests {
         let reopened = RemoteConfig::open(&repo).expect("reopen config");
         let remote = reopened.get("origin").expect("load remote");
         assert_eq!(remote.url, "http://heddle.example:8421/repo");
+
+        let _ = fs::remove_dir_all(temp);
+    }
+
+    #[test]
+    fn native_https_remote_round_trips_without_rewriting_the_scheme() {
+        let temp = unique_temp_dir("heddle-https-remote-test");
+        fs::create_dir_all(&temp).expect("create temp dir");
+        let repo = Repository::init_default(&temp).expect("init repo");
+        let url = "https://127.0.0.1:8431/acme/heddle";
+
+        let mut cfg = RemoteConfig::open(&repo).expect("open config");
+        cfg.add(
+            "origin",
+            Remote {
+                url: url.to_string(),
+                insecure: false,
+            },
+        )
+        .expect("add HTTPS remote");
+
+        let reopened = RemoteConfig::open(&repo).expect("reopen config");
+        assert_eq!(reopened.get("origin").expect("load remote").url, url);
+        let (target, key) =
+            resolve_remote_with_key(&repo, Some("origin")).expect("resolve native HTTPS remote");
+        assert!(matches!(target, RemoteTarget::Network { .. }));
+        assert_eq!(key.as_deref(), Some("127.0.0.1:8431"));
 
         let _ = fs::remove_dir_all(temp);
     }

--- a/crates/cli-shared/src/remote/target.rs
+++ b/crates/cli-shared/src/remote/target.rs
@@ -47,6 +47,21 @@ impl RemoteTarget {
         ))
     }
 
+    /// Parse a target under native repository source authority.
+    ///
+    /// Native repositories may use an HTTPS repository URL after the caller
+    /// has verified the server's well-known Iroh endpoint. The regular parser
+    /// deliberately keeps treating HTTPS as non-native so Git-owned callers
+    /// retain their existing transport classification.
+    pub fn parse_native(s: &str) -> Result<Self, String> {
+        if let Some(rest) = s.strip_prefix("https://") {
+            let (addr, repo_path) = parse_https_network_with_repo_path(rest)
+                .ok_or_else(|| format!("invalid native HTTPS remote url: {s}"))?;
+            return Ok(RemoteTarget::Network { addr, repo_path });
+        }
+        Self::parse(s)
+    }
+
     /// Check if this is a local target.
     pub fn is_local(&self) -> bool {
         matches!(self, RemoteTarget::Local(_))
@@ -96,6 +111,30 @@ fn parse_network_with_repo_path(s: &str) -> Option<(SocketAddr, Option<String>)>
     Some((addr, Some(repo_path.to_string())))
 }
 
+fn parse_https_network_with_repo_path(s: &str) -> Option<(SocketAddr, Option<String>)> {
+    if s.is_empty() || s.contains(['?', '#', '@']) {
+        return None;
+    }
+    let (authority, repo_path) = match s.split_once('/') {
+        Some((authority, path)) => (authority, Some(path.trim_matches('/'))),
+        None => (s, None),
+    };
+    if authority.is_empty() {
+        return None;
+    }
+    let addr = resolve_socket_addr(authority).or_else(|| {
+        let host = authority
+            .strip_prefix('[')
+            .and_then(|host| host.strip_suffix(']'))
+            .unwrap_or(authority);
+        (host, 443).to_socket_addrs().ok()?.next()
+    })?;
+    let repo_path = repo_path
+        .filter(|path| !path.is_empty())
+        .map(str::to_string);
+    Some((addr, repo_path))
+}
+
 fn resolve_socket_addr(addr: &str) -> Option<SocketAddr> {
     if let Ok(parsed) = addr.parse::<SocketAddr>() {
         return Some(parsed);
@@ -131,6 +170,31 @@ mod tests {
                 assert!(addr.ip().is_loopback());
                 assert_eq!(repo_path.as_deref(), Some("acme/heddle"));
             }
+            other => panic!("expected network target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn native_parser_accepts_https_without_changing_generic_classification() {
+        assert!(RemoteTarget::parse("https://127.0.0.1:8431/acme/heddle").is_err());
+
+        let target = RemoteTarget::parse_native("https://127.0.0.1:8431/acme/heddle")
+            .expect("parse native HTTPS URL");
+        match target {
+            RemoteTarget::Network { addr, repo_path } => {
+                assert_eq!(addr, "127.0.0.1:8431".parse().unwrap());
+                assert_eq!(repo_path.as_deref(), Some("acme/heddle"));
+            }
+            other => panic!("expected network target, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn native_https_parser_defaults_to_port_443() {
+        let target =
+            RemoteTarget::parse_native("https://127.0.0.1/acme/heddle").expect("parse HTTPS URL");
+        match target {
+            RemoteTarget::Network { addr, .. } => assert_eq!(addr.port(), 443),
             other => panic!("expected network target, got {other:?}"),
         }
     }

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -880,17 +880,50 @@ pub(super) enum RemoteTransportKind {
     Unknown,
 }
 
-pub(super) fn preflight_native_remote_transport(
+pub(super) async fn preflight_native_remote_transport(
     repo: &Repository,
     remote_arg: Option<&str>,
     action: &str,
 ) -> Result<()> {
+    if repo.capability() == RepositoryCapability::NativeHeddle
+        && let Some(spec) = remote_spec_for_transport(repo, remote_arg, RemoteAccess::Push)
+        && spec.starts_with("https://")
+    {
+        discover_native_https_remote(&spec, action).await?;
+    }
     match classify_push_remote_spec(repo, remote_arg) {
         Some(RemoteTransportKind::LocalGit | RemoteTransportKind::GitUrl) => Err(anyhow!(
             RecoveryAdvice::remote_transport_mismatch(action, remote_arg.unwrap_or("<default>"))
         )),
         _ => Ok(()),
     }
+}
+
+#[cfg(feature = "client")]
+async fn discover_native_https_remote(spec: &str, action: &str) -> Result<()> {
+    let RemoteTarget::Network { addr, .. } =
+        RemoteTarget::parse_native(spec).map_err(anyhow::Error::msg)?
+    else {
+        anyhow::bail!("native HTTPS discovery requires a network remote");
+    };
+    let server_key = cli_shared::remote::credential_key_from_remote_url(spec);
+    let session = HostedSession::build(
+        &UserConfig::load_default()?,
+        server_key,
+        HostedAuthMode::Unauthenticated,
+    )?;
+    match session.discover_endpoint(addr).await {
+        Ok(_) => Ok(()),
+        Err(heddle_client::hosted::HostedError::EndpointDescriptorUnavailable) => {
+            Err(RecoveryAdvice::native_https_iroh_endpoint_missing(action, spec).into())
+        }
+        Err(error) => Err(error.into()),
+    }
+}
+
+#[cfg(not(feature = "client"))]
+async fn discover_native_https_remote(_spec: &str, action: &str) -> Result<()> {
+    Err(anyhow!(RecoveryAdvice::network_feature_unavailable(action)))
 }
 
 fn classify_push_remote_spec(
@@ -919,7 +952,7 @@ fn classify_remote_spec(
     access: RemoteAccess,
 ) -> Option<RemoteTransportKind> {
     let spec = remote_spec_for_transport(repo, remote_arg, access)?;
-    if let Ok(target) = RemoteTarget::parse(&spec) {
+    if let Ok(target) = cli_shared::remote::parse_target_for_repository(repo, &spec) {
         return Some(match target {
             RemoteTarget::Local(path) => {
                 if let Ok(target_repo) = Repository::open(&path) {
@@ -1845,6 +1878,34 @@ mod tests {
             } if path == "acme/widget"
         ));
         assert_eq!(key.as_deref(), Some("127.0.0.1:8421"));
+    }
+
+    #[test]
+    fn https_transport_follows_repository_source_authority() {
+        let native_dir = tempfile::TempDir::new().unwrap();
+        let native = Repository::init_default(native_dir.path()).unwrap();
+        let https = "https://127.0.0.1:8431/acme/widget";
+        assert_eq!(
+            classify_push_remote_spec(&native, Some(https)),
+            Some(RemoteTransportKind::NetworkHeddle)
+        );
+        let (target, key) = resolve_push_target_with_key(&native, Some(https)).unwrap();
+        assert!(matches!(
+            target,
+            RemoteTarget::Network {
+                repo_path: Some(ref path),
+                ..
+            } if path == "acme/widget"
+        ));
+        assert_eq!(key.as_deref(), Some("127.0.0.1:8431"));
+
+        let overlay_dir = tempfile::TempDir::new().unwrap();
+        SleyRepository::init(overlay_dir.path()).unwrap();
+        let overlay = Repository::init_git_overlay_sidecar(overlay_dir.path()).unwrap();
+        assert_eq!(
+            classify_push_remote_spec(&overlay, Some(https)),
+            Some(RemoteTransportKind::GitUrl)
+        );
     }
 
     // Capability / push-routing pure decisions live in heddle_core::remote.

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1152,7 +1152,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
 }
 
 /// Execute remote command.
-pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
+pub async fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
     match &command {
@@ -1190,7 +1190,7 @@ pub fn cmd_remote(cli: &Cli, command: RemoteCommands) -> Result<()> {
             Ok(())
         }
         RemoteCommands::Add { name, url } => {
-            super::preflight_native_remote_transport(&repo, Some(&url), "remote add")?;
+            super::preflight_native_remote_transport(&repo, Some(&url), "remote add").await?;
             let mut cfg = RemoteConfig::open(&repo).map_err(anyhow::Error::new)?;
             cfg.add(
                 &name,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -614,7 +614,7 @@ async fn async_main() -> Result<()> {
             .await
         }
 
-        Commands::Remote { command } => cmd_remote(&cli, command.clone()),
+        Commands::Remote { command } => cmd_remote(&cli, command.clone()).await,
 
         #[cfg(feature = "client")]
         Commands::Auth { command } => {

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
+use cli::remote::RemoteConfig;
 use objects::object::{MarkerName, ThreadName};
 use sley::{ConfigEdit, ConfigEditPlan};
 
@@ -321,7 +322,7 @@ fn test_cli_remote_operations() {
 fn native_remote_add_rejects_local_git_remote_before_configuring_default() {
     let temp = TempDir::new().unwrap();
     let bare = TempDir::new().unwrap();
-    heddle(&["init"], Some(temp.path())).unwrap();
+    let repo = Repository::init_default(temp.path()).expect("init native Heddle repo");
     SleyRepository::init_bare(bare.path()).expect("init bare Git remote");
 
     let output = heddle_output(
@@ -358,12 +359,16 @@ fn native_remote_add_rejects_local_git_remote_before_configuring_default() {
         ]),
         "Git remote mismatch should offer clone/adopt path before native remote setup: {envelope}"
     );
+    assert!(
+        envelope["hint"]
+            .as_str()
+            .is_some_and(|hint| hint.contains("heddle://<host>/<repo>")),
+        "Git remote mismatch should name the explicit native scheme: {envelope}"
+    );
 
-    let remotes = heddle(&["--output", "json", "remote", "list"], Some(temp.path())).unwrap();
-    let remotes: Value = serde_json::from_str(&remotes).expect("remote list JSON");
-    assert_eq!(remotes["remotes"].as_array().unwrap().len(), 0);
-    let verify = verify_json(temp.path());
-    assert_eq!(verify["default_remote"], Value::Null);
+    let remotes = RemoteConfig::open(&repo).expect("open native remotes after refusal");
+    assert!(remotes.list().is_empty());
+    assert!(remotes.default_name().is_none());
 }
 
 #[test]

--- a/crates/client/src/hosted/bootstrap.rs
+++ b/crates/client/src/hosted/bootstrap.rs
@@ -190,6 +190,9 @@ pub async fn fetch_signed_endpoint_descriptor(
         request = request.header(HOST, host_header);
     }
     let response = request.send().await?;
+    if response.status() == StatusCode::NOT_FOUND {
+        return Err(HostedError::EndpointDescriptorUnavailable);
+    }
     if response.status() != StatusCode::OK {
         return Err(HostedError::InvalidDescriptor(format!(
             "endpoint descriptor request returned HTTP {}",

--- a/crates/client/src/hosted/descriptor_trust_acceptance.rs
+++ b/crates/client/src/hosted/descriptor_trust_acceptance.rs
@@ -269,6 +269,36 @@ async fn explicit_pair_skips_discovery_and_old_server_failure_is_actionable() {
     .await;
 }
 
+#[tokio::test]
+async fn missing_iroh_endpoint_is_named_and_never_downgrades() {
+    with_isolated_home_async(|_| async {
+        let signer = Ed25519Signer::generate().unwrap();
+        let server = TestHttpsServer::start(HashMap::from([(
+            KEY_PATH.to_string(),
+            VecDeque::from([TestResponse::json(key_document(
+                1,
+                "missing-endpoint",
+                signer.public_key(),
+            ))]),
+        )]));
+
+        let error =
+            resolve_and_verify_endpoint_descriptor(server.authority(), &trusted_config(&server))
+                .await
+                .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("server does not advertise an Iroh endpoint"),
+            "missing endpoint must be explicit, got: {error}"
+        );
+        assert!(load_automatic_pin(server.authority()).unwrap().is_none());
+        assert_eq!(server.requests(), [KEY_PATH, DESCRIPTOR_PATH]);
+    })
+    .await;
+}
+
 fn server_with_pair(
     key_id: &str,
     signer: &Ed25519Signer,

--- a/crates/client/src/hosted/error.rs
+++ b/crates/client/src/hosted/error.rs
@@ -5,6 +5,8 @@ use api::heddle::api::v1alpha1::{CallFailure, ErrorDetail};
 pub enum HostedError {
     #[error("server does not publish descriptor trust")]
     DescriptorTrustUnavailable,
+    #[error("server does not advertise an Iroh endpoint at /.well-known/heddle/iroh-endpoint")]
+    EndpointDescriptorUnavailable,
     #[error("{0}")]
     DescriptorTrust(String),
     #[error("hosted endpoint descriptor is invalid: {0}")]

--- a/crates/client/src/hosted/session.rs
+++ b/crates/client/src/hosted/session.rs
@@ -115,14 +115,22 @@ impl HostedSession {
         self
     }
 
-    pub async fn connect(&self, fallback_addr: SocketAddr) -> Result<HostedClient, ProtocolError> {
+    pub async fn discover_endpoint(
+        &self,
+        fallback_addr: SocketAddr,
+    ) -> super::Result<super::VerifiedEndpointDescriptor> {
         let server = self
             .config
             .server_key
             .as_deref()
             .map(str::to_string)
             .unwrap_or_else(|| fallback_addr.to_string());
-        let descriptor = resolve_and_verify_endpoint_descriptor(&server, &self.config)
+        resolve_and_verify_endpoint_descriptor(&server, &self.config).await
+    }
+
+    pub async fn connect(&self, fallback_addr: SocketAddr) -> Result<HostedClient, ProtocolError> {
+        let descriptor = self
+            .discover_endpoint(fallback_addr)
             .await
             .map_err(|error| ProtocolError::Remote(error.to_string()))?;
         let mut client = HostedClient::connect_with_config(&descriptor, &self.config)


### PR DESCRIPTION
## Summary

- Treat `https://` as a native network target only when repository source authority is native; Git-overlay classification stays unchanged, `heddle://` remains the explicit force-native form, and stored HTTPS URLs round-trip unchanged.
- Reuse the hosted signed endpoint-descriptor discovery and trust path before adding a native HTTPS remote. If `/.well-known/heddle/iroh-endpoint` is absent, refuse with structured advice and do not fall back to Git: that fallback would be an implicit transport downgrade.
- Name `heddle://<host>/<repo>` in the genuine-Git-remote mismatch advice. This does not change Git-lane CA handling from #1132.

## Closes

Closes #1133

## Test evidence

- Negative test was observed failing first with the old generic `InvalidDescriptor` 404, then passing as `missing_iroh_endpoint_is_named_and_never_downgrades`.
- Focused parser, source-authority routing, HTTPS round-trip, missing-endpoint, and Git-remote advice tests pass.
- Live local hosted verification: `remote add` preserved the HTTPS spelling and a real push returned `transport: heddle`, `status: pushed`; the explicit `heddle://` form also pushed successfully.
- Live 404 verification exits 74 with `kind: native_https_iroh_endpoint_missing`, names `/.well-known/heddle/iroh-endpoint`, and states that no Git fallback is attempted.
- CI affected-package `cargo build --locked ... --tests --bin heddle --bin heddle-fuse-worker` and `cargo clippy --locked ... --lib --bins --tests --examples -- -D warnings` pass.
- All four CI alternate-feature `cargo check --locked ... --no-default-features --features ...` commands pass (the existing alternate-feature dead-code warnings remain).
- The exact affected-package `cargo test --locked ...` command was also run. In this managed sandbox its integration fixtures see injected read-only `.git` mounts, producing broad unrelated failures; the run later stopped making progress in `stdout_stderr_split::json_mode_keeps_stdout_clean_on_every_catalog_command` and was interrupted after the failures were recorded. GitHub CI remains the authoritative full-suite run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787885986&installation_model_id=21489&pr_number=1134&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1134&signature=d61606b00dd387322933815aa398ca7fd2b58a4a1f5af3f0a3b1c2bac1cd4540"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->