### PR TITLE
feat(client): add inert owner-anchored authorization surface

### DIFF
--- a/crates/cli/tests/owner_authorization_offline_clone.rs
+++ b/crates/cli/tests/owner_authorization_offline_clone.rs
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(target_os = "linux")]
+
+use std::{
+    net::{Ipv4Addr, SocketAddrV4, TcpStream},
+    path::{Path, PathBuf},
+    process::Command,
+    time::Duration,
+};
+
+use heddle_client::owner_authorization::{
+    AuthorizationError, AuthorizationKey, CloneKeyringStore, GuardianSigner, OfflineAuthorizer,
+    OfflineRequest, RecoverySetup, VerificationLimits, create_clone_keyring,
+    create_direct_capability, create_human_owner_root, mint_subject_biscuit, verify_owner_root,
+    wire::{
+        CapabilityPrincipal, CapabilityPrincipalKind, CloneOwnerPinKind, SpoolCapabilityAction,
+        SpoolCapabilityGrant, SpoolSelector,
+    },
+};
+use sley::Repository as SleyRepository;
+use tempfile::TempDir;
+
+const NOW: i64 = 1_000;
+
+fn limits() -> VerificationLimits {
+    VerificationLimits::new(300, 3_600, 1024 * 1024).expect("limits")
+}
+
+fn heddle(args: &[&str], cwd: Option<&std::path::Path>, test_home: &std::path::Path) {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    command
+        .env_clear()
+        .args(args)
+        .env("HOME", test_home)
+        .env("HEDDLE_CONFIG", test_home.join("config.toml"))
+        .env("RUST_BACKTRACE", "1")
+        .env("HEDDLE_PRINCIPAL_NAME", "Offline Clone Test")
+        .env("HEDDLE_PRINCIPAL_EMAIL", "offline-clone@heddle.test");
+    if let Some(cwd) = cwd {
+        command.current_dir(cwd);
+    }
+    let output = command.output().expect("run heddle");
+    assert!(
+        output.status.success(),
+        "heddle {args:?} failed\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn disconnect_network_for_current_thread() {
+    const LOAD_SYSCALL_NUMBER: u16 = 0x20;
+    const JUMP_EQUAL: u16 = 0x15;
+    const RETURN: u16 = 0x06;
+    const SECCOMP_RETURN_ERRNO: u32 = 0x0005_0000;
+    const SECCOMP_RETURN_ALLOW: u32 = 0x7fff_0000;
+
+    let denied = [
+        libc::SYS_socket,
+        libc::SYS_socketpair,
+        libc::SYS_connect,
+        libc::SYS_bind,
+        libc::SYS_listen,
+        libc::SYS_accept,
+        libc::SYS_accept4,
+        libc::SYS_sendto,
+        libc::SYS_sendmsg,
+        libc::SYS_recvfrom,
+        libc::SYS_recvmsg,
+        libc::SYS_shutdown,
+    ];
+    let mut filters = Vec::with_capacity(denied.len() * 2 + 2);
+    filters.push(libc::sock_filter {
+        code: LOAD_SYSCALL_NUMBER,
+        jt: 0,
+        jf: 0,
+        k: 0,
+    });
+    for syscall in denied {
+        filters.push(libc::sock_filter {
+            code: JUMP_EQUAL,
+            jt: 0,
+            jf: 1,
+            k: syscall as u32,
+        });
+        filters.push(libc::sock_filter {
+            code: RETURN,
+            jt: 0,
+            jf: 0,
+            k: SECCOMP_RETURN_ERRNO | libc::EPERM as u32,
+        });
+    }
+    filters.push(libc::sock_filter {
+        code: RETURN,
+        jt: 0,
+        jf: 0,
+        k: SECCOMP_RETURN_ALLOW,
+    });
+    let program = libc::sock_fprog {
+        len: filters.len().try_into().expect("seccomp filter length"),
+        filter: filters.as_mut_ptr(),
+    };
+
+    // SAFETY: `program` points to `filters` for the duration of both prctl
+    // calls. NO_NEW_PRIVS permits this thread to add a strictly more
+    // restrictive seccomp filter; the filter returns EPERM for networking
+    // syscalls and ALLOW for every other syscall.
+    unsafe {
+        assert_eq!(
+            libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0),
+            0,
+            "enable no-new-privileges"
+        );
+        assert_eq!(
+            libc::prctl(
+                libc::PR_SET_SECCOMP,
+                libc::SECCOMP_MODE_FILTER,
+                &program as *const libc::sock_fprog,
+            ),
+            0,
+            "install network-denying seccomp filter"
+        );
+    }
+}
+
+fn create_real_clone(temp: &TempDir) -> PathBuf {
+    let source = temp.path().join("source");
+    let clone = temp.path().join("clone");
+    std::fs::create_dir(&source).expect("source directory");
+    SleyRepository::init(&source).expect("isolate source from ancestor Git repositories");
+    heddle(&["init"], Some(&source), temp.path());
+    std::fs::write(source.join("README.md"), "offline clone\n").expect("seed file");
+    heddle(
+        &["capture", "-m", "seed offline clone"],
+        Some(&source),
+        temp.path(),
+    );
+    heddle(
+        &[
+            "clone",
+            source.to_str().expect("source UTF-8"),
+            clone.to_str().expect("clone UTF-8"),
+        ],
+        None,
+        temp.path(),
+    );
+    assert!(clone.join(".heddle").is_dir(), "real clone must exist");
+    clone
+}
+
+fn install_owner_keyring(clone: &Path) -> (CloneKeyringStore, AuthorizationKey, Vec<u8>) {
+    let authority = AuthorizationKey::from_seed([41; 32]).expect("authority");
+    let recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(AuthorizationKey::from_seed([42; 32]).expect("paper")),
+        GuardianSigner::social(AuthorizationKey::from_seed([43; 32]).expect("social")),
+    ])
+    .expect("recovery");
+    let root = create_human_owner_root([44; 16], &authority, &recovery).expect("owner root");
+    let state = verify_owner_root(&root).expect("owner state");
+    let subject_key = AuthorizationKey::from_seed([45; 32]).expect("subject");
+    let spool_uuid = [46; 16];
+    let capability = create_direct_capability(
+        &state,
+        &authority,
+        CapabilityPrincipal {
+            kind: CapabilityPrincipalKind::Agent as i32,
+            principal_id: b"offline-agent".to_vec(),
+            key: Some(subject_key.verification_key()),
+        },
+        vec![SpoolCapabilityGrant {
+            spool: Some(SpoolSelector {
+                root_spool_uuid: spool_uuid.to_vec(),
+                path_segments: vec!["acme".to_string()],
+                include_descendants: true,
+            }),
+            actions: vec![SpoolCapabilityAction::Read as i32],
+        }],
+        NOW - 10,
+        NOW + 200,
+        limits(),
+    )
+    .expect("public clone capability");
+    let biscuit = mint_subject_biscuit(
+        capability.capability.as_ref().expect("capability"),
+        &subject_key,
+    )
+    .expect("subject Biscuit");
+    let keyring = create_clone_keyring(
+        spool_uuid,
+        vec!["acme".to_string(), "heddle".to_string()],
+        CloneOwnerPinKind::InvitationFingerprint,
+        state.owner_id(),
+        NOW,
+        root,
+        Vec::new(),
+        vec![capability],
+        NOW,
+        limits(),
+    )
+    .expect("keyring");
+    let store = CloneKeyringStore::new(clone.join(".heddle"), limits());
+    store.install(keyring, NOW).expect("pin clone keyring");
+    println!("CLONE_KEYRING={}", store.path().display());
+    (store, subject_key, biscuit)
+}
+
+fn prove_offline_allow_and_deny(
+    store: CloneKeyringStore,
+    subject_key: AuthorizationKey,
+    biscuit: Vec<u8>,
+) {
+    disconnect_network_for_current_thread();
+    let probe = TcpStream::connect_timeout(
+        &SocketAddrV4::new(Ipv4Addr::LOCALHOST, 9).into(),
+        Duration::from_millis(50),
+    )
+    .expect_err("seccomp must make the network genuinely unreachable");
+    assert_eq!(probe.raw_os_error(), Some(libc::EPERM));
+    println!("NETWORK_PROBE=blocked errno=EPERM syscall=socket");
+
+    let authorizer = OfflineAuthorizer::new(
+        store
+            .load(NOW)
+            .expect("load keyring after network is blocked"),
+    );
+    let request = |action| OfflineRequest {
+        subject_kind: CapabilityPrincipalKind::Agent,
+        principal_id: b"offline-agent".to_vec(),
+        subject_key: Some(subject_key.verification_key()),
+        subject_biscuit: biscuit.clone(),
+        path_segments: vec!["acme".to_string(), "heddle".to_string(), "src".to_string()],
+        action,
+        now_unix_seconds: NOW,
+    };
+    authorizer
+        .authorize(&request(SpoolCapabilityAction::Read))
+        .expect("offline READ allow");
+    println!("OFFLINE_ALLOW=READ path=acme/heddle/src");
+    assert!(matches!(
+        authorizer.authorize(&request(SpoolCapabilityAction::Write)),
+        Err(AuthorizationError::CapabilityDenied(_))
+    ));
+    println!("OFFLINE_DENY=WRITE path=acme/heddle/src");
+
+    let sibling_request = OfflineRequest {
+        subject_kind: CapabilityPrincipalKind::Agent,
+        principal_id: b"offline-agent".to_vec(),
+        subject_key: Some(subject_key.verification_key()),
+        subject_biscuit: biscuit,
+        path_segments: vec!["acme".to_string(), "sibling".to_string()],
+        action: SpoolCapabilityAction::Read,
+        now_unix_seconds: NOW,
+    };
+    assert!(matches!(
+        authorizer.authorize(&sibling_request),
+        Err(AuthorizationError::CapabilityDenied(_))
+    ));
+    println!("OFFLINE_DENY=READ path=acme/sibling reason=pinned-clone");
+}
+
+#[test]
+fn real_clone_pins_keyring_then_allows_and_denies_with_network_syscalls_blocked() {
+    let temp = TempDir::new().expect("tempdir");
+    let clone = create_real_clone(&temp);
+    let (store, subject_key, biscuit) = install_owner_keyring(&clone);
+    prove_offline_allow_and_deny(store, subject_key, biscuit);
+}

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -10,6 +10,8 @@ pub mod credential_file;
 pub mod credentials;
 pub mod device_flow;
 pub mod hosted;
+// Data/crypto only until Weft's exclusive owner-authorization cutover.
+pub mod owner_authorization;
 pub mod presence;
 pub mod support;
 pub mod support_requests;

--- a/crates/client/src/owner_authorization/anonymous.rs
+++ b/crates/client/src/owner_authorization/anonymous.rs
@@ -1,0 +1,147 @@
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, Result, VerificationLimits,
+    canonical::{
+        ANONYMOUS_CREDENTIAL_DOMAIN, ANONYMOUS_ID_DOMAIN, ANONYMOUS_REGISTRATION_DOMAIN,
+        anonymous_body, digest, key_id, nonce, registration_body,
+    },
+    key::verify_signature,
+    wire::{AnonymousKeyCredential, AuthorizationKeyAlgorithm, RegisterAnonymousKeyRequest},
+};
+
+/// Create a self-signed anonymous pseudonym under the explicit TTL ceiling.
+pub fn create_anonymous_credential(
+    key: &AuthorizationKey,
+    issued_at_unix_seconds: i64,
+    expires_at_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<AnonymousKeyCredential> {
+    if issued_at_unix_seconds < 0
+        || expires_at_unix_seconds <= issued_at_unix_seconds
+        || expires_at_unix_seconds.saturating_sub(issued_at_unix_seconds)
+            > limits.max_anonymous_ttl_seconds()
+    {
+        return Err(AuthorizationError::Invalid(
+            "anonymous credential exceeds the TTL ceiling".to_string(),
+        ));
+    }
+    let public = key.verification_key();
+    let anonymous_id = digest(ANONYMOUS_ID_DOMAIN, &key_id(&public)).to_vec();
+    let mut credential = AnonymousKeyCredential {
+        format_version: 1,
+        anonymous_id,
+        key: Some(public),
+        issued_at_unix_seconds,
+        expires_at_unix_seconds,
+        nonce: nonce(),
+        self_signature: None,
+    };
+    credential.self_signature =
+        Some(key.sign(ANONYMOUS_CREDENTIAL_DOMAIN, &anonymous_body(&credential)?)?);
+    Ok(credential)
+}
+
+/// Verify an anonymous pseudonym and its self-signature offline.
+pub fn verify_anonymous_credential(
+    credential: &AnonymousKeyCredential,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<()> {
+    if credential.format_version != 1
+        || credential.anonymous_id.len() != 32
+        || credential.nonce.len() != 32
+        || credential.issued_at_unix_seconds < 0
+        || credential.expires_at_unix_seconds <= credential.issued_at_unix_seconds
+        || credential
+            .expires_at_unix_seconds
+            .saturating_sub(credential.issued_at_unix_seconds)
+            > limits.max_anonymous_ttl_seconds()
+    {
+        return Err(AuthorizationError::Invalid(
+            "anonymous credential has invalid v1 fields".to_string(),
+        ));
+    }
+    if now_unix_seconds < credential.issued_at_unix_seconds
+        || now_unix_seconds > credential.expires_at_unix_seconds
+    {
+        return Err(AuthorizationError::Expired);
+    }
+    let key = credential.key.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("anonymous credential has no key".to_string())
+    })?;
+    if key.algorithm != AuthorizationKeyAlgorithm::Ed25519 as i32
+        || key.public_key.len() != 32
+        || credential.anonymous_id.as_slice() != digest(ANONYMOUS_ID_DOMAIN, &key_id(key))
+    {
+        return Err(AuthorizationError::Invalid(
+            "anonymous id or key is invalid".to_string(),
+        ));
+    }
+    verify_signature(
+        key,
+        credential
+            .self_signature
+            .as_ref()
+            .ok_or(AuthorizationError::InvalidSignature)?,
+        ANONYMOUS_CREDENTIAL_DOMAIN,
+        &anonymous_body(credential)?,
+    )
+}
+
+/// Create a registration request whose continuity proof requires the key.
+pub fn create_anonymous_registration(
+    credential: AnonymousKeyCredential,
+    key: &AuthorizationKey,
+    turnstile_token: Option<String>,
+    prior_continuity_token: String,
+    client_operation_id: String,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<RegisterAnonymousKeyRequest> {
+    verify_anonymous_credential(&credential, now_unix_seconds, limits)?;
+    if credential
+        .key
+        .as_ref()
+        .is_none_or(|public| key.key_id() != key_id(public))
+        || client_operation_id.is_empty()
+    {
+        return Err(AuthorizationError::Invalid(
+            "anonymous registration key or operation id is invalid".to_string(),
+        ));
+    }
+    let mut request = RegisterAnonymousKeyRequest {
+        credential: Some(credential),
+        turnstile_token,
+        prior_continuity_token,
+        continuity_proof: None,
+        client_operation_id,
+    };
+    request.continuity_proof =
+        Some(key.sign(ANONYMOUS_REGISTRATION_DOMAIN, &registration_body(&request)?)?);
+    Ok(request)
+}
+
+/// Verify anonymous registration continuity without trusting its token.
+pub fn verify_anonymous_registration(
+    request: &RegisterAnonymousKeyRequest,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<()> {
+    let credential = request.credential.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("anonymous registration has no credential".to_string())
+    })?;
+    verify_anonymous_credential(credential, now_unix_seconds, limits)?;
+    if request.client_operation_id.is_empty() {
+        return Err(AuthorizationError::Invalid(
+            "anonymous registration has no operation id".to_string(),
+        ));
+    }
+    verify_signature(
+        credential.key.as_ref().expect("verified credential key"),
+        request
+            .continuity_proof
+            .as_ref()
+            .ok_or(AuthorizationError::InvalidSignature)?,
+        ANONYMOUS_REGISTRATION_DOMAIN,
+        &registration_body(request)?,
+    )
+}

