### PR TITLE
test: report unavailable coverage honestly

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -616,6 +616,9 @@ jobs:
         run: |
           cargo test --locked -p heddle-mount --features fuse --test fuse_mount \
             -- --ignored --test-threads=1 --nocapture
+          cargo test --locked -p heddle-mount --features fuse \
+            --lib fuse_smoke::fuse_open_close_read_round_trip \
+            -- --ignored --test-threads=1 --nocapture
 
       # Panic-recovery unit tests live alongside the FUSE shell; run
       # them on the same job so a regression in the `guard_call`
@@ -662,12 +665,9 @@ jobs:
   # doesn't try to mount through a missing kernel adapter. CI opts
   # in explicitly via the env var below + `-- --ignored`.
   #
-  # If the DISM step fails (newer Server SKUs sometimes rename the
-  # feature, and home-edition Windows 10 hosts may have it disabled
-  # at the SKU level), the test will report itself as skipped via
-  # the `ProjFsShell::is_runtime_available()` guard in the smoke
-  # source. The job exits 0 in that case; treat a hard `assertion
-  # failed` from the test as the real regression signal.
+  # If neither feature name produces ProjectedFSLib.dll, fail the
+  # setup step. An unavailable runtime is missing coverage, not a
+  # passing smoke test.
   projfs-smoke:
     name: ProjFS mount smoke (Windows)
     needs: changes
@@ -699,7 +699,7 @@ jobs:
             Write-Host "Client-ProjFS unavailable on this SKU; trying Projected-FS (Server variant)"
             $server = Enable-WindowsOptionalFeature -Online -FeatureName Projected-FS -NoRestart -ErrorAction SilentlyContinue
             if ($null -eq $server) {
-              Write-Host "::warning::Neither Client-ProjFS nor Projected-FS could be enabled; smoke test will self-skip"
+              throw "Neither Client-ProjFS nor Projected-FS could be enabled"
             }
           }
           # Verify the DLL the shell probes for is actually present.
@@ -707,7 +707,7 @@ jobs:
           if (Test-Path $dll) {
             Write-Host "ProjectedFSLib.dll present: $dll"
           } else {
-            Write-Host "::warning::ProjectedFSLib.dll not present; smoke test will self-skip"
+            throw "ProjectedFSLib.dll not present after enabling ProjFS"
           }
 
       # Build + run the integration test. Single-threaded to keep a

--- a/crates/cli-contract/src/cli/commands/verification_health/tests.rs
+++ b/crates/cli-contract/src/cli/commands/verification_health/tests.rs
@@ -334,18 +334,20 @@ fn plain_git_worktree_status_preserves_staged_removal_alongside_untracked() {
         Some(output.status.success())
     };
 
