### PR TITLE
Standardize hc identifiers and review signing tag

### DIFF
--- a/crates/daemon/src/local_review/state_review.rs
+++ b/crates/daemon/src/local_review/state_review.rs
@@ -1261,10 +1261,22 @@ mod tests {
     }
 
     fn sign_request(state_id: &StateId, op_id: &str) -> SignStateRequest {
+        signed_request(state_id, op_id, false)
+    }
+
+    fn legacy_tag_sign_request(state_id: &StateId, op_id: &str) -> SignStateRequest {
+        signed_request(state_id, op_id, true)
+    }
+
+    fn signed_request(state_id: &StateId, op_id: &str, use_legacy_tag: bool) -> SignStateRequest {
         let signer = crypto::Ed25519Signer::generate().expect("generate ed25519 key");
         let scope = ReviewScope::WholeChange;
         let signed_at = chrono::Utc::now().timestamp();
-        let payload = signing_payload(*state_id, ReviewKind::Read, &scope, signed_at, None);
+        let mut payload = signing_payload(*state_id, ReviewKind::Read, &scope, signed_at, None);
+        if use_legacy_tag {
+            const LEGACY_TAG: &[u8] = b"hd-rev-sig-v1\x00";
+            payload[..LEGACY_TAG.len()].copy_from_slice(LEGACY_TAG);
+        }
         let signature = signer.sign(&payload).expect("sign payload");
         use api::heddle::api::v1alpha1::review_scope::{Scope, WholeChange};
         SignStateRequest {
@@ -1352,6 +1364,33 @@ mod tests {
             scope_case,
             Some(api::heddle::api::v1alpha1::review_scope::Scope::WholeChange(_))
         ));
+    }
+
+    #[tokio::test]
+    #[serial_test::serial(process_global)]
+    async fn sign_state_rejects_legacy_hd_domain_signature() {
+        let (svc, repo, _tmp) = fresh_service();
+        let state_id = capture_state(&repo);
+
+        let error = svc
+            .sign_state(local_request(legacy_tag_sign_request(&state_id, "")))
+            .await
+            .expect_err("signature made with the hd-rev-sig-v1 tag must fail");
+
+        assert_eq!(
+            error.code(),
+            crate::local_review::LocalReviewCode::InvalidArgument
+        );
+        assert!(error.message().contains("failed verification"));
+
+        let listing = svc
+            .list_signatures(local_request(ListSignaturesRequest {
+                repo_path: None,
+                state_id: Some(api_state_id(&state_id)),
+            }))
+            .await
+            .expect("list_signatures");
+        assert!(listing.signatures.is_empty());
     }
 
     #[tokio::test]

--- a/crates/object-model/src/object/hash.rs
+++ b/crates/object-model/src/object/hash.rs
@@ -302,6 +302,14 @@ mod tests {
     }
 
     #[test]
+    fn test_change_id_rejects_legacy_hd_prefix() {
+        let legacy = ChangeId::generate()
+            .to_string_full()
+            .replacen("hc-", "hd-", 1);
+        assert!(ChangeId::parse(&legacy).is_err());
+    }
+
+    #[test]
     fn test_change_id_short() {
         let id = ChangeId::generate();
         let short = id.short();

--- a/crates/object-model/src/object/state_review.rs
+++ b/crates/object-model/src/object/state_review.rs
@@ -16,10 +16,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::object::{hash::StateId, state_attribution::Principal};
 
-/// Stable byte prefix the signing payload begins with. Bumping this versions
-/// the payload format itself; old signatures with the old prefix continue to
-/// verify exactly as they did when written.
-pub const SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-rev-sig-v1\x00";
+/// Stable byte prefix the signing payload begins with. This pre-launch domain
+/// deliberately has no compatibility path for the superseded `hd-` draft tag.
+pub const SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hc-rev-sig-v1\x00";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReviewSignaturesBlob {
@@ -280,6 +279,7 @@ mod tests {
     fn signing_payload_starts_with_version_tag() {
         let id = StateId::from_bytes([1; 32]);
         let payload = signing_payload(id, ReviewKind::Read, &ReviewScope::WholeChange, 0, None);
+        assert_eq!(SIGNING_PAYLOAD_VERSION_TAG, b"hc-rev-sig-v1\x00");
         assert!(payload.starts_with(SIGNING_PAYLOAD_VERSION_TAG));
     }
 

--- a/docs/design/clonefile-threads.md
+++ b/docs/design/clonefile-threads.md
@@ -257,7 +257,7 @@ Otherwise falls back to `virtualized`. Users can override explicitly.
 
 ```toml
 schema_version = 1
-state_id = "hd-xxxxxxxx..."
+state_id = "hc-xxxxxxxx..."
 tree_hash = "blake3..."
 materialized_at = 1778800000
 

--- a/docs/design/reftable-spike.md
+++ b/docs/design/reftable-spike.md
@@ -52,7 +52,7 @@ The differences are entirely in the on-disk encoding:
 |---|---|---|
 | Bytes | Line-oriented UTF-8 text | Header + offset index + variable-length records + footer, little-endian |
 | Record | `<base32 ChangeId> refs/<kind>/<name>\n` | `[name_len u16][name][id 16 bytes]` |
-| ID encoding | base32 with `hd-` prefix (≈ 29 chars / ID) | Raw 16 bytes |
+| ID encoding | base32 with `hc-` prefix (≈ 29 chars / ID) | Raw 16 bytes |
 | Lookup cost (cold) | Full parse, then `HashMap` get | `O(log N)` binary search via offset index |
 | Lookup cost (warm) | `HashMap` get — `O(1)` | Binary search over sorted `Vec` — `O(log N)` |
 | File header | `# packed-refs with: peeled fully-peeled sorted` | 8-byte magic + thread/marker counts |
@@ -127,7 +127,7 @@ that motivate reftable, not the full spec.
 
 Reftable is **34 % smaller**. The win comes entirely from encoding the
 16-byte `ChangeId` raw rather than as a 26-character base32 string with
-`hd-` prefix.
+`hc-` prefix.
 
 ### Cold load (open file, parse to in-memory model)
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -90,9 +90,9 @@ Every CLI verb that takes a state argument accepts the same set of
 specifiers. Pass any of them — they all resolve to the same change ID:
 
 * **Full change ID** — the 32-character form printed by `show --output json`'s
-  `change_id_full`, e.g. `hd-sqr398dvx9ayt9bf8bf5gz0jg8`.
+  `change_id_full`, e.g. `hc-sqr398dvx9ayt9bf8bf5gz0jg8`.
 * **Short change ID** — the 12-character prefix printed by every other
-  `--output json` verb's `change_id` field, e.g. `hd-sqr398dvx9ay`. Any
+  `--output json` verb's `change_id` field, e.g. `hc-sqr398dvx9ay`. Any
   unambiguous prefix of length 4 or more works; ambiguous prefixes
   yield an `ambiguous state ID prefix '<X>' matches: <list>` error.
 * **`HEAD`, `@`, `HEAD~N`, `@~N`** — relative walks from the active
@@ -104,6 +104,19 @@ Verbs covered: `show`, `diff`, `revert`, `query --attribution --state`,
 `review sign`, `discuss open|list|resolve --state`, `retro --since`.
 The `heddle log --output json` `change_id` field is the canonical short form
 that downstream verbs consume.
+
+### Pre-launch compatibility policy
+
+`hc-` is the only accepted tagged ChangeId form. Heddle has no deployed data
+using the former prefix, so there is no legacy alias: no parser, API, or
+downstream client should accept or normalize `hd-`. Unprefixed base32 prefixes
+remain valid as described above.
+
+Review signatures use the `hc-rev-sig-v1\0` payload domain. The pre-launch
+`hd-rev-sig-v1\0` draft domain is intentionally not accepted: a signature over
+that old payload must fail verification. Renaming the domain now keeps the
+HeddleCo `hc-` namespace consistent without creating a permanent dual-domain
+compatibility requirement after launch.
 
 ---
 
@@ -193,9 +206,9 @@ in-progress operation.
     "checks": []
   },
   "thread": "feature/parser-fast",
-  "base_state": "hd-abc123",
-  "base_root": "hd-abc123",
-  "current_state": "hd-def456",
+  "base_state": "hc-abc123",
+  "base_root": "hc-abc123",
+  "current_state": "hc-def456",
   "path": "/repo",
   "execution_path": "/repo",
   "actor": {"provider": "anthropic", "model": "claude-opus-4-7"},
@@ -215,7 +228,7 @@ in-progress operation.
   "coordination_status": "clean",
   "is_isolated": false,
   "parallel_threads": [],
-  "state": {"change_id": "hd-def456", "content_hash": "deadbeef", "intent": null},
+  "state": {"change_id": "hc-def456", "content_hash": "deadbeef", "intent": null},
   "git_checkpoint": null,
   "changes": {"modified": [], "added": [], "deleted": []}
 }
@@ -396,7 +409,7 @@ through Sley; it does not require a Git executable.
   "output_kind": "capture",
   "status": "captured",
   "action": "capture",
-  "state_id": "hd-capture123",
+  "state_id": "hc-capture123",
   "content_hash": "deadbeef",
   "intent": "tighten parser validation",
   "confidence": 0.86,
@@ -408,7 +421,7 @@ through Sley; it does not require a Git executable.
   },
   "promotion_suggested": false,
   "heavy_impact_paths": [],
-  "message": "captured state hd-capture123"
+  "message": "captured state hc-capture123"
 }
 ```
 
@@ -422,7 +435,7 @@ hooks.
 {
   "output_kind": "commit",
   "status": "committed",
-  "state_id": "hd-head456",
+  "state_id": "hc-head456",
   "git_commit": "e97f61a",
   "summary": "committed",
   "recommended_action": null,
@@ -443,7 +456,7 @@ hooks.
   "next_action_template": {"program": "heddle", "args": ["undo", "--recover"], "placeholders": []},
   "recommended_action": null,
   "recommended_action_template": null,
-  "recovery_state": "hd-before123",
+  "recovery_state": "hc-before123",
   "recovery_marker": ".undo-recovery"
 }
 ```
@@ -464,7 +477,7 @@ the recovered work can be captured as new history:
   "next_action_template": {"program": "heddle", "args": ["capture", "-m", "<message>"], "placeholders": ["message"]},
   "recommended_action": "heddle capture -m \"...\"",
   "recommended_action_template": {"program": "heddle", "args": ["capture", "-m", "<message>"], "placeholders": ["message"]},