--- a/crates/client/src/owner_authorization/bootstrap.rs
+++ b/crates/client/src/owner_authorization/bootstrap.rs
@@ -1,0 +1,163 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use sha2::{Digest, Sha256};
+
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, Result, VerificationLimits,
+    canonical::{
+        DEFERRED_BOOTSTRAP_DOMAIN, OWNER_ROOT_DOMAIN, deferred_bootstrap_body, digest, key_id,
+        owner_root_body,
+    },
+    key::verify_signature,
+    root::verify_owner_root,
+    verify_authorization_bundle,
+    wire::{
+        BootstrapOwnerRootRequest, BootstrapOwnerRootResponse, DeferredOwnerRootApproval,
+        OwnerAuthorizationBundle, SignedOwnerRoot, WebAuthnOwnerRootApproval,
+        bootstrap_owner_root_request,
+    },
+};
+
+/// Compute the WebAuthn challenge bound to an exact owner root.
+pub fn bootstrap_challenge(
+    owner_root: &SignedOwnerRoot,
+    server_challenge_nonce: &[u8],
+) -> Result<String> {
+    if server_challenge_nonce.is_empty() {
+        return Err(AuthorizationError::Invalid(
+            "bootstrap server challenge nonce is empty".to_string(),
+        ));
+    }
+    let verified = verify_owner_root(owner_root)?;
+    let root = verified.signed_root().root.as_ref().expect("verified root");
+    let root_body_digest = digest(OWNER_ROOT_DOMAIN, &owner_root_body(root)?);
+    let mut hasher = Sha256::new();
+    hasher.update(b"heddle-owner-bootstrap-v1");
+    hasher.update(root_body_digest);
+    hasher.update(server_challenge_nonce);
+    Ok(URL_SAFE_NO_PAD.encode(hasher.finalize()))
+}
+
+/// Construct a human bootstrap transport after a WebAuthn ceremony.
+pub fn create_human_bootstrap(
+    owner_root: SignedOwnerRoot,
+    approval: WebAuthnOwnerRootApproval,
+    client_operation_id: String,
+) -> Result<BootstrapOwnerRootRequest> {
+    verify_owner_root(&owner_root)?;
+    if approval.challenge_id.is_empty()
+        || approval.proof.is_none()
+        || client_operation_id.is_empty()
+    {
+        return Err(AuthorizationError::Invalid(
+            "human bootstrap approval or operation id is incomplete".to_string(),
+        ));
+    }
+    Ok(BootstrapOwnerRootRequest {
+        owner_root: Some(owner_root),
+        approval: Some(bootstrap_owner_root_request::Approval::Human(approval)),
+        client_operation_id,
+    })
+}
+
+/// Construct an agent-authorized deferred-human bootstrap transport.
+pub fn create_deferred_bootstrap(
+    owner_root: SignedOwnerRoot,
+    provisioning_authority: OwnerAuthorizationBundle,
+    origin_key: &AuthorizationKey,
+    client_operation_id: String,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<BootstrapOwnerRootRequest> {
+    let new_state = verify_owner_root(&owner_root)?;
+    if !new_state.claimable_deferred_human
+        || now_unix_seconds > new_state.claimable_until_unix_seconds
+        || key_id(new_state.authority_key()) != origin_key.key_id()
+        || client_operation_id.is_empty()
+    {
+        return Err(AuthorizationError::Invalid(
+            "deferred bootstrap root or operation id is invalid".to_string(),
+        ));
+    }
+    let provisioning =
+        verify_authorization_bundle(&provisioning_authority, now_unix_seconds, limits)?;
+    let signature_body = deferred_bootstrap_body(
+        &new_state.state_hash(),
+        &provisioning.leaf().capability().capability_id,
+        &client_operation_id,
+    )?;
+    let approval = DeferredOwnerRootApproval {
+        provisioning_authority: Some(provisioning_authority),
+        origin_key_request_signature: Some(
+            origin_key.sign(DEFERRED_BOOTSTRAP_DOMAIN, &signature_body)?,
+        ),
+    };
+    Ok(BootstrapOwnerRootRequest {
+        owner_root: Some(owner_root),
+        approval: Some(bootstrap_owner_root_request::Approval::DeferredHuman(
+            approval,
+        )),
+        client_operation_id,
+    })
+}
+
+/// Verify the origin signature and both authorization chains in a deferred request.
+pub fn verify_deferred_bootstrap(
+    request: &BootstrapOwnerRootRequest,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<()> {
+    let owner_root = request.owner_root.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("bootstrap request has no owner root".to_string())
+    })?;
+    let new_state = verify_owner_root(owner_root)?;
+    if !new_state.claimable_deferred_human
+        || now_unix_seconds > new_state.claimable_until_unix_seconds
+        || request.client_operation_id.is_empty()
+    {
+        return Err(AuthorizationError::Invalid(
+            "deferred bootstrap root or operation id is invalid".to_string(),
+        ));
+    }
+    let approval = match request.approval.as_ref() {
+        Some(bootstrap_owner_root_request::Approval::DeferredHuman(approval)) => approval,
+        _ => {
+            return Err(AuthorizationError::Invalid(
+                "bootstrap request is not deferred-human".to_string(),
+            ));
+        }
+    };
+    let bundle = approval.provisioning_authority.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("deferred bootstrap has no provisioning bundle".to_string())
+    })?;
+    let provisioning = verify_authorization_bundle(bundle, now_unix_seconds, limits)?;
+    let signature_body = deferred_bootstrap_body(
+        &new_state.state_hash(),
+        &provisioning.leaf().capability().capability_id,
+        &request.client_operation_id,
+    )?;
+    verify_signature(
+        new_state.authority_key(),
+        approval
+            .origin_key_request_signature
+            .as_ref()
+            .ok_or(AuthorizationError::InvalidSignature)?,
+        DEFERRED_BOOTSTRAP_DOMAIN,
+        &signature_body,
+    )
+}
+
+/// Check an unsigned acknowledgement against the locally verified root.
+pub fn verify_bootstrap_response(
+    response: &BootstrapOwnerRootResponse,
+    owner_root: &SignedOwnerRoot,
+) -> Result<()> {
+    let state = verify_owner_root(owner_root)?;
+    if response.owner_id.as_slice() != state.owner_id()
+        || response.accepted_root_hash.as_slice() != state.state_hash()
+    {
+        return Err(AuthorizationError::Invalid(
+            "bootstrap acknowledgement does not match the submitted root".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/client/src/owner_authorization/canonical/encode.rs
+++ b/crates/client/src/owner_authorization/canonical/encode.rs
@@ -1,0 +1,98 @@
+use super::key_id;
+use crate::owner_authorization::{
+    AuthorizationError, Result,
+    wire::{AuthorizationVerificationKey, RecoveryGuardian, RecoveryPolicy},
+};
+
+pub(super) struct Encoder {
+    bytes: Vec<u8>,
+}
+
+impl Encoder {
+    pub(super) fn new() -> Self {
+        Self { bytes: Vec::new() }
+    }
+
+    pub(super) fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    pub(super) fn bool(&mut self, value: bool) {
+        self.bytes.push(u8::from(value));
+    }
+
+    pub(super) fn u32(&mut self, value: u32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(super) fn i32(&mut self, value: i32) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(super) fn u64(&mut self, value: u64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(super) fn i64(&mut self, value: i64) {
+        self.bytes.extend_from_slice(&value.to_be_bytes());
+    }
+
+    pub(super) fn bytes(&mut self, value: &[u8]) -> Result<()> {
+        let len = u32::try_from(value.len()).map_err(|_| {
+            AuthorizationError::Invalid("canonical field exceeds u32 length".to_string())
+        })?;
+        self.u32(len);
+        self.bytes.extend_from_slice(value);
+        Ok(())
+    }
+
+    pub(super) fn string(&mut self, value: &str) -> Result<()> {
+        self.bytes(value.as_bytes())
+    }
+
+    pub(super) fn count(&mut self, len: usize) -> Result<()> {
+        self.u32(u32::try_from(len).map_err(|_| {
+            AuthorizationError::Invalid("canonical collection exceeds u32 length".to_string())
+        })?);
+        Ok(())
+    }
+}
+
+pub(super) fn verification_key(
+    encoder: &mut Encoder,
+    key: &AuthorizationVerificationKey,
+) -> Result<()> {
+    encoder.i32(key.algorithm);
+    encoder.bytes(&key.public_key)
+}
+
+fn guardian(encoder: &mut Encoder, guardian: &RecoveryGuardian) -> Result<()> {
+    encoder.i32(guardian.kind);
+    verification_key(
+        encoder,
+        guardian.key.as_ref().ok_or_else(|| {
+            AuthorizationError::Invalid("recovery guardian has no key".to_string())
+        })?,
+    )
+}
+
+pub(super) fn recovery_policy(encoder: &mut Encoder, policy: &RecoveryPolicy) -> Result<()> {
+    let mut guardians = policy.guardians.iter().collect::<Vec<_>>();
+    guardians.sort_by_key(|guardian| guardian.key.as_ref().map(key_id).unwrap_or([0; 32]));
+    if guardians
+        .iter()
+        .zip(&policy.guardians)
+        .any(|(sorted, original)| !std::ptr::eq(*sorted, original))
+    {
+        return Err(AuthorizationError::Invalid(
+            "recovery guardians are not sorted by key id".to_string(),
+        ));
+    }
+
+    encoder.u32(policy.threshold);
+    encoder.count(guardians.len())?;
+    for guardian_value in guardians {
+        guardian(encoder, guardian_value)?;
+    }
+    Ok(())
+}

--- a/crates/client/src/owner_authorization/canonical/mod.rs
+++ b/crates/client/src/owner_authorization/canonical/mod.rs
@@ -1,0 +1,37 @@
+mod encode;
+mod objects;
+
+pub(crate) use objects::{
+    anonymous_body, capability_body, capability_without_id, deferred_bootstrap_body,
+    owner_root_body, owner_root_without_id, registration_body, transition_body,
+};
+use sha2::{Digest, Sha256};
+
+pub(crate) const OWNER_ROOT_DOMAIN: &[u8] = b"heddle-owner-root-v1";
+pub(crate) const OWNER_TRANSITION_DOMAIN: &[u8] = b"heddle-owner-key-transition-v1";
+pub(crate) const OWNER_CAPABILITY_DOMAIN: &[u8] = b"heddle-owner-capability-v1";
+pub(crate) const ANONYMOUS_ID_DOMAIN: &[u8] = b"heddle-anonymous-v1";
+pub(crate) const ANONYMOUS_CREDENTIAL_DOMAIN: &[u8] = b"heddle-anonymous-key-credential-v1";
+pub(crate) const ANONYMOUS_REGISTRATION_DOMAIN: &[u8] = b"heddle-anonymous-registration-v1";
+pub(crate) const DEFERRED_BOOTSTRAP_DOMAIN: &[u8] = b"heddle-owner-deferred-bootstrap-v1";
+
+pub(crate) fn digest(domain: &[u8], body: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(domain);
+    hasher.update(body);
+    hasher.finalize().into()
+}
+
+pub(crate) fn key_id(
+    key: &crate::owner_authorization::wire::AuthorizationVerificationKey,
+) -> [u8; 32] {
+    let mut body = Vec::with_capacity(4 + key.public_key.len());
+    body.extend_from_slice(&key.algorithm.to_be_bytes());
+    body.extend_from_slice(&key.public_key);
+    digest(b"heddle-key-v1", &body)
+}
+
+pub(crate) fn nonce() -> Vec<u8> {
+    let bytes: [u8; 32] = rand::random();
+    bytes.to_vec()
+}

--- a/crates/client/src/owner_authorization/canonical/objects.rs
+++ b/crates/client/src/owner_authorization/canonical/objects.rs
@@ -1,0 +1,189 @@
+use super::encode::{Encoder, recovery_policy, verification_key};
+use crate::owner_authorization::{
+    AuthorizationError, Result,
+    wire::{
+        AnonymousKeyCredential, CapabilityPrincipal, OwnerCapability, OwnerKeyTransition,
+        OwnerRoot, RegisterAnonymousKeyRequest, SpoolCapabilityGrant, SpoolSelector,
+    },
+};
+
+fn required<'a, T>(value: &'a Option<T>, field: &str) -> Result<&'a T> {
+    value
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid(format!("missing required field {field}")))
+}
+
+pub(crate) fn owner_root_without_id(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        required(&root.authority_key, "OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        required(&root.recovery_policy, "OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+pub(crate) fn owner_root_body(root: &OwnerRoot) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(root.format_version);
+    encoder.bytes(&root.owner_id)?;
+    encoder.bytes(&root.account_uuid)?;
+    verification_key(
+        &mut encoder,
+        required(&root.authority_key, "OwnerRoot.authority_key")?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        required(&root.recovery_policy, "OwnerRoot.recovery_policy")?,
+    )?;
+    encoder.bool(root.claimable_deferred_human);
+    encoder.bytes(&root.nonce)?;
+    encoder.i64(root.claimable_until_unix_seconds);
+    Ok(encoder.finish())
+}
+
+pub(crate) fn transition_body(transition: &OwnerKeyTransition) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(transition.format_version);
+    encoder.bytes(&transition.owner_id)?;
+    encoder.bytes(&transition.previous_state_hash)?;
+    encoder.u64(transition.sequence);
+    encoder.i32(transition.kind);
+    verification_key(
+        &mut encoder,
+        required(
+            &transition.next_authority_key,
+            "OwnerKeyTransition.next_authority_key",
+        )?,
+    )?;
+    recovery_policy(
+        &mut encoder,
+        required(
+            &transition.next_recovery_policy,
+            "OwnerKeyTransition.next_recovery_policy",
+        )?,
+    )?;
+    encoder.i64(transition.valid_from_unix_seconds);
+    encoder.i64(transition.previous_key_valid_until_unix_seconds);
+    encoder.bytes(&transition.nonce)?;
+    Ok(encoder.finish())
+}
+
+fn selector(encoder: &mut Encoder, value: &SpoolSelector) -> Result<()> {
+    encoder.bytes(&value.root_spool_uuid)?;
+    encoder.count(value.path_segments.len())?;
+    for segment in &value.path_segments {
+        encoder.string(segment)?;
+    }
+    encoder.bool(value.include_descendants);
+    Ok(())
+}
+
+fn principal(encoder: &mut Encoder, value: &CapabilityPrincipal) -> Result<()> {
+    encoder.i32(value.kind);
+    encoder.bytes(&value.principal_id)?;
+    match &value.key {
+        Some(key) => {
+            encoder.bool(true);
+            verification_key(encoder, key)?;
+        }
+        None => encoder.bool(false),
+    }
+    Ok(())
+}
+
+fn grant(encoder: &mut Encoder, value: &SpoolCapabilityGrant) -> Result<()> {
+    selector(
+        encoder,
+        required(&value.spool, "SpoolCapabilityGrant.spool")?,
+    )?;
+    encoder.count(value.actions.len())?;
+    for action in &value.actions {
+        encoder.i32(*action);
+    }
+    Ok(())
+}
+
+fn capability_fields(capability: &OwnerCapability, include_id: bool) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(capability.format_version);
+    encoder.bytes(&capability.owner_id)?;
+    encoder.bytes(&capability.issuer_state_hash)?;
+    encoder.bytes(&capability.parent_capability_id)?;
+    principal(
+        &mut encoder,
+        required(&capability.subject, "OwnerCapability.subject")?,
+    )?;
+    encoder.count(capability.grants.len())?;
+    for grant_value in &capability.grants {
+        grant(&mut encoder, grant_value)?;
+    }
+    encoder.i64(capability.not_before_unix_seconds);
+    encoder.i64(capability.expires_at_unix_seconds);
+    encoder.bytes(&capability.nonce)?;
+    if include_id {
+        encoder.bytes(&capability.capability_id)?;
+    }
+    Ok(encoder.finish())
+}
+
+pub(crate) fn capability_without_id(capability: &OwnerCapability) -> Result<Vec<u8>> {
+    capability_fields(capability, false)
+}
+
+pub(crate) fn capability_body(capability: &OwnerCapability) -> Result<Vec<u8>> {
+    capability_fields(capability, true)
+}
+
+pub(crate) fn anonymous_body(credential: &AnonymousKeyCredential) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.u32(credential.format_version);
+    encoder.bytes(&credential.anonymous_id)?;
+    verification_key(
+        &mut encoder,
+        required(&credential.key, "AnonymousKeyCredential.key")?,
+    )?;
+    encoder.i64(credential.issued_at_unix_seconds);
+    encoder.i64(credential.expires_at_unix_seconds);
+    encoder.bytes(&credential.nonce)?;
+    Ok(encoder.finish())
+}
+
+pub(crate) fn registration_body(request: &RegisterAnonymousKeyRequest) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    let credential = required(
+        &request.credential,
+        "RegisterAnonymousKeyRequest.credential",
+    )?;
+    encoder.bytes(&anonymous_body(credential)?)?;
+    match &request.turnstile_token {
+        Some(token) => {
+            encoder.bool(true);
+            encoder.string(token)?;
+        }
+        None => encoder.bool(false),
+    }
+    encoder.string(&request.prior_continuity_token)?;
+    encoder.string(&request.client_operation_id)?;
+    Ok(encoder.finish())
+}
+
+pub(crate) fn deferred_bootstrap_body(
+    root_hash: &[u8],
+    provisioning_capability_id: &[u8],
+    client_operation_id: &str,
+) -> Result<Vec<u8>> {
+    let mut encoder = Encoder::new();
+    encoder.bytes(root_hash)?;
+    encoder.bytes(provisioning_capability_id)?;
+    encoder.string(client_operation_id)?;
+    Ok(encoder.finish())
+}

