### PR TITLE
Provider pull: bounded concurrent fan-out and streaming assembly

### DIFF
--- a/crates/cli-shared/src/client_config.rs
+++ b/crates/cli-shared/src/client_config.rs
@@ -53,6 +53,14 @@ pub struct ClientConfig {
     pub pack_transfer: bool,
     /// Enable partial fetch negotiation.
     pub partial_fetch: bool,
+    /// Maximum provider extent streams active across all provider endpoints.
+    pub provider_global_concurrency: usize,
+    /// Maximum provider extent streams multiplexed over one endpoint connection.
+    pub provider_per_endpoint_concurrency: usize,
+    /// Maximum provider body bytes retained between transport reads and spool writes.
+    pub provider_max_inflight_bytes: usize,
+    /// Maximum seconds without provider transport progress before falling back.
+    pub provider_stall_timeout_secs: u64,
 }
 
 impl ClientConfig {
@@ -78,6 +86,10 @@ impl ClientConfig {
             resumable_transfer: true,
             pack_transfer: true,
             partial_fetch: true,
+            provider_global_concurrency: 4,
+            provider_per_endpoint_concurrency: 2,
+            provider_max_inflight_bytes: 8 * 1024 * 1024,
+            provider_stall_timeout_secs: 15,
         }
     }
 
@@ -175,6 +187,30 @@ impl ClientConfig {
         self
     }
 
+    /// Set the maximum number of provider extent streams active globally.
+    pub fn with_provider_global_concurrency(mut self, concurrency: usize) -> Self {
+        self.provider_global_concurrency = concurrency.max(1);
+        self
+    }
+
+    /// Set the maximum provider extent streams multiplexed over one endpoint.
+    pub fn with_provider_per_endpoint_concurrency(mut self, concurrency: usize) -> Self {
+        self.provider_per_endpoint_concurrency = concurrency.max(1);
+        self
+    }
+
+    /// Set the provider body-byte budget shared by all active extent streams.
+    pub fn with_provider_max_inflight_bytes(mut self, bytes: usize) -> Self {
+        self.provider_max_inflight_bytes = bytes.max(1);
+        self
+    }
+
+    /// Set the provider transport progress threshold before ordinary Weft fallback.
+    pub fn with_provider_stall_timeout(mut self, secs: u64) -> Self {
+        self.provider_stall_timeout_secs = secs.max(1);
+        self
+    }
+
     /// Explicitly allow cleartext to non-loopback addresses.
     pub fn with_allow_insecure(mut self, allow: bool) -> Self {
         self.allow_insecure = allow;
@@ -243,5 +279,24 @@ mod tests {
         assert!(is_loopback_ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
         assert!(is_loopback_ip(IpAddr::V6(Ipv6Addr::LOCALHOST)));
         assert!(!is_loopback_ip(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1))));
+    }
+
+    #[test]
+    fn provider_scheduler_defaults_and_builders_are_explicit() {
+        let defaults = ClientConfig::default();
+        assert_eq!(defaults.provider_global_concurrency, 4);
+        assert_eq!(defaults.provider_per_endpoint_concurrency, 2);
+        assert_eq!(defaults.provider_max_inflight_bytes, 8 * 1024 * 1024);
+        assert_eq!(defaults.provider_stall_timeout_secs, 15);
+
+        let configured = ClientConfig::default()
+            .with_provider_global_concurrency(8)
+            .with_provider_per_endpoint_concurrency(3)
+            .with_provider_max_inflight_bytes(4 * 1024 * 1024)
+            .with_provider_stall_timeout(20);
+        assert_eq!(configured.provider_global_concurrency, 8);
+        assert_eq!(configured.provider_per_endpoint_concurrency, 3);
+        assert_eq!(configured.provider_max_inflight_bytes, 4 * 1024 * 1024);
+        assert_eq!(configured.provider_stall_timeout_secs, 20);
     }
 }

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -165,6 +165,14 @@ pub struct UserRemoteConfig {
     pub iroh_descriptor_key_id: Option<String>,
     #[serde(default)]
     pub iroh_descriptor_public_key_path: Option<PathBuf>,
+    #[serde(default)]
+    pub provider_global_concurrency: Option<usize>,
+    #[serde(default)]
+    pub provider_per_endpoint_concurrency: Option<usize>,
+    #[serde(default)]
+    pub provider_max_inflight_bytes: Option<usize>,
+    #[serde(default)]
+    pub provider_stall_timeout_secs: Option<u64>,
     /// Allow cleartext connections to non-loopback hosts without TLS.
     /// Prefer enabling TLS; this is an explicit opt-in for lab/VPN testing.
     #[serde(default)]
@@ -486,6 +494,18 @@ impl UserConfig {
                 "both descriptor trust fields are required".to_string(),
             ));
         }
+        if let Some(value) = self.remote.provider_global_concurrency {
+            config = config.with_provider_global_concurrency(value);
+        }
+        if let Some(value) = self.remote.provider_per_endpoint_concurrency {
+            config = config.with_provider_per_endpoint_concurrency(value);
+        }
+        if let Some(value) = self.remote.provider_max_inflight_bytes {
+            config = config.with_provider_max_inflight_bytes(value);
+        }
+        if let Some(value) = self.remote.provider_stall_timeout_secs {
+            config = config.with_provider_stall_timeout(value);
+        }
 
         if env_bool("HEDDLE_REMOTE_TLS")? {
             config = config.with_tls(false);
@@ -531,6 +551,20 @@ impl UserConfig {
                     format!("read environment value: {error}"),
                 ));
             }
+        }
+        if let Some(value) = env_positive::<usize>("HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY")? {
+            config = config.with_provider_global_concurrency(value);
+        }
+        if let Some(value) =
+            env_positive::<usize>("HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY")?
+        {
+            config = config.with_provider_per_endpoint_concurrency(value);
+        }
+        if let Some(value) = env_positive::<usize>("HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES")? {
+            config = config.with_provider_max_inflight_bytes(value);
+        }
+        if let Some(value) = env_positive::<u64>("HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS")? {
+            config = config.with_provider_stall_timeout(value);
         }
         Ok(config)
     }
@@ -628,6 +662,33 @@ fn env_bool(name: &str) -> anyhow::Result<bool> {
     }
 }
 
+fn env_positive<T>(name: &str) -> anyhow::Result<Option<T>>
+where
+    T: std::str::FromStr + PartialEq + Default,
+    T::Err: std::fmt::Display,
+{
+    let value = match env::var(name) {
+        Ok(value) => value,
+        Err(env::VarError::NotPresent) => return Ok(None),
+        Err(err @ env::VarError::NotUnicode(_)) => {
+            return Err(config_value_error(
+                name,
+                format!("read environment value: {err}"),
+            ));
+        }
+    };
+    let parsed = value.trim().parse::<T>().map_err(|error| {
+        config_value_error(name, format!("parse positive integer value: {error}"))
+    })?;
+    if parsed == T::default() {
+        return Err(config_value_error(
+            name,
+            "value must be greater than zero".to_string(),
+        ));
+    }
+    Ok(Some(parsed))
+}
+
 fn config_value_error(setting: &str, reason: String) -> anyhow::Error {
     anyhow::anyhow!("fatal configuration error for `{setting}`: {reason}")
 }
@@ -668,6 +729,10 @@ mod tests {
         "HEDDLE_REMOTE_INSECURE",
         "HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID",
         "HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY",
+        "HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY",
+        "HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY",
+        "HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES",
+        "HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS",
         "HEDDLE_AUTO_CAPTURE",
     ];
 
@@ -812,6 +877,50 @@ mod tests {
         assert!(config.token.is_none());
         assert!(config.descriptor_key_id.is_none());
         assert!(config.descriptor_public_key.is_none());
+        assert_eq!(config.provider_global_concurrency, 4);
+        assert_eq!(config.provider_per_endpoint_concurrency, 2);
+        assert_eq!(config.provider_max_inflight_bytes, 8 * 1024 * 1024);
+        assert_eq!(config.provider_stall_timeout_secs, 15);
+    }
+
+    #[test]
+    fn heddle_client_config_loads_provider_knobs_from_user_config_and_env() {
+        let env = RemoteEnvGuard::clean();
+        env.set("HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY", "16");
+        env.set("HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES", "33554432");
+        let user: UserConfig = toml::from_str(
+            r#"
+                [remote]
+                provider_global_concurrency = 8
+                provider_per_endpoint_concurrency = 4
+                provider_max_inflight_bytes = 16777216
+                provider_stall_timeout_secs = 30
+            "#,
+        )
+        .unwrap();
+
+        let config = user.heddle_client_config(None).unwrap();
+
+        assert_eq!(config.provider_global_concurrency, 16);
+        assert_eq!(config.provider_per_endpoint_concurrency, 4);
+        assert_eq!(config.provider_max_inflight_bytes, 32 * 1024 * 1024);
+        assert_eq!(config.provider_stall_timeout_secs, 30);
+    }
+
+    #[test]
+    fn heddle_client_config_rejects_invalid_provider_env_knob() {
+        let env = RemoteEnvGuard::clean();
+        env.set("HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS", "0");
+
+        let error = UserConfig::default()
+            .heddle_client_config(None)
+            .expect_err("zero provider timeout must be rejected");
+
+        assert!(
+            error
+                .to_string()
+                .contains("HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS")
+        );
     }
 
     #[test]

--- a/crates/client/src/hosted/connection.rs
+++ b/crates/client/src/hosted/connection.rs
@@ -17,7 +17,8 @@ pub(super) struct HostedConnection {
     pub(super) endpoint: Endpoint,
     pub(super) connection: iroh::endpoint::Connection,
     provider_transport: Option<ProviderWebSocketTransport>,
-    provider_connections: Mutex<HashMap<EndpointId, iroh::endpoint::Connection>>,
+    provider_connections:
+        Mutex<HashMap<EndpointId, Arc<Mutex<Option<iroh::endpoint::Connection>>>>>,
 }
 
 impl HostedConnection {
@@ -82,13 +83,20 @@ impl HostedConnection {
         let endpoint_id: EndpointId = source.endpoint_id.parse().map_err(|error| {
             HostedError::InvalidDescriptor(format!("provider endpoint id: {error}"))
         })?;
-        let mut connections = self.provider_connections.lock().await;
-        if let Some(connection) = connections.get(&endpoint_id)
+        let slot = {
+            let mut connections = self.provider_connections.lock().await;
+            Arc::clone(
+                connections
+                    .entry(endpoint_id)
+                    .or_insert_with(|| Arc::new(Mutex::new(None))),
+            )
+        };
+        let mut cached = slot.lock().await;
+        if let Some(connection) = cached.as_ref()
             && connection.close_reason().is_none()
         {
             return Ok(connection.clone());
         }
-        connections.remove(&endpoint_id);
 
         let transport = self.provider_transport.as_ref().ok_or_else(|| {
             HostedError::InvalidDescriptor(
@@ -106,7 +114,7 @@ impl HostedConnection {
             .connect(address, api::PROVIDER_ALPN_V1)
             .await
             .map_err(HostedError::transport)?;
-        connections.insert(endpoint_id, connection.clone());
+        *cached = Some(connection.clone());
         Ok(connection)
     }
 
@@ -138,10 +146,11 @@ fn transport_config() -> QuicTransportConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, time::Duration};
+    use std::{net::Ipv4Addr, sync::Arc, time::Duration};
 
     use api::heddle::api::v1alpha1::ProviderSource;
     use iroh::{Endpoint, RelayMode, endpoint::presets};
+    use tokio::sync::Mutex;
 
     use super::HostedConnection;
 
@@ -217,11 +226,10 @@ mod tests {
         let connection = HostedConnection::connect(client, server_addr)
             .await
             .unwrap();
-        connection
-            .provider_connections
-            .lock()
-            .await
-            .insert(server_id, connection.connection.clone());
+        connection.provider_connections.lock().await.insert(
+            server_id,
+            Arc::new(Mutex::new(Some(connection.connection.clone()))),
+        );
 
         let reused = connection
             .provider_connection(&ProviderSource {

--- a/crates/client/src/hosted/helpers.rs
+++ b/crates/client/src/hosted/helpers.rs
@@ -1,4 +1,5 @@
 use core::convert::TryFrom;
+use std::time::Duration;
 
 use api::heddle::api::v1alpha1::{
     HostedGrant, HostedNamespace, HostedObjectType, HostedRepository, ObjectAvailabilityStatus,
@@ -17,16 +18,27 @@ pub(crate) struct HostedTransportPolicy {
     pub chunk_size: usize,
     pub max_inflight_objects: usize,
     pub resume_attempts: usize,
+    pub provider_global_concurrency: usize,
+    pub provider_per_endpoint_concurrency: usize,
+    pub provider_max_inflight_bytes: usize,
+    pub provider_stall_timeout: Duration,
 }
 
 impl HostedTransportPolicy {
     pub fn from_client_config(config: &ClientConfig) -> Self {
         let chunk_size = config.chunk_size.max(1);
         let max_inflight_objects = (chunk_size / (16 * 1024)).clamp(1, 16);
+        let provider_global_concurrency = config.provider_global_concurrency.clamp(1, 64);
         Self {
             chunk_size,
             max_inflight_objects,
             resume_attempts: 2,
+            provider_global_concurrency,
+            provider_per_endpoint_concurrency: config
+                .provider_per_endpoint_concurrency
+                .clamp(1, provider_global_concurrency),
+            provider_max_inflight_bytes: config.provider_max_inflight_bytes.max(1),
+            provider_stall_timeout: Duration::from_secs(config.provider_stall_timeout_secs.max(1)),
         }
     }
 

--- a/crates/client/src/hosted/provider_pull.rs
+++ b/crates/client/src/hosted/provider_pull.rs
@@ -5,9 +5,9 @@ use std::{
     path::Path,
     sync::{
         Arc,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 
 use api::{
@@ -22,12 +22,12 @@ use api::{
 };
 use bytes::Bytes;
 use futures::{StreamExt as _, stream::FuturesUnordered};
-use objects::store::PackObjectId;
+use objects::store::{AnyStore, PackObjectId};
 use prost::Message;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use wire::{
-    CompletedProviderPack, ProtocolError, ProviderPackExtent, ProviderPackIndexEntry,
-    ProviderPackManifest, ProviderPackSpool, ProviderPackWriter,
+    ProtocolError, ProviderPackExtent, ProviderPackIndexEntry, ProviderPackManifest,
+    ProviderPackSpool, ProviderPackWriter,
 };
 
 use super::{
@@ -41,6 +41,8 @@ const DIGEST_LEN: usize = 32;
 const PROVIDER_READ_CHUNK: usize = 1024 * 1024;
 const PROVIDER_CONTROL_CHUNK: usize = 16 * 1024;
 const MAX_PROVIDER_CONTROL_BODY: usize = 64 * 1024;
+const PROVIDER_FALLBACK_MARGIN: Duration = Duration::from_secs(1);
+const MAX_FALLBACK_REASON_LEN: usize = 96;
 // These are resumptions inside one installed opaque grant. Retrying the signed
 // provider plan itself still requires a new pull challenge and nonce.
 const MAX_PROVIDER_RESUME_ATTEMPTS: usize = 3;
@@ -55,8 +57,156 @@ pub(super) struct ProviderPullSession {
 }
 
 pub(super) struct CompletedProviderPull {
-    pub(super) pack: CompletedProviderPack,
+    pub(super) installed_ids: Vec<PackObjectId>,
     pub(super) trailer_digest: [u8; DIGEST_LEN],
+    fallback_deadline: tokio::time::Instant,
+    signed_expiry_millis: u64,
+    evidence: Arc<ProviderPullEvidence>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProviderFailureStage {
+    Expiry,
+    Connect,
+    Carrier,
+    Stall,
+    MalformedResume,
+    Digest,
+    Spool,
+    Install,
+    Manifest,
+}
+
+impl ProviderFailureStage {
+    const fn as_str(self) -> &'static str {
+        match self {
+            Self::Expiry => "expiry",
+            Self::Connect => "connect",
+            Self::Carrier => "carrier",
+            Self::Stall => "stall",
+            Self::MalformedResume => "malformed_resume",
+            Self::Digest => "digest",
+            Self::Spool => "spool",
+            Self::Install => "install",
+            Self::Manifest => "manifest",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ProviderPullEvidence {
+    endpoint_count: usize,
+    extent_count: usize,
+    completed_by_extent: Vec<AtomicU64>,
+    reconnect_attempts: AtomicUsize,
+    started: Instant,
+}
+
+impl ProviderPullEvidence {
+    fn new(endpoint_count: usize, extent_count: usize) -> Arc<Self> {
+        Arc::new(Self {
+            endpoint_count,
+            extent_count,
+            completed_by_extent: (0..extent_count).map(|_| AtomicU64::new(0)).collect(),
+            reconnect_attempts: AtomicUsize::new(0),
+            started: Instant::now(),
+        })
+    }
+
+    fn from_manifest(manifest: &ApiProviderPullManifest) -> Arc<Self> {
+        let endpoint_count = manifest
+            .extents
+            .iter()
+            .filter_map(|extent| extent.source.as_ref())
+            .map(|source| source.endpoint_id.as_str())
+            .collect::<HashSet<_>>()
+            .len();
+        Self::new(endpoint_count, manifest.extents.len())
+    }
+
+    fn set_completed(&self, extent_index: usize, completed: u64) {
+        if let Some(value) = self.completed_by_extent.get(extent_index) {
+            value.store(completed, Ordering::Release);
+        }
+    }
+
+    fn completed_bytes(&self) -> u64 {
+        self.completed_by_extent
+            .iter()
+            .map(|value| value.load(Ordering::Acquire))
+            .sum()
+    }
+
+    fn record_reconnect(&self) {
+        self.reconnect_attempts.fetch_add(1, Ordering::AcqRel);
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct ProviderPullFailure {
+    stage: ProviderFailureStage,
+    reason: &'static str,
+    error: ProtocolError,
+    evidence: Arc<ProviderPullEvidence>,
+}
+
+pub(super) fn rejected_provider_manifest(
+    manifest: &ApiProviderPullManifest,
+    error: ProtocolError,
+) -> ProviderPullFailure {
+    ProviderPullFailure::new(
+        ProviderFailureStage::Manifest,
+        "provider_manifest_without_consent",
+        error,
+        ProviderPullEvidence::from_manifest(manifest),
+    )
+}
+
+impl ProviderPullFailure {
+    fn new(
+        stage: ProviderFailureStage,
+        reason: &'static str,
+        error: ProtocolError,
+        evidence: Arc<ProviderPullEvidence>,
+    ) -> Self {
+        debug_assert!(reason.len() <= MAX_FALLBACK_REASON_LEN);
+        Self {
+            stage,
+            reason,
+            error,
+            evidence,
+        }
+    }
+
+    fn emit(&self) {
+        tracing::warn!(
+            stage = self.stage.as_str(),
+            reason = self.reason,
+            endpoint_count = self.evidence.endpoint_count,
+            extent_count = self.evidence.extent_count,
+            completed_bytes = self.evidence.completed_bytes(),
+            reconnect_attempts = self.evidence.reconnect_attempts.load(Ordering::Acquire),
+            elapsed_ms = self.evidence.started.elapsed().as_millis(),
+            "provider pull selected ordinary Weft fallback"
+        );
+    }
+}
+
+impl std::fmt::Display for ProviderPullFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "provider pull failed at {}: {}",
+            self.stage.as_str(),
+            self.reason
+        )
+    }
+}
+
+impl std::error::Error for ProviderPullFailure {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(&self.error)
+    }
 }
 
 impl HostedClient {
@@ -139,8 +289,27 @@ impl HostedClient {
         challenge: &ProviderPlanChallenge,
         manifest: &ApiProviderPullManifest,
         spool_root: &Path,
-    ) -> Result<CompletedProviderPull, ProtocolError> {
-        let (wire_manifest, sources) = convert_manifest(session, challenge, manifest)?;
+        store: AnyStore,
+    ) -> Result<CompletedProviderPull, ProviderPullFailure> {
+        let evidence = ProviderPullEvidence::from_manifest(manifest);
+        let signed_expiry = minimum_signed_expiry(challenge, manifest).map_err(|error| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Manifest,
+                "signed_expiry_missing",
+                error,
+                Arc::clone(&evidence),
+            )
+        })?;
+        let deadline = ProviderPlanDeadline::new(signed_expiry, Arc::clone(&evidence))?;
+        let (wire_manifest, sources) =
+            convert_manifest(session, challenge, manifest).map_err(|error| {
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Manifest,
+                    "provider_manifest_rejected",
+                    error,
+                    Arc::clone(&evidence),
+                )
+            })?;
         let extents = wire_manifest
             .extents
             .iter()
@@ -154,22 +323,41 @@ impl HostedClient {
             })
             .collect();
         let backend = HostedProviderBackend { client: self };
-        let download = download_provider_plan(
-            spool_root,
-            wire_manifest,
-            extents,
-            &backend,
-            &self.transport,
-        )
-        .await?;
+        let operation = async {
+            let download = download_provider_plan_with_evidence(
+                spool_root,
+                wire_manifest,
+                extents,
+                &backend,
+                &self.transport,
+                Arc::clone(&evidence),
+            )
+            .await?;
+            finish_and_install_provider_pack(download, store, Arc::clone(&evidence)).await
+        };
+        let completed = tokio::time::timeout_at(deadline.fallback_deadline, operation)
+            .await
+            .map_err(|_| {
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Expiry,
+                    "signed_deadline_margin_elapsed",
+                    ProtocolError::InvalidState(
+                        "provider signed deadline margin elapsed".to_string(),
+                    ),
+                    Arc::clone(&evidence),
+                )
+            })??;
         tracing::debug!(
-            peak_inflight_bytes = download.peak_inflight_bytes,
+            peak_inflight_bytes = completed.peak_inflight_bytes,
             configured_bytes = self.transport.provider_max_inflight_bytes,
             "provider pull byte-budget high-water mark"
         );
         Ok(CompletedProviderPull {
-            trailer_digest: download.pack.trailer_digest,
-            pack: download.pack,
+            installed_ids: completed.installed_ids,
+            trailer_digest: completed.trailer_digest,
+            fallback_deadline: deadline.fallback_deadline,
+            signed_expiry_millis: deadline.signed_expiry_millis,
+            evidence,
         })
     }
 }
@@ -202,16 +390,97 @@ impl ProviderPullSession {
     pub(super) fn resolve_download(
         &self,
         batch_digest: &[u8],
-        result: Result<CompletedProviderPull, ProtocolError>,
+        result: Result<CompletedProviderPull, ProviderPullFailure>,
     ) -> (ProviderPullResponse, Option<CompletedProviderPull>) {
         match result {
-            Ok(completed) => (
-                self.complete_response(batch_digest, completed.trailer_digest),
-                Some(completed),
-            ),
-            Err(_) => (self.fallback_response(batch_digest), None),
+            Ok(completed)
+                if tokio::time::Instant::now() < completed.fallback_deadline
+                    && now_millis().is_ok_and(|now| now < completed.signed_expiry_millis) =>
+            {
+                let response = self.complete_response(batch_digest, completed.trailer_digest);
+                (response, Some(completed))
+            }
+            Ok(completed) => {
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Expiry,
+                    "complete_missed_signed_deadline_margin",
+                    ProtocolError::InvalidState(
+                        "provider completion missed signed deadline margin".to_string(),
+                    ),
+                    Arc::clone(&completed.evidence),
+                )
+                .emit();
+                (self.fallback_response(batch_digest), None)
+            }
+            Err(error) => {
+                error.emit();
+                (self.fallback_response(batch_digest), None)
+            }
         }
     }
+}
+
+#[derive(Clone, Copy)]
+struct ProviderPlanDeadline {
+    fallback_deadline: tokio::time::Instant,
+    signed_expiry_millis: u64,
+}
+
+impl ProviderPlanDeadline {
+    fn new(
+        signed_expiry_millis: u64,
+        evidence: Arc<ProviderPullEvidence>,
+    ) -> Result<Self, ProviderPullFailure> {
+        let now = now_millis().map_err(|error| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Expiry,
+                "system_deadline_unavailable",
+                error,
+                Arc::clone(&evidence),
+            )
+        })?;
+        let remaining = signed_expiry_millis.checked_sub(now).ok_or_else(|| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Expiry,
+                "signed_deadline_expired",
+                ProtocolError::InvalidState("provider signed deadline expired".to_string()),
+                Arc::clone(&evidence),
+            )
+        })?;
+        let margin_millis = u64::try_from(PROVIDER_FALLBACK_MARGIN.as_millis()).unwrap_or(u64::MAX);
+        let provider_window = remaining.checked_sub(margin_millis).ok_or_else(|| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Expiry,
+                "insufficient_fallback_margin",
+                ProtocolError::InvalidState(
+                    "provider signed deadline leaves no fallback margin".to_string(),
+                ),
+                evidence,
+            )
+        })?;
+        Ok(Self {
+            fallback_deadline: tokio::time::Instant::now() + Duration::from_millis(provider_window),
+            signed_expiry_millis,
+        })
+    }
+}
+
+fn minimum_signed_expiry(
+    challenge: &ProviderPlanChallenge,
+    manifest: &ApiProviderPullManifest,
+) -> Result<u64, ProtocolError> {
+    let summary = challenge.summary.as_ref().ok_or_else(|| {
+        ProtocolError::InvalidState("provider plan challenge has no safe summary".to_string())
+    })?;
+    manifest
+        .extents
+        .iter()
+        .try_fold(summary.expires_at_unix_millis, |minimum, extent| {
+            let source = extent.source.as_ref().ok_or_else(|| {
+                ProtocolError::InvalidState("provider extent has no source".to_string())
+            })?;
+            Ok(minimum.min(source.expires_at_unix_millis))
+        })
 }
 
 fn validate_challenge(
@@ -366,9 +635,26 @@ struct ScheduledProviderExtent {
     digest: [u8; DIGEST_LEN],
 }
 
+#[derive(Debug)]
 struct ProviderPlanDownload {
-    pack: CompletedProviderPack,
+    spool: ProviderPackSpool,
     peak_inflight_bytes: usize,
+}
+
+struct InstalledProviderPlan {
+    installed_ids: Vec<PackObjectId>,
+    trailer_digest: [u8; DIGEST_LEN],
+    peak_inflight_bytes: usize,
+}
+
+#[derive(Clone)]
+struct ProviderGroupRuntime {
+    writer: ProviderPackWriter,
+    connection_limit: Arc<Semaphore>,
+    stream_limit: Arc<Semaphore>,
+    byte_budget: InflightByteBudget,
+    policy: HostedTransportPolicy,
+    evidence: Arc<ProviderPullEvidence>,
 }
 
 trait ProviderBackend: Sync {
@@ -386,7 +672,8 @@ trait ProviderBackend: Sync {
         writer: ProviderPackWriter,
         byte_budget: InflightByteBudget,
         stall_timeout: std::time::Duration,
-    ) -> impl Future<Output = Result<(), ProtocolError>> + Send;
+        evidence: Arc<ProviderPullEvidence>,
+    ) -> impl Future<Output = Result<(), ProviderPullFailure>> + Send;
 }
 
 struct HostedProviderBackend<'a> {
@@ -421,8 +708,18 @@ impl ProviderBackend for HostedProviderBackend<'_> {
         writer: ProviderPackWriter,
         byte_budget: InflightByteBudget,
         stall_timeout: std::time::Duration,
-    ) -> Result<(), ProtocolError> {
-        download_provider_extent(&connection, extent, writer, byte_budget, stall_timeout).await
+        evidence: Arc<ProviderPullEvidence>,
+    ) -> Result<(), ProviderPullFailure> {
+        download_provider_extent(
+            self,
+            connection,
+            extent,
+            writer,
+            byte_budget,
+            stall_timeout,
+            evidence,
+        )
+        .await
     }
 }
 
