### PR TITLE
feat: add client-authorized provider pull path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2139,7 +2139,7 @@ dependencies = [
 [[package]]
 name = "heddle-api"
 version = "0.2.0"
-source = "git+https://github.com/HeddleCo/api?rev=4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e#4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e"
+source = "git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76#88e3bce2152a3aa8c5dea8908b16efd694c3ef76"
 dependencies = [
  "bytes",
  "hex",
@@ -2165,7 +2165,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e)",
+ "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
  "heddle-cli-args",
  "heddle-cli-contract",
  "heddle-cli-render",
@@ -2302,10 +2302,11 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "biscuit-auth",
+ "blake3",
  "bytes",
  "chrono",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e)",
+ "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
  "heddle-cli-shared",
  "heddle-crypto",
  "heddle-objects",
@@ -2314,6 +2315,9 @@ dependencies = [
  "heddle-wire",
  "hex",
  "iroh",
+ "iroh-base",
+ "n0-watcher",
+ "noq-udp",
  "prost 0.14.1",
  "prost-reflect",
  "prost-types 0.14.1",
@@ -2385,7 +2389,7 @@ version = "0.10.4"
 dependencies = [
  "chrono",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e)",
+ "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
  "heddle-crypto",
  "heddle-objects",
  "heddle-oplog",
@@ -2736,6 +2740,7 @@ dependencies = [
 name = "heddle-wire"
 version = "0.10.4"
 dependencies = [
+ "blake3",
  "chrono",
  "heddle-objects",
  "heddle-repo",
@@ -3231,8 +3236,8 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.2"
-source = "git+https://github.com/n0-computer/iroh.git?rev=cc876c75e53171dfcaf2e5fa0b81a417904694ba#cc876c75e53171dfcaf2e5fa0b81a417904694ba"
+version = "1.0.3"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
 dependencies = [
  "backon",
  "blake3",
@@ -3280,8 +3285,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.2"
-source = "git+https://github.com/n0-computer/iroh.git?rev=cc876c75e53171dfcaf2e5fa0b81a417904694ba#cc876c75e53171dfcaf2e5fa0b81a417904694ba"
+version = "1.0.3"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
 dependencies = [
  "curve25519-dalek 5.0.0",
  "data-encoding",
@@ -3298,8 +3303,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.2"
-source = "git+https://github.com/n0-computer/iroh.git?rev=cc876c75e53171dfcaf2e5fa0b81a417904694ba#cc876c75e53171dfcaf2e5fa0b81a417904694ba"
+version = "1.0.3"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3348,8 +3353,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.2"
-source = "git+https://github.com/n0-computer/iroh.git?rev=cc876c75e53171dfcaf2e5fa0b81a417904694ba#cc876c75e53171dfcaf2e5fa0b81a417904694ba"
+version = "1.0.3"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
 dependencies = [
  "blake3",
  "bytes",
@@ -6035,9 +6040,9 @@ dependencies = [
 
 [[package]]
 name = "simple-dns"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a75cbde1bf934313596a004973e462f9a82caa814dcf1a5f507bdf51597eeb4"
+checksum = "2b6f884fa9a8d48101774bfbd3aeb81e968dd22cffd19a372da69f183db22c1a"
 dependencies = [
  "bitflags 2.13.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,13 +63,16 @@ sley-transport = "0.5.2"
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"
-iroh = { version = "=1.0.2", git = "https://github.com/n0-computer/iroh.git", rev = "cc876c75e53171dfcaf2e5fa0b81a417904694ba", default-features = false, features = ["tls-ring"] }
+iroh = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6", default-features = false, features = ["tls-ring", "unstable-custom-transports", "unstable-custom-transport-backpressure"] }
+iroh-base = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6" }
 libc = "0.2"
 lru = "0.18"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
 memmap2 = "0.9"
+n0-watcher = "=1.0.0"
 notify = "8"
 ntest = "0.9"
+noq-udp = { version = "=1.1.0", default-features = false }
 proptest = "1"
 p256 = { version = "0.14", features = ["ecdsa", "pem", "getrandom"] }
 pkcs8 = { version = "0.11", features = ["pem", "encryption"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e" }
+api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-cli-args = { path = "../cli-args", version = "0.10", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.10", default-features = false }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+blake3.workspace = true
 bytes.workspace = true
 base64.workspace = true
 biscuit-auth.workspace = true
@@ -18,6 +19,9 @@ chrono.workspace = true
 futures.workspace = true
 hex.workspace = true
 iroh.workspace = true
+iroh-base.workspace = true
+n0-watcher.workspace = true
+noq-udp.workspace = true
 prost.workspace = true
 prost-types.workspace = true
 rand.workspace = true
@@ -42,7 +46,7 @@ webpki-roots.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e", features = ["reflection"] }
+api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76", features = ["reflection"] }
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.10" }

--- a/crates/client/src/hosted/connection.rs
+++ b/crates/client/src/hosted/connection.rs
@@ -1,21 +1,29 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
+use api::heddle::api::v1alpha1::ProviderSource;
+use cli_shared::ClientConfig;
 use iroh::{
-    Endpoint, EndpointAddr, RelayMode,
+    Endpoint, EndpointAddr, EndpointId, RelayMode,
     endpoint::{AckFrequencyConfig, QuicTransportConfig, presets},
 };
+use tokio::sync::Mutex;
 
-use super::{HostedError, Result, VerifiedEndpointDescriptor};
+use super::{
+    HostedError, Result, VerifiedEndpointDescriptor, provider_transport::ProviderWebSocketTransport,
+};
 
 #[derive(Debug)]
 pub(super) struct HostedConnection {
     pub(super) endpoint: Endpoint,
     pub(super) connection: iroh::endpoint::Connection,
+    provider_transport: Option<ProviderWebSocketTransport>,
+    provider_connections: Mutex<HashMap<EndpointId, iroh::endpoint::Connection>>,
 }
 
 impl HostedConnection {
     pub(super) async fn connect_verified(
         descriptor: &VerifiedEndpointDescriptor,
+        config: &ClientConfig,
     ) -> Result<Arc<Self>> {
         let relays = descriptor.relay_urls()?;
         let address = descriptor.endpoint_addr()?;
@@ -24,16 +32,26 @@ impl HostedConnection {
         } else {
             RelayMode::custom(relays)
         };
+        let provider_transport = ProviderWebSocketTransport::new(config.clone());
         let endpoint = Endpoint::builder(presets::Minimal)
             .transport_config(transport_config())
             .relay_mode(relay_mode)
+            .add_custom_transport(Arc::new(provider_transport.clone()))
             .bind()
             .await
             .map_err(HostedError::transport)?;
-        Self::connect(endpoint, address).await
+        Self::connect_inner(endpoint, address, Some(provider_transport)).await
     }
 
     pub(super) async fn connect(endpoint: Endpoint, address: EndpointAddr) -> Result<Arc<Self>> {
+        Self::connect_inner(endpoint, address, None).await
+    }
+
+    async fn connect_inner(
+        endpoint: Endpoint,
+        address: EndpointAddr,
+        provider_transport: Option<ProviderWebSocketTransport>,
+    ) -> Result<Arc<Self>> {
         let connection = match endpoint.connect(address, api::HOSTED_ALPN_V1).await {
             Ok(connection) => connection,
             Err(error) => {
@@ -44,7 +62,52 @@ impl HostedConnection {
         Ok(Arc::new(Self {
             endpoint,
             connection,
+            provider_transport,
+            provider_connections: Mutex::new(HashMap::new()),
         }))
+    }
+
+    pub(super) fn endpoint_id(&self) -> EndpointId {
+        self.endpoint.id()
+    }
+
+    pub(super) fn supports_provider_transport(&self) -> bool {
+        self.provider_transport.is_some()
+    }
+
+    pub(super) async fn provider_connection(
+        &self,
+        source: &ProviderSource,
+    ) -> Result<iroh::endpoint::Connection> {
+        let endpoint_id: EndpointId = source.endpoint_id.parse().map_err(|error| {
+            HostedError::InvalidDescriptor(format!("provider endpoint id: {error}"))
+        })?;
+        let mut connections = self.provider_connections.lock().await;
+        if let Some(connection) = connections.get(&endpoint_id)
+            && connection.close_reason().is_none()
+        {
+            return Ok(connection.clone());
+        }
+        connections.remove(&endpoint_id);
+
+        let transport = self.provider_transport.as_ref().ok_or_else(|| {
+            HostedError::InvalidDescriptor(
+                "the active Iroh endpoint has no provider transport".to_string(),
+            )
+        })?;
+        let address = transport.register_source(
+            &source.provider_id,
+            &source.endpoint_id,
+            &source.direct_url,
+            &source.opaque_ticket,
+        )?;
+        let connection = self
+            .endpoint
+            .connect(address, api::PROVIDER_ALPN_V1)
+            .await
+            .map_err(HostedError::transport)?;
+        connections.insert(endpoint_id, connection.clone());
+        Ok(connection)
     }
 
     pub(super) async fn close(&self) {
@@ -77,6 +140,7 @@ fn transport_config() -> QuicTransportConfig {
 mod tests {
     use std::{net::Ipv4Addr, time::Duration};
 
+    use api::heddle::api::v1alpha1::ProviderSource;
     use iroh::{Endpoint, RelayMode, endpoint::presets};
 
     use super::HostedConnection;
@@ -118,6 +182,63 @@ mod tests {
 
         assert!(result.is_err());
         assert!(client_observer.is_closed());
+        server_task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn provider_connection_is_reused_by_cryptographic_endpoint_id() {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let server_id = server.id();
+        let server_addr = server.addr();
+        let server_task = tokio::spawn(async move {
+            let connection = server
+                .accept()
+                .await
+                .expect("incoming connection")
+                .await
+                .unwrap();
+            connection.closed().await;
+            server.close().await;
+        });
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let connection = HostedConnection::connect(client, server_addr)
+            .await
+            .unwrap();
+        connection
+            .provider_connections
+            .lock()
+            .await
+            .insert(server_id, connection.connection.clone());
+
+        let reused = connection
+            .provider_connection(&ProviderSource {
+                provider_id: "provider-a".to_string(),
+                endpoint_id: server_id.to_string(),
+                direct_url: "wss://unused.invalid/direct?provider=provider-a&ticket=unused"
+                    .to_string(),
+                opaque_ticket: "unused".to_string(),
+                expires_at_unix_millis: u64::MAX,
+            })
+            .await
+            .unwrap();
+
+        assert!(reused.close_reason().is_none());
+        assert_eq!(connection.provider_connections.lock().await.len(), 1);
+        println!("provider_connection_reuse endpoint={server_id} connection_count=1 reused=true");
+        connection.close().await;
         server_task.await.unwrap();
     }
 }

--- a/crates/client/src/hosted/context.rs
+++ b/crates/client/src/hosted/context.rs
@@ -222,6 +222,33 @@ impl CallContextFactory {
         })
     }
 
+    pub(crate) fn provider_plan_signature(
+        &self,
+        stream_id: &str,
+        repository: &str,
+        client_endpoint_id: &str,
+        plan_nonce: &[u8],
+        grant_batch_digest: &[u8],
+    ) -> Result<Vec<u8>> {
+        let signer = self
+            .signer
+            .as_ref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        let identity = self
+            .signing_identity
+            .as_deref()
+            .ok_or(HostedError::SigningIdentityRequired)?;
+        let canonical = signing::provider_plan_bytes(
+            identity,
+            stream_id,
+            repository,
+            client_endpoint_id,
+            plan_nonce,
+            grant_batch_digest,
+        );
+        Ok(signer.sign(&canonical)?)
+    }
+
     fn base(&self, method: &str, client_operation_id: String) -> Result<CallContext> {
         Ok(CallContext {
             deadline: Some(deadline(self.timeout)?),

--- a/crates/client/src/hosted/mod.rs
+++ b/crates/client/src/hosted/mod.rs
@@ -18,6 +18,8 @@ mod hydration;
 mod methods;
 pub mod monorepo;
 pub(crate) mod operation_id;
+mod provider_pull;
+mod provider_transport;
 mod resolver;
 mod session;
 mod state_review;
@@ -163,10 +165,11 @@ impl HostedClient {
     }
 
     pub async fn connect(descriptor: &VerifiedEndpointDescriptor) -> Result<Self> {
+        let config = ClientConfig::default();
         Ok(Self {
-            connection: HostedConnection::connect_verified(descriptor).await?,
+            connection: HostedConnection::connect_verified(descriptor, &config).await?,
             context: CallContextFactory::default(),
-            transport: helpers::HostedTransportPolicy::from_client_config(&ClientConfig::default()),
+            transport: helpers::HostedTransportPolicy::from_client_config(&config),
             on_human_signature: None,
             server_key: None,
         })
@@ -178,7 +181,7 @@ impl HostedClient {
     ) -> Result<Self> {
         let context = CallContextFactory::from_client_config(config)?;
         Ok(Self {
-            connection: HostedConnection::connect_verified(descriptor).await?,
+            connection: HostedConnection::connect_verified(descriptor, config).await?,
             context,
             transport: helpers::HostedTransportPolicy::from_client_config(config),
             on_human_signature: None,

--- a/crates/client/src/hosted/provider_pull.rs
+++ b/crates/client/src/hosted/provider_pull.rs
@@ -1,0 +1,1054 @@
+use std::{
+    collections::HashSet,
+    io,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use api::{
+    framing::{MAX_CONTROL_BODY, StreamFrame, decode_stream_frame, encode_stream_message},
+    heddle::api::v1alpha1::{
+        ProviderPlanChallenge, ProviderPlanResponse, ProviderPullCapabilityContext,
+        ProviderPullManifest as ApiProviderPullManifest, ProviderPullResponse,
+        ProviderPullResultStatus, ProviderReadCheckpoint, ProviderReadClientFrame,
+        ProviderReadComplete, ProviderReadReady, ProviderReadRequest, ProviderReadServerFrame,
+        ProviderSource, provider_read_client_frame, provider_read_server_frame,
+    },
+};
+use bytes::Bytes;
+use objects::store::PackObjectId;
+use prost::Message;
+use wire::{
+    NativePackBundle, ProtocolError, ProviderPackExtent, ProviderPackIndexEntry,
+    ProviderPackManifest, assemble_provider_pack,
+};
+
+use super::{HostedClient, helpers::hosted_to_protocol_error};
+
+const PROVIDER_VERSION: u32 = 1;
+const PLAN_NONCE_LEN: usize = 16;
+const DIGEST_LEN: usize = 32;
+const PROVIDER_READ_CHUNK: usize = 1024 * 1024;
+const MAX_PROVIDER_ATTEMPTS: usize = 3;
+
+#[derive(Debug, Clone)]
+pub(super) struct ProviderPullSession {
+    stream_id: String,
+    repository: String,
+    endpoint_id: String,
+    plan_nonce: [u8; PLAN_NONCE_LEN],
+    provider_enabled: bool,
+}
+
+pub(super) struct CompletedProviderPull {
+    pub(super) pack: NativePackBundle,
+    pub(super) trailer_digest: [u8; DIGEST_LEN],
+}
+
+impl HostedClient {
+    pub(super) fn begin_provider_pull(
+        &self,
+        stream_id: &str,
+        repository: &str,
+    ) -> Result<(ProviderPullSession, Vec<u8>), ProtocolError> {
+        let mut plan_nonce = [0; PLAN_NONCE_LEN];
+        rand::fill(&mut plan_nonce);
+        let session = ProviderPullSession {
+            stream_id: stream_id.to_string(),
+            repository: repository.to_string(),
+            endpoint_id: self.connection.endpoint_id().to_string(),
+            plan_nonce,
+            provider_enabled: self.connection.supports_provider_transport(),
+        };
+        let capability_context = if session.provider_enabled {
+            ProviderPullCapabilityContext {
+                version: PROVIDER_VERSION,
+                client_endpoint_id: session.endpoint_id.clone(),
+                plan_nonce: session.plan_nonce.to_vec(),
+            }
+            .encode_to_vec()
+        } else {
+            Vec::new()
+        };
+        Ok((session, capability_context))
+    }
+
+    pub(super) fn answer_provider_challenge(
+        &self,
+        session: &ProviderPullSession,
+        challenge: &ProviderPlanChallenge,
+    ) -> Result<ProviderPlanResponse, ProtocolError> {
+        if !session.provider_enabled {
+            return Err(ProtocolError::InvalidState(
+                "this client connection has no provider transport".to_string(),
+            ));
+        }
+        validate_challenge(session, challenge)?;
+        let signature = self
+            .context
+            .provider_plan_signature(
+                &session.stream_id,
+                &session.repository,
+                &session.endpoint_id,
+                &session.plan_nonce,
+                &challenge.grant_batch_digest,
+            )
+            .map_err(hosted_to_protocol_error)?;
+        Ok(ProviderPlanResponse {
+            version: PROVIDER_VERSION,
+            plan_nonce: session.plan_nonce.to_vec(),
+            grant_batch_digest: challenge.grant_batch_digest.clone(),
+            signature,
+            accepted: true,
+        })
+    }
+
+    pub(super) fn decline_provider_challenge(
+        &self,
+        session: &ProviderPullSession,
+        challenge: Option<&ProviderPlanChallenge>,
+    ) -> ProviderPlanResponse {
+        ProviderPlanResponse {
+            version: PROVIDER_VERSION,
+            plan_nonce: session.plan_nonce.to_vec(),
+            grant_batch_digest: challenge
+                .map(|challenge| challenge.grant_batch_digest.clone())
+                .unwrap_or_default(),
+            signature: Vec::new(),
+            accepted: false,
+        }
+    }
+
+    pub(super) async fn download_provider_pull(
+        &self,
+        session: &ProviderPullSession,
+        challenge: &ProviderPlanChallenge,
+        manifest: &ApiProviderPullManifest,
+    ) -> Result<CompletedProviderPull, ProtocolError> {
+        let (wire_manifest, sources) = convert_manifest(session, challenge, manifest)?;
+        let mut bodies = Vec::with_capacity(manifest.extents.len());
+        for (extent, source) in manifest.extents.iter().zip(sources) {
+            let digest: [u8; DIGEST_LEN] = extent.digest.as_slice().try_into().map_err(|_| {
+                ProtocolError::InvalidState(
+                    "provider extent digest must be exactly 32 bytes".to_string(),
+                )
+            })?;
+            let downloaded = self
+                .download_provider_extent(source, extent.length, digest)
+                .await?;
+            bodies.push(downloaded.bytes);
+        }
+        let bundle = assemble_provider_pack(&wire_manifest, &bodies)?;
+        Ok(CompletedProviderPull {
+            pack: bundle.pack,
+            trailer_digest: bundle.trailer_digest,
+        })
+    }
+
+    async fn download_provider_extent(
+        &self,
+        source: &ProviderSource,
+        expected_length: u64,
+        expected_digest: [u8; DIGEST_LEN],
+    ) -> Result<DownloadedExtent, ProtocolError> {
+        let mut retained = Vec::new();
+        let mut previous_generation = None;
+        let mut last_retryable = None;
+
+        for _ in 0..MAX_PROVIDER_ATTEMPTS {
+            let connection = match self.connection.provider_connection(source).await {
+                Ok(connection) => connection,
+                Err(error) => {
+                    last_retryable = Some(hosted_to_protocol_error(error));
+                    continue;
+                }
+            };
+            match download_attempt(
+                &connection,
+                &source.opaque_ticket,
+                expected_length,
+                expected_digest,
+                &mut retained,
+                &mut previous_generation,
+            )
+            .await
+            {
+                Ok(_) => return Ok(DownloadedExtent { bytes: retained }),
+                Err(AttemptFailure::Retryable { error }) => last_retryable = Some(error),
+                Err(AttemptFailure::Fatal(error)) => return Err(error),
+            }
+        }
+        Err(last_retryable.unwrap_or_else(|| {
+            ProtocolError::InvalidState("provider transfer attempts exhausted".to_string())
+        }))
+    }
+}
+
+impl ProviderPullSession {
+    pub(super) fn fallback_response(&self, batch_digest: &[u8]) -> ProviderPullResponse {
+        ProviderPullResponse {
+            version: PROVIDER_VERSION,
+            plan_nonce: self.plan_nonce.to_vec(),
+            grant_batch_digest: batch_digest.to_vec(),
+            status: ProviderPullResultStatus::Fallback as i32,
+            pack_digest: Vec::new(),
+        }
+    }
+
+    pub(super) fn complete_response(
+        &self,
+        batch_digest: &[u8],
+        pack_digest: [u8; DIGEST_LEN],
+    ) -> ProviderPullResponse {
+        ProviderPullResponse {
+            version: PROVIDER_VERSION,
+            plan_nonce: self.plan_nonce.to_vec(),
+            grant_batch_digest: batch_digest.to_vec(),
+            status: ProviderPullResultStatus::Complete as i32,
+            pack_digest: pack_digest.to_vec(),
+        }
+    }
+}
+
+struct DownloadedExtent {
+    bytes: Vec<u8>,
+}
+
+fn validate_challenge(
+    session: &ProviderPullSession,
+    challenge: &ProviderPlanChallenge,
+) -> Result<(), ProtocolError> {
+    if challenge.version != PROVIDER_VERSION
+        || challenge.plan_nonce != session.plan_nonce
+        || challenge.grant_batch_digest.len() != DIGEST_LEN
+    {
+        return Err(ProtocolError::InvalidState(
+            "provider plan challenge does not match the signed opening".to_string(),
+        ));
+    }
+    let summary = challenge.summary.as_ref().ok_or_else(|| {
+        ProtocolError::InvalidState("provider plan challenge has no safe summary".to_string())
+    })?;
+    let repository = summary.repository.as_ref().ok_or_else(|| {
+        ProtocolError::InvalidState("provider plan summary has no repository".to_string())
+    })?;
+    if repository
+        != &super::helpers::repository_ref(&session.repository).ok_or_else(|| {
+            ProtocolError::InvalidState("provider session repository is invalid".to_string())
+        })?
+        || summary.extent_count == 0
+        || summary.object_count == 0
+        || summary.total_bytes == 0
+        || summary.expires_at_unix_millis <= now_millis()?
+    {
+        return Err(ProtocolError::InvalidState(
+            "provider plan summary is invalid or expired".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn convert_manifest<'a>(
+    session: &ProviderPullSession,
+    challenge: &ProviderPlanChallenge,
+    manifest: &'a ApiProviderPullManifest,
+) -> Result<(ProviderPackManifest, Vec<&'a ProviderSource>), ProtocolError> {
+    validate_challenge(session, challenge)?;
+    if manifest.version != PROVIDER_VERSION
+        || manifest.plan_nonce != session.plan_nonce
+        || manifest.grant_batch_digest != challenge.grant_batch_digest
+    {
+        return Err(ProtocolError::InvalidState(
+            "provider manifest does not match the consented exact plan".to_string(),
+        ));
+    }
+    let header: [u8; 16] = manifest.pack_header.as_slice().try_into().map_err(|_| {
+        ProtocolError::InvalidState(
+            "provider manifest pack header must be exactly 16 bytes".to_string(),
+        )
+    })?;
+    let summary = challenge.summary.as_ref().ok_or_else(|| {
+        ProtocolError::InvalidState("provider plan challenge has no safe summary".to_string())
+    })?;
+    if u64::try_from(manifest.extents.len()).ok() != Some(summary.extent_count) {
+        return Err(ProtocolError::InvalidState(
+            "provider manifest extent count differs from the consented summary".to_string(),
+        ));
+    }
+    let now = now_millis()?;
+    let mut sources = Vec::with_capacity(manifest.extents.len());
+    let mut extents = Vec::with_capacity(manifest.extents.len());
+    let mut extent_ids = HashSet::with_capacity(manifest.extents.len());
+    let mut object_count = 0_u64;
+    let mut total_bytes = 0_u64;
+    for extent in &manifest.extents {
+        let source = extent.source.as_ref().ok_or_else(|| {
+            ProtocolError::InvalidState("provider extent has no source".to_string())
+        })?;
+        if extent.extent_id.is_empty() || !extent_ids.insert(extent.extent_id.as_str()) {
+            return Err(ProtocolError::InvalidState(
+                "provider extent identity is empty or duplicated".to_string(),
+            ));
+        }
+        if source.expires_at_unix_millis <= now
+            || source.expires_at_unix_millis > summary.expires_at_unix_millis
+        {
+            return Err(ProtocolError::InvalidState(
+                "provider extent source is expired".to_string(),
+            ));
+        }
+        let digest = extent.digest.as_slice().try_into().map_err(|_| {
+            ProtocolError::InvalidState(
+                "provider extent digest must be exactly 32 bytes".to_string(),
+            )
+        })?;
+        let mut objects = Vec::with_capacity(extent.objects.len());
+        object_count = object_count
+            .checked_add(u64::try_from(extent.objects.len()).map_err(|_| {
+                ProtocolError::InvalidState(
+                    "provider manifest object count exceeds u64".to_string(),
+                )
+            })?)
+            .ok_or_else(|| {
+                ProtocolError::InvalidState("provider manifest object count overflows".to_string())
+            })?;
+        total_bytes = total_bytes.checked_add(extent.length).ok_or_else(|| {
+            ProtocolError::InvalidState("provider manifest byte count overflows".to_string())
+        })?;
+        for object in &extent.objects {
+            let descriptor = object.object.clone().ok_or_else(|| {
+                ProtocolError::InvalidState("provider index entry has no object".to_string())
+            })?;
+            let info = super::helpers::parse_descriptor_to_info(descriptor)?;
+            if !info.obj_type.packable() {
+                return Err(ProtocolError::InvalidState(
+                    "provider manifest contains a non-packable object".to_string(),
+                ));
+            }
+            let id = match info.id {
+                wire::ObjectId::Hash(hash) => PackObjectId::Hash(hash),
+                wire::ObjectId::StateId(state) => PackObjectId::StateId(state),
+                wire::ObjectId::StateAttachment { id, .. } => PackObjectId::Hash(*id.as_hash()),
+            };
+            objects.push(ProviderPackIndexEntry {
+                id,
+                output_offset: object.output_offset,
+            });
+        }
+        extents.push(ProviderPackExtent {
+            output_offset: extent.output_offset,
+            length: extent.length,
+            digest,
+            objects,
+        });
+        sources.push(source);
+    }
+    if object_count != summary.object_count || total_bytes != summary.total_bytes {
+        return Err(ProtocolError::InvalidState(
+            "provider manifest differs from the consented safe summary".to_string(),
+        ));
+    }
+    Ok((
+        ProviderPackManifest {
+            header,
+            output_pack_length: manifest.output_pack_length,
+            extents,
+        },
+        sources,
+    ))
+}
+
+#[derive(Debug)]
+enum AttemptFailure {
+    Retryable { error: ProtocolError },
+    Fatal(ProtocolError),
+}
+
+async fn download_attempt(
+    connection: &iroh::endpoint::Connection,
+    opaque_ticket: &str,
+    expected_length: u64,
+    expected_digest: [u8; DIGEST_LEN],
+    retained: &mut Vec<u8>,
+    previous_generation: &mut Option<u64>,
+) -> Result<u64, AttemptFailure> {
+    let (mut send, recv) =
+        connection
+            .open_bi()
+            .await
+            .map_err(|error| AttemptFailure::Retryable {
+                error: transport_error(error),
+            })?;
+    send_provider_frame(
+        &mut send,
+        &ProviderReadClientFrame {
+            frame: Some(provider_read_client_frame::Frame::Request(
+                ProviderReadRequest {
+                    version: PROVIDER_VERSION,
+                    opaque_ticket: opaque_ticket.to_string(),
+                },
+            )),
+        },
+    )
+    .await
+    .map_err(|error| AttemptFailure::Retryable { error })?;
+
+    let mut reader = ProviderStreamReader::new(recv);
+    let ready = read_ready(&mut reader)
+        .await
+        .map_err(AttemptFailure::Fatal)?;
+    if ready.resume_offset > expected_length
+        || ready.resume_offset > retained.len() as u64
+        || ready.remaining_length != expected_length - ready.resume_offset
+        || ready.attempt_generation == 0
+        || previous_generation.is_some_and(|previous| previous == ready.attempt_generation)
+    {
+        abort_provider_stream(&mut send, &mut reader);
+        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
+            "provider returned an invalid resume offset or attempt generation".to_string(),
+        )));
+    }
+    *previous_generation = Some(ready.attempt_generation);
+    let resume_offset = usize::try_from(ready.resume_offset).map_err(|_| {
+        AttemptFailure::Fatal(ProtocolError::InvalidState(
+            "provider resume offset exceeds this platform".to_string(),
+        ))
+    })?;
+    retained.truncate(resume_offset);
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(retained);
+    let prefix_rehashed = ready.resume_offset;
+
+    let raw_length = reader
+        .next_raw_body()
+        .await
+        .map_err(|error| AttemptFailure::Retryable { error })?;
+    if raw_length != ready.remaining_length {
+        abort_provider_stream(&mut send, &mut reader);
+        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
+            "provider raw body length does not match its resume response".to_string(),
+        )));
+    }
+
+    while let Some(chunk) = reader
+        .read_raw_chunk(PROVIDER_READ_CHUNK)
+        .await
+        .map_err(|error| AttemptFailure::Retryable { error })?
+    {
+        hasher.update(&chunk);
+        retained.extend_from_slice(&chunk);
+        send_provider_frame(
+            &mut send,
+            &ProviderReadClientFrame {
+                frame: Some(provider_read_client_frame::Frame::Checkpoint(
+                    ProviderReadCheckpoint {
+                        attempt_generation: ready.attempt_generation,
+                        acknowledged_length: retained.len() as u64,
+                        final_digest: Vec::new(),
+                    },
+                )),
+            },
+        )
+        .await
+        .map_err(|error| AttemptFailure::Retryable { error })?;
+    }
+
+    if retained.len() as u64 != expected_length || hasher.finalize().as_bytes() != &expected_digest
+    {
+        abort_provider_stream(&mut send, &mut reader);
+        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
+            "provider extent digest mismatch".to_string(),
+        )));
+    }
+    send_provider_frame(
+        &mut send,
+        &ProviderReadClientFrame {
+            frame: Some(provider_read_client_frame::Frame::Checkpoint(
+                ProviderReadCheckpoint {
+                    attempt_generation: ready.attempt_generation,
+                    acknowledged_length: expected_length,
+                    final_digest: expected_digest.to_vec(),
+                },
+            )),
+        },
+    )
+    .await
+    .map_err(|error| AttemptFailure::Retryable { error })?;
+    send.finish().map_err(|error| AttemptFailure::Retryable {
+        error: transport_error(error),
+    })?;
+    let complete = read_complete(&mut reader)
+        .await
+        .map_err(AttemptFailure::Fatal)?;
+    if !complete.success || complete.committed_length != expected_length {
+        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
+            "provider did not commit the exact verified extent".to_string(),
+        )));
+    }
+    Ok(prefix_rehashed)
+}
+
+async fn send_provider_frame(
+    send: &mut iroh::endpoint::SendStream,
+    frame: &ProviderReadClientFrame,
+) -> Result<(), ProtocolError> {
+    let encoded = encode_stream_message(&frame.encode_to_vec())
+        .map_err(|error| ProtocolError::Serialization(error.to_string()))?;
+    send.write_all(&encoded).await.map_err(transport_error)
+}
+
+async fn read_ready(reader: &mut ProviderStreamReader) -> Result<ProviderReadReady, ProtocolError> {
+    let frame = reader.next_message().await?;
+    let frame = ProviderReadServerFrame::decode(frame.as_slice())
+        .map_err(|error| ProtocolError::Serialization(error.to_string()))?;
+    match frame.frame {
+        Some(provider_read_server_frame::Frame::Ready(ready)) => Ok(ready),
+        _ => Err(ProtocolError::InvalidState(
+            "provider did not begin with ProviderReadReady".to_string(),
+        )),
+    }
+}
+
+async fn read_complete(
+    reader: &mut ProviderStreamReader,
+) -> Result<ProviderReadComplete, ProtocolError> {
+    let frame = reader.next_message().await?;
+    let frame = ProviderReadServerFrame::decode(frame.as_slice())
+        .map_err(|error| ProtocolError::Serialization(error.to_string()))?;
+    match frame.frame {
+        Some(provider_read_server_frame::Frame::Complete(complete)) => Ok(complete),
+        _ => Err(ProtocolError::InvalidState(
+            "provider did not finish with ProviderReadComplete".to_string(),
+        )),
+    }
+}
+
+struct ProviderStreamReader {
+    recv: iroh::endpoint::RecvStream,
+    buffered: Vec<u8>,
+    raw_remaining: u64,
+}
+
+impl ProviderStreamReader {
+    fn new(recv: iroh::endpoint::RecvStream) -> Self {
+        Self {
+            recv,
+            buffered: Vec::new(),
+            raw_remaining: 0,
+        }
+    }
+
+    async fn next_message(&mut self) -> Result<Vec<u8>, ProtocolError> {
+        if self.raw_remaining != 0 {
+            return Err(ProtocolError::InvalidState(
+                "provider control frame arrived within a raw body".to_string(),
+            ));
+        }
+        match self.next_frame().await? {
+            OwnedProviderFrame::Message(message) => Ok(message),
+            OwnedProviderFrame::Failure(failure) => Err(ProtocolError::Remote(failure.message)),
+            OwnedProviderFrame::RawBody(_) => Err(ProtocolError::InvalidState(
+                "provider sent a raw body where control was required".to_string(),
+            )),
+        }
+    }
+
+    async fn next_raw_body(&mut self) -> Result<u64, ProtocolError> {
+        match self.next_frame().await? {
+            OwnedProviderFrame::RawBody(length) => {
+                self.raw_remaining = length;
+                Ok(length)
+            }
+            _ => Err(ProtocolError::InvalidState(
+                "provider did not send the declared extent body".to_string(),
+            )),
+        }
+    }
+
+    async fn next_frame(&mut self) -> Result<OwnedProviderFrame, ProtocolError> {
+        loop {
+            if let Some((frame, consumed)) = decode_stream_frame(&self.buffered)
+                .map_err(|error| ProtocolError::Serialization(error.to_string()))?
+            {
+                let owned = match frame {
+                    StreamFrame::Message(message) => OwnedProviderFrame::Message(message.to_vec()),
+                    StreamFrame::Failure(failure) => OwnedProviderFrame::Failure(failure),
+                    StreamFrame::RawBody { length } => OwnedProviderFrame::RawBody(length),
+                };
+                self.buffered.drain(..consumed);
+                return Ok(owned);
+            }
+            let chunk = self
+                .recv
+                .read_chunk(MAX_CONTROL_BODY + 5)
+                .await
+                .map_err(transport_error)?
+                .ok_or_else(|| {
+                    ProtocolError::Io(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "provider stream ended before its next frame",
+                    ))
+                })?;
+            self.buffered.extend_from_slice(&chunk);
+        }
+    }
+
+    async fn read_raw_chunk(&mut self, maximum: usize) -> Result<Option<Bytes>, ProtocolError> {
+        if self.raw_remaining == 0 {
+            return Ok(None);
+        }
+        if !self.buffered.is_empty() {
+            let length = self
+                .buffered
+                .len()
+                .min(maximum.max(1))
+                .min(usize::try_from(self.raw_remaining).unwrap_or(usize::MAX));
+            let chunk = Bytes::copy_from_slice(&self.buffered[..length]);
+            self.buffered.drain(..length);
+            self.raw_remaining -= length as u64;
+            return Ok(Some(chunk));
+        }
+        let chunk = self
+            .recv
+            .read_chunk(maximum.max(1))
+            .await
+            .map_err(transport_error)?
+            .ok_or_else(|| {
+                ProtocolError::Io(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "provider stream ended within its declared body",
+                ))
+            })?;
+        let accepted = chunk
+            .len()
+            .min(usize::try_from(self.raw_remaining).unwrap_or(usize::MAX));
+        if accepted < chunk.len() {
+            self.buffered.extend_from_slice(&chunk[accepted..]);
+        }
+        self.raw_remaining -= accepted as u64;
+        Ok(Some(chunk.slice(..accepted)))
+    }
+}
+
+enum OwnedProviderFrame {
+    Message(Vec<u8>),
+    Failure(api::heddle::api::v1alpha1::CallFailure),
+    RawBody(u64),
+}
+
+fn abort_provider_stream(send: &mut iroh::endpoint::SendStream, reader: &mut ProviderStreamReader) {
+    let _ = send.reset(1_u32.into());
+    let _ = reader.recv.stop(1_u32.into());
+}
+
+fn transport_error(error: impl std::fmt::Display) -> ProtocolError {
+    ProtocolError::Io(io::Error::other(error.to_string()))
+}
+
+fn now_millis() -> Result<u64, ProtocolError> {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?
+        .as_millis();
+    u64::try_from(millis)
+        .map_err(|_| ProtocolError::InvalidState("system time exceeds u64".to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{net::Ipv4Addr, time::Duration};
+
+    use api::{
+        framing::{encode_stream_message, encode_stream_raw_body},
+        heddle::api::v1alpha1::{
+            ProviderReadServerFrame, provider_read_client_frame, provider_read_server_frame,
+        },
+        signing,
+    };
+    use crypto::{Ed25519Signer, Signer as _};
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
+
+    use super::*;
+    use crate::hosted::CallContextFactory;
+
+    #[test]
+    fn captured_exact_plan_signature_does_not_verify_for_another_plan() {
+        let signer = Ed25519Signer::generate().unwrap();
+        let context = CallContextFactory::default()
+            .with_signing_key_pem(&signer.to_pem().unwrap(), "principal:alice")
+            .unwrap();
+        let first_digest = [7; DIGEST_LEN];
+        let second_digest = [8; DIGEST_LEN];
+        let capability_context = ProviderPullCapabilityContext {
+            version: PROVIDER_VERSION,
+            client_endpoint_id: "11".repeat(32),
+            plan_nonce: vec![4; PLAN_NONCE_LEN],
+        }
+        .encode_to_vec();
+        let opening_signature = signer
+            .sign(&signing::stream_open_bytes(
+                "principal:alice",
+                "pull:one",
+                "/heddle.api.v1alpha1.RepoSyncService/Pull",
+                "acme/widgets",
+                "",
+                &capability_context,
+            ))
+            .unwrap();
+        let signature = context
+            .provider_plan_signature(
+                "pull:one",
+                "acme/widgets",
+                &"11".repeat(32),
+                &[4; PLAN_NONCE_LEN],
+                &first_digest,
+            )
+            .unwrap();
+        let replayed_bytes = signing::provider_plan_bytes(
+            "principal:alice",
+            "pull:one",
+            "acme/widgets",
+            &"11".repeat(32),
+            &[4; PLAN_NONCE_LEN],
+            &second_digest,
+        );
+
+        assert!(
+            Ed25519Signer::verify_with_public_key(
+                &replayed_bytes,
+                signer.public_key(),
+                &opening_signature,
+            )
+            .is_err(),
+            "a captured opening signature must not authorize any exact plan"
+        );
+        assert!(
+            Ed25519Signer::verify_with_public_key(
+                &replayed_bytes,
+                signer.public_key(),
+                &signature,
+            )
+            .is_err(),
+            "one exact-plan signature must not authorize a different batch digest"
+        );
+        println!(
+            "replay_resistance opening_as_plan=rejected captured_plan={} replayed_plan={} exact_plan_replay=rejected",
+            hex::encode(first_digest),
+            hex::encode(second_digest),
+        );
+    }
+
+    #[tokio::test]
+    async fn interrupted_transfer_resumes_and_rehashes_the_retained_prefix() {
+        let complete = b"retained verified prefix and resumed suffix".to_vec();
+        let resume_offset = 24_usize;
+        let expected_digest = *blake3::hash(&complete).as_bytes();
+        let (
+            first_client_endpoint,
+            first_client_connection,
+            first_server_endpoint,
+            server_connection,
+        ) = provider_connection_pair().await;
+        let first_server_connection_guard = server_connection.clone();
+        let server_bytes = complete.clone();
+        let first_server_task = tokio::spawn(async move {
+            let (mut first_send, first_recv) = server_connection.accept_bi().await.unwrap();
+            let _first_reader = expect_read_request(first_recv).await;
+            send_ready(
+                &mut first_send,
+                0,
+                1,
+                u64::try_from(server_bytes.len()).unwrap(),
+            )
+            .await;
+            first_send
+                .write_all(
+                    &encode_stream_raw_body(u64::try_from(server_bytes.len()).unwrap()).unwrap(),
+                )
+                .await
+                .unwrap();
+            first_send
+                .write_all(&server_bytes[..resume_offset])
+                .await
+                .unwrap();
+            first_send.finish().unwrap();
+        });
+        let mut retained = Vec::new();
+        let mut generation = None;
+        let first = download_attempt(
+            &first_client_connection,
+            "opaque",
+            u64::try_from(complete.len()).unwrap(),
+            expected_digest,
+            &mut retained,
+            &mut generation,
+        )
+        .await;
+        assert!(matches!(first, Err(AttemptFailure::Retryable { .. })));
+        assert_eq!(retained, complete[..resume_offset]);
+        drop(first_server_connection_guard);
+        tokio::time::timeout(Duration::from_secs(2), first_server_task)
+            .await
+            .unwrap()
+            .unwrap();
+        first_client_endpoint.close().await;
+        first_server_endpoint.close().await;
+
+        let (client_endpoint, client_connection, server_endpoint, server_connection) =
+            provider_connection_pair().await;
+        let server_connection_guard = server_connection.clone();
+        let server_bytes = complete.clone();
+        let server_task = tokio::spawn(async move {
+            let (mut second_send, second_recv) = server_connection.accept_bi().await.unwrap();
+            let mut second_reader = expect_read_request(second_recv).await;
+            send_ready(
+                &mut second_send,
+                u64::try_from(resume_offset).unwrap(),
+                2,
+                u64::try_from(server_bytes.len() - resume_offset).unwrap(),
+            )
+            .await;
+            second_send
+                .write_all(
+                    &encode_stream_raw_body(
+                        u64::try_from(server_bytes.len() - resume_offset).unwrap(),
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+            second_send
+                .write_all(&server_bytes[resume_offset..])
+                .await
+                .unwrap();
+            expect_final_checkpoint(&mut second_reader, expected_digest).await;
+            send_complete(
+                &mut second_send,
+                true,
+                u64::try_from(server_bytes.len()).unwrap(),
+            )
+            .await;
+            second_send.finish().unwrap();
+        });
+
+        let prefix_rehashed = download_attempt(
+            &client_connection,
+            "opaque",
+            u64::try_from(complete.len()).unwrap(),
+            expected_digest,
+            &mut retained,
+            &mut generation,
+        )
+        .await
+        .unwrap();
+        assert_eq!(retained, complete);
+        assert_eq!(prefix_rehashed, u64::try_from(resume_offset).unwrap());
+        tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+        drop(server_connection_guard);
+        println!(
+            "resume_correctness interrupted_at={resume_offset} resume_offset={resume_offset} prefix_rehashed={prefix_rehashed} bytes_identical=true"
+        );
+        client_endpoint.close().await;
+        server_endpoint.close().await;
+    }
+
+    #[tokio::test]
+    async fn digest_mismatch_never_sends_a_final_ack_or_advances_committed_offset() {
+        let expected = b"authorized provider bytes".to_vec();
+        let corrupt = b"tampered---provider bytes".to_vec();
+        assert_eq!(expected.len(), corrupt.len());
+        let expected_digest = *blake3::hash(&expected).as_bytes();
+        let (client_endpoint, client_connection, server_endpoint, server_connection) =
+            provider_connection_pair().await;
+        let server_task = tokio::spawn(async move {
+            let (mut send, recv) = server_connection.accept_bi().await.unwrap();
+            let mut reader = expect_read_request(recv).await;
+            send_ready(&mut send, 0, 1, u64::try_from(corrupt.len()).unwrap()).await;
+            send.write_all(&encode_stream_raw_body(u64::try_from(corrupt.len()).unwrap()).unwrap())
+                .await
+                .unwrap();
+            send.write_all(&corrupt).await.unwrap();
+            send.finish().unwrap();
+
+            let mut committed_offset = 0_u64;
+            while let Ok(frame) = reader.next_message().await {
+                let frame = ProviderReadClientFrame::decode(frame.as_slice()).unwrap();
+                if let Some(provider_read_client_frame::Frame::Checkpoint(checkpoint)) = frame.frame
+                    && !checkpoint.final_digest.is_empty()
+                    && checkpoint.final_digest == expected_digest
+                {
+                    committed_offset = checkpoint.acknowledged_length;
+                }
+            }
+            committed_offset
+        });
+
+        let mut retained = Vec::new();
+        let mut generation = None;
+        let result = download_attempt(
+            &client_connection,
+            "opaque",
+            u64::try_from(expected.len()).unwrap(),
+            expected_digest,
+            &mut retained,
+            &mut generation,
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(AttemptFailure::Fatal(ProtocolError::InvalidState(message)))
+                if message == "provider extent digest mismatch"
+        ));
+        let committed_offset = tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(committed_offset, 0);
+        println!(
+            "digest_mismatch result=rejected committed_offset={committed_offset} final_ack_sent=false"
+        );
+        client_endpoint.close().await;
+        server_endpoint.close().await;
+    }
+
+    #[test]
+    fn fallback_response_carries_no_success_digest() {
+        let session = ProviderPullSession {
+            stream_id: "pull:one".to_string(),
+            repository: "acme/widgets".to_string(),
+            endpoint_id: "11".repeat(32),
+            plan_nonce: [4; PLAN_NONCE_LEN],
+            provider_enabled: true,
+        };
+
+        let response = session.fallback_response(&[7; DIGEST_LEN]);
+
+        assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
+        assert!(response.pack_digest.is_empty());
+        println!(
+            "fallback provider=unavailable selected=existing-weft caller_protocol=unchanged success_digest_present=false"
+        );
+    }
+
+    async fn provider_connection_pair() -> (
+        Endpoint,
+        iroh::endpoint::Connection,
+        Endpoint,
+        iroh::endpoint::Connection,
+    ) {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::PROVIDER_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let server_addr = server.addr();
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let (client_connection, server_connection) =
+            tokio::join!(client.connect(server_addr, api::PROVIDER_ALPN_V1), async {
+                server
+                    .accept()
+                    .await
+                    .expect("incoming provider connection")
+                    .await
+            },);
+        (
+            client,
+            client_connection.unwrap(),
+            server,
+            server_connection.unwrap(),
+        )
+    }
+
+    async fn expect_read_request(recv: iroh::endpoint::RecvStream) -> ProviderStreamReader {
+        let mut reader = ProviderStreamReader::new(recv);
+        let frame = reader.next_message().await.unwrap();
+        let frame = ProviderReadClientFrame::decode(frame.as_slice()).unwrap();
+        assert!(matches!(
+            frame.frame,
+            Some(provider_read_client_frame::Frame::Request(
+                ProviderReadRequest {
+                    version: PROVIDER_VERSION,
+                    ..
+                }
+            ))
+        ));
+        reader
+    }
+
+    async fn expect_final_checkpoint(
+        reader: &mut ProviderStreamReader,
+        expected_digest: [u8; DIGEST_LEN],
+    ) {
+        loop {
+            let frame = reader.next_message().await.unwrap();
+            let frame = ProviderReadClientFrame::decode(frame.as_slice()).unwrap();
+            if let Some(provider_read_client_frame::Frame::Checkpoint(checkpoint)) = frame.frame
+                && !checkpoint.final_digest.is_empty()
+            {
+                assert_eq!(checkpoint.final_digest, expected_digest);
+                return;
+            }
+        }
+    }
+
+    async fn send_ready(
+        send: &mut iroh::endpoint::SendStream,
+        resume_offset: u64,
+        attempt_generation: u64,
+        remaining_length: u64,
+    ) {
+        send_server_message(
+            send,
+            ProviderReadServerFrame {
+                frame: Some(provider_read_server_frame::Frame::Ready(
+                    ProviderReadReady {
+                        resume_offset,
+                        attempt_generation,
+                        remaining_length,
+                    },
+                )),
+            },
+        )
+        .await;
+    }
+
+    async fn send_complete(
+        send: &mut iroh::endpoint::SendStream,
+        success: bool,
+        committed_length: u64,
+    ) {
+        send_server_message(
+            send,
+            ProviderReadServerFrame {
+                frame: Some(provider_read_server_frame::Frame::Complete(
+                    ProviderReadComplete {
+                        success,
+                        committed_length,
+                        error: String::new(),
+                    },
+                )),
+            },
+        )
+        .await;
+    }
+
+    async fn send_server_message(
+        send: &mut iroh::endpoint::SendStream,
+        frame: ProviderReadServerFrame,
+    ) {
+        send.write_all(&encode_stream_message(&frame.encode_to_vec()).unwrap())
+            .await
+            .unwrap();
+    }
+}

--- a/crates/client/src/hosted/provider_transport.rs
+++ b/crates/client/src/hosted/provider_transport.rs
@@ -1,0 +1,451 @@
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Arc, Mutex},
+    task::{Context, Poll},
+};
+
+use bytes::Bytes;
+use cli_shared::ClientConfig;
+use futures::{SinkExt, StreamExt, task::AtomicWaker};
+use iroh::{
+    EndpointAddr, EndpointId, TransportAddr,
+    endpoint::transports::{CustomEndpoint, CustomSender, CustomTransport, RecvInfo, Transmit},
+};
+use iroh_base::CustomAddr;
+use n0_watcher::Watchable;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::{Message, client::IntoClientRequest};
+
+use super::{HostedError, Result};
+
+const WEBSOCKET_TRANSPORT_ID: u64 = 0x6864_646c_6577_7301;
+const LANE_QUEUE_DEPTH: usize = 64;
+
+#[derive(Clone)]
+pub(super) struct ProviderWebSocketTransport {
+    inner: Arc<TransportState>,
+}
+
+struct TransportState {
+    config: ClientConfig,
+    bound: Mutex<Option<mpsc::Sender<Incoming>>>,
+    lanes: Arc<Mutex<HashMap<Vec<u8>, Lane>>>,
+}
+
+struct Lane {
+    outgoing: mpsc::Sender<Bytes>,
+    waker: Arc<AtomicWaker>,
+}
+
+enum Incoming {
+    Packet { remote: CustomAddr, data: Bytes },
+    Error(io::Error),
+}
+
+impl std::fmt::Debug for ProviderWebSocketTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProviderWebSocketTransport")
+            .field(
+                "registered_provider_lanes",
+                &self.inner.lanes.lock().map_or(0, |lanes| lanes.len()),
+            )
+            .finish()
+    }
+}
+
+impl ProviderWebSocketTransport {
+    pub(super) fn new(config: ClientConfig) -> Self {
+        Self {
+            inner: Arc::new(TransportState {
+                config,
+                bound: Mutex::new(None),
+                lanes: Arc::new(Mutex::new(HashMap::new())),
+            }),
+        }
+    }
+
+    pub(super) fn register_source(
+        &self,
+        provider_id: &str,
+        endpoint_id: &str,
+        direct_url: &str,
+        opaque_ticket: &str,
+    ) -> Result<EndpointAddr> {
+        validate_source(provider_id, direct_url, opaque_ticket)?;
+        let endpoint_id: EndpointId = endpoint_id.parse().map_err(|error| {
+            HostedError::InvalidDescriptor(format!("provider endpoint id: {error}"))
+        })?;
+        let incoming = self
+            .inner
+            .bound
+            .lock()
+            .map_err(|_| HostedError::InvalidDescriptor("provider transport lock".to_string()))?
+            .clone()
+            .ok_or_else(|| {
+                HostedError::InvalidDescriptor("provider transport is not bound".to_string())
+            })?;
+
+        let handle = fresh_handle();
+        let remote = CustomAddr::from_parts(WEBSOCKET_TRANSPORT_ID, &handle);
+        let (outgoing, receiver) = mpsc::channel(LANE_QUEUE_DEPTH);
+        let waker = Arc::new(AtomicWaker::new());
+        self.inner
+            .lanes
+            .lock()
+            .map_err(|_| HostedError::InvalidDescriptor("provider lane lock".to_string()))?
+            .insert(
+                handle.to_vec(),
+                Lane {
+                    outgoing,
+                    waker: waker.clone(),
+                },
+            );
+        tokio::spawn(run_lane(
+            direct_url.to_string(),
+            remote.clone(),
+            receiver,
+            incoming,
+            waker,
+            self.inner.config.clone(),
+        ));
+
+        Ok(EndpointAddr::from_parts(
+            endpoint_id,
+            [TransportAddr::Custom(remote)],
+        ))
+    }
+}
+
+impl CustomTransport for ProviderWebSocketTransport {
+    fn bind(&self) -> io::Result<Box<dyn CustomEndpoint>> {
+        let (incoming, receiver) = mpsc::channel(LANE_QUEUE_DEPTH * 4);
+        let mut bound = self
+            .inner
+            .bound
+            .lock()
+            .map_err(|_| io::Error::other("provider transport lock poisoned"))?;
+        if bound.replace(incoming).is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "provider transport is already bound",
+            ));
+        }
+        Ok(Box::new(BoundTransport {
+            receiver,
+            lanes: self.inner.lanes.clone(),
+            local_addrs: Watchable::new(Vec::new()),
+        }))
+    }
+}
+
+struct BoundTransport {
+    receiver: mpsc::Receiver<Incoming>,
+    lanes: Arc<Mutex<HashMap<Vec<u8>, Lane>>>,
+    local_addrs: Watchable<Vec<CustomAddr>>,
+}
+
+impl std::fmt::Debug for BoundTransport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("BoundProviderWebSocketTransport")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CustomEndpoint for BoundTransport {
+    fn watch_local_addrs(&self) -> n0_watcher::Direct<Vec<CustomAddr>> {
+        self.local_addrs.watch()
+    }
+
+    fn create_sender(&self) -> Arc<dyn CustomSender> {
+        Arc::new(WebSocketSender {
+            lanes: self.lanes.clone(),
+        })
+    }
+
+    fn poll_recv(
+        &mut self,
+        context: &mut Context<'_>,
+        buffers: &mut [io::IoSliceMut<'_>],
+        metas: &mut [noq_udp::RecvMeta],
+        recv_infos: &mut [RecvInfo],
+    ) -> Poll<io::Result<usize>> {
+        if buffers.len() != metas.len() || buffers.len() != recv_infos.len() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "provider receive batch lengths differ",
+            )));
+        }
+        if buffers.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let first = match self.receiver.poll_recv(context) {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(None) => {
+                return Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "provider WebSocket transport closed",
+                )));
+            }
+            Poll::Ready(Some(incoming)) => incoming,
+        };
+        let mut incoming = Some(first);
+        let mut count = 0;
+        while count < buffers.len() {
+            let message = match incoming.take() {
+                Some(message) => message,
+                None => match self.receiver.try_recv() {
+                    Ok(message) => message,
+                    Err(_) => break,
+                },
+            };
+            match message {
+                Incoming::Error(error) if count == 0 => return Poll::Ready(Err(error)),
+                Incoming::Error(_) => break,
+                Incoming::Packet { remote, data } => {
+                    if buffers[count].len() < data.len() {
+                        return Poll::Ready(Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "provider WebSocket datagram exceeds receive buffer",
+                        )));
+                    }
+                    buffers[count][..data.len()].copy_from_slice(&data);
+                    metas[count].len = data.len();
+                    metas[count].stride = data.len();
+                    recv_infos[count] = RecvInfo::new(remote, None);
+                    count += 1;
+                }
+            }
+        }
+        Poll::Ready(Ok(count))
+    }
+}
+
+struct WebSocketSender {
+    lanes: Arc<Mutex<HashMap<Vec<u8>, Lane>>>,
+}
+
+impl std::fmt::Debug for WebSocketSender {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ProviderWebSocketSender")
+            .finish_non_exhaustive()
+    }
+}
+
+impl CustomSender for WebSocketSender {
+    fn is_valid_send_addr(&self, address: &CustomAddr) -> bool {
+        address.id() == WEBSOCKET_TRANSPORT_ID
+    }
+
+    fn poll_send(
+        &self,
+        context: &mut Context<'_>,
+        destination: &CustomAddr,
+        _source: Option<&CustomAddr>,
+        transmit: &Transmit<'_>,
+    ) -> Poll<io::Result<()>> {
+        if destination.id() != WEBSOCKET_TRANSPORT_ID {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid provider custom transport address",
+            )));
+        }
+        let lanes = match self.lanes.lock() {
+            Ok(lanes) => lanes,
+            Err(_) => return Poll::Ready(Err(io::Error::other("provider lane lock poisoned"))),
+        };
+        let Some(lane) = lanes.get(destination.data()) else {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "provider WebSocket lane is not registered",
+            )));
+        };
+        lane.waker.register(context.waker());
+        match lane
+            .outgoing
+            .try_send(Bytes::copy_from_slice(transmit.contents))
+        {
+            Ok(()) => Poll::Ready(Ok(())),
+            Err(mpsc::error::TrySendError::Full(_)) => Poll::Pending,
+            Err(mpsc::error::TrySendError::Closed(_)) => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "provider WebSocket lane closed",
+            ))),
+        }
+    }
+}
+
+async fn run_lane(
+    direct_url: String,
+    remote: CustomAddr,
+    mut outgoing: mpsc::Receiver<Bytes>,
+    incoming: mpsc::Sender<Incoming>,
+    waker: Arc<AtomicWaker>,
+    config: ClientConfig,
+) {
+    while let Some(first) = outgoing.recv().await {
+        waker.wake();
+        let request = match direct_url.as_str().into_client_request() {
+            Ok(request) => request,
+            Err(error) => {
+                let _ = incoming
+                    .send(Incoming::Error(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        error.to_string(),
+                    )))
+                    .await;
+                continue;
+            }
+        };
+        let websocket = match crate::connect_websocket(request, &config).await {
+            Ok((websocket, _)) => websocket,
+            Err(error) => {
+                let _ = incoming
+                    .send(Incoming::Error(io::Error::other(error.to_string())))
+                    .await;
+                continue;
+            }
+        };
+        let (mut sink, mut stream) = websocket.split();
+        if sink.send(Message::Binary(first)).await.is_err() {
+            let _ = incoming
+                .send(Incoming::Error(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "provider WebSocket send failed",
+                )))
+                .await;
+            continue;
+        }
+
+        loop {
+            tokio::select! {
+                packet = outgoing.recv() => {
+                    let Some(packet) = packet else {
+                        let _ = sink.close().await;
+                        return;
+                    };
+                    waker.wake();
+                    if sink.send(Message::Binary(packet)).await.is_err() {
+                        let _ = incoming.send(Incoming::Error(io::Error::new(
+                            io::ErrorKind::BrokenPipe,
+                            "provider WebSocket send failed",
+                        ))).await;
+                        break;
+                    }
+                }
+                message = stream.next() => {
+                    match message {
+                        Some(Ok(Message::Binary(data))) => {
+                            if incoming.send(Incoming::Packet {
+                                remote: remote.clone(),
+                                data,
+                            }).await.is_err() {
+                                return;
+                            }
+                        }
+                        Some(Ok(Message::Ping(data))) => {
+                            if sink.send(Message::Pong(data)).await.is_err() {
+                                break;
+                            }
+                        }
+                        Some(Ok(Message::Pong(_))) => {}
+                        Some(Ok(Message::Close(_))) | None => {
+                            let _ = incoming.send(Incoming::Error(io::Error::new(
+                                io::ErrorKind::ConnectionReset,
+                                "provider WebSocket closed",
+                            ))).await;
+                            break;
+                        }
+                        Some(Ok(_)) => {
+                            let _ = incoming.send(Incoming::Error(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                "provider WebSocket sent a non-binary data frame",
+                            ))).await;
+                            break;
+                        }
+                        Some(Err(_)) => {
+                            let _ = incoming.send(Incoming::Error(io::Error::new(
+                                io::ErrorKind::ConnectionReset,
+                                "provider WebSocket receive failed",
+                            ))).await;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn validate_source(provider_id: &str, direct_url: &str, opaque_ticket: &str) -> Result<()> {
+    if provider_id.is_empty() || opaque_ticket.is_empty() {
+        return Err(HostedError::InvalidDescriptor(
+            "provider source identity is empty".to_string(),
+        ));
+    }
+    let url = reqwest::Url::parse(direct_url)
+        .map_err(|error| HostedError::InvalidDescriptor(format!("provider direct URL: {error}")))?;
+    if url.scheme() != "wss"
+        || url.path() != "/direct"
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(HostedError::InvalidDescriptor(
+            "provider direct URL is not a bare authenticated WSS route".to_string(),
+        ));
+    }
+    let mut provider_matches = false;
+    let mut ticket_matches = false;
+    for (name, value) in url.query_pairs() {
+        match name.as_ref() {
+            "provider" if !provider_matches && value == provider_id => provider_matches = true,
+            "ticket" if !ticket_matches && value == opaque_ticket => ticket_matches = true,
+            _ => {
+                return Err(HostedError::InvalidDescriptor(
+                    "provider direct URL has ambiguous query data".to_string(),
+                ));
+            }
+        }
+    }
+    if !provider_matches || !ticket_matches {
+        return Err(HostedError::InvalidDescriptor(
+            "provider direct URL does not match its source".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn fresh_handle() -> [u8; 16] {
+    let mut handle = [0; 16];
+    rand::fill(&mut handle);
+    handle
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_source;
+
+    #[test]
+    fn provider_url_requires_exact_provider_and_ticket_query() {
+        validate_source(
+            "provider-a",
+            "wss://iroh.example/direct?provider=provider-a&ticket=opaque",
+            "opaque",
+        )
+        .unwrap();
+
+        for invalid in [
+            "ws://iroh.example/direct?provider=provider-a&ticket=opaque",
+            "wss://iroh.example/other?provider=provider-a&ticket=opaque",
+            "wss://iroh.example/direct?provider=provider-a&ticket=opaque&ticket=other",
+            "wss://attacker@iroh.example/direct?provider=provider-a&ticket=opaque",
+        ] {
+            assert!(validate_source("provider-a", invalid, "opaque").is_err());
+        }
+    }
+}

--- a/crates/client/src/hosted/sync.rs
+++ b/crates/client/src/hosted/sync.rs
@@ -14,12 +14,13 @@ use api::heddle::api::v1alpha1::{
     GitRefKind as ProtoGitRefKind, GitRefUpdateTransfer,
     IntegrationPolicyStatus as ProtoIntegrationPolicyStatus, ListRefsRequest,
     ObjectAvailabilityStatus, ObjectDescriptor, PackChunk, PackStreamKind, PartialFetchStatus,
-    PullClientFrame, PullRequest, PullServerFrame, PushClientFrame, PushRequest, PushServerFrame,
-    RedactionTransfer, StateAttachmentTransfer, StateVisibilityTransfer, StreamOpeningProof,
-    ThreadConfidenceSummary, ThreadFreshness as ProtoThreadFreshness, ThreadIntegrationPolicy,
-    ThreadMetadata, ThreadMode as ProtoThreadMode, ThreadVerificationSummary, TransportMode,
-    UpdateRefRequest, WantObjects, git_lane_transfer, pull_client_frame, pull_server_frame,
-    push_client_frame, push_server_frame, thread_state::Kind as ProtoThreadState,
+    ProviderPlanChallenge, PullClientFrame, PullRequest, PullServerFrame, PushClientFrame,
+    PushRequest, PushServerFrame, RedactionTransfer, StateAttachmentTransfer,
+    StateVisibilityTransfer, StreamOpeningProof, ThreadConfidenceSummary,
+    ThreadFreshness as ProtoThreadFreshness, ThreadIntegrationPolicy, ThreadMetadata,
+    ThreadMode as ProtoThreadMode, ThreadVerificationSummary, TransportMode, UpdateRefRequest,
+    WantObjects, git_lane_transfer, pull_client_frame, pull_server_frame, push_client_frame,
+    push_server_frame, thread_state::Kind as ProtoThreadState,
 };
 use objects::{
     Progress,
@@ -242,6 +243,7 @@ impl HostedClient {
         route: &str,
         repository: &str,
         resume_cursor: &str,
+        capability_context: Vec<u8>,
     ) -> Result<StreamOpeningProof, ProtocolError> {
         self.stream_opening_proof(
             route,
@@ -250,7 +252,7 @@ impl HostedClient {
                 ProtocolError::InvalidState("invalid repository path".to_string())
             })?,
             resume_cursor,
-            Vec::new(),
+            capability_context,
         )
         .map_err(hosted_to_protocol_error)
     }
@@ -672,6 +674,7 @@ impl HostedClient {
                     "/heddle.api.v1alpha1.RepoSyncService/Push",
                     repo_path,
                     "",
+                    Vec::new(),
                 )?,
             )),
             client_operation_id: operation_id.to_wire(),
@@ -1134,6 +1137,8 @@ impl HostedClient {
             options.target_state,
             uuid::Uuid::new_v4(),
         );
+        let (provider_session, provider_capability_context) =
+            self.begin_provider_pull(&transfer_id, repo_path)?;
         let request_message = PullClientFrame {
             frame: Some(pull_client_frame::Frame::Request(PullRequest {
                 repo_path: super::helpers::repository_ref(repo_path),
@@ -1173,6 +1178,7 @@ impl HostedClient {
                     "/heddle.api.v1alpha1.RepoSyncService/Pull",
                     repo_path,
                     "",
+                    provider_capability_context,
                 )?,
             )),
         })
@@ -1241,11 +1247,10 @@ impl HostedClient {
         })
         .await
         .map_err(|_| ProtocolError::InvalidState("pull stream closed unexpectedly".to_string()))?;
-        drop(tx);
-        request_pump
-            .await
-            .map_err(|err| ProtocolError::InvalidState(format!("pull request task failed: {err}")))?
-            .map_err(hosted_to_protocol_error)?;
+        let mut tx = Some(tx);
+        if !native_pack_required {
+            tx.take();
+        }
 
         let receive_start = Instant::now();
         let use_pack_spool = advertised_object_count > PULL_PACK_SPOOL_OBJECT_THRESHOLD;
@@ -1259,10 +1264,40 @@ impl HostedClient {
         let mut git_pack_state = GitPackPullInstallState::default();
         let mut staged_git_lane =
             StagedGitLanePull::snapshot(repo, options.target_state.is_none())?;
+        let mut consented_provider_plan: Option<ProviderPlanChallenge> = None;
+        let mut provider_pack = None;
+        let mut provider_fallback = false;
+        let mut ordinary_pack_received = false;
         let mut received = 0usize;
         while let Some(message) = next_pull_message(&mut response).await? {
             match message.frame {
                 Some(pull_server_frame::Frame::Pack(chunk)) => {
+                    if let Some(challenge) = consented_provider_plan.as_ref()
+                        && !provider_fallback
+                        && provider_pack.is_none()
+                    {
+                        provider_fallback = true;
+                        let sender = tx.as_ref().ok_or_else(|| {
+                            ProtocolError::InvalidState(
+                                "provider negotiation closed before fallback".to_string(),
+                            )
+                        })?;
+                        sender
+                            .send(PullClientFrame {
+                                frame: Some(pull_client_frame::Frame::ProviderResult(
+                                    provider_session
+                                        .fallback_response(&challenge.grant_batch_digest),
+                                )),
+                            })
+                            .await
+                            .map_err(|_| {
+                                ProtocolError::InvalidState(
+                                    "pull stream closed during provider fallback".to_string(),
+                                )
+                            })?;
+                    }
+                    tx.take();
+                    ordinary_pack_received = true;
                     profile.bytes_received =
                         profile.bytes_received.saturating_add(chunk.data.len());
                     profile.pack_bytes_received =
@@ -1304,6 +1339,96 @@ impl HostedClient {
                     profile.pack_decode += decode_elapsed;
                     profile.pack_decode_apply += decode_elapsed;
                     profile.decode += decode_elapsed;
+                }
+                Some(pull_server_frame::Frame::ProviderChallenge(challenge)) => {
+                    let (plan, consented_challenge) = if consented_provider_plan.is_some()
+                        || provider_fallback
+                    {
+                        provider_fallback = true;
+                        consented_provider_plan = None;
+                        (
+                            self.decline_provider_challenge(&provider_session, Some(&challenge)),
+                            None,
+                        )
+                    } else {
+                        match self.answer_provider_challenge(&provider_session, &challenge) {
+                            Ok(plan) => (plan, Some(challenge.clone())),
+                            Err(_) => {
+                                provider_fallback = true;
+                                (
+                                    self.decline_provider_challenge(
+                                        &provider_session,
+                                        Some(&challenge),
+                                    ),
+                                    None,
+                                )
+                            }
+                        }
+                    };
+                    let accepted = plan.accepted;
+                    tx.as_ref()
+                        .ok_or_else(|| {
+                            ProtocolError::InvalidState(
+                                "provider challenge arrived after request completion".to_string(),
+                            )
+                        })?
+                        .send(PullClientFrame {
+                            frame: Some(pull_client_frame::Frame::ProviderPlan(plan)),
+                        })
+                        .await
+                        .map_err(|_| {
+                            ProtocolError::InvalidState(
+                                "pull stream closed during provider plan consent".to_string(),
+                            )
+                        })?;
+                    if let Some(challenge) = consented_challenge {
+                        consented_provider_plan = Some(challenge);
+                    }
+                    if !accepted {
+                        tx.take();
+                    }
+                }
+                Some(pull_server_frame::Frame::ProviderManifest(manifest)) => {
+                    let result = match consented_provider_plan.as_ref() {
+                        Some(challenge) if !provider_fallback && provider_pack.is_none() => {
+                            self.download_provider_pull(&provider_session, challenge, &manifest)
+                                .await
+                        }
+                        _ => Err(ProtocolError::InvalidState(
+                            "provider manifest arrived without one matching consent".to_string(),
+                        )),
+                    };
+                    let provider_result = match result {
+                        Ok(completed) => {
+                            let response = provider_session.complete_response(
+                                &manifest.grant_batch_digest,
+                                completed.trailer_digest,
+                            );
+                            provider_pack = Some(completed);
+                            response
+                        }
+                        Err(_) => {
+                            provider_fallback = true;
+                            provider_pack = None;
+                            provider_session.fallback_response(&manifest.grant_batch_digest)
+                        }
+                    };
+                    tx.as_ref()
+                        .ok_or_else(|| {
+                            ProtocolError::InvalidState(
+                                "provider manifest arrived after request completion".to_string(),
+                            )
+                        })?
+                        .send(PullClientFrame {
+                            frame: Some(pull_client_frame::Frame::ProviderResult(provider_result)),
+                        })
+                        .await
+                        .map_err(|_| {
+                            ProtocolError::InvalidState(
+                                "pull stream closed during provider result".to_string(),
+                            )
+                        })?;
+                    tx.take();
                 }
                 Some(pull_server_frame::Frame::Redaction(transfer)) => {
                     // Out-of-pack channel: receive a redaction sidecar
@@ -1388,35 +1513,58 @@ impl HostedClient {
                     profile.store_receive_object += decode_elapsed;
                 }
                 Some(pull_server_frame::Frame::Complete(complete)) => {
+                    tx.take();
+                    request_pump
+                        .await
+                        .map_err(|err| {
+                            ProtocolError::InvalidState(format!("pull request task failed: {err}"))
+                        })?
+                        .map_err(hosted_to_protocol_error)?;
                     profile.receive_and_apply = receive_start.elapsed();
                     git_pack_state.ensure_idle()?;
                     let final_state = super::helpers::parse_proto_state_id(complete.new_state)?;
 
                     if complete.success {
                         apply_staged_git_lane_pull(repo, &mut git_lane_repo, &mut staged_git_lane)?;
-                        if native_pack_required {
+                        if native_pack_required || provider_pack.is_some() || ordinary_pack_received
+                        {
                             let store_start = Instant::now();
-                            let installed_ids = if let Some(pack_spool) = pack_spool.as_mut() {
-                                if !pack_spool.is_complete() {
-                                    return Err(ProtocolError::InvalidState(
-                                        "pull completed before native pack stream finished"
-                                            .to_string(),
-                                    ));
-                                }
-                                pack_spool.install_into(repo.store())?
-                            } else {
-                                if !pack_state.is_complete() {
-                                    return Err(ProtocolError::InvalidState(
-                                        "pull completed before native pack stream finished"
-                                            .to_string(),
-                                    ));
-                                }
-                                wire::install_received_pack(
+                            let mut installed_ids = Vec::new();
+                            if let Some(provider_pack) = provider_pack.as_ref() {
+                                installed_ids.extend(wire::install_received_pack(
                                     repo.store(),
-                                    &pack_state.pack_data,
-                                    &pack_state.index_data,
-                                )?
-                            };
+                                    &provider_pack.pack.pack_data,
+                                    &provider_pack.pack.index_data,
+                                )?);
+                            }
+                            if ordinary_pack_received {
+                                if let Some(pack_spool) = pack_spool.as_mut() {
+                                    if !pack_spool.is_complete() {
+                                        return Err(ProtocolError::InvalidState(
+                                            "pull completed before native pack stream finished"
+                                                .to_string(),
+                                        ));
+                                    }
+                                    installed_ids.extend(pack_spool.install_into(repo.store())?);
+                                } else {
+                                    if !pack_state.is_complete() {
+                                        return Err(ProtocolError::InvalidState(
+                                            "pull completed before native pack stream finished"
+                                                .to_string(),
+                                        ));
+                                    }
+                                    installed_ids.extend(wire::install_received_pack(
+                                        repo.store(),
+                                        &pack_state.pack_data,
+                                        &pack_state.index_data,
+                                    )?);
+                                }
+                            }
+                            if installed_ids.is_empty() {
+                                return Err(ProtocolError::InvalidState(
+                                    "pull completed without its required native pack".to_string(),
+                                ));
+                            }
                             profile.store_receive_object += store_start.elapsed();
                             received = installed_ids.len();
                             for id in installed_ids {

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "4f032f4e25e8a2e1a211cd8bfe530dc867d5ca7e" }
+api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -10,6 +10,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+blake3.workspace = true
 # `objects/zstd` is forwarded via this crate's own `zstd` feature
 # instead of being hardcoded on. Hardcoding here meant every consumer
 # (repo → ingest → cli) got zstd unconditionally even

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -16,6 +16,7 @@ mod native_pack;
 mod object_availability;
 mod object_graph;
 mod object_transfer;
+mod provider_pack;
 mod transfer_plan;
 
 pub use auth_token::AuthToken;
@@ -61,6 +62,10 @@ pub use object_transfer::{
     MAX_PULL_FRAME_MESSAGE_SIZE, MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
     MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, check_received_transfer_blob_size, chunk_bounds,
     chunk_count, chunk_offset, load_object_data, load_requested_object, store_received_object,
+};
+pub use provider_pack::{
+    ProviderPackBundle, ProviderPackExtent, ProviderPackIndexEntry, ProviderPackManifest,
+    assemble_provider_pack,
 };
 pub use transfer_plan::{
     GitLaneTransferIntent, RepositoryTransferPlan, TransferPartitions, TransferPlanStats,

--- a/crates/wire/src/provider_pack.rs
+++ b/crates/wire/src/provider_pack.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::collections::HashSet;
+
+use objects::store::pack::{PackContainerSpec, PackIndex, PackObjectId, verify_container};
+
+use crate::{MAX_RECEIVED_PACK_SIZE, NativePackBundle, ProtocolError, Result};
+
+const PACK_HEADER_LEN: usize = 16;
+const PACK_TRAILER_LEN: usize = 32;
+const PACK_SPEC: PackContainerSpec = PackContainerSpec {
+    magic: b"LMPK",
+    version: 3,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderPackIndexEntry {
+    pub id: PackObjectId,
+    pub output_offset: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderPackExtent {
+    pub output_offset: u64,
+    pub length: u64,
+    pub digest: [u8; 32],
+    pub objects: Vec<ProviderPackIndexEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderPackManifest {
+    pub header: [u8; PACK_HEADER_LEN],
+    pub output_pack_length: u64,
+    pub extents: Vec<ProviderPackExtent>,
+}
+
+#[derive(Debug)]
+pub struct ProviderPackBundle {
+    pub pack: NativePackBundle,
+    pub trailer_digest: [u8; 32],
+}
+
+/// Assemble and verify one virtual native pack from provider extent bodies.
+///
+/// `extent_bodies` uses the same order as `manifest.extents`. The manifest may
+/// arrive in any order, but its output layout must cover every byte between the
+/// 16-byte header and 32-byte trailer exactly once.
+pub fn assemble_provider_pack(
+    manifest: &ProviderPackManifest,
+    extent_bodies: &[Vec<u8>],
+) -> Result<ProviderPackBundle> {
+    validate_manifest(manifest)?;
+    if extent_bodies.len() != manifest.extents.len() {
+        return Err(ProtocolError::InvalidState(format!(
+            "provider extent count mismatch: expected {}, got {}",
+            manifest.extents.len(),
+            extent_bodies.len()
+        )));
+    }
+
+    let mut order = (0..manifest.extents.len()).collect::<Vec<_>>();
+    order.sort_unstable_by_key(|index| manifest.extents[*index].output_offset);
+    let output_len = usize::try_from(manifest.output_pack_length).map_err(|_| {
+        ProtocolError::InvalidState("provider output pack exceeds this platform".to_string())
+    })?;
+    let mut pack_data = Vec::with_capacity(output_len);
+    pack_data.extend_from_slice(&manifest.header);
+    for index in order {
+        let extent = &manifest.extents[index];
+        let body = &extent_bodies[index];
+        let expected_len = usize::try_from(extent.length).map_err(|_| {
+            ProtocolError::InvalidState("provider extent exceeds this platform".to_string())
+        })?;
+        if body.len() != expected_len {
+            return Err(ProtocolError::InvalidState(format!(
+                "provider extent length mismatch: expected {}, got {}",
+                extent.length,
+                body.len()
+            )));
+        }
+        if blake3::hash(body).as_bytes() != &extent.digest {
+            return Err(ProtocolError::InvalidState(
+                "provider extent digest mismatch".to_string(),
+            ));
+        }
+        pack_data.extend_from_slice(body);
+    }
+
+    let trailer_digest = *blake3::hash(&pack_data).as_bytes();
+    pack_data.extend_from_slice(&trailer_digest);
+    if pack_data.len() != output_len {
+        return Err(ProtocolError::InvalidState(format!(
+            "provider output pack length mismatch: expected {}, got {}",
+            manifest.output_pack_length,
+            pack_data.len()
+        )));
+    }
+    verify_container(&pack_data, PACK_SPEC).map_err(ProtocolError::from)?;
+
+    let mut index = PackIndex::new();
+    for extent in &manifest.extents {
+        for object in &extent.objects {
+            index.add(object.id, object.output_offset);
+        }
+    }
+    index.sort();
+
+    Ok(ProviderPackBundle {
+        pack: NativePackBundle {
+            pack_data,
+            index_data: index.to_bytes(),
+        },
+        trailer_digest,
+    })
+}
+
+fn validate_manifest(manifest: &ProviderPackManifest) -> Result<()> {
+    if manifest.output_pack_length > MAX_RECEIVED_PACK_SIZE
+        || manifest.output_pack_length < (PACK_HEADER_LEN + PACK_TRAILER_LEN) as u64
+    {
+        return Err(ProtocolError::InvalidState(
+            "provider output pack length is invalid".to_string(),
+        ));
+    }
+    if &manifest.header[..4] != PACK_SPEC.magic
+        || u32::from_be_bytes(manifest.header[4..8].try_into().map_err(|_| {
+            ProtocolError::InvalidState("provider pack header is truncated".to_string())
+        })?) != PACK_SPEC.version
+    {
+        return Err(ProtocolError::InvalidState(
+            "provider pack header has invalid magic or version".to_string(),
+        ));
+    }
+    let object_count = u64::from_be_bytes(manifest.header[8..16].try_into().map_err(|_| {
+        ProtocolError::InvalidState("provider pack header is truncated".to_string())
+    })?);
+    let expected_body_end = manifest.output_pack_length - PACK_TRAILER_LEN as u64;
+    let mut order = manifest.extents.iter().collect::<Vec<_>>();
+    order.sort_unstable_by_key(|extent| extent.output_offset);
+    let mut next_offset = PACK_HEADER_LEN as u64;
+    let mut ids = HashSet::new();
+    let mut object_offsets = HashSet::new();
+    let mut actual_object_count = 0_u64;
+
+    for extent in order {
+        if extent.length == 0 || extent.output_offset != next_offset {
+            return Err(ProtocolError::InvalidState(
+                "provider extents do not exactly cover the virtual pack body".to_string(),
+            ));
+        }
+        next_offset = extent
+            .output_offset
+            .checked_add(extent.length)
+            .ok_or_else(|| {
+                ProtocolError::InvalidState("provider extent output range overflows".to_string())
+            })?;
+        if next_offset > expected_body_end {
+            return Err(ProtocolError::InvalidState(
+                "provider extent exceeds the virtual pack body".to_string(),
+            ));
+        }
+        for object in &extent.objects {
+            if object.output_offset < extent.output_offset
+                || object.output_offset >= next_offset
+                || !ids.insert(object.id)
+                || !object_offsets.insert(object.output_offset)
+            {
+                return Err(ProtocolError::InvalidState(
+                    "provider object index is outside its extent or duplicated".to_string(),
+                ));
+            }
+            actual_object_count = actual_object_count.checked_add(1).ok_or_else(|| {
+                ProtocolError::InvalidState("provider object count overflows".to_string())
+            })?;
+        }
+    }
+    if next_offset != expected_body_end || actual_object_count != object_count {
+        return Err(ProtocolError::InvalidState(
+            "provider manifest body or object count is incomplete".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::{
+        object::ContentHash,
+        store::{
+            CompressionConfig,
+            pack::{ObjectType, PackBuilder, PackIndex, PackObjectId},
+        },
+    };
+
+    use super::*;
+
+    fn source_pack() -> (Vec<u8>, Vec<u8>, Vec<PackObjectId>) {
+        let ids = vec![
+            PackObjectId::Hash(ContentHash::from_bytes([1; 32])),
+            PackObjectId::Hash(ContentHash::from_bytes([2; 32])),
+        ];
+        let mut builder = PackBuilder::new(CompressionConfig {
+            enabled: false,
+            ..CompressionConfig::default()
+        });
+        builder.add_id(ids[0], ObjectType::Blob, b"provider-one".to_vec());
+        builder.add_id(ids[1], ObjectType::Blob, b"provider-two".to_vec());
+        let (pack, index, _) = builder.build().unwrap();
+        (pack, index, ids)
+    }
+
+    fn split_manifest() -> (ProviderPackManifest, Vec<Vec<u8>>, Vec<u8>, Vec<u8>) {
+        let (pack, index, ids) = source_pack();
+        let parsed_index = PackIndex::from_bytes(&index).unwrap();
+        let first = parsed_index.find(&ids[0]).unwrap();
+        let second = parsed_index.find(&ids[1]).unwrap();
+        let (first_id, first_offset, second_id, second_offset) = if first < second {
+            (ids[0], first, ids[1], second)
+        } else {
+            (ids[1], second, ids[0], first)
+        };
+        let body_end = pack.len() - PACK_TRAILER_LEN;
+        let first_body = pack[first_offset as usize..second_offset as usize].to_vec();
+        let second_body = pack[second_offset as usize..body_end].to_vec();
+        let manifest = ProviderPackManifest {
+            header: pack[..PACK_HEADER_LEN].try_into().unwrap(),
+            output_pack_length: pack.len() as u64,
+            extents: vec![
+                ProviderPackExtent {
+                    output_offset: first_offset,
+                    length: first_body.len() as u64,
+                    digest: *blake3::hash(&first_body).as_bytes(),
+                    objects: vec![ProviderPackIndexEntry {
+                        id: first_id,
+                        output_offset: first_offset,
+                    }],
+                },
+                ProviderPackExtent {
+                    output_offset: second_offset,
+                    length: second_body.len() as u64,
+                    digest: *blake3::hash(&second_body).as_bytes(),
+                    objects: vec![ProviderPackIndexEntry {
+                        id: second_id,
+                        output_offset: second_offset,
+                    }],
+                },
+            ],
+        };
+        (manifest, vec![first_body, second_body], pack, index)
+    }
+
+    #[test]
+    fn provider_and_ordinary_pack_results_are_byte_identical() {
+        let (manifest, bodies, source_pack, source_index) = split_manifest();
+
+        let assembled = assemble_provider_pack(&manifest, &bodies).unwrap();
+
+        assert_eq!(assembled.pack.pack_data, source_pack);
+        assert_eq!(assembled.pack.index_data, source_index);
+        let source_digest = blake3::Hash::from_bytes(
+            source_pack[source_pack.len() - PACK_TRAILER_LEN..]
+                .try_into()
+                .unwrap(),
+        );
+        println!(
+            "byte_identical provider_digest={} weft_digest={} pack_bytes={} index_bytes={} identical=true",
+            blake3::Hash::from_bytes(assembled.trailer_digest),
+            source_digest,
+            source_pack.len(),
+            source_index.len(),
+        );
+    }
+
+    #[test]
+    fn digest_mismatch_never_produces_an_installable_pack() {
+        let (manifest, mut bodies, _, _) = split_manifest();
+        bodies[1][0] ^= 0xff;
+
+        let error = assemble_provider_pack(&manifest, &bodies).unwrap_err();
+
+        assert!(error.to_string().contains("digest mismatch"));
+    }
+
+    #[test]
+    fn manifest_gaps_and_duplicate_index_entries_fail_closed() {
+        let (mut manifest, bodies, _, _) = split_manifest();
+        manifest.extents[1].output_offset += 1;
+        assert!(assemble_provider_pack(&manifest, &bodies).is_err());
+
+        let (mut manifest, bodies, _, _) = split_manifest();
+        manifest.extents[1].objects[0].id = manifest.extents[0].objects[0].id;
+        assert!(assemble_provider_pack(&manifest, &bodies).is_err());
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -168,7 +168,7 @@ allow-registry = ["https://github.com/rust-lang/crates.io-index"]
 # when they move to the registry package.
 allow-git = [
     "https://github.com/HeddleCo/api",
-    # Native transport is pinned to an audited Iroh revision until the
-    # corresponding 1.0.2 crates.io release carries the required fixes.
-    "https://github.com/n0-computer/iroh",
+    # Provider transport is pinned to the reviewable HeddleCo fork until
+    # custom-transport backpressure is available in an upstream release.
+    "https://github.com/HeddleCo/iroh",
 ]


### PR DESCRIPTION
## Summary

- add the client-authorized two-phase provider negotiation to the existing signed pull stream: the opening binds version, actual client Iroh endpoint, and a one-use nonce; the second signature consents to one exact grant-batch digest with the same cnf key
- add one pooled Iroh connection per cryptographic provider endpoint over a bounded WSS custom transport, reuse it across extents, and preserve custom-transport backpressure
- download only opaque logical extents, resume from server-selected offsets with retained-prefix rehashing, and send the final digest only after the complete extent verifies
- assemble a virtual LMPK from storage-coordinate-free output extents, compute the 32-byte BLAKE3 trailer locally, validate the container and index, and install nothing until the logical pull completes
- silently retain the existing multi-Want Weft path when provider negotiation is absent, declined, unavailable, interrupted, malformed, or digest-mismatched; callers still receive one PullComplete

Merge order: 1. HeddleCo/api#62, 2. this Heddle client/fallback PR, 3. the Weft server/Worker integration in HeddleCo/weft#892. This client safely half-closes into the current ordinary pack stream when Weft does not challenge; Weft must only challenge openings that advertise the v1 capability context.

The Iroh fork is needed client-side. This PR pins HeddleCo/iroh#1 at `6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6` and enables `unstable-custom-transports` plus `unstable-custom-transport-backpressure`; it does not enable the Worker-only custom runtime hook. The authoritative document names base commit `e8415b1ff21f104504f76feac030860c8e7beae4`, but that commit does not contain the requested backpressure feature, so the document's SHA and feature statement are internally inconsistent.

Weft/Worker contract required by this client:

- decode provider capability context only after verifying StreamOpeningProof; require v1, a 16-byte one-use nonce, and equality between the claimed client endpoint and the transport-observed peer, while binding grants only to the observed endpoint
- independently authorize the closed multi-Want object plan with the owner-rooted capability; the cnf signature is consent and possession proof, never repository authorization
- construct one immutable private grant batch and domain-separated BLAKE3 digest covering subject, repository, observed endpoint, nonce, provider endpoint, private R2 key/ETag/source range/digest, output layout/object identity, and expiry; Worker must use the same canonical encoder
- challenge before emitting ordinary transfer frames, with exact provider-only object/extent/byte totals and expiry but no R2 coordinates; verify an accepted response against the same cnf key, nonce, and digest
- forward the exact private batch, client signature, and owner chain to the broker/Worker; on success send a manifest echoing the digest/nonce with a complete 16-byte LMPK v3 header, output-only extents and object offsets, digests, endpoint, direct WSS URL, opaque ticket, and expiry
- accept `provider/1` Iroh streams containing a ticket-only read request; return server-selected resumeOffset, a fresh nonzero attemptGeneration, and exact remaining length; reject stale generations
- stream the declared raw body, treat ordinary checkpoints as resumable progress only, and commit completion only after the exact final 32-byte digest; failure or mismatch must leave the completed/committed offset unchanged
- after a decline, malformed/missing response, timeout, provider FALLBACK result, or any install failure, install no Worker grant and continue the same authorized request through the existing multi-Want Pack/sidecar/Complete path
- after provider COMPLETE, require the exact client-computed LMPK trailer digest before treating the provider transfer as complete; provider and ordinary packs may both be emitted for one logical pull
- do not wait for request EOF before sending a challenge or manifest; the client half-closes after decline/result or when ordinary transfer begins

Deferred until the parallel Weft half is available: a live cross-repository Weft/broker/Cloudflare Worker end-to-end run. The provider framing, direct Iroh transfer, resume/digest behavior, virtual-pack assembly, and ordinary fallback decision are covered locally; production grant installation and live WSS transport remain the integration gate for HeddleCo/weft#892.

## Closes

Refs HeddleCo/weft#892

## Test evidence

- `CARGO_HOME=/home/scratch/heddle-provider/cargo-home TMPDIR=/home/scratch cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker`
- `CARGO_HOME=/home/scratch/heddle-provider/cargo-home TMPDIR=/home/scratch cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings`
- `CARGO_HOME=/home/scratch/heddle-provider/cargo-home TMPDIR=/home/scratch cargo test --locked --workspace`
- `cargo test --locked -p heddle-client provider_ -- --nocapture`: 6 passed; digest mismatch rejected with committed offset 0 and no final ack, captured proof/different-plan replay rejected, interrupted transfer resumed at byte 24 after rehashing all 24 retained bytes, provider unavailability selected FALLBACK, and one provider connection was reused
- `cargo test --locked -p heddle-wire provider_pack -- --nocapture`: 3 passed; provider and ordinary paths produced identical 142-byte packs and 98-byte indexes with trailer `866c1fc447fa044ae18ce3f6c92c1bce04be13fcc7abeecd03adfebdbb94e6ef`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1163"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788036431&installation_model_id=21489&pr_number=1163&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1163&signature=8b592660ce7a276e38c955164e1b8e33178fd3db7db4bb5001bab7cf0be83405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->