--- a/crates/client/src/owner_authorization/capability/biscuit.rs
+++ b/crates/client/src/owner_authorization/capability/biscuit.rs
@@ -1,0 +1,168 @@
+use std::collections::BTreeSet;
+
+use biscuit_auth::{Biscuit, PublicKey, builder::Algorithm};
+
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, Result,
+    canonical::key_id,
+    wire::{CapabilityPrincipalKind, OwnerCapability},
+};
+
+fn path_hex(segments: &[String]) -> String {
+    let mut bytes = Vec::new();
+    for segment in segments {
+        bytes.extend_from_slice(&(segment.len() as u32).to_be_bytes());
+        bytes.extend_from_slice(segment.as_bytes());
+    }
+    hex::encode(bytes)
+}
+
+fn expected_grants(capability: &OwnerCapability) -> Result<BTreeSet<(String, String, bool, i64)>> {
+    let mut expected = BTreeSet::new();
+    for grant in &capability.grants {
+        let selector = grant.spool.as_ref().ok_or_else(|| {
+            AuthorizationError::Invalid("capability grant has no selector".to_string())
+        })?;
+        for action in &grant.actions {
+            expected.insert((
+                hex::encode(&selector.root_spool_uuid),
+                path_hex(&selector.path_segments),
+                selector.include_descendants,
+                i64::from(*action),
+            ));
+        }
+    }
+    Ok(expected)
+}
+
+/// Mint the subject-signed Biscuit carried in an authorization bundle.
+pub fn mint_subject_biscuit(
+    capability: &OwnerCapability,
+    subject_key: &AuthorizationKey,
+) -> Result<Vec<u8>> {
+    let subject = capability
+        .subject
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("capability has no subject".to_string()))?;
+    let public = subject.key.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("ANY_ANONYMOUS has no subject signing key".to_string())
+    })?;
+    if subject_key.key_id() != key_id(public) {
+        return Err(AuthorizationError::Invalid(
+            "Biscuit signer does not match the capability subject".to_string(),
+        ));
+    }
+    let mut builder = Biscuit::builder()
+        .fact(
+            format!(
+                "owner_subject({}, \"{}\", \"{}\")",
+                subject.kind,
+                hex::encode(&subject.principal_id),
+                hex::encode(key_id(public))
+            )
+            .as_str(),
+        )
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?
+        .fact(
+            format!(
+                "owner_capability(\"{}\")",
+                hex::encode(&capability.capability_id)
+            )
+            .as_str(),
+        )
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?
+        .fact(
+            format!(
+                "owner_validity({}, {})",
+                capability.not_before_unix_seconds, capability.expires_at_unix_seconds
+            )
+            .as_str(),
+        )
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    for (spool, path, descendants, action) in expected_grants(capability)? {
+        builder = builder
+            .fact(format!("owner_grant(\"{spool}\", \"{path}\", {descendants}, {action})").as_str())
+            .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    }
+    builder
+        .build(&subject_key.biscuit_key_pair()?)
+        .and_then(|biscuit| biscuit.to_vec())
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))
+}
+
+pub(crate) fn verify_subject_biscuit(capability: &OwnerCapability, bytes: &[u8]) -> Result<()> {
+    let subject = capability
+        .subject
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("capability has no subject".to_string()))?;
+    let kind = CapabilityPrincipalKind::try_from(subject.kind)
+        .map_err(|_| AuthorizationError::Invalid("unknown subject kind".to_string()))?;
+    if kind == CapabilityPrincipalKind::AnyAnonymous {
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        return Err(AuthorizationError::Invalid(
+            "ANY_ANONYMOUS bundle must not claim a subject-signed Biscuit".to_string(),
+        ));
+    }
+    let key = subject
+        .key
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("capability subject has no key".to_string()))?;
+    let public = PublicKey::from_bytes(&key.public_key, Algorithm::Ed25519)
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    let biscuit = Biscuit::from(bytes, move |_| Ok(public))
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    let mut authorizer = biscuit
+        .authorizer()
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+
+    let subjects: Vec<(i64, String, String)> = authorizer
+        .query("owner_subject($kind, $id, $key) <- owner_subject($kind, $id, $key)")
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    let expected_subject = (
+        i64::from(subject.kind),
+        hex::encode(&subject.principal_id),
+        hex::encode(key_id(key)),
+    );
+    if subjects.as_slice() != [expected_subject] {
+        return Err(AuthorizationError::CapabilityDenied(
+            "subject Biscuit identity does not match the leaf".to_string(),
+        ));
+    }
+    let ids: Vec<(String,)> = authorizer
+        .query("owner_capability($id) <- owner_capability($id)")
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    if ids.as_slice() != [(hex::encode(&capability.capability_id),)] {
+        return Err(AuthorizationError::CapabilityDenied(
+            "subject Biscuit names another capability".to_string(),
+        ));
+    }
+    let validity: Vec<(i64, i64)> = authorizer
+        .query("owner_validity($not_before, $expires) <- owner_validity($not_before, $expires)")
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+    if validity.as_slice()
+        != [(
+            capability.not_before_unix_seconds,
+            capability.expires_at_unix_seconds,
+        )]
+    {
+        return Err(AuthorizationError::CapabilityDenied(
+            "subject Biscuit widens the validity interval".to_string(),
+        ));
+    }
+    let grants: BTreeSet<(String, String, bool, i64)> = authorizer
+        .query::<_, (String, String, bool, i64), _>(
+            "owner_grant($spool, $path, $desc, $action) <- \
+             owner_grant($spool, $path, $desc, $action)",
+        )
+        .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?
+        .into_iter()
+        .collect();
+    if grants != expected_grants(capability)? {
+        return Err(AuthorizationError::CapabilityDenied(
+            "subject Biscuit grants differ from the leaf capability".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/client/src/owner_authorization/capability/create.rs
+++ b/crates/client/src/owner_authorization/capability/create.rs
@@ -1,0 +1,124 @@
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, Result, VerificationLimits, VerifiedCapability,
+    VerifiedOwnerState,
+    canonical::{
+        OWNER_CAPABILITY_DOMAIN, capability_body, capability_without_id, digest, key_id, nonce,
+    },
+    capability::{capability_is_well_formed, grant_covers},
+    wire::{CapabilityPrincipal, OwnerCapability, SignedOwnerCapability, SpoolCapabilityGrant},
+};
+
+pub(super) struct CapabilityLineage {
+    pub(super) owner_id: [u8; 32],
+    pub(super) issuer_state_hash: [u8; 32],
+    pub(super) parent_capability_id: Vec<u8>,
+}
+
+pub(super) fn unsigned_capability(
+    lineage: CapabilityLineage,
+    subject: CapabilityPrincipal,
+    grants: Vec<SpoolCapabilityGrant>,
+    not_before_unix_seconds: i64,
+    expires_at_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<OwnerCapability> {
+    let mut capability = OwnerCapability {
+        format_version: 1,
+        owner_id: lineage.owner_id.to_vec(),
+        issuer_state_hash: lineage.issuer_state_hash.to_vec(),
+        parent_capability_id: lineage.parent_capability_id,
+        subject: Some(subject),
+        grants,
+        not_before_unix_seconds,
+        expires_at_unix_seconds,
+        nonce: nonce(),
+        capability_id: vec![0; 32],
+    };
+    capability_is_well_formed(&capability, limits)?;
+    capability.capability_id = digest(
+        OWNER_CAPABILITY_DOMAIN,
+        &capability_without_id(&capability)?,
+    )
+    .to_vec();
+    Ok(capability)
+}
+
+/// Create a direct grant signed by the active owner authority.
+pub fn create_direct_capability(
+    state: &VerifiedOwnerState,
+    authority: &AuthorizationKey,
+    subject: CapabilityPrincipal,
+    grants: Vec<SpoolCapabilityGrant>,
+    not_before_unix_seconds: i64,
+    expires_at_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerCapability> {
+    if authority.key_id() != key_id(state.authority_key()) {
+        return Err(AuthorizationError::Invalid(
+            "direct capability signer is not the active owner authority".to_string(),
+        ));
+    }
+    let capability = unsigned_capability(
+        CapabilityLineage {
+            owner_id: state.owner_id(),
+            issuer_state_hash: state.state_hash(),
+            parent_capability_id: Vec::new(),
+        },
+        subject,
+        grants,
+        not_before_unix_seconds,
+        expires_at_unix_seconds,
+        limits,
+    )?;
+    let signature = authority.sign(OWNER_CAPABILITY_DOMAIN, &capability_body(&capability)?)?;
+    Ok(SignedOwnerCapability {
+        capability: Some(capability),
+        signature: Some(signature),
+    })
+}
+
+/// Create an attenuated child capability signed by the parent's subject key.
+pub fn create_child_capability(
+    parent: &VerifiedCapability,
+    parent_subject_key: &AuthorizationKey,
+    subject: CapabilityPrincipal,
+    grants: Vec<SpoolCapabilityGrant>,
+    not_before_unix_seconds: i64,
+    expires_at_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerCapability> {
+    let parent_body = parent.capability();
+    let parent_subject = parent_body.subject.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("parent capability has no subject".to_string())
+    })?;
+    let parent_key = parent_subject.key.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("ANY_ANONYMOUS cannot derive a child".to_string())
+    })?;
+    if parent_subject_key.key_id() != key_id(parent_key)
+        || not_before_unix_seconds < parent_body.not_before_unix_seconds
+        || expires_at_unix_seconds > parent_body.expires_at_unix_seconds
+        || !grant_covers(&parent_body.grants, &grants)
+    {
+        return Err(AuthorizationError::CapabilityDenied(
+            "child capability widens its parent".to_string(),
+        ));
+    }
+    let capability = unsigned_capability(
+        CapabilityLineage {
+            owner_id: parent.owner_id(),
+            issuer_state_hash: parent.issuer_state_hash(),
+            parent_capability_id: parent_body.capability_id.clone(),
+        },
+        subject,
+        grants,
+        not_before_unix_seconds,
+        expires_at_unix_seconds,
+        limits,
+    )?;
+    let signature =
+        parent_subject_key.sign(OWNER_CAPABILITY_DOMAIN, &capability_body(&capability)?)?;
+    Ok(SignedOwnerCapability {
+        capability: Some(capability),
+        signature: Some(signature),
+    })
+}

--- a/crates/client/src/owner_authorization/capability/mod.rs
+++ b/crates/client/src/owner_authorization/capability/mod.rs
@@ -1,0 +1,18 @@
+mod biscuit;
+mod create;
+mod scope;
+mod verify;
+
+#[cfg(test)]
+mod tests;
+
+pub use biscuit::mint_subject_biscuit;
+pub(crate) use biscuit::verify_subject_biscuit;
+pub use create::{create_child_capability, create_direct_capability};
+pub(crate) use scope::{
+    capability_is_well_formed, grant_covers, request_matches_selector, validate_path_segments,
+};
+pub use verify::{
+    VerifiedAuthorizationBundle, VerifiedCapability, verify_authorization_bundle,
+    verify_capability_chain,
+};

--- a/crates/client/src/owner_authorization/capability/scope.rs
+++ b/crates/client/src/owner_authorization/capability/scope.rs
@@ -1,0 +1,173 @@
+use std::collections::BTreeSet;
+
+use crate::owner_authorization::{
+    AuthorizationError, Result, VerificationLimits,
+    canonical::key_id,
+    wire::{
+        AuthorizationKeyAlgorithm, CapabilityPrincipalKind, OwnerCapability, SpoolCapabilityAction,
+        SpoolCapabilityGrant, SpoolSelector,
+    },
+};
+
+pub(crate) fn validate_path_segments(segments: &[String]) -> Result<()> {
+    if segments.iter().any(|segment| {
+        segment.is_empty()
+            || matches!(segment.as_str(), "." | "..")
+            || segment.contains('/')
+            || segment.contains('\0')
+    }) {
+        return Err(AuthorizationError::Invalid(
+            "spool path contains a non-canonical segment".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_selector(selector: &SpoolSelector) -> Result<()> {
+    if selector.root_spool_uuid.len() != 16 {
+        return Err(AuthorizationError::Invalid(
+            "spool selector UUID must be 16 bytes".to_string(),
+        ));
+    }
+    validate_path_segments(&selector.path_segments)
+}
+
+fn validate_grant(grant: &SpoolCapabilityGrant) -> Result<()> {
+    let selector = grant.spool.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("capability grant has no selector".to_string())
+    })?;
+    validate_selector(selector)?;
+    if grant.actions.is_empty() {
+        return Err(AuthorizationError::Invalid(
+            "capability grant has no actions".to_string(),
+        ));
+    }
+    let mut previous = None;
+    for value in &grant.actions {
+        let action = SpoolCapabilityAction::try_from(*value)
+            .ok()
+            .filter(|action| *action != SpoolCapabilityAction::Unspecified)
+            .ok_or_else(|| AuthorizationError::Invalid("unknown capability action".to_string()))?;
+        if previous.is_some_and(|prior| prior >= *value) {
+            return Err(AuthorizationError::Invalid(
+                "capability actions must be unique and sorted".to_string(),
+            ));
+        }
+        if action == SpoolCapabilityAction::Purge && selector.include_descendants {
+            return Err(AuthorizationError::Invalid(
+                "purge requires an exact spool selector".to_string(),
+            ));
+        }
+        previous = Some(*value);
+    }
+    Ok(())
+}
+
+pub(crate) fn capability_is_well_formed(
+    capability: &OwnerCapability,
+    limits: VerificationLimits,
+) -> Result<()> {
+    if capability.format_version != 1
+        || capability.owner_id.len() != 32
+        || capability.issuer_state_hash.len() != 32
+        || capability.nonce.len() != 32
+        || capability.capability_id.len() != 32
+        || capability.not_before_unix_seconds < 0
+        || capability.expires_at_unix_seconds <= capability.not_before_unix_seconds
+        || capability
+            .expires_at_unix_seconds
+            .saturating_sub(capability.not_before_unix_seconds)
+            > limits.max_capability_ttl_seconds()
+        || capability.grants.is_empty()
+    {
+        return Err(AuthorizationError::Invalid(
+            "owner capability has invalid v1 fields or lifetime".to_string(),
+        ));
+    }
+    let subject = capability.subject.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("owner capability has no subject".to_string())
+    })?;
+    let kind = CapabilityPrincipalKind::try_from(subject.kind)
+        .ok()
+        .filter(|kind| *kind != CapabilityPrincipalKind::Unspecified)
+        .ok_or_else(|| AuthorizationError::Invalid("unknown capability principal".to_string()))?;
+    match (kind, &subject.key) {
+        (CapabilityPrincipalKind::AnyAnonymous, None) if subject.principal_id.is_empty() => {}
+        (CapabilityPrincipalKind::AnyAnonymous, _) => {
+            return Err(AuthorizationError::Invalid(
+                "ANY_ANONYMOUS must omit key and principal id".to_string(),
+            ));
+        }
+        (_, Some(key))
+            if !subject.principal_id.is_empty()
+                && key.algorithm == AuthorizationKeyAlgorithm::Ed25519 as i32
+                && key.public_key.len() == 32 =>
+        {
+            let _ = key_id(key);
+        }
+        _ => {
+            return Err(AuthorizationError::Invalid(
+                "capability subject key or principal id is invalid".to_string(),
+            ));
+        }
+    }
+    for grant in &capability.grants {
+        validate_grant(grant)?;
+    }
+    Ok(())
+}
+
+fn selector_covers(parent: &SpoolSelector, child: &SpoolSelector) -> bool {
+    if parent.root_spool_uuid != child.root_spool_uuid {
+        return false;
+    }
+    if parent.include_descendants {
+        child
+            .path_segments
+            .starts_with(parent.path_segments.as_slice())
+    } else {
+        parent.path_segments == child.path_segments && !child.include_descendants
+    }
+}
+
+pub(crate) fn grant_covers(
+    parent: &[SpoolCapabilityGrant],
+    child: &[SpoolCapabilityGrant],
+) -> bool {
+    child.iter().all(|child_grant| {
+        let Some(child_selector) = child_grant.spool.as_ref() else {
+            return false;
+        };
+        parent.iter().any(|parent_grant| {
+            let Some(parent_selector) = parent_grant.spool.as_ref() else {
+                return false;
+            };
+            let actions = parent_grant
+                .actions
+                .iter()
+                .copied()
+                .collect::<BTreeSet<_>>();
+            actions.contains(&(SpoolCapabilityAction::Grant as i32))
+                && child_grant
+                    .actions
+                    .iter()
+                    .all(|action| actions.contains(action))
+                && selector_covers(parent_selector, child_selector)
+        })
+    })
+}
+
+pub(crate) fn request_matches_selector(
+    granted: &SpoolSelector,
+    requested_spool_uuid: &[u8; 16],
+    requested_path: &[String],
+) -> bool {
+    if granted.root_spool_uuid.as_slice() != requested_spool_uuid {
+        return false;
+    }
+    if granted.include_descendants {
+        requested_path.starts_with(&granted.path_segments)
+    } else {
+        requested_path == granted.path_segments
+    }
+}

--- a/crates/client/src/owner_authorization/capability/tests.rs
+++ b/crates/client/src/owner_authorization/capability/tests.rs
@@ -1,0 +1,97 @@
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, GuardianSigner, RecoverySetup, VerificationLimits,
+    canonical::{OWNER_CAPABILITY_DOMAIN, capability_body},
+    capability::{
+        create::{CapabilityLineage, unsigned_capability},
+        create_direct_capability, verify_capability_chain,
+    },
+    create_human_owner_root,
+    root::verify_owner_root,
+    wire::{
+        CapabilityPrincipal, CapabilityPrincipalKind, SignedOwnerCapability, SpoolCapabilityAction,
+        SpoolCapabilityGrant, SpoolSelector,
+    },
+};
+
+fn limits() -> VerificationLimits {
+    VerificationLimits::new(300, 3_600, 1024 * 1024).expect("limits")
+}
+
+#[test]
+fn capability_asserting_a_right_outside_parent_grant_does_not_verify() {
+    let authority = AuthorizationKey::from_seed([31; 32]).expect("authority");
+    let recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(AuthorizationKey::from_seed([32; 32]).expect("paper")),
+        GuardianSigner::social(AuthorizationKey::from_seed([33; 32]).expect("social")),
+    ])
+    .expect("recovery");
+    let root = create_human_owner_root([34; 16], &authority, &recovery).expect("root");
+    let state = verify_owner_root(&root).expect("state");
+    let subject_key = AuthorizationKey::from_seed([35; 32]).expect("subject");
+    let subject = CapabilityPrincipal {
+        kind: CapabilityPrincipalKind::Agent as i32,
+        principal_id: b"parent-agent".to_vec(),
+        key: Some(subject_key.verification_key()),
+    };
+    let selector = SpoolSelector {
+        root_spool_uuid: vec![36; 16],
+        path_segments: vec!["acme".to_string()],
+        include_descendants: true,
+    };
+    let parent = create_direct_capability(
+        &state,
+        &authority,
+        subject,
+        vec![SpoolCapabilityGrant {
+            spool: Some(selector.clone()),
+            actions: vec![
+                SpoolCapabilityAction::Read as i32,
+                SpoolCapabilityAction::Grant as i32,
+            ],
+        }],
+        100,
+        300,
+        limits(),
+    )
+    .expect("parent");
+    let parent_body = parent.capability.as_ref().expect("parent body");
+    let child_body = unsigned_capability(
+        CapabilityLineage {
+            owner_id: state.owner_id(),
+            issuer_state_hash: state.state_hash(),
+            parent_capability_id: parent_body.capability_id.clone(),
+        },
+        CapabilityPrincipal {
+            kind: CapabilityPrincipalKind::Agent as i32,
+            principal_id: b"child-agent".to_vec(),
+            key: Some(
+                AuthorizationKey::from_seed([37; 32])
+                    .expect("child")
+                    .verification_key(),
+            ),
+        },
+        vec![SpoolCapabilityGrant {
+            spool: Some(selector),
+            actions: vec![SpoolCapabilityAction::Write as i32],
+        }],
+        100,
+        300,
+        limits(),
+    )
+    .expect("well-formed but wider child");
+    let child = SignedOwnerCapability {
+        signature: Some(
+            subject_key
+                .sign(
+                    OWNER_CAPABILITY_DOMAIN,
+                    &capability_body(&child_body).expect("canonical child"),
+                )
+                .expect("sign wider child"),
+        ),
+        capability: Some(child_body),
+    };
+    assert!(matches!(
+        verify_capability_chain(&state, &[parent, child], 200, limits()),
+        Err(AuthorizationError::CapabilityDenied(_))
+    ));
+}