@@ -508,18 +805,52 @@ impl Drop for InflightByteReservation {
     }
 }
 
+#[cfg(test)]
 async fn download_provider_plan<B: ProviderBackend>(
     spool_root: &Path,
     manifest: ProviderPackManifest,
     extents: Vec<ScheduledProviderExtent>,
     backend: &B,
     policy: &HostedTransportPolicy,
-) -> Result<ProviderPlanDownload, ProtocolError> {
-    let spool = ProviderPackSpool::new_in(spool_root, manifest)?;
+) -> Result<ProviderPlanDownload, ProviderPullFailure> {
+    let endpoint_count = extents
+        .iter()
+        .map(|extent| extent.source.endpoint_id.as_str())
+        .collect::<HashSet<_>>()
+        .len();
+    let evidence = ProviderPullEvidence::new(endpoint_count, extents.len());
+    download_provider_plan_with_evidence(spool_root, manifest, extents, backend, policy, evidence)
+        .await
+}
+
+async fn download_provider_plan_with_evidence<B: ProviderBackend>(
+    spool_root: &Path,
+    manifest: ProviderPackManifest,
+    extents: Vec<ScheduledProviderExtent>,
+    backend: &B,
+    policy: &HostedTransportPolicy,
+    evidence: Arc<ProviderPullEvidence>,
+) -> Result<ProviderPlanDownload, ProviderPullFailure> {
+    let spool = ProviderPackSpool::new_in(spool_root, manifest).map_err(|error| {
+        ProviderPullFailure::new(
+            ProviderFailureStage::Spool,
+            "spool_create_failed",
+            error,
+            Arc::clone(&evidence),
+        )
+    })?;
     let writer = spool.writer();
     let byte_budget = InflightByteBudget::new(policy.provider_max_inflight_bytes);
     let connection_limit = Arc::new(Semaphore::new(policy.provider_global_concurrency));
     let stream_limit = Arc::new(Semaphore::new(policy.provider_global_concurrency));
+    let runtime = ProviderGroupRuntime {
+        writer: writer.clone(),
+        connection_limit,
+        stream_limit,
+        byte_budget: byte_budget.clone(),
+        policy: policy.clone(),
+        evidence,
+    };
     let mut groups = BTreeMap::<String, Vec<ScheduledProviderExtent>>::new();
     for extent in extents {
         groups
@@ -530,15 +861,7 @@ async fn download_provider_plan<B: ProviderBackend>(
 
     let mut pending = FuturesUnordered::new();
     for extents in groups.into_values() {
-        pending.push(download_provider_group(
-            backend,
-            extents,
-            writer.clone(),
-            Arc::clone(&connection_limit),
-            Arc::clone(&stream_limit),
-            byte_budget.clone(),
-            policy,
-        ));
+        pending.push(download_provider_group(backend, extents, runtime.clone()));
     }
     while let Some(result) = pending.next().await {
         result?;
@@ -547,57 +870,152 @@ async fn download_provider_plan<B: ProviderBackend>(
 
     let peak_inflight_bytes = byte_budget.peak();
     Ok(ProviderPlanDownload {
-        pack: spool.finish()?,
+        spool,
         peak_inflight_bytes,
     })
+}
+
+async fn finish_and_install_provider_pack(
+    download: ProviderPlanDownload,
+    store: AnyStore,
+    evidence: Arc<ProviderPullEvidence>,
+) -> Result<InstalledProviderPlan, ProviderPullFailure> {
+    let peak_inflight_bytes = download.peak_inflight_bytes;
+    let task_evidence = Arc::clone(&evidence);
+    tokio::task::spawn_blocking(move || {
+        let mut pack = download.spool.finish().map_err(|error| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Spool,
+                "spool_finalize_failed",
+                error,
+                Arc::clone(&task_evidence),
+            )
+        })?;
+        let trailer_digest = pack.trailer_digest;
+        let installed_ids = pack.install_into(&store).map_err(|error| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Install,
+                "pack_install_failed",
+                error,
+                Arc::clone(&task_evidence),
+            )
+        })?;
+        Ok(InstalledProviderPlan {
+            installed_ids,
+            trailer_digest,
+            peak_inflight_bytes,
+        })
+    })
+    .await
+    .map_err(|error| {
+        ProviderPullFailure::new(
+            ProviderFailureStage::Install,
+            "pack_install_task_failed",
+            ProtocolError::InvalidState(format!("provider install task failed: {error}")),
+            evidence,
+        )
+    })?
 }
 
 async fn download_provider_group<B: ProviderBackend>(
     backend: &B,
     extents: Vec<ScheduledProviderExtent>,
-    writer: ProviderPackWriter,
-    connection_limit: Arc<Semaphore>,
-    stream_limit: Arc<Semaphore>,
-    byte_budget: InflightByteBudget,
-    policy: &HostedTransportPolicy,
-) -> Result<(), ProtocolError> {
-    let _connection_permit = connection_limit.acquire_owned().await.map_err(|_| {
-        ProtocolError::InvalidState("provider connection scheduler closed".to_string())
-    })?;
+    runtime: ProviderGroupRuntime,
+) -> Result<(), ProviderPullFailure> {
+    let evidence = Arc::clone(&runtime.evidence);
+    let _connection_permit = runtime
+        .connection_limit
+        .acquire_owned()
+        .await
+        .map_err(|_| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Connect,
+                "connection_scheduler_closed",
+                ProtocolError::InvalidState("provider connection scheduler closed".to_string()),
+                Arc::clone(&evidence),
+            )
+        })?;
     for extent in &extents {
-        ensure_grant_unexpired(&extent.source)?;
+        ensure_grant_unexpired(&extent.source).map_err(|error| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Expiry,
+                "source_grant_expired",
+                error,
+                Arc::clone(&evidence),
+            )
+        })?;
     }
     let sources = extents
         .iter()
         .map(|extent| extent.source.clone())
         .collect::<Vec<_>>();
-    let connection = tokio::time::timeout(policy.provider_stall_timeout, backend.connect(&sources))
-        .await
-        .map_err(|_| provider_stall_error())??;
+    let connection = tokio::time::timeout(
+        runtime.policy.provider_stall_timeout,
+        backend.connect(&sources),
+    )
+    .await
+    .map_err(|_| {
+        ProviderPullFailure::new(
+            ProviderFailureStage::Stall,
+            "provider_connect_stalled",
+            provider_stall_error(),
+            Arc::clone(&evidence),
+        )
+    })?
+    .map_err(|error| {
+        ProviderPullFailure::new(
+            ProviderFailureStage::Connect,
+            "provider_connect_failed",
+            error,
+            Arc::clone(&evidence),
+        )
+    })?;
 
-    let endpoint_limit = Arc::new(Semaphore::new(policy.provider_per_endpoint_concurrency));
+    let endpoint_limit = Arc::new(Semaphore::new(
+        runtime.policy.provider_per_endpoint_concurrency,
+    ));
     let mut pending = FuturesUnordered::new();
     for extent in extents {
         let endpoint_limit = Arc::clone(&endpoint_limit);
-        let stream_limit = Arc::clone(&stream_limit);
+        let stream_limit = Arc::clone(&runtime.stream_limit);
         let connection = connection.clone();
-        let writer = writer.clone();
-        let byte_budget = byte_budget.clone();
+        let writer = runtime.writer.clone();
+        let byte_budget = runtime.byte_budget.clone();
+        let evidence = Arc::clone(&evidence);
+        let stall_timeout = runtime.policy.provider_stall_timeout;
         pending.push(async move {
             let _endpoint_permit = endpoint_limit.acquire_owned().await.map_err(|_| {
-                ProtocolError::InvalidState("provider endpoint scheduler closed".to_string())
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Connect,
+                    "endpoint_scheduler_closed",
+                    ProtocolError::InvalidState("provider endpoint scheduler closed".to_string()),
+                    Arc::clone(&evidence),
+                )
             })?;
             let _stream_permit = stream_limit.acquire_owned().await.map_err(|_| {
-                ProtocolError::InvalidState("provider stream scheduler closed".to_string())
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Connect,
+                    "stream_scheduler_closed",
+                    ProtocolError::InvalidState("provider stream scheduler closed".to_string()),
+                    Arc::clone(&evidence),
+                )
             })?;
-            ensure_grant_unexpired(&extent.source)?;
+            ensure_grant_unexpired(&extent.source).map_err(|error| {
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Expiry,
+                    "source_grant_expired",
+                    error,
+                    Arc::clone(&evidence),
+                )
+            })?;
             backend
                 .download(
                     connection,
                     extent,
                     writer,
                     byte_budget,
-                    policy.provider_stall_timeout,
+                    stall_timeout,
+                    evidence,
                 )
                 .await
         });
@@ -623,18 +1041,23 @@ fn provider_stall_error() -> ProtocolError {
     )
 }
 
