### PR TITLE
fix(deps): update event-listener for RUSTSEC-2026-0221

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,15 +806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,11 +1541,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]


### PR DESCRIPTION
## Summary

- Update `event-listener` from 5.4.1 to patched 5.4.2 for RUSTSEC-2026-0221.
- Remove the now-orphaned `concurrent-queue` 2.5.0 lock entry.
- Keep the change scoped to `Cargo.lock` only.

## Closes

n/a — security advisory

## Test evidence

Before (`cargo audit --deny warnings` against the base `Cargo.lock`):

```text
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1175 security advisories (from /home/scratch/heddle-rustsec-advisory-db)
    Updating crates.io index
    Scanning /dev/fd/63 for vulnerabilities (754 crate dependencies)
Crate:     event-listener
Version:   5.4.1
Warning:   unsound
Title:     `event-listener` allows `!Send` tags to cross thread boundaries via `StackSlot`
Date:      2026-07-13
ID:        RUSTSEC-2026-0221
URL:       https://rustsec.org/advisories/RUSTSEC-2026-0221

error: 1 denied warning found!
```

After (`cargo audit --deny warnings`):

```text
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 1175 security advisories (from /home/scratch/heddle-rustsec-advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (753 crate dependencies)
```

No other advisories were reported.

Passed:

- `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker`
- `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings`
- `cargo test --locked --workspace`
- `git diff --check`

Final diff stat:

```text
 Cargo.lock | 14 ++------------
 1 file changed, 2 insertions(+), 12 deletions(-)
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788105952&installation_model_id=21489&pr_number=1172&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1172&signature=287aec6b399c6f77eb884d62a8ca9091489d4acd856c21f7f78c97ec16063f7d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->