-    let Some(true) = run_git(&["init", "--quiet"]) else {
-        eprintln!("git not on PATH or init failed — skipping");
-        return;
-    };
+    assert_eq!(
+        run_git(&["init", "--quiet"]),
+        Some(true),
+        "git must be on PATH and initialize the verification fixture"
+    );
     for cmd in [
         ["config", "user.email", "test@example.com"].as_slice(),
         ["config", "user.name", "Test"].as_slice(),
     ] {
-        if !matches!(run_git(cmd), Some(true)) {
-            eprintln!("git config failed — skipping");
-            return;
-        }
+        assert_eq!(
+            run_git(cmd),
+            Some(true),
+            "git config must succeed for the verification fixture"
+        );
     }
     std::fs::write(root.join("file.txt"), "hello").expect("write file");
     for cmd in [
@@ -353,10 +355,11 @@ fn plain_git_worktree_status_preserves_staged_removal_alongside_untracked() {
         ["commit", "-m", "initial", "--quiet"].as_slice(),
         ["rm", "--cached", "--quiet", "file.txt"].as_slice(),
     ] {
-        if !matches!(run_git(cmd), Some(true)) {
-            eprintln!("git command failed — skipping");
-            return;
-        }
+        assert_eq!(
+            run_git(cmd),
+            Some(true),
+            "git fixture command must succeed: {cmd:?}"
+        );
     }
 
     let status = super::build_plain_git_verification_probe(root)

--- a/crates/cli/src/cli/commands/daemon/client.rs
+++ b/crates/cli/src/cli/commands/daemon/client.rs
@@ -554,14 +554,8 @@ mod tests {
         // the bytes, we just write garbage back so JSON decoding
         // fails, which is exactly what a v1 daemon's reply looks like
         // to a v2-speaking CLI in the worst case.
-        let listener = match TcpListener::bind("127.0.0.1:0") {
-            Ok(listener) => listener,
-            Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-                eprintln!("skipping stale-daemon RPC test: loopback bind denied: {err}");
-                return;
-            }
-            Err(err) => panic!("bind loopback listener: {err}"),
-        };
+        let listener =
+            TcpListener::bind("127.0.0.1:0").expect("bind loopback listener for daemon RPC test");
         let port = listener.local_addr().unwrap().port();
         let server_repo = repo_root.clone();
         let server = std::thread::spawn(move || {

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -1357,14 +1357,8 @@ fn git_replacement_matrix_https_push_uses_native_transport_without_git_on_path()
     heddle_without_git(&["capture", "-m", "attempt https push"], &work).unwrap();
     heddle_without_git(&["commit", "-m", "attempt https push"], &work).unwrap();
 
-    let listener = match std::net::TcpListener::bind("127.0.0.1:0") {
-        Ok(listener) => listener,
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("skipping HTTPS native transport test: loopback bind denied: {err}");
-            return;
-        }
-        Err(err) => panic!("reserve local port: {err}"),
-    };
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("reserve local port for HTTPS test");
     let port = listener.local_addr().expect("local addr").port();
     drop(listener);
     let err = heddle_without_git(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -8815,18 +8815,16 @@ fn text_surfaces_tolerate_closed_downstream_pipes() {
 
 #[test]
 fn tty_auto_mode_renders_text_and_explicit_json_stays_json() {
-    let script_probe = std::process::Command::new("script")
+    let probe = std::process::Command::new("script")
         .arg("--version")
-        .output();
-    let Ok(probe) = script_probe else {
-        eprintln!("skipping tty transcript test: util-linux script not installed");
-        return;
-    };
+        .output()
+        .expect("util-linux script must be installed for the TTY transcript test");
     let probe_stdout = String::from_utf8_lossy(&probe.stdout);
-    if !probe.status.success() || !probe_stdout.contains("util-linux") {
-        eprintln!("skipping tty transcript test: unsupported script implementation");
-        return;
-    }
+    assert!(
+        probe.status.success() && probe_stdout.contains("util-linux"),
+        "TTY transcript test requires util-linux script; got status {:?}, stdout: {probe_stdout}",
+        probe.status
+    );
 
     let temp = TempDir::new().unwrap();
     let repo = temp.path().join("repo");

--- a/crates/cli/tests/git_projection_engine_integration.rs
+++ b/crates/cli/tests/git_projection_engine_integration.rs
@@ -510,31 +510,21 @@ struct GitHttpBackend {
     basic_auth: Option<(String, String)>,
 }
 
-fn bind_loopback_ephemeral(context: &str) -> Option<TcpListener> {
-    match TcpListener::bind("127.0.0.1:0") {
-        Ok(listener) => Some(listener),
-        Err(err) if err.kind() == std::io::ErrorKind::PermissionDenied => {
-            eprintln!("skipping Git interop network test: {context}: {err}");
-            None
-        }
-        Err(err) => panic!("{context}: {err}"),
-    }
+fn bind_loopback_ephemeral(context: &str) -> TcpListener {
+    TcpListener::bind("127.0.0.1:0").unwrap_or_else(|err| panic!("{context}: {err}"))
 }
 
 impl GitHttpBackend {
-    fn spawn(root: &std::path::Path) -> Option<Self> {
+    fn spawn(root: &std::path::Path) -> Self {
         Self::spawn_with_auth(root, None)
     }
 
-    fn spawn_authenticated(root: &std::path::Path, username: &str, password: &str) -> Option<Self> {
+    fn spawn_authenticated(root: &std::path::Path, username: &str, password: &str) -> Self {
         Self::spawn_with_auth(root, Some((username.to_string(), password.to_string())))
     }
 
-    fn spawn_with_auth(
-        root: &std::path::Path,
-        basic_auth: Option<(String, String)>,
-    ) -> Option<Self> {
-        let listener = bind_loopback_ephemeral("bind ephemeral http port")?;
+    fn spawn_with_auth(root: &std::path::Path, basic_auth: Option<(String, String)>) -> Self {
+        let listener = bind_loopback_ephemeral("bind ephemeral http port");
         let port = listener.local_addr().expect("listener addr").port();
         listener
             .set_nonblocking(true)
@@ -562,12 +552,12 @@ impl GitHttpBackend {
         let mut delay = Duration::from_millis(10);
         for _ in 0..20 {
             if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-                return Some(Self {
+                return Self {
                     join: Some(join),
                     port,
                     stop,
                     basic_auth,
-                });
+                };
             }
             thread::sleep(delay);
             delay = (delay * 2).min(Duration::from_millis(500));
@@ -736,7 +726,7 @@ fn handle_http_backend_connection(
 }
 
 impl GitDaemon {
-    fn spawn(root: &std::path::Path) -> Option<Self> {
+    fn spawn(root: &std::path::Path) -> Self {
         Self::spawn_with_push(root, false)
     }
 
@@ -745,12 +735,12 @@ impl GitDaemon {
     /// remote — the only way to cover the URL/network destination reconciliation
     /// (heddle#316 r11). `git daemon` denies anonymous push unless
     /// `--enable=receive-pack` is passed.
-    fn spawn_push(root: &std::path::Path) -> Option<Self> {
+    fn spawn_push(root: &std::path::Path) -> Self {
         Self::spawn_with_push(root, true)
     }
 
-    fn spawn_with_push(root: &std::path::Path, allow_push: bool) -> Option<Self> {
-        let listener = bind_loopback_ephemeral("bind ephemeral port")?;
+    fn spawn_with_push(root: &std::path::Path, allow_push: bool) -> Self {
+        let listener = bind_loopback_ephemeral("bind ephemeral port");
         let port = listener.local_addr().expect("listener addr").port();
         drop(listener);
 
@@ -777,7 +767,7 @@ impl GitDaemon {
         let mut delay = Duration::from_millis(10);
         for _ in 0..20 {
             if TcpStream::connect(("127.0.0.1", port)).is_ok() {
-                return Some(Self { child, port });
+                return Self { child, port };
             }
             thread::sleep(delay);
             delay = (delay * 2).min(Duration::from_millis(500));
@@ -2251,9 +2241,7 @@ fn pull_imports_remote_branches_and_tags_from_git_daemon() {
     let commit_oid = commit_with_tree(&remote_repo, Some("refs/heads/main"), tree_oid, "base", &[]);
     create_annotated_tag(&remote_repo, "v1.0", commit_oid, "release");
 
-    let Some(daemon) = GitDaemon::spawn(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn(remote_root.path());
 
     let mut git_projection = GitProjection::new(&repo);
     git_projection
@@ -2285,9 +2273,7 @@ fn pull_imports_remote_branches_and_tags_from_git_http_backend() {
     let commit_oid = commit_with_tree(&remote_repo, Some("refs/heads/main"), tree_oid, "base", &[]);
     create_annotated_tag(&remote_repo, "v1.0", commit_oid, "release");
 
-    let Some(backend) = GitHttpBackend::spawn(remote_root.path()) else {
-        return;
-    };
+    let backend = GitHttpBackend::spawn(remote_root.path());
 
     let mut git_projection = GitProjection::new(&repo);
     git_projection
@@ -2319,10 +2305,7 @@ fn pull_imports_remote_branches_and_tags_from_authenticated_git_http_backend() {
     let commit_oid = commit_with_tree(&remote_repo, Some("refs/heads/main"), tree_oid, "base", &[]);
     create_annotated_tag(&remote_repo, "v1.0", commit_oid, "release");
 
-    let Some(backend) = GitHttpBackend::spawn_authenticated(remote_root.path(), "heddle", "secret")
-    else {
-        return;
-    };
+    let backend = GitHttpBackend::spawn_authenticated(remote_root.path(), "heddle", "secret");
 
     let mut git_projection = GitProjection::new(&repo);
     git_projection
@@ -6565,9 +6548,7 @@ fn retraction_delete_propagates_to_url_remote() {
         b"ref: refs/heads/__heddle_placeholder\n",
     )
     .unwrap();
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
 
     // Export public over the NETWORK push path — main lands on the remote.
@@ -6726,9 +6707,7 @@ fn foreign_ref_on_url_remote_survives() {
 
     let remote_root = TempDir::new().expect("remote root");
     let _remote_repo = init_named_bare_git_repo(&remote_root, "remote.git");
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
 
     // First public push — records main as heddle-exported to THIS url remote.
@@ -6883,9 +6862,7 @@ fn out_of_band_destination_descendant_not_force_overwritten() {
     // ---- URL/network destination ----
     let remote_root = TempDir::new().expect("remote root");
     let _remote_repo = init_named_bare_git_repo(&remote_root, "remote.git");
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
 
     git_projection
@@ -6984,9 +6961,7 @@ fn heddle_published_tip_embargo_rewind_still_forced() {
 
     let remote_root = TempDir::new().expect("remote root");
     let _remote_repo = init_named_bare_git_repo(&remote_root, "remote.git");
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
     git_projection
         .push(&url)
@@ -7129,9 +7104,7 @@ fn out_of_band_advance_after_embargo_not_deleted() {
         b"ref: refs/heads/__heddle_placeholder\n",
     )
     .unwrap();
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
     git_projection
         .push(&url)
@@ -7901,9 +7874,7 @@ fn out_of_band_destination_tag_not_overwritten() {
         b"ref: refs/heads/__heddle_placeholder\n",
     )
     .unwrap();
-    let Some(daemon) = GitDaemon::spawn_push(remote_root.path()) else {
-        return;
-    };
+    let daemon = GitDaemon::spawn_push(remote_root.path());
     let url = daemon.url("remote.git");
 
     git_projection

--- a/crates/cli/tests/lazy_blob_hydration_kernel.rs
+++ b/crates/cli/tests/lazy_blob_hydration_kernel.rs
@@ -287,21 +287,18 @@ fn hydration_survives_repository_reopen() {
 }
 
 /// `#[ignore]`-gated acceptance test from the issue body. Requires
-/// network access and the `git` binary; skips gracefully when either
-/// is missing so the gate doesn't flake in offline CI.
+/// network access and the `git` binary.
 #[test]
 #[ignore = "clones torvalds/linux.git; run via --include-ignored or nightly job"]
 fn hydration_fires_against_torvalds_linux() {
-    if std::process::Command::new("git")
+    let git = std::process::Command::new("git")
         .arg("--version")
         .output()
-        .ok()
-        .filter(|o| o.status.success())
-        .is_none()
-    {
-        eprintln!("SKIP: git binary not on PATH");
-        return;
-    }
+        .expect("git binary must be on PATH for the ignored kernel hydration test");
+    assert!(
+        git.status.success(),
+        "git --version must succeed for the ignored kernel hydration test"
+    );
 
     let temp = TempDir::new().expect("temp for linux clone");
     let bare = temp.path().join("linux.git");
@@ -310,10 +307,8 @@ fn hydration_fires_against_torvalds_linux() {
     eprintln!("cloning torvalds/linux.git at depth=1 + filter=blob:none ...");
     let started = Instant::now();
     let mut progress = sley::remote::SilentProgress;
-    if let Err(err) = clone_url_to_bare(url, &bare, Some(1), Some("blob:none"), &mut progress) {
-        eprintln!("SKIP: kernel clone failed (network?): {err}");
-        return;
-    }
+    clone_url_to_bare(url, &bare, Some(1), Some("blob:none"), &mut progress)
+        .expect("clone torvalds/linux.git for the ignored kernel hydration test");
     eprintln!("clone completed in {:?}", started.elapsed());
 
     let git_repo = open_git(&bare).expect("open kernel bare repo");

--- a/crates/cli/tests/multi_agent_worktrees/daemon_lifecycle.rs
+++ b/crates/cli/tests/multi_agent_worktrees/daemon_lifecycle.rs
@@ -10,10 +10,7 @@
 //! the `daemon stop`/`status` verbs, and the failure modes documented
 //! in `docs/design/mount-daemon.md` § "Failure modes".
 //!
-//! Gated to Linux because the FUSE shell only compiles there. Each
-//! test that needs a real kernel mount checks `/dev/fuse` first and
-//! returns gracefully (with a `eprintln!` warning) on hosts without
-//! it — same skip pattern the existing tests rely on. Marked
+//! Gated to Linux because the FUSE shell only compiles there. Marked
 //! `#[ignore]` so `cargo test` on developer laptops doesn't try to
 //! shell out to `fusermount` or bind to FUSE without opting in:
 //!
@@ -51,18 +48,12 @@ use super::{heddle, setup_repo};
 // then.
 // ---------------------------------------------------------------------------
 
-/// Skip the test (warn + return) when the host doesn't expose
-/// `/dev/fuse`. CI runners frequently lack it; a hard failure there
-/// would be useless noise.
-fn fuse_supported_or_skip(test_name: &str) -> bool {
-    if std::path::Path::new("/dev/fuse").exists() {
-        return true;
-    }
-    eprintln!(
-        "[daemon_lifecycle::{test_name}] skipping: /dev/fuse not present \
-         on this host"
+/// Require FUSE once an ignored daemon lifecycle test is explicitly selected.
+fn require_fuse(test_name: &str) {
+    assert!(
+        std::path::Path::new("/dev/fuse").exists(),
+        "[daemon_lifecycle::{test_name}] requires /dev/fuse"
     );
-    false
 }
 
 /// Conventional endpoint file path the daemon writes on bind. Kept
@@ -191,9 +182,7 @@ fn parse_mount_count(status_output: &str) -> Option<u32> {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn daemon_mount_survives_cli_exit() {
-    if !fuse_supported_or_skip("daemon_mount_survives_cli_exit") {
-        return;
-    }
+    require_fuse("daemon_mount_survives_cli_exit");
     let main = setup_repo("greet.txt", "hello from daemon");
 
     let raw = heddle(
@@ -247,9 +236,7 @@ fn daemon_mount_survives_cli_exit() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn daemon_spawns_on_demand_and_status_reports_healthy() {
-    if !fuse_supported_or_skip("daemon_spawns_on_demand_and_status_reports_healthy") {
-        return;
-    }
+    require_fuse("daemon_spawns_on_demand_and_status_reports_healthy");
     let main = setup_repo("greet.txt", "alive");
 
     assert!(
@@ -305,9 +292,7 @@ fn daemon_spawns_on_demand_and_status_reports_healthy() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn idempotent_mount_does_not_double_register() {
-    if !fuse_supported_or_skip("idempotent_mount_does_not_double_register") {
-        return;
-    }
+    require_fuse("idempotent_mount_does_not_double_register");
     let main = setup_repo("greet.txt", "once");
 
     let first = heddle(
@@ -393,9 +378,7 @@ fn idempotent_mount_does_not_double_register() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn daemon_stop_drains_mounts_and_exits() {
-    if !fuse_supported_or_skip("daemon_stop_drains_mounts_and_exits") {
-        return;
-    }
+    require_fuse("daemon_stop_drains_mounts_and_exits");
     let main = setup_repo("greet.txt", "stoppable");
 
     let raw = heddle(
@@ -475,9 +458,7 @@ fn daemon_stop_drains_mounts_and_exits() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn stale_endpoint_is_swept_and_daemon_respawns() {
-    if !fuse_supported_or_skip("stale_endpoint_is_swept_and_daemon_respawns") {
-        return;
-    }
+    require_fuse("stale_endpoint_is_swept_and_daemon_respawns");
     let main = setup_repo("greet.txt", "after stale sweep");
 
     let endpoint = endpoint_path(main.path());
@@ -569,9 +550,7 @@ fn stale_endpoint_is_swept_and_daemon_respawns() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn daemon_killed_mid_mount_recovers_on_next_invocation() {
-    if !fuse_supported_or_skip("daemon_killed_mid_mount_recovers_on_next_invocation") {
-        return;
-    }
+    require_fuse("daemon_killed_mid_mount_recovers_on_next_invocation");
     let main = setup_repo("greet.txt", "before kill");
 
     let raw = heddle(
@@ -665,9 +644,7 @@ fn daemon_killed_mid_mount_recovers_on_next_invocation() {
 #[test]
 #[ignore = "requires Linux + FUSE + heddle built with --features mount"]
 fn daemon_mount_with_from_serves_resolved_state() {
-    if !fuse_supported_or_skip("daemon_mount_with_from_serves_resolved_state") {
-        return;
-    }
+    require_fuse("daemon_mount_with_from_serves_resolved_state");
     // S1: setup_repo's initial snapshot (greet.txt = "S1").
     let main = setup_repo("greet.txt", "S1");
 

--- a/crates/cli/tests/ts_types_in_sync.rs
+++ b/crates/cli/tests/ts_types_in_sync.rs
@@ -79,9 +79,5 @@ mod full_feature {
     feature = "zstd"
 )))]
 #[test]
-fn drift_check_skipped_under_feature_pruned_build() {
-    eprintln!(
-        "skipping generated-TS drift check: requires the full feature set \
-         (git-overlay,native,semantic,zstd) the checked-in types were generated from"
-    );
-}
+#[ignore = "requires git-overlay,native,semantic,zstd features"]
+fn drift_check_skipped_under_feature_pruned_build() {}

--- a/crates/core/src/merge/mod.rs
+++ b/crates/core/src/merge/mod.rs
@@ -3079,18 +3079,16 @@ mod tests {
 
         let dir = tempfile::TempDir::new().unwrap();
         // Initialize a git repo with no user.name.
-        let init_status = Command::new("git")
+        let status = Command::new("git")
             .arg("-C")
             .arg(dir.path())
             .args(["init", "--quiet"])
-            .status();
-        let Ok(status) = init_status else {
-            eprintln!("git not on PATH — skipping");
-            return;
-        };
-        if !status.success() {
-            return;
-        }
+            .status()
+            .expect("git must be on PATH for the native Git validation test");
+        assert!(
+            status.success(),
+            "git init must succeed for the test fixture"
+        );
         let blockers =
             validate_git_commit_preconditions_extended(dir.path(), &["dummy.txt".to_string()]);
         assert!(

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -3346,11 +3346,13 @@ mod tests {
             .current_dir(root)
             .output()
             .expect("git commit");
-        repo::Repository::init_default(root).expect("heddle init");
+        repo::Repository::init_git_overlay_sidecar(root).expect("heddle Git Overlay init");
         let repo = repo::Repository::open(root).expect("open");
-        if repo.capability() != repo::RepositoryCapability::GitOverlay {
-            return;
-        }
+        assert_eq!(
+            repo.capability(),
+            repo::RepositoryCapability::GitOverlay,
+            "Git fixture must open as a Git Overlay repository"
+        );
         std::fs::write(root.join("tracked.txt"), "v2\n").unwrap();
         std::fs::write(root.join("untracked.txt"), "u\n").unwrap();
         std::process::Command::new("git")

--- a/crates/fs-prims/src/fs_clone.rs
+++ b/crates/fs-prims/src/fs_clone.rs
@@ -370,17 +370,15 @@ mod tests {
     /// reaching across worktrees.
     #[cfg(unix)]
     #[test]
+    #[ignore = "requires a reflink-capable filesystem"]
     fn successful_reflink_yields_distinct_inode() {
         use std::os::unix::fs::MetadataExt;
 
         let temp = TempDir::new().unwrap();
-        if !filesystem_supports_reflink(temp.path()) {
-            eprintln!(
-                "[skip] filesystem at {:?} does not support reflinks; cannot assert inode property",
-                temp.path()
-            );
-            return;
-        }
+        assert!(
+            filesystem_supports_reflink(temp.path()),
+            "successful_reflink_yields_distinct_inode requires reflink support"
+        );
 
         let src = temp.path().join("src.txt");
         let dst = temp.path().join("dst.txt");

--- a/crates/ingest/tests/extract_real_reasoning.rs
+++ b/crates/ingest/tests/extract_real_reasoning.rs
@@ -36,10 +36,11 @@ fn resolve_repo_root() -> PathBuf {
 #[ignore = "reads real $HOME transcript store; run with --ignored"]
 fn extracts_reasoning_points_from_recent_sessions() {
     let repo_root = resolve_repo_root();
-    if !repo_root.join(".git").exists() {
-        eprintln!("skip: {} is not a git repo", repo_root.display());
-        return;
-    }
+    assert!(
+        repo_root.join(".git").exists(),
+        "{} is not a git repo",
+        repo_root.display()
+    );
 
     let roots = TranscriptRoots::default();
     let mut transcripts = load_transcripts(&repo_root, &roots);
@@ -55,14 +56,11 @@ fn extracts_reasoning_points_from_recent_sessions() {
         "extracting from {} Claude sessions (newest first)",
         picks.len()
     );
-    if picks.is_empty() {
-        eprintln!(
-            "skip: no Claude transcripts found for cwd={}; \
-             set HEDDLE_MATCHER_SMOKE_REPO to a path with cached sessions to exercise the extractor",
-            repo_root.display()
-        );
-        return;
-    }
+    assert!(
+        !picks.is_empty(),
+        "no Claude transcripts found for cwd={}; set HEDDLE_MATCHER_SMOKE_REPO to a path with cached sessions",
+        repo_root.display()
+    );
 
     let hparams = HarvestParams::default();
     let kparams = KeepParams::default();

--- a/crates/ingest/tests/match_real_sessions.rs
+++ b/crates/ingest/tests/match_real_sessions.rs
@@ -77,10 +77,11 @@ fn changed_files(repo: &Path, sha: &str) -> Vec<String> {
 #[ignore = "reads real $HOME transcript store; run with --ignored"]
 fn matches_real_sessions_against_recent_heddle_commits() {
     let repo_root = resolve_repo_root();
-    if !repo_root.join(".git").exists() {
-        eprintln!("skip: {} is not a git repo", repo_root.display());
-        return;
-    }
+    assert!(
+        repo_root.join(".git").exists(),
+        "{} is not a git repo",
+        repo_root.display()
+    );
 
     let roots = TranscriptRoots::default();
     let transcripts = load_transcripts(&repo_root, &roots);
@@ -89,10 +90,10 @@ fn matches_real_sessions_against_recent_heddle_commits() {
         transcripts.len(),
         repo_root.display()
     );
-    if transcripts.is_empty() {
-        eprintln!("no transcripts under $HOME — nothing to score");
-        return;
-    }
+    assert!(
+        !transcripts.is_empty(),
+        "no transcripts under $HOME; ignored smoke coverage is unavailable"
+    );
 
     let matcher =
         TranscriptMatcher::new(&transcripts, &repo_root).with_params(MatchParams::default());

--- a/crates/mount/src/tests.rs
+++ b/crates/mount/src/tests.rs
@@ -4209,10 +4209,6 @@ mod fuse_smoke {
     use super::*;
     use crate::FuseShell;
 
-    fn fuse_available() -> bool {
-        std::path::Path::new("/dev/fuse").exists()
-    }
-
     /// Wait for `path` to come up, bounded by `deadline`.
     fn wait_until_exists(path: &std::path::Path, deadline: Duration) {
         let start = std::time::Instant::now();
@@ -4222,11 +4218,12 @@ mod fuse_smoke {
     }
 
     #[test]
+    #[ignore = "requires /dev/fuse; exercised by the FUSE mount smoke CI lane"]
     fn fuse_open_close_read_round_trip() {
-        if !fuse_available() {
-            eprintln!("skipping: /dev/fuse not present");
-            return;
-        }
+        assert!(
+            std::path::Path::new("/dev/fuse").exists(),
+            "fuse_open_close_read_round_trip requires /dev/fuse"
+        );
         let repo_dir = TempDir::new().unwrap();
         let repo = Repository::init_default(repo_dir.path()).unwrap();
         std::fs::write(repo_dir.path().join("seed.txt"), b"hello").unwrap();
@@ -4234,13 +4231,9 @@ mod fuse_smoke {
 
         let mount = ContentAddressedMount::new(repo, "main").unwrap();
         let mountpoint = TempDir::new().unwrap();
-        let session = match FuseShell::new(mount).mount_background(mountpoint.path()) {
-            Ok(s) => s,
-            Err(_) => {
-                eprintln!("skipping: FUSE mount failed (likely no kernel module)");
-                return;
-            }
-        };
+        let session = FuseShell::new(mount)
+            .mount_background(mountpoint.path())
+            .expect("mount FUSE session");
         wait_until_exists(&mountpoint.path().join("seed.txt"), Duration::from_secs(5));
         let read = std::fs::read_to_string(mountpoint.path().join("seed.txt")).unwrap();
         assert_eq!(read, "hello");

--- a/crates/mount/tests/cargo_build_smoke.rs
+++ b/crates/mount/tests/cargo_build_smoke.rs
@@ -83,22 +83,15 @@ const FIXTURE_MAIN_RS: &str = r#"fn main() {
 #[test]
 #[ignore = "requires FUSE + cargo on host; opt-in via --ignored"]
 fn cargo_build_succeeds_against_virtualized_mount() {
-    // Skip gracefully on hosts without FUSE so a developer who runs
-    // `cargo test -- --ignored` on a non-FUSE box gets a clear signal
-    // instead of a confusing mount error. Mirrors the early-exit
-    // pattern used elsewhere in the workspace's FUSE tests.
-    if !Path::new("/dev/fuse").exists() {
-        eprintln!("skipping: /dev/fuse not present on this host");
-        return;
-    }
-
-    // Likewise skip if `cargo` isn't on PATH. The test is about the
-    // mount holding up under a real downstream tool — if there's no
-    // tool to run, there's nothing to assert. Fail soft, don't lie.
-    if Command::new("cargo").arg("--version").output().is_err() {
-        eprintln!("skipping: `cargo` not on PATH");
-        return;
-    }
+    assert!(
+        Path::new("/dev/fuse").exists(),
+        "cargo_build_succeeds_against_virtualized_mount requires /dev/fuse"
+    );
+    let cargo = Command::new("cargo")
+        .arg("--version")
+        .output()
+        .expect("cargo must be on PATH for the ignored mount build smoke test");
+    assert!(cargo.status.success(), "cargo --version must succeed");
 
     // ----- Stage 1: build the fixture crate inside a tempdir -----
     //
@@ -211,14 +204,15 @@ fn cargo_build_succeeds_against_virtualized_mount() {
 #[test]
 #[ignore = "requires FUSE + cargo on host; opt-in via --ignored"]
 fn cargo_build_in_mount_target_dir_exercises_write_side_ops() {
-    if !Path::new("/dev/fuse").exists() {
-        eprintln!("skipping: /dev/fuse not present on this host");
-        return;
-    }
-    if Command::new("cargo").arg("--version").output().is_err() {
-        eprintln!("skipping: `cargo` not on PATH");
-        return;
-    }
+    assert!(
+        Path::new("/dev/fuse").exists(),
+        "cargo_build_in_mount_target_dir_exercises_write_side_ops requires /dev/fuse"
+    );
+    let cargo = Command::new("cargo")
+        .arg("--version")
+        .output()
+        .expect("cargo must be on PATH for the ignored mount build smoke test");
+    assert!(cargo.status.success(), "cargo --version must succeed");
 
     let repo_dir = TempDir::new().expect("repo tempdir");
     let crate_root = repo_dir.path();

--- a/crates/mount/tests/fskit_smoke.rs
+++ b/crates/mount/tests/fskit_smoke.rs
@@ -28,13 +28,11 @@ use tempfile::TempDir;
 #[test]
 #[ignore = "requires macOS 26.0 + FSKit entitlement; opt-in via HEDDLE_FSKIT_AVAILABLE=1"]
 fn fskit_session_constructs_for_extension_bootstrap() {
-    if env::var("HEDDLE_FSKIT_AVAILABLE").as_deref() != Ok("1") {
-        eprintln!(
-            "skipping fskit_session_constructs_for_extension_bootstrap: \
-             set HEDDLE_FSKIT_AVAILABLE=1 to enable"
-        );
-        return;
-    }
+    assert_eq!(
+        env::var("HEDDLE_FSKIT_AVAILABLE").as_deref(),
+        Ok("1"),
+        "set HEDDLE_FSKIT_AVAILABLE=1 to run the ignored FSKit smoke test"
+    );
     if !FSKitShell::is_runtime_available() {
         panic!(
             "FSKit not available at runtime — this test requires macOS 26.0+. \

--- a/crates/mount/tests/fuse_worker_crash.rs
+++ b/crates/mount/tests/fuse_worker_crash.rs
@@ -84,12 +84,11 @@ fn shrink_stop_grace() {
     });
 }
 
-fn skip_if_no_fuse() -> bool {
-    if !Path::new("/dev/fuse").exists() {
-        eprintln!("skipping: /dev/fuse not present on this host");
-        return true;
-    }
-    false
+fn require_fuse() {
+    assert!(
+        Path::new("/dev/fuse").exists(),
+        "ignored FUSE worker crash tests require /dev/fuse"
+    );
 }
 
 /// Wait up to `dur` for `target` to (dis)appear.
@@ -120,9 +119,7 @@ fn wait_for_path(target: &Path, expect_present: bool, dur: Duration) {
 #[test]
 #[ignore = "requires FUSE + heddle-fuse-worker binary on host; opt-in via --ignored"]
 fn panic_kills_only_worker_not_parent() {
-    if skip_if_no_fuse() {
-        return;
-    }
+    require_fuse();
     shrink_stop_grace();
 
     let (repo_dir, _repo) = build_fixture();
@@ -194,9 +191,7 @@ fn panic_kills_only_worker_not_parent() {
 #[test]
 #[ignore = "requires FUSE + heddle-fuse-worker binary on host; opt-in via --ignored"]
 fn sigkill_worker_auto_unmounts() {
-    if skip_if_no_fuse() {
-        return;
-    }
+    require_fuse();
     shrink_stop_grace();
 
     let (repo_dir, _repo) = build_fixture();

--- a/crates/mount/tests/nfs_smoke.rs
+++ b/crates/mount/tests/nfs_smoke.rs
@@ -36,13 +36,11 @@ use tempfile::TempDir;
 #[test]
 #[ignore = "requires sudo / admin to mount NFS; opt-in via HEDDLE_NFS_AVAILABLE=1"]
 fn nfs_mount_serves_blob_content() {
-    if env::var("HEDDLE_NFS_AVAILABLE").as_deref() != Ok("1") {
-        eprintln!(
-            "skipping nfs_mount_serves_blob_content: \
-             set HEDDLE_NFS_AVAILABLE=1 (with sudo/admin) to enable"
-        );
-        return;
-    }
+    assert_eq!(
+        env::var("HEDDLE_NFS_AVAILABLE").as_deref(),
+        Ok("1"),
+        "set HEDDLE_NFS_AVAILABLE=1 (with sudo/admin) to run the ignored NFS smoke test"
+    );
 
     // Build a tiny repo with one captured file.
     let repo_dir = TempDir::new().unwrap();

--- a/crates/mount/tests/projfs_smoke.rs
+++ b/crates/mount/tests/projfs_smoke.rs
@@ -69,29 +69,20 @@ use mount::{ContentAddressedMount, ProjFsSession, ProjFsShell};
 use repo::Repository;
 use tempfile::TempDir;
 
-/// Common skip-or-fail probe at the top of every test. Returns
-/// `true` when the test should run; `false` when it should silently
-/// no-op. Treats absence of `HEDDLE_PROJFS_AVAILABLE=1` as "this
-/// host opted out" (the CI matrix sets it; a generic dev box does
-/// not). Treats absence of `ProjectedFSLib.dll` as a soft skip with
-/// an eprintln so the CI log shows the reason.
-fn projfs_or_skip() -> bool {
-    if env::var("HEDDLE_PROJFS_AVAILABLE").as_deref() != Ok("1") {
-        eprintln!(
-            "skipping: set HEDDLE_PROJFS_AVAILABLE=1 to opt this host \
-             into the ProjFS smoke tests"
-        );
-        return false;
-    }
-    if !ProjFsShell::is_runtime_available() {
-        eprintln!(
-            "skipping: ProjFS runtime not available \
-             (run `Enable-WindowsOptionalFeature -Online -FeatureName Client-ProjFS` \
-             from an admin PowerShell)"
-        );
-        return false;
-    }
-    true
+/// Require the opt-in marker and runtime before an ignored smoke test runs.
+///
+/// These tests are ignored by default. Once explicitly selected, an unavailable
+/// runtime is a setup failure rather than coverage that can be counted as passed.
+fn require_projfs() {
+    assert_eq!(
+        env::var("HEDDLE_PROJFS_AVAILABLE").as_deref(),
+        Ok("1"),
+        "set HEDDLE_PROJFS_AVAILABLE=1 to opt this host into the ProjFS smoke tests"
+    );
+    assert!(
+        ProjFsShell::is_runtime_available(),
+        "ProjFS runtime not available; enable Client-ProjFS or Projected-FS"
+    );
 }
 
 /// Build a tiny repo with one captured file (`hello.txt` containing
@@ -137,9 +128,7 @@ fn wait_for(target: &Path, expect_present: bool, dur: Duration) {
 #[test]
 #[ignore = "requires Windows + ProjFS; opt-in via HEDDLE_PROJFS_AVAILABLE=1"]
 fn projfs_mount_serves_blob_content() {
-    if !projfs_or_skip() {
-        return;
-    }
+    require_projfs();
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
 
@@ -153,9 +142,7 @@ fn projfs_mount_serves_blob_content() {
 #[test]
 #[ignore = "requires Windows + ProjFS; opt-in via HEDDLE_PROJFS_AVAILABLE=1"]
 fn projfs_mount_round_trips_writes_to_existing_file() {
-    if !projfs_or_skip() {
-        return;
-    }
+    require_projfs();
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
 
@@ -203,9 +190,7 @@ fn projfs_mount_round_trips_writes_to_existing_file() {
 #[test]
 #[ignore = "requires Windows + ProjFS; opt-in via HEDDLE_PROJFS_AVAILABLE=1"]
 fn projfs_mount_serves_concurrent_readers() {
-    if !projfs_or_skip() {
-        return;
-    }
+    require_projfs();
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
 
@@ -240,9 +225,7 @@ fn projfs_mount_serves_concurrent_readers() {
 #[test]
 #[ignore = "requires Windows + ProjFS; opt-in via HEDDLE_PROJFS_AVAILABLE=1"]
 fn projfs_mount_unmounts_cleanly_on_session_drop() {
-    if !projfs_or_skip() {
-        return;
-    }
+    require_projfs();
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
     let target = mountpoint.path().join("hello.txt");
@@ -312,9 +295,7 @@ fn init_default_on_windows_tempdir_does_not_permission_deny() {
 #[test]
 #[ignore = "requires Windows + ProjFS; opt-in via HEDDLE_PROJFS_AVAILABLE=1"]
 fn projfs_mount_hides_instance_id_sidecar_from_listing() {
-    if !projfs_or_skip() {
-        return;
-    }
+    require_projfs();
     let (_repo_dir, repo) = build_fixture();
     let (session, mountpoint) = mount_fixture(repo);
 

--- a/crates/objects/src/fault_inject.rs
+++ b/crates/objects/src/fault_inject.rs
@@ -142,9 +142,10 @@ mod tests {
         // unset, which is the production default. A test runner
         // that exports the var globally would change behaviour, but
         // that would be the runner's problem to surface explicitly.
-        if std::env::var("HEDDLE_FAULT_INJECT").is_ok() {
-            return;
-        }
+        assert!(
+            std::env::var("HEDDLE_FAULT_INJECT").is_err(),
+            "no_env_var_is_a_silent_noop requires HEDDLE_FAULT_INJECT to be unset"
+        );
         // Should not panic — env var unset, all checkpoints inactive.
         maybe_panic_at("anything");
     }

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -661,12 +661,10 @@ mod tests {
     fn unlink_fails_closed_when_matching_file_cannot_be_removed() {
         use std::os::unix::fs::PermissionsExt;
 
-        if running_as_root() {
-            // Root bypasses the read-only-dir guard; this simulation only holds
-            // for an unprivileged user. The happy-path + no-op tests still
-            // cover removal semantics under root.
-            return;
-        }
+        assert!(
+            !running_as_root(),
+            "unlink_fails_closed_when_matching_file_cannot_be_removed requires an unprivileged user"
+        );
 
         let temp = TempDir::new().expect("temp dir");
         let dir = temp.path().join("home");

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -1362,22 +1362,20 @@ mod tests {
     /// hardlinks: hardlinks share inodes (the bug we fixed),
     /// reflinks do not.
     ///
-    /// On non-CoW filesystems the test soft-skips — `fs::copy`
-    /// also gives distinct inodes, but the test is targeted at
-    /// the reflink path specifically.
+    /// Ignored by default because `fs::copy` also gives distinct
+    /// inodes on non-CoW filesystems while this test specifically
+    /// targets the reflink path.
     #[test]
     #[cfg(unix)]
+    #[ignore = "requires a reflink-capable filesystem"]
     fn materialize_uses_reflink_when_filesystem_supports_it() {
         use std::os::unix::fs::MetadataExt;
 
         let temp_dir = TempDir::new().unwrap();
-        if !filesystem_supports_reflink(temp_dir.path()) {
-            eprintln!(
-                "[skip] filesystem at {:?} does not advertise reflink support",
-                temp_dir.path()
-            );
-            return;
-        }
+        assert!(
+            filesystem_supports_reflink(temp_dir.path()),
+            "materialize_uses_reflink_when_filesystem_supports_it requires reflink support"
+        );
 
         let repo = Repository::init_default(temp_dir.path()).unwrap();
         let blob = Blob::from("reflink correctness check, kept under compression threshold");
@@ -1719,22 +1717,20 @@ mod tests {
     /// without aliasing) rather than the in-memory `fs::write` path
     /// (which costs full duplicates).
     ///
-    /// On non-CoW filesystems the test soft-skips. The materializer
-    /// will use `fs::copy` and the storage win is not recoverable
-    /// without reflink support.
+    /// Ignored by default because the materializer uses `fs::copy`
+    /// on non-CoW filesystems and the reflink storage win is not
+    /// available there.
     #[test]
     #[cfg(unix)]
+    #[ignore = "requires a reflink-capable filesystem"]
     fn packed_repo_storage_win_after_warm_and_materialize() {
         use std::{collections::HashSet, os::unix::fs::MetadataExt};
 
         let temp_dir = TempDir::new().unwrap();
-        if !filesystem_supports_reflink(temp_dir.path()) {
-            eprintln!(
-                "[skip] filesystem at {:?} does not support reflinks; storage-win test is reflink-specific",
-                temp_dir.path()
-            );
-            return;
-        }
+        assert!(
+            filesystem_supports_reflink(temp_dir.path()),
+            "packed_repo_storage_win_after_warm_and_materialize requires reflink support"
+        );
 
         let repo = Repository::init_default(temp_dir.path()).unwrap();
 


### PR DESCRIPTION
## Summary

- mark the library FUSE round trip ignored by default, fail its prerequisites once selected, and run it explicitly in the dedicated FUSE-capable CI lane
- audit test early-return guards repo-wide: convert unavailable whole-test coverage to explicit `#[ignore]` requirements or fail-closed setup assertions
- make the ProjFS lane fail when its runtime cannot be enabled instead of warning and exiting green
- fix the Git Overlay short-status fixture exposed by the audit so it constructs the capability it claims to test

Decision: use `#[ignore]` for optional host capabilities, with required dedicated CI lanes for shipped kernel adapters. This keeps generic runners green while their summaries say `ignored`; explicit selection fails if the prerequisite is absent. It does not provide local real-FUSE coverage on hosts without `/dev/fuse`, nor a dedicated reflink, FSKit, NFS, daemon-lifecycle, worker-crash, transcript, or live-network lane.

## Closes

Closes #1141

## Test evidence

- PR Quality passed the exact all-workspace commands: `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker`, `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings`, and `cargo test --locked --workspace`
- absent FUSE, default selection: `0 passed; 0 failed; 1 ignored`
- absent FUSE, explicit `--ignored`: exits 101 with `fuse_open_close_read_round_trip requires /dev/fuse`; `0 passed; 1 failed`
- PR FUSE lane confirmed `/dev/fuse` is a character device, ran 8 integration tests (`8 passed; 0 ignored`), and ran the changed library round trip (`1 passed; 0 ignored`)
- PR ProjFS lane confirmed `ProjectedFSLib.dll`, then ran 6 integration tests (`6 passed; 0 ignored`)
- focused changed-test coverage passed for verification health, Git validation, Git Overlay short status, fault injection, fail-closed identity unlink, and TypeScript contracts
- reflink-specific focused selections report `0 passed; 1 ignored`
- the exact local `cargo test --locked --workspace` invocation reached the CLI integration suite but spawned CLI processes failed with exit 74 (`Read-only file system (os error 30)`) because the managed sandbox makes the user-config path read-only; the unrestricted PR Quality run passed the same command