--- a/crates/client/src/owner_authorization/capability/verify.rs
+++ b/crates/client/src/owner_authorization/capability/verify.rs
@@ -1,0 +1,171 @@
+use crate::owner_authorization::{
+    AuthorizationError, Result, VerificationLimits, VerifiedOwnerState, apply_transition,
+    canonical::{OWNER_CAPABILITY_DOMAIN, capability_body, capability_without_id, digest},
+    capability::{capability_is_well_formed, grant_covers, verify_subject_biscuit},
+    key::verify_signature,
+    root::verify_owner_root,
+    wire::{OwnerAuthorizationBundle, OwnerCapability, SignedOwnerCapability},
+};
+
+/// Capability whose id, lifetime, scope, ancestry, and signature are verified.
+#[derive(Clone)]
+pub struct VerifiedCapability {
+    signed: SignedOwnerCapability,
+}
+
+impl VerifiedCapability {
+    /// Verified body.
+    pub fn capability(&self) -> &OwnerCapability {
+        self.signed
+            .capability
+            .as_ref()
+            .expect("verified capability body")
+    }
+
+    /// Stable owner id.
+    pub fn owner_id(&self) -> [u8; 32] {
+        self.capability()
+            .owner_id
+            .as_slice()
+            .try_into()
+            .expect("verified owner id")
+    }
+
+    /// State hash named by the issuer.
+    pub fn issuer_state_hash(&self) -> [u8; 32] {
+        self.capability()
+            .issuer_state_hash
+            .as_slice()
+            .try_into()
+            .expect("verified state hash")
+    }
+
+    /// Signed wire object.
+    pub fn signed(&self) -> &SignedOwnerCapability {
+        &self.signed
+    }
+}
+
+/// Fully verified portable authorization bundle.
+pub struct VerifiedAuthorizationBundle {
+    owner_state: VerifiedOwnerState,
+    leaf: VerifiedCapability,
+}
+
+impl VerifiedAuthorizationBundle {
+    /// Accepted owner state.
+    pub fn owner_state(&self) -> &VerifiedOwnerState {
+        &self.owner_state
+    }
+
+    /// Leaf capability bound to the subject Biscuit.
+    pub fn leaf(&self) -> &VerifiedCapability {
+        &self.leaf
+    }
+}
+
+fn verify_capability_id(capability: &OwnerCapability) -> Result<()> {
+    let expected = digest(OWNER_CAPABILITY_DOMAIN, &capability_without_id(capability)?);
+    if capability.capability_id.as_slice() != expected {
+        return Err(AuthorizationError::Invalid(
+            "capability id does not match canonical body".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Verify a direct capability and all child derivations.
+pub fn verify_capability_chain(
+    state: &VerifiedOwnerState,
+    chain: &[SignedOwnerCapability],
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<Vec<VerifiedCapability>> {
+    if chain.is_empty() {
+        return Err(AuthorizationError::Invalid(
+            "authorization bundle has no capabilities".to_string(),
+        ));
+    }
+    let mut verified: Vec<VerifiedCapability> = Vec::with_capacity(chain.len());
+    for signed in chain {
+        let capability = signed.capability.as_ref().ok_or_else(|| {
+            AuthorizationError::Invalid("signed capability has no body".to_string())
+        })?;
+        capability_is_well_formed(capability, limits)?;
+        verify_capability_id(capability)?;
+        if capability.owner_id.as_slice() != state.owner_id()
+            || now_unix_seconds < capability.not_before_unix_seconds
+            || now_unix_seconds > capability.expires_at_unix_seconds
+        {
+            return Err(AuthorizationError::Expired);
+        }
+        let signature = signed
+            .signature
+            .as_ref()
+            .ok_or(AuthorizationError::InvalidSignature)?;
+        let signer = if let Some(parent) = verified.last() {
+            let parent_body = parent.capability();
+            if capability.parent_capability_id != parent_body.capability_id
+                || capability.issuer_state_hash != parent_body.issuer_state_hash
+                || capability.not_before_unix_seconds < parent_body.not_before_unix_seconds
+                || capability.expires_at_unix_seconds > parent_body.expires_at_unix_seconds
+                || !grant_covers(&parent_body.grants, &capability.grants)
+            {
+                return Err(AuthorizationError::CapabilityDenied(
+                    "child capability widens or detaches from its parent".to_string(),
+                ));
+            }
+            parent_body
+                .subject
+                .as_ref()
+                .and_then(|subject| subject.key.as_ref())
+                .ok_or_else(|| {
+                    AuthorizationError::CapabilityDenied(
+                        "parent subject has no delegation key".to_string(),
+                    )
+                })?
+        } else {
+            if !capability.parent_capability_id.is_empty() {
+                return Err(AuthorizationError::BrokenChain(
+                    "first capability is not a direct owner grant".to_string(),
+                ));
+            }
+            state.issuer_at(&capability.issuer_state_hash, now_unix_seconds)?
+        };
+        verify_signature(
+            signer,
+            signature,
+            OWNER_CAPABILITY_DOMAIN,
+            &capability_body(capability)?,
+        )?;
+        verified.push(VerifiedCapability {
+            signed: signed.clone(),
+        });
+    }
+    Ok(verified)
+}
+
+/// Verify a portable root/state/capability/Biscuit bundle offline.
+pub fn verify_authorization_bundle(
+    bundle: &OwnerAuthorizationBundle,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<VerifiedAuthorizationBundle> {
+    let mut state = verify_owner_root(bundle.owner_root.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("authorization bundle has no owner root".to_string())
+    })?)?;
+    for transition in &bundle.owner_state_chain {
+        state = apply_transition(&state, transition, now_unix_seconds, limits)?;
+    }
+    let chain =
+        verify_capability_chain(&state, &bundle.capability_chain, now_unix_seconds, limits)?;
+    let leaf = chain
+        .last()
+        .expect("nonempty verified capability chain")
+        .clone();
+    verify_subject_biscuit(leaf.capability(), &bundle.subject_biscuit)?;
+    Ok(VerifiedAuthorizationBundle {
+        owner_state: state,
+        leaf,
+    })
+}

--- a/crates/client/src/owner_authorization/error.rs
+++ b/crates/client/src/owner_authorization/error.rs
@@ -1,0 +1,51 @@
+use std::path::PathBuf;
+
+/// Failure while constructing, persisting, or verifying owner authorization.
+#[derive(Debug, thiserror::Error)]
+pub enum AuthorizationError {
+    #[error("invalid owner-authorization object: {0}")]
+    Invalid(String),
+    #[error("owner-authorization signature verification failed")]
+    InvalidSignature,
+    #[error("owner-authorization chain is broken: {0}")]
+    BrokenChain(String),
+    #[error("recovery threshold is not satisfied: required {required}, got {actual}")]
+    RecoveryThreshold { required: u32, actual: usize },
+    #[error("capability does not grant {0}")]
+    CapabilityDenied(String),
+    #[error("owner-authorization object is expired")]
+    Expired,
+    #[error("owner-authorization object is not yet valid")]
+    NotYetValid,
+    #[error("owner-authorization protobuf is not canonical")]
+    NonCanonicalProtobuf,
+    #[error("owner-authorization keyring exceeds {limit} bytes")]
+    KeyringTooLarge { limit: usize },
+    #[error("owner-authorization keyring is missing at '{0}'")]
+    MissingKeyring(PathBuf),
+    #[error("owner-authorization keyring is already pinned at '{0}'")]
+    AlreadyPinned(PathBuf),
+    #[error("owner-authorization cryptography failed: {0}")]
+    Crypto(String),
+    #[error("owner-authorization persistence failed: {0}")]
+    Persistence(String),
+    #[error("owner-authorization Biscuit failed: {0}")]
+    Biscuit(String),
+    #[error("owner-authorization I/O failed at '{path}': {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("owner-authorization protobuf decode failed: {0}")]
+    Decode(#[from] prost::DecodeError),
+}
+
+impl From<crypto::SignerError> for AuthorizationError {
+    fn from(error: crypto::SignerError) -> Self {
+        Self::Crypto(error.to_string())
+    }
+}
+
+/// Result type for owner-anchored authorization operations.
+pub type Result<T> = std::result::Result<T, AuthorizationError>;

--- a/crates/client/src/owner_authorization/key.rs
+++ b/crates/client/src/owner_authorization/key.rs
@@ -1,0 +1,127 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use biscuit_auth::{KeyPair, PrivateKey, builder::Algorithm};
+use crypto::{Ed25519Signer, Signer};
+
+use crate::owner_authorization::{
+    AuthorizationError, Result,
+    canonical::{digest, key_id},
+    wire::{AuthorizationKeyAlgorithm, AuthorizationSignature, AuthorizationVerificationKey},
+};
+
+/// In-memory Ed25519 authorization signing key.
+///
+/// Private bytes are never part of any wire object.
+pub struct AuthorizationKey {
+    seed: [u8; 32],
+    signer: Ed25519Signer,
+}
+
+impl AuthorizationKey {
+    /// Generate a fresh 256-bit Ed25519 seed locally.
+    pub fn generate() -> Result<Self> {
+        Self::from_seed(rand::random())
+    }
+
+    /// Construct a key from an exact 256-bit seed.
+    pub fn from_seed(seed: [u8; 32]) -> Result<Self> {
+        let signer = Ed25519Signer::from_seed(&seed)?;
+        Ok(Self { seed, signer })
+    }
+
+    /// Return the public wire representation.
+    pub fn verification_key(&self) -> AuthorizationVerificationKey {
+        AuthorizationVerificationKey {
+            algorithm: AuthorizationKeyAlgorithm::Ed25519 as i32,
+            public_key: self.signer.public_key().to_vec(),
+        }
+    }
+
+    /// Return the stable key identifier.
+    pub fn key_id(&self) -> [u8; 32] {
+        key_id(&self.verification_key())
+    }
+
+    pub(crate) fn sign(&self, domain: &[u8], body: &[u8]) -> Result<AuthorizationSignature> {
+        let message = digest(domain, body);
+        Ok(AuthorizationSignature {
+            signer_key_id: self.key_id().to_vec(),
+            signature: self.signer.sign(&message)?,
+        })
+    }
+
+    pub(crate) fn biscuit_key_pair(&self) -> Result<KeyPair> {
+        let private = PrivateKey::from_bytes(&self.seed, Algorithm::Ed25519)
+            .map_err(|error| AuthorizationError::Biscuit(error.to_string()))?;
+        Ok(KeyPair::from(&private))
+    }
+}
+
+/// Client-generated v1 paper recovery seed for paper or QR export.
+pub struct PaperRecoveryKit {
+    seed: [u8; 32],
+    key: AuthorizationKey,
+}
+
+impl PaperRecoveryKit {
+    /// Generate a new paper kit locally.
+    pub fn generate() -> Result<Self> {
+        Self::from_seed(rand::random())
+    }
+
+    /// Restore an exact 256-bit paper-kit seed.
+    pub fn from_seed(seed: [u8; 32]) -> Result<Self> {
+        Ok(Self {
+            seed,
+            key: AuthorizationKey::from_seed(seed)?,
+        })
+    }
+
+    /// Restore a URL-safe, unpadded base64 paper/QR encoding.
+    pub fn from_base64(value: &str) -> Result<Self> {
+        let bytes = URL_SAFE_NO_PAD.decode(value).map_err(|error| {
+            AuthorizationError::Invalid(format!("paper recovery seed: {error}"))
+        })?;
+        let seed = bytes.try_into().map_err(|_| {
+            AuthorizationError::Invalid(
+                "paper recovery seed must decode to exactly 32 bytes".to_string(),
+            )
+        })?;
+        Self::from_seed(seed)
+    }
+
+    /// Encode the 256-bit private seed for paper or QR storage.
+    pub fn to_base64(&self) -> String {
+        URL_SAFE_NO_PAD.encode(self.seed)
+    }
+
+    /// Borrow the recovery signer. Only its public key enters wire objects.
+    pub fn key(&self) -> &AuthorizationKey {
+        &self.key
+    }
+
+    /// Consume the printable kit and retain its signer in a recovery setup.
+    pub fn into_key(self) -> AuthorizationKey {
+        self.key
+    }
+}
+
+pub(crate) fn verify_signature(
+    key: &AuthorizationVerificationKey,
+    signature: &AuthorizationSignature,
+    domain: &[u8],
+    body: &[u8],
+) -> Result<()> {
+    if key.algorithm != AuthorizationKeyAlgorithm::Ed25519 as i32
+        || key.public_key.len() != 32
+        || signature.signer_key_id.as_slice() != key_id(key)
+        || signature.signature.len() != 64
+    {
+        return Err(AuthorizationError::InvalidSignature);
+    }
+    Ed25519Signer::verify_with_public_key(
+        &digest(domain, body),
+        &key.public_key,
+        &signature.signature,
+    )
+    .map_err(|_| AuthorizationError::InvalidSignature)
+}

--- a/crates/client/src/owner_authorization/keyring.rs
+++ b/crates/client/src/owner_authorization/keyring.rs
@@ -1,0 +1,264 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use prost::Message;
+
+use crate::owner_authorization::{
+    AuthorizationError, Result, VerificationLimits, VerifiedCapability, VerifiedOwnerState,
+    apply_transition,
+    canonical::key_id,
+    capability::{request_matches_selector, validate_path_segments, verify_subject_biscuit},
+    keyring_verification::verify_clone_keyring,
+    root::verify_owner_root,
+    wire::{
+        AuthorizationVerificationKey, CapabilityPrincipalKind, CloneAuthorizationKeyring,
+        CloneOwnerPin, CloneOwnerPinKind, SignedOwnerCapability, SignedOwnerKeyTransition,
+        SignedOwnerRoot, SpoolCapabilityAction,
+    },
+};
+
+const KEYRING_RELATIVE_PATH: &str = "owner-authorization/keyring.pb";
+
+/// A request evaluated solely from persisted clone bytes.
+pub struct OfflineRequest {
+    /// Subject category.
+    pub subject_kind: CapabilityPrincipalKind,
+    /// Signed audit identity.
+    pub principal_id: Vec<u8>,
+    /// Subject public key, absent only for `ANY_ANONYMOUS`.
+    pub subject_key: Option<AuthorizationVerificationKey>,
+    /// Subject-signed Biscuit bytes.
+    pub subject_biscuit: Vec<u8>,
+    /// Complete canonical path segments inside the root spool.
+    pub path_segments: Vec<String>,
+    /// Literal action being requested.
+    pub action: SpoolCapabilityAction,
+    /// Local verifier time.
+    pub now_unix_seconds: i64,
+}
+
+/// Keyring after its pin, owner chain, state hash, and public policy verify.
+pub struct VerifiedCloneKeyring {
+    pub(super) wire: CloneAuthorizationKeyring,
+    pub(super) owner_state: VerifiedOwnerState,
+    pub(super) capabilities: Vec<VerifiedCapability>,
+}
+
+impl VerifiedCloneKeyring {
+    /// Accepted owner state.
+    pub fn owner_state(&self) -> &VerifiedOwnerState {
+        &self.owner_state
+    }
+
+    /// Exact persisted transport object.
+    pub fn wire(&self) -> &CloneAuthorizationKeyring {
+        &self.wire
+    }
+}
+
+/// Filesystem persistence for a clone's public owner keyring.
+pub struct CloneKeyringStore {
+    path: PathBuf,
+    limits: VerificationLimits,
+}
+
+impl CloneKeyringStore {
+    /// Locate the dormant keyring under a clone's real `.heddle` directory.
+    pub fn new(heddle_dir: impl AsRef<Path>, limits: VerificationLimits) -> Self {
+        Self {
+            path: heddle_dir.as_ref().join(KEYRING_RELATIVE_PATH),
+            limits,
+        }
+    }
+
+    /// Exact persistence path, intentionally separate from legacy trust keys.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Verify and atomically persist a keyring.
+    pub fn install(
+        &self,
+        keyring: CloneAuthorizationKeyring,
+        now_unix_seconds: i64,
+    ) -> Result<VerifiedCloneKeyring> {
+        let verified = verify_clone_keyring(keyring, now_unix_seconds, self.limits)?;
+        if self
+            .path
+            .try_exists()
+            .map_err(|source| AuthorizationError::Io {
+                path: self.path.clone(),
+                source,
+            })?
+        {
+            return Err(AuthorizationError::AlreadyPinned(self.path.clone()));
+        }
+        self.persist(&verified)?;
+        Ok(verified)
+    }
+
+    fn persist(&self, verified: &VerifiedCloneKeyring) -> Result<()> {
+        let bytes = verified.wire.encode_to_vec();
+        if bytes.len() > self.limits.max_keyring_bytes() {
+            return Err(AuthorizationError::KeyringTooLarge {
+                limit: self.limits.max_keyring_bytes(),
+            });
+        }
+        let parent = self.path.parent().expect("keyring has parent");
+        fs::create_dir_all(parent).map_err(|source| AuthorizationError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+        objects::fs_atomic::write_file_atomic(&self.path, &bytes)
+            .map_err(|error| AuthorizationError::Persistence(error.to_string()))?;
+        Ok(())
+    }
+
+    /// Load and reverify the complete keyring without consulting a remote.
+    pub fn load(&self, now_unix_seconds: i64) -> Result<VerifiedCloneKeyring> {
+        let metadata = fs::metadata(&self.path).map_err(|source| {
+            if source.kind() == std::io::ErrorKind::NotFound {
+                AuthorizationError::MissingKeyring(self.path.clone())
+            } else {
+                AuthorizationError::Io {
+                    path: self.path.clone(),
+                    source,
+                }
+            }
+        })?;
+        if metadata.len() > self.limits.max_keyring_bytes() as u64 {
+            return Err(AuthorizationError::KeyringTooLarge {
+                limit: self.limits.max_keyring_bytes(),
+            });
+        }
+        let bytes = fs::read(&self.path).map_err(|source| AuthorizationError::Io {
+            path: self.path.clone(),
+            source,
+        })?;
+        let keyring = CloneAuthorizationKeyring::decode(bytes.as_slice())?;
+        if keyring.encode_to_vec() != bytes {
+            return Err(AuthorizationError::NonCanonicalProtobuf);
+        }
+        verify_clone_keyring(keyring, now_unix_seconds, self.limits)
+    }
+
+    /// Append a verified linear transition suffix and persist it atomically.
+    pub fn append_transitions(
+        &self,
+        transitions: &[SignedOwnerKeyTransition],
+        now_unix_seconds: i64,
+    ) -> Result<VerifiedCloneKeyring> {
+        let current = self.load(now_unix_seconds)?;
+        let mut wire = current.wire;
+        let mut state = current.owner_state;
+        for transition in transitions {
+            state = apply_transition(&state, transition, now_unix_seconds, self.limits)?;
+            wire.accepted_transitions.push(transition.clone());
+        }
+        wire.accepted_state_hash = state.state_hash().to_vec();
+        let verified = verify_clone_keyring(wire, now_unix_seconds, self.limits)?;
+        self.persist(&verified)?;
+        Ok(verified)
+    }
+}
+
+/// Construct a clone keyring from an externally authenticated owner fingerprint.
+#[allow(clippy::too_many_arguments)]
+pub fn create_clone_keyring(
+    spool_uuid: [u8; 16],
+    canonical_spool_path_segments: Vec<String>,
+    pin_kind: CloneOwnerPinKind,
+    expected_owner_id: [u8; 32],
+    first_seen_unix_seconds: i64,
+    owner_root: SignedOwnerRoot,
+    accepted_transitions: Vec<SignedOwnerKeyTransition>,
+    public_access_capabilities: Vec<SignedOwnerCapability>,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<CloneAuthorizationKeyring> {
+    let mut state = verify_owner_root(&owner_root)?;
+    for transition in &accepted_transitions {
+        state = apply_transition(&state, transition, now_unix_seconds, limits)?;
+    }
+    let keyring = CloneAuthorizationKeyring {
+        format_version: 1,
+        spool_uuid: spool_uuid.to_vec(),
+        canonical_spool_path_segments,
+        pin: Some(CloneOwnerPin {
+            kind: pin_kind as i32,
+            expected_owner_id: expected_owner_id.to_vec(),
+            first_seen_unix_seconds,
+        }),
+        owner_root: Some(owner_root),
+        accepted_transitions,
+        accepted_state_hash: state.state_hash().to_vec(),
+        public_access_capabilities,
+    };
+    verify_clone_keyring(keyring.clone(), now_unix_seconds, limits)?;
+    Ok(keyring)
+}
+
+/// Offline capability evaluator backed only by one verified clone keyring.
+pub struct OfflineAuthorizer {
+    keyring: VerifiedCloneKeyring,
+}
+
+impl OfflineAuthorizer {
+    /// Consume a verified keyring; no network handle is accepted or retained.
+    pub fn new(keyring: VerifiedCloneKeyring) -> Self {
+        Self { keyring }
+    }
+
+    /// Return `Ok(())` only for a literal matching subject, scope, action, and time.
+    pub fn authorize(&self, request: &OfflineRequest) -> Result<()> {
+        validate_path_segments(&request.path_segments)?;
+        if request.action == SpoolCapabilityAction::Unspecified
+            || request.subject_kind == CapabilityPrincipalKind::Unspecified
+            || !request
+                .path_segments
+                .starts_with(&self.keyring.wire.canonical_spool_path_segments)
+        {
+            return Err(AuthorizationError::CapabilityDenied(
+                "request is outside the pinned clone".to_string(),
+            ));
+        }
+        let spool_uuid: [u8; 16] = self
+            .keyring
+            .wire
+            .spool_uuid
+            .as_slice()
+            .try_into()
+            .expect("verified spool UUID");
+        for verified in &self.keyring.capabilities {
+            let capability = verified.capability();
+            if request.now_unix_seconds < capability.not_before_unix_seconds
+                || request.now_unix_seconds > capability.expires_at_unix_seconds
+            {
+                continue;
+            }
+            let subject = capability.subject.as_ref().expect("verified subject");
+            if subject.kind != request.subject_kind as i32
+                || subject.principal_id != request.principal_id
+                || subject.key.as_ref().map(key_id) != request.subject_key.as_ref().map(key_id)
+            {
+                continue;
+            }
+            verify_subject_biscuit(capability, &request.subject_biscuit)?;
+            if capability.grants.iter().any(|grant| {
+                grant.actions.contains(&(request.action as i32))
+                    && grant.spool.as_ref().is_some_and(|selector| {
+                        request_matches_selector(selector, &spool_uuid, &request.path_segments)
+                    })
+            }) {
+                return Ok(());
+            }
+        }
+        Err(AuthorizationError::CapabilityDenied(format!(
+            "{:?} on {}",
+            request.action,
+            request.path_segments.join("/")
+        )))
+    }
+}

--- a/crates/client/src/owner_authorization/keyring_verification.rs
+++ b/crates/client/src/owner_authorization/keyring_verification.rs
@@ -1,0 +1,109 @@
+use crate::owner_authorization::{
+    AuthorizationError, Result, VerificationLimits, apply_transition,
+    capability::{request_matches_selector, verify_capability_chain},
+    keyring::VerifiedCloneKeyring,
+    root::verify_owner_root,
+    wire::{CloneAuthorizationKeyring, CloneOwnerPinKind},
+};
+
+fn validate_clone_path(path: &[String]) -> Result<()> {
+    if path.iter().any(|segment| {
+        segment.is_empty()
+            || matches!(segment.as_str(), "." | "..")
+            || segment.contains('/')
+            || segment.contains('\0')
+    }) {
+        return Err(AuthorizationError::Invalid(
+            "clone keyring has a non-canonical spool path".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn verify_pin(keyring: &CloneAuthorizationKeyring) -> Result<()> {
+    let pin = keyring
+        .pin
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("clone keyring has no owner pin".to_string()))?;
+    let pin_kind = CloneOwnerPinKind::try_from(pin.kind)
+        .ok()
+        .filter(|kind| *kind != CloneOwnerPinKind::Unspecified)
+        .ok_or_else(|| AuthorizationError::Invalid("unknown clone pin kind".to_string()))?;
+    if !matches!(
+        pin_kind,
+        CloneOwnerPinKind::LocalCreation | CloneOwnerPinKind::InvitationFingerprint
+    ) || pin.expected_owner_id.len() != 32
+        || pin.first_seen_unix_seconds < 0
+    {
+        return Err(AuthorizationError::Invalid(
+            "clone owner pin is invalid".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+pub(super) fn verify_clone_keyring(
+    keyring: CloneAuthorizationKeyring,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<VerifiedCloneKeyring> {
+    if keyring.format_version != 1
+        || keyring.spool_uuid.len() != 16
+        || keyring.accepted_state_hash.len() != 32
+    {
+        return Err(AuthorizationError::Invalid(
+            "clone keyring has invalid v1 field lengths".to_string(),
+        ));
+    }
+    validate_clone_path(&keyring.canonical_spool_path_segments)?;
+    verify_pin(&keyring)?;
+
+    let pin = keyring.pin.as_ref().expect("verified pin");
+    let mut state = verify_owner_root(keyring.owner_root.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("clone keyring has no owner root".to_string())
+    })?)?;
+    if pin.expected_owner_id.as_slice() != state.owner_id() {
+        return Err(AuthorizationError::Invalid(
+            "clone owner pin does not match the signed root".to_string(),
+        ));
+    }
+    for transition in &keyring.accepted_transitions {
+        state = apply_transition(&state, transition, now_unix_seconds, limits)?;
+    }
+    if keyring.accepted_state_hash.as_slice() != state.state_hash() {
+        return Err(AuthorizationError::BrokenChain(
+            "accepted state hash does not match transition history".to_string(),
+        ));
+    }
+
+    let spool_uuid: [u8; 16] = keyring.spool_uuid.as_slice().try_into().expect("checked");
+    let mut capabilities = Vec::new();
+    for signed in &keyring.public_access_capabilities {
+        let verified = verify_capability_chain(
+            &state,
+            std::slice::from_ref(signed),
+            now_unix_seconds,
+            limits,
+        )?;
+        let capability = verified[0].capability();
+        if !capability.grants.iter().all(|grant| {
+            grant.spool.as_ref().is_some_and(|selector| {
+                request_matches_selector(
+                    selector,
+                    &spool_uuid,
+                    &keyring.canonical_spool_path_segments,
+                )
+            })
+        }) {
+            return Err(AuthorizationError::Invalid(
+                "keyring contains a capability for another spool".to_string(),
+            ));
+        }
+        capabilities.extend(verified);
+    }
+    Ok(VerifiedCloneKeyring {
+        wire: keyring,
+        owner_state: state,
+        capabilities,
+    })
+}

--- a/crates/client/src/owner_authorization/limits.rs
+++ b/crates/client/src/owner_authorization/limits.rs
@@ -1,0 +1,51 @@
+use crate::owner_authorization::{AuthorizationError, Result};
+
+/// Client-side security ceilings required by offline verification.
+///
+/// api#55 leaves the numeric TTL values as cutover product inputs. They are
+/// therefore mandatory construction inputs here rather than server-provided
+/// values or permissive defaults.
+#[derive(Clone, Copy, Debug)]
+pub struct VerificationLimits {
+    max_capability_ttl_seconds: i64,
+    max_anonymous_ttl_seconds: i64,
+    max_keyring_bytes: usize,
+}
+
+impl VerificationLimits {
+    /// Construct explicit offline-verification ceilings.
+    pub fn new(
+        max_capability_ttl_seconds: i64,
+        max_anonymous_ttl_seconds: i64,
+        max_keyring_bytes: usize,
+    ) -> Result<Self> {
+        if max_capability_ttl_seconds <= 0
+            || max_anonymous_ttl_seconds <= 0
+            || max_keyring_bytes == 0
+        {
+            return Err(AuthorizationError::Invalid(
+                "verification limits must all be positive".to_string(),
+            ));
+        }
+        Ok(Self {
+            max_capability_ttl_seconds,
+            max_anonymous_ttl_seconds,
+            max_keyring_bytes,
+        })
+    }
+
+    /// Maximum owner-capability lifetime and key-handover overlap.
+    pub fn max_capability_ttl_seconds(self) -> i64 {
+        self.max_capability_ttl_seconds
+    }
+
+    /// Maximum anonymous pseudonym lifetime.
+    pub fn max_anonymous_ttl_seconds(self) -> i64 {
+        self.max_anonymous_ttl_seconds
+    }
+
+    /// Maximum serialized clone-keyring size.
+    pub fn max_keyring_bytes(self) -> usize {
+        self.max_keyring_bytes
+    }
+}

--- a/crates/client/src/owner_authorization/mod.rs
+++ b/crates/client/src/owner_authorization/mod.rs
@@ -1,0 +1,52 @@
+//! Inert client primitives for owner-anchored authorization.
+//!
+//! This module deliberately has no hosted transport, CLI dispatch, bearer
+//! conversion, or clone hook. It can construct and verify the reviewed wire
+//! objects and persist a clone keyring, but no current authorization path
+//! imports it. Weft's exclusive cutover must wire the module and remove the
+//! server-minted path in the same change.
+
+mod anonymous;
+mod bootstrap;
+mod canonical;
+mod capability;
+mod error;
+mod key;
+mod keyring;
+mod keyring_verification;
+mod limits;
+mod recovery;
+mod root;
+mod transition;
+pub mod wire;
+
+pub use anonymous::{
+    create_anonymous_credential, create_anonymous_registration, verify_anonymous_credential,
+    verify_anonymous_registration,
+};
+pub use bootstrap::{
+    bootstrap_challenge, create_deferred_bootstrap, create_human_bootstrap,
+    verify_bootstrap_response, verify_deferred_bootstrap,
+};
+pub use capability::{
+    VerifiedAuthorizationBundle, VerifiedCapability, create_child_capability,
+    create_direct_capability, mint_subject_biscuit, verify_authorization_bundle,
+    verify_capability_chain,
+};
+pub use error::{AuthorizationError, Result};
+pub use key::{AuthorizationKey, PaperRecoveryKit};
+pub use keyring::{
+    CloneKeyringStore, OfflineAuthorizer, OfflineRequest, VerifiedCloneKeyring,
+    create_clone_keyring,
+};
+pub use limits::VerificationLimits;
+pub use recovery::{
+    CustodialRecoveryConfirmation, GuardianSigner, RecoverySetup, confirm_custodial_weft_only,
+};
+pub use root::{
+    VerifiedOwnerState, create_deferred_owner_root, create_human_owner_root, verify_owner_root,
+};
+pub use transition::{
+    apply_transition, create_claim_transition, create_recovery_policy_transition,
+    create_recovery_transition, create_rotation_transition,
+};

--- a/crates/client/src/owner_authorization/recovery.rs
+++ b/crates/client/src/owner_authorization/recovery.rs
@@ -1,0 +1,245 @@
+use std::collections::BTreeSet;
+
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, Result,
+    canonical::key_id,
+    wire::{AuthorizationKeyAlgorithm, RecoveryGuardian, RecoveryGuardianKind, RecoveryPolicy},
+};
+
+/// Dedicated recovery signer and its signed guardian provenance.
+pub struct GuardianSigner {
+    kind: RecoveryGuardianKind,
+    key: AuthorizationKey,
+}
+
+impl GuardianSigner {
+    /// Construct a paper-kit guardian.
+    pub fn paper(key: AuthorizationKey) -> Self {
+        Self {
+            kind: RecoveryGuardianKind::Paper,
+            key,
+        }
+    }
+
+    /// Construct a social guardian.
+    pub fn social(key: AuthorizationKey) -> Self {
+        Self {
+            kind: RecoveryGuardianKind::Social,
+            key,
+        }
+    }
+
+    /// Construct an opt-in Weft guardian.
+    pub fn weft(key: AuthorizationKey) -> Self {
+        Self {
+            kind: RecoveryGuardianKind::Weft,
+            key,
+        }
+    }
+
+    /// Borrow the dedicated signing key.
+    pub fn key(&self) -> &AuthorizationKey {
+        &self.key
+    }
+}
+
+/// Explicit acknowledgement required to construct custodial Weft-only recovery.
+pub struct CustodialRecoveryConfirmation {
+    _private: (),
+}
+
+/// Confirm that a 1-of-1 Weft policy makes the account custodial.
+#[must_use]
+pub fn confirm_custodial_weft_only() -> CustodialRecoveryConfirmation {
+    CustodialRecoveryConfirmation { _private: () }
+}
+
+/// Validated guardian threshold plus the private signers used for setup proofs.
+pub struct RecoverySetup {
+    threshold: u32,
+    guardians: Vec<GuardianSigner>,
+}
+
+impl RecoverySetup {
+    /// Construct the default two-of-N recovery policy.
+    pub fn recommended(guardians: Vec<GuardianSigner>) -> Result<Self> {
+        Self::with_threshold(2, guardians)
+    }
+
+    /// Construct a non-custodial threshold policy.
+    pub fn with_threshold(threshold: u32, guardians: Vec<GuardianSigner>) -> Result<Self> {
+        if threshold < 2 {
+            return Err(AuthorizationError::Invalid(
+                "recovery threshold below 2 requires the explicit Weft-only confirmation path"
+                    .to_string(),
+            ));
+        }
+        let setup = Self {
+            threshold,
+            guardians,
+        };
+        setup.validate(None, false)?;
+        Ok(setup)
+    }
+
+    /// Construct the explicitly confirmed 1-of-1 custodial Weft policy.
+    pub fn custodial_weft_only(
+        guardian: GuardianSigner,
+        _confirmation: CustodialRecoveryConfirmation,
+    ) -> Result<Self> {
+        if guardian.kind != RecoveryGuardianKind::Weft {
+            return Err(AuthorizationError::Invalid(
+                "custodial recovery requires exactly one Weft guardian".to_string(),
+            ));
+        }
+        let setup = Self {
+            threshold: 1,
+            guardians: vec![guardian],
+        };
+        setup.validate(None, true)?;
+        Ok(setup)
+    }
+
+    /// Threshold committed to the owner state.
+    pub fn threshold(&self) -> u32 {
+        self.threshold
+    }
+
+    /// Guardian signers used for root and policy possession proofs.
+    pub fn guardians(&self) -> &[GuardianSigner] {
+        &self.guardians
+    }
+
+    pub(crate) fn to_wire(&self, authority: &AuthorizationKey) -> Result<RecoveryPolicy> {
+        self.validate(Some(&authority.key_id()), self.threshold == 1)?;
+        let mut guardians = self
+            .guardians
+            .iter()
+            .map(|guardian| RecoveryGuardian {
+                kind: guardian.kind as i32,
+                key: Some(guardian.key.verification_key()),
+            })
+            .collect::<Vec<_>>();
+        guardians.sort_by_key(|guardian| {
+            key_id(guardian.key.as_ref().expect("constructed guardian key"))
+        });
+        Ok(RecoveryPolicy {
+            threshold: self.threshold,
+            guardians,
+        })
+    }
+
+    fn validate(&self, authority_key_id: Option<&[u8; 32]>, allow_custodial: bool) -> Result<()> {
+        if self.threshold == 0 || self.threshold as usize > self.guardians.len() {
+            return Err(AuthorizationError::Invalid(
+                "recovery threshold exceeds the guardian set".to_string(),
+            ));
+        }
+        if self.threshold < 2
+            && (!allow_custodial
+                || self.guardians.len() != 1
+                || self.guardians[0].kind != RecoveryGuardianKind::Weft)
+        {
+            return Err(AuthorizationError::Invalid(
+                "1-of-1 recovery is allowed only for explicitly confirmed Weft custody".to_string(),
+            ));
+        }
+        if self
+            .guardians
+            .iter()
+            .any(|guardian| guardian.kind == RecoveryGuardianKind::Weft)
+            && self.threshold >= 2
+            && !self.guardians.iter().any(|guardian| {
+                matches!(
+                    guardian.kind,
+                    RecoveryGuardianKind::Paper | RecoveryGuardianKind::Social
+                )
+            })
+        {
+            return Err(AuthorizationError::Invalid(
+                "a Weft guardian requires a paper or social co-factor".to_string(),
+            ));
+        }
+
+        let mut ids = BTreeSet::new();
+        for guardian in &self.guardians {
+            let id = guardian.key.key_id();
+            if authority_key_id == Some(&id) || !ids.insert(id) {
+                return Err(AuthorizationError::Invalid(
+                    "authority and recovery guardian keys must be distinct".to_string(),
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn validate_wire_policy(
+    policy: &RecoveryPolicy,
+    authority_key_id: &[u8; 32],
+    allow_empty: bool,
+) -> Result<()> {
+    if allow_empty && policy.threshold == 0 && policy.guardians.is_empty() {
+        return Ok(());
+    }
+    if policy.threshold == 0 || policy.threshold as usize > policy.guardians.len() {
+        return Err(AuthorizationError::Invalid(
+            "recovery threshold is outside the guardian set".to_string(),
+        ));
+    }
+    let custodial = policy.threshold == 1
+        && policy.guardians.len() == 1
+        && policy.guardians[0].kind == RecoveryGuardianKind::Weft as i32;
+    if policy.threshold < 2 && !custodial {
+        return Err(AuthorizationError::Invalid(
+            "wire policy has an unapproved threshold below 2".to_string(),
+        ));
+    }
+    let has_weft = policy
+        .guardians
+        .iter()
+        .any(|guardian| guardian.kind == RecoveryGuardianKind::Weft as i32);
+    let has_independent_cofactor = policy.guardians.iter().any(|guardian| {
+        matches!(
+            RecoveryGuardianKind::try_from(guardian.kind),
+            Ok(RecoveryGuardianKind::Paper | RecoveryGuardianKind::Social)
+        )
+    });
+    if has_weft && !custodial && !has_independent_cofactor {
+        return Err(AuthorizationError::Invalid(
+            "Weft recovery lacks a paper or social co-factor".to_string(),
+        ));
+    }
+
+    let mut ids = Vec::with_capacity(policy.guardians.len());
+    for guardian in &policy.guardians {
+        RecoveryGuardianKind::try_from(guardian.kind)
+            .ok()
+            .filter(|kind| *kind != RecoveryGuardianKind::Unspecified)
+            .ok_or_else(|| {
+                AuthorizationError::Invalid("unknown recovery guardian kind".to_string())
+            })?;
+        let key = guardian.key.as_ref().ok_or_else(|| {
+            AuthorizationError::Invalid("recovery guardian has no key".to_string())
+        })?;
+        if key.algorithm != AuthorizationKeyAlgorithm::Ed25519 as i32 || key.public_key.len() != 32
+        {
+            return Err(AuthorizationError::Invalid(
+                "recovery guardian key is not 32-byte Ed25519".to_string(),
+            ));
+        }
+        let id = key_id(key);
+        if &id == authority_key_id {
+            return Err(AuthorizationError::Invalid(
+                "authority key cannot also be a recovery guardian".to_string(),
+            ));
+        }
+        ids.push(id);
+    }
+    if ids.windows(2).any(|pair| pair[0] >= pair[1]) {
+        return Err(AuthorizationError::Invalid(
+            "recovery guardians must be unique and sorted by key id".to_string(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/client/src/owner_authorization/root.rs
+++ b/crates/client/src/owner_authorization/root.rs
@@ -1,0 +1,247 @@
+use std::collections::BTreeMap;
+
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, RecoverySetup, Result,
+    canonical::{OWNER_ROOT_DOMAIN, digest, key_id, nonce, owner_root_body, owner_root_without_id},
+    key::verify_signature,
+    recovery::validate_wire_policy,
+    wire::{
+        AuthorizationKeyAlgorithm, AuthorizationVerificationKey, OwnerRoot, RecoveryPolicy,
+        SignedOwnerRoot,
+    },
+};
+
+#[derive(Clone)]
+pub(crate) struct HistoricalAuthority {
+    pub(crate) key: AuthorizationVerificationKey,
+    pub(crate) valid_until: Option<i64>,
+}
+
+/// Fully verified owner root plus all accepted offline state.
+#[derive(Clone)]
+pub struct VerifiedOwnerState {
+    pub(crate) signed_root: SignedOwnerRoot,
+    pub(crate) owner_id: [u8; 32],
+    pub(crate) state_hash: [u8; 32],
+    pub(crate) sequence: u64,
+    pub(crate) authority_key: AuthorizationVerificationKey,
+    pub(crate) recovery_policy: RecoveryPolicy,
+    pub(crate) claimable_deferred_human: bool,
+    pub(crate) claimable_until_unix_seconds: i64,
+    pub(crate) issuers: BTreeMap<[u8; 32], HistoricalAuthority>,
+}
+
+impl VerifiedOwnerState {
+    /// Stable authorization identity.
+    pub fn owner_id(&self) -> [u8; 32] {
+        self.owner_id
+    }
+
+    /// Hash of the currently accepted state.
+    pub fn state_hash(&self) -> [u8; 32] {
+        self.state_hash
+    }
+
+    /// Current transition sequence, with the root at sequence zero.
+    pub fn sequence(&self) -> u64 {
+        self.sequence
+    }
+
+    /// Active authority public key.
+    pub fn authority_key(&self) -> &AuthorizationVerificationKey {
+        &self.authority_key
+    }
+
+    /// Active recovery policy.
+    pub fn recovery_policy(&self) -> &RecoveryPolicy {
+        &self.recovery_policy
+    }
+
+    /// Original signed root retained for portable bundles.
+    pub fn signed_root(&self) -> &SignedOwnerRoot {
+        &self.signed_root
+    }
+
+    pub(crate) fn issuer_at(
+        &self,
+        state_hash: &[u8],
+        now_unix_seconds: i64,
+    ) -> Result<&AuthorizationVerificationKey> {
+        let state_hash: [u8; 32] = state_hash.try_into().map_err(|_| {
+            AuthorizationError::Invalid("issuer state hash must be 32 bytes".to_string())
+        })?;
+        let issuer = self.issuers.get(&state_hash).ok_or_else(|| {
+            AuthorizationError::BrokenChain("unknown capability issuer state".to_string())
+        })?;
+        if issuer
+            .valid_until
+            .is_some_and(|valid_until| valid_until == 0 || now_unix_seconds > valid_until)
+        {
+            return Err(AuthorizationError::Expired);
+        }
+        if self.claimable_deferred_human
+            && self.claimable_until_unix_seconds > 0
+            && now_unix_seconds > self.claimable_until_unix_seconds
+        {
+            return Err(AuthorizationError::Expired);
+        }
+        Ok(&issuer.key)
+    }
+}
+
+/// Create and self-sign an ordinary human owner root.
+pub fn create_human_owner_root(
+    account_uuid: [u8; 16],
+    authority: &AuthorizationKey,
+    recovery: &RecoverySetup,
+) -> Result<SignedOwnerRoot> {
+    create_owner_root(account_uuid, authority, Some(recovery), false, 0)
+}
+
+/// Create a deferred-human origin root with its immutable claim deadline.
+pub fn create_deferred_owner_root(
+    account_uuid: [u8; 16],
+    origin: &AuthorizationKey,
+    claimable_until_unix_seconds: i64,
+) -> Result<SignedOwnerRoot> {
+    if claimable_until_unix_seconds <= 0 {
+        return Err(AuthorizationError::Invalid(
+            "deferred owner root requires a positive claim deadline".to_string(),
+        ));
+    }
+    create_owner_root(
+        account_uuid,
+        origin,
+        None,
+        true,
+        claimable_until_unix_seconds,
+    )
+}
+
+fn create_owner_root(
+    account_uuid: [u8; 16],
+    authority: &AuthorizationKey,
+    recovery: Option<&RecoverySetup>,
+    claimable: bool,
+    claimable_until: i64,
+) -> Result<SignedOwnerRoot> {
+    let policy = match recovery {
+        Some(setup) => setup.to_wire(authority)?,
+        None => RecoveryPolicy {
+            threshold: 0,
+            guardians: Vec::new(),
+        },
+    };
+    let mut root = OwnerRoot {
+        format_version: 1,
+        owner_id: Vec::new(),
+        account_uuid: account_uuid.to_vec(),
+        authority_key: Some(authority.verification_key()),
+        recovery_policy: Some(policy),
+        claimable_deferred_human: claimable,
+        nonce: nonce(),
+        claimable_until_unix_seconds: claimable_until,
+    };
+    root.owner_id = digest(OWNER_ROOT_DOMAIN, &owner_root_without_id(&root)?).to_vec();
+    let body = owner_root_body(&root)?;
+    let authority_proof = authority.sign(OWNER_ROOT_DOMAIN, &body)?;
+    let mut recovery_key_proofs = recovery
+        .into_iter()
+        .flat_map(RecoverySetup::guardians)
+        .map(|guardian| guardian.key().sign(OWNER_ROOT_DOMAIN, &body))
+        .collect::<Result<Vec<_>>>()?;
+    recovery_key_proofs.sort_by(|left, right| left.signer_key_id.cmp(&right.signer_key_id));
+    Ok(SignedOwnerRoot {
+        root: Some(root),
+        authority_proof: Some(authority_proof),
+        recovery_key_proofs,
+    })
+}
+
+/// Verify all root fields and possession proofs without network access.
+pub fn verify_owner_root(signed: &SignedOwnerRoot) -> Result<VerifiedOwnerState> {
+    let root = signed
+        .root
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("signed owner root has no body".to_string()))?;
+    if root.format_version != 1
+        || root.owner_id.len() != 32
+        || root.account_uuid.len() != 16
+        || root.nonce.len() != 32
+    {
+        return Err(AuthorizationError::Invalid(
+            "owner root has invalid v1 field lengths".to_string(),
+        ));
+    }
+    let authority = root.authority_key.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("owner root has no authority key".to_string())
+    })?;
+    if authority.algorithm != AuthorizationKeyAlgorithm::Ed25519 as i32
+        || authority.public_key.len() != 32
+    {
+        return Err(AuthorizationError::Invalid(
+            "owner authority is not 32-byte Ed25519".to_string(),
+        ));
+    }
+    if root.claimable_deferred_human != (root.claimable_until_unix_seconds > 0) {
+        return Err(AuthorizationError::Invalid(
+            "deferred claim flag and deadline disagree".to_string(),
+        ));
+    }
+    let expected_owner_id = digest(OWNER_ROOT_DOMAIN, &owner_root_without_id(root)?);
+    if root.owner_id.as_slice() != expected_owner_id {
+        return Err(AuthorizationError::Invalid(
+            "owner id does not match the canonical root".to_string(),
+        ));
+    }
+
+    let policy = root.recovery_policy.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("owner root has no recovery policy".to_string())
+    })?;
+    validate_wire_policy(policy, &key_id(authority), root.claimable_deferred_human)?;
+    let body = owner_root_body(root)?;
+    verify_signature(
+        authority,
+        signed.authority_proof.as_ref().ok_or_else(|| {
+            AuthorizationError::Invalid("owner root has no authority proof".to_string())
+        })?,
+        OWNER_ROOT_DOMAIN,
+        &body,
+    )?;
+    if signed.recovery_key_proofs.len() != policy.guardians.len() {
+        return Err(AuthorizationError::Invalid(
+            "owner root recovery proof count does not match guardians".to_string(),
+        ));
+    }
+    for (guardian, proof) in policy.guardians.iter().zip(&signed.recovery_key_proofs) {
+        verify_signature(
+            guardian.key.as_ref().ok_or_else(|| {
+                AuthorizationError::Invalid("recovery guardian has no key".to_string())
+            })?,
+            proof,
+            OWNER_ROOT_DOMAIN,
+            &body,
+        )?;
+    }
+
+    let state_hash = digest(OWNER_ROOT_DOMAIN, &body);
+    let mut issuers = BTreeMap::new();
+    issuers.insert(
+        state_hash,
+        HistoricalAuthority {
+            key: authority.clone(),
+            valid_until: None,
+        },
+    );
+    Ok(VerifiedOwnerState {
+        signed_root: signed.clone(),
+        owner_id: expected_owner_id,
+        state_hash,
+        sequence: 0,
+        authority_key: authority.clone(),
+        recovery_policy: policy.clone(),
+        claimable_deferred_human: root.claimable_deferred_human,
+        claimable_until_unix_seconds: root.claimable_until_unix_seconds,
+        issuers,
+    })
+}

--- a/crates/client/src/owner_authorization/transition/create.rs
+++ b/crates/client/src/owner_authorization/transition/create.rs
@@ -1,0 +1,236 @@
+use crate::owner_authorization::{
+    AuthorizationError, AuthorizationKey, RecoverySetup, Result, VerificationLimits,
+    VerifiedOwnerState,
+    canonical::{OWNER_TRANSITION_DOMAIN, nonce, transition_body},
+    wire::{
+        AuthorizationSignature, OwnerKeyTransition, OwnerKeyTransitionKind,
+        SignedOwnerKeyTransition,
+    },
+};
+
+fn validate_overlap(
+    valid_from: i64,
+    previous_valid_until: i64,
+    limits: VerificationLimits,
+) -> Result<()> {
+    if valid_from < 0
+        || previous_valid_until < 0
+        || (previous_valid_until > 0 && previous_valid_until < valid_from)
+        || previous_valid_until.saturating_sub(valid_from) > limits.max_capability_ttl_seconds()
+    {
+        return Err(AuthorizationError::Invalid(
+            "previous-key handover exceeds the capability TTL ceiling".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn transition_body_for(
+    state: &VerifiedOwnerState,
+    kind: OwnerKeyTransitionKind,
+    next_authority: &AuthorizationKey,
+    next_recovery_policy: crate::owner_authorization::wire::RecoveryPolicy,
+    valid_from: i64,
+    previous_valid_until: i64,
+    limits: VerificationLimits,
+) -> Result<OwnerKeyTransition> {
+    validate_overlap(valid_from, previous_valid_until, limits)?;
+    Ok(OwnerKeyTransition {
+        format_version: 1,
+        owner_id: state.owner_id().to_vec(),
+        previous_state_hash: state.state_hash().to_vec(),
+        sequence: state.sequence() + 1,
+        kind: kind as i32,
+        next_authority_key: Some(next_authority.verification_key()),
+        next_recovery_policy: Some(next_recovery_policy),
+        valid_from_unix_seconds: valid_from,
+        previous_key_valid_until_unix_seconds: previous_valid_until,
+        nonce: nonce(),
+    })
+}
+
+fn threshold_authorizations(
+    policy: &crate::owner_authorization::wire::RecoveryPolicy,
+    guardians: &[&AuthorizationKey],
+    body: &[u8],
+) -> Result<Vec<AuthorizationSignature>> {
+    let allowed = policy
+        .guardians
+        .iter()
+        .filter_map(|guardian| guardian.key.as_ref())
+        .map(crate::owner_authorization::canonical::key_id)
+        .collect::<std::collections::BTreeSet<_>>();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut signatures = Vec::new();
+    for guardian in guardians {
+        let id = guardian.key_id();
+        if !allowed.contains(&id) || !seen.insert(id) {
+            return Err(AuthorizationError::Invalid(
+                "recovery signer is absent or duplicated in the active policy".to_string(),
+            ));
+        }
+        signatures.push(guardian.sign(OWNER_TRANSITION_DOMAIN, body)?);
+    }
+    if signatures.len() < policy.threshold as usize {
+        return Err(AuthorizationError::RecoveryThreshold {
+            required: policy.threshold,
+            actual: signatures.len(),
+        });
+    }
+    signatures.sort_by(|left, right| left.signer_key_id.cmp(&right.signer_key_id));
+    Ok(signatures)
+}
+
+fn next_guardian_proofs(
+    recovery: &RecoverySetup,
+    body: &[u8],
+) -> Result<Vec<AuthorizationSignature>> {
+    let mut proofs = recovery
+        .guardians()
+        .iter()
+        .map(|guardian| guardian.key().sign(OWNER_TRANSITION_DOMAIN, body))
+        .collect::<Result<Vec<_>>>()?;
+    proofs.sort_by(|left, right| left.signer_key_id.cmp(&right.signer_key_id));
+    Ok(proofs)
+}
+
+/// Create a hot-key rotation authorized by the current and next authority.
+pub fn create_rotation_transition(
+    state: &VerifiedOwnerState,
+    current_authority: &AuthorizationKey,
+    next_authority: &AuthorizationKey,
+    valid_from_unix_seconds: i64,
+    previous_key_valid_until_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerKeyTransition> {
+    if current_authority.key_id()
+        != crate::owner_authorization::canonical::key_id(state.authority_key())
+        || current_authority.key_id() == next_authority.key_id()
+    {
+        return Err(AuthorizationError::Invalid(
+            "rotation keys do not match the active state or are unchanged".to_string(),
+        ));
+    }
+    let transition = transition_body_for(
+        state,
+        OwnerKeyTransitionKind::Rotate,
+        next_authority,
+        state.recovery_policy().clone(),
+        valid_from_unix_seconds,
+        previous_key_valid_until_unix_seconds,
+        limits,
+    )?;
+    let body = transition_body(&transition)?;
+    Ok(SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: vec![current_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?],
+        next_authority_key_proof: Some(next_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?),
+        next_recovery_key_proofs: Vec::new(),
+    })
+}
+
+/// Create a threshold recovery with no retired-key overlap.
+pub fn create_recovery_transition(
+    state: &VerifiedOwnerState,
+    recovery_guardians: &[&AuthorizationKey],
+    next_authority: &AuthorizationKey,
+    valid_from_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerKeyTransition> {
+    let transition = transition_body_for(
+        state,
+        OwnerKeyTransitionKind::Recover,
+        next_authority,
+        state.recovery_policy().clone(),
+        valid_from_unix_seconds,
+        0,
+        limits,
+    )?;
+    let body = transition_body(&transition)?;
+    Ok(SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: threshold_authorizations(
+            state.recovery_policy(),
+            recovery_guardians,
+            &body,
+        )?,
+        next_authority_key_proof: Some(next_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?),
+        next_recovery_key_proofs: Vec::new(),
+    })
+}
+
+/// Replace the recovery policy under both active trust anchors.
+pub fn create_recovery_policy_transition(
+    state: &VerifiedOwnerState,
+    current_authority: &AuthorizationKey,
+    current_recovery_guardians: &[&AuthorizationKey],
+    next_recovery: &RecoverySetup,
+    valid_from_unix_seconds: i64,
+    previous_key_valid_until_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerKeyTransition> {
+    if current_authority.key_id()
+        != crate::owner_authorization::canonical::key_id(state.authority_key())
+    {
+        return Err(AuthorizationError::Invalid(
+            "recovery-policy signer is not the active authority".to_string(),
+        ));
+    }
+    let transition = transition_body_for(
+        state,
+        OwnerKeyTransitionKind::RecoveryPolicy,
+        current_authority,
+        next_recovery.to_wire(current_authority)?,
+        valid_from_unix_seconds,
+        previous_key_valid_until_unix_seconds,
+        limits,
+    )?;
+    let body = transition_body(&transition)?;
+    let mut authorizations =
+        threshold_authorizations(state.recovery_policy(), current_recovery_guardians, &body)?;
+    authorizations.push(current_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?);
+    authorizations.sort_by(|left, right| left.signer_key_id.cmp(&right.signer_key_id));
+    Ok(SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations,
+        next_authority_key_proof: None,
+        next_recovery_key_proofs: next_guardian_proofs(next_recovery, &body)?,
+    })
+}
+
+/// Claim a deferred-human root with a new human authority and recovery policy.
+pub fn create_claim_transition(
+    state: &VerifiedOwnerState,
+    origin_authority: &AuthorizationKey,
+    next_human_authority: &AuthorizationKey,
+    next_recovery: &RecoverySetup,
+    valid_from_unix_seconds: i64,
+    previous_key_valid_until_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<SignedOwnerKeyTransition> {
+    if !state.claimable_deferred_human
+        || valid_from_unix_seconds > state.claimable_until_unix_seconds
+        || origin_authority.key_id()
+            != crate::owner_authorization::canonical::key_id(state.authority_key())
+    {
+        return Err(AuthorizationError::Invalid(
+            "deferred claim is not valid for the active origin state".to_string(),
+        ));
+    }
+    let transition = transition_body_for(
+        state,
+        OwnerKeyTransitionKind::ClaimDeferredHuman,
+        next_human_authority,
+        next_recovery.to_wire(next_human_authority)?,
+        valid_from_unix_seconds,
+        previous_key_valid_until_unix_seconds,
+        limits,
+    )?;
+    let body = transition_body(&transition)?;
+    Ok(SignedOwnerKeyTransition {
+        transition: Some(transition),
+        authorizations: vec![origin_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?],
+        next_authority_key_proof: Some(next_human_authority.sign(OWNER_TRANSITION_DOMAIN, &body)?),
+        next_recovery_key_proofs: next_guardian_proofs(next_recovery, &body)?,
+    })
+}

--- a/crates/client/src/owner_authorization/transition/mod.rs
+++ b/crates/client/src/owner_authorization/transition/mod.rs
@@ -1,0 +1,8 @@
+mod create;
+mod verify;
+
+pub use create::{
+    create_claim_transition, create_recovery_policy_transition, create_recovery_transition,
+    create_rotation_transition,
+};
+pub use verify::apply_transition;

--- a/crates/client/src/owner_authorization/transition/verify.rs
+++ b/crates/client/src/owner_authorization/transition/verify.rs
@@ -1,0 +1,257 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::owner_authorization::{
+    AuthorizationError, Result, VerificationLimits, VerifiedOwnerState,
+    canonical::{OWNER_TRANSITION_DOMAIN, digest, key_id, transition_body},
+    key::verify_signature,
+    recovery::validate_wire_policy,
+    root::HistoricalAuthority,
+    wire::{
+        AuthorizationSignature, AuthorizationVerificationKey, OwnerKeyTransitionKind,
+        RecoveryPolicy, SignedOwnerKeyTransition,
+    },
+};
+
+fn verify_threshold(
+    policy: &RecoveryPolicy,
+    signatures: &[&AuthorizationSignature],
+    body: &[u8],
+) -> Result<()> {
+    let guardians = policy
+        .guardians
+        .iter()
+        .filter_map(|guardian| guardian.key.as_ref())
+        .map(|key| (key_id(key), key))
+        .collect::<BTreeMap<_, _>>();
+    let mut seen = BTreeSet::new();
+    for signature in signatures {
+        let id: [u8; 32] = signature
+            .signer_key_id
+            .as_slice()
+            .try_into()
+            .map_err(|_| AuthorizationError::InvalidSignature)?;
+        let key = guardians
+            .get(&id)
+            .ok_or(AuthorizationError::InvalidSignature)?;
+        if !seen.insert(id) {
+            return Err(AuthorizationError::InvalidSignature);
+        }
+        verify_signature(key, signature, OWNER_TRANSITION_DOMAIN, body)?;
+    }
+    if seen.len() < policy.threshold as usize {
+        return Err(AuthorizationError::RecoveryThreshold {
+            required: policy.threshold,
+            actual: seen.len(),
+        });
+    }
+    Ok(())
+}
+
+fn verify_exact_signature<'a>(
+    signatures: &'a [AuthorizationSignature],
+    key: &AuthorizationVerificationKey,
+    body: &[u8],
+) -> Result<Vec<&'a AuthorizationSignature>> {
+    let expected = key_id(key);
+    let matching = signatures
+        .iter()
+        .filter(|signature| signature.signer_key_id.as_slice() == expected)
+        .collect::<Vec<_>>();
+    if matching.len() != 1 {
+        return Err(AuthorizationError::InvalidSignature);
+    }
+    verify_signature(key, matching[0], OWNER_TRANSITION_DOMAIN, body)?;
+    Ok(signatures
+        .iter()
+        .filter(|signature| signature.signer_key_id.as_slice() != expected)
+        .collect())
+}
+
+fn verify_next_guardians(
+    policy: &RecoveryPolicy,
+    proofs: &[AuthorizationSignature],
+    body: &[u8],
+) -> Result<()> {
+    if proofs.len() != policy.guardians.len() {
+        return Err(AuthorizationError::Invalid(
+            "next recovery proof count does not match policy".to_string(),
+        ));
+    }
+    for (guardian, proof) in policy.guardians.iter().zip(proofs) {
+        verify_signature(
+            guardian.key.as_ref().ok_or_else(|| {
+                AuthorizationError::Invalid("next guardian has no key".to_string())
+            })?,
+            proof,
+            OWNER_TRANSITION_DOMAIN,
+            body,
+        )?;
+    }
+    Ok(())
+}
+
+/// Verify and apply exactly one owner-state transition offline.
+pub fn apply_transition(
+    state: &VerifiedOwnerState,
+    signed: &SignedOwnerKeyTransition,
+    now_unix_seconds: i64,
+    limits: VerificationLimits,
+) -> Result<VerifiedOwnerState> {
+    let transition = signed
+        .transition
+        .as_ref()
+        .ok_or_else(|| AuthorizationError::Invalid("signed transition has no body".to_string()))?;
+    if transition.format_version != 1
+        || transition.owner_id.as_slice() != state.owner_id()
+        || transition.previous_state_hash.as_slice() != state.state_hash()
+        || transition.sequence != state.sequence() + 1
+        || transition.nonce.len() != 32
+    {
+        return Err(AuthorizationError::BrokenChain(
+            "owner id, previous state hash, or sequence does not match".to_string(),
+        ));
+    }
+    if transition.valid_from_unix_seconds < 0
+        || transition.previous_key_valid_until_unix_seconds < 0
+        || (transition.previous_key_valid_until_unix_seconds > 0
+            && transition.previous_key_valid_until_unix_seconds
+                < transition.valid_from_unix_seconds)
+        || transition
+            .previous_key_valid_until_unix_seconds
+            .saturating_sub(transition.valid_from_unix_seconds)
+            > limits.max_capability_ttl_seconds()
+    {
+        return Err(AuthorizationError::Invalid(
+            "transition handover exceeds the capability TTL ceiling".to_string(),
+        ));
+    }
+    if now_unix_seconds < transition.valid_from_unix_seconds {
+        return Err(AuthorizationError::NotYetValid);
+    }
+    let kind = OwnerKeyTransitionKind::try_from(transition.kind)
+        .ok()
+        .filter(|kind| *kind != OwnerKeyTransitionKind::Unspecified)
+        .ok_or_else(|| AuthorizationError::Invalid("unknown transition kind".to_string()))?;
+    let next_authority = transition.next_authority_key.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("transition has no next authority".to_string())
+    })?;
+    let next_policy = transition.next_recovery_policy.as_ref().ok_or_else(|| {
+        AuthorizationError::Invalid("transition has no next recovery policy".to_string())
+    })?;
+    validate_wire_policy(next_policy, &key_id(next_authority), false)?;
+    let body = transition_body(transition)?;
+
+    match kind {
+        OwnerKeyTransitionKind::Rotate => {
+            if next_policy != state.recovery_policy()
+                || signed.authorizations.len() != 1
+                || !signed.next_recovery_key_proofs.is_empty()
+            {
+                return Err(AuthorizationError::Invalid(
+                    "rotation changed recovery policy or has extra proofs".to_string(),
+                ));
+            }
+            verify_signature(
+                state.authority_key(),
+                &signed.authorizations[0],
+                OWNER_TRANSITION_DOMAIN,
+                &body,
+            )?;
+            verify_signature(
+                next_authority,
+                signed
+                    .next_authority_key_proof
+                    .as_ref()
+                    .ok_or(AuthorizationError::InvalidSignature)?,
+                OWNER_TRANSITION_DOMAIN,
+                &body,
+            )?;
+        }
+        OwnerKeyTransitionKind::Recover => {
+            if next_policy != state.recovery_policy()
+                || transition.previous_key_valid_until_unix_seconds != 0
+                || !signed.next_recovery_key_proofs.is_empty()
+            {
+                return Err(AuthorizationError::Invalid(
+                    "recovery changed policy or retained compromised authority".to_string(),
+                ));
+            }
+            verify_threshold(
+                state.recovery_policy(),
+                &signed.authorizations.iter().collect::<Vec<_>>(),
+                &body,
+            )?;
+            verify_signature(
+                next_authority,
+                signed
+                    .next_authority_key_proof
+                    .as_ref()
+                    .ok_or(AuthorizationError::InvalidSignature)?,
+                OWNER_TRANSITION_DOMAIN,
+                &body,
+            )?;
+        }
+        OwnerKeyTransitionKind::RecoveryPolicy => {
+            if next_authority != state.authority_key() || signed.next_authority_key_proof.is_some()
+            {
+                return Err(AuthorizationError::Invalid(
+                    "recovery-policy transition changed authority".to_string(),
+                ));
+            }
+            let guardian_signatures =
+                verify_exact_signature(&signed.authorizations, state.authority_key(), &body)?;
+            verify_threshold(state.recovery_policy(), &guardian_signatures, &body)?;
+            verify_next_guardians(next_policy, &signed.next_recovery_key_proofs, &body)?;
+        }
+        OwnerKeyTransitionKind::ClaimDeferredHuman => {
+            if !state.claimable_deferred_human
+                || now_unix_seconds > state.claimable_until_unix_seconds
+                || transition.valid_from_unix_seconds > state.claimable_until_unix_seconds
+                || signed.authorizations.len() != 1
+            {
+                return Err(AuthorizationError::Invalid(
+                    "claim transition does not originate from a claimable state".to_string(),
+                ));
+            }
+            verify_signature(
+                state.authority_key(),
+                &signed.authorizations[0],
+                OWNER_TRANSITION_DOMAIN,
+                &body,
+            )?;
+            verify_signature(
+                next_authority,
+                signed
+                    .next_authority_key_proof
+                    .as_ref()
+                    .ok_or(AuthorizationError::InvalidSignature)?,
+                OWNER_TRANSITION_DOMAIN,
+                &body,
+            )?;
+            verify_next_guardians(next_policy, &signed.next_recovery_key_proofs, &body)?;
+        }
+        OwnerKeyTransitionKind::Unspecified => unreachable!(),
+    }
+
+    let next_hash = digest(OWNER_TRANSITION_DOMAIN, &body);
+    let mut next = state.clone();
+    next.sequence = transition.sequence;
+    next.state_hash = next_hash;
+    next.authority_key = next_authority.clone();
+    next.recovery_policy = next_policy.clone();
+    if kind == OwnerKeyTransitionKind::ClaimDeferredHuman {
+        next.claimable_deferred_human = false;
+    }
+    next.issuers
+        .get_mut(&state.state_hash())
+        .expect("verified current issuer")
+        .valid_until = Some(transition.previous_key_valid_until_unix_seconds);
+    next.issuers.insert(
+        next_hash,
+        HistoricalAuthority {
+            key: next_authority.clone(),
+            valid_until: None,
+        },
+    );
+    Ok(next)
+}

--- a/crates/client/src/owner_authorization/wire/anonymous.rs
+++ b/crates/client/src/owner_authorization/wire/anonymous.rs
@@ -1,0 +1,46 @@
+use super::{AuthorizationSignature, AuthorizationVerificationKey};
+
+/// Self-authenticated anonymous pseudonym.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AnonymousKeyCredential {
+    #[prost(uint32, tag = "1")]
+    pub format_version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub anonymous_id: Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub key: Option<AuthorizationVerificationKey>,
+    #[prost(int64, tag = "4")]
+    pub issued_at_unix_seconds: i64,
+    #[prost(int64, tag = "5")]
+    pub expires_at_unix_seconds: i64,
+    #[prost(bytes = "vec", tag = "6")]
+    pub nonce: Vec<u8>,
+    #[prost(message, optional, tag = "7")]
+    pub self_signature: Option<AuthorizationSignature>,
+}
+
+/// Anonymous-key registration request.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterAnonymousKeyRequest {
+    #[prost(message, optional, tag = "1")]
+    pub credential: Option<AnonymousKeyCredential>,
+    #[prost(string, optional, tag = "2")]
+    pub turnstile_token: Option<String>,
+    #[prost(string, tag = "3")]
+    pub prior_continuity_token: String,
+    #[prost(message, optional, tag = "4")]
+    pub continuity_proof: Option<AuthorizationSignature>,
+    #[prost(string, tag = "5")]
+    pub client_operation_id: String,
+}
+
+/// Unsigned continuity receipt carrying no authorization.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RegisterAnonymousKeyResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub anonymous_id: Vec<u8>,
+    #[prost(string, tag = "2")]
+    pub continuity_token: String,
+    #[prost(int64, tag = "3")]
+    pub continuity_expires_at_unix_seconds: i64,
+}

--- a/crates/client/src/owner_authorization/wire/bootstrap.rs
+++ b/crates/client/src/owner_authorization/wire/bootstrap.rs
@@ -1,0 +1,84 @@
+use super::{AuthorizationSignature, OwnerAuthorizationBundle, SignedOwnerRoot};
+
+/// Passkey creation proof for a new human account.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct NewPasskeyOwnerRootApproval {
+    #[prost(bytes = "vec", tag = "1")]
+    pub client_data_json: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub attestation_object: Vec<u8>,
+}
+
+/// Passkey assertion proof for an existing human account.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExistingPasskeyOwnerRootApproval {
+    #[prost(bytes = "vec", tag = "1")]
+    pub credential_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub client_data_json: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub authenticator_data: Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub signature: Vec<u8>,
+}
+
+/// WebAuthn approval bound to the exact owner-root challenge.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct WebAuthnOwnerRootApproval {
+    #[prost(string, tag = "1")]
+    pub challenge_id: String,
+    #[prost(oneof = "web_authn_owner_root_approval::Proof", tags = "2, 3")]
+    pub proof: Option<web_authn_owner_root_approval::Proof>,
+}
+
+/// WebAuthn proof variants.
+pub mod web_authn_owner_root_approval {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Proof {
+        #[prost(message, tag = "2")]
+        NewPasskey(super::NewPasskeyOwnerRootApproval),
+        #[prost(message, tag = "3")]
+        ExistingPasskey(super::ExistingPasskeyOwnerRootApproval),
+    }
+}
+
+/// Agent-authorized deferred-human bootstrap proof.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DeferredOwnerRootApproval {
+    #[prost(message, optional, tag = "1")]
+    pub provisioning_authority: Option<OwnerAuthorizationBundle>,
+    #[prost(message, optional, tag = "2")]
+    pub origin_key_request_signature: Option<AuthorizationSignature>,
+}
+
+/// Owner-root bootstrap request.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BootstrapOwnerRootRequest {
+    #[prost(message, optional, tag = "1")]
+    pub owner_root: Option<SignedOwnerRoot>,
+    #[prost(oneof = "bootstrap_owner_root_request::Approval", tags = "2, 3")]
+    pub approval: Option<bootstrap_owner_root_request::Approval>,
+    #[prost(string, tag = "4")]
+    pub client_operation_id: String,
+}
+
+/// Bootstrap approval variants.
+pub mod bootstrap_owner_root_request {
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    #[allow(clippy::large_enum_variant)]
+    pub enum Approval {
+        #[prost(message, tag = "2")]
+        Human(super::WebAuthnOwnerRootApproval),
+        #[prost(message, tag = "3")]
+        DeferredHuman(super::DeferredOwnerRootApproval),
+    }
+}
+
+/// Unsigned bootstrap acknowledgement.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct BootstrapOwnerRootResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub owner_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub accepted_root_hash: Vec<u8>,
+}

--- a/crates/client/src/owner_authorization/wire/capability.rs
+++ b/crates/client/src/owner_authorization/wire/capability.rs
@@ -1,0 +1,126 @@
+use super::{
+    AuthorizationSignature, AuthorizationVerificationKey, SignedOwnerKeyTransition, SignedOwnerRoot,
+};
+
+/// Principal category named by a capability.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CapabilityPrincipalKind {
+    Unspecified = 0,
+    HumanDevice = 1,
+    ServiceAccount = 2,
+    Agent = 3,
+    AnonymousKey = 4,
+    AnyAnonymous = 5,
+}
+
+/// Literal spool action. No action implies another action.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SpoolCapabilityAction {
+    Unspecified = 0,
+    Read = 1,
+    Write = 2,
+    Merge = 3,
+    Approve = 4,
+    Admin = 5,
+    Redact = 6,
+    Grant = 7,
+    Purge = 8,
+}
+
+/// Exact spool or complete-segment descendant selector.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SpoolSelector {
+    #[prost(bytes = "vec", tag = "1")]
+    pub root_spool_uuid: Vec<u8>,
+    #[prost(string, repeated, tag = "2")]
+    pub path_segments: Vec<String>,
+    #[prost(bool, tag = "3")]
+    pub include_descendants: bool,
+}
+
+/// Audited subject and optional subject verification key.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CapabilityPrincipal {
+    #[prost(enumeration = "CapabilityPrincipalKind", tag = "1")]
+    pub kind: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub principal_id: Vec<u8>,
+    #[prost(message, optional, tag = "3")]
+    pub key: Option<AuthorizationVerificationKey>,
+}
+
+/// Actions granted for one selector.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SpoolCapabilityGrant {
+    #[prost(message, optional, tag = "1")]
+    pub spool: Option<SpoolSelector>,
+    #[prost(enumeration = "SpoolCapabilityAction", repeated, tag = "2")]
+    pub actions: Vec<i32>,
+}
+
+/// Owner-anchored capability body.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OwnerCapability {
+    #[prost(uint32, tag = "1")]
+    pub format_version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub issuer_state_hash: Vec<u8>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub parent_capability_id: Vec<u8>,
+    #[prost(message, optional, tag = "5")]
+    pub subject: Option<CapabilityPrincipal>,
+    #[prost(message, repeated, tag = "6")]
+    pub grants: Vec<SpoolCapabilityGrant>,
+    #[prost(int64, tag = "7")]
+    pub not_before_unix_seconds: i64,
+    #[prost(int64, tag = "8")]
+    pub expires_at_unix_seconds: i64,
+    #[prost(bytes = "vec", tag = "9")]
+    pub nonce: Vec<u8>,
+    #[prost(bytes = "vec", tag = "10")]
+    pub capability_id: Vec<u8>,
+}
+
+/// Signed owner capability.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignedOwnerCapability {
+    #[prost(message, optional, tag = "1")]
+    pub capability: Option<OwnerCapability>,
+    #[prost(message, optional, tag = "2")]
+    pub signature: Option<AuthorizationSignature>,
+}
+
+/// Portable owner-root, state, capability, and subject proof.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OwnerAuthorizationBundle {
+    #[prost(message, optional, tag = "1")]
+    pub owner_root: Option<SignedOwnerRoot>,
+    #[prost(message, repeated, tag = "2")]
+    pub owner_state_chain: Vec<SignedOwnerKeyTransition>,
+    #[prost(message, repeated, tag = "3")]
+    pub capability_chain: Vec<SignedOwnerCapability>,
+    #[prost(bytes = "vec", tag = "4")]
+    pub subject_biscuit: Vec<u8>,
+}
+
+/// Data-only submission request; no RPC consumes it before cutover.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubmitOwnerAuthorizationRequest {
+    #[prost(message, optional, tag = "1")]
+    pub authorization: Option<OwnerAuthorizationBundle>,
+    #[prost(string, tag = "2")]
+    pub client_operation_id: String,
+}
+
+/// Unsigned submission receipt.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SubmitOwnerAuthorizationResponse {
+    #[prost(bytes = "vec", tag = "1")]
+    pub capability_id: Vec<u8>,
+    #[prost(int64, tag = "2")]
+    pub expires_at_unix_seconds: i64,
+}

