### PR TITLE
fix(undo): prevent recovery deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Changed
 
+- **Undo recovery no longer deadlocks on ignored local files.** Destructive
+  worktree rewinds now require `undo --hard`, preserve ignore-control files,
+  and leave unrelated local files available to `undo --recover`. Checkpoint-only
+  Git publication undo remains non-destructive and does not require `--hard`.
+
 - **Security boundaries hardened across local, hosted, and release paths.**
   Dynamic Bash completion no longer re-evaluates ref names; recursive clone
   mounts are confined beneath the clone root; hosted Git ref updates are

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -577,8 +577,9 @@ pub struct RevertArgs {
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Examples:
-  heddle undo                # roll back the most recent operation
-  heddle undo -n 3           # roll back the last three operations
+  heddle undo --preview      # inspect the most recent operation
+  heddle undo --hard         # roll it back and rewind the worktree
+  heddle undo -n 3 --hard    # roll back the last three operations
   heddle undo --recover      # restore the state preserved by the last undo
   heddle undo --list         # preview undoable operations on this thread
   heddle undo --dry-run      # show what would change without applying
@@ -627,6 +628,12 @@ pub struct UndoArgs {
     #[arg(long, visible_alias = "dry-run")]
     pub preview: bool,
 
+    /// Permit undo to rewind worktree files to the selected operation's prior
+    /// state. Without this explicit opt-in, an undo that would rewrite the
+    /// worktree refuses before changing repository state or files.
+    #[arg(long, conflicts_with_all = ["list", "preview", "redo", "recover"])]
+    pub hard: bool,
+
     /// Re-apply operations that a prior `undo` rewound.
     #[arg(long, conflicts_with = "list")]
     pub redo: bool,
@@ -635,7 +642,7 @@ pub struct UndoArgs {
     /// worktree changes. HEAD and the current thread remain unchanged.
     #[arg(
         long,
-        conflicts_with_all = ["steps", "list", "preview", "redo", "allow_redact_undo"]
+        conflicts_with_all = ["steps", "list", "preview", "hard", "redo", "allow_redact_undo"]
     )]
     pub recover: bool,
 

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -547,7 +547,32 @@ fn undo_may_rewrite_worktree(repo: &Repository, batches: &[OpBatch]) -> Result<b
             OpRecord::ThreadUpdate { name, .. } => active_thread
                 .as_ref()
                 .is_some_and(|thread| thread.as_str() == name.as_str()),
-            _ => false,
+            OpRecord::Snapshot {
+                prev_head: None, ..
+            }
+            | OpRecord::Goto {
+                prev_head: None, ..
+            }
+            | OpRecord::ThreadCreate { .. }
+            | OpRecord::ThreadDelete { .. }
+            | OpRecord::Fork { .. }
+            | OpRecord::Collapse { .. }
+            | OpRecord::MarkerCreate { .. }
+            | OpRecord::MarkerDelete { .. }
+            | OpRecord::Checkpoint { .. }
+            | OpRecord::TransactionAbort { .. }
+            | OpRecord::EphemeralThreadCollapse { .. }
+            | OpRecord::ConflictResolved { .. }
+            | OpRecord::TransactionCommit { .. }
+            | OpRecord::Redact { .. }
+            | OpRecord::Purge { .. }
+            | OpRecord::GitCheckpoint { .. }
+            | OpRecord::RemoteThreadUpdate { .. }
+            | OpRecord::RemoteThreadDelete { .. }
+            | OpRecord::UndoRecoveryUpdate { .. }
+            | OpRecord::StateVisibilitySet { .. }
+            | OpRecord::StateVisibilityPromote { .. }
+            | OpRecord::HeadUpdate { .. } => false,
         })
     }))
 }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -16,7 +16,7 @@ use heddle_core::{
     plan_undo_batches, summarize_batch, validate_undo_list_preview_modes,
 };
 use objects::store::ObjectStore;
-use oplog::OpBatch;
+use oplog::{OpBatch, OpRecord};
 use refs::UNDO_RECOVERY_HANDLE;
 use repo::{Repository, ThreadManager};
 use serde::Serialize;
@@ -93,6 +93,7 @@ pub(crate) fn undo_batches_quiet(repo: &Repository, batches: Vec<OpBatch>) -> Re
     ensure_redaction_undo_safe(repo, &batches, false)?;
     ensure_thread_worktree_undo_safe(repo, &batches)?;
     preflight_undo_execution(repo, &batches)?;
+    ensure_worktree_clean(repo, "undo")?;
     let recovery_state = repo.head()?;
     let scope = repo.op_scope();
     let generation = repo.oplog().head_id()?;
@@ -108,6 +109,7 @@ pub fn cmd_undo(
     list: bool,
     depth: usize,
     preview: bool,
+    hard: bool,
     allow_redact_undo: bool,
 ) -> Result<()> {
     let repo = cli.open_repo()?;
@@ -184,6 +186,24 @@ pub fn cmd_undo(
 
         return Ok(());
     }
+
+    if !hard && undo_may_rewrite_worktree(&repo, &apply_plan.batches)? {
+        return Err(anyhow!(RecoveryAdvice::safety_refusal(
+            "undo_requires_hard",
+            "Undo would rewind repository state and worktree files",
+            "Inspect the selected operation with `heddle undo --preview`, then rerun with `heddle undo --hard` to permit the worktree rewind.",
+            "the selected undo operation materializes an earlier saved tree",
+            "captured worktree files would be replaced by the selected operation's prior tree",
+            "repository state and worktree files were left unchanged",
+            "heddle undo --hard",
+            vec![
+                "heddle undo --preview".to_string(),
+                "heddle undo --hard".to_string(),
+            ],
+        )));
+    }
+
+    ensure_worktree_clean(&repo, "undo")?;
 
     // heddle#305: capture the pre-undo state into thread history BEFORE the
     // reset, so the worktree content the undone batch(es) absorbed is never
@@ -297,7 +317,6 @@ pub fn cmd_undo_recover(cli: &Cli) -> Result<()> {
         )));
     }
 
-    ensure_worktree_clean(&repo, "recover the pre-undo state")?;
     repo.restore_state_tree_to_worktree(&recovery_state)?;
 
     let recovered_repo = Repository::open(repo.root())?;