-  "recovery_state": "hd-before123",
+  "recovery_state": "hc-before123",
   "recovery_marker": ".undo-recovery"
 }
 ```
@@ -512,12 +525,12 @@ saves a Heddle state without recommending a Git checkpoint.
   "next_action": "heddle land --thread feature/parser",
   "recommended_action": "heddle land --thread feature/parser",
   "captured": true,
-  "captured_state": "hd-sqr398dvx9ay",
+  "captured_state": "hc-sqr398dvx9ay",
   "thread_state": "ready",
   "readiness": {
     "status": "ready",
     "captured": true,
-    "captured_state": "hd-sqr398dvx9ay",
+    "captured_state": "hc-sqr398dvx9ay",
     "checks": {
       "status": "completed",
       "reason": "readiness preview ran"
@@ -554,7 +567,7 @@ saves a Heddle state without recommending a Git checkpoint.
   "integrated": true,
   "performed_steps": ["merge", "checkpoint"],
   "skipped_steps": ["capture(no changes)", "sync(current)"],
-  "merge_state": "hd-land123",
+  "merge_state": "hc-land123",
   "chosen_path": "capture_sync_merge_checkpoint",
   "siblings_restacked": ["feature/peer-b"],
   "siblings_restack_failed": []
@@ -637,7 +650,7 @@ add/modify/delete badges from `diff` alone:
 ```json
 {
   "output_kind": "diff",
-  "from_state": "hd-base123",
+  "from_state": "hc-base123",
   "to_state": null,
   "changes": {
     "modified": [{"path": "src/lib.rs", "kind": "modified"}],
@@ -653,8 +666,8 @@ flat `array<object>`:
 ```json
 {
   "output_kind": "diff",
-  "from_state": "hd-base123",
-  "to_state": "hd-head456",
+  "from_state": "hc-base123",
+  "to_state": "hc-head456",
   "changes": []
 }
 ```
@@ -713,7 +726,7 @@ available, checkout paths, and post-command verification.
 {
   "output_kind": "thread_create",
   "name": "feature/parser",
-  "message": "Created thread 'feature/parser' at hd-sqr398dvx9ay",
+  "message": "Created thread 'feature/parser' at hc-sqr398dvx9ay",
   "thread": null,
   "path": null,
   "execution_path": null
@@ -741,7 +754,7 @@ List recent saved states on a thread.
 ```json
 [
   {
-    "change_id": "hd-sqr398dvx9ay",
+    "change_id": "hc-sqr398dvx9ay",
     "created_at": "2026-05-23T23:57:09Z",
     "intent": "capture parser fix",
     "confidence": 0.86,
@@ -791,8 +804,8 @@ Move captured paths between isolated threads.
   "from_thread": "feature/parser",
   "to_thread": "feature/tests",
   "moved_paths": ["src/parser.rs"],
-  "source_state_id": "hd-src123",
-  "target_state_id": "hd-tgt456",
+  "source_state_id": "hc-src123",
+  "target_state_id": "hc-tgt456",
   "message": "Moved selected paths between threads"
 }
 ```
@@ -848,7 +861,7 @@ emits an array of the same object.
   "repo_path": "acme/project",
   "source_thread": "feature/parser",
   "target_thread": "main",
-  "source_state": "hd-src123",
+  "source_state": "hc-src123",
   "approver_user_id": "user_42",
   "note": "looks good",
   "approved_at": 1779580000,
@@ -867,7 +880,7 @@ emits an array of the same object.
     "repo_path": "acme/project",
     "source_thread": "feature/parser",
     "target_thread": "main",
-    "source_state": "hd-src123",
+    "source_state": "hc-src123",
     "approver_user_id": "user_42",
     "note": "looks good",
     "approved_at": 1779580000,
@@ -957,9 +970,9 @@ verification.
   "name": "parser-fast",
   "operation": {},
   "remote_tracking": {},
-  "base_state": "hd-base123",
-  "base_root": "hd-base123",
-  "current_state": "hd-head456",
+  "base_state": "hc-base123",
+  "base_root": "hc-base123",
+  "current_state": "hc-head456",
   "path": "../parser-fast",
   "execution_path": "../parser-fast",
   "actor": {"provider": "codex-cli", "model": "oss-cold-flow"},
@@ -1067,7 +1080,7 @@ verification.
   "markers": [
     {
       "name": "verified-parser",
-      "state_id": "hd-def456"
+      "state_id": "hc-def456"
     }
   ]
 }
@@ -1079,8 +1092,8 @@ verification.
 {
   "output_kind": "thread_marker_create",
   "name": "verified-parser",
-  "state_id": "hd-def456",
-  "message": "Created marker 'verified-parser' at hd-def456"
+  "state_id": "hc-def456",
+  "message": "Created marker 'verified-parser' at hc-def456"
 }
 ```
 
@@ -1101,8 +1114,8 @@ verification.
 {
   "output_kind": "thread_marker_show",
   "name": "verified-parser",
-  "state_id": "hd-def456",
-  "message": "Marker 'verified-parser' -> hd-def456"
+  "state_id": "hc-def456",
+  "message": "Marker 'verified-parser' -> hc-def456"
 }
 ```
 
@@ -1184,7 +1197,7 @@ also enveloped so agents never have to special-case a raw array.
   "presence": {
     "session_id": "agent-4dvta2dd6as3uzjrszmq",
     "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
-    "base_state": "hd-sqr398dvx9ay",
+    "base_state": "hc-sqr398dvx9ay",
     "provider": "openai",
     "model": "gpt-5",
     "usage_summary": {},
@@ -1370,7 +1383,7 @@ and release emit the same reservation shape without `token`:
     "lease_id": "lease-kvd9yn2z5kk3ehm0x8be",
     "actor_session_id": "agent-k3f2w58q7f8rmm3qj0v8",
     "thread": "main",
-    "anchor_state": "hd-sqr398dvx9ay",
+    "anchor_state": "hc-sqr398dvx9ay",
     "anchor_root": "32fc0aff",
     "task_assignment_id": null,
     "status": "active",
@@ -1389,13 +1402,13 @@ and release emit the same reservation shape without `token`:
 ## `heddle agent heartbeat --output json`
 
 ```json
-{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hd-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"active","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:21:00Z","liveness":"alive"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
+{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hc-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"active","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:21:00Z","liveness":"alive"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
 ```
 
 ## `heddle agent release --output json`
 
 ```json
-{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hd-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"released","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:16:00Z","liveness":"released"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
+{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hc-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"released","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:16:00Z","liveness":"released"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
 ```
 
 ---
@@ -1410,13 +1423,13 @@ shape is the same capture envelope.
   "output_kind": "capture",
   "status": "captured",
   "action": "capture",
-  "state_id": "hd-sqr398dvx9ay",
+  "state_id": "hc-sqr398dvx9ay",
   "content_hash": "sha256:...",
   "intent": "agent capture",
   "confidence": 0.8,
   "promotion_suggested": false,
   "heavy_impact_paths": [],
-  "message": "Captured hd-sqr398dvx9ay"
+  "message": "Captured hc-sqr398dvx9ay"
 }
 ```
 
@@ -1677,7 +1690,7 @@ the same ready envelope.
   "output_kind": "agent_fanout_plan",
   "title": "Coordinate Wave 4 lanes",
   "parent_thread": "main",
-  "base_state": "hd-base123",
+  "base_state": "hc-base123",
   "base_root": "tr-root123",
   "coordination_discussion_id": "discussion-123",
   "parent_task": null,
@@ -1738,7 +1751,7 @@ the same ready envelope.
   "output_kind": "agent_fanout_start",
   "title": "Coordinate Wave 4 lanes",
   "parent_thread": "main",
-  "base_state": "hd-base123",
+  "base_state": "hc-base123",
   "base_root": "tr-root123",
   "coordination_discussion_id": "discussion-123",
   "parent_task": {
@@ -1748,7 +1761,7 @@ the same ready envelope.
     "body": "- feature/lane-d4 -> ../lane-d4: Implement native fan-out UX",
     "status": "in_progress",
     "target_thread": "main",
-    "base_state": "hd-base123",
+    "base_state": "hc-base123",
     "base_root": "tr-root123",
     "parent_task_id": null,
     "coordination_discussion_id": "discussion-123",
@@ -1770,7 +1783,7 @@ the same ready envelope.
         "body": "Fan-out child lane for parent task task-parent",
         "status": "in_progress",
         "target_thread": "feature/lane-d4",
-        "base_state": "hd-base123",
+        "base_state": "hc-base123",
         "base_root": "tr-root123",
         "parent_task_id": "task-parent",
         "coordination_discussion_id": "discussion-123",
@@ -2180,14 +2193,14 @@ State history walking from a given starting state.
   "storage_model": "git+heddle-sidecar",
   "states": [
     {
-      "change_id": "hd-def456",
+      "change_id": "hc-def456",
       "content_hash": "deadbeef",
       "intent": "Capture audit pipeline",
       "principal": "Ada <ada@example.com>",
       "agent": "anthropic/claude-opus-4-7",
       "confidence": 0.95,
       "created_at": "2026-05-09 12:00:00",
-      "parents": ["hd-abc123"],
+      "parents": ["hc-abc123"],
       "git_checkpoint": "abc123def456"
     }
   ]
@@ -2237,8 +2250,8 @@ tool-call navigation state:
   "cursor": {
     "branch_id": "tlb-main",
     "step_id": "tls-2",
-    "state": "hd-def456",
-    "state_full": "hd-def4561234567890abcdef"
+    "state": "hc-def456",
+    "state_full": "hc-def4561234567890abcdef"
   },
   "branches": [
     {
@@ -2269,11 +2282,11 @@ tool-call navigation state:
       "changed": true,
       "touched_paths": ["src/lib.rs"],
       "labels": ["repo-reversible"],
-      "before_state": "hd-abc123",
-      "after_state": "hd-def456",
-      "capture_state": "hd-def456",
-      "cursor_state": "hd-def456",
-      "cursor_state_full": "hd-def4561234567890abcdef",
+      "before_state": "hc-abc123",
+      "after_state": "hc-def456",
+      "capture_state": "hc-def456",
+      "cursor_state": "hc-def456",
+      "cursor_state_full": "hc-def4561234567890abcdef",
       "payload_summary": "edit src/lib.rs",
       "payload_hash": "hpb-abc123",
       "capture_oplog_batch_id": 42,
@@ -2310,7 +2323,7 @@ values, argv, or filename lists.
   "thread": "main",
   "cursor_branch_id": "tlb-main",
   "cursor_step_id": "tls-1",
-  "cursor_state": "hd-0123456789abcdefghijklmnop",
+  "cursor_state": "hc-0123456789abcdefghijklmnop",
   "current_step": {
     "step_id": "tls-1",
     "branch_id": "tlb-main",
@@ -2351,7 +2364,7 @@ result after appending a versioned tool-call-start operation body:
   "branch_id": "tlb-main",
   "parent_step_id": null,
   "operation_id": "tl-0123456789abcdefghijklmnopqrstuv",
-  "before_state": "hd-0123456789abcdefghijklmnop",
+  "before_state": "hc-0123456789abcdefghijklmnop",
   "after_state": null,
   "changed": null,
   "tool_status": null,
@@ -2375,8 +2388,8 @@ result after appending a versioned tool-call-finish operation body:
   "branch_id": "tlb-main",
   "parent_step_id": null,
   "operation_id": "tl-1123456789abcdefghijklmnopqrstuv",
-  "before_state": "hd-0123456789abcdefghijklmnop",
-  "after_state": "hd-1123456789abcdefghijklmnop",
+  "before_state": "hc-0123456789abcdefghijklmnop",
+  "after_state": "hc-1123456789abcdefghijklmnop",
   "changed": true,
   "tool_status": "succeeded",
   "payload_summary": "Read project metadata",
@@ -2424,11 +2437,11 @@ State detail view, pretty-printed.
   "output_kind": "show",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
-  "state_id": "hd-def456",
-  "state_id_full": "hd-def4561234567890abcdef",
+  "state_id": "hc-def456",
+  "state_id_full": "hc-def4561234567890abcdef",
   "content_hash": "deadbeef…",
   "tree": "…",
-  "parents": ["hd-abc123"],
+  "parents": ["hc-abc123"],
   "intent": "Capture audit pipeline",
   "confidence": 0.95,
   "principal": {"name": "Ada", "email": "ada@example.com"},
@@ -2471,7 +2484,7 @@ State detail view, pretty-printed.
   "threads": [
     {
       "name": "feature/parser-fast",
-      "current_state": "hd-def456",
+      "current_state": "hc-def456",
       "is_current": true,
       "thread_state": "active",
       "freshness": "current",
@@ -2756,7 +2769,7 @@ Hosted-review payload for a single state.
 ```json
 {
   "output_kind": "review_show",
-  "state_id": "hd-def456",
+  "state_id": "hc-def456",
   "headline": "Tighten parser recovery",
   "agent_narrative": null,
   "files_changed": 3,
@@ -2783,7 +2796,7 @@ payload carries only `output_kind` and `next: null` — never a
 top-level `null`.
 
 ```json
-{"output_kind": "review_next", "state_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0, "next": {"state_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0}}
+{"output_kind": "review_next", "state_id": "hc-def456", "headline": "Tighten parser recovery", "existing_signatures": 0, "next": {"state_id": "hc-def456", "headline": "Tighten parser recovery", "existing_signatures": 0}}
 ```
 
 `heddle review health --output json` emits:
@@ -3144,7 +3157,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
   "ts": "2026-05-23T00:00:00Z",
   "thread": "main",
   "kind": "snapshot",
-  "state_id": "hd-sqr398dvx9ay",
+  "state_id": "hc-sqr398dvx9ay",
   "intent": "capture parser fix",
   "confidence": 0.91,
   "actor": {"provider": "openai", "model": "gpt-5"},
@@ -3165,12 +3178,12 @@ lives in `recovery_commands`.
 {
   "status": "completed",
   "action": "try",
-  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hd-sqr398dvx9ay). Run `heddle ready --thread try-1234abcd` to land.",
+  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hc-sqr398dvx9ay). Run `heddle ready --thread try-1234abcd` to land.",
   "thread": "try-1234abcd",
   "thread_dropped": false,
   "exit_code": 0,
   "duration_ms": 1420,
-  "captured_state": "hd-sqr398dvx9ay",
+  "captured_state": "hc-sqr398dvx9ay",
   "merge_state": null,
   "next_action": "heddle ready --thread try-1234abcd",
   "recommended_action": "heddle ready --thread try-1234abcd",
@@ -3214,7 +3227,7 @@ Refresh the active or named thread, or report the verification/action blocker.
   "next_action": "heddle land",
   "recommended_action": "heddle land",
   "thread": "feature/parser",
-  "current_state": "hd-sqr398dvx9ay",
+  "current_state": "hc-sqr398dvx9ay",
   "chosen_path": "refresh"
 }
 ```
@@ -3255,7 +3268,7 @@ Apply the inverse of a state. With `--no-commit`, `state_id` is
 {
   "output_kind": "revert",
   "state_id": null,
-  "reverted_state": "hd-sqr398dvx9ay",
+  "reverted_state": "hc-sqr398dvx9ay",
   "files_affected": ["M src/parser.rs"],
   "message": "Changes applied to worktree (not committed)"
 }
@@ -3277,7 +3290,7 @@ a structured object (`provider`, `model`, optional `session_id` /
 required:
 
 ```json
-{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
+{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
 ```
 
 `heddle context reason git --output json` emits:
@@ -3289,25 +3302,25 @@ required:
 `heddle collapse --output json` emits:
 
 ```json
-{"change_id": "hd-collapsed123", "collapsed": 3, "message": "collapse feature checkpoints", "parents": ["hd-base123"]}
+{"change_id": "hc-collapsed123", "collapsed": 3, "message": "collapse feature checkpoints", "parents": ["hc-base123"]}
 ```
 
 `heddle expand --output json` emits the ordered captures recorded by a squashed land collapse:
 
 ```json
-{"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hd-collapsed123", "change_id_full": "hd-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hd-source111", "change_id_full": "hd-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hd-base123"]}, {"change_id": "hd-source222", "change_id_full": "hd-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hd-source111"]}]}
+{"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hc-collapsed123", "change_id_full": "hc-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hc-source111", "change_id_full": "hc-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hc-base123"]}, {"change_id": "hc-source222", "change_id_full": "hc-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hc-source111"]}]}
 ```
 
 `heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
 
 ```json
-{"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hd-k6a0wfrbgcg7"}
+{"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hc-k6a0wfrbgcg7"}
 ```
 
 `heddle context list --output json` wraps its rows in an `items` envelope; the rows themselves carry no per-row discriminator (the envelope owns it). Each row is `{"target_kind": ..., "target": ..., "annotations": [...]}` — it emits:
 
 ```json
-{"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hd-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
+{"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hc-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
 ```
 
 `heddle daemon serve|status --output json` emit:
