### PR TITLE
Pin heddle-api consumers to crates.io 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,49 +331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
-dependencies = [
- "axum-core",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "serde_core",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
-dependencies = [
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "sync_wrapper",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,41 +2062,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heddle-api"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a42c0b7c4952bf0d07b335fb1e7904115b33edf565204bba17c3ccd7724b6265"
-dependencies = [
- "bytes",
- "hex",
- "prost 0.14.1",
- "prost-types 0.14.1",
- "protoc-bin-vendored",
- "sha2 0.10.9",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
-]
-
-[[package]]
-name = "heddle-api"
-version = "0.2.0"
-source = "git+https://github.com/HeddleCo/api?rev=3acac53f3527ba4a9ea510c331cfffa556f92e1b#3acac53f3527ba4a9ea510c331cfffa556f92e1b"
-dependencies = [
- "bytes",
- "hex",
- "prost 0.14.1",
- "prost-build",
- "prost-reflect",
- "prost-types 0.14.1",
- "protoc-bin-vendored",
- "sha2 0.10.9",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "heddle-api"
-version = "0.2.0"
-source = "git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76#88e3bce2152a3aa8c5dea8908b16efd694c3ef76"
+checksum = "81db11fe2caea0dcc030f21cb6016fcb6a499609f543d25e5f18bff64e938f63"
 dependencies = [
  "bytes",
  "hex",
@@ -2165,7 +2090,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
+ "heddle-api",
  "heddle-cli-args",
  "heddle-cli-contract",
  "heddle-cli-render",
@@ -2225,7 +2150,7 @@ version = "0.10.4"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api 0.1.4",
+ "heddle-api",
  "heddle-cli-shared",
  "heddle-client",
  "heddle-objects",
@@ -2306,7 +2231,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
+ "heddle-api",
  "heddle-cli-shared",
  "heddle-crypto",
  "heddle-objects",
@@ -2389,7 +2314,7 @@ version = "0.10.4"
 dependencies = [
  "chrono",
  "futures",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=88e3bce2152a3aa8c5dea8908b16efd694c3ef76)",
+ "heddle-api",
  "heddle-crypto",
  "heddle-objects",
  "heddle-oplog",
@@ -2491,7 +2416,7 @@ name = "heddle-iroh-transport-experiment"
 version = "0.10.4"
 dependencies = [
  "bytes",
- "heddle-api 0.2.0 (git+https://github.com/HeddleCo/api?rev=3acac53f3527ba4a9ea510c331cfffa556f92e1b)",
+ "heddle-api",
  "heddle-objects",
  "heddle-wire",
  "iroh",
@@ -2957,19 +2882,6 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
-dependencies = [
- "hyper",
- "hyper-util",
- "pin-project-lite",
- "tokio",
  "tower-service",
 ]
 
@@ -3654,12 +3566,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matchit"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
-
-[[package]]
 name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3692,12 +3598,6 @@ checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -4917,8 +4817,6 @@ dependencies = [
  "prettyplease",
  "prost 0.14.1",
  "prost-types 0.14.1",
- "pulldown-cmark",
- "pulldown-cmark-to-cmark",
  "regex",
  "syn 2.0.119",
  "tempfile",
@@ -5042,26 +4940,6 @@ name = "protoc-bin-vendored-win32"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
-
-[[package]]
-name = "pulldown-cmark"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
-dependencies = [
- "bitflags 2.13.1",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark-to-cmark"
-version = "21.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8246feae3db61428fd0bb94285c690b460e4517d83152377543ca802357785f1"
-dependencies = [
- "pulldown-cmark",
-]
 
 [[package]]
 name = "quick-error"
@@ -7153,74 +7031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
-name = "tonic"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "socket2",
- "sync_wrapper",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.14.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "tonic-prost"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
-dependencies = [
- "bytes",
- "prost 0.14.1",
- "tonic",
-]
-
-[[package]]
-name = "tonic-prost-build"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4a16cba4043dc3ff43fcb3f96b4c5c154c64cbd18ca8dce2ab2c6a451d058a2"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "prost-types 0.14.1",
- "quote",
- "syn 2.0.119",
- "tempfile",
- "tonic-build",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7228,15 +7038,11 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -7505,12 +7311,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unicase"
-version = "2.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "=0.1.4", features = ["client"] }
+api = { package = "heddle-api", version = "0.2.1" }
 clap.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-client = { path = "../client", version = "0.10", optional = true }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,7 +36,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.10" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.10" }
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76" }
+api = { package = "heddle-api", version = "0.2.1" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 heddle-cli-args = { path = "../cli-args", version = "0.10", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.10", default-features = false }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -46,7 +46,7 @@ webpki-roots.workspace = true
 # matching versions from the registry.
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.10" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76", features = ["reflection"] }
+api = { package = "heddle-api", version = "0.2.1", features = ["reflection"] }
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }
 wire = { path = "../wire", package = "heddle-wire", version = "0.10", default-features = false }
 refs = { path = "../refs", package = "heddle-refs", version = "0.10" }

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.10" }
 futures.workspace = true
-api = { package = "heddle-api", version = "=0.2.0", git = "https://github.com/HeddleCo/api", rev = "88e3bce2152a3aa8c5dea8908b16efd694c3ef76" }
+api = { package = "heddle-api", version = "0.2.1" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.10" }

--- a/deny.toml
+++ b/deny.toml
@@ -163,11 +163,7 @@ skip-tree = []
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-# Temporary exact-revision API dependency while `heddle-api` 0.1.0 awaits its
-# crates.io publication. Consumer manifests pin the commit; remove this entry
-# when they move to the registry package.
 allow-git = [
-    "https://github.com/HeddleCo/api",
     # Provider transport is pinned to the reviewable HeddleCo fork until
     # custom-transport backpressure is available in an upstream release.
     "https://github.com/HeddleCo/iroh",

--- a/experiments/iroh-transport/Cargo.toml
+++ b/experiments/iroh-transport/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-api = { package = "heddle-api", git = "https://github.com/HeddleCo/api", rev = "3acac53f3527ba4a9ea510c331cfffa556f92e1b" }
+api = { package = "heddle-api", version = "0.2.1" }
 bytes.workspace = true
 iroh.workspace = true
 objects = { path = "../../crates/objects", package = "heddle-objects" }


### PR DESCRIPTION
## Summary

- Move every workspace `heddle-api` consumer to the published crates.io `0.2.1` package, preserve `reflection` for `heddle-client`, remove the obsolete API git-source allowlist, and update `Cargo.lock` to one registry package.
- Drop `features = ["client"]` from `heddle-cli-args`. At 0.1.4 that feature generated tonic client bindings, while `cli-args` uses only the transport-neutral `ReviewKind` proto enum; it does not use a generated client, tonic type, framing API, or signing API, so no required capability is removed.
- Also repin the `heddle-iroh-transport-experiment` workspace member, which was missing from the four-consumer inventory and still referenced an older API git revision. Leaving it pinned would retain a second contract implementation in full-workspace builds.
- Use Cargo's normal `version = "0.2.1"` requirement rather than `=0.2.1`: every consumer now has the same compatible 0.2.x range, while this application's lockfile selects exactly 0.2.1. This keeps one resolved contract without forcing downstream crates to an exact patch forever.
- Verify the published 0.2.1 crate contents directly, not just through a green build: its manifest exposes only `default` and `reflection`; its source includes the hand-written `framing` and `signing` modules; and its `repo_sync.proto` contains the provider capability, challenge/response, manifest/result, provider-read frames, and pull-stream variants used by heddle#1163/#1166.

## Closes

Refs HeddleCo/api#68

## Test evidence

All commands used `TMPDIR=/home/scratch`.

- `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker` — passed, `dev` profile.
- `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings` — passed.
- `cargo test --locked --workspace` — passed, including doctests.
- `cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd` — passed.
- `cargo check --locked -p heddle-repo --no-default-features --features native,zstd` — passed.
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd` — passed with the existing conditional-compilation warnings.
- `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd` — passed with the existing conditional-compilation warnings.
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v` — 12 passed.
- `bash scripts/check-default-cli-contracts.sh` — passed.
- `cargo deny check sources` — passed.
- `grep -rn --exclude-dir=.git --exclude-dir=target "github.com/HeddleCo/api" .` — only the four expected documentation links remain; no dependency manifest, lockfile source, or source allowlist remains.
- `cargo metadata --locked --offline --format-version 1` resolves exactly one `heddle-api`, registry version 0.2.1 with `default` and `reflection` enabled.
- No Rust source files changed, so touched-file `rustfmt +nightly --edition 2024` was not applicable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1169"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788098531&installation_model_id=21489&pr_number=1169&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1169&signature=6e729e310c9b15485a12426e5ddaa31a9a9b6eec3e994bdc8cfd5a9b58451f86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->