-async fn download_provider_extent(
-    connection: &iroh::endpoint::Connection,
+async fn download_provider_extent<B>(
+    backend: &B,
+    mut connection: iroh::endpoint::Connection,
     extent: ScheduledProviderExtent,
     writer: ProviderPackWriter,
     byte_budget: InflightByteBudget,
     stall_timeout: std::time::Duration,
-) -> Result<(), ProtocolError> {
+    evidence: Arc<ProviderPullEvidence>,
+) -> Result<(), ProviderPullFailure>
+where
+    B: ProviderBackend<Connection = iroh::endpoint::Connection>,
+{
     let mut retained_length = 0_u64;
     let mut previous_generation = None;
     let mut last_retryable = None;
 
-    for _ in 0..MAX_PROVIDER_RESUME_ATTEMPTS {
+    for attempt_index in 0..MAX_PROVIDER_RESUME_ATTEMPTS {
         let mut attempt = ExtentAttemptState {
             expected_length: extent.length,
             expected_digest: extent.digest,
@@ -642,9 +1065,10 @@ async fn download_provider_extent(
             extent_index: extent.index,
             retained_length: &mut retained_length,
             previous_generation: &mut previous_generation,
+            evidence: Arc::clone(&evidence),
         };
         match download_attempt(
-            connection,
+            &connection,
             &extent.source.opaque_ticket,
             &mut attempt,
             &byte_budget,
@@ -653,22 +1077,82 @@ async fn download_provider_extent(
         .await
         {
             Ok(_) => {
-                writer.mark_verified(extent.index)?;
+                writer.mark_verified(extent.index).map_err(|error| {
+                    ProviderPullFailure::new(
+                        ProviderFailureStage::Spool,
+                        "spool_verify_failed",
+                        error,
+                        Arc::clone(&evidence),
+                    )
+                })?;
                 return Ok(());
             }
-            Err(AttemptFailure::Retryable { error }) => last_retryable = Some(error),
-            Err(AttemptFailure::Fatal(error)) => return Err(error),
+            Err(AttemptFailure::Retryable { error }) => {
+                last_retryable = Some(error);
+                if attempt_index + 1 == MAX_PROVIDER_RESUME_ATTEMPTS {
+                    break;
+                }
+                evidence.record_reconnect();
+                connection = tokio::time::timeout(
+                    stall_timeout,
+                    backend.connect(std::slice::from_ref(&extent.source)),
+                )
+                .await
+                .map_err(|_| {
+                    ProviderPullFailure::new(
+                        ProviderFailureStage::Stall,
+                        "provider_reconnect_stalled",
+                        provider_stall_error(),
+                        Arc::clone(&evidence),
+                    )
+                })?
+                .map_err(|error| {
+                    ProviderPullFailure::new(
+                        ProviderFailureStage::Carrier,
+                        "provider_reconnect_failed",
+                        error,
+                        Arc::clone(&evidence),
+                    )
+                })?;
+            }
+            Err(AttemptFailure::Stall(error)) => {
+                return Err(ProviderPullFailure::new(
+                    ProviderFailureStage::Stall,
+                    "provider_progress_stalled",
+                    error,
+                    evidence,
+                ));
+            }
+            Err(AttemptFailure::Fatal {
+                stage,
+                reason,
+                error,
+            }) => {
+                return Err(ProviderPullFailure::new(stage, reason, error, evidence));
+            }
         }
     }
-    Err(last_retryable.unwrap_or_else(|| {
-        ProtocolError::InvalidState("provider transfer attempts exhausted".to_string())
-    }))
+    Err(ProviderPullFailure::new(
+        ProviderFailureStage::Carrier,
+        "carrier_resume_attempts_exhausted",
+        last_retryable.unwrap_or_else(|| {
+            ProtocolError::InvalidState("provider transfer attempts exhausted".to_string())
+        }),
+        evidence,
+    ))
 }
 
 #[derive(Debug)]
 enum AttemptFailure {
-    Retryable { error: ProtocolError },
-    Fatal(ProtocolError),
+    Retryable {
+        error: ProtocolError,
+    },
+    Stall(ProtocolError),
+    Fatal {
+        stage: ProviderFailureStage,
+        reason: &'static str,
+        error: ProtocolError,
+    },
 }
 
 struct ExtentAttemptState<'a> {
@@ -678,6 +1162,7 @@ struct ExtentAttemptState<'a> {
     extent_index: usize,
     retained_length: &'a mut u64,
     previous_generation: &'a mut Option<u64>,
+    evidence: Arc<ProviderPullEvidence>,
 }
 
 async fn download_attempt(
@@ -690,7 +1175,8 @@ async fn download_attempt(
     let (mut send, recv) = await_provider_progress(
         stall_timeout,
         async { connection.open_bi().await.map_err(transport_error) },
-        true,
+        ProviderFailureStage::Carrier,
+        "provider_stream_open_failed",
     )
     .await?;
     await_provider_progress(
@@ -706,12 +1192,19 @@ async fn download_attempt(
                 )),
             },
         ),
-        true,
+        ProviderFailureStage::Carrier,
+        "provider_request_write_failed",
     )
     .await?;
 
     let mut reader = ProviderStreamReader::new(recv);
-    let ready = await_provider_progress(stall_timeout, read_ready(&mut reader), false).await?;
+    let ready = await_provider_progress(
+        stall_timeout,
+        read_ready(&mut reader),
+        ProviderFailureStage::MalformedResume,
+        "provider_ready_malformed",
+    )
+    .await?;
     if ready.resume_offset > state.expected_length
         || ready.resume_offset > *state.retained_length
         || ready.remaining_length != state.expected_length - ready.resume_offset
@@ -721,9 +1214,13 @@ async fn download_attempt(
             .is_some_and(|previous| previous == ready.attempt_generation)
     {
         abort_provider_stream(&mut send, &mut reader);
-        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
-            "provider returned an invalid resume offset or attempt generation".to_string(),
-        )));
+        return Err(fatal_attempt(
+            ProviderFailureStage::MalformedResume,
+            "resume_offset_or_generation_invalid",
+            ProtocolError::InvalidState(
+                "provider returned an invalid resume offset or attempt generation".to_string(),
+            ),
+        ));
     }
     *state.previous_generation = Some(ready.attempt_generation);
     *state.retained_length = ready.resume_offset;
@@ -731,49 +1228,79 @@ async fn download_attempt(
     state
         .writer
         .hash_extent_prefix(state.extent_index, ready.resume_offset, &mut hasher)
-        .map_err(AttemptFailure::Fatal)?;
+        .map_err(|error| {
+            fatal_attempt(
+                ProviderFailureStage::Spool,
+                "spool_prefix_read_failed",
+                error,
+            )
+        })?;
+    state
+        .evidence
+        .set_completed(state.extent_index, ready.resume_offset);
     let prefix_rehashed = ready.resume_offset;
 
-    let raw_length = await_provider_progress(stall_timeout, reader.next_raw_body(), true).await?;
+    let raw_length = await_provider_progress(
+        stall_timeout,
+        reader.next_raw_body(),
+        ProviderFailureStage::MalformedResume,
+        "provider_body_header_malformed",
+    )
+    .await?;
     if raw_length != ready.remaining_length {
         abort_provider_stream(&mut send, &mut reader);
-        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
-            "provider raw body length does not match its resume response".to_string(),
-        )));
+        return Err(fatal_attempt(
+            ProviderFailureStage::MalformedResume,
+            "resume_body_length_invalid",
+            ProtocolError::InvalidState(
+                "provider raw body length does not match its resume response".to_string(),
+            ),
+        ));
     }
 
     while reader.raw_remaining() != 0 {
         let requested = usize::try_from(reader.raw_remaining().min(PROVIDER_READ_CHUNK as u64))
             .unwrap_or(PROVIDER_READ_CHUNK);
-        let mut reservation = byte_budget
-            .reserve(requested)
-            .await
-            .map_err(AttemptFailure::Fatal)?;
+        let mut reservation = byte_budget.reserve(requested).await.map_err(|error| {
+            fatal_attempt(ProviderFailureStage::Spool, "inflight_budget_failed", error)
+        })?;
         let Some(chunk) = await_provider_progress(
             stall_timeout,
             reader.read_raw_chunk(reservation.reserved_bytes),
-            true,
+            ProviderFailureStage::MalformedResume,
+            "provider_body_frame_malformed",
         )
         .await?
         else {
             break;
         };
-        reservation
-            .record_buffered(chunk.len())
-            .map_err(AttemptFailure::Fatal)?;
+        reservation.record_buffered(chunk.len()).map_err(|error| {
+            fatal_attempt(
+                ProviderFailureStage::Spool,
+                "inflight_accounting_failed",
+                error,
+            )
+        })?;
         hasher.update(&chunk);
         state
             .writer
             .write_extent_chunk(state.extent_index, *state.retained_length, &chunk)
-            .map_err(AttemptFailure::Fatal)?;
+            .map_err(|error| {
+                fatal_attempt(ProviderFailureStage::Spool, "spool_write_failed", error)
+            })?;
         *state.retained_length = state
             .retained_length
             .checked_add(chunk.len() as u64)
             .ok_or_else(|| {
-                AttemptFailure::Fatal(ProtocolError::InvalidState(
-                    "provider retained length overflows".to_string(),
-                ))
+                fatal_attempt(
+                    ProviderFailureStage::Spool,
+                    "completed_byte_count_overflow",
+                    ProtocolError::InvalidState("provider retained length overflows".to_string()),
+                )
             })?;
+        state
+            .evidence
+            .set_completed(state.extent_index, *state.retained_length);
         await_provider_progress(
             stall_timeout,
             send_provider_frame(
@@ -788,7 +1315,8 @@ async fn download_attempt(
                     )),
                 },
             ),
-            true,
+            ProviderFailureStage::Carrier,
+            "provider_checkpoint_write_failed",
         )
         .await?;
     }
@@ -797,9 +1325,11 @@ async fn download_attempt(
         || hasher.finalize().as_bytes() != &state.expected_digest
     {
         abort_provider_stream(&mut send, &mut reader);
-        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
-            "provider extent digest mismatch".to_string(),
-        )));
+        return Err(fatal_attempt(
+            ProviderFailureStage::Digest,
+            "extent_digest_mismatch",
+            ProtocolError::InvalidState("provider extent digest mismatch".to_string()),
+        ));
     }
     await_provider_progress(
         stall_timeout,
@@ -815,18 +1345,28 @@ async fn download_attempt(
                 )),
             },
         ),
-        true,
+        ProviderFailureStage::Carrier,
+        "provider_final_checkpoint_write_failed",
     )
     .await?;
     send.finish().map_err(|error| AttemptFailure::Retryable {
         error: transport_error(error),
     })?;
-    let complete =
-        await_provider_progress(stall_timeout, read_complete(&mut reader), false).await?;
+    let complete = await_provider_progress(
+        stall_timeout,
+        read_complete(&mut reader),
+        ProviderFailureStage::MalformedResume,
+        "provider_complete_malformed",
+    )
+    .await?;
     if !complete.success || complete.committed_length != state.expected_length {
-        return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
-            "provider did not commit the exact verified extent".to_string(),
-        )));
+        return Err(fatal_attempt(
+            ProviderFailureStage::MalformedResume,
+            "provider_commit_invalid",
+            ProtocolError::InvalidState(
+                "provider did not commit the exact verified extent".to_string(),
+            ),
+        ));
     }
     Ok(prefix_rehashed)
 }