@@ -3413,20 +3426,20 @@ set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`).
 `.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "purge_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "redactions_marked": 1, "blob_bytes_removed": false, "blob_remains_in_pack": false, "purger": "A. Engineer <a@example.com>", "message": "purged blob sha256:abc123 at secrets.env in hd-sqr398dvx9ay (1 redaction(s) marked)", "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
+{"output_kind": "purge_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hc-sqr398dvx9ay", "path": "secrets.env", "redactions_marked": 1, "blob_bytes_removed": false, "blob_remains_in_pack": false, "purger": "A. Engineer <a@example.com>", "message": "purged blob sha256:abc123 at secrets.env in hc-sqr398dvx9ay (1 redaction(s) marked)", "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle query --output json` emits:
 
 ```json
-{"output_kind": "query", "hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hd-sqr398dvx9ay"}]}
+{"output_kind": "query", "hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hc-sqr398dvx9ay"}]}
 ```
 
 `heddle query --attribution --output json` emits structured attribution
 for a tracked file:
 
 ```json
-{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": null, "timestamp": "2026-01-01T00:00:00Z", "origins": null}]}
+{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": null, "timestamp": "2026-01-01T00:00:00Z", "origins": null}]}
 ```
 
 `heddle redact apply|list|show --output json` emit (each carries
@@ -3436,7 +3449,7 @@ is signed (`--sign-with`); `ignore_hint` only when the path is not yet
 covered by a `.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "redactor": "A. Engineer <a@example.com>", "redacted_at": "2026-01-01T00:00:00Z", "all_states": false, "states_redacted": 1, "signed": false, "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
+{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hc-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "redactor": "A. Engineer <a@example.com>", "redacted_at": "2026-01-01T00:00:00Z", "all_states": false, "states_redacted": 1, "signed": false, "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle redact trust add|list|remove --output json` emit (each carries
@@ -3456,14 +3469,14 @@ set to the snake-cased subcommand). `label` is present only for the
 declaration:
 
 ```json
-{"output_kind": "visibility_set", "state": "hd-sqr398dvx9ay", "tier": "internal", "record_id": "hd-vis123", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}
+{"output_kind": "visibility_set", "state": "hc-sqr398dvx9ay", "tier": "internal", "record_id": "hc-vis123", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}
 ```
 
 `heddle visibility promote --output json` emits the same shape as `set`,
 with `supersedes` carrying the prior record it replaces:
 
 ```json
-{"output_kind": "visibility_promote", "state": "hd-sqr398dvx9ay", "tier": "internal", "record_id": "hd-vis456", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "supersedes": "hd-vis123"}
+{"output_kind": "visibility_promote", "state": "hc-sqr398dvx9ay", "tier": "internal", "record_id": "hc-vis456", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "supersedes": "hc-vis123"}
 ```
 
 `heddle visibility show --output json` emits the effective tier for one
@@ -3471,13 +3484,13 @@ state (`effective_public` is true and the declarer fields are omitted when
 no record exists — public-by-absence):
 
 ```json
-{"output_kind": "visibility_show", "state": "hd-sqr398dvx9ay", "tier": "internal", "effective_public": false, "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "record_count": 1}
+{"output_kind": "visibility_show", "state": "hc-sqr398dvx9ay", "tier": "internal", "effective_public": false, "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "record_count": 1}
 ```
 
 `heddle visibility list --output json` emits every non-public state:
 
 ```json
-{"output_kind": "visibility_list", "states": [{"state": "hd-sqr398dvx9ay", "tier": "internal", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}], "count": 1}
+{"output_kind": "visibility_list", "states": [{"state": "hc-sqr398dvx9ay", "tier": "internal", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}], "count": 1}
 ```
 
 `heddle resolve --output json` emits:
@@ -3491,7 +3504,7 @@ no record exists — public-by-absence):
 --full --output json` emits expanded timeline summaries:
 
 ```json
-{"since": "hd-base123", "until": "hd-head456", "duration_secs": 3600, "states_captured": [{"change_id": "hd-head456", "intent": "capture parser fix", "confidence": 0.91, "agent": "codex/gpt-5", "principal": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z"}], "agents_active": [{"session_id": "session-123", "provider": "codex", "model": "gpt-5", "status": "active", "started_at": "2026-01-01T00:00:00Z", "completed_at": null, "tokens": {"input": 1200, "output": 800, "reasoning": 300, "tool_calls": 12}}], "agent_tasks": [{"task_id": "task-parser-fast", "title": "Tighten parser validation", "status": "in_progress", "target_thread": "feature/parser-fast", "updated_at": "2026-01-01T00:00:00Z", "completed_at": null, "coordination_discussion_id": null}], "timeline_steps": [{"thread": "feature/parser-fast", "step_id": "tls-1", "branch_id": "tlb-main", "parent_step_id": null, "tool_name": "edit", "tool_status": "succeeded", "changed": true, "payload_summary": "Edit parser validation", "payload_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "before_state": "hd-base123", "after_state": "hd-head456", "capture_state": "hd-head456", "started_at_ms": 1770000000000, "finished_at_ms": 1770000001000}], "markers_created": [{"name": "verified-parser", "state": "hd-head456", "timestamp": "2026-01-01T00:00:00Z"}], "context_annotations": [{"path": "src/lib.rs", "scope": "file", "kind": "rationale", "content_excerpt": "Parser accepts the new token form.", "attribution": "A. Engineer <a@example.com>", "created_at": "2026-01-01T00:00:00Z"}], "verify_signals": [{"kind": "test_passed", "label": "verified: cargo test", "timestamp": "2026-01-01T00:00:00Z"}], "merges": [{"description": "Collapsed feature/parser", "timestamp": "2026-01-01T00:00:00Z"}], "undos": [{"description": "Undo capture", "timestamp": "2026-01-01T00:00:00Z"}]}
+{"since": "hc-base123", "until": "hc-head456", "duration_secs": 3600, "states_captured": [{"change_id": "hc-head456", "intent": "capture parser fix", "confidence": 0.91, "agent": "codex/gpt-5", "principal": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z"}], "agents_active": [{"session_id": "session-123", "provider": "codex", "model": "gpt-5", "status": "active", "started_at": "2026-01-01T00:00:00Z", "completed_at": null, "tokens": {"input": 1200, "output": 800, "reasoning": 300, "tool_calls": 12}}], "agent_tasks": [{"task_id": "task-parser-fast", "title": "Tighten parser validation", "status": "in_progress", "target_thread": "feature/parser-fast", "updated_at": "2026-01-01T00:00:00Z", "completed_at": null, "coordination_discussion_id": null}], "timeline_steps": [{"thread": "feature/parser-fast", "step_id": "tls-1", "branch_id": "tlb-main", "parent_step_id": null, "tool_name": "edit", "tool_status": "succeeded", "changed": true, "payload_summary": "Edit parser validation", "payload_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "before_state": "hc-base123", "after_state": "hc-head456", "capture_state": "hc-head456", "started_at_ms": 1770000000000, "finished_at_ms": 1770000001000}], "markers_created": [{"name": "verified-parser", "state": "hc-head456", "timestamp": "2026-01-01T00:00:00Z"}], "context_annotations": [{"path": "src/lib.rs", "scope": "file", "kind": "rationale", "content_excerpt": "Parser accepts the new token form.", "attribution": "A. Engineer <a@example.com>", "created_at": "2026-01-01T00:00:00Z"}], "verify_signals": [{"kind": "test_passed", "label": "verified: cargo test", "timestamp": "2026-01-01T00:00:00Z"}], "merges": [{"description": "Collapsed feature/parser", "timestamp": "2026-01-01T00:00:00Z"}], "undos": [{"description": "Undo capture", "timestamp": "2026-01-01T00:00:00Z"}]}
 ```
 
 `heddle semantic hot --output json` emits:

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -2045,6 +2045,29 @@ let changes = status.collect()?;
 Heddle would use this under status, diff, verify, and thread-list health so the
 same Sley primitive backs all Git-overlay worktree reads.
 
+### TLS Trust Source
+
+At the start of the #1132 investigation, Sley 0.5.0's default smart-HTTPS
+client was `UreqHttpClient`. Heddle enabled its `tls-rustls` feature, so ureq
+verified servers with compiled-in Mozilla `webpki-roots`. That client did not
+consult Heddle's `HEDDLE_REMOTE_TLS_CA_CERT` setting, `SSL_CERT_FILE`, or the
+platform trust store.
+
+This is a dependency default, not a deliberate Heddle policy. The hosted
+bootstrap path separately reads `HEDDLE_REMOTE_TLS_CA_CERT` into
+`ClientConfig.tls_ca_certificate_pem` and merges those certificates into
+reqwest's roots. Consequently the two transports in one Heddle binary can
+disagree about the same server certificate. Git smart-HTTPS must use the same
+operator-facing CA setting as hosted bootstrap, and certificate failures must
+name that setting.
+
+Heddle now resolves the configured CA through the same `UserConfig` method for
+both transports. When a custom CA is present, it supplies Sley's fetch, clone,
+ls-remote, and push operations with an HTTPS client whose roots combine the
+platform store and that PEM bundle. Without a configured CA, Sley's existing
+compiled-root default remains unchanged. `SSL_CERT_FILE` is not a second Heddle
+configuration mechanism.
+
 ## Heddle Hardening Gates
 
 Keep these Heddle-side checks required while Sley settles in:
@@ -3249,6 +3272,7 @@ Environment-based local testing:
 - `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
 - Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
+- Provider pulls can be tuned in the user config under `[remote]` with `provider_global_concurrency`, `provider_per_endpoint_concurrency`, `provider_max_inflight_bytes`, and `provider_stall_timeout_secs`. The corresponding environment overrides are `HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES`, and `HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS`.
 
 ## Hosted Admin Operations
 
@@ -4055,9 +4079,9 @@ Every CLI verb that takes a state argument accepts the same set of
 specifiers. Pass any of them — they all resolve to the same change ID:
 
 * **Full change ID** — the 32-character form printed by `show --output json`'s
-  `change_id_full`, e.g. `hd-sqr398dvx9ayt9bf8bf5gz0jg8`.
+  `change_id_full`, e.g. `hc-sqr398dvx9ayt9bf8bf5gz0jg8`.
 * **Short change ID** — the 12-character prefix printed by every other
-  `--output json` verb's `change_id` field, e.g. `hd-sqr398dvx9ay`. Any
+  `--output json` verb's `change_id` field, e.g. `hc-sqr398dvx9ay`. Any
   unambiguous prefix of length 4 or more works; ambiguous prefixes
   yield an `ambiguous state ID prefix '<X>' matches: <list>` error.
 * **`HEAD`, `@`, `HEAD~N`, `@~N`** — relative walks from the active
@@ -4069,6 +4093,19 @@ Verbs covered: `show`, `diff`, `revert`, `query --attribution --state`,
 `review sign`, `discuss open|list|resolve --state`, `retro --since`.
 The `heddle log --output json` `change_id` field is the canonical short form
 that downstream verbs consume.
+
+### Pre-launch compatibility policy
+
+`hc-` is the only accepted tagged ChangeId form. Heddle has no deployed data
+using the former prefix, so there is no legacy alias: no parser, API, or
+downstream client should accept or normalize `hd-`. Unprefixed base32 prefixes
+remain valid as described above.
+
+Review signatures use the `hc-rev-sig-v1\0` payload domain. The pre-launch
+`hd-rev-sig-v1\0` draft domain is intentionally not accepted: a signature over
+that old payload must fail verification. Renaming the domain now keeps the
+HeddleCo `hc-` namespace consistent without creating a permanent dual-domain
+compatibility requirement after launch.
 
 ---
 
@@ -4158,9 +4195,9 @@ in-progress operation.
     "checks": []
   },
   "thread": "feature/parser-fast",