--- a/crates/client/src/owner_authorization/wire/keyring.rs
+++ b/crates/client/src/owner_authorization/wire/keyring.rs
@@ -1,0 +1,42 @@
+use super::{SignedOwnerCapability, SignedOwnerKeyTransition, SignedOwnerRoot};
+
+/// Authentic local origin of an owner fingerprint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CloneOwnerPinKind {
+    Unspecified = 0,
+    LocalCreation = 1,
+    InvitationFingerprint = 2,
+}
+
+/// Client-local owner fingerprint pin.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CloneOwnerPin {
+    #[prost(enumeration = "CloneOwnerPinKind", tag = "1")]
+    pub kind: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub expected_owner_id: Vec<u8>,
+    #[prost(int64, tag = "3")]
+    pub first_seen_unix_seconds: i64,
+}
+
+/// Public bytes persisted by a clone for later offline verification.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CloneAuthorizationKeyring {
+    #[prost(uint32, tag = "1")]
+    pub format_version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub spool_uuid: Vec<u8>,
+    #[prost(string, repeated, tag = "3")]
+    pub canonical_spool_path_segments: Vec<String>,
+    #[prost(message, optional, tag = "4")]
+    pub pin: Option<CloneOwnerPin>,
+    #[prost(message, optional, tag = "5")]
+    pub owner_root: Option<SignedOwnerRoot>,
+    #[prost(message, repeated, tag = "6")]
+    pub accepted_transitions: Vec<SignedOwnerKeyTransition>,
+    #[prost(bytes = "vec", tag = "7")]
+    pub accepted_state_hash: Vec<u8>,
+    #[prost(message, repeated, tag = "8")]
+    pub public_access_capabilities: Vec<SignedOwnerCapability>,
+}

