### PR TITLE
fix(discovery): keep repository resolution inside root

### DIFF
--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -10,9 +10,8 @@ use heddle_core::{
     select_init_principal,
 };
 use objects::object::Principal;
-use repo::{Repository, RepositoryCapability};
+use repo::{Repository, RepositoryCapability, open_git_repository_at_root};
 use serde::Serialize;
-use sley::Repository as SleyRepository;
 use tracing::{debug, info};
 
 use super::{
@@ -103,7 +102,10 @@ pub fn cmd_init(cli: &Cli, args: InitArgs) -> Result<()> {
         None
     };
 
-    let git = SleyRepository::discover(&path).ok();
+    // `init <path>` owns exactly that path. An ancestor Git worktree is not
+    // the requested repository and must never redirect initialization or
+    // receive exclude-file writes.
+    let git = open_git_repository_at_root(&path)?;
     let existing_repo = if path.join(".heddle").exists() {
         Some(Repository::open(&path)?)
     } else {

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -19,6 +19,7 @@ use heddle_core::{
 };
 use repo::{
     RepoConfig, Repository, ThreadFreshness, ThreadMode, ThreadState, WorktreeCompareProfile,
+    discover_heddle_root,
 };
 #[cfg(feature = "client")]
 use serde::Deserialize;
@@ -131,7 +132,10 @@ fn try_fast_short_status_report(cli: &Cli) -> Result<Option<FastShortStatusRepor
 
 fn pending_incomplete_land_marker_exists(start: &Path) -> bool {
     let canonical = start.canonicalize().unwrap_or_else(|_| start.to_path_buf());
-    if let Ok(git) = SleyRepository::discover(&canonical)
+    if let Some(heddle_root) = discover_heddle_root(&canonical) {
+        return heddle_root.join(".heddle/incomplete-land.json").is_file();
+    }
+    if let Ok(git) = SleyRepository::open_from_environment(&canonical)
         && let Some(workdir) = git.workdir()
     {
         // A nested plain-Git repository under a Heddle checkout is its own
@@ -144,7 +148,15 @@ fn pending_incomplete_land_marker_exists(start: &Path) -> bool {
 }
 
 fn fast_short_repo_config(start: &Path) -> Result<Option<RepoConfig>> {
-    let Ok(git) = SleyRepository::discover(start) else {
+    if let Some(heddle_root) = discover_heddle_root(start) {
+        let config_path = heddle_root.join(".heddle/config.toml");
+        return if config_path.is_file() {
+            Ok(Some(RepoConfig::load_for_repository(&config_path)?))
+        } else {
+            Ok(None)
+        };
+    }
+    let Ok(git) = SleyRepository::open_from_environment(start) else {
         return Ok(None);
     };
     let Some(workdir) = git.workdir() else {

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -8,7 +8,7 @@ use heddle_core::{
     MachineContractInput, RepositorySetupGuidance, RepositoryVerificationState, VerificationCheck,
     VerifyOptions, VerifyReport, repository_setup_guidance, verify as core_verify,
 };
-use repo::Repository;
+use repo::{Repository, discover_heddle_root};
 
 use super::{RecoveryAdvice, action_line::print_next};
 use crate::{
@@ -142,17 +142,10 @@ fn verify_execution_context_from_cli(cli: &Cli, start: &Path) -> Result<VerifyEx
 /// True when `start` or an ancestor already has a Heddle sidecar (main repo or
 /// worktree pointer). Used to avoid auto-bootstrap on observe-only verify.
 fn heddle_sidecar_present(start: &Path) -> bool {
-    let mut current = Some(start);
-    while let Some(dir) = current {
-        let heddle = dir.join(".heddle");
-        if heddle.is_dir()
-            && (heddle.join("objects").is_dir() || heddle.join("objectstore").is_file())
-        {
-            return true;
-        }
-        current = dir.parent();
-    }
-    false
+    discover_heddle_root(start).is_some_and(|root| {
+        let heddle = root.join(".heddle");
+        heddle.join("objects").is_dir() || heddle.join("objectstore").is_file()
+    })
 }
 
 fn render_verify(output: &VerifyReport, verbose: bool, as_json: bool) -> Result<()> {

--- a/crates/cli/tests/onboarding_contract.rs
+++ b/crates/cli/tests/onboarding_contract.rs
@@ -54,6 +54,41 @@ fn json(output: &Output) -> Value {
     serde_json::from_slice(&output.stdout).expect("parse heddle JSON")
 }
 
+fn snapshot_outside_repository(
+    root: &Path,
+    repository: &Path,
+) -> Vec<(std::path::PathBuf, Vec<u8>)> {
+    fn visit(
+        root: &Path,
+        directory: &Path,
+        repository: &Path,
+        snapshot: &mut Vec<(std::path::PathBuf, Vec<u8>)>,
+    ) {
+        let mut entries = fs::read_dir(directory)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect::<Vec<_>>();
+        entries.sort();
+        for path in entries {
+            if path == repository {
+                continue;
+            }
+            if path.is_dir() {
+                visit(root, &path, repository, snapshot);
+            } else if path.is_file() {
+                snapshot.push((
+                    path.strip_prefix(root).unwrap().to_path_buf(),
+                    fs::read(path).unwrap(),
+                ));
+            }
+        }
+    }
+
+    let mut snapshot = Vec::new();
+    visit(root, root, repository, &mut snapshot);
+    snapshot
+}
+
 #[test]
 fn committed_git_and_unborn_git_both_enter_through_init() {
     for committed in [false, true] {
@@ -100,6 +135,96 @@ fn native_empty_directory_initializes_native_storage() {
     assert_eq!(init["git_detected"], false);
     assert!(repo.path().join(".heddle").is_dir());
     assert!(!repo.path().join(".git").exists());
+}
+
+#[test]
+fn init_in_fresh_directory_does_not_write_to_ancestor_git_repository() {
+    let fixture = TempDir::new().unwrap();
+    let outer = fixture.path().join("outer");
+    let repo = outer.join("fresh/repo");
+    let config = repo.join("user/config.toml");
+    fs::create_dir_all(&repo).unwrap();
+    fs::create_dir_all(&outer).unwrap();
+    init_git(&outer);
+    let outside_before = snapshot_outside_repository(&outer, &repo);
+
+    let init = json(&heddle(&repo, &config, &["init", "--output", "json"]));
+
+    assert_eq!(init["repository_mode"], "native-heddle");
+    assert_eq!(init["git_detected"], false);
+    assert_eq!(
+        snapshot_outside_repository(&outer, &repo),
+        outside_before,
+        "init must not write anywhere outside the requested repository root"
+    );
+    assert!(!outer.join(".heddle").exists());
+    assert!(repo.join(".heddle").is_dir());
+}
+
+#[test]
+fn cwd_native_repository_wins_over_readable_ancestor_git_repository() {
+    let fixture = TempDir::new().unwrap();
+    let outer = fixture.path().join("outer");
+    let repo = outer.join("native");
+    let config = repo.join("user/config.toml");
+    fs::create_dir_all(&repo).unwrap();
+    init_git(&outer);
+    repo::Repository::init_default(&repo).unwrap();
+
+    let status = json(&heddle(&repo, &config, &["status", "--output", "json"]));
+
+    assert_eq!(status["repository_capability"], "native-heddle");
+    assert_eq!(status["storage_model"], "heddle-native");
+}
+
+#[cfg(unix)]
+#[test]
+fn unreadable_ancestor_git_worktree_entry_is_non_fatal_for_native_status() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = TempDir::new().unwrap();
+    let outer = fixture.path().join("outer");
+    let repo = outer.join("native");
+    let unreadable = outer.join("aaa-unreadable");
+    let config = repo.join("user/config.toml");
+    fs::create_dir_all(&repo).unwrap();
+    fs::create_dir_all(&unreadable).unwrap();
+    fs::write(unreadable.join("secret"), "not part of the native repo").unwrap();
+    init_git(&outer);
+    repo::Repository::init_default(&repo).unwrap();
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let output = heddle(&repo, &config, &["status", "--output", "json"]);
+
+    fs::set_permissions(&unreadable, fs::Permissions::from_mode(0o755)).unwrap();
+    let status = json(&output);
+    assert_eq!(status["repository_capability"], "native-heddle");
+    assert_eq!(status["storage_model"], "heddle-native");
+}
+
+#[cfg(unix)]
+#[test]
+fn local_git_metadata_io_error_names_the_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = TempDir::new().unwrap();
+    let repo = fixture.path().join("repo");
+    let git_file = repo.join(".git");
+    let config = repo.join("user/config.toml");
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(&git_file, "gitdir: /unreadable\n").unwrap();
+    fs::set_permissions(&git_file, fs::Permissions::from_mode(0o000)).unwrap();
+
+    let output = heddle(&repo, &config, &["init", "--output", "json"]);
+
+    fs::set_permissions(&git_file, fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&git_file.display().to_string()),
+        "I/O error must name the failing path: {stderr}"
+    );
+    assert!(!repo.join(".heddle").exists());
 }
 
 #[test]

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -25,7 +25,8 @@ use repo::{
     GitOverlayOutOfBandCommits, GitRemoteTrackingStatus, RepoConfig, Repository,
     RepositoryCapability, RepositoryOperationStatus, Thread, ThreadFreshness, ThreadImpactCategory,
     ThreadManager, ThreadMode, ThreadState, WorktreeCompareProfile,
-    describe_thread_advice_with_initial, is_synthetic_root, refresh_thread_freshness,
+    describe_thread_advice_with_initial, discover_heddle_root, is_synthetic_root,
+    refresh_thread_freshness,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -2881,7 +2882,10 @@ pub fn large_capture_requires_force(
 pub fn fast_short_status_report(start: &Path) -> Result<Option<FastShortStatusReport>> {
     let total_start = Instant::now();
     let discover_start = Instant::now();
-    let git = match SleyRepository::discover(start) {
+    if discover_heddle_root(start).is_some() {
+        return Ok(None);
+    }
+    let git = match SleyRepository::open_from_environment(start) {
         Ok(git) => git,
         Err(_) => return Ok(None),
     };

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -8,7 +8,10 @@ use std::{
 };
 
 use ::objects::{HeddleError, error::Result, worktree::WorktreeStatus};
-use repo::{Repository, Thread, ThreadManager, describe_thread_advice, refresh_thread_freshness};
+use repo::{
+    Repository, Thread, ThreadManager, describe_thread_advice, discover_heddle_root,
+    refresh_thread_freshness,
+};
 use schemars::JsonSchema;
 use serde::{Serialize, Serializer};
 use sley::{Repository as SleyRepository, ShortStatusOptions, StatusUntrackedMode, StreamControl};
@@ -344,7 +347,14 @@ pub fn build_plain_git_verification_probe_with_machine_contract(
     start: &Path,
     machine_contract_input: &MachineContractInput,
 ) -> Result<Option<PlainGitVerifyProbe>> {
-    let git_repo = match SleyRepository::discover(start) {
+    // Native Heddle metadata owns the path before any ancestor Git repository
+    // is considered. In particular, do not ask Sley to scan the ancestor
+    // worktree: that can crawl unrelated siblings and fail on their
+    // permissions before Heddle opens its own repository.
+    if discover_heddle_root(start).is_some() {
+        return Ok(None);
+    }
+    let git_repo = match SleyRepository::open_from_environment(start) {
         Ok(repo) => repo,
         Err(_) => return Ok(None),
     };

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -141,8 +141,9 @@ pub use repository::{
     RepositoryPerformanceInspectionReport, RepositorySourceAuthority, SUGGESTION_WINDOW,
     SnapshotExecution, SnapshotProfile, SpoolFacet, ThreadCaptureOutcome, TreeBuildProfile,
     TrustedKey, UntrackedSet, UntrackedSubtree, WarmCanonicalStoreStats, WorktreeCompareProfile,
-    WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct, find_merge_base,
-    is_major_rewrite, is_synthetic_root, query_history_from_source,
+    WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct, discover_heddle_root,
+    find_merge_base, is_major_rewrite, is_synthetic_root, open_git_repository_at_root,
+    query_history_from_source,
 };
 #[cfg(feature = "git-overlay")]
 pub use repository::{GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitOverlayShortStatus};

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -60,7 +60,7 @@ use objects::object::MarkerName;
 use objects::{
     Progress,
     error::{HeddleError, Result},
-    fs_atomic::write_file_atomic,
+    fs_atomic::{enrich_fs_error, write_file_atomic},
     lock::{RepoLock, RepositoryLockExt},
     object::{Attribution, ContentHash, Principal, State, StateId, ThreadName, Tree},
     store::{AnyStore, FsStore, ObjectStore, ShallowInfo},
@@ -132,6 +132,126 @@ mod status_untracked_scan;
 const GIT_CHECKPOINTS_FILE: &str = "git-checkpoints.json";
 const GIT_CHECKPOINT_INTENT_FILE: &str = "git-checkpoint-intent.json";
 const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[".heddle/"];
+
+fn git_discovery_across_filesystem() -> bool {
+    std::env::var("GIT_DISCOVERY_ACROSS_FILESYSTEM")
+        .is_ok_and(|value| !matches!(value.as_str(), "" | "0" | "false" | "no" | "off"))
+}
+
+fn filesystem_device(path: &Path) -> Option<u64> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+
+        fs::metadata(path).ok().map(|metadata| metadata.dev())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+        None
+    }
+}
+
+fn bounded_ancestor_paths(start: &Path) -> Vec<PathBuf> {
+    bounded_ancestor_paths_with_device(start, git_discovery_across_filesystem(), filesystem_device)
+}
+
+fn bounded_ancestor_paths_with_device(
+    start: &Path,
+    across_filesystem: bool,
+    device_of: impl Fn(&Path) -> Option<u64>,
+) -> Vec<PathBuf> {
+    let start_device = if across_filesystem {
+        None
+    } else {
+        device_of(start)
+    };
+    let mut ancestors = Vec::new();
+    let mut current = Some(start);
+    while let Some(path) = current {
+        ancestors.push(path.to_path_buf());
+        let Some(parent) = path.parent() else {
+            break;
+        };
+        if let (Some(start_device), Some(parent_device)) = (start_device, device_of(parent))
+            && parent_device != start_device
+        {
+            break;
+        }
+        // A metadata failure for an unreadable parent yields no device. Keep
+        // discovery fault-tolerant: marker probes on that path will simply
+        // miss, while a later readable ancestor may still provide a boundary.
+        current = Some(parent);
+    }
+    ancestors
+}
+
+/// Find the nearest Heddle sidecar without allowing Git discovery to claim the
+/// path first. The walk follows Git's filesystem-boundary policy and honors
+/// `GIT_DISCOVERY_ACROSS_FILESYSTEM`.
+pub fn discover_heddle_root(start: &Path) -> Option<PathBuf> {
+    let absolute = if start.is_absolute() {
+        start.to_path_buf()
+    } else {
+        std::env::current_dir().ok()?.join(start)
+    };
+    let start = absolute.canonicalize().unwrap_or(absolute);
+    bounded_ancestor_paths(&start)
+        .into_iter()
+        .find(|path| path.join(".heddle").is_dir())
+}
+
+/// Open only the Git repository rooted at `root`; never inherit an ancestor.
+/// This accepts both a normal worktree and Heddle's embedded bare `.git`
+/// layout, while rejecting a worktree resolved to any other root.
+pub fn open_git_repository_at_root(root: &Path) -> Result<Option<SleyRepository>> {
+    let dot_git = root.join(".git");
+    let metadata = match fs::metadata(&dot_git) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(HeddleError::Io(enrich_fs_error(
+                &dot_git,
+                "inspecting Git metadata",
+                error,
+            )));
+        }
+    };
+    if !(metadata.is_dir() || metadata.is_file()) {
+        return Ok(None);
+    }
+    let repo = SleyRepository::open(&dot_git).map_err(|error| {
+        HeddleError::Config(format!(
+            "failed to open Git metadata at '{}': {error}",
+            dot_git.display()
+        ))
+    })?;
+    if let Some(workdir) = repo.workdir() {
+        let resolved_root = root.canonicalize().map_err(|error| {
+            HeddleError::Io(enrich_fs_error(root, "resolving Git worktree root", error))
+        })?;
+        let resolved_workdir = workdir.canonicalize().map_err(|error| {
+            HeddleError::Io(enrich_fs_error(
+                &workdir,
+                "resolving Git metadata worktree",
+                error,
+            ))
+        })?;
+        if resolved_workdir != resolved_root {
+            return Err(HeddleError::Config(format!(
+                "Git metadata at '{}' resolves to worktree '{}', not repository root '{}'",
+                dot_git.display(),
+                resolved_workdir.display(),
+                resolved_root.display()
+            )));
+        }
+    }
+    Ok(Some(repo))
+}
+
+fn has_git_repository_at_root(root: &Path) -> bool {
+    open_git_repository_at_root(root).ok().flatten().is_some()
+}
 
 #[derive(Debug)]
 pub struct GitOverlayShortStatus {
@@ -887,7 +1007,14 @@ impl Repository {
     ///   authority), `.heddle/HEAD` (per-checkout), `.heddle/state/`
     ///   (per-checkout cached state).
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
-        let start_path = path.as_ref().canonicalize()?;
+        let requested_path = path.as_ref();
+        let start_path = requested_path.canonicalize().map_err(|error| {
+            HeddleError::Io(enrich_fs_error(
+                requested_path,
+                "resolving repository path",
+                error,
+            ))
+        })?;
         // A virtualized thread mounts at
         // `.heddle/threads/<encoded>/<repo-name>` and writes no checkout
         // metadata of its own. Without this guard, the upward walk below would
@@ -908,8 +1035,8 @@ impl Repository {
         }
         let mut discovered_git_root = None;
 
-        let mut current = Some(start_path.as_path());
-        while let Some(dir) = current {
+        for dir in bounded_ancestor_paths(&start_path) {
+            let dir = dir.as_path();
             if discovered_git_root.is_none() && has_git_metadata(dir) {
                 discovered_git_root = Some(dir.to_path_buf());
             }
@@ -935,7 +1062,13 @@ impl Repository {
                 if pointer_path.is_file() {
                     // Worktree mode: pointer dir at <dir>/.heddle/, shared
                     // object store at the path read from .heddle/objectstore.
-                    let content = fs::read_to_string(&pointer_path)?;
+                    let content = fs::read_to_string(&pointer_path).map_err(|error| {
+                        HeddleError::Io(enrich_fs_error(
+                            &pointer_path,
+                            "reading worktree pointer",
+                            error,
+                        ))
+                    })?;
                     let pointer = parse_objectstore_pointer(&content).ok_or_else(|| {
                         HeddleError::Config(format!(
                             "invalid .heddle/objectstore pointer at {}: expected objectstore and source-authority entries",
@@ -1059,8 +1192,6 @@ impl Repository {
                     return Ok(repo);
                 }
             }
-
-            current = dir.parent();
         }
 
         // Mutating commands historically rely on open() bootstrapping a plain
@@ -1161,11 +1292,10 @@ impl Repository {
             return Ok(Some(repo));
         }
 
-        let repo = SleyRepository::discover(&self.root).map_err(|error| {
+        let repo = open_git_repository_at_root(&self.root)?.ok_or_else(|| {
             HeddleError::Config(format!(
-                "failed to inspect Git repository at '{}': {}",
-                self.root.display(),
-                error
+                "failed to inspect Git-overlay repository rooted at '{}': no valid .git metadata at that root",
+                self.root.display()
             ))
         })?;
         *cached = Some(repo.clone());
@@ -3024,18 +3154,31 @@ impl Repository {
 }
 
 fn ensure_git_overlay_exclude(root: &Path) -> Result<()> {
-    let git_dir = match SleyRepository::discover(root) {
-        Ok(repo) if repo.workdir().is_some() => repo.git_dir().to_path_buf(),
-        _ => root.join(".git"),
-    };
-    if !git_dir.is_dir() {
+    let Some(git) = open_git_repository_at_root(root)? else {
         return Ok(());
-    }
+    };
+    let git_dir = git.git_dir();
 
     let info_dir = git_dir.join("info");
-    fs::create_dir_all(&info_dir)?;
+    fs::create_dir_all(&info_dir).map_err(|error| {
+        HeddleError::Io(enrich_fs_error(
+            &info_dir,
+            "creating Git metadata directory",
+            error,
+        ))
+    })?;
     let exclude_path = info_dir.join("exclude");
-    let mut contents = fs::read_to_string(&exclude_path).unwrap_or_default();
+    let mut contents = match fs::read_to_string(&exclude_path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => {
+            return Err(HeddleError::Io(enrich_fs_error(
+                &exclude_path,
+                "reading Git exclude file",
+                error,
+            )));
+        }
+    };
     let existing_lines = contents.lines().map(str::trim).collect::<BTreeSet<_>>();
     let mut missing = Vec::new();
     for pattern in GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS {
@@ -3057,7 +3200,13 @@ fn ensure_git_overlay_exclude(root: &Path) -> Result<()> {
         contents.push_str(pattern);
         contents.push('\n');
     }
-    fs::write(exclude_path, contents)?;
+    fs::write(&exclude_path, contents).map_err(|error| {
+        HeddleError::Io(enrich_fs_error(
+            &exclude_path,
+            "writing Git exclude file",
+            error,
+        ))
+    })?;
     Ok(())
 }
 
@@ -3117,12 +3266,7 @@ fn parse_objectstore_pointer(content: &str) -> Option<WorktreePointer> {
 }
 
 pub(crate) fn has_git_metadata(path: &Path) -> bool {
-    let dot_git = path.join(".git");
-    if !(dot_git.is_dir() || dot_git.is_file()) {
-        return false;
-    }
-
-    SleyRepository::discover(path).is_ok()
+    has_git_repository_at_root(path)
 }
 
 fn repository_capability_for_authority(
@@ -3148,8 +3292,8 @@ fn repository_capability_for_authority(
 /// one path component, so any direct checkout leaf below it has the
 /// unambiguous `<leaf> → <encoded> → threads → .heddle` shape (heddle#572 r2).
 fn metadataless_managed_thread_root(start_path: &Path) -> Option<PathBuf> {
-    let mut cur: Option<&Path> = Some(start_path);
-    while let Some(dir) = cur {
+    for dir in bounded_ancestor_paths(start_path) {
+        let dir = dir.as_path();
         if let Some(thread_dir) = dir.parent()
             && let Some(threads) = thread_dir.parent()
             && threads.file_name().and_then(|n| n.to_str()) == Some("threads")
@@ -3160,13 +3304,12 @@ fn metadataless_managed_thread_root(start_path: &Path) -> Option<PathBuf> {
         {
             return Some(dir.to_path_buf());
         }
-        cur = dir.parent();
     }
     None
 }
 
 fn git_config_principal(root: &Path) -> Option<Principal> {
-    let git_repo = SleyRepository::discover(root).ok()?;
+    let git_repo = open_git_repository_at_root(root).ok().flatten()?;
     let config = git_repo.config_snapshot().ok()?;
     let name = config.get("user", None, "name")?.to_string();
     let email = config.get("user", None, "email")?.to_string();
@@ -3245,9 +3388,8 @@ fn git_overlay_untracked_path_ignored(
 }
 
 fn git_remote_names(root: &Path) -> Result<Vec<String>> {
-    let repo = match SleyRepository::discover(root) {
-        Ok(repo) => repo,
-        Err(_) => return Ok(Vec::new()),
+    let Some(repo) = open_git_repository_at_root(root)? else {
+        return Ok(Vec::new());
     };
     repo.remote_names()
         .map(|names| {
@@ -3379,11 +3521,10 @@ fn append_ignore_file_patterns(patterns: &mut Vec<String>, path: &Path) -> Resul
 /// Read git's HEAD via sley's [`SleyRepository::head_state`], including
 /// worktree `gitdir:` indirections and detached HEAD.
 fn detect_git_head_state(path: &Path) -> Result<Option<GitHeadState>> {
-    let repo = SleyRepository::discover(path).map_err(|error| {
+    let repo = open_git_repository_at_root(path)?.ok_or_else(|| {
         HeddleError::Config(format!(
-            "failed to inspect git repository at '{}': {}",
-            path.display(),
-            error
+            "failed to inspect Git repository rooted at '{}': no valid .git metadata at that root",
+            path.display()
         ))
     })?;
     let head = match repo.head_state() {
@@ -3419,11 +3560,10 @@ fn detect_git_head(path: &Path) -> Result<Option<Head>> {
 }
 
 fn resolve_git_dir(path: &Path) -> Result<PathBuf> {
-    let repo = SleyRepository::discover(path).map_err(|error| {
+    let repo = open_git_repository_at_root(path)?.ok_or_else(|| {
         HeddleError::Config(format!(
-            "failed to resolve git dir at '{}': {}",
-            path.display(),
-            error
+            "failed to resolve Git directory for repository root '{}': no valid .git metadata at that root",
+            path.display()
         ))
     })?;
     Ok(repo.git_dir().to_path_buf())

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -16,6 +16,7 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 use tempfile::TempDir;
 
 use super::{
+    bounded_ancestor_paths_with_device,
     repo_config::SUPPORTED_REPO_FORMAT,
     repository_snapshot::{SnapshotFault, with_snapshot_fault, with_snapshot_prepare_probe},
 };
@@ -28,6 +29,36 @@ fn create_test_repo() -> (TempDir, Repository) {
     let temp_dir = TempDir::new().unwrap();
     let repo = Repository::init_default(temp_dir.path()).unwrap();
     (temp_dir, repo)
+}
+
+#[cfg(unix)]
+#[test]
+fn ancestor_discovery_stops_at_filesystem_boundary_unless_opted_out() {
+    let start = Path::new("/same-device/repo/nested");
+    let device_of = |path: &Path| {
+        if path.starts_with("/same-device/repo") {
+            Some(2)
+        } else {
+            Some(1)
+        }
+    };
+
+    assert_eq!(
+        bounded_ancestor_paths_with_device(start, false, device_of),
+        vec![
+            PathBuf::from("/same-device/repo/nested"),
+            PathBuf::from("/same-device/repo"),
+        ]
+    );
+    assert_eq!(
+        bounded_ancestor_paths_with_device(start, true, device_of),
+        vec![
+            PathBuf::from("/same-device/repo/nested"),
+            PathBuf::from("/same-device/repo"),
+            PathBuf::from("/same-device"),
+            PathBuf::from("/"),
+        ]
+    );
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -304,8 +335,7 @@ fn open_refuses_legacy_oplog_before_mutating_repository() {
 fn open_bootstraps_plain_git_sidecar_for_mutators() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();
-    fs::create_dir_all(root.join(".git")).unwrap();
-    fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
+    sley::Repository::init(root).expect("init valid Git worktree");
 
     let repo = Repository::open(root).expect("open should bootstrap plain Git for mutators");
     assert!(


### PR DESCRIPTION
## Summary

- Make cwd Heddle metadata authoritative before considering any ancestor Git repository.
- Restrict init and Git-overlay metadata writes to a valid `.git` rooted at the resolved repository root.
- Bound Heddle ancestor discovery at filesystem boundaries by default, with the Git-compatible `GIT_DISCOVERY_ACROSS_FILESYSTEM` opt-out, and treat inaccessible marker probes as misses.
- Route plain-Git fallback through environment-aware Sley discovery and add paths to discovery and overlay metadata I/O failures.

## Closes

Closes #1147.

Does not close #1144. The preserved failure does not reproduce on current main or this branch, but this change does not alter the context bootstrap/write-through mechanism that produced its orphan root; #1144 should remain open independently.

## Test evidence

Before the fix, initializing `outer/fresh/probe` beneath `outer/.git` reported `repository_mode: git-overlay`, changed the ancestor `.git/info/exclude` SHA from `6671fe...` to `d23a58...`, and appended the Heddle metadata marker. Native status beneath that Git worktree exited 78 on an unreadable sibling with `configuration error: io error: Permission denied (os error 13)` and no path.

After the fix, the same init reports `repository_mode: native-heddle`, `git_detected: false`, and leaves the ancestor exclude SHA unchanged. The same native status exits 0 and reports `native-heddle` / `heddle-native`; a file trace contains no access to the ancestor `.git` or unreadable sibling.

Controlled timing on the compact fixture was 0.14s before and 0.17s after for init, and 0.02s failing before versus 0.02s successful after for status. Status tracing fell from 1,000 syscalls to 917, and the ancestor scan disappeared entirely. The evaluator separately measured the pathological shared-root case at about 7s before versus 0.1s with a Git boundary fence.

Regression coverage asserts: no file outside the requested init root changes; cwd native metadata wins over a readable ancestor Git worktree; unreadable ancestor-worktree entries are non-fatal; local metadata I/O errors name the failing path; and discovery stops at a filesystem boundary unless explicitly opted out.

Verification:
- `cargo test --locked -p heddle-repo --lib`: 605 passed, 2 ignored
- `cargo test --locked -p heddle-core --lib`: 413 passed
- `cargo test --locked -p heddle-cli --lib`: 452 passed
- `cargo test --locked -p heddle-cli --test onboarding_contract`: 10 passed
- `cargo test --locked -p heddle-cli --tests --no-fail-fast`: all test binaries passed; primary integration binary 867 passed, 19 ignored
- touched files formatted with `rustfmt +nightly --edition 2024`

For #1144, read-only inspection confirmed the preserved orphan root (`530f4ff...`, no parents) and 407-commit upstream history. Disposable `init` and exact `clone -> start -> context set -> capture -> ready -> land` reproductions both retained the real Git tip as parent and a valid merge base. That means #1144 does not reproduce here, not that this PR fixes its bootstrap path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987275&installation_model_id=21489&pr_number=1158&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1158&signature=c2da4571cd4b4f7fe252d185ea9cd6874677710c10e20ce672c1fca01cd260c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->