-  "base_state": "hd-abc123",
-  "base_root": "hd-abc123",
-  "current_state": "hd-def456",
+  "base_state": "hc-abc123",
+  "base_root": "hc-abc123",
+  "current_state": "hc-def456",
   "path": "/repo",
   "execution_path": "/repo",
   "actor": {"provider": "anthropic", "model": "claude-opus-4-7"},
@@ -4180,7 +4217,7 @@ in-progress operation.
   "coordination_status": "clean",
   "is_isolated": false,
   "parallel_threads": [],
-  "state": {"change_id": "hd-def456", "content_hash": "deadbeef", "intent": null},
+  "state": {"change_id": "hc-def456", "content_hash": "deadbeef", "intent": null},
   "git_checkpoint": null,
   "changes": {"modified": [], "added": [], "deleted": []}
 }
@@ -4361,7 +4398,7 @@ through Sley; it does not require a Git executable.
   "output_kind": "capture",
   "status": "captured",
   "action": "capture",
-  "state_id": "hd-capture123",
+  "state_id": "hc-capture123",
   "content_hash": "deadbeef",
   "intent": "tighten parser validation",
   "confidence": 0.86,
@@ -4373,7 +4410,7 @@ through Sley; it does not require a Git executable.
   },
   "promotion_suggested": false,
   "heavy_impact_paths": [],
-  "message": "captured state hd-capture123"
+  "message": "captured state hc-capture123"
 }
 ```
 
@@ -4387,7 +4424,7 @@ hooks.
 {
   "output_kind": "commit",
   "status": "committed",
-  "state_id": "hd-head456",
+  "state_id": "hc-head456",
   "git_commit": "e97f61a",
   "summary": "committed",
   "recommended_action": null,
@@ -4408,7 +4445,7 @@ hooks.
   "next_action_template": {"program": "heddle", "args": ["undo", "--recover"], "placeholders": []},
   "recommended_action": null,
   "recommended_action_template": null,
-  "recovery_state": "hd-before123",
+  "recovery_state": "hc-before123",
   "recovery_marker": ".undo-recovery"
 }
 ```
@@ -4429,7 +4466,7 @@ the recovered work can be captured as new history:
   "next_action_template": {"program": "heddle", "args": ["capture", "-m", "<message>"], "placeholders": ["message"]},
   "recommended_action": "heddle capture -m \"...\"",
   "recommended_action_template": {"program": "heddle", "args": ["capture", "-m", "<message>"], "placeholders": ["message"]},