--- a/crates/client/src/owner_authorization/wire/mod.rs
+++ b/crates/client/src/owner_authorization/wire/mod.rs
@@ -1,0 +1,18 @@
+//! Protobuf-compatible transport objects from HeddleCo/api#57.
+//!
+//! These are data containers only. Signatures cover the canonical encodings
+//! in the parent module, never their protobuf serialization.
+
+mod anonymous;
+mod bootstrap;
+mod capability;
+mod keyring;
+mod root;
+mod transition;
+
+pub use anonymous::*;
+pub use bootstrap::*;
+pub use capability::*;
+pub use keyring::*;
+pub use root::*;
+pub use transition::*;

--- a/crates/client/src/owner_authorization/wire/root.rs
+++ b/crates/client/src/owner_authorization/wire/root.rs
@@ -1,0 +1,85 @@
+/// Supported owner-authorization public-key algorithms.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum AuthorizationKeyAlgorithm {
+    Unspecified = 0,
+    Ed25519 = 1,
+}
+
+/// Public verification key carried on the wire.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizationVerificationKey {
+    #[prost(enumeration = "AuthorizationKeyAlgorithm", tag = "1")]
+    pub algorithm: i32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub public_key: Vec<u8>,
+}
+
+/// Detached Ed25519 signature and stable signer identifier.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AuthorizationSignature {
+    #[prost(bytes = "vec", tag = "1")]
+    pub signer_key_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "2")]
+    pub signature: Vec<u8>,
+}
+
+/// Signed provenance of a dedicated recovery guardian.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum RecoveryGuardianKind {
+    Unspecified = 0,
+    Paper = 1,
+    Social = 2,
+    Weft = 3,
+}
+
+/// Recovery guardian public key plus its signed provenance.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RecoveryGuardian {
+    #[prost(enumeration = "RecoveryGuardianKind", tag = "1")]
+    pub kind: i32,
+    #[prost(message, optional, tag = "2")]
+    pub key: Option<AuthorizationVerificationKey>,
+}
+
+/// Precommitted threshold recovery policy.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RecoveryPolicy {
+    #[prost(uint32, tag = "1")]
+    pub threshold: u32,
+    #[prost(message, repeated, tag = "2")]
+    pub guardians: Vec<RecoveryGuardian>,
+}
+
+/// Stable owner-root body.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OwnerRoot {
+    #[prost(uint32, tag = "1")]
+    pub format_version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub account_uuid: Vec<u8>,
+    #[prost(message, optional, tag = "4")]
+    pub authority_key: Option<AuthorizationVerificationKey>,
+    #[prost(message, optional, tag = "5")]
+    pub recovery_policy: Option<RecoveryPolicy>,
+    #[prost(bool, tag = "6")]
+    pub claimable_deferred_human: bool,
+    #[prost(bytes = "vec", tag = "7")]
+    pub nonce: Vec<u8>,
+    #[prost(int64, tag = "8")]
+    pub claimable_until_unix_seconds: i64,
+}
+
+/// Owner root with proof of possession from every declared key.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignedOwnerRoot {
+    #[prost(message, optional, tag = "1")]
+    pub root: Option<OwnerRoot>,
+    #[prost(message, optional, tag = "2")]
+    pub authority_proof: Option<AuthorizationSignature>,
+    #[prost(message, repeated, tag = "3")]
+    pub recovery_key_proofs: Vec<AuthorizationSignature>,
+}

