### PR TITLE
Update Iroh fork and noq to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -195,7 +195,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1160,7 +1160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.119",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3149,7 +3149,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "1.0.3"
-source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6774e846e16aa9f82fe67d4eafa956c46d6e9713#6774e846e16aa9f82fe67d4eafa956c46d6e9713"
 dependencies = [
  "backon",
  "blake3",
@@ -3198,7 +3198,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "1.0.3"
-source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6774e846e16aa9f82fe67d4eafa956c46d6e9713#6774e846e16aa9f82fe67d4eafa956c46d6e9713"
 dependencies = [
  "curve25519-dalek 5.0.0",
  "data-encoding",
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "iroh-dns"
 version = "1.0.3"
-source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6774e846e16aa9f82fe67d4eafa956c46d6e9713#6774e846e16aa9f82fe67d4eafa956c46d6e9713"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3266,7 +3266,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "1.0.3"
-source = "git+https://github.com/HeddleCo/iroh.git?rev=6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6#6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6"
+source = "git+https://github.com/HeddleCo/iroh.git?rev=6774e846e16aa9f82fe67d4eafa956c46d6e9713#6774e846e16aa9f82fe67d4eafa956c46d6e9713"
 dependencies = [
  "blake3",
  "bytes",
@@ -3315,7 +3315,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3874,9 +3874,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2"
+checksum = "09e4bb6601fa543c110d8957813267d5a8d775a0f8fbaccf1f615d06ba9b10da"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3896,9 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e"
+checksum = "baa7b5ccd819a9c68a0d955e67a881032d09b1a17219b1f90b0997a0888e1a15"
 dependencies = [
  "aes-gcm 0.10.3",
  "bytes",
@@ -3923,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
+checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4000,7 +4000,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5019,7 +5019,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5402,7 +5402,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5461,7 +5461,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5643,7 +5643,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6301,7 +6301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6731,10 +6731,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7669,7 +7669,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,8 +63,8 @@ sley-transport = "0.5.2"
 hex = "0.4"
 hyper-util = { version = "0.1", features = ["tokio", "server-auto"] }
 ignore = "0.4"
-iroh = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6", default-features = false, features = ["tls-ring", "unstable-custom-transports", "unstable-custom-transport-backpressure"] }
-iroh-base = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6d50cebc0a18a8b2d2cc9303d938bd5fa39fffd6" }
+iroh = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6774e846e16aa9f82fe67d4eafa956c46d6e9713", default-features = false, features = ["tls-ring", "unstable-custom-transports", "unstable-custom-transport-backpressure"] }
+iroh-base = { version = "=1.0.3", git = "https://github.com/HeddleCo/iroh.git", rev = "6774e846e16aa9f82fe67d4eafa956c46d6e9713" }
 libc = "0.2"
 lru = "0.18"
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }
@@ -72,7 +72,7 @@ memmap2 = "0.9"
 n0-watcher = "=1.0.0"
 notify = "8"
 ntest = "0.9"
-noq-udp = { version = "=1.1.0", default-features = false }
+noq-udp = { version = "=1.1.1", default-features = false }
 proptest = "1"
 p256 = { version = "0.14", features = ["ecdsa", "pem", "getrandom"] }
 pkcs8 = { version = "0.11", features = ["pem", "encryption"] }


### PR DESCRIPTION
## Summary

- pin the Heddle Iroh fork to `6774e846e16aa9f82fe67d4eafa956c46d6e9713`, rebased on current upstream `main`
- update the complete noq family (`noq`, `noq-proto`, and `noq-udp`) from 1.1.0 to the latest published 1.1.1 release
- keep the custom transport/backpressure patch behavior unchanged

## Validation

- `cargo check --locked -p heddle-client --all-features`
- `cargo clippy --locked -p heddle-client --all-features -- -D warnings`
- dependency-tree verification confirms one `noq`/`noq-proto`/`noq-udp` version: 1.1.1
- 148/155 `heddle-client` unit tests pass; the seven failing descriptor HTTPS acceptance tests fail identically on untouched `main` in this environment
- `cargo fmt --all -- --check` is blocked by existing formatting drift on `main` (including `crates/cli/src/ts_codegen.rs` and `crates/cli/tests/ts_types_in_sync.rs`); this PR changes no Rust source

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098269&installation_model_id=21489&pr_number=1168&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1168&signature=6e2d320c4c7d41e4c807af8100617dc8607d147a967b6d61224c9ff9b1d16613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->