-  "recovery_state": "hd-before123",
+  "recovery_state": "hc-before123",
   "recovery_marker": ".undo-recovery"
 }
 ```
@@ -4477,12 +4514,12 @@ saves a Heddle state without recommending a Git checkpoint.
   "next_action": "heddle land --thread feature/parser",
   "recommended_action": "heddle land --thread feature/parser",
   "captured": true,
-  "captured_state": "hd-sqr398dvx9ay",
+  "captured_state": "hc-sqr398dvx9ay",
   "thread_state": "ready",
   "readiness": {
     "status": "ready",
     "captured": true,
-    "captured_state": "hd-sqr398dvx9ay",
+    "captured_state": "hc-sqr398dvx9ay",
     "checks": {
       "status": "completed",
       "reason": "readiness preview ran"
@@ -4519,7 +4556,7 @@ saves a Heddle state without recommending a Git checkpoint.
   "integrated": true,
   "performed_steps": ["merge", "checkpoint"],
   "skipped_steps": ["capture(no changes)", "sync(current)"],
-  "merge_state": "hd-land123",
+  "merge_state": "hc-land123",
   "chosen_path": "capture_sync_merge_checkpoint",
   "siblings_restacked": ["feature/peer-b"],
   "siblings_restack_failed": []
@@ -4602,7 +4639,7 @@ add/modify/delete badges from `diff` alone:
 ```json
 {
   "output_kind": "diff",
-  "from_state": "hd-base123",
+  "from_state": "hc-base123",
   "to_state": null,
   "changes": {
     "modified": [{"path": "src/lib.rs", "kind": "modified"}],
@@ -4618,8 +4655,8 @@ flat `array<object>`:
 ```json
 {
   "output_kind": "diff",
-  "from_state": "hd-base123",
-  "to_state": "hd-head456",
+  "from_state": "hc-base123",
+  "to_state": "hc-head456",
   "changes": []
 }
 ```
@@ -4678,7 +4715,7 @@ available, checkout paths, and post-command verification.
 {
   "output_kind": "thread_create",
   "name": "feature/parser",
-  "message": "Created thread 'feature/parser' at hd-sqr398dvx9ay",
+  "message": "Created thread 'feature/parser' at hc-sqr398dvx9ay",
   "thread": null,
   "path": null,
   "execution_path": null
@@ -4706,7 +4743,7 @@ List recent saved states on a thread.
 ```json
 [
   {
-    "change_id": "hd-sqr398dvx9ay",
+    "change_id": "hc-sqr398dvx9ay",
     "created_at": "2026-05-23T23:57:09Z",
     "intent": "capture parser fix",
     "confidence": 0.86,
@@ -4756,8 +4793,8 @@ Move captured paths between isolated threads.
   "from_thread": "feature/parser",
   "to_thread": "feature/tests",
   "moved_paths": ["src/parser.rs"],
-  "source_state_id": "hd-src123",
-  "target_state_id": "hd-tgt456",
+  "source_state_id": "hc-src123",
+  "target_state_id": "hc-tgt456",
   "message": "Moved selected paths between threads"
 }
 ```
@@ -4813,7 +4850,7 @@ emits an array of the same object.
   "repo_path": "acme/project",
   "source_thread": "feature/parser",
   "target_thread": "main",
-  "source_state": "hd-src123",
+  "source_state": "hc-src123",
   "approver_user_id": "user_42",
   "note": "looks good",
   "approved_at": 1779580000,
@@ -4832,7 +4869,7 @@ emits an array of the same object.
     "repo_path": "acme/project",
     "source_thread": "feature/parser",
     "target_thread": "main",
-    "source_state": "hd-src123",
+    "source_state": "hc-src123",
     "approver_user_id": "user_42",
     "note": "looks good",
     "approved_at": 1779580000,
@@ -4922,9 +4959,9 @@ verification.
   "name": "parser-fast",
   "operation": {},
   "remote_tracking": {},
-  "base_state": "hd-base123",
-  "base_root": "hd-base123",
-  "current_state": "hd-head456",
+  "base_state": "hc-base123",
+  "base_root": "hc-base123",
+  "current_state": "hc-head456",
   "path": "../parser-fast",
   "execution_path": "../parser-fast",
   "actor": {"provider": "codex-cli", "model": "oss-cold-flow"},
@@ -5032,7 +5069,7 @@ verification.
   "markers": [
     {
       "name": "verified-parser",
-      "state_id": "hd-def456"
+      "state_id": "hc-def456"
     }
   ]
 }
@@ -5044,8 +5081,8 @@ verification.
 {
   "output_kind": "thread_marker_create",
   "name": "verified-parser",
-  "state_id": "hd-def456",
-  "message": "Created marker 'verified-parser' at hd-def456"
+  "state_id": "hc-def456",
+  "message": "Created marker 'verified-parser' at hc-def456"
 }
 ```
 
@@ -5066,8 +5103,8 @@ verification.
 {
   "output_kind": "thread_marker_show",
   "name": "verified-parser",
-  "state_id": "hd-def456",
-  "message": "Marker 'verified-parser' -> hd-def456"
+  "state_id": "hc-def456",
+  "message": "Marker 'verified-parser' -> hc-def456"
 }
 ```
 
@@ -5149,7 +5186,7 @@ also enveloped so agents never have to special-case a raw array.
   "presence": {
     "session_id": "agent-4dvta2dd6as3uzjrszmq",
     "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
-    "base_state": "hd-sqr398dvx9ay",
+    "base_state": "hc-sqr398dvx9ay",
     "provider": "openai",
     "model": "gpt-5",
     "usage_summary": {},
@@ -5335,7 +5372,7 @@ and release emit the same reservation shape without `token`:
     "lease_id": "lease-kvd9yn2z5kk3ehm0x8be",
     "actor_session_id": "agent-k3f2w58q7f8rmm3qj0v8",
     "thread": "main",
-    "anchor_state": "hd-sqr398dvx9ay",
+    "anchor_state": "hc-sqr398dvx9ay",
     "anchor_root": "32fc0aff",
     "task_assignment_id": null,
     "status": "active",
@@ -5354,13 +5391,13 @@ and release emit the same reservation shape without `token`:
 ## `heddle agent heartbeat --output json`
 
 ```json
-{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hd-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"active","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:21:00Z","liveness":"alive"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
+{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hc-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"active","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:21:00Z","liveness":"alive"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
 ```
 
 ## `heddle agent release --output json`
 
 ```json
-{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hd-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"released","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:16:00Z","liveness":"released"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
+{"reservation":{"lease_id":"lease-kvd9yn2z5kk3ehm0x8be","actor_session_id":"agent-k3f2w58q7f8rmm3qj0v8","thread":"main","anchor_state":"hc-sqr398dvx9ay","anchor_root":"32fc0aff","task_assignment_id":null,"status":"released","path":null,"heartbeat_at":"2026-07-12T23:16:00Z","lease_expires_at":"2026-07-12T23:16:00Z","liveness":"released"},"token":null,"verification":{"verified":true,"status":"clean","repository_mode":"native-heddle","heddle_initialized":true,"git_branch":null,"heddle_thread":"main","worktree_dirty":false,"worktree_state":"clean","import_state":"not_applicable","mapping_state":"not_applicable","remote_drift":"clean","active_operation":null,"default_remote":null,"clone_verification":"not_applicable","machine_contract":"available","workflow_status":"idle","workflow_summary":"No ready thread is waiting to merge","summary":"Repository is healthy","recommended_action":null,"recommended_action_template":null,"recovery_commands":[],"recovery_action_templates":[],"checks":[]}}
 ```
 
 ---
@@ -5375,13 +5412,13 @@ shape is the same capture envelope.
   "output_kind": "capture",
   "status": "captured",
   "action": "capture",
-  "state_id": "hd-sqr398dvx9ay",
+  "state_id": "hc-sqr398dvx9ay",
   "content_hash": "sha256:...",
   "intent": "agent capture",
   "confidence": 0.8,
   "promotion_suggested": false,
   "heavy_impact_paths": [],
-  "message": "Captured hd-sqr398dvx9ay"
+  "message": "Captured hc-sqr398dvx9ay"
 }
 ```
 
@@ -5642,7 +5679,7 @@ the same ready envelope.
   "output_kind": "agent_fanout_plan",
   "title": "Coordinate Wave 4 lanes",
   "parent_thread": "main",
-  "base_state": "hd-base123",
+  "base_state": "hc-base123",
   "base_root": "tr-root123",
   "coordination_discussion_id": "discussion-123",
   "parent_task": null,
@@ -5703,7 +5740,7 @@ the same ready envelope.
   "output_kind": "agent_fanout_start",
   "title": "Coordinate Wave 4 lanes",
   "parent_thread": "main",
-  "base_state": "hd-base123",
+  "base_state": "hc-base123",
   "base_root": "tr-root123",
   "coordination_discussion_id": "discussion-123",
   "parent_task": {
@@ -5713,7 +5750,7 @@ the same ready envelope.
     "body": "- feature/lane-d4 -> ../lane-d4: Implement native fan-out UX",
     "status": "in_progress",
     "target_thread": "main",
-    "base_state": "hd-base123",
+    "base_state": "hc-base123",
     "base_root": "tr-root123",
     "parent_task_id": null,
     "coordination_discussion_id": "discussion-123",
@@ -5735,7 +5772,7 @@ the same ready envelope.
         "body": "Fan-out child lane for parent task task-parent",
         "status": "in_progress",
         "target_thread": "feature/lane-d4",
-        "base_state": "hd-base123",
+        "base_state": "hc-base123",
         "base_root": "tr-root123",
         "parent_task_id": "task-parent",
         "coordination_discussion_id": "discussion-123",
@@ -5814,6 +5851,36 @@ the same ready envelope.
   "credential_id": "cred-123",
   "expires_at": "2026-06-27T00:00:00Z",
   "recommended_action": null
+}
+```
+
+---
+
+## `heddle auth trust show --output json`
+
+```json
+{
+  "output_kind": "auth_trust_show",
+  "canonical_server": "https://api.heddle.sh",
+  "source": "automatic",
+  "key_id": "production-2026-01",
+  "public_key": "7c5eb1d4f7c09c8981789c759b1445676336afe9c88d08f57d02893df9ea23c4",
+  "fingerprint": "sha256:f31c0dbdb183e33f2366f5daa71273d3444006c0143e0f8d65e0745478c14b48"
+}
+```
+
+---
+
+## `heddle auth trust replace --output json`
+
+```json
+{
+  "output_kind": "auth_trust_replace",
+  "canonical_server": "https://api.heddle.sh",
+  "source": "automatic",
+  "key_id": "production-2026-02",
+  "public_key": "280c37c667a6334f69e878f90588d8813bb44fc88333757b3e2d6b1e79bdab01",
+  "fingerprint": "sha256:06d1aac7c406aa1cd62280ae9948af0fd2d42ac10ba5c8c0b3a7840d9deb7275"
 }
 ```
 
@@ -6115,14 +6182,14 @@ State history walking from a given starting state.
   "storage_model": "git+heddle-sidecar",
   "states": [
     {
-      "change_id": "hd-def456",
+      "change_id": "hc-def456",
       "content_hash": "deadbeef",
       "intent": "Capture audit pipeline",
       "principal": "Ada <ada@example.com>",
       "agent": "anthropic/claude-opus-4-7",
       "confidence": 0.95,
       "created_at": "2026-05-09 12:00:00",
-      "parents": ["hd-abc123"],
+      "parents": ["hc-abc123"],
       "git_checkpoint": "abc123def456"
     }
   ]
@@ -6172,8 +6239,8 @@ tool-call navigation state:
   "cursor": {
     "branch_id": "tlb-main",
     "step_id": "tls-2",
-    "state": "hd-def456",
-    "state_full": "hd-def4561234567890abcdef"
+    "state": "hc-def456",
+    "state_full": "hc-def4561234567890abcdef"
   },
   "branches": [
     {
@@ -6204,11 +6271,11 @@ tool-call navigation state:
       "changed": true,
       "touched_paths": ["src/lib.rs"],
       "labels": ["repo-reversible"],
-      "before_state": "hd-abc123",
-      "after_state": "hd-def456",
-      "capture_state": "hd-def456",
-      "cursor_state": "hd-def456",
-      "cursor_state_full": "hd-def4561234567890abcdef",
+      "before_state": "hc-abc123",
+      "after_state": "hc-def456",
+      "capture_state": "hc-def456",
+      "cursor_state": "hc-def456",
+      "cursor_state_full": "hc-def4561234567890abcdef",
       "payload_summary": "edit src/lib.rs",
       "payload_hash": "hpb-abc123",
       "capture_oplog_batch_id": 42,
@@ -6245,7 +6312,7 @@ values, argv, or filename lists.
   "thread": "main",
   "cursor_branch_id": "tlb-main",
   "cursor_step_id": "tls-1",
-  "cursor_state": "hd-0123456789abcdefghijklmnop",
+  "cursor_state": "hc-0123456789abcdefghijklmnop",
   "current_step": {
     "step_id": "tls-1",
     "branch_id": "tlb-main",
@@ -6286,7 +6353,7 @@ result after appending a versioned tool-call-start operation body:
   "branch_id": "tlb-main",
   "parent_step_id": null,
   "operation_id": "tl-0123456789abcdefghijklmnopqrstuv",
-  "before_state": "hd-0123456789abcdefghijklmnop",
+  "before_state": "hc-0123456789abcdefghijklmnop",
   "after_state": null,
   "changed": null,
   "tool_status": null,
@@ -6310,8 +6377,8 @@ result after appending a versioned tool-call-finish operation body:
   "branch_id": "tlb-main",
   "parent_step_id": null,
   "operation_id": "tl-1123456789abcdefghijklmnopqrstuv",
-  "before_state": "hd-0123456789abcdefghijklmnop",
-  "after_state": "hd-1123456789abcdefghijklmnop",
+  "before_state": "hc-0123456789abcdefghijklmnop",
+  "after_state": "hc-1123456789abcdefghijklmnop",
   "changed": true,
   "tool_status": "succeeded",
   "payload_summary": "Read project metadata",
@@ -6359,11 +6426,11 @@ State detail view, pretty-printed.
   "output_kind": "show",
   "repository_capability": "git-overlay",
   "storage_model": "git+heddle-sidecar",
-  "state_id": "hd-def456",
-  "state_id_full": "hd-def4561234567890abcdef",
+  "state_id": "hc-def456",
+  "state_id_full": "hc-def4561234567890abcdef",
   "content_hash": "deadbeef…",
   "tree": "…",
-  "parents": ["hd-abc123"],
+  "parents": ["hc-abc123"],
   "intent": "Capture audit pipeline",
   "confidence": 0.95,
   "principal": {"name": "Ada", "email": "ada@example.com"},
@@ -6406,7 +6473,7 @@ State detail view, pretty-printed.
   "threads": [
     {
       "name": "feature/parser-fast",
-      "current_state": "hd-def456",
+      "current_state": "hc-def456",
       "is_current": true,
       "thread_state": "active",
       "freshness": "current",
@@ -6691,7 +6758,7 @@ Hosted-review payload for a single state.
 ```json
 {
   "output_kind": "review_show",
-  "state_id": "hd-def456",
+  "state_id": "hc-def456",
   "headline": "Tighten parser recovery",
   "agent_narrative": null,
   "files_changed": 3,
@@ -6718,7 +6785,7 @@ payload carries only `output_kind` and `next: null` — never a
 top-level `null`.
 
 ```json
-{"output_kind": "review_next", "state_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0, "next": {"state_id": "hd-def456", "headline": "Tighten parser recovery", "existing_signatures": 0}}
+{"output_kind": "review_next", "state_id": "hc-def456", "headline": "Tighten parser recovery", "existing_signatures": 0, "next": {"state_id": "hc-def456", "headline": "Tighten parser recovery", "existing_signatures": 0}}
 ```
 
 `heddle review health --output json` emits:
@@ -7004,40 +7071,40 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust remove",
       "redact purge apply"
     ],
-    "advanced_scope_json_commands_total": 106,
+    "advanced_scope_json_commands_total": 108,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
-    "advanced_scope_mutating_commands_total": 61,
+    "advanced_scope_mutating_commands_total": 62,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 22,
-    "catalog_commands_total": 185,
+    "catalog_commands_total": 186,
     "catalog_mutating_commands_total": 90,
-    "json_commands_total": 149,
+    "json_commands_total": 148,
     "json_commands_with_accepted_opaque_schema": 39,
-    "json_commands_with_schema": 110,
+    "json_commands_with_schema": 109,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 87,
+    "json_mutating_commands_total": 86,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 87,
+    "mutating_commands_total": 86,
     "mutating_commands_with_accepted_opaque_schema": 22,
-    "mutating_commands_with_schema": 65,
+    "mutating_commands_with_schema": 64,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 39,
     "status": "available",
-    "summary": "185 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
     "undocumented_schema_verbs_total": 0,
     "verified_scope": "everyday_and_agent",
     "verified_scope_accepted_opaque_schema_examples": [],
-    "verified_scope_json_commands_total": 43,
+    "verified_scope_json_commands_total": 40,
     "verified_scope_json_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_json_commands_with_schema": 43,
+    "verified_scope_json_commands_with_schema": 40,
     "verified_scope_json_commands_without_schema": 0,
     "verified_scope_missing_schema_examples": [],
-    "verified_scope_mutating_commands_total": 26,
+    "verified_scope_mutating_commands_total": 24,
     "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_mutating_commands_with_schema": 26,
+    "verified_scope_mutating_commands_with_schema": 24,
     "verified_scope_mutating_commands_without_schema": 0
   },
   "doc_path": "/repo/docs/json-schemas.md",
@@ -7061,7 +7128,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "185 command(s), 149 JSON command(s), 90 mutating command(s), 87 mutating JSON command(s); verified everyday/agent machine surface has 43 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -7079,7 +7146,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
   "ts": "2026-05-23T00:00:00Z",
   "thread": "main",
   "kind": "snapshot",
-  "state_id": "hd-sqr398dvx9ay",
+  "state_id": "hc-sqr398dvx9ay",
   "intent": "capture parser fix",
   "confidence": 0.91,
   "actor": {"provider": "openai", "model": "gpt-5"},
@@ -7100,12 +7167,12 @@ lives in `recovery_commands`.
 {
   "status": "completed",
   "action": "try",
-  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hd-sqr398dvx9ay). Run `heddle ready --thread try-1234abcd` to land.",
+  "message": "`cargo test` succeeded; thread 'try-1234abcd' ready (state hc-sqr398dvx9ay). Run `heddle ready --thread try-1234abcd` to land.",
   "thread": "try-1234abcd",
   "thread_dropped": false,
   "exit_code": 0,
   "duration_ms": 1420,
-  "captured_state": "hd-sqr398dvx9ay",
+  "captured_state": "hc-sqr398dvx9ay",
   "merge_state": null,
   "next_action": "heddle ready --thread try-1234abcd",
   "recommended_action": "heddle ready --thread try-1234abcd",
@@ -7149,7 +7216,7 @@ Refresh the active or named thread, or report the verification/action blocker.
   "next_action": "heddle land",
   "recommended_action": "heddle land",
   "thread": "feature/parser",
-  "current_state": "hd-sqr398dvx9ay",
+  "current_state": "hc-sqr398dvx9ay",
   "chosen_path": "refresh"
 }
 ```
@@ -7190,7 +7257,7 @@ Apply the inverse of a state. With `--no-commit`, `state_id` is
 {
   "output_kind": "revert",
   "state_id": null,
-  "reverted_state": "hd-sqr398dvx9ay",
+  "reverted_state": "hc-sqr398dvx9ay",
   "files_affected": ["M src/parser.rs"],
   "message": "Changes applied to worktree (not committed)"
 }
@@ -7212,7 +7279,7 @@ a structured object (`provider`, `model`, optional `session_id` /
 required:
 
 ```json
-{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
+{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z", "origins": [{"change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "anthropic", "model": "claude-opus-4-7"}, "timestamp": "2026-01-01T00:00:00Z"}]}]}
 ```
 
 `heddle context reason git --output json` emits:
@@ -7224,25 +7291,25 @@ required:
 `heddle collapse --output json` emits:
 
 ```json
-{"change_id": "hd-collapsed123", "collapsed": 3, "message": "collapse feature checkpoints", "parents": ["hd-base123"]}
+{"change_id": "hc-collapsed123", "collapsed": 3, "message": "collapse feature checkpoints", "parents": ["hc-base123"]}
 ```
 
 `heddle expand --output json` emits the ordered captures recorded by a squashed land collapse:
 
 ```json
-{"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hd-collapsed123", "change_id_full": "hd-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hd-source111", "change_id_full": "hd-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hd-base123"]}, {"change_id": "hd-source222", "change_id_full": "hd-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hd-source111"]}]}
+{"output_kind": "expand", "status": "completed", "requested": "HEAD", "collapsed": {"change_id": "hc-collapsed123", "change_id_full": "hc-collapsed123000000000000000000", "git_commit": "abc123def456abc123def456abc123def456abcd", "thread": "feature/parser", "source_count": 2}, "captures": [{"change_id": "hc-source111", "change_id_full": "hc-source1110000000000000000000", "content_hash": "h1-source", "intent": "first parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": null, "confidence": null, "created_at": "2026-01-01 00:00:00", "parents": ["hc-base123"]}, {"change_id": "hc-source222", "change_id_full": "hc-source2220000000000000000000", "content_hash": "h1-source2", "intent": "second parser checkpoint", "principal": "A. Engineer <a@example.com>", "agent": "codex/gpt-5", "confidence": 0.91, "created_at": "2026-01-01 00:05:00", "parents": ["hc-source111"]}]}
 ```
 
 `heddle context set|get|list|history|edit|supersede|rm|check|suggest|audit --output json` emit per-subcommand shapes (each carries `output_kind` set to the snake-cased subcommand, e.g. `context_set`, `context_get`) — there is no single shared shape. For example, `context set` (and `edit`/`supersede`/`rm`) reports the mutated target and the new state:
 
 ```json
-{"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hd-k6a0wfrbgcg7"}
+{"output_kind": "context_set", "target": "src/lib.rs", "annotations": 1, "state": "hc-k6a0wfrbgcg7"}
 ```
 
 `heddle context list --output json` wraps its rows in an `items` envelope; the rows themselves carry no per-row discriminator (the envelope owns it). Each row is `{"target_kind": ..., "target": ..., "annotations": [...]}` — it emits:
 
 ```json
-{"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hd-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
+{"output_kind": "context_list", "items": [{"target_kind": "file", "target": "src/lib.rs", "annotations": [{"annotation_id": "hc-hy06md66hab4qb5ctkwphyc22r", "attribution": "A. Engineer <a@example.com>", "content": "returns false on timing mismatch", "created_at": 1767225600, "kind": "rationale", "revision_count": 1, "scope": "file", "status": "active", "supersedes_annotation_id": null, "supersedes_rewrite_pct": null, "tags": []}]}]}
 ```
 
 `heddle daemon serve|status --output json` emit:
@@ -7348,20 +7415,20 @@ set to the snake-cased subcommand, e.g. `purge_apply`, `purge_list`).
 `.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "purge_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "redactions_marked": 1, "blob_bytes_removed": false, "blob_remains_in_pack": false, "purger": "A. Engineer <a@example.com>", "message": "purged blob sha256:abc123 at secrets.env in hd-sqr398dvx9ay (1 redaction(s) marked)", "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
+{"output_kind": "purge_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hc-sqr398dvx9ay", "path": "secrets.env", "redactions_marked": 1, "blob_bytes_removed": false, "blob_remains_in_pack": false, "purger": "A. Engineer <a@example.com>", "message": "purged blob sha256:abc123 at secrets.env in hc-sqr398dvx9ay (1 redaction(s) marked)", "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle query --output json` emits:
 
 ```json
-{"output_kind": "query", "hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hd-sqr398dvx9ay"}]}
+{"output_kind": "query", "hits": [{"seq": 1, "timestamp_secs": 1767225600, "verb": "capture", "actor_email": "a@example.com", "operation_id": "op-123", "thread": "main", "symbols": ["verify"], "signal_kinds": ["test_passed"], "change_id": "hc-sqr398dvx9ay"}]}
 ```
 
 `heddle query --attribution --output json` emits structured attribution
 for a tracked file:
 
 ```json
-{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hd-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": null, "timestamp": "2026-01-01T00:00:00Z", "origins": null}]}
+{"output_kind": "query_attribution", "status": "completed", "file": "src/lib.rs", "lines": [{"line_number": 1, "content": "pub fn run() {}", "change_id": "hc-sqr398dvx9ay", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": null, "timestamp": "2026-01-01T00:00:00Z", "origins": null}]}
 ```
 
 `heddle redact apply|list|show --output json` emit (each carries
@@ -7371,7 +7438,7 @@ is signed (`--sign-with`); `ignore_hint` only when the path is not yet
 covered by a `.heddleignore` / `.gitignore` glob:
 
 ```json
-{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hd-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "redactor": "A. Engineer <a@example.com>", "redacted_at": "2026-01-01T00:00:00Z", "all_states": false, "states_redacted": 1, "signed": false, "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
+{"output_kind": "redact_apply", "redaction_id": "redact-123", "blob": "sha256:abc123", "state": "hc-sqr398dvx9ay", "path": "secrets.env", "reason": "credential", "redactor": "A. Engineer <a@example.com>", "redacted_at": "2026-01-01T00:00:00Z", "all_states": false, "states_redacted": 1, "signed": false, "ignore_hint": {"ignore_file": ".heddleignore", "already_exists": false, "suggested_pattern": "secrets.env", "message": "hint: create .heddleignore with `secrets.env` so the next `heddle capture` doesn't re-import the leaked bytes"}}
 ```
 
 `heddle redact trust add|list|remove --output json` emit (each carries
@@ -7391,14 +7458,14 @@ set to the snake-cased subcommand). `label` is present only for the
 declaration:
 
 ```json
-{"output_kind": "visibility_set", "state": "hd-sqr398dvx9ay", "tier": "internal", "record_id": "hd-vis123", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}
+{"output_kind": "visibility_set", "state": "hc-sqr398dvx9ay", "tier": "internal", "record_id": "hc-vis123", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}
 ```
 
 `heddle visibility promote --output json` emits the same shape as `set`,
 with `supersedes` carrying the prior record it replaces:
 
 ```json
-{"output_kind": "visibility_promote", "state": "hd-sqr398dvx9ay", "tier": "internal", "record_id": "hd-vis456", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "supersedes": "hd-vis123"}
+{"output_kind": "visibility_promote", "state": "hc-sqr398dvx9ay", "tier": "internal", "record_id": "hc-vis456", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "supersedes": "hc-vis123"}
 ```
 
 `heddle visibility show --output json` emits the effective tier for one
@@ -7406,13 +7473,13 @@ state (`effective_public` is true and the declarer fields are omitted when
 no record exists — public-by-absence):
 
 ```json
-{"output_kind": "visibility_show", "state": "hd-sqr398dvx9ay", "tier": "internal", "effective_public": false, "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "record_count": 1}
+{"output_kind": "visibility_show", "state": "hc-sqr398dvx9ay", "tier": "internal", "effective_public": false, "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z", "record_count": 1}
 ```
 
 `heddle visibility list --output json` emits every non-public state:
 
 ```json
-{"output_kind": "visibility_list", "states": [{"state": "hd-sqr398dvx9ay", "tier": "internal", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}], "count": 1}
+{"output_kind": "visibility_list", "states": [{"state": "hc-sqr398dvx9ay", "tier": "internal", "declarer": "A. Engineer <a@example.com>", "declared_at": "2026-01-01T00:00:00Z"}], "count": 1}
 ```
 
 `heddle resolve --output json` emits:
@@ -7426,7 +7493,7 @@ no record exists — public-by-absence):
 --full --output json` emits expanded timeline summaries:
 
 ```json
-{"since": "hd-base123", "until": "hd-head456", "duration_secs": 3600, "states_captured": [{"change_id": "hd-head456", "intent": "capture parser fix", "confidence": 0.91, "agent": "codex/gpt-5", "principal": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z"}], "agents_active": [{"session_id": "session-123", "provider": "codex", "model": "gpt-5", "status": "active", "started_at": "2026-01-01T00:00:00Z", "completed_at": null, "tokens": {"input": 1200, "output": 800, "reasoning": 300, "tool_calls": 12}}], "agent_tasks": [{"task_id": "task-parser-fast", "title": "Tighten parser validation", "status": "in_progress", "target_thread": "feature/parser-fast", "updated_at": "2026-01-01T00:00:00Z", "completed_at": null, "coordination_discussion_id": null}], "timeline_steps": [{"thread": "feature/parser-fast", "step_id": "tls-1", "branch_id": "tlb-main", "parent_step_id": null, "tool_name": "edit", "tool_status": "succeeded", "changed": true, "payload_summary": "Edit parser validation", "payload_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "before_state": "hd-base123", "after_state": "hd-head456", "capture_state": "hd-head456", "started_at_ms": 1770000000000, "finished_at_ms": 1770000001000}], "markers_created": [{"name": "verified-parser", "state": "hd-head456", "timestamp": "2026-01-01T00:00:00Z"}], "context_annotations": [{"path": "src/lib.rs", "scope": "file", "kind": "rationale", "content_excerpt": "Parser accepts the new token form.", "attribution": "A. Engineer <a@example.com>", "created_at": "2026-01-01T00:00:00Z"}], "verify_signals": [{"kind": "test_passed", "label": "verified: cargo test", "timestamp": "2026-01-01T00:00:00Z"}], "merges": [{"description": "Collapsed feature/parser", "timestamp": "2026-01-01T00:00:00Z"}], "undos": [{"description": "Undo capture", "timestamp": "2026-01-01T00:00:00Z"}]}
+{"since": "hc-base123", "until": "hc-head456", "duration_secs": 3600, "states_captured": [{"change_id": "hc-head456", "intent": "capture parser fix", "confidence": 0.91, "agent": "codex/gpt-5", "principal": "A. Engineer <a@example.com>", "timestamp": "2026-01-01T00:00:00Z"}], "agents_active": [{"session_id": "session-123", "provider": "codex", "model": "gpt-5", "status": "active", "started_at": "2026-01-01T00:00:00Z", "completed_at": null, "tokens": {"input": 1200, "output": 800, "reasoning": 300, "tool_calls": 12}}], "agent_tasks": [{"task_id": "task-parser-fast", "title": "Tighten parser validation", "status": "in_progress", "target_thread": "feature/parser-fast", "updated_at": "2026-01-01T00:00:00Z", "completed_at": null, "coordination_discussion_id": null}], "timeline_steps": [{"thread": "feature/parser-fast", "step_id": "tls-1", "branch_id": "tlb-main", "parent_step_id": null, "tool_name": "edit", "tool_status": "succeeded", "changed": true, "payload_summary": "Edit parser validation", "payload_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "before_state": "hc-base123", "after_state": "hc-head456", "capture_state": "hc-head456", "started_at_ms": 1770000000000, "finished_at_ms": 1770000001000}], "markers_created": [{"name": "verified-parser", "state": "hc-head456", "timestamp": "2026-01-01T00:00:00Z"}], "context_annotations": [{"path": "src/lib.rs", "scope": "file", "kind": "rationale", "content_excerpt": "Parser accepts the new token form.", "attribution": "A. Engineer <a@example.com>", "created_at": "2026-01-01T00:00:00Z"}], "verify_signals": [{"kind": "test_passed", "label": "verified: cargo test", "timestamp": "2026-01-01T00:00:00Z"}], "merges": [{"description": "Collapsed feature/parser", "timestamp": "2026-01-01T00:00:00Z"}], "undos": [{"description": "Undo capture", "timestamp": "2026-01-01T00:00:00Z"}]}
 ```
 
 `heddle semantic hot --output json` emits:

--- a/docs/program/PRODUCT_CONTRACT.md
+++ b/docs/program/PRODUCT_CONTRACT.md
@@ -59,7 +59,7 @@ delivery (CLI / future daemon / tests)
 | Git object bytes (public, lossless path) | Byte-identical SHAs on round-trip |
 | Raw Git Object Residuals | Preserve non-reconstructable object bytes |
 | ContentHash (BLAKE3) | Content-addressed equality |
-| ChangeId (`hd-…` physical) | Stable handle for a specific state, not rewrite lineage |
+| ChangeId (`hc-…` physical) | Stable handle for a specific state, not rewrite lineage |
 | Public JSON schemas | Field-stable; alpha may break names when model improves (documented) |
 | Hosted protobuf `heddle.api.v1alpha1` | Net-new public-contract candidate owned by `HeddleCo/api`; the blocked coordinated cutover is tracked in ADR 0048 |
 | Text CLI | User-facing; not byte-stable |

--- a/docs/spikes/heddle-266-commit-visibility-tiers.md
+++ b/docs/spikes/heddle-266-commit-visibility-tiers.md
@@ -946,7 +946,7 @@ requires widening the single-`ChangeId` request shape:
    function of the served `ChangeId` (`RefEntry.change_id`, `:91`) so it is stable,
    identity-bound, and never reused for a different state. The name carries the
    **full** `ChangeId` — `ChangeId::to_string_full()` (`crates/objects/src/object/hash.rs:129`,
-   the `hd-`+base32 form that round-trips via `parse()`, `:143`) — **never** the
+   the `hc-`+base32 form that round-trips via `parse()`, `:143`) — **never** the
    truncatable `short()`/`Display` form (`:137`, `:167-170`): two distinct sibling
    `ChangeId`s must map to two distinct names or one frontier root would
    overwrite the other. But uniqueness alone is **not** collision-proof: the name lives
@@ -1012,7 +1012,7 @@ requires widening the single-`ChangeId` request shape:
    (`git_sync.rs:129`) writes (Invariant C, §5.4). The reservation is what makes the
    synthetic ref collision-proof: `refs/heddle/*` is **disjoint from** `refs/heads/*`,
    so no user thread — published only ever to `refs/heads/{track_name}` — and no
-   raw-Git / imported `refs/heads/main@hd-…` branch can target the synthetic ref's
+   raw-Git / imported `refs/heads/main@hc-…` branch can target the synthetic ref's
    location. *(Tradeoff: a **vanilla** `git clone` with the default
    `refs/heads/*`+`refs/tags/*` refspec will not auto-fetch `refs/heddle/frontier/*`,
    so the sibling-line roots are fetched by a **Heddle-aware** clone whose refspec
@@ -1428,7 +1428,7 @@ of them rather than restating its own rule:
   validation** (`identifiers.rs:23-25,99-102`) and `validate_ref_name`
   (`name.rs:11-31`) rejects only controls / `..` / `//` / backslash / slash-edges /
   leading-`.` / `.lock`, **allowing** `@` (legitimately used by scoped names like
-  `main@review`, §3 Design C). So a user could create a thread `main@hd-<changeid>`
+  `main@review`, §3 Design C). So a user could create a thread `main@hc-<changeid>`
   whose name *equals* the encoded synthetic form, and the bridge publishes every user
   thread to `refs/heads/{track_name}` (`sync_track_to_branch`, `git_sync.rs:129`) —
   the user thread and the synthetic sibling root would target the **same Git ref**,
@@ -1500,7 +1500,7 @@ of them rather than restating its own rule:
   different surfaces.** *Name reservation without publish separation* still collides
   on the **Git-ref** surface: `refs/heads/*` is writable by *raw Git*
   (`git branch` / `git update-ref`) and by *imported foreign branches* — neither passes
-  through Heddle's validator — so a branch `refs/heads/main@hd-…` can exist that Heddle
+  through Heddle's validator — so a branch `refs/heads/main@hc-…` can exist that Heddle
   never named; only moving synthetic refs **out of** `refs/heads/` forecloses that.
   *Publish separation without name reservation* still collides on the **wire /
   CLI-resolution** surface: `ListRefs` names a synthetic root with a `ThreadName`-shaped
@@ -2378,7 +2378,7 @@ issues are checked against:
      `git clone` gets only the own-line `refs/heads/<thread>`, the deliberate cost of
      collision-proofness, §5.3). A conformance test must assert (a) prefix-sharing
      siblings get distinct, individually-fetchable refs, and (b) a user thread named
-     `<thread>@hd-…` (or a raw-Git branch at that `refs/heads/` location) does **not**
+     `<thread>@hc-…` (or a raw-Git branch at that `refs/heads/` location) does **not**
      collide with or overwrite any synthetic frontier root. `<thread>` itself only ever
      advances FF **along its own line** to the maximal served descendant of its prior
      tip, else retains its prior tip — **never moves sideways to a sibling member and

--- a/docs/spikes/heddle-267-tree-edit-rpc-surface.md
+++ b/docs/spikes/heddle-267-tree-edit-rpc-surface.md
@@ -211,7 +211,7 @@ message TreeEditRepo {
 message TreeBase {
   oneof base {
     string ref = 1;          // thread, marker, or state spec
-    string state_id = 2;     // full hd-* string
+    string state_id = 2;     // full hc-* string
     bytes tree_hash = 3;     // raw ContentHash bytes
     bool empty = 4;
   }

--- a/docs/spikes/heddle-578-checkpoint-change-id.md
+++ b/docs/spikes/heddle-578-checkpoint-change-id.md
@@ -152,7 +152,7 @@ current tip (`repo.head()`), else refuse with a precise error. On success it is
 the existing checkpoint flow, just with an explicit assertion that you're
 checkpointing the state you named.
 
-- **Pros:** explicit, auditable ("I am checkpointing exactly hd-…"), reuses the
+- **Pros:** explicit, auditable ("I am checkpointing exactly hc-…"), reuses the
   canonical resolver, replaces the hidden `--from-index-snapshot` recovery
   string with a self-documenting one, zero new commit machinery.
 - **Cons:** the flag is *only ever* a no-op-or-assertion when X==tip. A user who


### PR DESCRIPTION
## Summary

- Updated the canonical ChangeId examples from `hd-` to the runtime `hc-` form. Before the change, the source-doc grep found 110 matches across seven files: `docs/json-schemas.md:93`, `docs/design/clonefile-threads.md:260`, `docs/design/reftable-spike.md:55`, `docs/program/PRODUCT_CONTRACT.md:62`, `docs/spikes/heddle-266-commit-visibility-tiers.md:949`, `docs/spikes/heddle-267-tree-edit-rpc-surface.md:214`, and `docs/spikes/heddle-578-checkpoint-change-id.md:155`. Regenerated `docs/llms-full.txt` from those sources.
- Recorded the pre-launch compatibility policy at `docs/json-schemas.md:108`: `hc-` is the only accepted tagged ChangeId form. There is no deployed `hd-` data and no legacy alias; parsers, APIs, and downstream clients must reject rather than normalize `hd-`. `crates/object-model/src/object/hash.rs:304` tests that rejection explicitly.
- Renamed the review-signature payload domain to `hc-rev-sig-v1\0` at `crates/object-model/src/object/state_review.rs:21`. This is intentionally a pre-launch break: consistency with the HeddleCo `hc-` namespace is free now, while dual-domain acceptance after launch would become permanent compatibility surface. The canonical producer is `crates/object-model/src/object/state_review.rs:153`; the production verifier reconstructs that payload at `crates/daemon/src/local_review/state_review.rs:456`.
- After the change, `rg -n --hidden 'hd-' docs` reports only the deliberate rejection-policy references at `docs/json-schemas.md:112` and `docs/json-schemas.md:116`, plus their generated `docs/llms-full.txt` mirror. They remain because they name the forms clients and signature verification must reject.

## Closes

Closes #1170

## Test evidence

- Positive round trip: `crates/daemon/src/local_review/state_review.rs:1333` signs the canonical payload, verifies it through `sign_state`, persists it, and reads it back. Negative case: `crates/daemon/src/local_review/state_review.rs:1369` signs with the old `hd-rev-sig-v1\0` domain and proves verification returns `InvalidArgument` without persisting the signature.
- Focused tests passed:
  - `TMPDIR=/home/scratch CARGO_HOME=/home/scratch/audit-1170-cargo-home cargo test --locked -p heddle-object-model test_change_id_ -- --nocapture`
  - `TMPDIR=/home/scratch CARGO_HOME=/home/scratch/audit-1170-cargo-home cargo test --locked -p heddle-object-model signing_payload_ -- --nocapture`
  - `TMPDIR=/home/scratch CARGO_HOME=/home/scratch/audit-1170-cargo-home cargo test --locked -p heddle-daemon sign_state_ -- --nocapture`
- CI affected-package commands passed for all 26 packages selected by `scripts/ci-affected-rust-packages.sh`:
  - `cargo build --locked "${package_args[@]}" --tests --bin heddle --bin heddle-fuse-worker`
  - `cargo clippy --locked "${package_args[@]}" --lib --bins --tests --examples -- -D warnings`
  - `cargo test --locked "${package_args[@]}"`
- CI contract/profile commands passed:
  - `python3 -m unittest discover -s scripts/tests -p 'test_*.py' -v`
  - `bash scripts/check-default-cli-contracts.sh`
  - `cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd`
  - `cargo check --locked -p heddle-repo --no-default-features --features native,zstd`
  - `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd`
  - `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd`
- `rustfmt +nightly --edition 2024 --check crates/object-model/src/object/hash.rs crates/object-model/src/object/state_review.rs crates/daemon/src/local_review/state_review.rs`
- `python3 scripts/gen-llms-txt.py --check`
- `git diff --check`

All cited lines are from head `91043fa0`, based directly on audited Heddle commit `fb9906d0`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788107536&installation_model_id=21489&pr_number=1173&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1173&signature=945145242fde23cafdbf151bb18ac3c5459e0b6a48ba665101466a71d2bb04ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->