--- a/crates/client/src/owner_authorization/wire/transition.rs
+++ b/crates/client/src/owner_authorization/wire/transition.rs
@@ -1,0 +1,50 @@
+use super::{AuthorizationSignature, AuthorizationVerificationKey, RecoveryPolicy};
+
+/// Owner-state transition operation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum OwnerKeyTransitionKind {
+    Unspecified = 0,
+    Rotate = 1,
+    Recover = 2,
+    RecoveryPolicy = 3,
+    ClaimDeferredHuman = 4,
+}
+
+/// Canonical body for an owner-state transition.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct OwnerKeyTransition {
+    #[prost(uint32, tag = "1")]
+    pub format_version: u32,
+    #[prost(bytes = "vec", tag = "2")]
+    pub owner_id: Vec<u8>,
+    #[prost(bytes = "vec", tag = "3")]
+    pub previous_state_hash: Vec<u8>,
+    #[prost(uint64, tag = "4")]
+    pub sequence: u64,
+    #[prost(enumeration = "OwnerKeyTransitionKind", tag = "5")]
+    pub kind: i32,
+    #[prost(message, optional, tag = "6")]
+    pub next_authority_key: Option<AuthorizationVerificationKey>,
+    #[prost(message, optional, tag = "7")]
+    pub next_recovery_policy: Option<RecoveryPolicy>,
+    #[prost(int64, tag = "8")]
+    pub valid_from_unix_seconds: i64,
+    #[prost(int64, tag = "9")]
+    pub previous_key_valid_until_unix_seconds: i64,
+    #[prost(bytes = "vec", tag = "10")]
+    pub nonce: Vec<u8>,
+}
+
+/// Signed owner-state transition.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SignedOwnerKeyTransition {
+    #[prost(message, optional, tag = "1")]
+    pub transition: Option<OwnerKeyTransition>,
+    #[prost(message, repeated, tag = "2")]
+    pub authorizations: Vec<AuthorizationSignature>,
+    #[prost(message, optional, tag = "3")]
+    pub next_authority_key_proof: Option<AuthorizationSignature>,
+    #[prost(message, repeated, tag = "4")]
+    pub next_recovery_key_proofs: Vec<AuthorizationSignature>,
+}

--- a/crates/client/tests/owner_authorization_contract.rs
+++ b/crates/client/tests/owner_authorization_contract.rs
@@ -1,0 +1,8 @@
+#[path = "owner_authorization_contract/common.rs"]
+mod common;
+#[path = "owner_authorization_contract/negative.rs"]
+mod negative;
+#[path = "owner_authorization_contract/round_trip.rs"]
+mod round_trip;
+#[path = "owner_authorization_contract/transitions.rs"]
+mod transitions;

--- a/crates/client/tests/owner_authorization_contract/common.rs
+++ b/crates/client/tests/owner_authorization_contract/common.rs
@@ -1,0 +1,97 @@
+#![allow(dead_code)]
+
+use heddle_client::owner_authorization::{
+    AuthorizationKey, GuardianSigner, RecoverySetup, VerificationLimits, VerifiedOwnerState,
+    create_direct_capability, create_human_owner_root, mint_subject_biscuit, verify_owner_root,
+    wire::{
+        CapabilityPrincipal, CapabilityPrincipalKind, OwnerAuthorizationBundle,
+        SignedOwnerCapability, SpoolCapabilityAction, SpoolCapabilityGrant, SpoolSelector,
+    },
+};
+
+pub const NOW: i64 = 1_000;
+
+pub fn limits() -> VerificationLimits {
+    VerificationLimits::new(300, 3_600, 1024 * 1024).expect("test limits")
+}
+
+pub struct Fixture {
+    pub authority: AuthorizationKey,
+    pub recovery: RecoverySetup,
+    pub root: heddle_client::owner_authorization::wire::SignedOwnerRoot,
+    pub state: VerifiedOwnerState,
+    pub subject: AuthorizationKey,
+    pub spool_uuid: [u8; 16],
+}
+
+impl Fixture {
+    pub fn new() -> Self {
+        let authority = AuthorizationKey::from_seed([1; 32]).expect("authority");
+        let paper = GuardianSigner::paper(AuthorizationKey::from_seed([2; 32]).expect("paper"));
+        let social = GuardianSigner::social(AuthorizationKey::from_seed([3; 32]).expect("social"));
+        let recovery =
+            RecoverySetup::recommended(vec![paper, social]).expect("recommended recovery");
+        let root = create_human_owner_root([4; 16], &authority, &recovery).expect("signed root");
+        let state = verify_owner_root(&root).expect("verified root");
+        Self {
+            authority,
+            recovery,
+            root,
+            state,
+            subject: AuthorizationKey::from_seed([5; 32]).expect("subject"),
+            spool_uuid: [6; 16],
+        }
+    }
+
+    pub fn subject(&self) -> CapabilityPrincipal {
+        CapabilityPrincipal {
+            kind: CapabilityPrincipalKind::Agent as i32,
+            principal_id: b"agent-test".to_vec(),
+            key: Some(self.subject.verification_key()),
+        }
+    }
+
+    pub fn grant(&self, actions: &[SpoolCapabilityAction]) -> SpoolCapabilityGrant {
+        let mut actions = actions
+            .iter()
+            .map(|action| *action as i32)
+            .collect::<Vec<_>>();
+        actions.sort_unstable();
+        actions.dedup();
+        SpoolCapabilityGrant {
+            spool: Some(SpoolSelector {
+                root_spool_uuid: self.spool_uuid.to_vec(),
+                path_segments: vec!["acme".to_string(), "heddle".to_string()],
+                include_descendants: true,
+            }),
+            actions,
+        }
+    }
+
+    pub fn direct(&self, actions: &[SpoolCapabilityAction]) -> SignedOwnerCapability {
+        create_direct_capability(
+            &self.state,
+            &self.authority,
+            self.subject(),
+            vec![self.grant(actions)],
+            NOW - 10,
+            NOW + 200,
+            limits(),
+        )
+        .expect("direct capability")
+    }
+
+    pub fn bundle(&self, capability: SignedOwnerCapability) -> OwnerAuthorizationBundle {
+        let biscuit = mint_subject_biscuit(
+            capability.capability.as_ref().expect("capability"),
+            &self.subject,
+        )
+        .expect("subject Biscuit");
+        OwnerAuthorizationBundle {
+            owner_root: Some(self.root.clone()),
+            owner_state_chain: Vec::new(),
+            capability_chain: vec![capability],
+            subject_biscuit: biscuit,
+        }
+    }
+}

--- a/crates/client/tests/owner_authorization_contract/negative.rs
+++ b/crates/client/tests/owner_authorization_contract/negative.rs
@@ -1,0 +1,86 @@
+use heddle_client::owner_authorization::{
+    AuthorizationError, AuthorizationKey, GuardianSigner, PaperRecoveryKit, RecoverySetup,
+    confirm_custodial_weft_only, create_human_owner_root, verify_owner_root,
+    wire::RecoveryGuardianKind,
+};
+use prost::Message;
+
+#[test]
+fn weft_only_recovery_requires_explicit_custodial_confirmation() {
+    let silent = RecoverySetup::with_threshold(
+        1,
+        vec![GuardianSigner::weft(
+            AuthorizationKey::from_seed([10; 32]).expect("Weft guardian"),
+        )],
+    );
+    assert!(matches!(silent, Err(AuthorizationError::Invalid(_))));
+
+    let explicit = RecoverySetup::custodial_weft_only(
+        GuardianSigner::weft(AuthorizationKey::from_seed([10; 32]).expect("Weft guardian")),
+        confirm_custodial_weft_only(),
+    )
+    .expect("explicit custodial recovery");
+    let authority = AuthorizationKey::from_seed([11; 32]).expect("authority");
+    let root = create_human_owner_root([12; 16], &authority, &explicit).expect("explicit root");
+    verify_owner_root(&root).expect("explicitly confirmed policy verifies");
+}
+
+#[test]
+fn guardian_kind_cannot_be_forged_from_weft_to_paper() {
+    let authority = AuthorizationKey::from_seed([13; 32]).expect("authority");
+    let recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(AuthorizationKey::from_seed([14; 32]).expect("paper")),
+        GuardianSigner::weft(AuthorizationKey::from_seed([15; 32]).expect("Weft")),
+    ])
+    .expect("two-factor recovery");
+    let mut root = create_human_owner_root([16; 16], &authority, &recovery).expect("signed root");
+    verify_owner_root(&root).expect("unmodified guardian provenance verifies");
+
+    let forged = root
+        .root
+        .as_mut()
+        .expect("root")
+        .recovery_policy
+        .as_mut()
+        .expect("policy")
+        .guardians
+        .iter_mut()
+        .find(|guardian| guardian.kind == RecoveryGuardianKind::Weft as i32)
+        .expect("Weft guardian");
+    forged.kind = RecoveryGuardianKind::Paper as i32;
+    assert!(
+        verify_owner_root(&root).is_err(),
+        "signed guardian provenance must make a WEFT-to-PAPER rewrite fail closed"
+    );
+}
+
+#[test]
+fn paper_kit_round_trips_the_256_bit_seed_but_wires_only_its_public_key() {
+    let seed = [17; 32];
+    let kit = PaperRecoveryKit::from_seed(seed).expect("paper kit");
+    let encoded = kit.to_base64();
+    assert_eq!(
+        encoded.len(),
+        43,
+        "unpadded base64 encodes exactly 256 bits"
+    );
+    let restored = PaperRecoveryKit::from_base64(&encoded).expect("restored kit");
+    assert_eq!(
+        restored.key().verification_key(),
+        kit.key().verification_key()
+    );
+
+    let authority = AuthorizationKey::from_seed([18; 32]).expect("authority");
+    let recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(restored.into_key()),
+        GuardianSigner::social(AuthorizationKey::from_seed([19; 32]).expect("social guardian")),
+    ])
+    .expect("paper-backed recovery");
+    let root = create_human_owner_root([20; 16], &authority, &recovery).expect("root");
+    let root_bytes = root.encode_to_vec();
+    assert!(
+        !root_bytes.windows(seed.len()).any(|window| window == seed),
+        "the printable paper seed must never enter the wire object"
+    );
+    verify_owner_root(&root).expect("public paper guardian verifies");
+}