@@ -502,7 +521,6 @@ fn human_post_undo_trust_status(trust: &RepositoryVerificationState) -> String {
 
 fn preflight_undo_execution(repo: &Repository, batches: &[OpBatch]) -> Result<()> {
     ensure_no_active_operation(repo, "undo")?;
-    ensure_worktree_clean(repo, "undo")?;
     // Refuse before mutating anything when a state the batch needs to
     // restore is missing from the object store — typically because `gc
     // --prune` or a truncated oplog has reached past the live window.
@@ -510,6 +528,29 @@ fn preflight_undo_execution(repo: &Repository, batches: &[OpBatch]) -> Result<()
     // repo half-undone (worktree partially rewritten, batch not marked).
     ensure_undo_states_reachable(repo, batches)?;
     preflight_undo_batches(repo, batches)
+}
+
+fn undo_may_rewrite_worktree(repo: &Repository, batches: &[OpBatch]) -> Result<bool> {
+    let active_thread = match repo.head_ref()? {
+        refs::Head::Attached { thread } => Some(thread),
+        refs::Head::Detached { .. } => None,
+    };
+    Ok(batches.iter().any(|batch| {
+        batch.entries.iter().any(|entry| match &entry.operation {
+            OpRecord::Snapshot {
+                prev_head: Some(_), ..
+            }
+            | OpRecord::Goto {
+                prev_head: Some(_), ..
+            }
+            | OpRecord::FastForward { .. }
+            | OpRecord::GitCheckpoint { .. } => true,
+            OpRecord::ThreadUpdate { name, .. } => active_thread
+                .as_ref()
+                .is_some_and(|thread| thread.as_str() == name.as_str()),
+            _ => false,
+        })
+    }))
 }
 
 fn ensure_no_active_operation(repo: &Repository, action: &str) -> Result<()> {

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -543,8 +543,7 @@ fn undo_may_rewrite_worktree(repo: &Repository, batches: &[OpBatch]) -> Result<b
             | OpRecord::Goto {
                 prev_head: Some(_), ..
             }
-            | OpRecord::FastForward { .. }
-            | OpRecord::GitCheckpoint { .. } => true,
+            | OpRecord::FastForward { .. } => true,
             OpRecord::ThreadUpdate { name, .. } => active_thread
                 .as_ref()
                 .is_some_and(|thread| thread.as_str() == name.as_str()),

--- a/crates/cli/src/cli/commands/undo_apply/mod.rs
+++ b/crates/cli/src/cli/commands/undo_apply/mod.rs
@@ -20,8 +20,8 @@ use oplog::{
 };
 use refs::Head;
 use repo::{
-    CommitGraphIndex, Repository, Thread, ThreadFreshness, ThreadIntegrationPolicy, ThreadManager,
-    ThreadState, VisibilitySidecarRestore,
+    CommitGraphIndex, Repository, RepositoryCapability, Thread, ThreadFreshness,
+    ThreadIntegrationPolicy, ThreadManager, ThreadState, VisibilitySidecarRestore,
     atomic::{AtomicMutation, DeferredMutation, StagedCommit, Tx},
     refresh_thread_freshness,
 };
@@ -1888,6 +1888,105 @@ pub(super) fn undo_redo_transaction_id(
     format!("{action}:{scope}:gen{generation}:[{}]", ids.join(","))
 }
 
+#[derive(Clone)]
+struct PreservedWorktreeFile {
+    path: PathBuf,
+    bytes: Vec<u8>,
+}
+
+fn capture_preserved_worktree_files(repo: &Repository) -> HeddleResult<Vec<PreservedWorktreeFile>> {
+    let mut names = vec![".heddleignore"];
+    if repo.capability() == RepositoryCapability::GitOverlay {
+        names.push(".gitignore");
+    }
+
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let path = repo.root().join(name);
+            match fs::read(&path) {
+                Ok(bytes) => Some(Ok(PreservedWorktreeFile { path, bytes })),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+                Err(error) => Some(Err(HeddleError::Io(error))),
+            }
+        })
+        .collect()
+}
+
+fn read_optional_worktree_file(path: &Path) -> HeddleResult<Option<Vec<u8>>> {
+    match fs::read(path) {
+        Ok(bytes) => Ok(Some(bytes)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(HeddleError::Io(error)),
+    }
+}
+
+fn restore_optional_worktree_file(path: &Path, bytes: Option<&[u8]>) -> HeddleResult<()> {
+    match bytes {
+        Some(bytes) => {
+            match fs::read(path) {
+                Ok(current) if current == bytes => return Ok(()),
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(HeddleError::Io(error)),
+            }
+            objects::fs_atomic::write_file_atomic(path, bytes)?;
+            Ok(())
+        }
+        None => match fs::remove_file(path) {
+            Ok(()) => {
+                if let Some(parent) = path.parent() {
+                    objects::fs_atomic::sync_directory(parent)?;
+                }
+                Ok(())
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(HeddleError::Io(error)),
+        },
+    }
+}
+
+/// Deferred child: restore worktree-resident files whose presence controls the
+/// dirty-set calculation. Undo may move HEAD across a state that lacks one of
+/// these files, but it must not make previously ignored local paths visible and
+/// strand its own recovery command.
+struct RestorePreservedWorktreeFiles {
+    files: Vec<PreservedWorktreeFile>,
+}
+
+impl AtomicMutation for RestorePreservedWorktreeFiles {
+    type Output = ();
+
+    fn transaction_id(&self) -> String {
+        "undo:restore-preserved-worktree-files".to_string()
+    }
+
+    fn isolation_keys(&self, repo: &Repository) -> HeddleResult<BTreeSet<IsolationKey>> {
+        let mut keys = BTreeSet::new();
+        keys.insert(IsolationKey::LocalHead {
+            scope: repo.op_scope(),
+        });
+        Ok(keys)
+    }
+
+    fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<()>> {
+        for file in &self.files {
+            let capture_path = file.path.clone();
+            let restore_path = file.path.clone();
+            let forward_path = file.path.clone();
+            let forward_bytes = file.bytes.clone();
+            tx.step_nonatomic(
+                move || read_optional_worktree_file(&capture_path),
+                move |prior| restore_optional_worktree_file(&restore_path, prior.as_deref()),
+                move || restore_optional_worktree_file(&forward_path, Some(&forward_bytes)),
+            )?;
+        }
+        Ok(StagedCommit::pure(()))
+    }
+}
+
+impl DeferredMutation for RestorePreservedWorktreeFiles {}
+
 /// Deferred child: preserve the pre-undo HEAD into the heddle-internal
 /// recovery pointer (the heddle#305 `ORIG_HEAD`-style ref), registering its
 /// restore as the inverse so an outer failure puts the prior pointer back
@@ -2120,6 +2219,7 @@ impl AtomicMutation for UndoOp {
     }
 
     fn apply(&mut self, tx: &mut Tx<'_>) -> HeddleResult<StagedCommit<Vec<OpBatch>>> {
+        let preserved_worktree_files = capture_preserved_worktree_files(tx.repo())?;
         tx.enroll(StageUndoRecovery {
             head: self.recovery_head,
         })?;
@@ -2128,6 +2228,9 @@ impl AtomicMutation for UndoOp {
             let staged = tx.enroll(ApplyUndoBatch::new(batch.clone()))?;
             updated.push(staged.output);
         }
+        tx.enroll(RestorePreservedWorktreeFiles {
+            files: preserved_worktree_files,
+        })?;
         Ok(StagedCommit::pure(updated))
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -532,6 +532,7 @@ async fn async_main() -> Result<()> {
             list,
             depth,
             preview,
+            hard,
             redo,
             recover,
             allow_redact_undo,
@@ -541,7 +542,15 @@ async fn async_main() -> Result<()> {
             } else if *redo {
                 cmd_redo(&cli, *steps, *preview)
             } else {
-                cmd_undo(&cli, *steps, *list, *depth, *preview, *allow_redact_undo)
+                cmd_undo(
+                    &cli,
+                    *steps,
+                    *list,
+                    *depth,
+                    *preview,
+                    *hard,
+                    *allow_redact_undo,
+                )
             }
         }
 

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -400,6 +400,42 @@ pub(crate) fn assert_json_recovery_advice_fields(envelope: &Value, context: &str
     );
 }
 
+fn assert_undo_requires_hard(cwd: &Path) -> Value {
+    let output = heddle_output(&["--output", "json", "undo"], Some(cwd))
+        .expect("plain undo should return typed safety advice");
+    assert_eq!(
+        output.status.code(),
+        Some(74),
+        "destructive plain undo should use the safety-refusal exit code: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "JSON safety refusal should keep stdout empty: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let envelope: Value =
+        serde_json::from_slice(&output.stderr).expect("undo refusal should be JSON");
+    assert_eq!(envelope["kind"], "undo_requires_hard", "{envelope}");
+    assert_eq!(
+        envelope["unsafe_condition"],
+        "the selected undo operation materializes an earlier saved tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["would_change"],
+        "captured worktree files would be replaced by the selected operation's prior tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["preserved"], "repository state and worktree files were left unchanged",
+        "{envelope}"
+    );
+    assert_json_recovery_advice_fields(&envelope, "undo --hard refusal");
+    envelope
+}
+
 fn heddle(args: &[&str], cwd: Option<&std::path::Path>) -> Result<String, String> {
     let output = heddle_output(args, cwd)?;
     let stdout = str::from_utf8(&output.stdout).unwrap_or("").to_string();

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -2414,7 +2414,20 @@ fn test_cli_undo_changes_worktree() {
     let content = std::fs::read_to_string(temp.path().join("version.txt")).unwrap();
     assert_eq!(content, "v2");
 
-    assert!(heddle(&["undo"], Some(temp.path())).is_ok());
+    let head_before_refusal = status_json(temp.path());
+    assert_undo_requires_hard(temp.path());
+    assert_eq!(
+        status_json(temp.path())["state"]["state_id"],
+        head_before_refusal["state"]["state_id"],
+        "refused undo must leave HEAD unchanged"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("version.txt")).unwrap(),
+        "v2",
+        "refused undo must preserve the current captured file"
+    );
+
+    assert!(heddle(&["undo", "--hard"], Some(temp.path())).is_ok());
     let content = std::fs::read_to_string(temp.path().join("version.txt")).unwrap();
     assert_eq!(content, "v1", "File should be restored to v1");
 }
@@ -2441,7 +2454,19 @@ fn test_cli_undo_redo() {
         .expect("state state_id should be string")
         .to_string();
 
-    assert!(heddle(&["undo"], Some(temp.path())).is_ok());
+    assert_undo_requires_hard(temp.path());
+    assert_eq!(
+        status_json(temp.path())["state"]["state_id"],
+        second_id,
+        "refused undo must leave HEAD at the second state"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+        "updated",
+        "refused undo must preserve the second state's file content"
+    );
+
+    assert!(heddle(&["undo", "--hard"], Some(temp.path())).is_ok());
     let head_after_undo = status_json(temp.path());
     let undo_id = head_after_undo["state"]["state_id"]
         .as_str()

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -551,6 +551,11 @@ fn git_overlay_matrix_undo_reconciles_stale_mirror_after_push_pull() {
     let undo = json(&work, &["undo"]);
     assert_eq!(undo["status"], "completed", "{undo}");
     assert_eq!(git_stdout(&work, &["rev-parse", "HEAD"]), previous);
+    assert_eq!(
+        std::fs::read_to_string(work.join("second.txt")).unwrap(),
+        "second\n",
+        "undoing Git publication must preserve the captured worktree"
+    );
     let mirror = work.join(".heddle/git");
     assert_eq!(
         git_stdout(

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -35,7 +35,7 @@ use cli::cli::commands::{
 use serde_json::Value;
 use tempfile::TempDir;
 
-use super::{git_hermetic, heddle, heddle_output};
+use super::{assert_undo_requires_hard, git_hermetic, heddle, heddle_output};
 
 /// Verbs whose `output_kind` invariant is enforced — both the catalog
 /// declaration and (where invocable) the runtime emission.
@@ -1572,16 +1572,23 @@ fn folded_verb_flag_variants_emit_only_advertised_output_kinds() {
     std::fs::write(temp.path().join("a.txt"), "two").unwrap();
     heddle(&["capture", "-m", "second"], Some(temp.path())).expect("capture second");
 
+    assert_undo_requires_hard(temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
+        "two",
+        "the rejected unqualified undo must preserve the current captured file"
+    );
+
     // Drive each JSON-emitting variant, in an order that keeps the repo
-    // consistent: undo --list (read-only) → undo (rewinds, making a redo
-    // available) → undo --redo (re-applies) → undo → undo --recover. The
-    // second undo recreates a clean recovery baseline before recovery restores
-    // it as worktree changes.
+    // consistent: undo --list (read-only) → undo --hard (explicitly rewinds,
+    // making a redo available) → undo --redo (re-applies) → undo --hard →
+    // undo --recover. The second hard undo recreates a clean recovery baseline
+    // before recovery restores it as worktree changes.
     let cases: &[(&[&str], &str, &str)] = &[
         (&["--output", "json", "undo", "--list"], "undo_list", "undo"),
-        (&["--output", "json", "undo"], "undo", "undo"),
+        (&["--output", "json", "undo", "--hard"], "undo", "undo"),
         (&["--output", "json", "undo", "--redo"], "redo", "undo"),
-        (&["--output", "json", "undo"], "undo", "undo"),
+        (&["--output", "json", "undo", "--hard"], "undo", "undo"),
         (
             &["--output", "json", "undo", "--recover"],
             "undo_recover",

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -889,7 +889,20 @@ fn test_cli_pull_local_clean_active_checkout_materializes_before_publish() {
     let status: Value = serde_json::from_str(&status_json).expect("status JSON parses");
     assert_eq!(status["thread"], "main", "{status_json}");
 
-    heddle(&["undo"], Some(&target_path)).expect("pull fast-forward should be undoable");
+    assert_undo_requires_hard(&target_path);
+    assert_eq!(
+        current_thread_state(&target_path, "main"),
+        source_main,
+        "refused pull undo must leave the published main ref unchanged"
+    );
+    assert_eq!(
+        std::fs::read_to_string(target_path.join("shared.txt")).unwrap(),
+        "remote\n",
+        "refused pull undo must preserve the pulled worktree"
+    );
+
+    heddle(&["undo", "--hard"], Some(&target_path))
+        .expect("pull fast-forward should be undoable with explicit worktree rewind");
     assert_eq!(
         current_thread_state(&target_path, "main"),
         pre_pull_ref,

--- a/crates/cli/tests/cli_integration/visibility.rs
+++ b/crates/cli/tests/cli_integration/visibility.rs
@@ -16,7 +16,7 @@ use std::{fs, path::Path};
 use serde_json::Value;
 use tempfile::TempDir;
 
-use super::heddle;
+use super::{assert_undo_requires_hard, heddle};
 
 /// Pin `[review.discussion] default_visibility` while preserving the current
 /// repository-format and source-authority fields written by `heddle init`.
@@ -178,7 +178,24 @@ fn undo_after_capture_with_nonpublic_default_reverts_snapshot_and_visibility_in_
 
     // ONE undo must revert BOTH the snapshot (HEAD back to `first`) AND the
     // auto-applied visibility (the captured state reads public-by-absence again).
-    heddle(&["undo"], Some(temp.path())).expect("undo capture");
+    assert_undo_requires_hard(temp.path());
+    assert_eq!(
+        latest_state(temp.path()),
+        second,
+        "refused undo must leave the second captured state current"
+    );
+    assert_eq!(
+        fs::read(temp.path().join("note.txt")).unwrap(),
+        b"secret",
+        "refused undo must preserve the current captured file"
+    );
+    assert_eq!(
+        show_json(temp.path(), &second)["tier"],
+        "internal",
+        "refused undo must preserve the folded visibility sidecar"
+    );
+
+    heddle(&["undo", "--hard"], Some(temp.path())).expect("hard undo capture");
 
     assert_eq!(
         latest_state(temp.path()),

--- a/crates/cli/tests/comprehensive.rs
+++ b/crates/cli/tests/comprehensive.rs
@@ -6,7 +6,7 @@
 use std::{
     fs,
     path::Path,
-    process::Command,
+    process::{Command, Output},
     str,
     sync::{Arc, Barrier},
     thread,
@@ -36,19 +36,7 @@ mod platform_compat;
 mod resolve_comprehensive;
 
 fn heddle(args: &[&str], cwd: Option<&Path>) -> Result<String, String> {
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_heddle"));
-    cmd.args(args);
-
-    if let Some(dir) = cwd {
-        cmd.current_dir(dir);
-    }
-    // Heddle refuses captures without an accountable principal. Pin
-    // the identity here so the suite is deterministic regardless of
-    // the runner's git global config or shell env.
-    cmd.env("HEDDLE_PRINCIPAL_NAME", "Heddle Test")
-        .env("HEDDLE_PRINCIPAL_EMAIL", "test@heddle.dev");
-
-    let output = cmd.output().map_err(|e| e.to_string())?;
+    let output = heddle_output(args, cwd)?;
     let stdout = str::from_utf8(&output.stdout).unwrap_or("").to_string();
     let stderr = str::from_utf8(&output.stderr).unwrap_or("").to_string();
 
@@ -62,6 +50,46 @@ fn heddle(args: &[&str], cwd: Option<&Path>) -> Result<String, String> {
             stderr
         ))
     }
+}
+
+fn heddle_output(args: &[&str], cwd: Option<&Path>) -> Result<Output, String> {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    cmd.args(args);
+
+    if let Some(dir) = cwd {
+        cmd.current_dir(dir);
+    }
+    // Heddle refuses captures without an accountable principal. Pin
+    // the identity here so the suite is deterministic regardless of
+    // the runner's git global config or shell env.
+    cmd.env("HEDDLE_PRINCIPAL_NAME", "Heddle Test")
+        .env("HEDDLE_PRINCIPAL_EMAIL", "test@heddle.dev");
+
+    cmd.output().map_err(|e| e.to_string())
+}
+
+fn assert_undo_requires_hard(cwd: &Path) {
+    let output = heddle_output(&["--output", "json", "undo"], Some(cwd))
+        .expect("plain undo should return typed safety advice");
+    assert_eq!(output.status.code(), Some(74));
+    assert!(output.stdout.is_empty());
+    let envelope: Value =
+        serde_json::from_slice(&output.stderr).expect("undo refusal should be JSON");
+    assert_eq!(envelope["kind"], "undo_requires_hard", "{envelope}");
+    assert_eq!(
+        envelope["unsafe_condition"],
+        "the selected undo operation materializes an earlier saved tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["would_change"],
+        "captured worktree files would be replaced by the selected operation's prior tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["preserved"], "repository state and worktree files were left unchanged",
+        "{envelope}"
+    );
 }
 
 fn status_json(path: &Path) -> Value {

--- a/crates/cli/tests/comprehensive/integration.rs
+++ b/crates/cli/tests/comprehensive/integration.rs
@@ -71,7 +71,20 @@ fn test_undo_redo_workflow() {
     fs::write(temp.path().join("file.txt"), "v3").unwrap();
     heddle(&["capture", "-m", "V3"], Some(temp.path())).unwrap();
 
-    heddle(&["undo"], Some(temp.path())).unwrap();
+    let state_before_refusal = status_json(temp.path())["state"]["state_id"].clone();
+    assert_undo_requires_hard(temp.path());
+    assert_eq!(
+        status_json(temp.path())["state"]["state_id"],
+        state_before_refusal,
+        "refused undo must leave HEAD at V3"
+    );
+    assert_eq!(
+        fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+        "v3",
+        "refused undo must preserve the V3 file"
+    );
+
+    heddle(&["undo", "--hard"], Some(temp.path())).unwrap();
     let content = fs::read_to_string(temp.path().join("file.txt")).unwrap();
     assert_eq!(content, "v2", "undo should restore v2");
 

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -34,9 +34,9 @@ fn test_undo_at_beginning() {
     heddle_must_succeed(&["init"], temp.path());
     std::fs::write(temp.path().join("file.txt"), "content").unwrap();
     heddle_must_succeed(&["capture", "-m", "Initial"], temp.path());
-    let result = heddle(&["undo"], Some(temp.path()));
+    let result = heddle(&["undo", "--hard"], Some(temp.path()));
     assert!(result.is_ok());
-    let result = heddle(&["undo"], Some(temp.path()));
+    let result = heddle(&["undo", "--hard"], Some(temp.path()));
     assert!(result.is_err());
 }
 
@@ -124,7 +124,7 @@ fn test_undo_preserves_ignored_siblings_in_tracked_dirs() {
     std::fs::create_dir_all(temp.path().join("target")).unwrap();
     std::fs::write(temp.path().join("target/foo.bin"), "build").unwrap();
 
-    heddle(&["undo", "-n", "1"], Some(temp.path())).expect("undo must succeed");
+    heddle(&["undo", "-n", "1", "--hard"], Some(temp.path())).expect("undo must succeed");
 
     // Tracked content reverted.
     assert!(!temp.path().join("main.rs").exists());
@@ -165,8 +165,11 @@ fn test_undo_refuses_when_untracked_file_present() {
     let untracked = temp.path().join("my-notes.md");
     std::fs::write(&untracked, "user-written content").unwrap();
 
-    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
-        .expect_err("undo must refuse on dirty worktree");
+    let err = heddle(
+        &["undo", "-n", "1", "--hard", "--output", "json"],
+        Some(temp.path()),
+    )
+    .expect_err("hard undo must refuse on dirty worktree");
     assert!(
         err.contains("untracked"),
         "error should mention untracked: {err}"
@@ -193,8 +196,11 @@ fn test_undo_refuses_when_tracked_file_modified() {
 
     std::fs::write(temp.path().join("a.txt"), "uncommitted edit").unwrap();
 
-    let err = heddle(&["undo", "-n", "1", "--output", "json"], Some(temp.path()))
-        .expect_err("undo must refuse with modified file");
+    let err = heddle(
+        &["undo", "-n", "1", "--hard", "--output", "json"],
+        Some(temp.path()),
+    )
+    .expect_err("hard undo must refuse with modified file");
     assert!(
         err.contains("modified"),
         "error should mention modified: {err}"
@@ -207,7 +213,8 @@ fn test_undo_refuses_when_tracked_file_modified() {
 
     // Capturing the change unblocks undo.
     heddle_must_succeed(&["capture", "-m", "edit"], temp.path());
-    heddle(&["undo", "-n", "1"], Some(temp.path())).expect("undo succeeds once worktree is clean");
+    heddle(&["undo", "-n", "1", "--hard"], Some(temp.path()))
+        .expect("undo succeeds once worktree is clean");
 }
 
 #[test]
@@ -227,7 +234,8 @@ fn test_undo_with_dotgit_directory_present() {
     std::fs::write(temp.path().join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
     std::fs::write(temp.path().join(".git/objects/01/abc"), "fake git object").unwrap();
 
-    heddle(&["undo", "-n", "1"], Some(temp.path())).expect("undo must succeed alongside .git");
+    heddle(&["undo", "-n", "1", "--hard"], Some(temp.path()))
+        .expect("undo must succeed alongside .git");
     assert!(!temp.path().join("file.txt").exists());
     assert!(
         temp.path().join(".git/HEAD").exists(),
@@ -272,7 +280,7 @@ fn test_undo_capture_restores_head_to_parent() {
         "second capture must produce a fresh state"
     );
 
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     assert_eq!(
         head_short(temp.path()),
         parent,
@@ -282,6 +290,70 @@ fn test_undo_capture_restores_head_to_parent() {
         std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
         "v1",
         "worktree must reflect the parent state's tree after undo"
+    );
+}
+
+#[test]
+fn test_undo_capture_requires_hard_before_rewriting_worktree() {
+    let temp = TempDir::new().unwrap();
+    drop(Repository::init_default(temp.path()).unwrap());
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+
+    std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    let parent = head_short(temp.path());
+
+    std::fs::write(temp.path().join("notes.md"), "captured change\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "change"], temp.path());
+    let captured = head_short(temp.path());
+
+    let refusal = heddle(&["undo", "--output", "json"], Some(temp.path()))
+        .expect_err("plain undo must refuse before a worktree rewind");
+    assert!(refusal.contains("undo_requires_hard"), "{refusal}");
+    assert!(refusal.contains("heddle undo --hard"), "{refusal}");
+    assert_eq!(head_short(temp.path()), captured);
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "captured change\n"
+    );
+
+    std::fs::write(temp.path().join("notes.md"), "unsaved local edit\n").unwrap();
+    let dirty_refusal = heddle(&["undo", "--hard", "--output", "json"], Some(temp.path()))
+        .expect_err("hard undo must refuse before overwriting an uncommitted edit");
+    assert!(dirty_refusal.contains("dirty_worktree"), "{dirty_refusal}");
+    assert!(
+        dirty_refusal.contains("modified: notes.md"),
+        "{dirty_refusal}"
+    );
+    assert_eq!(head_short(temp.path()), captured);
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "unsaved local edit\n"
+    );
+
+    std::fs::write(temp.path().join("notes.md"), "captured change\n").unwrap();
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
+    assert_eq!(head_short(temp.path()), parent);
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
+        "base\n"
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_capture_escaping_symlink_error_names_path_and_target() {
+    let temp = TempDir::new().unwrap();
+    drop(Repository::init_default(temp.path()).unwrap());
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+    std::fs::create_dir_all(temp.path().join(".venv/bin")).unwrap();
+    std::os::unix::fs::symlink("/usr/bin/python3", temp.path().join(".venv/bin/python")).unwrap();
+
+    let error = heddle(&["capture", "-m", "venv"], Some(temp.path()))
+        .expect_err("escaping symlink must be rejected");
+    assert!(
+        error.contains(".venv/bin/python -> /usr/bin/python3"),
+        "{error}"
     );
 }
 
@@ -307,7 +379,7 @@ fn test_undo_captures_pre_undo_state_into_recovery_marker() {
     heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
     let friction_state = head_short(temp.path());
 
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
 
     // The reset happened: worktree reverted to the parent state.
     assert_eq!(
@@ -352,7 +424,7 @@ fn test_undo_recover_survives_divergent_capture() {
     let friction_state = head_short(temp.path());
 
     let undo: Value = serde_json::from_str(&heddle_must_succeed(
-        &["--output", "json", "undo"],
+        &["--output", "json", "undo", "--hard"],
         temp.path(),
     ))
     .unwrap();
@@ -402,6 +474,79 @@ fn test_undo_recover_survives_divergent_capture() {
 }
 
 #[test]
+fn test_undo_recover_round_trips_with_heddleignore_present() {
+    let temp = TempDir::new().unwrap();
+    drop(Repository::init_default(temp.path()).unwrap());
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+
+    std::fs::write(temp.path().join("seed.txt"), "seed\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "seed"], temp.path());
+
+    std::fs::write(temp.path().join(".heddleignore"), "ignored/\n").unwrap();
+    std::fs::write(temp.path().join("source.py"), "print('safe')\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source and ignore"], temp.path());
+
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join(".heddleignore")).unwrap(),
+        "ignored/\n",
+        "undo must preserve the file that defines the worktree dirty set"
+    );
+
+    heddle_must_succeed(&["undo", "--recover"], temp.path());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("source.py")).unwrap(),
+        "print('safe')\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join(".heddleignore")).unwrap(),
+        "ignored/\n"
+    );
+}
+
+#[test]
+fn test_undo_recover_ignores_unrelated_untracked_junk_exposed_by_missing_ignore_file() {
+    let temp = TempDir::new().unwrap();
+    drop(Repository::init_default(temp.path()).unwrap());
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
+
+    std::fs::write(temp.path().join("seed.txt"), "seed\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "seed"], temp.path());
+
+    std::fs::write(temp.path().join(".heddleignore"), ".venv/\n").unwrap();
+    std::fs::write(temp.path().join("source.py"), "print('recover me')\n").unwrap();
+    std::fs::create_dir_all(temp.path().join(".venv/lib")).unwrap();
+    std::fs::write(temp.path().join(".venv/lib/junk.pyc"), "ignored junk\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "source with ignored junk"], temp.path());
+
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
+    assert!(
+        temp.path().join(".venv/lib/junk.pyc").exists(),
+        "ignored junk must survive the worktree rewind"
+    );
+    std::fs::remove_file(temp.path().join(".heddleignore")).unwrap();
+
+    let recovered = heddle(&["undo", "--recover"], Some(temp.path()))
+        .expect("unrelated untracked junk must not block recovery");
+    assert!(
+        recovered.contains("Recovered pre-undo state"),
+        "{recovered}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("source.py")).unwrap(),
+        "print('recover me')\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join(".heddleignore")).unwrap(),
+        ".venv/\n"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join(".venv/lib/junk.pyc")).unwrap(),
+        "ignored junk\n"
+    );
+}
+
+#[test]
 fn test_undo_recover_ref_lives_outside_user_marker_namespace() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
@@ -412,7 +557,7 @@ fn test_undo_recover_ref_lives_outside_user_marker_namespace() {
     heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
     let friction_state = head_short(temp.path());
 
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     let markers: Value = serde_json::from_str(&heddle_must_succeed(
         &["--output", "json", "thread", "marker", "list"],
         temp.path(),
@@ -468,7 +613,7 @@ fn test_undo_recover_is_unshadowable_by_same_named_user_marker() {
     std::fs::write(temp.path().join("notes.md"), "FRICTION\n").unwrap();
     heddle_must_succeed(&["capture", "-m", "friction"], temp.path());
     let friction_state = head_short(temp.path());
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     assert_eq!(
         Repository::open(temp.path())
             .unwrap()
@@ -499,9 +644,10 @@ fn test_undo_recover_is_unshadowable_by_same_named_user_marker() {
 }
 
 #[test]
-fn test_undo_recover_refuses_without_recovery_state_or_clean_worktree() {
+fn test_undo_recover_refuses_without_recovery_state_or_with_overlapping_worktree_change() {
     let temp = TempDir::new().unwrap();
-    heddle_must_succeed(&["init"], temp.path());
+    drop(Repository::init_default(temp.path()).unwrap());
+    std::fs::create_dir(temp.path().join(".git")).unwrap();
     std::fs::write(temp.path().join("notes.md"), "base\n").unwrap();
     heddle_must_succeed(&["capture", "-m", "base"], temp.path());
 
@@ -514,13 +660,13 @@ fn test_undo_recover_refuses_without_recovery_state_or_clean_worktree() {
 
     std::fs::write(temp.path().join("notes.md"), "recover me\n").unwrap();
     heddle_must_succeed(&["capture", "-m", "recoverable"], temp.path());
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     std::fs::write(temp.path().join("notes.md"), "unsaved\n").unwrap();
     let dirty = heddle(
         &["--output", "json", "undo", "--recover"],
         Some(temp.path()),
     )
-    .expect_err("recovery must refuse a dirty worktree");
+    .expect_err("recovery must refuse an overlapping dirty worktree path");
     assert!(dirty.contains("dirty_worktree"), "{dirty}");
     assert_eq!(
         std::fs::read_to_string(temp.path().join("notes.md")).unwrap(),
@@ -537,7 +683,7 @@ fn test_undo_recover_refuses_when_preserved_state_is_missing() {
     std::fs::write(temp.path().join("notes.md"), "recover me\n").unwrap();
     heddle_must_succeed(&["capture", "-m", "recoverable"], temp.path());
     let recovery_state = head_short(temp.path());
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
 
     let state_path = locate_state_loose_file(temp.path(), &recovery_state)
         .expect("preserved state has a loose object");
@@ -643,7 +789,6 @@ fn test_undo_refuses_when_prior_state_missing() {
 #[test]
 fn test_undo_help_lists_undoable_and_unsupported() {
     let temp = TempDir::new().unwrap();
-    heddle_must_succeed(&["init"], temp.path());
 
     let help = heddle_must_succeed(&["undo", "--help"], temp.path());
     let lower = help.to_lowercase();
@@ -662,6 +807,10 @@ fn test_undo_help_lists_undoable_and_unsupported() {
     assert!(
         lower.contains("--recover") && lower.contains("worktree changes"),
         "--help should explain recovery without moving HEAD: {help}"
+    );
+    assert!(
+        lower.contains("--hard") && lower.contains("rewind"),
+        "--help should require an explicit opt-in before rewriting the worktree: {help}"
     );
     assert!(
         lower.contains("push") || lower.contains("pull") || lower.contains("cross-worktree"),
@@ -1583,7 +1732,7 @@ fn test_undo_thread_refresh_restores_base_state() {
         );
     }
 
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
 
     let repo = Repository::open(temp.path()).unwrap();
     let feature_ref = repo
@@ -1690,7 +1839,7 @@ fn test_undo_pull_local_restores_thread_ref() {
         "second pull must advance main to a new state"
     );
 
-    heddle_must_succeed(&["undo"], target.path());
+    heddle_must_succeed(&["undo", "--hard"], target.path());
     assert_eq!(
         head_short(target.path()),
         main_after_first_pull,
@@ -1762,7 +1911,7 @@ fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
 
     // Undo the abort — `FastForward { pre = post = feature_tip_before }`
     // so the observable state is unchanged.
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     let repo = Repository::open(temp.path()).unwrap();
     let feature_tip = repo
         .refs()
@@ -1867,7 +2016,7 @@ fn test_undo_land_manual_resolution_restores_thread_ref() {
         "land must advance main; otherwise the FF is a no-op and there's nothing to undo: {land_out}"
     );
 
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
     let repo = Repository::open(temp.path()).unwrap();
     let main_tip = repo
         .refs()
@@ -1910,7 +2059,7 @@ fn test_redo_pull_pins_recorded_tip_when_source_advances() {
     heddle_must_succeed(&["pull", &source_path, "--thread", "main"], target.path());
     let main_after_second_pull = head_short(target.path());
 
-    heddle_must_succeed(&["undo"], target.path());
+    heddle_must_succeed(&["undo", "--hard"], target.path());
     assert_eq!(head_short(target.path()), main_after_first_pull);
 
     // Advance the source past the recorded pull target. Pre-fix
@@ -1939,7 +2088,7 @@ fn test_undo_list_hides_atomic_commit_marker_batches() {
     heddle_must_succeed(&["capture", "-m", "b"], temp.path());
 
     // Undo appends a record-less atomic commit-marker batch to the oplog.
-    heddle_must_succeed(&["undo"], temp.path());
+    heddle_must_succeed(&["undo", "--hard"], temp.path());
 
     // The RAW oplog does contain the marker-only commit batch (the sentinel)...
     let repo = Repository::open(temp.path()).unwrap();

--- a/crates/cli/tests/multi_agent_worktrees.rs
+++ b/crates/cli/tests/multi_agent_worktrees.rs
@@ -62,6 +62,30 @@ fn heddle_output(args: &[&str], cwd: Option<&std::path::Path>) -> Result<Output,
     cmd.output().map_err(|e| e.to_string())
 }
 
+fn assert_undo_requires_hard(cwd: &std::path::Path) {
+    let output = heddle_output(&["--output", "json", "undo"], Some(cwd))
+        .expect("plain undo should return typed safety advice");
+    assert_eq!(output.status.code(), Some(74));
+    assert!(output.stdout.is_empty());
+    let envelope: Value =
+        serde_json::from_slice(&output.stderr).expect("undo refusal should be JSON");
+    assert_eq!(envelope["kind"], "undo_requires_hard", "{envelope}");
+    assert_eq!(
+        envelope["unsafe_condition"],
+        "the selected undo operation materializes an earlier saved tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["would_change"],
+        "captured worktree files would be replaced by the selected operation's prior tree",
+        "{envelope}"
+    );
+    assert_eq!(
+        envelope["preserved"], "repository state and worktree files were left unchanged",
+        "{envelope}"
+    );
+}
+
 fn heddle_argv_json<I, S>(args: I) -> Value
 where
     I: IntoIterator<Item = S>,

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -1120,7 +1120,17 @@ fn undo_is_scoped_to_the_current_thread() {
     )
     .unwrap();
 
-    heddle(&["undo"], Some(&auth_path)).unwrap();
+    assert_undo_requires_hard(&auth_path);
+    assert!(
+        auth_path.join("auth.rs").exists(),
+        "refused undo must preserve the auth thread worktree"
+    );
+    assert!(
+        search_path.join("search.rs").exists(),
+        "refused auth undo must preserve the sibling thread worktree"
+    );
+
+    heddle(&["undo", "--hard"], Some(&auth_path)).unwrap();
 
     assert!(
         !auth_path.join("auth.rs").exists(),

--- a/crates/object-model/src/error.rs
+++ b/crates/object-model/src/error.rs
@@ -234,8 +234,15 @@ pub enum HeddleError {
     InvalidRefName(String),
     #[error("file too large: {0} bytes")]
     InvalidFileSize(u64),
-    #[error("symlink target escapes repository: {0}")]
-    InvalidSymlinkTarget(std::path::PathBuf),
+    #[error(
+        "symlink target escapes repository: {} -> {}",
+        path.display(),
+        target.display()
+    )]
+    InvalidSymlinkTarget {
+        path: std::path::PathBuf,
+        target: std::path::PathBuf,
+    },
     #[error("object corruption: expected {expected}, found {found}")]
     Corruption {
         expected: ContentHash,

--- a/crates/repo/src/repository_materialization.rs
+++ b/crates/repo/src/repository_materialization.rs
@@ -556,7 +556,13 @@ impl Repository {
                     let target_path = Path::new(target);
                     let symlink_dir = path.parent().unwrap_or(validation_root);
                     if !validate_symlink_target(validation_root, symlink_dir, target_path) {
-                        return Err(HeddleError::InvalidSymlinkTarget(target_path.to_path_buf()));
+                        return Err(HeddleError::InvalidSymlinkTarget {
+                            path: path
+                                .strip_prefix(validation_root)
+                                .unwrap_or(path)
+                                .to_path_buf(),
+                            target: target_path.to_path_buf(),
+                        });
                     }
                     remove_materialized_leaf(path)?;
                     std::os::unix::fs::symlink(target, path)?;

--- a/crates/repo/src/repository_recovery.rs
+++ b/crates/repo/src/repository_recovery.rs
@@ -1,11 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Recovery worktree materialization that preserves repository refs.
 
-use objects::{lock::RepositoryLockExt, store::ObjectStore};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use objects::{
+    RecoveryDetails, lock::RepositoryLockExt, object::Blob, store::ObjectStore,
+    util::symlink_target_bytes,
+};
 
 use super::{
-    HeddleError, Repository, Result, repository_worktree_apply::WorktreeApplyDirtyBehavior,
+    HeddleError, Repository, Result,
+    repository_materialization::WorktreeWriteOp,
+    repository_worktree_apply::{WorktreeApplyDirtyBehavior, WorktreeApplyPlan},
 };
+use crate::WorktreeStatusDetailed;
 
 impl Repository {
     /// Materialize a saved state as recoverable worktree changes.
@@ -40,16 +51,153 @@ impl Repository {
             }
             None => None,
         };
+        let detailed = match current_tree.as_ref() {
+            Some(tree) => Some(self.compare_worktree_cached_detailed(tree)?),
+            None => None,
+        };
         let plan = self.plan_worktree_apply(
             current_tree.as_ref(),
             &target_tree,
             self.root(),
-            false,
+            true,
             WorktreeApplyDirtyBehavior::RefuseOnDirty,
         )?;
+        if let Some(detailed) = detailed {
+            let conflicts = recovery_conflicting_paths(self.root(), &detailed, &plan)?;
+            if !conflicts.is_empty() {
+                return Err(recovery_dirty_conflict(conflicts));
+            }
+        }
         self.execute_worktree_apply(&plan, &target_tree, self.root())?;
         Ok(())
     }
+}
+
+fn recovery_conflicting_paths(
+    root: &Path,
+    detailed: &WorktreeStatusDetailed,
+    plan: &WorktreeApplyPlan,
+) -> Result<Vec<String>> {
+    let untracked = detailed.untracked.flatten_paths();
+    let dirty = detailed
+        .modified
+        .iter()
+        .map(|path| ("modified", path))
+        .chain(detailed.deleted.iter().map(|path| ("deleted", path)))
+        .chain(untracked.iter().map(|path| ("untracked", path)));
+
+    let mut conflicts = Vec::new();
+    for (kind, path) in dirty {
+        let absolute = absolute_worktree_path(root, path);
+        if recovery_path_conflicts(&absolute, plan)? {
+            conflicts.push(format!("{kind}: {}", path.display()));
+        }
+    }
+    Ok(conflicts)
+}
+
+fn recovery_path_conflicts(path: &Path, plan: &WorktreeApplyPlan) -> Result<bool> {
+    for write in &plan.writes {
+        let write_path = write.path();
+        if path == write_path {
+            return Ok(!worktree_matches_write(write)?);
+        }
+        if path.starts_with(write_path) || write_path.starts_with(path) {
+            return Ok(true);
+        }
+    }
+
+    for removal in &plan.removals {
+        if path == removal {
+            return Ok(fs::symlink_metadata(path).is_ok());
+        }
+        if removal.starts_with(path) {
+            return Ok(true);
+        }
+        // A dirty descendant does not conflict with removing a tracked
+        // directory. Incremental apply removes only tracked leaves and leaves
+        // a non-empty directory in place, so unrelated local children survive.
+    }
+
+    Ok(false)
+}
+
+fn absolute_worktree_path(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+fn worktree_matches_write(write: &WorktreeWriteOp) -> Result<bool> {
+    let metadata = match fs::symlink_metadata(write.path()) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(HeddleError::Io(error)),
+    };
+
+    match write {
+        WorktreeWriteOp::Blob {
+            path,
+            hash,
+            executable,
+        } => {
+            if !metadata.file_type().is_file() {
+                return Ok(false);
+            }
+            let bytes = fs::read(path)?;
+            Ok(Blob::new(bytes).hash() == *hash && executable_mode_matches(&metadata, *executable))
+        }
+        WorktreeWriteOp::Symlink { path, hash, .. } => {
+            if !metadata.file_type().is_symlink() {
+                return Ok(false);
+            }
+            let target = fs::read_link(path)?;
+            Ok(Blob::new(symlink_target_bytes(&target)).hash() == *hash)
+        }
+        WorktreeWriteOp::GitlinkPlaceholder { path, .. } => {
+            if !metadata.file_type().is_file() {
+                return Ok(false);
+            }
+            Ok(Blob::new(fs::read(path)?).hash() == write.hash())
+        }
+    }
+}
+
+#[cfg(unix)]
+fn executable_mode_matches(metadata: &fs::Metadata, executable: bool) -> bool {
+    use std::os::unix::fs::PermissionsExt;
+
+    (metadata.permissions().mode() & 0o111 != 0) == executable
+}
+
+#[cfg(not(unix))]
+fn executable_mode_matches(_metadata: &fs::Metadata, _executable: bool) -> bool {
+    true
+}
+
+fn recovery_dirty_conflict(paths: Vec<String>) -> HeddleError {
+    let rendered = paths
+        .iter()
+        .take(12)
+        .cloned()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let overflow = paths.len().saturating_sub(12);
+    let rendered = if overflow == 0 {
+        rendered
+    } else {
+        format!("{rendered}, and {overflow} more")
+    };
+    HeddleError::recovery(RecoveryDetails::safety_refusal(
+        "dirty_worktree",
+        format!("recovery would overwrite local worktree changes: {rendered}"),
+        "Move or capture the listed paths, then retry `heddle undo --recover`.",
+        format!("unsaved recovery-target path(s): {rendered}"),
+        "recovery would replace differing local content at paths stored in the preserved state",
+        "HEAD, repository state, and worktree files were left unchanged",
+    ))
 }
 
 #[cfg(test)]

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -708,7 +708,14 @@ impl WorktreeWalkPolicy for SnapshotFingerprintPolicy<'_> {
             let target = std::fs::read_link(entry.path)?;
             let symlink_dir = entry.path.parent().unwrap_or(self.walk_root);
             if !validate_symlink_target(self.walk_root, symlink_dir, &target) {
-                return Err(HeddleError::InvalidSymlinkTarget(target));
+                return Err(HeddleError::InvalidSymlinkTarget {
+                    path: entry
+                        .path
+                        .strip_prefix(self.walk_root)
+                        .unwrap_or(entry.path)
+                        .to_path_buf(),
+                    target,
+                });
             }
             Blob::new(objects::util::symlink_target_bytes(&target)).hash()
         };

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -1412,7 +1412,10 @@ fn test_build_tree_rejects_escaping_symlinks() {
     std::os::unix::fs::symlink(outside_dir.path(), &symlink_path).unwrap();
 
     let result = repo.build_tree(temp_dir.path());
-    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(matches!(
+        result,
+        Err(HeddleError::InvalidSymlinkTarget { .. })
+    ));
 }
 
 #[test]
@@ -1516,7 +1519,10 @@ fn test_materialize_tree_rejects_relative_symlink_escape() {
 
     let result = repo.materialize_tree(&tree, &materialize_root);
 
-    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(matches!(
+        result,
+        Err(HeddleError::InvalidSymlinkTarget { .. })
+    ));
     assert!(
         fs::symlink_metadata(materialize_root.join("link")).is_err(),
         "escaping symlink must fail before the link is created"
@@ -1532,7 +1538,10 @@ fn test_materialize_tree_rejects_normalized_relative_symlink_escape() {
 
     let result = repo.materialize_tree(&tree, &materialize_root);
 
-    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(matches!(
+        result,
+        Err(HeddleError::InvalidSymlinkTarget { .. })
+    ));
     assert!(
         fs::symlink_metadata(materialize_root.join("link")).is_err(),
         "normalized escaping symlink must fail before the link is created"
@@ -1549,7 +1558,10 @@ fn test_materialize_tree_rejects_absolute_symlink_escape() {
 
     let result = repo.materialize_tree(&tree, &materialize_root);
 
-    assert!(matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))));
+    assert!(matches!(
+        result,
+        Err(HeddleError::InvalidSymlinkTarget { .. })
+    ));
     assert!(
         fs::symlink_metadata(materialize_root.join("link")).is_err(),
         "absolute escaping symlink must fail before the link is created"
@@ -1584,7 +1596,7 @@ fn test_capture_and_materialize_reject_same_escaping_symlink_target() {
     let capture_result = repo.build_tree(temp_dir.path());
     assert!(matches!(
         capture_result,
-        Err(HeddleError::InvalidSymlinkTarget(_))
+        Err(HeddleError::InvalidSymlinkTarget { .. })
     ));
 
     let materialize_root = temp_dir.path().join("materialized");
@@ -1592,7 +1604,7 @@ fn test_capture_and_materialize_reject_same_escaping_symlink_target() {
     let materialize_result = repo.materialize_tree(&tree, &materialize_root);
     assert!(matches!(
         materialize_result,
-        Err(HeddleError::InvalidSymlinkTarget(_))
+        Err(HeddleError::InvalidSymlinkTarget { .. })
     ));
     assert!(
         fs::symlink_metadata(materialize_root.join("link")).is_err(),
@@ -1680,7 +1692,7 @@ fn test_build_tree_rejects_dangling_symlink_escaping_repo() {
 
     let result = repo.build_tree(temp_dir.path());
     assert!(
-        matches!(result, Err(HeddleError::InvalidSymlinkTarget(_))),
+        matches!(result, Err(HeddleError::InvalidSymlinkTarget { .. })),
         "Should reject dangling symlink that escapes repo via .. traversal"
     );
 }

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -676,7 +676,14 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         // unchanged.
         let symlink_dir = entry.path.parent().unwrap_or(self.walk_root);
         if !validate_symlink_target(self.walk_root, symlink_dir, &target) {
-            return Err(HeddleError::InvalidSymlinkTarget(target));
+            return Err(HeddleError::InvalidSymlinkTarget {
+                path: entry
+                    .path
+                    .strip_prefix(self.walk_root)
+                    .unwrap_or(entry.path)
+                    .to_path_buf(),
+                target,
+            });
         }
 
         let blob = Blob::new(objects::util::symlink_target_bytes(&target));

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -6,8 +6,14 @@ Every completed undo preserves its pre-undo state in a checkout-local internal
 ref. Run `heddle undo --recover` to materialize that state later, even after a
 divergent capture has made redo unavailable. Recovery preserves the current
 `HEAD` and attached thread, restores the saved tree as dirty worktree changes,
-and recommends `heddle capture`. It refuses without changing files when the
-recovery state is absent or the worktree is dirty.
+and recommends `heddle capture`. Unrelated local changes do not block recovery;
+it refuses without changing files only when the recovery state is absent or
+when recovery would overwrite a differing local change at the same path.
+
+Undo operations that materialize an earlier tree are explicitly destructive.
+Run `heddle undo --preview` to inspect them and `heddle undo --hard` to permit
+the worktree rewind. Plain `heddle undo` refuses before changing repository
+state or files when the selected inverse would rewrite the worktree.
 
 This document describes the user-facing surface shipped under
 [HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). The
@@ -76,12 +82,20 @@ contracts below are enforced by integration tests in
   destroyed the underlying bytes (the redaction's audit-trail role is then
   load-bearing).
 
-- **Dirty worktree refusal.** If you have uncommitted changes (modified
-  tracked files, untracked files), `heddle undo` refuses and surfaces the
-  dirty paths. Capture the changes with `heddle capture -m "..."` (or remove
-  them) and retry. `heddle undo --recover` enforces the same refusal before
-  materializing the preserved state. The check is shared with `revert` and
-  `sync`.
+- **Explicit destructive opt-in.** If the selected inverse would materialize
+  an earlier tree, plain `heddle undo` refuses before mutation and points to
+  `--preview` and `--hard`. `heddle undo --hard` still refuses if the worktree
+  is dirty and surfaces the exact paths that would otherwise be lost. Capture
+  the changes with `heddle capture -m "..."` (or move them) and retry.
+- **Recovery overlays unrelated changes.** `heddle undo --recover` restores
+  the preserved tree as worktree changes without moving `HEAD`. Unrelated
+  modified or untracked paths are left in place. Recovery refuses only when
+  it would overwrite differing local content at a path it needs to write or
+  remove.
+- **Ignore controls survive undo.** A worktree rewind preserves the existing
+  `.heddleignore`. Git-overlay repositories also preserve their existing
+  `.gitignore`. Undo therefore cannot expose previously ignored local junk and
+  strand its own recovery command.
 - **Destructive-boundary refusal.** If the state the inverse would restore
   has been removed from the object store — typically by `heddle maintenance gc --prune`
   reaching past the live oplog window — `heddle undo` refuses with a single
@@ -119,6 +133,7 @@ contracts below are enforced by integration tests in
 | `--list`                   | Print the recent batches without undoing.                   |
 | `--depth <N>`              | How many batches `--list` shows (default 20).               |
 | `--preview` / `--dry-run`  | Print what would change without applying.                   |
+| `--hard`                   | Permit an undo that rewinds worktree files.                  |
 | `--redo`                   | Re-apply operations that a prior `undo` rewound.            |
 | `--recover`                | Restore the last undo's saved state as worktree changes without moving HEAD. |
 | `--allow-redact-undo`      | Explicit opt-in to undo a `heddle redact apply` (see "Safety contracts"). |

--- a/scripts/verify-cold-flow-agent.sh
+++ b/scripts/verify-cold-flow-agent.sh
@@ -612,6 +612,39 @@ if verification.get("verified") is not False:
 PYJSON
 }
 
+run_json_expect_undo_requires_hard() {
+  local transcript="$1"
+  local repo="$2"
+  local label="$3"
+  shift 3
+  run_json_expect_failure "$transcript" "$repo" "$label" "$@"
+  python3 - "$ARTIFACT_ROOT/$label.json" "$transcript" <<'PYJSON'
+import json
+import sys
+
+artifact_path, transcript_path = sys.argv[1:]
+with open(artifact_path, encoding="utf-8") as handle:
+    artifact = json.load(handle)
+expected = {
+    "kind": "undo_requires_hard",
+    "unsafe_condition": "the selected undo operation materializes an earlier saved tree",
+    "would_change": "captured worktree files would be replaced by the selected operation's prior tree",
+    "preserved": "repository state and worktree files were left unchanged",
+    "primary_command": "heddle undo --hard",
+}
+for key, value in expected.items():
+    if artifact.get(key) != value:
+        raise SystemExit(f"undo refusal {key} mismatch: {artifact!r}")
+with open(transcript_path, encoding="utf-8") as handle:
+    records = [json.loads(line) for line in handle if line.strip()]
+record = records[-1]
+if record.get("exit_code") != 74:
+    raise SystemExit(f"undo refusal should exit 74, got {record!r}")
+if record.get("stdout"):
+    raise SystemExit(f"undo refusal should keep JSON stdout empty, got {record!r}")
+PYJSON
+}
+
 assert_current_verify_clean_json() {
   local repo="$1"
   local json
@@ -821,7 +854,9 @@ PYJSON
   assert_source_authority "$clone_path" native
   printf 'native authority proof for %s\n' "$shape" > "$clone_path/native-authority-proof.txt"
   run_json "$transcript" "$clone_path" "$shape.00.native-capture" capture -m "native authority proof $shape" --confidence 0.9
-  run_json "$transcript" "$clone_path" "$shape.00.native-undo" undo
+  run_json_expect_undo_requires_hard "$transcript" "$clone_path" "$shape.00.native-undo-refusal" undo
+  grep -Fx "native authority proof for $shape" "$clone_path/native-authority-proof.txt" >/dev/null
+  run_json "$transcript" "$clone_path" "$shape.00.native-undo" undo --hard
   run_json "$transcript" "$clone_path" "$shape.00.native-verify" verify
   assert_clean_git_status "$clone_path"
 

--- a/scripts/verify-cold-flow-human.sh
+++ b/scripts/verify-cold-flow-human.sh
@@ -553,6 +553,52 @@ run_text_expect_failure() {
   RUN_TEXT_ALLOW_FAILURE=1 run_text "$@"
 }
 
+run_text_expect_undo_requires_hard() {
+  local transcript="$1"
+  local repo="$2"
+  local label="$3"
+  local stdout_file="$ARTIFACT_ROOT/$label.stdout"
+  local stderr_file="$ARTIFACT_ROOT/$label.json"
+  local exit_code
+  set +e
+  (cd "$repo" && heddle_runtime undo --output json) > "$stdout_file" 2> "$stderr_file"
+  exit_code=$?
+  set -e
+  python3 - "$stdout_file" "$stderr_file" "$exit_code" <<'PYJSON'
+import json
+import sys
+
+stdout_path, stderr_path, exit_code_text = sys.argv[1:]
+with open(stdout_path, encoding="utf-8") as handle:
+    stdout = handle.read()
+with open(stderr_path, encoding="utf-8") as handle:
+    stderr = handle.read()
+if int(exit_code_text) != 74:
+    raise SystemExit(f"undo refusal should exit 74, got {exit_code_text}: {stderr!r}")
+if stdout:
+    raise SystemExit(f"undo refusal should keep JSON stdout empty, got {stdout!r}")
+stderr_lines = [line for line in stderr.splitlines() if line.strip()]
+if len(stderr_lines) != 1:
+    raise SystemExit(f"expected one undo refusal envelope, got {stderr!r}")
+artifact = json.loads(stderr)
+expected = {
+    "kind": "undo_requires_hard",
+    "unsafe_condition": "the selected undo operation materializes an earlier saved tree",
+    "would_change": "captured worktree files would be replaced by the selected operation's prior tree",
+    "preserved": "repository state and worktree files were left unchanged",
+    "primary_command": "heddle undo --hard",
+}
+for key, value in expected.items():
+    if artifact.get(key) != value:
+        raise SystemExit(f"undo refusal {key} mismatch: {artifact!r}")
+PYJSON
+  {
+    printf '\n$ (cd %s && heddle undo --output json)\n' "$repo"
+    cat "$stderr_file"
+  } >> "$transcript"
+  rm -f "$stdout_file"
+}
+
 assert_current_verify_clean() {
   local repo="$1"
   local json
@@ -637,7 +683,9 @@ run_shape() {
   assert_source_authority "$clone_path" native
   printf 'native authority proof for %s\n' "$shape" > "$clone_path/native-authority-proof.txt"
   run_text "$transcript" "$clone_path" capture -m "native authority proof $shape" --output text
-  run_text "$transcript" "$clone_path" undo --output text
+  run_text_expect_undo_requires_hard "$transcript" "$clone_path" "$shape.native-undo-refusal"
+  grep -Fx "native authority proof for $shape" "$clone_path/native-authority-proof.txt" >/dev/null
+  run_text "$transcript" "$clone_path" undo --hard --output text
   run_text "$transcript" "$clone_path" verify --output text
   assert_clean_git_status "$clone_path"
 


### PR DESCRIPTION
## Summary

- require `--hard` before an undo may rewind worktree files; plain undo refuses pre-mutation and points to `--preview`
- preserve `.heddleignore` during every undo worktree rewind, plus `.gitignore` for Git-overlay repositories
- make recovery overlay-aware: unrelated dirty paths survive, while differing changes at recovery target paths still fail safely
- include the repository-relative symlink path and target in escaping-symlink diagnostics

The chosen semantics keep undo explicit: operations that do not rewrite the worktree remain available as plain `heddle undo`, while tree-rewriting inverses require `heddle undo --hard`. `--hard` still refuses and names unsaved paths. This keeps the destructive boundary visible without changing recovery's existing ideal shape: recovery restores the saved state as worktree changes without moving HEAD.

## Closes

Closes #1148

## Test evidence

Before the fix, the complete six-step deadlock reproduced in a fresh native repository:

```text
$ find .venv \( -type f -o -type l \) | wc -l
1814
$ heddle capture -m initial-source
Captured state hs-fs2vtjsh9wg6p2k (7e45bd4b)
exit=0
$ heddle undo
Undid 1 saved change
Preserved pre-undo state hs-fs2vtjsh9wg6p2k as `.undo-recovery`
Next: heddle undo --recover
exit=0
$ ls -la src
total 12
drwxr-xr-x 3 heddleco heddleco 4096 Jul 30 08:36 .
drwx------ 6 heddleco heddleco 4096 Jul 30 08:36 ..
drwxr-xr-x 2 heddleco heddleco 4096 Jul 30 08:36 __pycache__
$ test -e .heddleignore; echo $?
1
$ heddle undo --recover
Error: Capture worktree changes before recover the pre-undo state
Next: heddle capture -m "..."
Paths: unsaved worktree path(s): .venv/bin/python, .venv/bin/python3, .venv/lib/file-0001, .venv/lib/file-0002, .venv/lib/file-0003, .venv/lib/file-0004, .venv/lib/file-0005, .venv/lib/file-0006, .venv/lib/file-0007, .venv/lib/file-0008, .venv/lib/file-0009, .venv/lib/file-0010, and 1803 more
exit=65
$ heddle capture -m clear-recovery-blocker
Error: symlink target escapes repository: python3
exit=74
```

The two new load-bearing regressions were also run against the pre-fix binary and failed:

```text
test_undo_recover_round_trips_with_heddleignore_present ... FAILED
NotFound: .heddleignore

test_undo_recover_ignores_unrelated_untracked_junk_exposed_by_missing_ignore_file ... FAILED
Capture worktree changes before recover the pre-undo state
Paths: unsaved worktree path(s): .venv/lib/junk.pyc
```

After the fix:

```text
$ heddle undo --output json
{"kind":"undo_requires_hard","error":"Undo would rewind repository state and worktree files","preserved":"repository state and worktree files were left unchanged",...}
plain_undo_exit=74
source_present_after_plain_refusal=yes
heddleignore_present_after_plain_refusal=yes

$ # with src/app.py changed but uncaptured
$ heddle undo --hard --output json
{"kind":"dirty_worktree","unsafe_condition":"unsaved worktree path(s): modified: src/app.py","preserved":"repository state and worktree files were left unchanged; no snapshot has been written for these paths",...}
dirty_hard_undo_exit=65
source_after_dirty_refusal=print("unsaved local edit")
heddleignore_present_after_dirty_refusal=yes

$ # after restoring the captured bytes
$ heddle undo --hard --output json
{"output_kind":"undo","status":"completed","recovery_marker":".undo-recovery",...}
hard_undo_exit=0
$ ls -la src
total 12
drwxr-xr-x 3 heddleco heddleco 4096 Jul 30 08:59 .
drwxr-xr-x 6 heddleco heddleco 4096 Jul 30 08:59 ..
drwxr-xr-x 2 heddleco heddleco 4096 Jul 30 08:59 __pycache__
heddleignore_survived_hard_undo=yes

$ # remove the preserved ignore file to recreate the former blocking state
$ heddle status --output json
{"summary":"1815 Heddle worktree path(s) are not captured in the current state",...}
$ heddle undo --recover --output json
{"output_kind":"undo_recover","status":"completed","message":"restored the state preserved by the most recent undo as worktree changes",...}
recover_exit=0
source_restored=yes
heddleignore_restored=yes
unrelated_venv_survived=yes
$ find .venv \( -type f -o -type l \) | wc -l
1814

$ heddle capture -m clear-recovery-blocker --output json
{"error":"symlink target escapes repository: .venv/bin/python -> python3","exit_code":74,...}
```

Automated verification:

```text
cargo test -p heddle-cli undo_apply -- --nocapture --test-threads=1
28 passed; 0 failed

cargo test -p heddle-repo --lib -- --test-threads=1
604 passed; 0 failed; 2 ignored

Focused CLI tests:
test_undo_capture_requires_hard_before_rewriting_worktree ... ok
test_undo_recover_round_trips_with_heddleignore_present ... ok
test_undo_recover_ignores_unrelated_untracked_junk_exposed_by_missing_ignore_file ... ok
test_undo_recover_refuses_without_recovery_state_or_with_overlapping_worktree_change ... ok
test_capture_escaping_symlink_error_names_path_and_target ... ok
test_undo_help_lists_undoable_and_unsupported ... ok

cargo clippy -p heddle-cli --all-targets -- -D warnings
Finished successfully
```

Formatting used `rustfmt +nightly --edition 2024` on the touched Rust files only. No ignore-resolution, discovery, config-resolution, or thread-lifecycle files were changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987445&installation_model_id=21489&pr_number=1160&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1160&signature=24bd3195bdb35ff1045ae77409fe2752a433e2862d1166c40c28bb5cd1ff9395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->