### PR TITLE
Record attributed conflict resolutions in the oplog

### DIFF
--- a/crates/cli/src/cli/commands/rebase/rebase_ops.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_ops.rs
@@ -11,16 +11,18 @@ use objects::{
     },
     store::ObjectStore,
 };
-use oplog::OpRecord;
+use oplog::{ConflictResolutionMode, OpRecord};
 use refs::Head;
 use repo::{Repository, StateAttachmentKind};
 
 use super::{
-    super::{advice::RecoveryAdvice, ff_record::ff_advance_deferred},
+    super::{
+        advice::RecoveryAdvice, ff_record::ff_advance_deferred, snapshot::resolve_attribution,
+    },
     emit_rebase_progress,
     rebase_state::{load_rebase_state, save_rebase_state},
 };
-use crate::cli::Cli;
+use crate::{cli::Cli, config::UserConfig};
 
 /// Synthetic `source_thread` for `OpRecord::FastForward` entries
 /// emitted during a rebase replay. Each replayed commit becomes its
@@ -61,6 +63,7 @@ fn replay_commits_internal(
 ) -> Result<()> {
     let mut state = load_rebase_state(rebase_state_path)?;
     resume_manual_resolution_if_present(repo, &mut state, rebase_state_path, cli)?;
+    let resolver = resolve_attribution(repo, &UserConfig::load_default()?)?;
 
     let mut current_head = if state.current_index == 0 {
         state.onto
@@ -99,11 +102,24 @@ fn replay_commits_internal(
         let result = apply_commit(repo, &commit_state, &current_head, discard_local_changes)?;
 
         match result {
-            ApplyResult::Success { new_head, advance } => {
+            ApplyResult::Success {
+                new_head,
+                advance,
+                auto_resolved_conflicts,
+            } => {
                 current_head = new_head;
                 state.current_index += 1;
                 state.pending_manual_resolution = None;
                 state.pre_conflict_head = None;
+                state
+                    .pending_advances
+                    .extend(auto_resolved_conflicts.into_iter().map(|conflict_id| {
+                        OpRecord::conflict_resolved(
+                            conflict_id,
+                            resolver.clone(),
+                            ConflictResolutionMode::Auto,
+                        )
+                    }));
                 state.pending_advances.push(*advance);
                 save_rebase_state(rebase_state_path, &state)?;
             }
@@ -312,6 +328,7 @@ enum ApplyResult {
         /// — the worktree/ref mutation has already happened by the
         /// time this is returned.
         advance: Box<OpRecord>,
+        auto_resolved_conflicts: Vec<String>,
     },
     Conflict,
 }
@@ -361,6 +378,7 @@ fn apply_commit(
     let changes = compute_tree_diff(&parent_tree, &commit_tree);
 
     let mut has_conflicts = false;
+    let mut auto_resolved_conflicts = Vec::new();
     let mut updated_entries: Vec<TreeEntry> = Vec::new();
     let mut deleted_paths: Vec<String> = Vec::new();
 
@@ -427,6 +445,7 @@ fn apply_commit(
                             mode == FileMode::Executable,
                         )?;
                         updated_entries.push(merged);
+                        auto_resolved_conflicts.push(path.clone());
                         continue;
                     }
                     if blob_contains_both(repo, &new_hash, &existing_hash, &parent_hash)?
@@ -434,6 +453,7 @@ fn apply_commit(
                     {
                         let merged = new.with_mode(mode)?;
                         updated_entries.push(merged);
+                        auto_resolved_conflicts.push(path.clone());
                         continue;
                     }
                 }
@@ -493,6 +513,7 @@ fn apply_commit(
     Ok(ApplyResult::Success {
         new_head: new_state_id,
         advance: Box::new(advance),
+        auto_resolved_conflicts,
     })
 }
 
@@ -650,6 +671,7 @@ fn apply_tree_to_worktree(
     Ok(ApplyResult::Success {
         new_head: new_state_id,
         advance: Box::new(advance),
+        auto_resolved_conflicts: Vec::new(),
     })
 }
 

--- a/crates/cli/src/cli/commands/rebase/rebase_state.rs
+++ b/crates/cli/src/cli/commands/rebase/rebase_state.rs
@@ -18,12 +18,11 @@ pub(crate) struct RebaseState {
     pub(crate) original_head: StateId,
     pub(crate) pending_manual_resolution: Option<StateId>,
     pub(crate) pre_conflict_head: Option<StateId>,
-    /// FastForward (or, on detached HEAD, Goto) records buffered from
-    /// the per-commit replay loop. Flushed as a single oplog batch
-    /// when the rebase completes so `heddle undo` rewinds the whole
-    /// transaction atomically (heddle#198). Persisted across
-    /// `--continue` invocations so a conflict pause doesn't drop the
-    /// in-flight records.
+    /// Oplog records buffered from the per-commit replay loop. Each replayed
+    /// commit contributes a FastForward (or, on detached HEAD, Goto); an
+    /// automatic merge may precede it with ConflictResolved events. Flushed as
+    /// one oplog batch when the rebase completes and persisted across
+    /// `--continue` invocations.
     pub(crate) pending_advances: Vec<OpRecord>,
     /// Stable id for the rebase batch's `TransactionCommit` envelope.
     /// Persisted at rebase start so that a crash between
@@ -211,18 +210,17 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                     Err(_) if for_abort => continue,
                     Err(e) => return Err(e),
                     Ok(advance) => match advance {
-                        // heddle#198 r4 (Codex PR #218 P2): only the
-                        // FF-advance variants plus `Goto` can legitimately
-                        // appear in a rebase batch.
+                        // Rebase batches contain their FF/Goto advances plus
+                        // attributed automatic conflict-resolution events.
                         // Anything else — MarkerCreate, ThreadX,
                         // Snapshot — would land in the committed batch
                         // verbatim and pollute undo/redo with records
                         // the rebase never produced. Strict loader
                         // rejects; abort silently drops them since the
                         // buffered FF history is discarded on rewind.
-                        OpRecord::FastForward { .. } | OpRecord::Goto { .. } => {
-                            pending_advances.push(advance)
-                        }
+                        OpRecord::FastForward { .. }
+                        | OpRecord::Goto { .. }
+                        | OpRecord::ConflictResolved { .. } => pending_advances.push(advance),
                         // Anything else would land in the committed batch
                         // verbatim and pollute undo/redo with records the
                         // rebase never produced. Abort silently drops them (the
@@ -241,7 +239,6 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                         | OpRecord::Checkpoint { .. }
                         | OpRecord::TransactionAbort { .. }
                         | OpRecord::EphemeralThreadCollapse { .. }
-                        | OpRecord::ConflictResolved { .. }
                         | OpRecord::TransactionCommit { .. }
                         | OpRecord::Redact { .. }
                         | OpRecord::Purge { .. }
@@ -258,7 +255,7 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
                             return Err(anyhow!(RecoveryAdvice::rebase_state_corrupted(
                                 "Unexpected pending_advance variant in rebase state",
                                 format!(
-                                    "{} — only FastForward/Goto are accepted",
+                                    "{} — only FastForward/Goto/ConflictResolved are accepted",
                                     advance.description()
                                 ),
                             )));
@@ -311,21 +308,18 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
         }
     };
 
-    // heddle#198 r4 (Codex PR #218 P1): the persisted invariant is
-    // `pending_advances.len() == current_index` — `replay_commits_internal`
-    // and `resume_manual_resolution_if_present` always bump both in
-    // lockstep before the save. A crash-truncated REBASE_STATE that keeps
-    // `current_index=` but drops trailing `pending_advance=` lines breaks
-    // it; strict `--continue` must hard-fail rather than silently flush
-    // an incomplete batch. Abort tolerates because it discards the
-    // buffered FF history when rewinding to `original_head`.
-    if !for_abort && pending_advances.len() != current_index {
+    // Each successfully replayed commit contributes exactly one FF/Goto.
+    // ConflictResolved events may add more buffered records, so validate the
+    // advance count rather than the total record count.
+    let advance_count = pending_advances
+        .iter()
+        .filter(|record| matches!(record, OpRecord::FastForward { .. } | OpRecord::Goto { .. }))
+        .count();
+    if !for_abort && advance_count != current_index {
         return Err(anyhow!(RecoveryAdvice::rebase_state_corrupted(
             "Inconsistent rebase state",
             format!(
-                "pending_advance lines ({}) do not match current_index ({})",
-                pending_advances.len(),
-                current_index,
+                "pending_advance FF/Goto records ({advance_count}) do not match current_index ({current_index})",
             ),
         )));
     }
@@ -344,18 +338,17 @@ fn load_rebase_state_internal(path: &std::path::Path, for_abort: bool) -> Result
 
 #[cfg(test)]
 mod tests {
-    use objects::object::StateId;
-    use oplog::OpRecord;
+    use objects::object::{Attribution, Principal, StateId};
+    use oplog::{ConflictResolutionMode, OpRecord};
     use tempfile::TempDir;
 
     use super::*;
 
     fn sample_state(pending: Vec<OpRecord>) -> RebaseState {
-        // The persisted invariant (heddle#198 r4 / Codex PR #218 P1) is
-        // `pending_advances.len() == current_index`; derive `current_index`
-        // from the supplied vec so every fixture round-trips cleanly
-        // through the strict loader.
-        let current_index = pending.len();
+        let current_index = pending
+            .iter()
+            .filter(|record| matches!(record, OpRecord::FastForward { .. } | OpRecord::Goto { .. }))
+            .count();
         let commits_to_replay = (0..(current_index + 1))
             .map(|_| StateId::from_bytes([16; 32]))
             .collect();
@@ -378,6 +371,14 @@ mod tests {
             pre_target_id: StateId::from_bytes([21; 32]),
             post_target_id: StateId::from_bytes([22; 32]),
         }
+    }
+
+    fn auto_resolution_record() -> OpRecord {
+        OpRecord::conflict_resolved(
+            "src/lib.rs",
+            Attribution::human(Principal::new("Resolver", "resolver@example.com")),
+            ConflictResolutionMode::Auto,
+        )
     }
 
     /// Round-trip cover: the `pending_advances` vec must survive a
@@ -413,6 +414,26 @@ mod tests {
             let want_bytes = rmp_serde::to_vec(want).unwrap();
             assert_eq!(got_bytes, want_bytes);
         }
+    }
+
+    #[test]
+    fn save_then_load_round_trips_auto_resolution_before_advance() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("REBASE_STATE");
+        let original = sample_state(vec![auto_resolution_record(), ff_record()]);
+
+        save_rebase_state(&path, &original).unwrap();
+        let loaded = load_rebase_state(&path).unwrap();
+
+        assert_eq!(loaded.current_index, 1);
+        assert!(matches!(
+            &loaded.pending_advances[0],
+            OpRecord::ConflictResolved {
+                conflict_id,
+                mode: ConflictResolutionMode::Auto,
+                ..
+            } if conflict_id == "src/lib.rs"
+        ));
     }
 
     /// Even with no buffered FFs (the conflict-on-first-commit case),
@@ -669,7 +690,7 @@ mod tests {
     /// decodes can inject non-rebase operations (e.g. `MarkerCreate`,
     /// `ThreadDelete`) into the rebase's undo/redo history — undo would
     /// replay records the rebase never produced. The strict loader
-    /// must whitelist only the FF-advance records (`FastForward` / `Goto`) and
+    /// must whitelist the FF-advance records plus ConflictResolved events and
     /// reject anything else.
     #[test]
     fn load_strict_rejects_non_advance_pending_record() {
@@ -858,8 +879,8 @@ mod tests {
     }
 
     /// heddle#198 r4 (Codex PR #218 P1): the persisted invariant in
-    /// REBASE_STATE is `pending_advances.len() == current_index` — each
-    /// successful per-commit replay bumps both in lockstep (see
+    /// REBASE_STATE has one FF/Goto per `current_index` — each successful
+    /// per-commit replay bumps both in lockstep (see
     /// `replay_commits_internal` Success arm and
     /// `resume_manual_resolution_if_present`). A crash mid-write to
     /// REBASE_STATE that preserves the `current_index=` line but

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -7,12 +7,16 @@ use anyhow::{Context, Result, anyhow};
 use heddle_core::{
     contains_line_start_conflict_markers, path_is_active_conflict, unresolved_conflict_paths,
 };
-use objects::store::ObjectStore;
+use objects::{object::Attribution, store::ObjectStore};
+use oplog::{ConflictResolutionMode, OpLogBackend, OpRecord};
 use repo::{MergeState, Repository};
 use serde::Serialize;
 
-use super::{action_line::print_next_step, advice::RecoveryAdvice};
-use crate::cli::{Cli, should_output_json};
+use super::{action_line::print_next_step, advice::RecoveryAdvice, snapshot::resolve_attribution};
+use crate::{
+    cli::{Cli, should_output_json},
+    config::UserConfig,
+};
 
 #[derive(Serialize)]
 struct ResolveOutput {
@@ -163,11 +167,14 @@ fn cmd_resolve_all(
     if unresolved.is_empty() {
         return Err(anyhow!(no_conflicts_to_resolve_advice()));
     }
+    let resolver = resolve_attribution(repo, &UserConfig::load_default()?)?;
+    let mode = manual_resolution_mode(ours, theirs);
 
     for path in &unresolved {
         resolve_file_with_version(repo, &merge_state, path, ours, theirs)?;
         ensure_resolved_file_has_no_conflict_markers(repo, path, ours || theirs, force)?;
         merge_manager.resolve(path)?;
+        record_conflict_resolved(repo, path, &resolver, mode)?;
     }
 
     let remaining = merge_manager.unresolved()?;
@@ -208,9 +215,12 @@ fn cmd_resolve_file(
     if !path_is_active_conflict(&merge_state.conflicts, path) {
         return Err(anyhow!(path_not_in_active_merge_advice(path)));
     }
+    let resolver = resolve_attribution(repo, &UserConfig::load_default()?)?;
+    let mode = manual_resolution_mode(ours, theirs);
     resolve_file_with_version(repo, &merge_state, path, ours, theirs)?;
     ensure_resolved_file_has_no_conflict_markers(repo, path, ours || theirs, force)?;
     merge_manager.resolve(path)?;
+    record_conflict_resolved(repo, path, &resolver, mode)?;
 
     let remaining = merge_manager.unresolved()?;
     let continuation = continue_if_resolution_complete(repo, remaining.is_empty())?;
@@ -243,6 +253,33 @@ fn continue_if_resolution_complete(
     } else {
         Ok(None)
     }
+}
+
+fn manual_resolution_mode(ours: bool, theirs: bool) -> ConflictResolutionMode {
+    if ours {
+        ConflictResolutionMode::Ours
+    } else if theirs {
+        ConflictResolutionMode::Theirs
+    } else {
+        ConflictResolutionMode::Edit
+    }
+}
+
+fn record_conflict_resolved(
+    repo: &Repository,
+    conflict_id: &str,
+    resolver: &Attribution,
+    mode: ConflictResolutionMode,
+) -> Result<()> {
+    repo.oplog().record_batch_scoped(
+        vec![OpRecord::conflict_resolved(
+            conflict_id,
+            resolver.clone(),
+            mode,
+        )],
+        Some(&repo.op_scope()),
+    )?;
+    Ok(())
 }
 
 fn resolve_output(

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -6,6 +6,8 @@
 use std::{fs, process::Command, str};
 
 use ntest::timeout;
+use oplog::{ConflictResolutionMode, OpLogBackend, OpRecord};
+use repo::Repository;
 use serde_json::Value;
 use serial_test::serial;
 use tempfile::TempDir;
@@ -139,6 +141,14 @@ mod resolve {
         refresh_thread_expect_conflict(temp.path(), "feature");
     }
 
+    fn recent_oplog_entries(temp: &TempDir) -> Vec<oplog::OpEntry> {
+        Repository::open(temp.path())
+            .unwrap()
+            .oplog()
+            .recent(200)
+            .unwrap()
+    }
+
     #[test]
     #[timeout(15000)]
     #[serial]
@@ -150,6 +160,109 @@ mod resolve {
 
         let result = heddle(&["resolve", "file.txt"], Some(temp.path()));
         assert!(result.is_ok(), "resolve failed: {:?}", result.err());
+    }
+
+    #[test]
+    #[timeout(15000)]
+    #[serial]
+    fn manual_resolve_appends_attributed_conflict_resolved_op_record() {
+        let temp = TempDir::new().unwrap();
+        create_conflict(&temp);
+        fs::write(temp.path().join("file.txt"), "resolved content").unwrap();
+
+        heddle_with_env(
+            &["resolve", "file.txt"],
+            Some(temp.path()),
+            &[
+                ("HEDDLE_PRINCIPAL_NAME", "Resolution Owner"),
+                ("HEDDLE_PRINCIPAL_EMAIL", "owner@example.com"),
+                ("HEDDLE_AGENT_PROVIDER", "openai"),
+                ("HEDDLE_AGENT_MODEL", "gpt-resolver"),
+            ],
+        )
+        .unwrap();
+
+        let entries = recent_oplog_entries(&temp);
+        let event = entries
+            .iter()
+            .find_map(|entry| match &entry.operation {
+                OpRecord::ConflictResolved {
+                    conflict_id,
+                    resolution,
+                    resolver,
+                    mode,
+                } => Some((conflict_id, resolution, resolver, mode)),
+                _ => None,
+            })
+            .expect("production resolve must append ConflictResolved");
+        assert_eq!(event.0, "file.txt");
+        assert_eq!(event.1, "edit");
+        assert_eq!(*event.3, ConflictResolutionMode::Edit);
+        assert_eq!(event.2.principal.name, "Resolution Owner");
+        assert_eq!(event.2.principal.email, "owner@example.com");
+        let agent = event.2.agent.as_ref().expect("resolver agent attribution");
+        assert_eq!(agent.provider, "openai");
+        assert_eq!(agent.model, "gpt-resolver");
+    }
+
+    #[test]
+    #[timeout(15000)]
+    #[serial]
+    fn rebase_auto_resolution_appends_attributed_conflict_resolved_op_record() {
+        let temp = TempDir::new().unwrap();
+        heddle(&["init"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("file.txt"), "one\ntwo\nthree\n").unwrap();
+        heddle(&["capture", "-m", "Base"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "create", "feature"], Some(temp.path())).unwrap();
+        heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("file.txt"), "feature-one\ntwo\nthree\n").unwrap();
+        heddle(&["capture", "-m", "Feature"], Some(temp.path())).unwrap();
+
+        heddle(&["thread", "switch", "main"], Some(temp.path())).unwrap();
+        fs::write(temp.path().join("file.txt"), "one\ntwo\nmain-three\n").unwrap();
+        heddle(&["capture", "-m", "Main"], Some(temp.path())).unwrap();
+        heddle(&["thread", "switch", "feature"], Some(temp.path())).unwrap();
+        heddle_with_env(
+            &["thread", "refresh", "feature"],
+            Some(temp.path()),
+            &[
+                ("HEDDLE_PRINCIPAL_NAME", "Automation Owner"),
+                ("HEDDLE_PRINCIPAL_EMAIL", "automation@example.com"),
+                ("HEDDLE_AGENT_PROVIDER", "openai"),
+                ("HEDDLE_AGENT_MODEL", "gpt-auto-resolver"),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(temp.path().join("file.txt")).unwrap(),
+            "feature-one\ntwo\nmain-three\n"
+        );
+        let entries = recent_oplog_entries(&temp);
+        let event = entries
+            .iter()
+            .find_map(|entry| match &entry.operation {
+                OpRecord::ConflictResolved {
+                    conflict_id,
+                    resolution,
+                    resolver,
+                    mode: ConflictResolutionMode::Auto,
+                } => Some((conflict_id, resolution, resolver)),
+                _ => None,
+            })
+            .expect("rebase auto-merge must append ConflictResolved");
+        assert_eq!(event.0, "file.txt");
+        assert_eq!(event.1, "auto");
+        assert_eq!(event.2.principal.name, "Automation Owner");
+        assert_eq!(event.2.principal.email, "automation@example.com");
+        let agent = event
+            .2
+            .agent
+            .as_ref()
+            .expect("auto resolver agent attribution");
+        assert_eq!(agent.provider, "openai");
+        assert_eq!(agent.model, "gpt-auto-resolver");
     }
 
     #[test]
@@ -228,6 +341,15 @@ mod resolve {
 
         let content = fs::read_to_string(temp.path().join("file.txt")).unwrap();
         assert_eq!(content, "feature version", "should use our version");
+        assert!(recent_oplog_entries(&temp).iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::ConflictResolved {
+                conflict_id,
+                resolution,
+                mode: ConflictResolutionMode::Ours,
+                ..
+            } if conflict_id == "file.txt" && resolution == "ours"
+        )));
     }
 
     #[test]
@@ -246,6 +368,15 @@ mod resolve {
 
         let content = fs::read_to_string(temp.path().join("file.txt")).unwrap();
         assert_eq!(content, "main version", "should use their version");
+        assert!(recent_oplog_entries(&temp).iter().any(|entry| matches!(
+            &entry.operation,
+            OpRecord::ConflictResolved {
+                conflict_id,
+                resolution,
+                mode: ConflictResolutionMode::Theirs,
+                ..
+            } if conflict_id == "file.txt" && resolution == "theirs"
+        )));
     }
 
     #[test]

--- a/crates/oplog/src/oplog/mod.rs
+++ b/crates/oplog/src/oplog/mod.rs
@@ -17,9 +17,9 @@ pub use oplog_backend::OpLogBackend;
 pub use oplog_core::{OpLog, ReconstructibleCommitOutcome};
 pub use oplog_recorder::{OpLogRecorder, VisibilitySidecarSnapshots};
 pub use oplog_types::{
-    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpBatch, OpEntry, OpRecord,
-    RecordedHead, RedactionUndoClass, ThreadUpdateSnapshots, is_transaction_commit,
-    is_transaction_commit_for, isolation_keys_for_record,
+    ConditionalCommitOutcome, ConflictResolutionMode, IsolationKey, IsolationPrecondition, OpBatch,
+    OpEntry, OpRecord, RecordedHead, RedactionUndoClass, ThreadUpdateSnapshots,
+    is_transaction_commit, is_transaction_commit_for, isolation_keys_for_record,
 };
 pub use packed_oplog::OplogRecoveryReport;
 #[cfg(feature = "postgres")]

--- a/crates/oplog/src/oplog/oplog_tests.rs
+++ b/crates/oplog/src/oplog/oplog_tests.rs
@@ -8,7 +8,9 @@ use std::{
     thread,
 };
 
-use objects::object::{ContentHash, MarkerName, StateId, ThreadName};
+use objects::object::{
+    Agent, Attribution, ContentHash, MarkerName, Principal, StateId, ThreadName,
+};
 use tempfile::TempDir;
 
 use super::{
@@ -702,6 +704,11 @@ fn op_record_variants_roundtrip_and_describe() {
         OpRecord::ConflictResolved {
             conflict_id: "c1".into(),
             resolution: "ours".into(),
+            resolver: Attribution::with_agent(
+                Principal::new("Resolver", "resolver@example.com"),
+                Agent::new("openai", "gpt-5-codex"),
+            ),
+            mode: super::ConflictResolutionMode::Ours,
         },
         OpRecord::TransactionCommit {
             transaction_id: "tx".into(),

--- a/crates/repo/src/atomic/tests.rs
+++ b/crates/repo/src/atomic/tests.rs
@@ -10,11 +10,13 @@ use std::{
 
 use objects::{
     error::{HeddleError, Result},
-    object::{ContentHash, MarkerName, StateId, ThreadName, VisibilityTier},
+    object::{
+        Attribution, ContentHash, MarkerName, Principal, StateId, ThreadName, VisibilityTier,
+    },
 };
 use oplog::{
-    ConditionalCommitOutcome, IsolationKey, IsolationPrecondition, OpLogBackend, OpLogRecorder,
-    OpRecord, ThreadUpdateSnapshots, isolation_keys_for_record,
+    ConditionalCommitOutcome, ConflictResolutionMode, IsolationKey, IsolationPrecondition,
+    OpLogBackend, OpLogRecorder, OpRecord, ThreadUpdateSnapshots, isolation_keys_for_record,
 };
 use refs::{Head, RefExpectation, RefManager, RefUpdate};
 use tempfile::TempDir;
@@ -1334,6 +1336,8 @@ fn staged_record_coverage_cases(scope: &str) -> Vec<(OpRecord, BTreeSet<Isolatio
             OpRecord::ConflictResolved {
                 conflict_id: "conflict-1".to_string(),
                 resolution: "ours".to_string(),
+                resolver: Attribution::human(Principal::new("Resolver", "resolver@example.com")),
+                mode: ConflictResolutionMode::Ours,
             },
             BTreeSet::new(),
         ),

--- a/crates/schema/src/op_record/codec.rs
+++ b/crates/schema/src/op_record/codec.rs
@@ -9,11 +9,11 @@
 
 use objects::{
     error::{HeddleError, Result},
-    object::{ContentHash, StateId, VisibilityTier},
+    object::{Attribution, ContentHash, StateId, VisibilityTier},
 };
 use serde::Deserialize;
 
-use super::{OpRecord, RecordedHead, ThreadUpdateSnapshots};
+use super::{ConflictResolutionMode, OpRecord, RecordedHead, ThreadUpdateSnapshots};
 
 pub const CURRENT_OP_RECORD_SCHEMA_VERSION: u32 = 4;
 const CURRENT_OP_RECORD_SCHEMA_NAME: &str = "state-id-v4";
@@ -126,6 +126,8 @@ enum StrictCurrentOpRecord {
     ConflictResolved {
         conflict_id: String,
         resolution: String,
+        resolver: Attribution,
+        mode: ConflictResolutionMode,
     },
     TransactionCommit {
         transaction_id: String,
@@ -285,9 +287,13 @@ impl StrictCurrentOpRecord {
             Self::ConflictResolved {
                 conflict_id,
                 resolution,
+                resolver,
+                mode,
             } => OpRecord::ConflictResolved {
                 conflict_id,
                 resolution,
+                resolver,
+                mode,
             },
             Self::TransactionCommit {
                 transaction_id,
@@ -384,6 +390,8 @@ impl StrictCurrentOpRecord {
 
 #[cfg(test)]
 mod tests {
+    use objects::object::{Agent, Principal};
+
     use super::*;
 
     fn state(byte: u8) -> StateId {
@@ -470,6 +478,11 @@ mod tests {
             OpRecord::ConflictResolved {
                 conflict_id: "conflict".into(),
                 resolution: "ours".into(),
+                resolver: Attribution::with_agent(
+                    Principal::new("Resolver", "resolver@example.com"),
+                    Agent::new("openai", "gpt-5-codex"),
+                ),
+                mode: ConflictResolutionMode::Ours,
             },
             OpRecord::TransactionCommit {
                 transaction_id: "tx".into(),

--- a/crates/schema/src/op_record/types.rs
+++ b/crates/schema/src/op_record/types.rs
@@ -4,8 +4,35 @@
 use std::{collections::BTreeSet, sync::Arc};
 
 use chrono::{DateTime, Utc};
-use objects::object::{ContentHash, OperationId, Principal, StateId, VisibilityTier};
+use objects::object::{Attribution, ContentHash, OperationId, Principal, StateId, VisibilityTier};
 use serde::{Deserialize, Serialize};
+
+/// How a conflict was resolved.
+///
+/// The three manual variants preserve the explicit operator choice. `Auto`
+/// means the rebase merge driver resolved overlapping changes mechanically,
+/// without a human or agent editing or selecting a side.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConflictResolutionMode {
+    Ours,
+    Theirs,
+    Edit,
+    Auto,
+}
+
+impl ConflictResolutionMode {
+    /// Stable lower-case spelling used in persisted resolution summaries and
+    /// human-facing oplog descriptions.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ours => "ours",
+            Self::Theirs => "theirs",
+            Self::Edit => "edit",
+            Self::Auto => "auto",
+        }
+    }
+}
 
 /// Logical key used by conditional transaction commits to detect intervening
 /// same-thread changes.
@@ -177,6 +204,10 @@ pub enum OpRecord {
     ConflictResolved {
         conflict_id: String,
         resolution: String,
+        /// Principal and optional agent that performed or initiated the
+        /// resolution, using the same shape as state authorship.
+        resolver: Attribution,
+        mode: ConflictResolutionMode,
     },
     /// Recorded when a transaction is successfully committed. The number
     /// of buffered ops at commit time is captured so the audit trail
@@ -529,6 +560,20 @@ pub fn isolation_keys_for_record(record: &OpRecord, scope: Option<&str>) -> BTre
 }
 
 impl OpRecord {
+    /// Construct an attributed conflict-resolution event.
+    pub fn conflict_resolved(
+        conflict_id: impl Into<String>,
+        resolver: Attribution,
+        mode: ConflictResolutionMode,
+    ) -> Self {
+        Self::ConflictResolved {
+            conflict_id: conflict_id.into(),
+            resolution: mode.as_str().to_string(),
+            resolver,
+            mode,
+        }
+    }
+
     /// Get a short description of the operation.
     pub fn description(&self) -> String {
         match self {
@@ -574,8 +619,18 @@ impl OpRecord {
             OpRecord::EphemeralThreadCollapse { thread, .. } => {
                 format!("collapse ephemeral thread {}", thread)
             }
-            OpRecord::ConflictResolved { conflict_id, .. } => {
-                format!("resolve conflict {}", conflict_id)
+            OpRecord::ConflictResolved {
+                conflict_id,
+                resolver,
+                mode,
+                ..
+            } => {
+                format!(
+                    "resolve conflict {} ({} by {})",
+                    conflict_id,
+                    mode.as_str(),
+                    resolver
+                )
             }
             OpRecord::TransactionCommit {
                 transaction_id,
@@ -1149,6 +1204,8 @@ mod verb_catalog_tests {
             OpRecord::ConflictResolved {
                 conflict_id: "c".into(),
                 resolution: "r".into(),
+                resolver: Attribution::human(Principal::new("Resolver", "resolver@example.com")),
+                mode: ConflictResolutionMode::Edit,
             },
             OpRecord::TransactionCommit {
                 transaction_id: "tx".into(),


### PR DESCRIPTION
## Summary

- append `ConflictResolved` from the production `heddle resolve` path with `ours`, `theirs`, or `edit` mode
- append attributed `ConflictResolved` events for rebase auto-merges, preserving them in the atomic rebase oplog batch
- reuse state authorship's principal/agent `Attribution` shape and cover both paths through real CLI workflows
- deliberately exclude part (c), including any hosted RPC, pending the owner’s API-contract decision

## Closes

Closes #1171

## Test evidence

- pre-fix real-conflict resolve: `{"output_kind":"undo_list","conflict_resolved_records":[]}`
- manual resolve after fix: `{"output_kind":"undo_list","conflict_resolved_records":["resolve conflict file.txt (edit by Resolution Owner <owner@example.com> (via openai/gpt-resolver))"]}`
- rebase auto-resolution after fix: `{"output_kind":"undo_list","conflict_resolved_records":["resolve conflict file.txt (auto by Automation Owner <automation@example.com> (via openai/gpt-auto-resolver))"]}`
- `cargo test --locked` for CI's expanded affected-package set (pass)
- `cargo clippy --locked` for CI's expanded affected-package set with `--lib --bins --tests --examples -- -D warnings` (pass)
- all four CI feature-contract `cargo check --locked` invocations for native/git-overlay combinations (pass)
- PostgreSQL backend clippy with `heddle-oplog/postgres` (pass); the live ignored test was attempted but this host's local PostgreSQL rejected CI's documented `heddle_test` password, so the service-backed runtime check remains for PR CI
- `rustfmt +nightly --edition 2024` on touched files and `git diff --check` (pass)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788110468&installation_model_id=21489&pr_number=1174&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1174&signature=e4fa112120ea0f7c4f8d956aa749cd10f2e2595582be64801be33b15e01c1001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->