### PR TITLE
fix(client): close hosted Iroh endpoints

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1506,18 +1506,6 @@ async fn clone_network(
         config::UserConfig,
     };
 
-    let CloneOptions {
-        thread,
-        depth,
-        lazy,
-        filter,
-        insecure,
-    } = options;
-    let depth = *depth;
-    // `--filter blob:none` is a synonym for `--lazy` on hosted/network
-    // remotes; both produce a clone whose blob content is hydrated on demand.
-    let lazy = *lazy || filter.is_some();
-
     let user_config = UserConfig::load_default()?;
     // On every network-connecting command, TLS/auth config validation
     // (`heddle_client_config`) must succeed before any irreversible
@@ -1526,11 +1514,46 @@ async fn clone_network(
     // no partial on-disk artifact.
     let session =
         HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
-            .with_allow_insecure(*insecure);
+            .with_allow_insecure(options.insecure);
     let repo_path = repo_path.context("network remotes must include a hosted repository path")?;
 
-    let json_output = should_output_json(cli, None);
     let mut client = session.connect(addr).await?;
+    let result = clone_network_connected(
+        cli,
+        addr,
+        repo_path,
+        local_path,
+        options,
+        endpoint_spec,
+        &mut client,
+    )
+    .await;
+    client.close().await;
+    result
+}
+
+#[cfg(feature = "client")]
+async fn clone_network_connected(
+    cli: &Cli,
+    addr: std::net::SocketAddr,
+    repo_path: &str,
+    local_path: &Path,
+    options: &CloneOptions,
+    endpoint_spec: String,
+    client: &mut HostedClient,
+) -> Result<()> {
+    let CloneOptions {
+        thread,
+        depth,
+        lazy,
+        filter,
+        insecure: _,
+    } = options;
+    let depth = *depth;
+    // `--filter blob:none` is a synonym for `--lazy` on hosted/network
+    // remotes; both produce a clone whose blob content is hydrated on demand.
+    let lazy = *lazy || filter.is_some();
+    let json_output = should_output_json(cli, None);
 
     if json_output {
         println!(
@@ -1630,8 +1653,7 @@ async fn clone_network(
         // hosted CollaborationService discussions for the cloned head into the
         // local op-log so `discuss list` / `discuss show` see them. Best-effort:
         // a fetch hiccup warns rather than failing an otherwise-good clone.
-        match crate::client::discussion_sync::pull_discussions(&local_repo, &mut client, repo_path)
-            .await
+        match crate::client::discussion_sync::pull_discussions(&local_repo, client, repo_path).await
         {
             Ok(_) => {}
             Err(error) => {
@@ -1644,7 +1666,7 @@ async fn clone_network(
         // Read path for hosted context annotations (heddle context): materialize
         // the hosted head's annotations into the local Context attachment so
         // `context list` sees them. Best-effort, mirroring discussions.
-        match crate::client::context_sync::pull_context(&local_repo, &mut client, repo_path).await {
+        match crate::client::context_sync::pull_context(&local_repo, client, repo_path).await {
             Ok(_) => {}
             Err(error) => {
                 eprintln!("{} context sync skipped: {error:#}", style::warn_marker());
@@ -1737,8 +1759,24 @@ async fn clone_monorepo(
         HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?
             .with_allow_insecure(options.insecure);
 
-    let json_output = should_output_json(cli, None);
     let mut client = session.connect(addr).await?;
+    let result =
+        clone_monorepo_connected(cli, addr, root_path, local_path, endpoint_spec, &mut client)
+            .await;
+    client.close().await;
+    result
+}
+
+#[cfg(feature = "client")]
+async fn clone_monorepo_connected(
+    cli: &Cli,
+    addr: std::net::SocketAddr,
+    root_path: &str,
+    local_path: &Path,
+    endpoint_spec: String,
+    client: &mut HostedClient,
+) -> Result<()> {
+    let json_output = should_output_json(cli, None);
     if json_output {
         println!(
             "{}",
@@ -1777,7 +1815,7 @@ async fn clone_monorepo(
                 )
             })?;
         execute_monorepo_node_steps(
-            &mut client,
+            client,
             node_exec,
             &dest,
             &endpoint_spec,

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -1300,7 +1300,17 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         .connect(options.addr)
         .await?
         .with_human_signature_callback(crate::client::cli_human_signature_callback());
+    let result = push_network_connected(repo, &mut client, options).await;
+    client.close().await;
+    result
+}
 
+#[cfg(feature = "client")]
+async fn push_network_connected(
+    repo: &Repository,
+    client: &mut HostedClient,
+    options: PushNetworkOptions<'_>,
+) -> Result<()> {
     if !should_output_json(options.cli, Some(repo.config())) {
         let line = format_connected_to(&options.addr.to_string());
         if let Some(addr) = line.strip_prefix("connected to ") {
@@ -1312,7 +1322,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
 
     let repo_path = match options.repo_path {
         Some(repo_path) => repo_path.to_string(),
-        None => auto_provision_hosted_repo(repo, &mut client, &options).await?,
+        None => auto_provision_hosted_repo(repo, client, &options).await?,
     };
 
     // --all-threads (heddle#838) on the NATIVE hosted path fans out one push
@@ -1324,7 +1334,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
     // single projection push below; only the non-Git-backed path loops.
     // Plan is pure (capability + flag); network bodies stay here.
     if matches!(options.plan.hosted, HostedPushPlan::NativePerThreadFanout) {
-        return push_network_all_threads(repo, &mut client, &repo_path, &options).await;
+        return push_network_all_threads(repo, client, &repo_path, &options).await;
     }
 
     let progress = progress_for(options.cli, repo);
@@ -1341,7 +1351,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
     };
     let result = push_network_one_thread(
         repo,
-        &mut client,
+        client,
         &repo_path,
         &state_id,
         options.track_name,
@@ -1358,8 +1368,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
     // the object push already succeeded, so a discussion-sync hiccup warns
     // rather than failing the push (the next push resumes from the mirror map).
     if result.success {
-        match crate::client::discussion_sync::push_discussions(repo, &mut client, &repo_path).await
-        {
+        match crate::client::discussion_sync::push_discussions(repo, client, &repo_path).await {
             Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                 println!(
                     "{} synced {count} discussion(s) to {}",
@@ -1381,7 +1390,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
         // rejects these attachments in the pack, so they only reach the server
         // over the caller-authenticated RPCs. Best-effort: the object push
         // already landed, so a sync hiccup warns rather than failing the push.
-        match crate::client::context_sync::push_context(repo, &mut client, &repo_path).await {
+        match crate::client::context_sync::push_context(repo, client, &repo_path).await {
             Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                 println!(
                     "{} synced {count} annotation(s) to {}",
@@ -1394,9 +1403,7 @@ async fn push_network(repo: &Repository, options: PushNetworkOptions<'_>) -> Res
                 eprintln!("{} context sync skipped: {error:#}", style::warn_marker());
             }
         }
-        match crate::client::review_sync::push_review_signatures(repo, &mut client, &repo_path)
-            .await
-        {
+        match crate::client::review_sync::push_review_signatures(repo, client, &repo_path).await {
             Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                 println!(
                     "{} synced {count} review signature(s) to {}",

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1003,13 +1003,24 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
     let mut client = HostedClient::open_session_with_insecure(
         options.addr,
         options.user_config,
-        options.server_key,
+        options.server_key.clone(),
         HostedAuthMode::CredentialFallback,
         options.insecure,
     )
     .await?
     .with_human_signature_callback(crate::client::cli_human_signature_callback());
+    let result = pull_network_connected(repo, &mut client, repo_path, options).await;
+    client.close().await;
+    result
+}
 
+#[cfg(feature = "client")]
+async fn pull_network_connected(
+    repo: &Repository,
+    client: &mut HostedClient,
+    repo_path: &str,
+    options: PullNetworkOptions<'_>,
+) -> Result<()> {
     if !should_output_json(options.cli, Some(repo.config())) {
         let line = format_connected_to(&options.addr.to_string());
         if let Some(addr) = line.strip_prefix("connected to ") {
@@ -1083,9 +1094,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
             // new hosted CollaborationService discussions/turns for the pulled
             // head into the local op-log. Best-effort — a fetch hiccup warns
             // rather than failing the pull.
-            match crate::client::discussion_sync::pull_discussions(repo, &mut client, repo_path)
-                .await
-            {
+            match crate::client::discussion_sync::pull_discussions(repo, client, repo_path).await {
                 Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} discussion(s) from {}",
@@ -1102,7 +1111,7 @@ async fn pull_network(repo: &Repository, options: PullNetworkOptions<'_>) -> Res
                 }
             }
             // Read path for hosted context annotations — same seam as discussions.
-            match crate::client::context_sync::pull_context(repo, &mut client, repo_path).await {
+            match crate::client::context_sync::pull_context(repo, client, repo_path).await {
                 Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} annotation(s) from {}",

--- a/crates/cli/src/cli/commands/thread_approval.rs
+++ b/crates/cli/src/cli/commands/thread_approval.rs
@@ -161,7 +161,9 @@ pub async fn cmd_thread_approve(cli: &Cli, args: ThreadApproveArgs) -> Result<()
             args.note.as_deref(),
             cli.operation_id_wire(),
         )
-        .await?;
+        .await;
+    client.close().await;
+    let approval = approval?;
 
     if should_output_json(cli, Some(repo.config())) {
         let out = ApprovalOutput {
@@ -198,7 +200,9 @@ pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Resul
     let (mut client, repo_path) = open_heddle_client(&repo, &args.remote).await?;
     let approvals = client
         .list_thread_approvals(&repo_path, &args.source, &args.target)
-        .await?;
+        .await;
+    client.close().await;
+    let approvals = approvals?;
 
     if should_output_json(cli, Some(repo.config())) {
         let out: Vec<ApprovalOutput> = approvals
@@ -249,9 +253,11 @@ pub async fn cmd_thread_approvals(cli: &Cli, args: ThreadApprovalsArgs) -> Resul
 pub async fn cmd_thread_revoke_approval(cli: &Cli, args: ThreadRevokeApprovalArgs) -> Result<()> {
     let repo = cli.open_repo()?;
     let (mut client, _repo_path) = open_heddle_client(&repo, &args.remote).await?;
-    client
+    let result = client
         .revoke_approval(&args.id, cli.operation_id_wire())
-        .await?;
+        .await;
+    client.close().await;
+    result?;
     if should_output_json(cli, Some(repo.config())) {
         let output = ApprovalRevokeOutput {
             output_kind: "thread_revoke_approval",
@@ -279,7 +285,9 @@ pub async fn cmd_thread_check_merge(cli: &Cli, args: ThreadCheckMergeArgs) -> Re
             args.changed_paths,
             None,
         )
-        .await?;
+        .await;
+    client.close().await;
+    let resp = resp?;
 
     let unmet: Vec<UnmetOutput> = resp
         .unmet

--- a/crates/client/src/auth_cmd.rs
+++ b/crates/client/src/auth_cmd.rs
@@ -653,7 +653,7 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
         .or_else(|_| std::env::var("HOST"))
         .unwrap_or_else(|_| "heddle-cli".to_string());
 
-    let response: DeviceAuthorizationResponse = auth_client
+    let response: Result<DeviceAuthorizationResponse> = auth_client
         .routes()
         .create_device_authorization(&CreateDeviceAuthorizationRequest {
             device_name: hostname,
@@ -662,7 +662,14 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
             client_operation_id: String::new(),
         })
         .await
-        .map_err(|error| anyhow::anyhow!("create_device_authorization failed: {error}"))?;
+        .map_err(|error| anyhow::anyhow!("create_device_authorization failed: {error}"));
+    let response = match response {
+        Ok(response) => response,
+        Err(error) => {
+            auth_client.close().await;
+            return Err(error);
+        }
+    };
 
     let verification_uri = &response.verification_uri;
     let user_code = &response.user_code;
@@ -706,7 +713,9 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
         &signer,
         response.expires_at,
     )
-    .await?;
+    .await;
+    auth_client.close().await;
+    let access_token = access_token?;
 
     // 7. Store credential.
     let credential = ServerCredential {
@@ -895,6 +904,29 @@ async fn cmd_create_service_token(
     let user_config = UserConfig::load_default()?;
     let session = HostedSession::build_stored_credential(&user_config, &server)?;
     let mut auth_client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let result = create_service_token_connected(
+        ctx,
+        &mut auth_client,
+        server,
+        name,
+        namespace,
+        scope,
+        credential_path,
+    )
+    .await;
+    auth_client.close().await;
+    result
+}
+
+async fn create_service_token_connected(
+    ctx: &dyn CliContext,
+    auth_client: &mut HostedClient,
+    server: String,
+    name: String,
+    namespace: String,
+    scope: String,
+    credential_path: std::path::PathBuf,
+) -> Result<()> {
     let create_operation_id = ClientOperationId::caller_or_fresh(
         "heddle.api.v1alpha1.IdentityService/CreateServiceAccount",
         ctx.operation_id_wire(),

--- a/crates/client/src/hosted/call.rs
+++ b/crates/client/src/hosted/call.rs
@@ -457,6 +457,7 @@ mod tests {
                 .expect("dropping ServerStream must signal STOP_SENDING")
                 .expect("remote response sender observes the stop code");
             assert_eq!(stop_code, Some(1u32.into()));
+            server.close().await;
         });
 
         let client = Endpoint::builder(presets::Minimal)
@@ -466,6 +467,7 @@ mod tests {
             .bind()
             .await
             .unwrap();
+        let client_observer = client.clone();
         let connection = HostedConnection::connect(client, server_addr)
             .await
             .unwrap();
@@ -477,5 +479,7 @@ mod tests {
         drop(response);
 
         server_task.await.unwrap();
+        connection.close().await;
+        assert!(client_observer.is_closed());
     }
 }

--- a/crates/client/src/hosted/connection.rs
+++ b/crates/client/src/hosted/connection.rs
@@ -9,7 +9,7 @@ use super::{HostedError, Result, VerifiedEndpointDescriptor};
 
 #[derive(Debug)]
 pub(super) struct HostedConnection {
-    pub(super) _endpoint: Endpoint,
+    pub(super) endpoint: Endpoint,
     pub(super) connection: iroh::endpoint::Connection,
 }
 
@@ -18,6 +18,7 @@ impl HostedConnection {
         descriptor: &VerifiedEndpointDescriptor,
     ) -> Result<Arc<Self>> {
         let relays = descriptor.relay_urls()?;
+        let address = descriptor.endpoint_addr()?;
         let relay_mode = if relays.is_empty() {
             RelayMode::Disabled
         } else {
@@ -29,18 +30,26 @@ impl HostedConnection {
             .bind()
             .await
             .map_err(HostedError::transport)?;
-        Self::connect(endpoint, descriptor.endpoint_addr()?).await
+        Self::connect(endpoint, address).await
     }
 
     pub(super) async fn connect(endpoint: Endpoint, address: EndpointAddr) -> Result<Arc<Self>> {
-        let connection = endpoint
-            .connect(address, api::HOSTED_ALPN_V1)
-            .await
-            .map_err(HostedError::transport)?;
+        let connection = match endpoint.connect(address, api::HOSTED_ALPN_V1).await {
+            Ok(connection) => connection,
+            Err(error) => {
+                endpoint.close().await;
+                return Err(HostedError::transport(error));
+            }
+        };
         Ok(Arc::new(Self {
-            _endpoint: endpoint,
+            endpoint,
             connection,
         }))
+    }
+
+    pub(super) async fn close(&self) {
+        self.connection.close(0u32.into(), b"Heddle client closed");
+        self.endpoint.close().await;
     }
 }
 
@@ -62,4 +71,53 @@ fn transport_config() -> QuicTransportConfig {
         .receive_window(CONNECTION_RECEIVE_WINDOW.into())
         .ack_frequency_config(Some(acknowledgements))
         .build()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, time::Duration};
+
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
+
+    use super::HostedConnection;
+
+    #[tokio::test]
+    async fn failed_connect_closes_the_client_endpoint() {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![b"not-heddle".to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let incoming = server.accept().await.expect("incoming connection");
+            assert!(
+                incoming.await.is_err(),
+                "ALPN mismatch must reject the dial"
+            );
+            server.close().await;
+        });
+
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let client_observer = client.clone();
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            HostedConnection::connect(client, server_addr),
+        )
+        .await
+        .expect("ALPN mismatch must fail promptly");
+
+        assert!(result.is_err());
+        assert!(client_observer.is_closed());
+        server_task.await.unwrap();
+    }
 }

--- a/crates/client/src/hosted/hydration.rs
+++ b/crates/client/src/hosted/hydration.rs
@@ -162,10 +162,9 @@ impl BlobHydrator for LazyHostedHydrator {
 /// `#[tokio::main]` async context: the worker's runtime is private, so the
 /// nested `block_on` happens entirely off the caller's runtime.
 struct HydrationBridge {
-    tx: mpsc::Sender<HydrateMessage>,
-    /// Join handle for the worker. Kept so that dropping the bridge
-    /// closes the channel and lets the worker exit cleanly.
-    _worker: thread::JoinHandle<()>,
+    tx: Option<mpsc::Sender<HydrateMessage>>,
+    /// Joined after the sender is dropped so the worker can close its client.
+    worker: Option<thread::JoinHandle<()>>,
 }
 
 enum HydrateMessage {
@@ -247,26 +246,18 @@ impl HydrationBridge {
                     // (clone, fetch, push, pull, support, approval) opens
                     // through — so a process whose cached token has slipped
                     // past expiry recovers on first lazy hydrate.
-                    let client = match tokio::time::timeout(
-                        DEFAULT_HOSTED_HYDRATION_TIMEOUT,
-                        session.connect(addr),
-                    )
-                    .await
-                    {
-                        Ok(result) => result.map_err(|err: ProtocolError| {
-                            HeddleError::Config(format!(
-                                "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
+                    //
+                    // Do not cancel this future on the bridge's ready timeout:
+                    // cancellation after binding would drop Iroh's endpoint
+                    // before its async close can run. The caller still times
+                    // out below; this private worker finishes the dial and
+                    // closes the client if the caller has gone away.
+                    let client = session.connect(addr).await.map_err(|err: ProtocolError| {
+                        HeddleError::Config(format!(
+                            "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
                                      (resolved to {addr}): {err}",
-                            ))
-                        })?,
-                        Err(_) => {
-                            return Err(HeddleError::Config(format!(
-                                "lazy hosted hydrator: connect to '{endpoint_for_thread}' \
-                                     (resolved to {addr}) timed out after {}",
-                                format_duration(DEFAULT_HOSTED_HYDRATION_TIMEOUT)
-                            )));
-                        }
-                    };
+                        ))
+                    })?;
                     Ok::<_, HeddleError>(client)
                 });
                 let mut client = match connect_result {
@@ -277,20 +268,20 @@ impl HydrationBridge {
                     }
                 };
 
-                // Signal the bridge constructor that connect succeeded
-                // BEFORE entering the request loop. After this point any
-                // bridge-construction errors are gone; the channel is open
-                // and `HydrationBridge::hydrate` calls will succeed.
-                if ready_tx.send(Ok(())).is_err() {
-                    return;
-                }
-
-                // Drive the request loop. `recv` returns Err when the
-                // last `Sender` is dropped (i.e. the LazyHostedHydrator
-                // owning the bridge has been dropped), which is our
-                // shutdown signal — we drop the runtime + client and
-                // exit.
                 runtime.block_on(async {
+                    // Signal the bridge constructor that connect succeeded
+                    // BEFORE entering the request loop. After this point any
+                    // bridge-construction errors are gone; the channel is open
+                    // and `HydrationBridge::hydrate` calls will succeed.
+                    if ready_tx.send(Ok(())).is_err() {
+                        client.close().await;
+                        return;
+                    }
+
+                    // Drive the request loop. `recv` returns Err when the
+                    // last `Sender` is dropped (i.e. the LazyHostedHydrator
+                    // owning the bridge has been dropped), which is our
+                    // shutdown signal.
                     while let Ok(message) = rx.recv() {
                         match message {
                             HydrateMessage::Run {
@@ -313,6 +304,7 @@ impl HydrationBridge {
                             }
                         }
                     }
+                    client.close().await;
                 });
             })
             .map_err(|err| {
@@ -324,8 +316,8 @@ impl HydrationBridge {
         // wedge the sync read path.
         match ready_rx.recv_timeout(DEFAULT_HOSTED_HYDRATION_TIMEOUT) {
             Ok(Ok(())) => Ok(Self {
-                tx,
-                _worker: worker,
+                tx: Some(tx),
+                worker: Some(worker),
             }),
             Ok(Err(err)) => Err(err),
             Err(mpsc::RecvTimeoutError::Timeout) => Err(HeddleError::Config(format!(
@@ -369,6 +361,8 @@ impl HydrationBridge {
         // the worker returns the hosted result for this request.
         let (reply_tx, reply_rx) = mpsc::sync_channel::<Result<usize, ProtocolError>>(1);
         self.tx
+            .as_ref()
+            .expect("hydration bridge sender is present until drop")
             .send(HydrateMessage::Run {
                 repo,
                 repo_path: repo_path.to_string(),
@@ -394,6 +388,15 @@ impl HydrationBridge {
                     "lazy hosted hydrator: worker reply channel closed before hydration completed",
                 )))
             }
+        }
+    }
+}
+
+impl Drop for HydrationBridge {
+    fn drop(&mut self) {
+        self.tx.take();
+        if let Some(worker) = self.worker.take() {
+            let _ = worker.join();
         }
     }
 }
@@ -528,8 +531,8 @@ mod tests {
             })
             .expect("spawn test worker");
         HydrationBridge {
-            tx,
-            _worker: worker,
+            tx: Some(tx),
+            worker: Some(worker),
         }
     }
 
@@ -635,8 +638,8 @@ mod tests {
             })
             .expect("spawn inspect worker");
         let bridge = HydrationBridge {
-            tx,
-            _worker: worker,
+            tx: Some(tx),
+            worker: Some(worker),
         };
 
         let hydrator =
@@ -741,8 +744,8 @@ mod tests {
             })
             .expect("spawn stalling worker");
         let bridge = HydrationBridge {
-            tx,
-            _worker: worker,
+            tx: Some(tx),
+            worker: Some(worker),
         };
 
         let started = Instant::now();

--- a/crates/client/src/hosted/mod.rs
+++ b/crates/client/src/hosted/mod.rs
@@ -176,9 +176,10 @@ impl HostedClient {
         descriptor: &VerifiedEndpointDescriptor,
         config: &ClientConfig,
     ) -> Result<Self> {
+        let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
             connection: HostedConnection::connect_verified(descriptor).await?,
-            context: CallContextFactory::from_client_config(config)?,
+            context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,
             server_key: config.server_key.clone(),
@@ -201,9 +202,10 @@ impl HostedClient {
         address: EndpointAddr,
         config: &ClientConfig,
     ) -> Result<Self> {
+        let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
             connection: HostedConnection::connect(endpoint, address).await?,
-            context: CallContextFactory::from_client_config(config)?,
+            context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,
             server_key: config.server_key.clone(),
@@ -227,6 +229,11 @@ impl HostedClient {
     pub fn with_human_signature_callback(mut self, callback: HumanSignatureCallback) -> Self {
         self.on_human_signature = Some(callback);
         self
+    }
+
+    /// Gracefully close the native connection and its owning Iroh endpoint.
+    pub async fn close(self) {
+        self.connection.close().await;
     }
 
     pub(super) async fn auto_rotate_if_needed(

--- a/crates/client/src/support.rs
+++ b/crates/client/src/support.rs
@@ -217,8 +217,8 @@ async fn run_grant(ctx: &dyn CliContext, args: SupportGrant) -> Result<()> {
         )));
     }
     let repo = Repository::open(resolve_repo_path(ctx)?)?;
-    let mut client = open_client(&repo, &args.remote).await?;
     let ttl_secs = parse_ttl(&args.ttl)?;
+    let mut client = open_client(&repo, &args.remote).await?;
     let op_id = ctx.operation_id_wire();
     let grant = client
         .grant_support_access(
@@ -229,8 +229,9 @@ async fn run_grant(ctx: &dyn CliContext, args: SupportGrant) -> Result<()> {
             &args.reason,
             op_id,
         )
-        .await?;
-    let out: SupportAccessOutput = grant.into();
+        .await;
+    client.close().await;
+    let out: SupportAccessOutput = grant?.into();
     if ctx.should_output_json(Some(repo.config())) {
         let output = SupportGrantOutput {
             output_kind: "support_grant",
@@ -269,8 +270,9 @@ async fn run_list(ctx: &dyn CliContext, args: SupportList) -> Result<()> {
             args.repo.as_deref(),
             args.include_inactive,
         )
-        .await?;
-    let entries: Vec<SupportAccessOutput> = grants.into_iter().map(Into::into).collect();
+        .await;
+    client.close().await;
+    let entries: Vec<SupportAccessOutput> = grants?.into_iter().map(Into::into).collect();
     if ctx.should_output_json(Some(repo.config())) {
         let output = SupportListOutput {
             output_kind: "support_list",
@@ -311,7 +313,9 @@ async fn run_revoke(ctx: &dyn CliContext, args: SupportRevoke) -> Result<()> {
     let repo = Repository::open(resolve_repo_path(ctx)?)?;
     let mut client = open_client(&repo, &args.remote).await?;
     let op_id = ctx.operation_id_wire();
-    client.revoke_support_access(&args.id, op_id).await?;
+    let result = client.revoke_support_access(&args.id, op_id).await;
+    client.close().await;
+    result?;
     if ctx.should_output_json(Some(repo.config())) {
         let output = SupportRevokeOutput {
             output_kind: "support_revoke",

--- a/crates/client/src/whoami.rs
+++ b/crates/client/src/whoami.rs
@@ -184,7 +184,9 @@ async fn fetch_identity(server: &str) -> Result<WhoamiIdentity> {
     let response = client
         .who_am_i()
         .await
-        .map_err(|error| anyhow::anyhow!(error))?;
+        .map_err(|error| anyhow::anyhow!(error));
+    client.close().await;
+    let response = response?;
     Ok(WhoamiIdentity {
         subject: response.subject,
         actor_subject: response.actor_subject,


### PR DESCRIPTION
## Summary

- Add explicit async teardown for `HostedClient`: close the QUIC connection, then await `Endpoint::close()`.
- Run teardown after every owned hosted-client operation on both success and error paths, including push, pull, clone, auth, whoami, support, approvals, and lazy hydration shutdown.
- Close endpoints when connection establishment fails and avoid cancelling the lazy hydration dial after endpoint binding.
- Keep the real operation error as the returned error; no log filtering or transport/auth changes.

## Closes

Closes #1143

## Test evidence

### Same successful push before

```text
[ok] connected to 127.0.0.1:8421
[ok] created hosted spool issue-1143-codex/repro-source
Next: heddle remote add origin heddle://127.0.0.1:8421/issue-1143-codex/repro-source
[ok] pushed to main
remote state: hs-cg80gnfeegt5ca2
2026-07-30T05:57:40.433482Z ERROR iroh::socket: Endpoint dropped without calling `Endpoint::close`. Aborting ungracefully.
elapsed=0.27 s
push_rc=0
```

### Same successful push after

```text
[ok] connected to 127.0.0.1:8421
[ok] using hosted spool issue-1143-codex/repro-source
Next: heddle remote add origin heddle://127.0.0.1:8421/issue-1143-codex/repro-source
[ok] pushed to main
remote state: hs-cg80gnfeegt5ca2
elapsed=1.14 s
push_rc=0
```

The graceful QUIC drain adds 0.87 s in this local debug run (0.27 s before, 1.14 s after). That wait is the awaited Iroh endpoint drain; teardown is explicit rather than spawned or blocked from `Drop`.

### Native pull and clone

```text
[ok] connected to 127.0.0.1:8421
[ok] already up to date with main; repository verification checked below
elapsed=1.12 s
pull_rc=0
```

```text
Connected to 127.0.0.1:8421
[ok] cloned heddle://127.0.0.1:8421/issue-1143-codex/repro-source into /home/scratch/issue-1143/repro-clone-final-2
  state: hs-cg80gnfeegt5ca2
elapsed=1.52 s
clone_rc=0
```

### Unauthorized push error path

```text
[ok] connected to 127.0.0.1:8421
Error: remote failure (PermissionDenied): access denied
Next: heddle status
Also: heddle help push
Command exited with non-zero status 77
elapsed=1.09 s
push_rc=77
```

No `iroh::socket` error appeared in any after transcript, while the actual authorization error and exit status remained intact.

### Automated checks

- `cargo build --locked -p heddle-client -p heddle-cli --tests --bin heddle --bin heddle-fuse-worker`
- `cargo clippy --locked -p heddle-client -p heddle-cli --lib --bins --tests --examples -- -D warnings`
- `cargo test --locked -p heddle-client` — 139 unit, 13 contract, and 1 inertness test passed
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd`

The combined CLI integration suite cannot use the mandated `TMPDIR=/home/scratch` cleanly on this evaluation host because `/home/scratch/.git` is a pre-existing read-only parent repository; a one-test isolation repro exits 74 with `Read-only file system` during `heddle init`, before the patch path executes. The CI runner does not have that parent-repository collision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787985008&installation_model_id=21489&pr_number=1151&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1151&signature=a284798a7f68039e9e41cc53d356d02c1595c1904591df045c3f40c664ed7c20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->