### PR TITLE
fix(cli): isolate HEDDLE_HOME and unify principal resolution

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -977,6 +977,9 @@
         "principal": {
           "$ref": "#/$defs/CommitPrincipalSchema"
         },
+        "principal_source": {
+          "type": "string"
+        },
         "promotion_suggested": {
           "type": "boolean"
         },
@@ -1024,6 +1027,7 @@
         "state_id",
         "content_hash",
         "principal",
+        "principal_source",
         "promotion_suggested",
         "heavy_impact_paths",
         "signed",
@@ -12101,6 +12105,9 @@
         "principal": {
           "$ref": "#/$defs/CommitPrincipalSchema"
         },
+        "principal_source": {
+          "type": "string"
+        },
         "promotion_suggested": {
           "type": "boolean"
         },
@@ -12148,6 +12155,7 @@
         "state_id",
         "content_hash",
         "principal",
+        "principal_source",
         "promotion_suggested",
         "heavy_impact_paths",
         "signed",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -125,6 +125,7 @@ export interface AgentCaptureSchema {
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "capture";
   principal: CommitPrincipalSchema;
+  principal_source: string;
   promotion_suggested: boolean;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
@@ -515,6 +516,7 @@ export interface CaptureSchema {
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
   output_kind: "capture";
   principal: CommitPrincipalSchema;
+  principal_source: string;
   promotion_suggested: boolean;
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -1223,6 +1223,7 @@ pub struct CaptureSchema {
     pub confidence: Option<f32>,
     pub task_assignment_id: Option<String>,
     pub principal: CommitPrincipalSchema,
+    pub principal_source: String,
     pub agent: Option<CommitAgentSchema>,
     pub promotion_suggested: bool,
     pub heavy_impact_paths: Vec<String>,

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -520,7 +520,17 @@ docs.\n\
 \n\
 This is intentional. The everyday surface stays minimal so first-time users aren't\n\
 overwhelmed; agents and power users reach for the advanced affordances when they\n\
-need them.\n";
+need them.\n\
+\n\
+Configuration environment:\n\
+  HEDDLE_HOME    Relocates global Heddle state (credentials, device identity,\n\
+                 session state, and the default user config).\n\
+  HEDDLE_CONFIG  Overrides the user config file. Takes precedence over\n\
+                 HEDDLE_HOME; otherwise HEDDLE_HOME uses <path>/config.toml.\n\
+\n\
+Principal resolution (highest first): HEDDLE_PRINCIPAL_NAME and\n\
+HEDDLE_PRINCIPAL_EMAIL, repository config, Git config, user config, then\n\
+Unknown <unknown@example.com>. Init, status, and capture use this same order.\n";
 
 // The single full statement of the --output machine contract (plus the
 // one-paragraph version on the top-level `heddle help`). The global
@@ -1362,6 +1372,17 @@ mod tests {
             !advanced.contains("Advanced commands:"),
             "the flat list header is replaced by area groups: {advanced}"
         );
+    }
+
+    #[test]
+    fn advanced_help_documents_home_and_config_overrides() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let advanced = render_help(&cmd, &["advanced".to_string()]);
+        assert!(advanced.contains("HEDDLE_HOME"));
+        assert!(advanced.contains("HEDDLE_CONFIG"));
+        assert!(advanced.contains("<path>/config.toml"));
+        assert!(advanced.contains("Principal resolution (highest first)"));
     }
 
     /// heddle#652. The grouped advanced surface is exhaustive and

--- a/crates/cli-render/src/cli/tips.rs
+++ b/crates/cli-render/src/cli/tips.rs
@@ -7,8 +7,8 @@
 //! - **stderr only**: piping `heddle <verb>` to other tools never includes
 //!   tips.
 //! - **never in `--output json`**: scripted consumers don't get advisory output.
-//! - **once per session per repo**: a session marker file at
-//!   `~/.heddle/session/<repo-id>/tips-shown.toml` records which tips
+//! - **once per session per repo**: a session marker file under
+//!   `<heddle-home>/session/<repo-id>/tips-shown.toml` records which tips
 //!   have been shown so we don't nag.
 //! - **per-repo permanently suppressible** via `[ui.tips] enabled = false`
 //!   in `.heddle/config.toml` (or `[ui.tips.suppress] keys = [...]` to
@@ -57,12 +57,7 @@ pub fn session_marker_dir(repo_root: &std::path::Path) -> PathBuf {
     let canonical = std::fs::canonicalize(repo_root).unwrap_or_else(|_| repo_root.to_path_buf());
     let hash = blake3::hash(canonical.to_string_lossy().as_bytes());
     let id = hex::encode(&hash.as_bytes()[..8]);
-    let home = dirs_home().unwrap_or_else(|| PathBuf::from("/tmp"));
-    home.join(".heddle").join("session").join(id)
-}
-
-fn dirs_home() -> Option<PathBuf> {
-    std::env::var_os("HOME").map(PathBuf::from)
+    repo::identity::heddle_home_dir().join("session").join(id)
 }
 
 fn marker_file(repo_root: &std::path::Path) -> PathBuf {

--- a/crates/cli-shared/src/config/mod.rs
+++ b/crates/cli-shared/src/config/mod.rs
@@ -2,9 +2,10 @@
 mod user_config;
 
 pub use user_config::{
-    HarnessMode, HarnessTranscriptMode, HarnessTransport, UserAgentConfig, UserAutoCaptureMode,
-    UserCaptureConfig, UserConfig, UserDisplayConfig, UserHarnessConfig, UserHarnessOverride,
-    UserHarnessRootThreadPolicy, UserHarnessSubagentThreadPolicy, UserHarnessThreadingConfig,
-    UserLoggingConfig, UserOutputConfig, UserPrincipalConfig, UserRemoteConfig,
-    UserThreadWorkspaceConfig, UserThreadWorkspaceMode, UserWorktreeConfig,
+    HarnessMode, HarnessTranscriptMode, HarnessTransport, ResolvedPrincipal, UserAgentConfig,
+    UserAutoCaptureMode, UserCaptureConfig, UserConfig, UserDisplayConfig, UserHarnessConfig,
+    UserHarnessOverride, UserHarnessRootThreadPolicy, UserHarnessSubagentThreadPolicy,
+    UserHarnessThreadingConfig, UserLoggingConfig, UserOutputConfig, UserPrincipalConfig,
+    UserRemoteConfig, UserThreadWorkspaceConfig, UserThreadWorkspaceMode, UserWorktreeConfig,
+    principal_source_display, resolve_principal,
 };

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -6,8 +6,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use objects::fs_atomic::{StagedAtomicWrite, stage_file_atomic_secret};
-use repo::{FsMonitorMode, FsMonitorSettings, OutputFormat, WorktreeStatusOptions};
+use objects::{
+    fs_atomic::{StagedAtomicWrite, stage_file_atomic_secret},
+    object::Principal,
+};
+use repo::{
+    FsMonitorMode, FsMonitorSettings, OutputFormat, Repository, WorktreeStatusOptions,
+    identity::heddle_home_override,
+};
 use serde::{Deserialize, Serialize};
 use wire::AuthToken;
 
@@ -40,6 +46,29 @@ pub struct UserConfig {
 pub struct StagedUserConfig {
     path: PathBuf,
     write: StagedAtomicWrite,
+}
+
+/// A principal together with the configuration surface that selected it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPrincipal {
+    pub principal: Principal,
+    pub source: Option<&'static str>,
+}
+
+impl ResolvedPrincipal {
+    fn configured(principal: Principal, source: &'static str) -> Self {
+        Self {
+            principal,
+            source: Some(source),
+        }
+    }
+
+    fn unknown(principal: Principal) -> Self {
+        Self {
+            principal,
+            source: None,
+        }
+    }
 }
 
 impl StagedUserConfig {
@@ -315,6 +344,9 @@ impl UserConfig {
         {
             return Some(PathBuf::from(path));
         }
+        if let Some(home) = heddle_home_override() {
+            return Some(home.join("config.toml"));
+        }
         if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME")
             && !xdg.is_empty()
         {
@@ -555,6 +587,53 @@ impl UserConfig {
             fsmonitor: FsMonitorSettings { mode },
         }
     }
+}
+
+/// Resolve capture attribution once for init, status, capture, and other
+/// identity-bearing commands.
+///
+/// Precedence is environment, repository config, Git config (including a
+/// shared parent checkout), user config, then the built-in Unknown principal.
+pub fn resolve_principal(
+    repo: &Repository,
+    user_config: &UserConfig,
+) -> repo::Result<ResolvedPrincipal> {
+    if let Some(principal) = Principal::from_env() {
+        return Ok(ResolvedPrincipal::configured(principal, "environment"));
+    }
+    if let Some(config) = &repo.config().principal {
+        return Ok(ResolvedPrincipal::configured(
+            Principal::new(&config.name, &config.email),
+            "repository",
+        ));
+    }
+    let principal = repo.get_principal()?;
+    if principal_is_accountable(&principal) {
+        return Ok(ResolvedPrincipal::configured(principal, "git_config"));
+    }
+    if let Some(config) = &user_config.principal {
+        return Ok(ResolvedPrincipal::configured(
+            Principal::new(&config.name, &config.email),
+            "user_config",
+        ));
+    }
+    Ok(ResolvedPrincipal::unknown(principal))
+}
+
+/// Human-facing source label. User config is called out as global because it
+/// is shared across repositories unless `HEDDLE_HOME` or `HEDDLE_CONFIG`
+/// isolates it.
+pub fn principal_source_display(source: &str) -> &str {
+    match source {
+        "user_config" => "user_config (shared global config)",
+        _ => source,
+    }
+}
+
+fn principal_is_accountable(principal: &Principal) -> bool {
+    let name = principal.name.trim();
+    let email = principal.email.trim();
+    !name.is_empty() && !email.is_empty() && !(name == "Unknown" && email == "unknown@example.com")
 }
 
 fn parse_auto_capture_env(setting: &str, value: &str) -> anyhow::Result<UserAutoCaptureMode> {

--- a/crates/cli-shared/src/lib.rs
+++ b/crates/cli-shared/src/lib.rs
@@ -17,7 +17,7 @@ pub mod remote;
 pub use client_config::{
     ClientConfig, cleartext_connect_allowed, cleartext_refused_message, is_loopback_ip,
 };
-pub use config::UserConfig;
+pub use config::{ResolvedPrincipal, UserConfig, principal_source_display, resolve_principal};
 pub use logging::{
     LogFormat, LoggingConfig, LoggingGuard, init_logging, init_logging_default, is_enabled,
 };

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -78,6 +78,15 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
     };
     let path = path.canonicalize().unwrap_or(path.clone());
 
+    if let Some(home) = repo::identity::heddle_home_override() {
+        fs::create_dir_all(&home).map_err(|error| {
+            anyhow::anyhow!(
+                "failed to create HEDDLE_HOME at {}: {error}",
+                home.display()
+            )
+        })?;
+    }
+
     info!(path = %path.display(), "Initializing repository");
 
     let mut user_config = UserConfig::load_default()?;
@@ -258,6 +267,7 @@ fn render_init(output: &InitOutput, json: bool) -> Result<()> {
                 let source = output
                     .principal_source
                     .as_deref()
+                    .map(cli_shared::principal_source_display)
                     .map(|source| format!(" from {source}"))
                     .unwrap_or_default();
                 println!(
@@ -299,19 +309,11 @@ fn init_principal_status(
     repo: &Repository,
     user_config: &UserConfig,
 ) -> Result<InitPrincipalStatus> {
-    let mut candidates: Vec<(&'static str, Principal)> = Vec::new();
-    if let Some(principal) = Principal::from_env() {
-        candidates.push(("environment", principal));
-    }
-    if let Some(config) = &repo.config().principal {
-        candidates.push(("repository", Principal::new(&config.name, &config.email)));
-    }
-    if repo.capability() == RepositoryCapability::GitOverlay {
-        candidates.push(("git_config", repo.get_principal()?));
-    }
-    if let Some(config) = &user_config.principal {
-        candidates.push(("user_config", Principal::new(&config.name, &config.email)));
-    }
+    let resolved = cli_shared::resolve_principal(repo, user_config)?;
+    let candidates = resolved
+        .source
+        .map(|source| vec![(source, resolved.principal)])
+        .unwrap_or_default();
     Ok(init_principal_status_from_plan(select_init_principal(
         &candidates,
     )))

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -59,6 +59,7 @@ pub(crate) struct SnapshotOutput {
     pub confidence: Option<f32>,
     pub task_assignment_id: Option<String>,
     pub principal: SnapshotPrincipalOutput,
+    pub principal_source: String,
     pub agent: Option<SnapshotAgentOutput>,
     pub promotion_suggested: bool,
     pub heavy_impact_paths: Vec<String>,
@@ -293,8 +294,9 @@ pub async fn cmd_snapshot(
             style::dim(&output.content_hash),
         );
         println!(
-            "Saved by: {}",
-            style::principal(&output.principal.name, &output.principal.email)
+            "Saved by: {} from {}",
+            style::principal(&output.principal.name, &output.principal.email),
+            cli_shared::principal_source_display(&output.principal_source)
         );
         if let Some(agent) = &output.agent {
             println!(
@@ -804,7 +806,7 @@ fn create_snapshot_profiled_inner(
         plan.precomputed_worktree_status = Some(clone_worktree_status_result(status));
     }
     let report = execute_save(repo, plan)?;
-    snapshot_output_from_save_report(repo, report)
+    snapshot_output_from_save_report(repo, user_config, report)
 }
 
 #[allow(dead_code)]
@@ -848,7 +850,7 @@ pub(crate) fn create_snapshot_from_tree_profiled(
         precomputed_worktree_status: None,
     };
     let report = execute_save(repo, plan)?;
-    snapshot_output_from_save_report(repo, report)
+    snapshot_output_from_save_report(repo, user_config, report)
 }
 
 fn clone_worktree_status_result(
@@ -867,6 +869,7 @@ fn clone_worktree_status_result(
 
 fn snapshot_output_from_save_report(
     repo: &Repository,
+    user_config: &UserConfig,
     report: heddle_core::SaveReport,
 ) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
     // Public capture JSON still uses the CLI verification adapter so
@@ -880,6 +883,10 @@ fn snapshot_output_from_save_report(
         .and_then(action_template)
         .or_else(|| trust.recommended_action_template.clone());
     let task_assignment_id = active_task_assignment_id(repo)?;
+    let principal_source = cli_shared::resolve_principal(repo, user_config)?
+        .source
+        .unwrap_or("unknown")
+        .to_string();
     let output = SnapshotOutput {
         output_kind: "capture",
         status: "captured",
@@ -890,6 +897,7 @@ fn snapshot_output_from_save_report(
         confidence: report.confidence,
         task_assignment_id,
         principal: (&report.principal).into(),
+        principal_source,
         agent: report.agent.as_ref().map(SnapshotAgentOutput::from),
         promotion_suggested: report.promotion_suggested,
         heavy_impact_paths: report.heavy_impact_paths.clone(),
@@ -1196,33 +1204,7 @@ pub(crate) fn resolve_attribution(
 }
 
 pub(crate) fn resolve_principal(repo: &Repository, user_config: &UserConfig) -> Result<Principal> {
-    // Precedence: env > repo .heddle/config.toml > Git-overlay Git config
-    // (including the shared parent checkout for isolated work) > user
-    // ~/.config/heddle/config.toml > Unknown.
-    //
-    // Repo-level config must win over user-level: a repo carrying an
-    // explicit `[principal]` is recording "captures in this project use
-    // this identity," and the user-level config is the default for
-    // repos that DON'T pin one. Inverting that order (the previous
-    // implementation) meant every capture in every repo silently
-    // adopted the user-level identity, even when the repo had its own
-    // `[principal]` declared — regression seen in
-    // `e2e::log_never_surfaces_unknown_principal_after_init` where a
-    // repo-level "Adam" was overridden by a stray user-level "test".
-    if let Some(principal) = Principal::from_env() {
-        return Ok(principal);
-    }
-    if let Some(config) = &repo.config().principal {
-        return Ok(Principal::new(&config.name, &config.email));
-    }
-    let principal = repo.get_principal()?;
-    if !is_default_unknown_principal(&principal) {
-        return Ok(principal);
-    }
-    if let Some(config) = &user_config.principal {
-        return Ok(Principal::new(&config.name, &config.email));
-    }
-    Ok(principal)
+    Ok(cli_shared::resolve_principal(repo, user_config)?.principal)
 }
 
 pub(crate) fn is_placeholder_principal(principal: &Principal) -> bool {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -313,9 +313,11 @@ fn build_status_command_output(cli: &Cli, short: bool) -> Result<StatusCommandOu
         StatusDetail::DefaultText
     };
     let status_options = worktree_status_options(Some(&repo_config));
+    let user_config = cli_shared::UserConfig::load_default()?;
     let ctx = heddle_core::ExecutionContext::builder()
         .start_path(start.clone())
         .repo(repo)
+        .config(user_config)
         .build();
     let mut output = core_status(
         &ctx,

--- a/crates/cli/src/operation_id.rs
+++ b/crates/cli/src/operation_id.rs
@@ -389,10 +389,9 @@ fn bootstrap_op_id_scope_for_root(root: PathBuf) -> Result<BootstrapOpIdScope> {
 }
 
 fn bootstrap_op_id_store_dir(scope: &BootstrapOpIdScope) -> PathBuf {
-    let base = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(std::env::temp_dir);
-    base.join(".heddle").join("bootstrap-op-id").join(&scope.id)
+    repo::identity::heddle_home_dir()
+        .join("bootstrap-op-id")
+        .join(&scope.id)
 }
 
 /// Same as [`resolve_operation_id`] but returns the wire-string form
@@ -401,7 +400,7 @@ pub fn wire(cli: &Cli) -> String {
     cli.op_id.clone().unwrap_or_default()
 }
 
-/// Per-repo session directory under `$HOME/.heddle/session/<repo-id>`.
+/// Per-repo session directory under `<heddle-home>/session/<repo-id>`.
 /// `<repo-id>` is a 16-char SHA-256 of the canonical repo root so two
 /// worktrees of the same repo don't collide.
 fn session_dir_for(repo: &Repository) -> PathBuf {
@@ -412,10 +411,9 @@ fn session_dir_for(repo: &Repository) -> PathBuf {
     hasher.update(canonical.to_string_lossy().as_bytes());
     let digest = hex::encode(hasher.finalize());
     let repo_id = &digest[..16.min(digest.len())];
-    let base = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(std::env::temp_dir);
-    base.join(".heddle").join("session").join(repo_id)
+    repo::identity::heddle_home_dir()
+        .join("session")
+        .join(repo_id)
 }
 
 fn last_op_id_path(repo: &Repository) -> PathBuf {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -304,6 +304,8 @@ mod harness_error_surface;
 mod hooks;
 #[path = "cli_integration/hydrate.rs"]
 mod hydrate;
+#[path = "cli_integration/identity_resolution.rs"]
+mod identity_resolution;
 #[path = "cli_integration/misc.rs"]
 mod misc;
 #[path = "cli_integration/next_action_contract.rs"]

--- a/crates/cli/tests/cli_integration/identity_resolution.rs
+++ b/crates/cli/tests/cli_integration/identity_resolution.rs
@@ -1,0 +1,300 @@
+use std::{
+    fs,
+    path::Path,
+    process::{Command, Output},
+};
+
+use tempfile::TempDir;
+
+fn isolated_command(repo: &Path, home: &Path, heddle_home: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    command
+        .args(args)
+        .current_dir(repo)
+        .env("HOME", home)
+        .env("HEDDLE_HOME", heddle_home)
+        .env_remove("HEDDLE_CONFIG")
+        .env_remove("HEDDLE_PRINCIPAL_NAME")
+        .env_remove("HEDDLE_PRINCIPAL_EMAIL")
+        .env_remove("HEDDLE_AGENT_PROVIDER")
+        .env_remove("HEDDLE_AGENT_MODEL")
+        .env_remove("NO_COLOR");
+    command
+}
+
+fn output_text(output: &Output) -> String {
+    String::from_utf8_lossy(&[output.stdout.as_slice(), output.stderr.as_slice()].concat())
+        .into_owned()
+}
+
+fn assert_success(output: &Output, command: &str) {
+    assert!(
+        output.status.success(),
+        "{command} failed with {:?}:\n{}",
+        output.status.code(),
+        output_text(output)
+    );
+}
+
+#[test]
+fn heddle_home_is_honored_alongside_heddle_config() {
+    let temp = TempDir::new().expect("tempdir");
+    let shared_home = temp.path().join("shared-home");
+    let repo = temp.path().join("repo");
+    let heddle_home = temp.path().join("myhome");
+    let config = temp.path().join("my.toml");
+    fs::create_dir_all(&shared_home).expect("shared home");
+    fs::create_dir_all(&repo).expect("repo");
+    super::git_hermetic(&["init"], &repo);
+
+    let output = isolated_command(
+        &repo,
+        &shared_home,
+        &heddle_home,
+        &[
+            "init",
+            "--principal-name",
+            "T",
+            "--principal-email",
+            "t@x.io",
+        ],
+    )
+    .env("HEDDLE_CONFIG", &config)
+    .output()
+    .expect("run init");
+    assert_success(&output, "init with HEDDLE_HOME and HEDDLE_CONFIG");
+    assert!(config.is_file(), "HEDDLE_CONFIG should be written");
+    assert!(
+        heddle_home.is_dir(),
+        "HEDDLE_HOME should be created instead of silently ignored"
+    );
+}
+
+#[test]
+fn unusable_heddle_home_fails_loudly_without_fallback() {
+    let temp = TempDir::new().expect("tempdir");
+    let shared_home = temp.path().join("shared-home");
+    let repo = temp.path().join("repo");
+    let heddle_home = temp.path().join("not-a-directory");
+    let config = temp.path().join("my.toml");
+    fs::create_dir_all(&shared_home).expect("shared home");
+    fs::create_dir_all(&repo).expect("repo");
+    fs::write(&heddle_home, "blocking file\n").expect("blocking file");
+    super::git_hermetic(&["init"], &repo);
+
+    let output = isolated_command(
+        &repo,
+        &shared_home,
+        &heddle_home,
+        &[
+            "init",
+            "--principal-name",
+            "T",
+            "--principal-email",
+            "t@x.io",
+        ],
+    )
+    .env("HEDDLE_CONFIG", &config)
+    .output()
+    .expect("run init");
+    assert!(!output.status.success(), "unusable HEDDLE_HOME must fail");
+    assert!(
+        output_text(&output).contains(&heddle_home.display().to_string()),
+        "error must identify the HEDDLE_HOME path:\n{}",
+        output_text(&output)
+    );
+    assert!(!config.exists(), "must not fall back to HEDDLE_CONFIG only");
+    assert!(
+        !shared_home.join(".heddle").exists(),
+        "must not write global state to the shared HOME"
+    );
+}
+
+#[test]
+fn heddle_home_isolates_concurrent_user_configs() {
+    let temp = TempDir::new().expect("tempdir");
+    let shared_home = temp.path().join("shared-home");
+    let repo_a = temp.path().join("repo-a");
+    let repo_b = temp.path().join("repo-b");
+    let home_a = temp.path().join("heddle-a");
+    let home_b = temp.path().join("heddle-b");
+    fs::create_dir_all(&shared_home).expect("shared home");
+    fs::create_dir_all(&repo_a).expect("repo a");
+    fs::create_dir_all(&repo_b).expect("repo b");
+    super::git_hermetic(&["init"], &repo_a);
+    super::git_hermetic(&["init"], &repo_b);
+
+    let child_a = isolated_command(
+        &repo_a,
+        &shared_home,
+        &home_a,
+        &[
+            "init",
+            "--principal-name",
+            "Agent A",
+            "--principal-email",
+            "a@example.test",
+        ],
+    )
+    .spawn()
+    .expect("spawn init a");
+    let child_b = isolated_command(
+        &repo_b,
+        &shared_home,
+        &home_b,
+        &[
+            "init",
+            "--principal-name",
+            "Agent B",
+            "--principal-email",
+            "b@example.test",
+        ],
+    )
+    .spawn()
+    .expect("spawn init b");
+
+    let output_a = child_a.wait_with_output().expect("wait init a");
+    let output_b = child_b.wait_with_output().expect("wait init b");
+    assert_success(&output_a, "init a");
+    assert_success(&output_b, "init b");
+
+    let config_a = fs::read_to_string(home_a.join("config.toml"))
+        .expect("HEDDLE_HOME A should contain its user config");
+    let config_b = fs::read_to_string(home_b.join("config.toml"))
+        .expect("HEDDLE_HOME B should contain its user config");
+    assert!(config_a.contains("Agent A") && !config_a.contains("Agent B"));
+    assert!(config_b.contains("Agent B") && !config_b.contains("Agent A"));
+    assert!(
+        !shared_home.join(".config/heddle/config.toml").exists(),
+        "HEDDLE_HOME must prevent fallback to the shared HOME"
+    );
+
+    let native_a = temp.path().join("native-a");
+    let native_b = temp.path().join("native-b");
+    repo::Repository::init_default(&native_a).expect("native repo a");
+    repo::Repository::init_default(&native_b).expect("native repo b");
+    super::git_hermetic(&["init"], &native_a);
+    super::git_hermetic(&["init"], &native_b);
+    fs::write(native_a.join("a.txt"), "a\n").expect("worktree a");
+    fs::write(native_b.join("b.txt"), "b\n").expect("worktree b");
+
+    let capture_a = isolated_command(
+        &native_a,
+        &shared_home,
+        &home_a,
+        &["capture", "-m", "isolated capture a"],
+    )
+    .spawn()
+    .expect("spawn capture a");
+    let capture_b = isolated_command(
+        &native_b,
+        &shared_home,
+        &home_b,
+        &["capture", "-m", "isolated capture b"],
+    )
+    .spawn()
+    .expect("spawn capture b");
+    let capture_output_a = capture_a.wait_with_output().expect("wait capture a");
+    let capture_output_b = capture_b.wait_with_output().expect("wait capture b");
+    assert_success(&capture_output_a, "capture a");
+    assert_success(&capture_output_b, "capture b");
+    assert!(home_a.join("session").is_dir());
+    assert!(home_b.join("session").is_dir());
+    assert!(
+        !shared_home.join(".heddle/session").exists(),
+        "session state must not fall back to the shared HOME"
+    );
+}
+
+#[test]
+fn init_status_and_capture_agree_on_user_config_principal() {
+    let temp = TempDir::new().expect("tempdir");
+    let shared_home = temp.path().join("shared-home");
+    let heddle_home = temp.path().join("isolated-heddle-home");
+    let repo = temp.path().join("repo");
+    fs::create_dir_all(&repo).expect("repo");
+    super::git_hermetic(&["init"], &repo);
+    fs::create_dir_all(shared_home.join(".config/heddle")).expect("shared config directory");
+    fs::write(
+        shared_home.join(".config/heddle/config.toml"),
+        "[principal]\nname = \"Stale Stranger\"\nemail = \"stale@example.invalid\"\n",
+    )
+    .expect("stale shared config");
+
+    let init = isolated_command(
+        &repo,
+        &shared_home,
+        &heddle_home,
+        &[
+            "init",
+            "--principal-name",
+            "Luke Thorne",
+            "--principal-email",
+            "luke@example.test",
+        ],
+    )
+    .output()
+    .expect("run init");
+    assert_success(&init, "init");
+    assert!(
+        output_text(&init).contains(
+            "Principal: Luke Thorne <luke@example.test> from user_config (shared global config)"
+        ),
+        "init must report the resolved principal and its global source:\n{}",
+        output_text(&init)
+    );
+
+    let status = isolated_command(&repo, &shared_home, &heddle_home, &["status"])
+        .output()
+        .expect("run status");
+    assert_success(&status, "status");
+    assert!(
+        output_text(&status).contains(
+            "Identity: Luke Thorne <luke@example.test> from user_config (shared global config)"
+        ),
+        "status must report the same principal and source:\n{}",
+        output_text(&status)
+    );
+
+    fs::write(repo.join("identity.txt"), "identity evidence\n").expect("worktree change");
+    let capture = isolated_command(
+        &repo,
+        &shared_home,
+        &heddle_home,
+        &["capture", "-m", "identity resolution evidence"],
+    )
+    .output()
+    .expect("run capture");
+    assert_success(&capture, "capture");
+    assert!(
+        output_text(&capture).contains(
+            "Saved by: Luke Thorne <luke@example.test> from user_config (shared global config)"
+        ),
+        "capture must report the same principal and source:\n{}",
+        output_text(&capture)
+    );
+
+    fs::write(repo.join("identity-json.txt"), "machine evidence\n").expect("second change");
+    let json_capture = isolated_command(
+        &repo,
+        &shared_home,
+        &heddle_home,
+        &["capture", "-m", "machine evidence", "--output", "json"],
+    )
+    .output()
+    .expect("JSON capture");
+    assert_success(&json_capture, "JSON capture");
+    let json: serde_json::Value =
+        serde_json::from_slice(&json_capture.stdout).expect("capture JSON");
+    assert_eq!(json["principal_source"], "user_config");
+
+    let isolated_config =
+        fs::read_to_string(heddle_home.join("config.toml")).expect("isolated user config");
+    assert!(isolated_config.contains("Luke Thorne"));
+    let stale_config = fs::read_to_string(shared_home.join(".config/heddle/config.toml"))
+        .expect("shared config remains readable");
+    assert!(
+        stale_config.contains("Stale Stranger"),
+        "the isolated run must not overwrite shared global config"
+    );
+}

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -1990,6 +1990,7 @@ fn capture_json_reports_recorded_confidence_principal_and_agent() {
     assert_eq!(capture["confidence"], serde_json::json!(0.9));
     assert_eq!(capture["principal"]["name"], "Ada Agent");
     assert_eq!(capture["principal"]["email"], "ada-agent@example.com");
+    assert_eq!(capture["principal_source"], "environment");
     assert_eq!(capture["agent"]["provider"], "codex");
     assert_eq!(capture["agent"]["model"], "gpt-5-codex");
     assert!(capture["agent"].get("session_id").is_none());

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -2830,30 +2830,18 @@ fn first_capture_identity_notice(
     if !current_state.map(is_synthetic_root).unwrap_or(true) {
         return Ok(None);
     }
-    let principal = resolve_principal(repo, ctx.config())?;
-    if principal_is_default_unknown(&principal) {
+    let resolved = cli_shared::resolve_principal(repo, ctx.config())?;
+    if principal_is_default_unknown(&resolved.principal) {
         return Ok(Some(
             "no principal configured; the first capture would use Unknown <unknown@example.com>. Set HEDDLE_PRINCIPAL_NAME and HEDDLE_PRINCIPAL_EMAIL or run `heddle init --principal-name <name> --principal-email <email>`.".to_string(),
         ));
     }
-    Ok(None)
-}
-
-fn resolve_principal(repo: &Repository, user_config: &cli_shared::UserConfig) -> Result<Principal> {
-    if let Some(principal) = Principal::from_env() {
-        return Ok(principal);
-    }
-    if let Some(config) = &repo.config().principal {
-        return Ok(Principal::new(&config.name, &config.email));
-    }
-    let principal = repo.get_principal()?;
-    if !principal_is_default_unknown(&principal) {
-        return Ok(principal);
-    }
-    if let Some(config) = &user_config.principal {
-        return Ok(Principal::new(&config.name, &config.email));
-    }
-    Ok(principal)
+    let source = resolved
+        .source
+        .map(cli_shared::principal_source_display)
+        .map(|source| format!(" from {source}"))
+        .unwrap_or_default();
+    Ok(Some(format!("{}{}", resolved.principal, source)))
 }
 
 /// Whether principal is the built-in unknown placeholder (exact match).

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -68,13 +68,20 @@ pub struct DeviceIdentity {
 /// sits beside `credentials.toml`. `HEDDLE_HOME` exists primarily as a test
 /// and power-user override; production resolves to `$HOME/.heddle`.
 pub fn heddle_home_dir() -> PathBuf {
-    if let Some(explicit) = std::env::var_os("HEDDLE_HOME") {
-        return PathBuf::from(explicit);
+    if let Some(explicit) = heddle_home_override() {
+        return explicit;
     }
     std::env::var_os("HOME")
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("."))
         .join(".heddle")
+}
+
+/// Explicit non-empty `HEDDLE_HOME` override, when configured.
+pub fn heddle_home_override() -> Option<PathBuf> {
+    std::env::var_os("HEDDLE_HOME")
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
 }
 
 /// Path to the global device identity file.


### PR DESCRIPTION
## Summary

- #1146: make `HEDDLE_HOME` the root for the default user config as well as credentials, device identity, persisted operation IDs, and tip-session state. `HEDDLE_CONFIG` remains the higher-precedence file override. `init` now creates an explicitly requested home even when `HEDDLE_CONFIG` is also set, and fails with the requested path instead of silently falling back when that home is unusable.
- #1150: centralize principal resolution as environment → repository config → Git config → user config → Unknown, inject user config into `status`, and expose the selected source in init/status/capture text plus capture JSON. User-config attribution is labeled as shared global config.
- Document `HEDDLE_HOME`, `HEDDLE_CONFIG`, and principal precedence in `heddle help advanced`.

## Closes

Closes #1146

Closes #1150

## Test evidence

Failing first on the untouched release binary (#1146):

```text
Principal: T <t@x.io> from user_config
$ find .../before-1146-hermetic -maxdepth 1 -mindepth 1 -printf '%f\n'
my.toml
repo
shared-home
# myhome is absent
```

Failing first with two evaluator homes sharing one `HOME` (#1150): evaluator A initialized Luke, evaluator B then initialized Coldrun Agent, and evaluator A observed:

```text
Identity: no principal configured; the first capture would use Unknown <unknown@example.com>...
Captured state hs-mvhm79b3wy8jxek (a6e343a5)
Saved by: Coldrun Agent <agent@example.invalid>
```

After (#1146, same inline `HEDDLE_HOME` + `HEDDLE_CONFIG` shape):

```text
Principal: T <t@x.io> from user_config (shared global config)
my.toml
myhome
repo
shared-home
```

After concurrent isolation, both inits ran simultaneously and produced separate files while the shared `HOME` remained empty:

```text
heddle-a/config.toml: name = "Luke Thorne"
heddle-a/config.toml: email = "luke@example.test"
heddle-b/config.toml: name = "Coldrun Agent"
heddle-b/config.toml: email = "agent@example.invalid"
```

After (#1150), all three surfaces agree:

```text
Principal: Luke Thorne <luke@example.test> from user_config (shared global config)
Identity: Luke Thorne <luke@example.test> from user_config (shared global config)
Saved by: Luke Thorne <luke@example.test> from user_config (shared global config)
```

Verification:

- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration identity_resolution` — 4 passed, including concurrent config/session isolation and unusable-home fail-loud behavior.
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib` — 452 passed.
- affected cli-contract/cli-render/cli-shared/core library run — 592 passed; 2 unrelated core tempdir tests hit the documented read-only ancestor `.git` discovery hazard from #1147.
- `TMPDIR=/home/scratch cargo test -p heddle-client credentials_path_honors_heddle_home` — passed.
- `TMPDIR=/home/scratch cargo test -p heddle-repo repository_signing --lib` — 10 passed.
- `TMPDIR=/home/scratch cargo build -p heddle-cli` — passed.
- `TMPDIR=/home/scratch cargo clippy -p heddle-cli -p heddle-cli-shared -p heddle-cli-contract -p heddle-cli-render -p heddle-core -p heddle-repo --all-targets -- -D warnings` — passed.
- `rustfmt +nightly --edition 2024 --check <touched Rust files>` — passed; no `cargo fmt` or `cargo clean` used.

No Heddle-owned path remains unable to relocate: credentials, device identity, default user config, operation-ID persistence, and tip-session state all resolve through `HEDDLE_HOME`. External Git/harness/integration homes remain `HOME`-based because they are not Heddle-owned state.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987193&installation_model_id=21489&pr_number=1157&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1157&signature=a1bb43506811e7462e73f6bce00802bf3e32d476caeaa613ddf6553eff01f3d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->