--- a/crates/client/tests/owner_authorization_contract/round_trip.rs
+++ b/crates/client/tests/owner_authorization_contract/round_trip.rs
@@ -1,0 +1,206 @@
+use std::fmt::Debug;
+
+use heddle_client::owner_authorization::{
+    AuthorizationError, AuthorizationKey, CloneKeyringStore, create_anonymous_credential,
+    create_anonymous_registration, create_clone_keyring, create_deferred_bootstrap,
+    create_deferred_owner_root, create_human_bootstrap, create_rotation_transition,
+    verify_anonymous_registration, verify_authorization_bundle, verify_bootstrap_response,
+    verify_deferred_bootstrap, verify_owner_root, wire::*,
+};
+use prost::Message;
+use tempfile::TempDir;
+
+use crate::common::{Fixture, NOW, limits};
+
+fn round_trip<T>(value: &T) -> T
+where
+    T: Message + Default + PartialEq + Debug,
+{
+    let bytes = value.encode_to_vec();
+    let decoded = T::decode(bytes.as_slice()).expect("protobuf decodes");
+    assert_eq!(&decoded, value);
+    decoded
+}
+
+#[test]
+fn owner_root_and_human_bootstrap_objects_round_trip_and_verify() {
+    let fixture = Fixture::new();
+    let signed_root = round_trip(&fixture.root);
+    let root = signed_root.root.as_ref().expect("root");
+    round_trip(root);
+    round_trip(root.authority_key.as_ref().expect("authority key"));
+    round_trip(
+        signed_root
+            .authority_proof
+            .as_ref()
+            .expect("authority proof"),
+    );
+    let policy = root.recovery_policy.as_ref().expect("policy");
+    round_trip(policy);
+    round_trip(&policy.guardians[0]);
+    verify_owner_root(&signed_root).expect("root verifies after serialization");
+
+    let new_passkey = NewPasskeyOwnerRootApproval {
+        client_data_json: b"client-data".to_vec(),
+        attestation_object: b"attestation".to_vec(),
+    };
+    round_trip(&new_passkey);
+    let existing_passkey = ExistingPasskeyOwnerRootApproval {
+        credential_id: b"credential".to_vec(),
+        client_data_json: b"client-data".to_vec(),
+        authenticator_data: b"authenticator".to_vec(),
+        signature: b"passkey-signature".to_vec(),
+    };
+    round_trip(&existing_passkey);
+    let approval = WebAuthnOwnerRootApproval {
+        challenge_id: "challenge-1".to_string(),
+        proof: Some(web_authn_owner_root_approval::Proof::NewPasskey(
+            new_passkey,
+        )),
+    };
+    round_trip(&approval);
+    round_trip(&WebAuthnOwnerRootApproval {
+        challenge_id: "challenge-2".to_string(),
+        proof: Some(web_authn_owner_root_approval::Proof::ExistingPasskey(
+            existing_passkey,
+        )),
+    });
+    let bootstrap =
+        create_human_bootstrap(fixture.root.clone(), approval, "bootstrap-op".to_string())
+            .expect("bootstrap request");
+    round_trip(&bootstrap);
+    let bootstrap_response = BootstrapOwnerRootResponse {
+        owner_id: fixture.state.owner_id().to_vec(),
+        accepted_root_hash: fixture.state.state_hash().to_vec(),
+    };
+    verify_bootstrap_response(&round_trip(&bootstrap_response), &fixture.root)
+        .expect("bootstrap receipt matches");
+}
+
+#[test]
+fn transition_and_capability_objects_round_trip_and_verify() {
+    let fixture = Fixture::new();
+    let next = AuthorizationKey::from_seed([20; 32]).expect("next key");
+    let transition = create_rotation_transition(
+        &fixture.state,
+        &fixture.authority,
+        &next,
+        NOW,
+        NOW + 20,
+        limits(),
+    )
+    .expect("rotation");
+    round_trip(transition.transition.as_ref().expect("transition body"));
+    round_trip(&transition);
+
+    let capability = fixture.direct(&[SpoolCapabilityAction::Read, SpoolCapabilityAction::Grant]);
+    let capability_body = capability.capability.as_ref().expect("capability");
+    round_trip(capability_body.subject.as_ref().expect("subject"));
+    round_trip(&capability_body.grants[0]);
+    round_trip(capability_body.grants[0].spool.as_ref().expect("selector"));
+    round_trip(capability_body);
+    round_trip(&capability);
+    let bundle = fixture.bundle(capability.clone());
+    round_trip(&bundle);
+    verify_authorization_bundle(&round_trip(&bundle), NOW, limits())
+        .expect("authorization bundle verifies");
+    let submit = SubmitOwnerAuthorizationRequest {
+        authorization: Some(bundle.clone()),
+        client_operation_id: "submit-op".to_string(),
+    };
+    round_trip(&submit);
+    round_trip(&SubmitOwnerAuthorizationResponse {
+        capability_id: capability_body.capability_id.clone(),
+        expires_at_unix_seconds: capability_body.expires_at_unix_seconds,
+    });
+}
+
+#[test]
+fn anonymous_and_clone_keyring_objects_round_trip_and_verify() {
+    let fixture = Fixture::new();
+    let anonymous_key = AuthorizationKey::from_seed([21; 32]).expect("anonymous");
+    let credential = create_anonymous_credential(&anonymous_key, NOW - 10, NOW + 100, limits())
+        .expect("anonymous credential");
+    round_trip(&credential);
+    let registration = create_anonymous_registration(
+        credential,
+        &anonymous_key,
+        Some("turnstile".to_string()),
+        "continuity".to_string(),
+        "anonymous-op".to_string(),
+        NOW,
+        limits(),
+    )
+    .expect("anonymous registration");
+    verify_anonymous_registration(&round_trip(&registration), NOW, limits())
+        .expect("anonymous request verifies");
+    round_trip(&RegisterAnonymousKeyResponse {
+        anonymous_id: registration
+            .credential
+            .as_ref()
+            .expect("credential")
+            .anonymous_id
+            .clone(),
+        continuity_token: "receipt-only".to_string(),
+        continuity_expires_at_unix_seconds: NOW + 100,
+    });
+
+    let capability = fixture.direct(&[SpoolCapabilityAction::Read]);
+    let keyring = create_clone_keyring(
+        fixture.spool_uuid,
+        vec!["acme".to_string(), "heddle".to_string()],
+        CloneOwnerPinKind::InvitationFingerprint,
+        fixture.state.owner_id(),
+        NOW,
+        fixture.root.clone(),
+        Vec::new(),
+        vec![capability],
+        NOW,
+        limits(),
+    )
+    .expect("clone keyring");
+    round_trip(keyring.pin.as_ref().expect("pin"));
+    round_trip(&keyring);
+    let temp = TempDir::new().expect("tempdir");
+    let store = CloneKeyringStore::new(temp.path(), limits());
+    store
+        .install(keyring.clone(), NOW)
+        .expect("keyring installs")
+        .wire();
+    assert!(matches!(
+        store.install(keyring, NOW),
+        Err(AuthorizationError::AlreadyPinned(_))
+    ));
+    store.load(NOW).expect("keyring reload verifies");
+}
+
+#[test]
+fn deferred_bootstrap_objects_round_trip_and_verify() {
+    let fixture = Fixture::new();
+    let capability = fixture.direct(&[SpoolCapabilityAction::Read, SpoolCapabilityAction::Grant]);
+    let bundle = fixture.bundle(capability);
+    let origin = AuthorizationKey::from_seed([22; 32]).expect("origin key");
+    let deferred_root =
+        create_deferred_owner_root([23; 16], &origin, NOW + 100).expect("deferred root");
+    let deferred = create_deferred_bootstrap(
+        deferred_root,
+        bundle,
+        &origin,
+        "deferred-bootstrap-op".to_string(),
+        NOW,
+        limits(),
+    )
+    .expect("deferred bootstrap");
+    let deferred = round_trip(&deferred);
+    let deferred_approval = match deferred.approval.as_ref() {
+        Some(bootstrap_owner_root_request::Approval::DeferredHuman(approval)) => approval,
+        _ => panic!("deferred bootstrap approval"),
+    };
+    round_trip(deferred_approval);
+    verify_deferred_bootstrap(&deferred, NOW, limits())
+        .expect("deferred bootstrap verifies after serialization");
+    assert!(matches!(
+        verify_deferred_bootstrap(&deferred, NOW + 101, limits()),
+        Err(AuthorizationError::Invalid(_))
+    ));
+}

--- a/crates/client/tests/owner_authorization_contract/transitions.rs
+++ b/crates/client/tests/owner_authorization_contract/transitions.rs
@@ -1,0 +1,185 @@
+use heddle_client::owner_authorization::{
+    AuthorizationError, AuthorizationKey, GuardianSigner, RecoverySetup, apply_transition,
+    create_claim_transition, create_deferred_owner_root, create_direct_capability,
+    create_recovery_policy_transition, create_recovery_transition, create_rotation_transition,
+    verify_capability_chain, verify_owner_root,
+    wire::{SignedOwnerKeyTransition, SpoolCapabilityAction},
+};
+use prost::Message;
+
+use crate::common::{Fixture, NOW, limits};
+
+#[test]
+fn rotation_accepts_new_key_and_retires_previous_key_after_handover() {
+    let fixture = Fixture::new();
+    let old_capability = fixture.direct(&[SpoolCapabilityAction::Read]);
+    let next = AuthorizationKey::from_seed([7; 32]).expect("next authority");
+    let rotation = create_rotation_transition(
+        &fixture.state,
+        &fixture.authority,
+        &next,
+        NOW,
+        NOW + 20,
+        limits(),
+    )
+    .expect("rotation");
+    let rotated =
+        apply_transition(&fixture.state, &rotation, NOW, limits()).expect("apply rotation");
+
+    verify_capability_chain(
+        &rotated,
+        std::slice::from_ref(&old_capability),
+        NOW + 20,
+        limits(),
+    )
+    .expect("old key remains valid through handover");
+    assert!(matches!(
+        verify_capability_chain(
+            &rotated,
+            std::slice::from_ref(&old_capability),
+            NOW + 21,
+            limits(),
+        ),
+        Err(AuthorizationError::Expired)
+    ));
+
+    let new_capability = create_direct_capability(
+        &rotated,
+        &next,
+        fixture.subject(),
+        vec![fixture.grant(&[SpoolCapabilityAction::Read])],
+        NOW,
+        NOW + 200,
+        limits(),
+    )
+    .expect("new-key capability");
+    verify_capability_chain(&rotated, &[new_capability], NOW + 21, limits())
+        .expect("rotated key verifies");
+}
+
+#[test]
+fn recovery_requires_the_committed_threshold() {
+    let fixture = Fixture::new();
+    let next = AuthorizationKey::from_seed([8; 32]).expect("recovered authority");
+    let guardians = fixture.recovery.guardians();
+    let complete = create_recovery_transition(
+        &fixture.state,
+        &[guardians[0].key(), guardians[1].key()],
+        &next,
+        NOW,
+        limits(),
+    )
+    .expect("threshold recovery");
+    let complete = SignedOwnerKeyTransition::decode(complete.encode_to_vec().as_slice())
+        .expect("recovery transition round trip");
+    apply_transition(&fixture.state, &complete, NOW, limits())
+        .expect("threshold-satisfied transition verifies");
+
+    let mut one_short = complete;
+    one_short.authorizations.pop();
+    assert!(matches!(
+        apply_transition(&fixture.state, &one_short, NOW, limits()),
+        Err(AuthorizationError::RecoveryThreshold {
+            required: 2,
+            actual: 1
+        })
+    ));
+}
+
+#[test]
+fn recovery_policy_transition_requires_both_anchors_and_next_possession() {
+    let fixture = Fixture::new();
+    let next_recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(AuthorizationKey::from_seed([21; 32]).expect("next paper")),
+        GuardianSigner::social(AuthorizationKey::from_seed([22; 32]).expect("next social")),
+    ])
+    .expect("next recovery");
+    let current = fixture.recovery.guardians();
+    let transition = create_recovery_policy_transition(
+        &fixture.state,
+        &fixture.authority,
+        &[current[0].key(), current[1].key()],
+        &next_recovery,
+        NOW,
+        NOW + 20,
+        limits(),
+    )
+    .expect("recovery policy transition");
+    let transition = SignedOwnerKeyTransition::decode(transition.encode_to_vec().as_slice())
+        .expect("policy transition round trip");
+    let updated = apply_transition(&fixture.state, &transition, NOW, limits())
+        .expect("policy transition verifies");
+    assert_eq!(updated.recovery_policy().threshold, 2);
+    assert_eq!(updated.recovery_policy().guardians.len(), 2);
+}
+
+#[test]
+fn deferred_human_claim_round_trips_and_installs_the_human_key() {
+    let origin = AuthorizationKey::from_seed([23; 32]).expect("origin");
+    let deferred = create_deferred_owner_root([24; 16], &origin, NOW + 100).expect("deferred root");
+    let deferred_state = verify_owner_root(&deferred).expect("deferred state");
+    let human = AuthorizationKey::from_seed([25; 32]).expect("human");
+    let human_recovery = RecoverySetup::recommended(vec![
+        GuardianSigner::paper(AuthorizationKey::from_seed([26; 32]).expect("human paper")),
+        GuardianSigner::social(AuthorizationKey::from_seed([27; 32]).expect("human social")),
+    ])
+    .expect("human recovery");
+    let claim = create_claim_transition(
+        &deferred_state,
+        &origin,
+        &human,
+        &human_recovery,
+        NOW,
+        NOW + 20,
+        limits(),
+    )
+    .expect("claim transition");
+    let claim = SignedOwnerKeyTransition::decode(claim.encode_to_vec().as_slice())
+        .expect("claim transition round trip");
+    let claimed = apply_transition(&deferred_state, &claim, NOW, limits())
+        .expect("claim transition verifies");
+    assert_eq!(claimed.authority_key(), &human.verification_key());
+}
+
+#[test]
+fn transition_with_broken_previous_state_hash_is_refused() {
+    let fixture = Fixture::new();
+    let next = AuthorizationKey::from_seed([9; 32]).expect("next authority");
+    let mut rotation = create_rotation_transition(
+        &fixture.state,
+        &fixture.authority,
+        &next,
+        NOW,
+        NOW + 20,
+        limits(),
+    )
+    .expect("rotation");
+    rotation
+        .transition
+        .as_mut()
+        .expect("body")
+        .previous_state_hash = vec![0xAA; 32];
+    assert!(matches!(
+        apply_transition(&fixture.state, &rotation, NOW, limits()),
+        Err(AuthorizationError::BrokenChain(_))
+    ));
+}
+
+#[test]
+fn future_transition_is_not_applied_early() {
+    let fixture = Fixture::new();
+    let next = AuthorizationKey::from_seed([10; 32]).expect("next authority");
+    let rotation = create_rotation_transition(
+        &fixture.state,
+        &fixture.authority,
+        &next,
+        NOW + 10,
+        NOW + 20,
+        limits(),
+    )
+    .expect("future rotation");
+    assert!(matches!(
+        apply_transition(&fixture.state, &rotation, NOW, limits()),
+        Err(AuthorizationError::NotYetValid)
+    ));
+}

--- a/crates/client/tests/owner_authorization_inertness.rs
+++ b/crates/client/tests/owner_authorization_inertness.rs
@@ -1,0 +1,79 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+fn rust_files(root: &Path, output: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(root).expect("read source directory") {
+        let path = entry.expect("source entry").path();
+        if path.is_dir() {
+            rust_files(&path, output);
+        } else if path.extension().is_some_and(|extension| extension == "rs") {
+            output.push(path);
+        }
+    }
+}
+
+#[test]
+fn owner_authorization_stays_unreachable_from_current_runtime_paths() {
+    let client = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = client
+        .parent()
+        .and_then(Path::parent)
+        .expect("workspace root");
+    let owner_module = client.join("src/owner_authorization");
+    let client_lib = client.join("src/lib.rs");
+    let lib_source = fs::read_to_string(&client_lib).expect("read client lib");
+    assert_eq!(
+        lib_source.matches("pub mod owner_authorization;").count(),
+        1,
+        "the inert surface is exposed only as a data/crypto module"
+    );
+
+    let mut production_files = Vec::new();
+    for relative in [
+        "crates/client/src",
+        "crates/cli/src",
+        "crates/cli-args/src",
+        "crates/core/src",
+        "crates/repo/src",
+    ] {
+        rust_files(&workspace.join(relative), &mut production_files);
+    }
+    let imports = production_files
+        .into_iter()
+        .filter(|path| !path.starts_with(&owner_module) && path != &client_lib)
+        .filter_map(|path| {
+            let source = fs::read_to_string(&path).expect("read production Rust");
+            source.contains("owner_authorization").then(|| {
+                path.strip_prefix(workspace)
+                    .expect("workspace path")
+                    .to_path_buf()
+            })
+        })
+        .collect::<Vec<_>>();
+    assert!(
+        imports.is_empty(),
+        "owner authorization must remain unreachable until the exclusive cutover; \
+         current runtime references: {imports:?}"
+    );
+
+    let mut owner_files = Vec::new();
+    rust_files(&owner_module, &mut owner_files);
+    let owner_source = owner_files
+        .iter()
+        .map(|path| fs::read_to_string(path).expect("read owner module"))
+        .collect::<String>();
+    for forbidden_live_edge in [
+        "impl HostedClient",
+        "CallContext",
+        "grant_envelope",
+        "MintBiscuitRequest",
+        "MintAnonBiscuitRequest",
+    ] {
+        assert!(
+            !owner_source.contains(forbidden_live_edge),
+            "inert owner module gained current authorization edge {forbidden_live_edge}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the client-side api#57 owner-authorization contract as data/crypto primitives: the owner root, human and deferred bootstrap objects, all four rotation/recovery transitions, owner-signed capability chains plus subject Biscuits, anonymous self-authentication, and clone keyring persistence/offline evaluation. The wire containers mirror the reviewed protobuf fields and tags, while signatures use fixed-order, length-prefixed canonical encodings rather than protobuf bytes.

Recovery construction defaults to threshold 2, requires a paper or social co-factor whenever Weft participates, preserves PAPER/SOCIAL/WEFT provenance inside the signed policy, and exposes 1-of-1 Weft custody only through the explicit confirmation type. Paper kit v1 is an exact client-generated 32-byte Ed25519 seed; only its public key enters the wire policy. Numeric TTL ceilings remain explicit `VerificationLimits` inputs because api#55 deliberately leaves their values as cutover product inputs.

Clone keyrings are bounded, canonically re-encoded, chain-verified, pinned once, and atomically persisted at `.heddle/owner-authorization/keyring.pb`. The offline authorizer accepts no network handle and binds evaluation to the pinned clone path as well as the signed spool selector.

No Cargo manifest, `Cargo.lock`, API dependency pin, TLS, or CA configuration changed, keeping this patch outside #1135.

### Inertness by surface

- Owner root: only the new data/crypto module can construct or inspect it. No ownership lookup, trust list, hosted client, CLI, core, or repository verifier imports it. It becomes live only when the exclusive post-cutover verifier consumes `owner_id` after the server-minted path is removed.
- Bootstrap: request/receipt types have no RPC or hosted transport path; the response is checked only as an unsigned acknowledgement and cannot yield a bearer. It becomes live when the bootstrap route is added in the atomic Weft cutover.
- Rotation and recovery: transitions are pure signed objects applied only to an explicitly supplied `VerifiedOwnerState`; they cannot mutate `device_roots` or current credential authority. They become live when the exclusive owner-state verifier applies them.
- Capability submission: the bundle and submission receipt are data-only. Nothing copies them into `grant_envelope`, `CallContext`, or a bearer, and no current handler reads them. They become live when an owner-only submission/verifier replaces minting.
- Anonymous auth: the self-signed credential and continuity request have no endpoint or current verifier integration. They become live only when the exclusive anonymous verifier replaces server-minted anonymous credentials.
- Clone keyring: persistence uses a new path that current clone, trusted-key, redact, and purge receivers do not read. It becomes live only when the later clone/receiver cutover imports this module and switches to it without a legacy fallback.

`owner_authorization_inertness.rs` enforces the structural boundary by scanning production client, CLI, core, and repository sources for any current import and by rejecting known live credential edges inside the new module.

## Closes

Closes #1136

## Test evidence

- `rustfmt +nightly --edition 2024 <touched files>` on touched Rust files only.
- `cargo test --locked -p heddle-client --lib --test owner_authorization_contract --test owner_authorization_inertness`: 137 library tests, 13 contract tests, and the inertness tripwire pass on rebased current main.
- `cargo test --locked -p heddle-cli --test owner_authorization_offline_clone -- --nocapture`: passes after a real `heddle init`, `capture`, and filesystem `clone`; the test then installs a per-thread seccomp filter denying socket/socketpair/connect/bind/listen/accept/send/recv/shutdown syscalls before loading or evaluating the keyring.

```text
CLONE_KEYRING=/home/scratch/.tmpcqetnA/clone/.heddle/owner-authorization/keyring.pb
NETWORK_PROBE=blocked errno=EPERM syscall=socket
OFFLINE_ALLOW=READ path=acme/heddle/src
OFFLINE_DENY=WRITE path=acme/heddle/src
OFFLINE_DENY=READ path=acme/sibling reason=pinned-clone
```

- Exact selected-package build passes: `cargo build --locked -p heddle-cli -p heddle-cli-args -p heddle-client -p heddle-cli-contract -p heddle-cli-render --tests --bin heddle --bin heddle-fuse-worker`.
- Exact selected-package lint passes: `cargo clippy --locked -p heddle-cli -p heddle-cli-args -p heddle-client -p heddle-cli-contract -p heddle-cli-render --lib --bins --tests --examples -- -D warnings`.
- CI feature checks pass for `heddle-repo` with `git-overlay,zstd` and `native,zstd`, and for `heddle-cli` with `git-overlay,client,semantic,zstd` and `native,semantic,zstd`, all with `--no-default-features --locked`.
- `bash scripts/check-facade-render-free.sh` passes; 12 script unit tests pass.
- Required negative assertions reject implicit 1-of-1 Weft custody, capability widening, a broken `previous_state_hash`, and WEFT-to-PAPER guardian-kind rewriting. Threshold recovery succeeds at 2 signatures and rejects one signature short; rotation accepts the new key and expires the old key after the handover.

The broad affected-package cargo test command was also watched locally. Existing native CLI temp-directory cases fail in this managed sandbox because read-only injected ancestor `/home/scratch/.git` and `/tmp/.git` directories are discovered before those tests run; the new focused client and real-clone tests isolate that environment and pass. PR CI is the authoritative unsandboxed broad-suite result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1138"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787897175&installation_model_id=21489&pr_number=1138&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1138&signature=da3bbc83c2f5ddc9ae88de7ab69168f710d913a75e9cf6b37e76ef630ddc80e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->