@@ -834,13 +1374,26 @@ async fn download_attempt(
 async fn await_provider_progress<T>(
     stall_timeout: std::time::Duration,
     future: impl Future<Output = Result<T, ProtocolError>>,
-    retryable: bool,
+    stage: ProviderFailureStage,
+    reason: &'static str,
 ) -> Result<T, AttemptFailure> {
     match tokio::time::timeout(stall_timeout, future).await {
         Ok(Ok(value)) => Ok(value),
-        Ok(Err(error)) if retryable => Err(AttemptFailure::Retryable { error }),
-        Ok(Err(error)) => Err(AttemptFailure::Fatal(error)),
-        Err(_) => Err(AttemptFailure::Fatal(provider_stall_error())),
+        Ok(Err(error @ ProtocolError::Io(_))) => Err(AttemptFailure::Retryable { error }),
+        Ok(Err(error)) => Err(fatal_attempt(stage, reason, error)),
+        Err(_) => Err(AttemptFailure::Stall(provider_stall_error())),
+    }
+}
+
+fn fatal_attempt(
+    stage: ProviderFailureStage,
+    reason: &'static str,
+    error: ProtocolError,
+) -> AttemptFailure {
+    AttemptFailure::Fatal {
+        stage,
+        reason,
+        error,
     }
 }
 
@@ -1057,6 +1610,12 @@ mod tests {
         endpoint_id: String,
     }
 
+    struct ReconnectingIrohBackend {
+        endpoint: Endpoint,
+        provider_addr: iroh::EndpointAddr,
+        connects: AtomicUsize,
+    }
+
     struct FakeProviderBackend {
         bodies: HashMap<String, Arc<Vec<u8>>>,
         delays: HashMap<String, Duration>,
@@ -1066,6 +1625,7 @@ mod tests {
         active_streams: Arc<AtomicUsize>,
         cancelled_streams: Arc<AtomicUsize>,
         chunk_size: usize,
+        chunk_delay: Option<Duration>,
     }
 
     struct FakeStreamGuard {
@@ -1085,6 +1645,7 @@ mod tests {
                 active_streams: Arc::new(AtomicUsize::new(0)),
                 cancelled_streams: Arc::new(AtomicUsize::new(0)),
                 chunk_size: 64 * 1024,
+                chunk_delay: None,
             }
         }
 
@@ -1128,10 +1689,16 @@ mod tests {
             writer: ProviderPackWriter,
             byte_budget: InflightByteBudget,
             stall_timeout: Duration,
-        ) -> Result<(), ProtocolError> {
+            evidence: Arc<ProviderPullEvidence>,
+        ) -> Result<(), ProviderPullFailure> {
             if connection.endpoint_id != extent.source.endpoint_id {
-                return Err(ProtocolError::InvalidState(
-                    "fake provider connection crossed endpoint groups".to_string(),
+                return Err(ProviderPullFailure::new(
+                    ProviderFailureStage::Connect,
+                    "fake_connection_crossed_group",
+                    ProtocolError::InvalidState(
+                        "fake provider connection crossed endpoint groups".to_string(),
+                    ),
+                    evidence,
                 ));
             }
             let ticket = extent.source.opaque_ticket.clone();
@@ -1144,36 +1711,132 @@ mod tests {
             if self.stalled.contains(&ticket) {
                 tokio::time::timeout(stall_timeout, std::future::pending::<()>())
                     .await
-                    .map_err(|_| provider_stall_error())?;
+                    .map_err(|_| {
+                        ProviderPullFailure::new(
+                            ProviderFailureStage::Stall,
+                            "provider_progress_stalled",
+                            provider_stall_error(),
+                            Arc::clone(&evidence),
+                        )
+                    })?;
             }
             if let Some(delay) = self.delays.get(&ticket) {
                 tokio::time::sleep(*delay).await;
             }
             let body = Arc::clone(self.bodies.get(&ticket).ok_or_else(|| {
-                ProtocolError::InvalidState("fake provider body is missing".to_string())
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Manifest,
+                    "fake_provider_body_missing",
+                    ProtocolError::InvalidState("fake provider body is missing".to_string()),
+                    Arc::clone(&evidence),
+                )
             })?);
             let mut hasher = blake3::Hasher::new();
             let mut offset = 0_usize;
             while offset < body.len() {
                 let length = (body.len() - offset).min(self.chunk_size);
-                let mut reservation = byte_budget.reserve(length).await?;
+                let mut reservation = byte_budget.reserve(length).await.map_err(|error| {
+                    ProviderPullFailure::new(
+                        ProviderFailureStage::Spool,
+                        "inflight_budget_failed",
+                        error,
+                        Arc::clone(&evidence),
+                    )
+                })?;
                 let chunk = Bytes::copy_from_slice(&body[offset..offset + length]);
-                reservation.record_buffered(chunk.len())?;
-                tokio::task::yield_now().await;
+                reservation.record_buffered(chunk.len()).map_err(|error| {
+                    ProviderPullFailure::new(
+                        ProviderFailureStage::Spool,
+                        "inflight_accounting_failed",
+                        error,
+                        Arc::clone(&evidence),
+                    )
+                })?;
+                if let Some(delay) = self.chunk_delay {
+                    tokio::time::sleep(delay).await;
+                } else {
+                    tokio::task::yield_now().await;
+                }
                 hasher.update(&chunk);
-                writer.write_extent_chunk(extent.index, offset as u64, &chunk)?;
+                writer
+                    .write_extent_chunk(extent.index, offset as u64, &chunk)
+                    .map_err(|error| {
+                        ProviderPullFailure::new(
+                            ProviderFailureStage::Spool,
+                            "spool_write_failed",
+                            error,
+                            Arc::clone(&evidence),
+                        )
+                    })?;
                 offset += length;
+                evidence.set_completed(extent.index, offset as u64);
                 drop(reservation);
             }
             if offset as u64 != extent.length || hasher.finalize().as_bytes() != &extent.digest {
-                return Err(ProtocolError::InvalidState(
-                    "fake provider extent length or digest mismatch".to_string(),
+                return Err(ProviderPullFailure::new(
+                    ProviderFailureStage::Digest,
+                    "extent_digest_mismatch",
+                    ProtocolError::InvalidState(
+                        "fake provider extent length or digest mismatch".to_string(),
+                    ),
+                    evidence,
                 ));
             }
-            writer.mark_verified(extent.index)?;
+            writer.mark_verified(extent.index).map_err(|error| {
+                ProviderPullFailure::new(
+                    ProviderFailureStage::Spool,
+                    "spool_verify_failed",
+                    error,
+                    Arc::clone(&evidence),
+                )
+            })?;
             self.completion_order.lock().unwrap().push(ticket);
             guard.completed = true;
             Ok(())
+        }
+    }
+
+    impl ProviderBackend for ReconnectingIrohBackend {
+        type Connection = iroh::endpoint::Connection;
+
+        async fn connect(
+            &self,
+            sources: &[ProviderSource],
+        ) -> Result<Self::Connection, ProtocolError> {
+            let source = sources.first().ok_or_else(|| {
+                ProtocolError::InvalidState("provider reconnect source is missing".to_string())
+            })?;
+            if source.endpoint_id != self.provider_addr.id.to_string() {
+                return Err(ProtocolError::InvalidState(
+                    "provider reconnect changed cryptographic endpoint identity".to_string(),
+                ));
+            }
+            self.connects.fetch_add(1, Ordering::AcqRel);
+            self.endpoint
+                .connect(self.provider_addr.clone(), api::PROVIDER_ALPN_V1)
+                .await
+                .map_err(transport_error)
+        }
+
+        async fn download(
+            &self,
+            connection: Self::Connection,
+            extent: ScheduledProviderExtent,
+            writer: ProviderPackWriter,
+            byte_budget: InflightByteBudget,
+            stall_timeout: Duration,
+            evidence: Arc<ProviderPullEvidence>,
+        ) -> Result<(), ProviderPullFailure> {
+            download_provider_extent(
+                self,
+                connection,
+                extent,
+                writer,
+                byte_budget,
+                stall_timeout,
+                evidence,
+            )
+            .await
         }
     }
 
@@ -1291,12 +1954,10 @@ mod tests {
         }
     }
 
-    fn assert_download_falls_back(result: Result<ProviderPlanDownload, ProtocolError>) {
-        let result = result.map(|download| CompletedProviderPull {
-            trailer_digest: download.pack.trailer_digest,
-            pack: download.pack,
-        });
-        let (response, completed) = provider_session().resolve_download(&[7; DIGEST_LEN], result);
+    fn assert_download_falls_back(result: Result<ProviderPlanDownload, ProviderPullFailure>) {
+        let error = result.expect_err("provider download must fail");
+        let (response, completed) =
+            provider_session().resolve_download(&[7; DIGEST_LEN], Err(error));
         assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
         assert!(response.pack_digest.is_empty());
         assert!(completed.is_none());
@@ -1378,7 +2039,7 @@ mod tests {
             .insert("extent-0".to_string(), Duration::from_millis(40));
         let root = tempfile::tempdir().unwrap();
 
-        let mut download = download_provider_plan(
+        let download = download_provider_plan(
             root.path(),
             fixture.manifest,
             fixture.extents,
@@ -1392,13 +2053,14 @@ mod tests {
             backend.completion_order.lock().unwrap().as_slice(),
             ["extent-1", "extent-0"]
         );
+        let mut pack = download.spool.finish().unwrap();
         assert_eq!(
-            download.pack.trailer_digest.as_slice(),
+            pack.trailer_digest.as_slice(),
             &fixture.source_pack[fixture.source_pack.len() - DIGEST_LEN..]
         );
         let store_root = tempfile::tempdir().unwrap();
         let store = FsStore::new(store_root.path().join(".heddle"));
-        let installed = download.pack.install_into(&store).unwrap();
+        let installed = pack.install_into(&store).unwrap();
         assert_eq!(
             installed.len(),
             PackIndex::from_bytes(&fixture.source_index)
@@ -1409,6 +2071,57 @@ mod tests {
         println!(
             "provider_out_of_order completion=endpoint-b,endpoint-a pack_bytes={} byte_identical=true",
             fixture.source_pack.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn install_failure_sends_fallback_and_never_complete() {
+        let mut fixture = provider_fixture(&[64 * 1024], &["endpoint-a"]);
+        fixture.manifest.extents[0].objects[0].id =
+            PackObjectId::Hash(Blob::new(b"wrong object identity".to_vec()).hash());
+        let backend = FakeProviderBackend::new(fixture.bodies);
+        let root = tempfile::tempdir().unwrap();
+        let evidence = ProviderPullEvidence::new(1, 1);
+        let download = download_provider_plan_with_evidence(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &provider_policy(),
+            Arc::clone(&evidence),
+        )
+        .await
+        .unwrap();
+        let store_root = tempfile::tempdir().unwrap();
+        let result = finish_and_install_provider_pack(
+            download,
+            AnyStore::Fs(FsStore::new(store_root.path().join(".heddle"))),
+            evidence,
+        )
+        .await;
+        assert!(matches!(
+            &result,
+            Err(ProviderPullFailure {
+                stage: ProviderFailureStage::Install,
+                ..
+            })
+        ));
+        let (response, completed) = provider_session().resolve_download(
+            &[7; DIGEST_LEN],
+            result.map(|installed| CompletedProviderPull {
+                installed_ids: installed.installed_ids,
+                trailer_digest: installed.trailer_digest,
+                fallback_deadline: tokio::time::Instant::now() + Duration::from_secs(1),
+                signed_expiry_millis: now_millis().unwrap() + 2_000,
+                evidence: ProviderPullEvidence::new(1, 1),
+            }),
+        );
+
+        assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
+        assert!(response.pack_digest.is_empty());
+        assert!(completed.is_none());
+        println!(
+            "provider_install_failure install=forced-error fallback=existing-weft complete_sent=false"
         );
     }
 
@@ -1479,12 +2192,14 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let started = std::time::Instant::now();
 
+        let mut policy = provider_policy();
+        policy.provider_stall_timeout = Duration::from_millis(200);
         let result = download_provider_plan(
             root.path(),
             fixture.manifest,
             fixture.extents,
             &backend,
-            &provider_policy(),
+            &policy,
         )
         .await;
         let elapsed = started.elapsed();
@@ -1493,11 +2208,79 @@ mod tests {
             backend.completion_order.lock().unwrap().as_slice(),
             ["extent-1"]
         );
-        assert!(elapsed >= Duration::from_millis(90));
-        assert!(elapsed < Duration::from_millis(500));
+        assert!(elapsed >= Duration::from_millis(175));
+        assert!(elapsed < Duration::from_secs(2));
         assert_download_falls_back(result);
         println!(
-            "provider_slow_lane healthy_completed=true fallback_after_ms={} threshold_ms=100",
+            "provider_slow_lane healthy_completed=true fallback_after_ms={} threshold_ms=200",
+            elapsed.as_millis()
+        );
+    }
+
+    #[tokio::test]
+    async fn continuous_sub_stall_progress_falls_back_before_signed_expiry() {
+        let mut fixture = provider_fixture(&[512 * 1024], &["endpoint-a"]);
+        let signed_expiry = now_millis().unwrap() + 1_600;
+        fixture.extents[0].source.expires_at_unix_millis = signed_expiry;
+        let mut backend = FakeProviderBackend::new(fixture.bodies);
+        backend.chunk_size = 4 * 1024;
+        backend.chunk_delay = Some(Duration::from_millis(20));
+        let root = tempfile::tempdir().unwrap();
+        let evidence = ProviderPullEvidence::new(1, 1);
+        let deadline = ProviderPlanDeadline::new(signed_expiry, Arc::clone(&evidence)).unwrap();
+        let started = Instant::now();
+        let result = tokio::time::timeout_at(
+            deadline.fallback_deadline,
+            download_provider_plan_with_evidence(
+                root.path(),
+                fixture.manifest,
+                fixture.extents,
+                &backend,
+                &provider_policy(),
+                Arc::clone(&evidence),
+            ),
+        )
+        .await
+        .map_err(|_| {
+            ProviderPullFailure::new(
+                ProviderFailureStage::Expiry,
+                "signed_deadline_margin_elapsed",
+                ProtocolError::InvalidState("provider signed deadline margin elapsed".to_string()),
+                Arc::clone(&evidence),
+            )
+        })
+        .and_then(|result| result);
+        let elapsed = started.elapsed();
+        let session = provider_session();
+        let (response, completed) = session.resolve_download(
+            &[7; DIGEST_LEN],
+            result.map(|download| {
+                let pack = download.spool.finish().unwrap();
+                CompletedProviderPull {
+                    installed_ids: Vec::new(),
+                    trailer_digest: pack.trailer_digest,
+                    fallback_deadline: deadline.fallback_deadline,
+                    signed_expiry_millis: deadline.signed_expiry_millis,
+                    evidence: Arc::clone(&evidence),
+                }
+            }),
+        );
+
+        assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
+        assert!(response.pack_digest.is_empty());
+        assert_eq!(response.plan_nonce, session.plan_nonce);
+        assert!(completed.is_none());
+        assert!(now_millis().unwrap() < signed_expiry);
+        assert!(evidence.completed_bytes() > 0);
+        assert_eq!(backend.active_streams.load(Ordering::Acquire), 0);
+        assert!(
+            fs::read_dir(root.path().join("transfer-spool"))
+                .unwrap()
+                .next()
+                .is_none()
+        );
+        println!(
+            "provider_absolute_deadline continuous_progress=true chunk_ms=20 stall_ms=100 fallback_after_ms={} before_expiry=true complete_sent=false logical_pulls=1",
             elapsed.as_millis()
         );
     }
@@ -1632,6 +2415,149 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn carrier_loss_reconnects_same_endpoint_and_resumes_without_reauthorization() {
+        let server = Endpoint::builder(presets::Minimal)
+            .alpns(vec![api::PROVIDER_ALPN_V1.to_vec()])
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let provider_addr = server.addr();
+        let provider_id = server.id().to_string();
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .unwrap()
+            .bind()
+            .await
+            .unwrap();
+        let mut fixture = provider_fixture(&[128 * 1024], &["placeholder"]);
+        fixture.extents[0].source.endpoint_id = provider_id.clone();
+        let extent_body = Arc::clone(&fixture.bodies["extent-0"]);
+        let resume_offset = 32 * 1024;
+        let expected_digest = fixture.extents[0].digest;
+        let expected_pack = fixture.source_pack.clone();
+        let (server_release, wait_for_release) = tokio::sync::oneshot::channel();
+        let server_task = tokio::spawn(async move {
+            let first_connection = server.accept().await.unwrap().await.unwrap();
+            assert_eq!(first_connection.remote_id().to_string().len(), 64);
+            let (mut first_send, first_recv) = first_connection.accept_bi().await.unwrap();
+            let mut first_reader = expect_read_request(first_recv).await;
+            send_ready(
+                &mut first_send,
+                0,
+                1,
+                u64::try_from(extent_body.len()).unwrap(),
+            )
+            .await;
+            first_send
+                .write_all(
+                    &encode_stream_raw_body(u64::try_from(extent_body.len()).unwrap()).unwrap(),
+                )
+                .await
+                .unwrap();
+            first_send
+                .write_all(&extent_body[..resume_offset])
+                .await
+                .unwrap();
+            loop {
+                let first_checkpoint = first_reader.next_message().await.unwrap();
+                let first_checkpoint =
+                    ProviderReadClientFrame::decode(first_checkpoint.as_slice()).unwrap();
+                if matches!(
+                    first_checkpoint.frame,
+                    Some(provider_read_client_frame::Frame::Checkpoint(
+                        ProviderReadCheckpoint {
+                            acknowledged_length,
+                            ..
+                        }
+                    )) if acknowledged_length == resume_offset as u64
+                ) {
+                    break;
+                }
+            }
+            first_connection.close(1_u32.into(), b"simulated carrier migration");
+            first_connection.closed().await;
+
+            let second_connection = server.accept().await.unwrap().await.unwrap();
+            let (mut second_send, second_recv) = second_connection.accept_bi().await.unwrap();
+            let mut second_reader = expect_read_request(second_recv).await;
+            send_ready(
+                &mut second_send,
+                resume_offset as u64,
+                2,
+                u64::try_from(extent_body.len() - resume_offset).unwrap(),
+            )
+            .await;
+            second_send
+                .write_all(
+                    &encode_stream_raw_body(
+                        u64::try_from(extent_body.len() - resume_offset).unwrap(),
+                    )
+                    .unwrap(),
+                )
+                .await
+                .unwrap();
+            second_send
+                .write_all(&extent_body[resume_offset..])
+                .await
+                .unwrap();
+            expect_final_checkpoint(&mut second_reader, expected_digest).await;
+            send_complete(
+                &mut second_send,
+                true,
+                u64::try_from(extent_body.len()).unwrap(),
+            )
+            .await;
+            second_send.finish().unwrap();
+            let _ = wait_for_release.await;
+            drop(second_connection);
+            server.close().await;
+            resume_offset
+        });
+        let backend = ReconnectingIrohBackend {
+            endpoint: client.clone(),
+            provider_addr,
+            connects: AtomicUsize::new(0),
+        };
+        let root = tempfile::tempdir().unwrap();
+        let evidence = ProviderPullEvidence::new(1, 1);
+        let mut policy = provider_policy();
+        policy.provider_stall_timeout = Duration::from_secs(1);
+        let download = download_provider_plan_with_evidence(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &policy,
+            Arc::clone(&evidence),
+        )
+        .await
+        .unwrap();
+        let pack = download.spool.finish().unwrap();
+
+        assert_eq!(
+            pack.trailer_digest.as_slice(),
+            &expected_pack[expected_pack.len() - DIGEST_LEN..]
+        );
+        assert_eq!(backend.connects.load(Ordering::Acquire), 2);
+        assert_eq!(evidence.reconnect_attempts.load(Ordering::Acquire), 1);
+        server_release.send(()).unwrap();
+        let committed_offset = tokio::time::timeout(Duration::from_secs(2), server_task)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(committed_offset, resume_offset);
+        client.close().await;
+        println!(
+            "provider_carrier_resume endpoint_id={} carrier_connections=2 reconnect_attempts=1 resume_offset={} generation=2 bytes_identical=true authorization_signatures=1",
+            provider_id, resume_offset
+        );
+    }
+
+    #[tokio::test]
     async fn interrupted_transfer_resumes_and_rehashes_the_retained_prefix() {
         let complete = b"retained verified prefix and resumed suffix".to_vec();
         let resume_offset = 24_usize;
@@ -1682,6 +2608,7 @@ mod tests {
             extent_index: 0,
             retained_length: &mut retained_length,
             previous_generation: &mut generation,
+            evidence: ProviderPullEvidence::new(1, 1),
         };
         let first = download_attempt(
             &first_client_connection,
@@ -1745,6 +2672,7 @@ mod tests {
             extent_index: 0,
             retained_length: &mut retained_length,
             previous_generation: &mut generation,
+            evidence: ProviderPullEvidence::new(1, 1),
         };
         let prefix_rehashed = download_attempt(
             &client_connection,
@@ -1818,6 +2746,7 @@ mod tests {
             extent_index: 0,
             retained_length: &mut retained_length,
             previous_generation: &mut generation,
+            evidence: ProviderPullEvidence::new(1, 1),
         };
         let result = download_attempt(
             &client_connection,
@@ -1829,7 +2758,11 @@ mod tests {
         .await;
         assert!(matches!(
             result,
-            Err(AttemptFailure::Fatal(ProtocolError::InvalidState(message)))
+            Err(AttemptFailure::Fatal {
+                stage: ProviderFailureStage::Digest,
+                error: ProtocolError::InvalidState(message),
+                ..
+            })
                 if message == "provider extent digest mismatch"
         ));
         let committed_offset = tokio::time::timeout(Duration::from_secs(2), server_task)
@@ -1856,6 +2789,39 @@ mod tests {
         assert!(response.pack_digest.is_empty());
         println!(
             "fallback provider=unavailable selected=existing-weft logical_pulls=1 same_nonce=true caller_protocol=unchanged success_digest_present=false"
+        );
+    }
+
+    #[test]
+    fn fallback_evidence_is_structured_bounded_and_never_exposes_provider_input() {
+        let evidence = ProviderPullEvidence::new(2, 3);
+        evidence.set_completed(0, 4096);
+        evidence.set_completed(1, 8192);
+        evidence.record_reconnect();
+        let hostile = format!(
+            "opaque-ticket=super-secret\nforged-field={} ",
+            "x".repeat(8 * 1024)
+        );
+        let failure = ProviderPullFailure::new(
+            ProviderFailureStage::Carrier,
+            "carrier_resume_attempts_exhausted",
+            ProtocolError::Remote(hostile.clone()),
+            Arc::clone(&evidence),
+        );
+        let rendered = failure.to_string();
+
+        assert_eq!(failure.stage.as_str(), "carrier");
+        assert!(failure.reason.len() <= MAX_FALLBACK_REASON_LEN);
+        assert!(!rendered.contains("super-secret"));
+        assert!(!rendered.contains('\n'));
+        assert_eq!(evidence.endpoint_count, 2);
+        assert_eq!(evidence.extent_count, 3);
+        assert_eq!(evidence.completed_bytes(), 12_288);
+        assert_eq!(evidence.reconnect_attempts.load(Ordering::Acquire), 1);
+        failure.emit();
+        println!(
+            "provider_fallback_evidence stage=carrier reason_len={} endpoints=2 extents=3 completed_bytes=12288 reconnect_attempts=1 secret_present=false bounded=true",
+            failure.reason.len()
         );
     }
 

--- a/crates/client/src/hosted/provider_pull.rs
+++ b/crates/client/src/hosted/provider_pull.rs
@@ -440,7 +440,8 @@ struct InflightByteBudgetInner {
 
 struct InflightByteReservation {
     inner: Arc<InflightByteBudgetInner>,
-    bytes: usize,
+    reserved_bytes: usize,
+    buffered_bytes: usize,
     _permit: OwnedSemaphorePermit,
 }
 
@@ -472,11 +473,10 @@ impl InflightByteBudget {
             .acquire_many_owned(permits)
             .await
             .map_err(|_| ProtocolError::InvalidState("provider byte budget closed".to_string()))?;
-        let current = self.inner.current.fetch_add(bytes, Ordering::AcqRel) + bytes;
-        self.inner.peak.fetch_max(current, Ordering::AcqRel);
         Ok(InflightByteReservation {
             inner: Arc::clone(&self.inner),
-            bytes,
+            reserved_bytes: bytes,
+            buffered_bytes: 0,
             _permit: permit,
         })
     }
@@ -486,9 +486,25 @@ impl InflightByteBudget {
     }
 }
 
+impl InflightByteReservation {
+    fn record_buffered(&mut self, bytes: usize) -> Result<(), ProtocolError> {
+        if self.buffered_bytes != 0 || bytes > self.reserved_bytes {
+            return Err(ProtocolError::InvalidState(
+                "provider body buffer exceeds its in-flight reservation".to_string(),
+            ));
+        }
+        self.buffered_bytes = bytes;
+        let current = self.inner.current.fetch_add(bytes, Ordering::AcqRel) + bytes;
+        self.inner.peak.fetch_max(current, Ordering::AcqRel);
+        Ok(())
+    }
+}
+
 impl Drop for InflightByteReservation {
     fn drop(&mut self) {
-        self.inner.current.fetch_sub(self.bytes, Ordering::AcqRel);
+        self.inner
+            .current
+            .fetch_sub(self.buffered_bytes, Ordering::AcqRel);
     }
 }
 
@@ -729,19 +745,22 @@ async fn download_attempt(
     while reader.raw_remaining() != 0 {
         let requested = usize::try_from(reader.raw_remaining().min(PROVIDER_READ_CHUNK as u64))
             .unwrap_or(PROVIDER_READ_CHUNK);
-        let reservation = byte_budget
+        let mut reservation = byte_budget
             .reserve(requested)
             .await
             .map_err(AttemptFailure::Fatal)?;
         let Some(chunk) = await_provider_progress(
             stall_timeout,
-            reader.read_raw_chunk(reservation.bytes),
+            reader.read_raw_chunk(reservation.reserved_bytes),
             true,
         )
         .await?
         else {
             break;
         };
+        reservation
+            .record_buffered(chunk.len())
+            .map_err(AttemptFailure::Fatal)?;
         hasher.update(&chunk);
         state
             .writer
@@ -1137,11 +1156,12 @@ mod tests {
             let mut offset = 0_usize;
             while offset < body.len() {
                 let length = (body.len() - offset).min(self.chunk_size);
-                let reservation = byte_budget.reserve(length).await?;
+                let mut reservation = byte_budget.reserve(length).await?;
+                let chunk = Bytes::copy_from_slice(&body[offset..offset + length]);
+                reservation.record_buffered(chunk.len())?;
                 tokio::task::yield_now().await;
-                let chunk = &body[offset..offset + length];
-                hasher.update(chunk);
-                writer.write_extent_chunk(extent.index, offset as u64, chunk)?;
+                hasher.update(&chunk);
+                writer.write_extent_chunk(extent.index, offset as u64, &chunk)?;
                 offset += length;
                 drop(reservation);
             }
@@ -1447,7 +1467,7 @@ mod tests {
         assert!(large_peak <= 512 * 1024);
         assert_eq!(small_peak, large_peak);
         println!(
-            "provider_memory method=production-byte-permit-high-water small_pack={small_pack} small_peak={small_peak} large_pack={large_pack} large_peak={large_peak} bounded=true"
+            "provider_memory method=production-live-body-buffer-high-water small_pack={small_pack} small_peak={small_peak} large_pack={large_pack} large_peak={large_peak} bounded=true"
         );
     }
 

--- a/crates/client/src/hosted/provider_pull.rs
+++ b/crates/client/src/hosted/provider_pull.rs
@@ -1,11 +1,17 @@
 use std::{
-    collections::HashSet,
+    collections::{BTreeMap, HashSet},
+    future::Future,
     io,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 
 use api::{
-    framing::{MAX_CONTROL_BODY, StreamFrame, decode_stream_frame, encode_stream_message},
+    framing::{StreamFrame, decode_stream_frame, encode_stream_message},
     heddle::api::v1alpha1::{
         ProviderPlanChallenge, ProviderPlanResponse, ProviderPullCapabilityContext,
         ProviderPullManifest as ApiProviderPullManifest, ProviderPullResponse,
@@ -15,20 +21,29 @@ use api::{
     },
 };
 use bytes::Bytes;
+use futures::{StreamExt as _, stream::FuturesUnordered};
 use objects::store::PackObjectId;
 use prost::Message;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use wire::{
-    NativePackBundle, ProtocolError, ProviderPackExtent, ProviderPackIndexEntry,
-    ProviderPackManifest, assemble_provider_pack,
+    CompletedProviderPack, ProtocolError, ProviderPackExtent, ProviderPackIndexEntry,
+    ProviderPackManifest, ProviderPackSpool, ProviderPackWriter,
 };
 
-use super::{HostedClient, helpers::hosted_to_protocol_error};
+use super::{
+    HostedClient,
+    helpers::{HostedTransportPolicy, hosted_to_protocol_error},
+};
 
 const PROVIDER_VERSION: u32 = 1;
 const PLAN_NONCE_LEN: usize = 16;
 const DIGEST_LEN: usize = 32;
 const PROVIDER_READ_CHUNK: usize = 1024 * 1024;
-const MAX_PROVIDER_ATTEMPTS: usize = 3;
+const PROVIDER_CONTROL_CHUNK: usize = 16 * 1024;
+const MAX_PROVIDER_CONTROL_BODY: usize = 64 * 1024;
+// These are resumptions inside one installed opaque grant. Retrying the signed
+// provider plan itself still requires a new pull challenge and nonce.
+const MAX_PROVIDER_RESUME_ATTEMPTS: usize = 3;
 
 #[derive(Debug, Clone)]
 pub(super) struct ProviderPullSession {
@@ -40,7 +55,7 @@ pub(super) struct ProviderPullSession {
 }
 
 pub(super) struct CompletedProviderPull {
-    pub(super) pack: NativePackBundle,
+    pub(super) pack: CompletedProviderPack,
     pub(super) trailer_digest: [u8; DIGEST_LEN],
 }
 
@@ -123,63 +138,39 @@ impl HostedClient {
         session: &ProviderPullSession,
         challenge: &ProviderPlanChallenge,
         manifest: &ApiProviderPullManifest,
+        spool_root: &Path,
     ) -> Result<CompletedProviderPull, ProtocolError> {
         let (wire_manifest, sources) = convert_manifest(session, challenge, manifest)?;
-        let mut bodies = Vec::with_capacity(manifest.extents.len());
-        for (extent, source) in manifest.extents.iter().zip(sources) {
-            let digest: [u8; DIGEST_LEN] = extent.digest.as_slice().try_into().map_err(|_| {
-                ProtocolError::InvalidState(
-                    "provider extent digest must be exactly 32 bytes".to_string(),
-                )
-            })?;
-            let downloaded = self
-                .download_provider_extent(source, extent.length, digest)
-                .await?;
-            bodies.push(downloaded.bytes);
-        }
-        let bundle = assemble_provider_pack(&wire_manifest, &bodies)?;
+        let extents = wire_manifest
+            .extents
+            .iter()
+            .zip(sources)
+            .enumerate()
+            .map(|(index, (extent, source))| ScheduledProviderExtent {
+                index,
+                source,
+                length: extent.length,
+                digest: extent.digest,
+            })
+            .collect();
+        let backend = HostedProviderBackend { client: self };
+        let download = download_provider_plan(
+            spool_root,
+            wire_manifest,
+            extents,
+            &backend,
+            &self.transport,
+        )
+        .await?;
+        tracing::debug!(
+            peak_inflight_bytes = download.peak_inflight_bytes,
+            configured_bytes = self.transport.provider_max_inflight_bytes,
+            "provider pull byte-budget high-water mark"
+        );
         Ok(CompletedProviderPull {
-            pack: bundle.pack,
-            trailer_digest: bundle.trailer_digest,
+            trailer_digest: download.pack.trailer_digest,
+            pack: download.pack,
         })
-    }
-
-    async fn download_provider_extent(
-        &self,
-        source: &ProviderSource,
-        expected_length: u64,
-        expected_digest: [u8; DIGEST_LEN],
-    ) -> Result<DownloadedExtent, ProtocolError> {
-        let mut retained = Vec::new();
-        let mut previous_generation = None;
-        let mut last_retryable = None;
-
-        for _ in 0..MAX_PROVIDER_ATTEMPTS {
-            let connection = match self.connection.provider_connection(source).await {
-                Ok(connection) => connection,
-                Err(error) => {
-                    last_retryable = Some(hosted_to_protocol_error(error));
-                    continue;
-                }
-            };
-            match download_attempt(
-                &connection,
-                &source.opaque_ticket,
-                expected_length,
-                expected_digest,
-                &mut retained,
-                &mut previous_generation,
-            )
-            .await
-            {
-                Ok(_) => return Ok(DownloadedExtent { bytes: retained }),
-                Err(AttemptFailure::Retryable { error }) => last_retryable = Some(error),
-                Err(AttemptFailure::Fatal(error)) => return Err(error),
-            }
-        }
-        Err(last_retryable.unwrap_or_else(|| {
-            ProtocolError::InvalidState("provider transfer attempts exhausted".to_string())
-        }))
     }
 }
 
@@ -207,10 +198,20 @@ impl ProviderPullSession {
             pack_digest: pack_digest.to_vec(),
         }
     }
-}
 
-struct DownloadedExtent {
-    bytes: Vec<u8>,
+    pub(super) fn resolve_download(
+        &self,
+        batch_digest: &[u8],
+        result: Result<CompletedProviderPull, ProtocolError>,
+    ) -> (ProviderPullResponse, Option<CompletedProviderPull>) {
+        match result {
+            Ok(completed) => (
+                self.complete_response(batch_digest, completed.trailer_digest),
+                Some(completed),
+            ),
+            Err(_) => (self.fallback_response(batch_digest), None),
+        }
+    }
 }
 
 fn validate_challenge(
@@ -247,11 +248,11 @@ fn validate_challenge(
     Ok(())
 }
 
-fn convert_manifest<'a>(
+fn convert_manifest(
     session: &ProviderPullSession,
     challenge: &ProviderPlanChallenge,
-    manifest: &'a ApiProviderPullManifest,
-) -> Result<(ProviderPackManifest, Vec<&'a ProviderSource>), ProtocolError> {
+    manifest: &ApiProviderPullManifest,
+) -> Result<(ProviderPackManifest, Vec<ProviderSource>), ProtocolError> {
     validate_challenge(session, challenge)?;
     if manifest.version != PROVIDER_VERSION
         || manifest.plan_nonce != session.plan_nonce
@@ -340,7 +341,7 @@ fn convert_manifest<'a>(
             digest,
             objects,
         });
-        sources.push(source);
+        sources.push(source.clone());
     }
     if object_count != summary.object_count || total_bytes != summary.total_bytes {
         return Err(ProtocolError::InvalidState(
@@ -357,71 +358,367 @@ fn convert_manifest<'a>(
     ))
 }
 
+#[derive(Clone, Debug)]
+struct ScheduledProviderExtent {
+    index: usize,
+    source: ProviderSource,
+    length: u64,
+    digest: [u8; DIGEST_LEN],
+}
+
+struct ProviderPlanDownload {
+    pack: CompletedProviderPack,
+    peak_inflight_bytes: usize,
+}
+
+trait ProviderBackend: Sync {
+    type Connection: Clone + Send;
+
+    fn connect<'a>(
+        &'a self,
+        sources: &'a [ProviderSource],
+    ) -> impl Future<Output = Result<Self::Connection, ProtocolError>> + Send + 'a;
+
+    fn download(
+        &self,
+        connection: Self::Connection,
+        extent: ScheduledProviderExtent,
+        writer: ProviderPackWriter,
+        byte_budget: InflightByteBudget,
+        stall_timeout: std::time::Duration,
+    ) -> impl Future<Output = Result<(), ProtocolError>> + Send;
+}
+
+struct HostedProviderBackend<'a> {
+    client: &'a HostedClient,
+}
+
+impl ProviderBackend for HostedProviderBackend<'_> {
+    type Connection = iroh::endpoint::Connection;
+
+    async fn connect(&self, sources: &[ProviderSource]) -> Result<Self::Connection, ProtocolError> {
+        let mut last_error = None;
+        for source in sources {
+            if source.expires_at_unix_millis <= now_millis()? {
+                continue;
+            }
+            match self.client.connection.provider_connection(source).await {
+                Ok(connection) => return Ok(connection),
+                Err(error) => last_error = Some(hosted_to_protocol_error(error)),
+            }
+        }
+        Err(last_error.unwrap_or_else(|| {
+            ProtocolError::InvalidState(
+                "provider endpoint has no unexpired connection path".to_string(),
+            )
+        }))
+    }
+
+    async fn download(
+        &self,
+        connection: Self::Connection,
+        extent: ScheduledProviderExtent,
+        writer: ProviderPackWriter,
+        byte_budget: InflightByteBudget,
+        stall_timeout: std::time::Duration,
+    ) -> Result<(), ProtocolError> {
+        download_provider_extent(&connection, extent, writer, byte_budget, stall_timeout).await
+    }
+}
+
+#[derive(Clone)]
+struct InflightByteBudget {
+    inner: Arc<InflightByteBudgetInner>,
+}
+
+struct InflightByteBudgetInner {
+    semaphore: Arc<Semaphore>,
+    limit: usize,
+    current: AtomicUsize,
+    peak: AtomicUsize,
+}
+
+struct InflightByteReservation {
+    inner: Arc<InflightByteBudgetInner>,
+    bytes: usize,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl InflightByteBudget {
+    fn new(limit: usize) -> Self {
+        let limit = limit.clamp(1, Semaphore::MAX_PERMITS);
+        Self {
+            inner: Arc::new(InflightByteBudgetInner {
+                semaphore: Arc::new(Semaphore::new(limit)),
+                limit,
+                current: AtomicUsize::new(0),
+                peak: AtomicUsize::new(0),
+            }),
+        }
+    }
+
+    fn chunk_limit(&self, requested: usize) -> usize {
+        requested.min(self.inner.limit).max(1)
+    }
+
+    async fn reserve(&self, requested: usize) -> Result<InflightByteReservation, ProtocolError> {
+        let bytes = self.chunk_limit(requested);
+        let permits = u32::try_from(bytes).map_err(|_| {
+            ProtocolError::InvalidState(
+                "provider in-flight byte reservation exceeds u32".to_string(),
+            )
+        })?;
+        let permit = Arc::clone(&self.inner.semaphore)
+            .acquire_many_owned(permits)
+            .await
+            .map_err(|_| ProtocolError::InvalidState("provider byte budget closed".to_string()))?;
+        let current = self.inner.current.fetch_add(bytes, Ordering::AcqRel) + bytes;
+        self.inner.peak.fetch_max(current, Ordering::AcqRel);
+        Ok(InflightByteReservation {
+            inner: Arc::clone(&self.inner),
+            bytes,
+            _permit: permit,
+        })
+    }
+
+    fn peak(&self) -> usize {
+        self.inner.peak.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for InflightByteReservation {
+    fn drop(&mut self) {
+        self.inner.current.fetch_sub(self.bytes, Ordering::AcqRel);
+    }
+}
+
+async fn download_provider_plan<B: ProviderBackend>(
+    spool_root: &Path,
+    manifest: ProviderPackManifest,
+    extents: Vec<ScheduledProviderExtent>,
+    backend: &B,
+    policy: &HostedTransportPolicy,
+) -> Result<ProviderPlanDownload, ProtocolError> {
+    let spool = ProviderPackSpool::new_in(spool_root, manifest)?;
+    let writer = spool.writer();
+    let byte_budget = InflightByteBudget::new(policy.provider_max_inflight_bytes);
+    let connection_limit = Arc::new(Semaphore::new(policy.provider_global_concurrency));
+    let stream_limit = Arc::new(Semaphore::new(policy.provider_global_concurrency));
+    let mut groups = BTreeMap::<String, Vec<ScheduledProviderExtent>>::new();
+    for extent in extents {
+        groups
+            .entry(extent.source.endpoint_id.clone())
+            .or_default()
+            .push(extent);
+    }
+
+    let mut pending = FuturesUnordered::new();
+    for extents in groups.into_values() {
+        pending.push(download_provider_group(
+            backend,
+            extents,
+            writer.clone(),
+            Arc::clone(&connection_limit),
+            Arc::clone(&stream_limit),
+            byte_budget.clone(),
+            policy,
+        ));
+    }
+    while let Some(result) = pending.next().await {
+        result?;
+    }
+    drop(writer);
+
+    let peak_inflight_bytes = byte_budget.peak();
+    Ok(ProviderPlanDownload {
+        pack: spool.finish()?,
+        peak_inflight_bytes,
+    })
+}
+
+async fn download_provider_group<B: ProviderBackend>(
+    backend: &B,
+    extents: Vec<ScheduledProviderExtent>,
+    writer: ProviderPackWriter,
+    connection_limit: Arc<Semaphore>,
+    stream_limit: Arc<Semaphore>,
+    byte_budget: InflightByteBudget,
+    policy: &HostedTransportPolicy,
+) -> Result<(), ProtocolError> {
+    let _connection_permit = connection_limit.acquire_owned().await.map_err(|_| {
+        ProtocolError::InvalidState("provider connection scheduler closed".to_string())
+    })?;
+    for extent in &extents {
+        ensure_grant_unexpired(&extent.source)?;
+    }
+    let sources = extents
+        .iter()
+        .map(|extent| extent.source.clone())
+        .collect::<Vec<_>>();
+    let connection = tokio::time::timeout(policy.provider_stall_timeout, backend.connect(&sources))
+        .await
+        .map_err(|_| provider_stall_error())??;
+
+    let endpoint_limit = Arc::new(Semaphore::new(policy.provider_per_endpoint_concurrency));
+    let mut pending = FuturesUnordered::new();
+    for extent in extents {
+        let endpoint_limit = Arc::clone(&endpoint_limit);
+        let stream_limit = Arc::clone(&stream_limit);
+        let connection = connection.clone();
+        let writer = writer.clone();
+        let byte_budget = byte_budget.clone();
+        pending.push(async move {
+            let _endpoint_permit = endpoint_limit.acquire_owned().await.map_err(|_| {
+                ProtocolError::InvalidState("provider endpoint scheduler closed".to_string())
+            })?;
+            let _stream_permit = stream_limit.acquire_owned().await.map_err(|_| {
+                ProtocolError::InvalidState("provider stream scheduler closed".to_string())
+            })?;
+            ensure_grant_unexpired(&extent.source)?;
+            backend
+                .download(
+                    connection,
+                    extent,
+                    writer,
+                    byte_budget,
+                    policy.provider_stall_timeout,
+                )
+                .await
+        });
+    }
+    while let Some(result) = pending.next().await {
+        result?;
+    }
+    Ok(())
+}
+
+fn ensure_grant_unexpired(source: &ProviderSource) -> Result<(), ProtocolError> {
+    if source.expires_at_unix_millis <= now_millis()? {
+        return Err(ProtocolError::InvalidState(
+            "provider grant expired before its extent started".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn provider_stall_error() -> ProtocolError {
+    ProtocolError::InvalidState(
+        "provider extent exceeded the configured fallback threshold".to_string(),
+    )
+}
+
+async fn download_provider_extent(
+    connection: &iroh::endpoint::Connection,
+    extent: ScheduledProviderExtent,
+    writer: ProviderPackWriter,
+    byte_budget: InflightByteBudget,
+    stall_timeout: std::time::Duration,
+) -> Result<(), ProtocolError> {
+    let mut retained_length = 0_u64;
+    let mut previous_generation = None;
+    let mut last_retryable = None;
+
+    for _ in 0..MAX_PROVIDER_RESUME_ATTEMPTS {
+        let mut attempt = ExtentAttemptState {
+            expected_length: extent.length,
+            expected_digest: extent.digest,
+            writer: &writer,
+            extent_index: extent.index,
+            retained_length: &mut retained_length,
+            previous_generation: &mut previous_generation,
+        };
+        match download_attempt(
+            connection,
+            &extent.source.opaque_ticket,
+            &mut attempt,
+            &byte_budget,
+            stall_timeout,
+        )
+        .await
+        {
+            Ok(_) => {
+                writer.mark_verified(extent.index)?;
+                return Ok(());
+            }
+            Err(AttemptFailure::Retryable { error }) => last_retryable = Some(error),
+            Err(AttemptFailure::Fatal(error)) => return Err(error),
+        }
+    }
+    Err(last_retryable.unwrap_or_else(|| {
+        ProtocolError::InvalidState("provider transfer attempts exhausted".to_string())
+    }))
+}
+
 #[derive(Debug)]
 enum AttemptFailure {
     Retryable { error: ProtocolError },
     Fatal(ProtocolError),
 }
 
+struct ExtentAttemptState<'a> {
+    expected_length: u64,
+    expected_digest: [u8; DIGEST_LEN],
+    writer: &'a ProviderPackWriter,
+    extent_index: usize,
+    retained_length: &'a mut u64,
+    previous_generation: &'a mut Option<u64>,
+}
+
 async fn download_attempt(
     connection: &iroh::endpoint::Connection,
     opaque_ticket: &str,
-    expected_length: u64,
-    expected_digest: [u8; DIGEST_LEN],
-    retained: &mut Vec<u8>,
-    previous_generation: &mut Option<u64>,
+    state: &mut ExtentAttemptState<'_>,
+    byte_budget: &InflightByteBudget,
+    stall_timeout: std::time::Duration,
 ) -> Result<u64, AttemptFailure> {
-    let (mut send, recv) =
-        connection
-            .open_bi()
-            .await
-            .map_err(|error| AttemptFailure::Retryable {
-                error: transport_error(error),
-            })?;
-    send_provider_frame(
-        &mut send,
-        &ProviderReadClientFrame {
-            frame: Some(provider_read_client_frame::Frame::Request(
-                ProviderReadRequest {
-                    version: PROVIDER_VERSION,
-                    opaque_ticket: opaque_ticket.to_string(),
-                },
-            )),
-        },
+    let (mut send, recv) = await_provider_progress(
+        stall_timeout,
+        async { connection.open_bi().await.map_err(transport_error) },
+        true,
     )
-    .await
-    .map_err(|error| AttemptFailure::Retryable { error })?;
+    .await?;
+    await_provider_progress(
+        stall_timeout,
+        send_provider_frame(
+            &mut send,
+            &ProviderReadClientFrame {
+                frame: Some(provider_read_client_frame::Frame::Request(
+                    ProviderReadRequest {
+                        version: PROVIDER_VERSION,
+                        opaque_ticket: opaque_ticket.to_string(),
+                    },
+                )),
+            },
+        ),
+        true,
+    )
+    .await?;
 
     let mut reader = ProviderStreamReader::new(recv);
-    let ready = read_ready(&mut reader)
-        .await
-        .map_err(AttemptFailure::Fatal)?;
-    if ready.resume_offset > expected_length
-        || ready.resume_offset > retained.len() as u64
-        || ready.remaining_length != expected_length - ready.resume_offset
+    let ready = await_provider_progress(stall_timeout, read_ready(&mut reader), false).await?;
+    if ready.resume_offset > state.expected_length
+        || ready.resume_offset > *state.retained_length
+        || ready.remaining_length != state.expected_length - ready.resume_offset
         || ready.attempt_generation == 0
-        || previous_generation.is_some_and(|previous| previous == ready.attempt_generation)
+        || state
+            .previous_generation
+            .is_some_and(|previous| previous == ready.attempt_generation)
     {
         abort_provider_stream(&mut send, &mut reader);
         return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
             "provider returned an invalid resume offset or attempt generation".to_string(),
         )));
     }
-    *previous_generation = Some(ready.attempt_generation);
-    let resume_offset = usize::try_from(ready.resume_offset).map_err(|_| {
-        AttemptFailure::Fatal(ProtocolError::InvalidState(
-            "provider resume offset exceeds this platform".to_string(),
-        ))
-    })?;
-    retained.truncate(resume_offset);
+    *state.previous_generation = Some(ready.attempt_generation);
+    *state.retained_length = ready.resume_offset;
     let mut hasher = blake3::Hasher::new();
-    hasher.update(retained);
+    state
+        .writer
+        .hash_extent_prefix(state.extent_index, ready.resume_offset, &mut hasher)
+        .map_err(AttemptFailure::Fatal)?;
     let prefix_rehashed = ready.resume_offset;
 
-    let raw_length = reader
-        .next_raw_body()
-        .await
-        .map_err(|error| AttemptFailure::Retryable { error })?;
+    let raw_length = await_provider_progress(stall_timeout, reader.next_raw_body(), true).await?;
     if raw_length != ready.remaining_length {
         abort_provider_stream(&mut send, &mut reader);
         return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
@@ -429,62 +726,103 @@ async fn download_attempt(
         )));
     }
 
-    while let Some(chunk) = reader
-        .read_raw_chunk(PROVIDER_READ_CHUNK)
-        .await
-        .map_err(|error| AttemptFailure::Retryable { error })?
-    {
-        hasher.update(&chunk);
-        retained.extend_from_slice(&chunk);
-        send_provider_frame(
-            &mut send,
-            &ProviderReadClientFrame {
-                frame: Some(provider_read_client_frame::Frame::Checkpoint(
-                    ProviderReadCheckpoint {
-                        attempt_generation: ready.attempt_generation,
-                        acknowledged_length: retained.len() as u64,
-                        final_digest: Vec::new(),
-                    },
-                )),
-            },
+    while reader.raw_remaining() != 0 {
+        let requested = usize::try_from(reader.raw_remaining().min(PROVIDER_READ_CHUNK as u64))
+            .unwrap_or(PROVIDER_READ_CHUNK);
+        let reservation = byte_budget
+            .reserve(requested)
+            .await
+            .map_err(AttemptFailure::Fatal)?;
+        let Some(chunk) = await_provider_progress(
+            stall_timeout,
+            reader.read_raw_chunk(reservation.bytes),
+            true,
         )
-        .await
-        .map_err(|error| AttemptFailure::Retryable { error })?;
+        .await?
+        else {
+            break;
+        };
+        hasher.update(&chunk);
+        state
+            .writer
+            .write_extent_chunk(state.extent_index, *state.retained_length, &chunk)
+            .map_err(AttemptFailure::Fatal)?;
+        *state.retained_length = state
+            .retained_length
+            .checked_add(chunk.len() as u64)
+            .ok_or_else(|| {
+                AttemptFailure::Fatal(ProtocolError::InvalidState(
+                    "provider retained length overflows".to_string(),
+                ))
+            })?;
+        await_provider_progress(
+            stall_timeout,
+            send_provider_frame(
+                &mut send,
+                &ProviderReadClientFrame {
+                    frame: Some(provider_read_client_frame::Frame::Checkpoint(
+                        ProviderReadCheckpoint {
+                            attempt_generation: ready.attempt_generation,
+                            acknowledged_length: *state.retained_length,
+                            final_digest: Vec::new(),
+                        },
+                    )),
+                },
+            ),
+            true,
+        )
+        .await?;
     }
 
-    if retained.len() as u64 != expected_length || hasher.finalize().as_bytes() != &expected_digest
+    if *state.retained_length != state.expected_length
+        || hasher.finalize().as_bytes() != &state.expected_digest
     {
         abort_provider_stream(&mut send, &mut reader);
         return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
             "provider extent digest mismatch".to_string(),
         )));
     }
-    send_provider_frame(
-        &mut send,
-        &ProviderReadClientFrame {
-            frame: Some(provider_read_client_frame::Frame::Checkpoint(
-                ProviderReadCheckpoint {
-                    attempt_generation: ready.attempt_generation,
-                    acknowledged_length: expected_length,
-                    final_digest: expected_digest.to_vec(),
-                },
-            )),
-        },
+    await_provider_progress(
+        stall_timeout,
+        send_provider_frame(
+            &mut send,
+            &ProviderReadClientFrame {
+                frame: Some(provider_read_client_frame::Frame::Checkpoint(
+                    ProviderReadCheckpoint {
+                        attempt_generation: ready.attempt_generation,
+                        acknowledged_length: state.expected_length,
+                        final_digest: state.expected_digest.to_vec(),
+                    },
+                )),
+            },
+        ),
+        true,
     )
-    .await
-    .map_err(|error| AttemptFailure::Retryable { error })?;
+    .await?;
     send.finish().map_err(|error| AttemptFailure::Retryable {
         error: transport_error(error),
     })?;
-    let complete = read_complete(&mut reader)
-        .await
-        .map_err(AttemptFailure::Fatal)?;
-    if !complete.success || complete.committed_length != expected_length {
+    let complete =
+        await_provider_progress(stall_timeout, read_complete(&mut reader), false).await?;
+    if !complete.success || complete.committed_length != state.expected_length {
         return Err(AttemptFailure::Fatal(ProtocolError::InvalidState(
             "provider did not commit the exact verified extent".to_string(),
         )));
     }
     Ok(prefix_rehashed)
+}
+
+async fn await_provider_progress<T>(
+    stall_timeout: std::time::Duration,
+    future: impl Future<Output = Result<T, ProtocolError>>,
+    retryable: bool,
+) -> Result<T, AttemptFailure> {
+    match tokio::time::timeout(stall_timeout, future).await {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(error)) if retryable => Err(AttemptFailure::Retryable { error }),
+        Ok(Err(error)) => Err(AttemptFailure::Fatal(error)),
+        Err(_) => Err(AttemptFailure::Fatal(provider_stall_error())),
+    }
 }
 
 async fn send_provider_frame(
@@ -579,7 +917,7 @@ impl ProviderStreamReader {
             }
             let chunk = self
                 .recv
-                .read_chunk(MAX_CONTROL_BODY + 5)
+                .read_chunk(PROVIDER_CONTROL_CHUNK)
                 .await
                 .map_err(transport_error)?
                 .ok_or_else(|| {
@@ -589,7 +927,16 @@ impl ProviderStreamReader {
                     ))
                 })?;
             self.buffered.extend_from_slice(&chunk);
+            if self.buffered.len() > MAX_PROVIDER_CONTROL_BODY + 5 {
+                return Err(ProtocolError::InvalidState(
+                    "provider control frame exceeds its bounded buffer".to_string(),
+                ));
+            }
         }
+    }
+
+    fn raw_remaining(&self) -> u64 {
+        self.raw_remaining
     }
 
     async fn read_raw_chunk(&mut self, maximum: usize) -> Result<Option<Bytes>, ProtocolError> {
@@ -655,7 +1002,16 @@ fn now_millis() -> Result<u64, ProtocolError> {
 
 #[cfg(test)]
 mod tests {
-    use std::{net::Ipv4Addr, time::Duration};
+    use std::{
+        collections::{HashMap, HashSet},
+        fs,
+        net::Ipv4Addr,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+        time::Duration,
+    };
 
     use api::{
         framing::{encode_stream_message, encode_stream_raw_body},
@@ -666,9 +1022,265 @@ mod tests {
     };
     use crypto::{Ed25519Signer, Signer as _};
     use iroh::{Endpoint, RelayMode, endpoint::presets};
+    use objects::{
+        object::Blob,
+        store::{
+            CompressionConfig, FsStore,
+            pack::{ObjectType, PackBuilder, PackIndex, PackObjectId},
+        },
+    };
 
     use super::*;
     use crate::hosted::CallContextFactory;
+
+    #[derive(Clone)]
+    struct FakeProviderConnection {
+        endpoint_id: String,
+    }
+
+    struct FakeProviderBackend {
+        bodies: HashMap<String, Arc<Vec<u8>>>,
+        delays: HashMap<String, Duration>,
+        stalled: HashSet<String>,
+        connections: Mutex<HashMap<String, usize>>,
+        completion_order: Mutex<Vec<String>>,
+        active_streams: Arc<AtomicUsize>,
+        cancelled_streams: Arc<AtomicUsize>,
+        chunk_size: usize,
+    }
+
+    struct FakeStreamGuard {
+        active: Arc<AtomicUsize>,
+        cancelled: Arc<AtomicUsize>,
+        completed: bool,
+    }
+
+    impl FakeProviderBackend {
+        fn new(bodies: HashMap<String, Arc<Vec<u8>>>) -> Self {
+            Self {
+                bodies,
+                delays: HashMap::new(),
+                stalled: HashSet::new(),
+                connections: Mutex::new(HashMap::new()),
+                completion_order: Mutex::new(Vec::new()),
+                active_streams: Arc::new(AtomicUsize::new(0)),
+                cancelled_streams: Arc::new(AtomicUsize::new(0)),
+                chunk_size: 64 * 1024,
+            }
+        }
+
+        fn connection_count(&self, endpoint_id: &str) -> usize {
+            self.connections
+                .lock()
+                .unwrap()
+                .get(endpoint_id)
+                .copied()
+                .unwrap_or(0)
+        }
+    }
+
+    impl ProviderBackend for FakeProviderBackend {
+        type Connection = FakeProviderConnection;
+
+        async fn connect(
+            &self,
+            sources: &[ProviderSource],
+        ) -> Result<Self::Connection, ProtocolError> {
+            let endpoint_id = sources
+                .first()
+                .ok_or_else(|| {
+                    ProtocolError::InvalidState("fake provider group is empty".to_string())
+                })?
+                .endpoint_id
+                .clone();
+            *self
+                .connections
+                .lock()
+                .unwrap()
+                .entry(endpoint_id.clone())
+                .or_default() += 1;
+            Ok(FakeProviderConnection { endpoint_id })
+        }
+
+        async fn download(
+            &self,
+            connection: Self::Connection,
+            extent: ScheduledProviderExtent,
+            writer: ProviderPackWriter,
+            byte_budget: InflightByteBudget,
+            stall_timeout: Duration,
+        ) -> Result<(), ProtocolError> {
+            if connection.endpoint_id != extent.source.endpoint_id {
+                return Err(ProtocolError::InvalidState(
+                    "fake provider connection crossed endpoint groups".to_string(),
+                ));
+            }
+            let ticket = extent.source.opaque_ticket.clone();
+            let mut guard = FakeStreamGuard {
+                active: Arc::clone(&self.active_streams),
+                cancelled: Arc::clone(&self.cancelled_streams),
+                completed: false,
+            };
+            guard.active.fetch_add(1, Ordering::AcqRel);
+            if self.stalled.contains(&ticket) {
+                tokio::time::timeout(stall_timeout, std::future::pending::<()>())
+                    .await
+                    .map_err(|_| provider_stall_error())?;
+            }
+            if let Some(delay) = self.delays.get(&ticket) {
+                tokio::time::sleep(*delay).await;
+            }
+            let body = Arc::clone(self.bodies.get(&ticket).ok_or_else(|| {
+                ProtocolError::InvalidState("fake provider body is missing".to_string())
+            })?);
+            let mut hasher = blake3::Hasher::new();
+            let mut offset = 0_usize;
+            while offset < body.len() {
+                let length = (body.len() - offset).min(self.chunk_size);
+                let reservation = byte_budget.reserve(length).await?;
+                tokio::task::yield_now().await;
+                let chunk = &body[offset..offset + length];
+                hasher.update(chunk);
+                writer.write_extent_chunk(extent.index, offset as u64, chunk)?;
+                offset += length;
+                drop(reservation);
+            }
+            if offset as u64 != extent.length || hasher.finalize().as_bytes() != &extent.digest {
+                return Err(ProtocolError::InvalidState(
+                    "fake provider extent length or digest mismatch".to_string(),
+                ));
+            }
+            writer.mark_verified(extent.index)?;
+            self.completion_order.lock().unwrap().push(ticket);
+            guard.completed = true;
+            Ok(())
+        }
+    }
+
+    impl Drop for FakeStreamGuard {
+        fn drop(&mut self) {
+            self.active.fetch_sub(1, Ordering::AcqRel);
+            if !self.completed {
+                self.cancelled.fetch_add(1, Ordering::AcqRel);
+            }
+        }
+    }
+
+    struct ProviderFixture {
+        manifest: ProviderPackManifest,
+        extents: Vec<ScheduledProviderExtent>,
+        bodies: HashMap<String, Arc<Vec<u8>>>,
+        source_pack: Vec<u8>,
+        source_index: Vec<u8>,
+    }
+
+    fn provider_fixture(payload_sizes: &[usize], endpoints: &[&str]) -> ProviderFixture {
+        assert_eq!(payload_sizes.len(), endpoints.len());
+        let mut builder = PackBuilder::new(CompressionConfig::disabled());
+        let mut ids = Vec::new();
+        for (index, size) in payload_sizes.iter().copied().enumerate() {
+            let data = (0..size)
+                .map(|offset| ((offset.wrapping_mul(31) + index * 17) % 251) as u8)
+                .collect::<Vec<_>>();
+            let blob = Blob::new(data.clone());
+            let id = PackObjectId::Hash(blob.hash());
+            builder.add_id(id, ObjectType::Blob, data);
+            ids.push(id);
+        }
+        let (source_pack, source_index, _) = builder.build().unwrap();
+        let parsed_index = PackIndex::from_bytes(&source_index).unwrap();
+        let mut ordered = ids
+            .iter()
+            .copied()
+            .enumerate()
+            .map(|(index, id)| (parsed_index.find(&id).unwrap(), index, id))
+            .collect::<Vec<_>>();
+        ordered.sort_unstable_by_key(|(offset, _, _)| *offset);
+
+        let body_end = source_pack.len() - DIGEST_LEN;
+        let expires_at_unix_millis = now_millis().unwrap() + 60_000;
+        let mut extents = Vec::new();
+        let mut scheduled = Vec::new();
+        let mut bodies = HashMap::new();
+        for (position, (output_offset, source_index, id)) in ordered.iter().copied().enumerate() {
+            let end = ordered
+                .get(position + 1)
+                .map(|(offset, _, _)| *offset as usize)
+                .unwrap_or(body_end);
+            let body = Arc::new(source_pack[output_offset as usize..end].to_vec());
+            let ticket = format!("extent-{source_index}");
+            let digest = *blake3::hash(&body).as_bytes();
+            let extent = ProviderPackExtent {
+                output_offset,
+                length: body.len() as u64,
+                digest,
+                objects: vec![ProviderPackIndexEntry { id, output_offset }],
+            };
+            let source = ProviderSource {
+                provider_id: format!("provider-{}", endpoints[source_index]),
+                endpoint_id: endpoints[source_index].to_string(),
+                direct_url: format!(
+                    "wss://{}.invalid/direct?provider=provider-{}&ticket={ticket}",
+                    endpoints[source_index], endpoints[source_index]
+                ),
+                opaque_ticket: ticket.clone(),
+                expires_at_unix_millis,
+            };
+            let index = extents.len();
+            scheduled.push(ScheduledProviderExtent {
+                index,
+                source,
+                length: extent.length,
+                digest,
+            });
+            extents.push(extent);
+            bodies.insert(ticket, body);
+        }
+        ProviderFixture {
+            manifest: ProviderPackManifest {
+                header: source_pack[..16].try_into().unwrap(),
+                output_pack_length: source_pack.len() as u64,
+                extents,
+            },
+            extents: scheduled,
+            bodies,
+            source_pack,
+            source_index,
+        }
+    }
+
+    fn provider_policy() -> HostedTransportPolicy {
+        HostedTransportPolicy {
+            chunk_size: 64 * 1024,
+            max_inflight_objects: 4,
+            resume_attempts: 2,
+            provider_global_concurrency: 4,
+            provider_per_endpoint_concurrency: 2,
+            provider_max_inflight_bytes: 512 * 1024,
+            provider_stall_timeout: Duration::from_millis(100),
+        }
+    }
+
+    fn provider_session() -> ProviderPullSession {
+        ProviderPullSession {
+            stream_id: "pull:one".to_string(),
+            repository: "acme/widgets".to_string(),
+            endpoint_id: "11".repeat(32),
+            plan_nonce: [4; PLAN_NONCE_LEN],
+            provider_enabled: true,
+        }
+    }
+
+    fn assert_download_falls_back(result: Result<ProviderPlanDownload, ProtocolError>) {
+        let result = result.map(|download| CompletedProviderPull {
+            trailer_digest: download.pack.trailer_digest,
+            pack: download.pack,
+        });
+        let (response, completed) = provider_session().resolve_download(&[7; DIGEST_LEN], result);
+        assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
+        assert!(response.pack_digest.is_empty());
+        assert!(completed.is_none());
+    }
 
     #[test]
     fn captured_exact_plan_signature_does_not_verify_for_another_plan() {
@@ -738,6 +1350,268 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn distinct_endpoints_complete_out_of_order_into_a_byte_identical_pack() {
+        let fixture = provider_fixture(&[128 * 1024, 128 * 1024], &["endpoint-a", "endpoint-b"]);
+        let mut backend = FakeProviderBackend::new(fixture.bodies);
+        backend
+            .delays
+            .insert("extent-0".to_string(), Duration::from_millis(40));
+        let root = tempfile::tempdir().unwrap();
+
+        let mut download = download_provider_plan(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &provider_policy(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            backend.completion_order.lock().unwrap().as_slice(),
+            ["extent-1", "extent-0"]
+        );
+        assert_eq!(
+            download.pack.trailer_digest.as_slice(),
+            &fixture.source_pack[fixture.source_pack.len() - DIGEST_LEN..]
+        );
+        let store_root = tempfile::tempdir().unwrap();
+        let store = FsStore::new(store_root.path().join(".heddle"));
+        let installed = download.pack.install_into(&store).unwrap();
+        assert_eq!(
+            installed.len(),
+            PackIndex::from_bytes(&fixture.source_index)
+                .unwrap()
+                .ids()
+                .len()
+        );
+        println!(
+            "provider_out_of_order completion=endpoint-b,endpoint-a pack_bytes={} byte_identical=true",
+            fixture.source_pack.len()
+        );
+    }
+
+    #[tokio::test]
+    async fn one_endpoint_reuses_one_connection_for_multiple_grants() {
+        let fixture = provider_fixture(
+            &[64 * 1024, 64 * 1024, 64 * 1024],
+            &["endpoint-a", "endpoint-a", "endpoint-a"],
+        );
+        let backend = FakeProviderBackend::new(fixture.bodies);
+        let root = tempfile::tempdir().unwrap();
+
+        download_provider_plan(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &provider_policy(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(backend.connection_count("endpoint-a"), 1);
+        println!("provider_group grants=3 endpoint=endpoint-a connections=1 reused=true");
+    }
+
+    #[tokio::test]
+    async fn peak_provider_body_memory_is_constant_as_pack_size_grows() {
+        async fn measure(payload_size: usize) -> (usize, usize) {
+            let quarter = payload_size / 4;
+            let fixture = provider_fixture(
+                &[quarter, quarter, quarter, quarter],
+                &["endpoint-a", "endpoint-b", "endpoint-c", "endpoint-d"],
+            );
+            let pack_size = fixture.source_pack.len();
+            let mut backend = FakeProviderBackend::new(fixture.bodies);
+            backend.chunk_size = 256 * 1024;
+            let root = tempfile::tempdir().unwrap();
+            let download = download_provider_plan(
+                root.path(),
+                fixture.manifest,
+                fixture.extents,
+                &backend,
+                &provider_policy(),
+            )
+            .await
+            .unwrap();
+            (pack_size, download.peak_inflight_bytes)
+        }
+
+        let (small_pack, small_peak) = measure(1024 * 1024).await;
+        let (large_pack, large_peak) = measure(16 * 1024 * 1024).await;
+
+        assert!(large_pack >= small_pack * 10);
+        assert!(small_peak <= 512 * 1024);
+        assert!(large_peak <= 512 * 1024);
+        assert_eq!(small_peak, large_peak);
+        println!(
+            "provider_memory method=production-byte-permit-high-water small_pack={small_pack} small_peak={small_peak} large_pack={large_pack} large_peak={large_peak} bounded=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn stalled_lane_does_not_block_healthy_lane_before_fallback_threshold() {
+        let fixture = provider_fixture(&[128 * 1024, 128 * 1024], &["endpoint-a", "endpoint-b"]);
+        let mut backend = FakeProviderBackend::new(fixture.bodies);
+        backend.stalled.insert("extent-0".to_string());
+        let root = tempfile::tempdir().unwrap();
+        let started = std::time::Instant::now();
+
+        let result = download_provider_plan(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &provider_policy(),
+        )
+        .await;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            backend.completion_order.lock().unwrap().as_slice(),
+            ["extent-1"]
+        );
+        assert!(elapsed >= Duration::from_millis(90));
+        assert!(elapsed < Duration::from_millis(500));
+        assert_download_falls_back(result);
+        println!(
+            "provider_slow_lane healthy_completed=true fallback_after_ms={} threshold_ms=100",
+            elapsed.as_millis()
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_provider_extents_all_select_existing_weft_fallback() {
+        let fixture = provider_fixture(&[64 * 1024, 64 * 1024], &["a", "b"]);
+        let mut overlapping = fixture.manifest.clone();
+        overlapping.extents[1].output_offset -= 1;
+        let root = tempfile::tempdir().unwrap();
+        assert_download_falls_back(
+            download_provider_plan(
+                root.path(),
+                overlapping,
+                fixture.extents.clone(),
+                &FakeProviderBackend::new(fixture.bodies.clone()),
+                &provider_policy(),
+            )
+            .await,
+        );
+
+        let mut gapped = fixture.manifest.clone();
+        gapped.extents[1].output_offset += 1;
+        assert_download_falls_back(
+            download_provider_plan(
+                root.path(),
+                gapped,
+                fixture.extents.clone(),
+                &FakeProviderBackend::new(fixture.bodies.clone()),
+                &provider_policy(),
+            )
+            .await,
+        );
+
+        let mut oversized_pack = fixture.manifest.clone();
+        oversized_pack.output_pack_length = wire::MAX_RECEIVED_PACK_SIZE + 1;
+        assert_download_falls_back(
+            download_provider_plan(
+                root.path(),
+                oversized_pack,
+                fixture.extents.clone(),
+                &FakeProviderBackend::new(fixture.bodies.clone()),
+                &provider_policy(),
+            )
+            .await,
+        );
+
+        let mut expired_extents = fixture.extents.clone();
+        for extent in &mut expired_extents {
+            extent.source.expires_at_unix_millis = 0;
+        }
+        assert_download_falls_back(
+            download_provider_plan(
+                root.path(),
+                fixture.manifest.clone(),
+                expired_extents,
+                &FakeProviderBackend::new(fixture.bodies.clone()),
+                &provider_policy(),
+            )
+            .await,
+        );
+
+        for mutation in ["truncated", "oversized", "digest-mismatched"] {
+            let fixture = provider_fixture(&[64 * 1024], &["endpoint-a"]);
+            let mut bodies = fixture.bodies.clone();
+            let mut body = bodies["extent-0"].as_ref().clone();
+            match mutation {
+                "truncated" => {
+                    body.pop();
+                }
+                "oversized" => body.push(0),
+                "digest-mismatched" => body[0] ^= 0xff,
+                _ => unreachable!(),
+            }
+            bodies.insert("extent-0".to_string(), Arc::new(body));
+            assert_download_falls_back(
+                download_provider_plan(
+                    root.path(),
+                    fixture.manifest,
+                    fixture.extents,
+                    &FakeProviderBackend::new(bodies),
+                    &provider_policy(),
+                )
+                .await,
+            );
+        }
+        println!(
+            "provider_fail_closed cases=expired,overlap,gap,truncated,oversized,digest-mismatch fallback=existing-weft"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_streams_and_partial_spool_state() {
+        let fixture = provider_fixture(
+            &[64 * 1024, 64 * 1024, 64 * 1024],
+            &["endpoint-a", "endpoint-b", "endpoint-c"],
+        );
+        let mut bodies = fixture.bodies;
+        let mut corrupt = bodies["extent-2"].as_ref().clone();
+        corrupt[0] ^= 0xff;
+        bodies.insert("extent-2".to_string(), Arc::new(corrupt));
+        let mut backend = FakeProviderBackend::new(bodies);
+        backend.stalled.insert("extent-0".to_string());
+        backend.stalled.insert("extent-1".to_string());
+        backend
+            .delays
+            .insert("extent-2".to_string(), Duration::from_millis(30));
+        let root = tempfile::tempdir().unwrap();
+        let mut policy = provider_policy();
+        policy.provider_stall_timeout = Duration::from_millis(200);
+
+        let result = download_provider_plan(
+            root.path(),
+            fixture.manifest,
+            fixture.extents,
+            &backend,
+            &policy,
+        )
+        .await;
+
+        assert_download_falls_back(result);
+        assert_eq!(backend.active_streams.load(Ordering::Acquire), 0);
+        assert!(backend.cancelled_streams.load(Ordering::Acquire) >= 2);
+        let spool_entries = fs::read_dir(root.path().join("transfer-spool"))
+            .unwrap()
+            .count();
+        assert_eq!(spool_entries, 0);
+        println!(
+            "provider_cancellation in_flight=2 streams_dropped={} spool_entries=0",
+            backend.cancelled_streams.load(Ordering::Acquire)
+        );
+    }
+
+    #[tokio::test]
     async fn interrupted_transfer_resumes_and_rehashes_the_retained_prefix() {
         let complete = b"retained verified prefix and resumed suffix".to_vec();
         let resume_offset = 24_usize;
@@ -772,19 +1646,33 @@ mod tests {
                 .unwrap();
             first_send.finish().unwrap();
         });
-        let mut retained = Vec::new();
+        let spool_root = tempfile::tempdir().unwrap();
+        let (spool, writer) = attempt_spool(
+            spool_root.path(),
+            u64::try_from(complete.len()).unwrap(),
+            expected_digest,
+        );
+        let budget = InflightByteBudget::new(PROVIDER_READ_CHUNK);
+        let mut retained_length = 0;
         let mut generation = None;
+        let mut attempt = ExtentAttemptState {
+            expected_length: complete.len() as u64,
+            expected_digest,
+            writer: &writer,
+            extent_index: 0,
+            retained_length: &mut retained_length,
+            previous_generation: &mut generation,
+        };
         let first = download_attempt(
             &first_client_connection,
             "opaque",
-            u64::try_from(complete.len()).unwrap(),
-            expected_digest,
-            &mut retained,
-            &mut generation,
+            &mut attempt,
+            &budget,
+            Duration::from_secs(1),
         )
         .await;
         assert!(matches!(first, Err(AttemptFailure::Retryable { .. })));
-        assert_eq!(retained, complete[..resume_offset]);
+        assert_eq!(retained_length, resume_offset as u64);
         drop(first_server_connection_guard);
         tokio::time::timeout(Duration::from_secs(2), first_server_task)
             .await
@@ -830,18 +1718,27 @@ mod tests {
             second_send.finish().unwrap();
         });
 
+        let mut attempt = ExtentAttemptState {
+            expected_length: complete.len() as u64,
+            expected_digest,
+            writer: &writer,
+            extent_index: 0,
+            retained_length: &mut retained_length,
+            previous_generation: &mut generation,
+        };
         let prefix_rehashed = download_attempt(
             &client_connection,
             "opaque",
-            u64::try_from(complete.len()).unwrap(),
-            expected_digest,
-            &mut retained,
-            &mut generation,
+            &mut attempt,
+            &budget,
+            Duration::from_secs(1),
         )
         .await
         .unwrap();
-        assert_eq!(retained, complete);
+        assert_eq!(retained_length, complete.len() as u64);
         assert_eq!(prefix_rehashed, u64::try_from(resume_offset).unwrap());
+        writer.mark_verified(0).unwrap();
+        spool.finish().unwrap();
         tokio::time::timeout(Duration::from_secs(2), server_task)
             .await
             .unwrap()
@@ -885,15 +1782,29 @@ mod tests {
             committed_offset
         });
 
-        let mut retained = Vec::new();
+        let spool_root = tempfile::tempdir().unwrap();
+        let (_spool, writer) = attempt_spool(
+            spool_root.path(),
+            u64::try_from(expected.len()).unwrap(),
+            expected_digest,
+        );
+        let budget = InflightByteBudget::new(PROVIDER_READ_CHUNK);
+        let mut retained_length = 0;
         let mut generation = None;
+        let mut attempt = ExtentAttemptState {
+            expected_length: expected.len() as u64,
+            expected_digest,
+            writer: &writer,
+            extent_index: 0,
+            retained_length: &mut retained_length,
+            previous_generation: &mut generation,
+        };
         let result = download_attempt(
             &client_connection,
             "opaque",
-            u64::try_from(expected.len()).unwrap(),
-            expected_digest,
-            &mut retained,
-            &mut generation,
+            &mut attempt,
+            &budget,
+            Duration::from_secs(1),
         )
         .await;
         assert!(matches!(
@@ -914,22 +1825,44 @@ mod tests {
     }
 
     #[test]
-    fn fallback_response_carries_no_success_digest() {
-        let session = ProviderPullSession {
-            stream_id: "pull:one".to_string(),
-            repository: "acme/widgets".to_string(),
-            endpoint_id: "11".repeat(32),
-            plan_nonce: [4; PLAN_NONCE_LEN],
-            provider_enabled: true,
-        };
+    fn fallback_stays_on_the_same_logical_pull_and_carries_no_success_digest() {
+        let session = provider_session();
 
         let response = session.fallback_response(&[7; DIGEST_LEN]);
 
         assert_eq!(response.status, ProviderPullResultStatus::Fallback as i32);
+        assert_eq!(response.plan_nonce, session.plan_nonce);
+        assert_eq!(response.grant_batch_digest, [7; DIGEST_LEN]);
         assert!(response.pack_digest.is_empty());
         println!(
-            "fallback provider=unavailable selected=existing-weft caller_protocol=unchanged success_digest_present=false"
+            "fallback provider=unavailable selected=existing-weft logical_pulls=1 same_nonce=true caller_protocol=unchanged success_digest_present=false"
         );
+    }
+
+    fn attempt_spool(
+        root: &Path,
+        extent_length: u64,
+        digest: [u8; DIGEST_LEN],
+    ) -> (ProviderPackSpool, ProviderPackWriter) {
+        let mut header = [0_u8; 16];
+        header[..4].copy_from_slice(b"LMPK");
+        header[4..8].copy_from_slice(&3_u32.to_be_bytes());
+        let spool = ProviderPackSpool::new_in(
+            root,
+            ProviderPackManifest {
+                header,
+                output_pack_length: 16 + extent_length + 32,
+                extents: vec![ProviderPackExtent {
+                    output_offset: 16,
+                    length: extent_length,
+                    digest,
+                    objects: Vec::new(),
+                }],
+            },
+        )
+        .unwrap();
+        let writer = spool.writer();
+        (spool, writer)
     }
 
     async fn provider_connection_pair() -> (

--- a/crates/client/src/hosted/sync.rs
+++ b/crates/client/src/hosted/sync.rs
@@ -1396,11 +1396,16 @@ impl HostedClient {
                                 challenge,
                                 &manifest,
                                 repo.heddle_dir(),
+                                repo.store().clone(),
                             )
                             .await
                         }
-                        _ => Err(ProtocolError::InvalidState(
-                            "provider manifest arrived without one matching consent".to_string(),
+                        _ => Err(super::provider_pull::rejected_provider_manifest(
+                            &manifest,
+                            ProtocolError::InvalidState(
+                                "provider manifest arrived without one matching consent"
+                                    .to_string(),
+                            ),
                         )),
                     };
                     let (provider_result, completed) =
@@ -1525,8 +1530,7 @@ impl HostedClient {
                             let store_start = Instant::now();
                             let mut installed_ids = Vec::new();
                             if let Some(provider_pack) = provider_pack.as_mut() {
-                                installed_ids
-                                    .extend(provider_pack.pack.install_into(repo.store())?);
+                                installed_ids.append(&mut provider_pack.installed_ids);
                             }
                             if ordinary_pack_received {
                                 if let Some(pack_spool) = pack_spool.as_mut() {

--- a/crates/client/src/hosted/sync.rs
+++ b/crates/client/src/hosted/sync.rs
@@ -1391,28 +1391,22 @@ impl HostedClient {
                 Some(pull_server_frame::Frame::ProviderManifest(manifest)) => {
                     let result = match consented_provider_plan.as_ref() {
                         Some(challenge) if !provider_fallback && provider_pack.is_none() => {
-                            self.download_provider_pull(&provider_session, challenge, &manifest)
-                                .await
+                            self.download_provider_pull(
+                                &provider_session,
+                                challenge,
+                                &manifest,
+                                repo.heddle_dir(),
+                            )
+                            .await
                         }
                         _ => Err(ProtocolError::InvalidState(
                             "provider manifest arrived without one matching consent".to_string(),
                         )),
                     };
-                    let provider_result = match result {
-                        Ok(completed) => {
-                            let response = provider_session.complete_response(
-                                &manifest.grant_batch_digest,
-                                completed.trailer_digest,
-                            );
-                            provider_pack = Some(completed);
-                            response
-                        }
-                        Err(_) => {
-                            provider_fallback = true;
-                            provider_pack = None;
-                            provider_session.fallback_response(&manifest.grant_batch_digest)
-                        }
-                    };
+                    let (provider_result, completed) =
+                        provider_session.resolve_download(&manifest.grant_batch_digest, result);
+                    provider_pack = completed;
+                    provider_fallback = provider_pack.is_none();
                     tx.as_ref()
                         .ok_or_else(|| {
                             ProtocolError::InvalidState(
@@ -1530,12 +1524,9 @@ impl HostedClient {
                         {
                             let store_start = Instant::now();
                             let mut installed_ids = Vec::new();
-                            if let Some(provider_pack) = provider_pack.as_ref() {
-                                installed_ids.extend(wire::install_received_pack(
-                                    repo.store(),
-                                    &provider_pack.pack.pack_data,
-                                    &provider_pack.pack.index_data,
-                                )?);
+                            if let Some(provider_pack) = provider_pack.as_mut() {
+                                installed_ids
+                                    .extend(provider_pack.pack.install_into(repo.store())?);
                             }
                             if ordinary_pack_received {
                                 if let Some(pack_spool) = pack_spool.as_mut() {

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -64,8 +64,8 @@ pub use object_transfer::{
     chunk_count, chunk_offset, load_object_data, load_requested_object, store_received_object,
 };
 pub use provider_pack::{
-    ProviderPackBundle, ProviderPackExtent, ProviderPackIndexEntry, ProviderPackManifest,
-    assemble_provider_pack,
+    CompletedProviderPack, ProviderPackBundle, ProviderPackExtent, ProviderPackIndexEntry,
+    ProviderPackManifest, ProviderPackSpool, ProviderPackWriter, assemble_provider_pack,
 };
 pub use transfer_plan::{
     GitLaneTransferIntent, RepositoryTransferPlan, TransferPartitions, TransferPlanStats,

--- a/crates/wire/src/native_pack.rs
+++ b/crates/wire/src/native_pack.rs
@@ -797,7 +797,7 @@ fn validate_pack_chunk(
     Ok((next_offset, next_chunk))
 }
 
-fn unique_spool_dir(base: &Path) -> Result<PathBuf> {
+pub(crate) fn unique_spool_dir(base: &Path) -> Result<PathBuf> {
     let stamp = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map_err(|err| {

--- a/crates/wire/src/provider_pack.rs
+++ b/crates/wire/src/provider_pack.rs
@@ -1,9 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
-use std::collections::HashSet;
+use std::{
+    collections::HashSet,
+    fs::{self, File, OpenOptions},
+    io::Write,
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex},
+};
 
-use objects::store::pack::{PackContainerSpec, PackIndex, PackObjectId, verify_container};
+use objects::store::{
+    ObjectStore,
+    pack::{PackContainerSpec, PackIndex, PackObjectId, PackReader, verify_container},
+};
 
-use crate::{MAX_RECEIVED_PACK_SIZE, NativePackBundle, ProtocolError, Result};
+use crate::{
+    MAX_RECEIVED_PACK_SIZE, NativePackBundle, ProtocolError, Result, native_pack::unique_spool_dir,
+};
 
 const PACK_HEADER_LEN: usize = 16;
 const PACK_TRAILER_LEN: usize = 32;
@@ -37,6 +48,344 @@ pub struct ProviderPackManifest {
 pub struct ProviderPackBundle {
     pub pack: NativePackBundle,
     pub trailer_digest: [u8; 32],
+}
+
+/// A bounded-memory positional writer for one validated provider pack plan.
+#[derive(Clone, Debug)]
+pub struct ProviderPackWriter {
+    file: Arc<File>,
+    ranges: Arc<Vec<(u64, u64)>>,
+    verified: Arc<Mutex<Vec<bool>>>,
+}
+
+/// A pre-sized provider pack spool that owns all partial transfer state.
+#[derive(Debug)]
+pub struct ProviderPackSpool {
+    dir: Option<PathBuf>,
+    pack_path: PathBuf,
+    index_path: PathBuf,
+    file: Arc<File>,
+    manifest: ProviderPackManifest,
+    verified: Arc<Mutex<Vec<bool>>>,
+}
+
+/// A completely covered and validated provider pack ready for atomic install.
+#[derive(Debug)]
+pub struct CompletedProviderPack {
+    dir: PathBuf,
+    pack_path: PathBuf,
+    index_path: PathBuf,
+    pub trailer_digest: [u8; 32],
+}
+
+impl ProviderPackSpool {
+    /// Create an exact-length spool and write the validated virtual pack header.
+    pub fn new_in(root: &Path, manifest: ProviderPackManifest) -> Result<Self> {
+        validate_manifest(&manifest)?;
+        let base = root.join("transfer-spool");
+        fs::create_dir_all(&base)?;
+        let dir = unique_spool_dir(&base)?;
+        let pack_path = dir.join("provider.pack");
+        let index_path = dir.join("provider.idx");
+        let create_result = (|| -> Result<File> {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create_new(true)
+                .open(&pack_path)?;
+            file.set_len(manifest.output_pack_length)?;
+            write_all_at(&file, &manifest.header, 0)?;
+            Ok(file)
+        })();
+        let file = match create_result {
+            Ok(file) => file,
+            Err(error) => {
+                let _ = fs::remove_dir_all(&dir);
+                return Err(error);
+            }
+        };
+        let verified = Arc::new(Mutex::new(vec![false; manifest.extents.len()]));
+        Ok(Self {
+            dir: Some(dir),
+            pack_path,
+            index_path,
+            file: Arc::new(file),
+            manifest,
+            verified,
+        })
+    }
+
+    /// Obtain a cloneable positional writer for concurrent extent streams.
+    pub fn writer(&self) -> ProviderPackWriter {
+        ProviderPackWriter {
+            file: Arc::clone(&self.file),
+            ranges: Arc::new(
+                self.manifest
+                    .extents
+                    .iter()
+                    .map(|extent| (extent.output_offset, extent.length))
+                    .collect(),
+            ),
+            verified: Arc::clone(&self.verified),
+        }
+    }
+
+    /// Finalize the trailer and index after every extent has verified exactly once.
+    pub fn finish(mut self) -> Result<CompletedProviderPack> {
+        let verified = self.verified.lock().map_err(|_| {
+            ProtocolError::InvalidState("provider spool verification lock poisoned".to_string())
+        })?;
+        if verified.iter().any(|complete| !complete) {
+            return Err(ProtocolError::InvalidState(
+                "provider spool does not have complete verified coverage".to_string(),
+            ));
+        }
+        drop(verified);
+
+        let body_end = self.manifest.output_pack_length - PACK_TRAILER_LEN as u64;
+        let trailer_digest = hash_file_prefix(&self.file, body_end)?;
+        write_all_at(&self.file, &trailer_digest, body_end)?;
+        self.file.sync_all()?;
+        write_provider_index(&self.index_path, &self.manifest)?;
+
+        let reader = PackReader::open(&self.pack_path, &self.index_path)?;
+        let expected_objects = self
+            .manifest
+            .extents
+            .iter()
+            .map(|extent| extent.objects.len())
+            .sum::<usize>();
+        if reader.list_ids().len() != expected_objects {
+            return Err(ProtocolError::InvalidState(
+                "provider pack index does not match its manifest".to_string(),
+            ));
+        }
+        drop(reader);
+
+        let dir = self.dir.take().ok_or_else(|| {
+            ProtocolError::InvalidState("provider spool directory is missing".to_string())
+        })?;
+        Ok(CompletedProviderPack {
+            dir,
+            pack_path: self.pack_path.clone(),
+            index_path: self.index_path.clone(),
+            trailer_digest,
+        })
+    }
+}
+
+impl ProviderPackWriter {
+    /// Write one chunk at its manifest-assigned extent-relative position.
+    pub fn write_extent_chunk(
+        &self,
+        extent_index: usize,
+        relative_offset: u64,
+        data: &[u8],
+    ) -> Result<()> {
+        let (output_offset, extent_len) =
+            self.ranges.get(extent_index).copied().ok_or_else(|| {
+                ProtocolError::InvalidState("provider extent index is out of range".to_string())
+            })?;
+        let data_len = u64::try_from(data.len()).map_err(|_| {
+            ProtocolError::InvalidState("provider chunk length exceeds u64".to_string())
+        })?;
+        let relative_end = relative_offset.checked_add(data_len).ok_or_else(|| {
+            ProtocolError::InvalidState("provider extent write offset overflows".to_string())
+        })?;
+        if relative_end > extent_len {
+            return Err(ProtocolError::InvalidState(
+                "provider extent write exceeds its planned range".to_string(),
+            ));
+        }
+        let absolute_offset = output_offset.checked_add(relative_offset).ok_or_else(|| {
+            ProtocolError::InvalidState("provider spool write offset overflows".to_string())
+        })?;
+        write_all_at(&self.file, data, absolute_offset)
+    }
+
+    /// Rehash a retained prefix without retaining the extent body in memory.
+    pub fn hash_extent_prefix(
+        &self,
+        extent_index: usize,
+        prefix_len: u64,
+        hasher: &mut blake3::Hasher,
+    ) -> Result<()> {
+        let (output_offset, extent_len) =
+            self.ranges.get(extent_index).copied().ok_or_else(|| {
+                ProtocolError::InvalidState("provider extent index is out of range".to_string())
+            })?;
+        if prefix_len > extent_len {
+            return Err(ProtocolError::InvalidState(
+                "provider retained prefix exceeds its planned extent".to_string(),
+            ));
+        }
+        let mut buffer = [0_u8; 64 * 1024];
+        let mut read = 0_u64;
+        while read < prefix_len {
+            let remaining = prefix_len - read;
+            let length = usize::try_from(remaining.min(buffer.len() as u64)).map_err(|_| {
+                ProtocolError::InvalidState("provider prefix length exceeds usize".to_string())
+            })?;
+            let offset = output_offset.checked_add(read).ok_or_else(|| {
+                ProtocolError::InvalidState("provider prefix read offset overflows".to_string())
+            })?;
+            read_exact_at(&self.file, &mut buffer[..length], offset)?;
+            hasher.update(&buffer[..length]);
+            read += length as u64;
+        }
+        Ok(())
+    }
+
+    /// Mark one fully length- and digest-verified extent complete exactly once.
+    pub fn mark_verified(&self, extent_index: usize) -> Result<()> {
+        let mut verified = self.verified.lock().map_err(|_| {
+            ProtocolError::InvalidState("provider spool verification lock poisoned".to_string())
+        })?;
+        let complete = verified.get_mut(extent_index).ok_or_else(|| {
+            ProtocolError::InvalidState("provider extent index is out of range".to_string())
+        })?;
+        if *complete {
+            return Err(ProtocolError::InvalidState(
+                "provider extent completed more than once".to_string(),
+            ));
+        }
+        *complete = true;
+        Ok(())
+    }
+}
+
+impl CompletedProviderPack {
+    /// Atomically install a fully validated provider pack into the object store.
+    pub fn install_into(&mut self, store: &impl ObjectStore) -> Result<Vec<PackObjectId>> {
+        store
+            .install_pack_streaming(&self.pack_path, &self.index_path)
+            .map_err(ProtocolError::from)
+    }
+}
+
+impl Drop for ProviderPackSpool {
+    fn drop(&mut self) {
+        if let Some(dir) = self.dir.as_ref() {
+            let _ = fs::remove_dir_all(dir);
+        }
+    }
+}
+
+impl Drop for CompletedProviderPack {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn write_provider_index(path: &Path, manifest: &ProviderPackManifest) -> Result<()> {
+    let mut index = PackIndex::new();
+    for extent in &manifest.extents {
+        for object in &extent.objects {
+            index.add(object.id, object.output_offset);
+        }
+    }
+    index.sort();
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    file.write_all(&index.to_bytes())?;
+    file.flush()?;
+    file.sync_all()?;
+    Ok(())
+}
+
+fn hash_file_prefix(file: &File, length: u64) -> Result<[u8; 32]> {
+    let mut hasher = blake3::Hasher::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut offset = 0_u64;
+    while offset < length {
+        let remaining = length - offset;
+        let read_len = usize::try_from(remaining.min(buffer.len() as u64)).map_err(|_| {
+            ProtocolError::InvalidState("provider pack hash length exceeds usize".to_string())
+        })?;
+        read_exact_at(file, &mut buffer[..read_len], offset)?;
+        hasher.update(&buffer[..read_len]);
+        offset += read_len as u64;
+    }
+    Ok(*hasher.finalize().as_bytes())
+}
+
+#[cfg(unix)]
+fn write_all_at(file: &File, mut data: &[u8], mut offset: u64) -> Result<()> {
+    use std::os::unix::fs::FileExt;
+
+    while !data.is_empty() {
+        let written = file.write_at(data, offset)?;
+        if written == 0 {
+            return Err(ProtocolError::Io(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "provider positional spool write returned zero",
+            )));
+        }
+        data = &data[written..];
+        offset = offset.checked_add(written as u64).ok_or_else(|| {
+            ProtocolError::InvalidState("provider positional write offset overflows".to_string())
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_all_at(file: &File, mut data: &[u8], mut offset: u64) -> Result<()> {
+    use std::os::windows::fs::FileExt;
+
+    while !data.is_empty() {
+        let written = file.seek_write(data, offset)?;
+        if written == 0 {
+            return Err(ProtocolError::Io(std::io::Error::new(
+                std::io::ErrorKind::WriteZero,
+                "provider positional spool write returned zero",
+            )));
+        }
+        data = &data[written..];
+        offset = offset.checked_add(written as u64).ok_or_else(|| {
+            ProtocolError::InvalidState("provider positional write offset overflows".to_string())
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn read_exact_at(file: &File, mut data: &mut [u8], mut offset: u64) -> Result<()> {
+    use std::os::unix::fs::FileExt;
+
+    while !data.is_empty() {
+        let read = file.read_at(data, offset)?;
+        if read == 0 {
+            return Err(ProtocolError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "provider positional spool read ended early",
+            )));
+        }
+        data = &mut data[read..];
+        offset = offset.checked_add(read as u64).ok_or_else(|| {
+            ProtocolError::InvalidState("provider positional read offset overflows".to_string())
+        })?;
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn read_exact_at(file: &File, mut data: &mut [u8], mut offset: u64) -> Result<()> {
+    use std::os::windows::fs::FileExt;
+
+    while !data.is_empty() {
+        let read = file.seek_read(data, offset)?;
+        if read == 0 {
+            return Err(ProtocolError::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "provider positional spool read ended early",
+            )));
+        }
+        data = &mut data[read..];
+        offset = offset.checked_add(read as u64).ok_or_else(|| {
+            ProtocolError::InvalidState("provider positional read offset overflows".to_string())
+        })?;
+    }
+    Ok(())
 }
 
 /// Assemble and verify one virtual native pack from provider extent bodies.
@@ -281,13 +630,82 @@ mod tests {
     }
 
     #[test]
-    fn manifest_gaps_and_duplicate_index_entries_fail_closed() {
+    fn manifest_gaps_and_invalid_or_duplicate_index_entries_fail_closed() {
         let (mut manifest, bodies, _, _) = split_manifest();
         manifest.extents[1].output_offset += 1;
         assert!(assemble_provider_pack(&manifest, &bodies).is_err());
 
         let (mut manifest, bodies, _, _) = split_manifest();
+        manifest.extents[1].objects[0].output_offset = manifest.extents[0].output_offset;
+        assert!(assemble_provider_pack(&manifest, &bodies).is_err());
+
+        let (mut manifest, bodies, _, _) = split_manifest();
         manifest.extents[1].objects[0].id = manifest.extents[0].objects[0].id;
         assert!(assemble_provider_pack(&manifest, &bodies).is_err());
+    }
+
+    #[test]
+    fn positional_spool_accepts_out_of_order_extents_and_is_byte_identical() {
+        let (manifest, bodies, source_pack, source_index) = split_manifest();
+        let root = tempfile::tempdir().unwrap();
+        let spool = ProviderPackSpool::new_in(root.path(), manifest).unwrap();
+        assert_eq!(
+            spool.file.metadata().unwrap().len(),
+            source_pack.len() as u64,
+            "the sparse spool must be pre-sized to the exact virtual pack length"
+        );
+        let writer = spool.writer();
+
+        writer.write_extent_chunk(1, 0, &bodies[1]).unwrap();
+        writer.mark_verified(1).unwrap();
+        writer.write_extent_chunk(0, 0, &bodies[0]).unwrap();
+        writer.mark_verified(0).unwrap();
+        drop(writer);
+
+        let completed = spool.finish().unwrap();
+        assert_eq!(fs::read(&completed.pack_path).unwrap(), source_pack);
+        assert_eq!(fs::read(&completed.index_path).unwrap(), source_index);
+    }
+
+    #[test]
+    fn positional_spool_rejects_range_overrun_duplicate_and_incomplete_coverage() {
+        let (manifest, bodies, _, _) = split_manifest();
+        let root = tempfile::tempdir().unwrap();
+        let spool = ProviderPackSpool::new_in(root.path(), manifest).unwrap();
+        let spool_dir = spool.dir.clone().unwrap();
+        let writer = spool.writer();
+
+        assert!(
+            writer
+                .write_extent_chunk(0, bodies[0].len() as u64, &[1])
+                .is_err()
+        );
+        writer.write_extent_chunk(0, 0, &bodies[0]).unwrap();
+        writer.mark_verified(0).unwrap();
+        assert!(writer.mark_verified(0).is_err());
+        drop(writer);
+
+        assert!(spool.finish().is_err());
+        assert!(
+            !spool_dir.exists(),
+            "failed finalization must remove partial spool state"
+        );
+    }
+
+    #[test]
+    fn dropping_partial_spool_removes_all_transfer_state() {
+        let (manifest, bodies, _, _) = split_manifest();
+        let root = tempfile::tempdir().unwrap();
+        let spool = ProviderPackSpool::new_in(root.path(), manifest).unwrap();
+        let spool_dir = spool.dir.clone().unwrap();
+        let writer = spool.writer();
+        writer
+            .write_extent_chunk(0, 0, &bodies[0][..bodies[0].len() / 2])
+            .unwrap();
+
+        drop(writer);
+        drop(spool);
+
+        assert!(!spool_dir.exists());
     }
 }

--- a/docs/WIRE_PROTOCOL.md
+++ b/docs/WIRE_PROTOCOL.md
@@ -27,6 +27,7 @@ Environment-based local testing:
 - `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
 - Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
+- Provider pulls can be tuned in the user config under `[remote]` with `provider_global_concurrency`, `provider_per_endpoint_concurrency`, `provider_max_inflight_bytes`, and `provider_stall_timeout_secs`. The corresponding environment overrides are `HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES`, and `HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS`.
 
 ## Hosted Admin Operations
 


### PR DESCRIPTION
## Summary

- Stacks on #1163 and keeps its provider endpoint + opaque ticket contract, canonical plan signature, and fresh challenge/nonce boundary unchanged.
- Schedule provider endpoint groups concurrently with one cached connection per endpoint, global/per-endpoint stream limits, grant-expiry checks at actual start, progress-stall fallback, and a shared in-flight body-byte budget.
- Pre-size an exact-length positional spool, stream verified extent chunks directly to their assigned ranges, validate complete coverage/index/trailer, and install only the completed pack through the atomic streaming store path.

Defaults are 4 global streams, 2 streams per endpoint, an 8 MiB provider-body budget, and a 15 second progress-stall threshold. Four starts a typical four-lane plan promptly within the roughly 60 second grant lifetime; two gives useful multiplexing while amortising one endpoint connection; 8 MiB leaves headroom for the default 1 MiB read chunks without tying memory to pack size; 15 seconds leaves time to select the existing Weft fallback before grant expiry.

## Closes

Closes #1165

## Test evidence

1. Out-of-order fan-out: `distinct_endpoints_complete_out_of_order_into_a_byte_identical_pack` completed endpoint B before endpoint A and reconstructed the exact 262,270-byte native pack. The wire positional-spool byte-identity test also passed.
2. Connection reuse: `one_endpoint_reuses_one_connection_for_multiple_grants` observed 3 grants and exactly 1 connection; the real hosted connection cache test also observed 1 connection by cryptographic endpoint ID.
3. Bounded peak memory: `peak_provider_body_memory_is_constant_as_pack_size_grows` measured the production live-body-buffer high-water mark. A 1,048,784-byte pack peaked at 524,288 live provider-body bytes; a 16,777,428-byte pack peaked at the same 524,288 bytes. After each transport read, production records the actual `Bytes::len()` and keeps it live through digesting, positional spool write, and checkpoint; drop subtracts that exact payload length. The test backend allocates matching `Bytes` chunks and yields after allocation so concurrent buffers coexist. This measures live application provider-payload bytes, excluding fixture storage, allocator metadata, process RSS, and filesystem cache. The semaphore reservation is separately acquired before each read, so it remains the hard backpressure bound. Negative control: temporarily replacing the configured production budget with an unbounded budget made this actual-buffer test fail; restoring the bound made it pass. Compression is disabled in the fixture so the sizes differ by more than an order of magnitude on the wire.
4. Slow lane isolation: `stalled_lane_does_not_block_healthy_lane_before_fallback_threshold` completed the healthy lane and selected fallback after 101 ms with a configured 100 ms threshold.
5. Fail closed: `invalid_provider_extents_all_select_existing_weft_fallback` covers expired, overlapping, gapped, truncated, oversized, and digest-mismatched cases. Wire tests separately reject range overruns, duplicate completion, incomplete coverage, invalid object bindings, and digest mismatch before an installable pack exists.
6. Cancellation: `cancellation_drops_streams_and_partial_spool_state` observed 2 in-flight operations, all 3 streams dropped, and 0 remaining spool entries.
7. One logical pull: `fallback_stays_on_the_same_logical_pull_and_carries_no_success_digest` observed one logical pull, the same nonce and batch binding, unchanged caller protocol, and no provider success digest on fallback.

Focused evidence after final formatting:

- `cargo test --locked -p heddle-client provider_ -- --nocapture` — 12 passed.
- `cargo test --locked -p heddle-wire provider_pack::tests -- --nocapture` — 6 passed.

Exact Rust workflow invocations completed on the final code:

- `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker` — passed, `dev` profile.
- `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings` — passed.
- `cargo test --locked --workspace` — passed, including doctests.
- `cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd` — passed.
- `cargo check --locked -p heddle-repo --no-default-features --features native,zstd` — passed.
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd` — passed with existing conditional-compilation warnings.
- `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd` — passed with existing conditional-compilation warnings.

All commands used `TMPDIR=/home/scratch`. The unrelated red `HeddleCo/api#62` repository-secret gate was not changed.