### PR TITLE
perf(repo): pack canonical timeline operations

### DIFF
--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -26,6 +26,7 @@ use objects::store::{
     AnyStore, ObjectStore, PackInstallMetricsSnapshot, pack_install_metrics_snapshot,
     recover_pack_install_intents,
 };
+use repo::TimelineStore;
 use serde::Serialize;
 
 use crate::cli::{Cli, render::write_json_stdout, should_output_json};
@@ -41,6 +42,11 @@ struct GcOutput {
     bytes_saved: u64,
     pruned_loose: u64,
     bytes_freed: u64,
+    timeline_packed_count: u64,
+    timeline_bytes_saved: u64,
+    timeline_pruned_loose: u64,
+    timeline_bytes_freed: u64,
+    timeline_unpaired_packs_pruned: u64,
     /// L8 Option D: unpaired `.pack` files removed (no matching `.idx`).
     unpaired_packs_pruned: u64,
     /// L8 install-intent recover: intents completed during this GC.
@@ -75,6 +81,7 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
     // these files, but the audit step costs O(redactions) and gives
     // operators a hard guarantee in writing.
     let redactions_before = repo.list_all_redactions().unwrap_or_default();
+    let timeline = TimelineStore::open(repo.heddle_dir())?;
     let pinned_redactions: usize = redactions_before
         .iter()
         .map(|(_, blob)| blob.redactions.len())
@@ -86,6 +93,7 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
         let trees = repo.store().list_trees()?;
         let plan = plan_gc_dry_run(blobs.len(), trees.len());
         summary.packed_count = plan.packed_count;
+        summary.timeline_packed_count = timeline.loose_operation_count()?;
         summary.status = plan.status;
 
         if !json {
@@ -93,6 +101,10 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
             for line in gc_dry_run_messages(blobs.len(), trees.len(), pinned_redactions) {
                 println!("{line}");
             }
+            println!(
+                "Would pack {} loose timeline operations and prune their redundant copies",
+                summary.timeline_packed_count
+            );
         }
     } else {
         let (packed_count, bytes_saved) = repo.store().pack_objects(aggressive)?;
@@ -101,6 +113,32 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
 
         if !json {
             println!("{}", gc_pack_message(packed_count, bytes_saved));
+        }
+
+        let (timeline_packed_count, timeline_bytes_saved) = timeline.pack_operations(aggressive)?;
+        summary.timeline_packed_count = timeline_packed_count;
+        summary.timeline_bytes_saved = timeline_bytes_saved;
+        if !json {
+            println!(
+                "Packed {timeline_packed_count} timeline operations ({timeline_bytes_saved} bytes saved)"
+            );
+        }
+
+        let (timeline_pruned_loose, timeline_bytes_freed) = timeline.prune_loose_operations()?;
+        summary.timeline_pruned_loose = timeline_pruned_loose;
+        summary.timeline_bytes_freed = timeline_bytes_freed;
+        if !json {
+            println!(
+                "Pruned {timeline_pruned_loose} loose timeline operations ({timeline_bytes_freed} bytes freed)"
+            );
+        }
+        let (timeline_unpaired_removed, timeline_unpaired_bytes) =
+            timeline.prune_unpaired_packs()?;
+        summary.timeline_unpaired_packs_pruned = timeline_unpaired_removed;
+        if !json && timeline_unpaired_removed > 0 {
+            println!(
+                "Pruned {timeline_unpaired_removed} unpaired timeline packs ({timeline_unpaired_bytes} bytes freed)"
+            );
         }
 
         repo.refs().pack_refs()?;

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -674,6 +674,9 @@ fn decode_native_pack(pack_data: &[u8], index_data: &[u8]) -> Vec<ObjectData> {
                 PackObjectType::SnapshotCommit => {
                     panic!("decoded native pack should not surface local snapshot commit artifacts")
                 }
+                PackObjectType::TimelineOperation => {
+                    panic!("decoded native pack should not contain timeline operations")
+                }
             };
             ObjectData {
                 id: object_id,

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -295,6 +295,9 @@ fn validate_pack_entry(id: &PackObjectId, obj_type: ObjectType, data: &[u8]) -> 
             }
             Ok(())
         }
+        (_, ObjectType::TimelineOperation) => Err(HeddleError::InvalidObject(
+            "timeline operations belong in the timeline pack store".to_string(),
+        )),
         _ => Err(HeddleError::InvalidObject(format!(
             "unsupported native pack object: {:?} {:?}",
             id, obj_type

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -658,6 +658,11 @@ pub trait ObjectStore: Send + Sync {
                 (pack::PackObjectId::StateId(change_id), pack::ObjectType::State) => {
                     self.put_state_serialized(&data, *change_id)?;
                 }
+                (_, pack::ObjectType::TimelineOperation) => {
+                    return Err(HeddleError::InvalidObject(
+                        "timeline operations belong in the timeline pack store".to_string(),
+                    ));
+                }
                 _ => {
                     return Err(HeddleError::InvalidObject(format!(
                         "unsupported native pack object: {:?} {:?}",

--- a/crates/pack/src/store/pack/mod.rs
+++ b/crates/pack/src/store/pack/mod.rs
@@ -39,6 +39,7 @@ pub enum ObjectType {
     Delta = 4,
     StateAttachment = 5,
     SnapshotCommit = 6,
+    TimelineOperation = 7,
 }
 
 pub(crate) fn pack_container_spec() -> PackContainerSpec {
@@ -58,6 +59,7 @@ impl ObjectType {
             4 => Some(ObjectType::Delta),
             5 => Some(ObjectType::StateAttachment),
             6 => Some(ObjectType::SnapshotCommit),
+            7 => Some(ObjectType::TimelineOperation),
             _ => None,
         }
     }

--- a/crates/pack/src/store/pack/varint.rs
+++ b/crates/pack/src/store/pack/varint.rs
@@ -172,6 +172,7 @@ mod tests {
             (4, ObjectType::Delta),
             (5, ObjectType::StateAttachment),
             (6, ObjectType::SnapshotCommit),
+            (7, ObjectType::TimelineOperation),
         ] {
             let mut buf = Vec::new();
             encode_type_and_size(obj_type, 42, &mut buf);
@@ -239,12 +240,5 @@ mod tests {
     fn test_decode_empty() {
         assert!(decode_type_and_size(&[]).is_none());
         assert!(decode_varint(&[]).is_none());
-    }
-
-    #[test]
-    fn test_invalid_type_rejected() {
-        // Type 7 is unassigned.
-        let buf = [0x70]; // type = 7, size = 0
-        assert!(decode_type_and_size(&buf).is_none());
     }
 }

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -81,6 +81,7 @@ mod thread_worktree_target;
 mod timeline_actions;
 mod timeline_materialize;
 mod timeline_navigation;
+mod timeline_pack;
 mod timeline_store;
 mod timeline_view;
 pub mod visibility;

--- a/crates/repo/src/timeline_pack.rs
+++ b/crates/repo/src/timeline_pack.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Strict reader index for canonical timeline-operation packs.
+
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::{Path, PathBuf},
+};
+
+use objects::{
+    error::{HeddleError, Result},
+    object::{ContentHash, TimelineOperationId},
+    store::{
+        CompressionConfig, PackBuilder, install_pack_bytes_journaled,
+        pack::{ObjectType, PackObjectId, PackReader},
+    },
+};
+
+pub(crate) struct TimelinePackSet {
+    packs_dir: PathBuf,
+    packs: Vec<TimelinePack>,
+    operation_locations: HashMap<TimelineOperationId, usize>,
+}
+
+struct TimelinePack {
+    pack_path: PathBuf,
+    index_path: PathBuf,
+    reader: PackReader<'static>,
+}
+
+impl TimelinePackSet {
+    pub(crate) fn open(packs_dir: PathBuf) -> Result<Self> {
+        let mut set = Self {
+            packs_dir,
+            packs: Vec::new(),
+            operation_locations: HashMap::new(),
+        };
+        set.reload()?;
+        Ok(set)
+    }
+
+    pub(crate) fn reload_if_disk_changed(&mut self) -> Result<()> {
+        let disk_paths = paired_pack_paths(&self.packs_dir)?;
+        let loaded_paths = self
+            .packs
+            .iter()
+            .map(|pack| (pack.pack_path.clone(), pack.index_path.clone()))
+            .collect::<Vec<_>>();
+        if disk_paths != loaded_paths {
+            self.reload()?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reload(&mut self) -> Result<()> {
+        let mut packs = Vec::new();
+        let mut operation_locations = HashMap::new();
+        for (pack_path, index_path) in paired_pack_paths(&self.packs_dir)? {
+            let reader = PackReader::open(&pack_path, &index_path)?;
+            let pack_index = packs.len();
+            for id in reader.list_ids() {
+                let operation_id = timeline_id_from_pack_id(id)?;
+                operation_locations
+                    .entry(operation_id)
+                    .or_insert(pack_index);
+            }
+            packs.push(TimelinePack {
+                pack_path,
+                index_path,
+                reader,
+            });
+        }
+        self.packs = packs;
+        self.operation_locations = operation_locations;
+        Ok(())
+    }
+
+    pub(crate) fn operation_ids(&self) -> Vec<TimelineOperationId> {
+        self.operation_locations.keys().copied().collect()
+    }
+
+    pub(crate) fn read_operation(&self, id: &TimelineOperationId) -> Result<Option<Vec<u8>>> {
+        let Some(pack_index) = self.operation_locations.get(id).copied() else {
+            return Ok(None);
+        };
+        let pack_id = timeline_pack_id(id);
+        let Some((object_type, bytes)) = self.packs[pack_index].reader.get_object(&pack_id)? else {
+            return Err(HeddleError::InvalidObject(format!(
+                "timeline pack index names missing operation {}",
+                id.short()
+            )));
+        };
+        if object_type != ObjectType::TimelineOperation {
+            return Err(HeddleError::InvalidObject(format!(
+                "timeline pack entry {} has object type {object_type:?}",
+                id.short()
+            )));
+        }
+        let computed_id = TimelineOperationId::for_bytes(&bytes);
+        if computed_id != *id {
+            return Err(HeddleError::InvalidObject(format!(
+                "timeline packed operation id mismatch: expected {}, decoded {}",
+                id.short(),
+                computed_id.short()
+            )));
+        }
+        Ok(Some(bytes))
+    }
+
+    pub(crate) fn consolidate(
+        &mut self,
+        loose_operations: Vec<(TimelineOperationId, Vec<u8>)>,
+        aggressive: bool,
+    ) -> Result<(u64, u64)> {
+        self.reload()?;
+        let old_pack_files = self
+            .file_paths()
+            .into_iter()
+            .map(|(pack, index)| (pack.to_path_buf(), index.to_path_buf()))
+            .collect::<Vec<_>>();
+        if loose_operations.is_empty() && old_pack_files.len() <= 1 {
+            return Ok((0, 0));
+        }
+
+        let mut canonical_operations = BTreeMap::new();
+        for id in self.operation_ids() {
+            let bytes = self.read_operation(&id)?.ok_or_else(|| {
+                HeddleError::InvalidObject(format!(
+                    "timeline pack lost indexed operation {}",
+                    id.short()
+                ))
+            })?;
+            canonical_operations.insert(id, bytes);
+        }
+        merge_loose_operations(&mut canonical_operations, loose_operations)?;
+        if canonical_operations.is_empty() {
+            return Ok((0, 0));
+        }
+
+        let mut compression = CompressionConfig::default();
+        if !aggressive {
+            compression.max_delta_size = 0;
+        }
+        let mut builder = PackBuilder::new(compression);
+        for (id, bytes) in &canonical_operations {
+            builder.add_id(
+                timeline_pack_id(id),
+                ObjectType::TimelineOperation,
+                bytes.clone(),
+            );
+        }
+        let (pack_data, index_data, stats) = builder.build()?;
+        verify_candidate_pack(&pack_data, &index_data, &canonical_operations)?;
+        let new_pack_name = install_pack_bytes_journaled(&self.packs_dir, &pack_data, &index_data)?;
+        self.reload()?;
+        verify_canonical_operations(self, &canonical_operations)?;
+        retire_old_packs(&old_pack_files, &new_pack_name)?;
+        self.reload()?;
+        verify_canonical_operations(self, &canonical_operations)?;
+
+        Ok((
+            stats.object_count,
+            stats
+                .total_uncompressed
+                .saturating_sub(stats.total_compressed),
+        ))
+    }
+
+    pub(crate) fn file_paths(&self) -> Vec<(&Path, &Path)> {
+        self.packs
+            .iter()
+            .map(|pack| (pack.pack_path.as_path(), pack.index_path.as_path()))
+            .collect()
+    }
+}
+
+fn verify_candidate_pack(
+    pack_data: &[u8],
+    index_data: &[u8],
+    expected: &BTreeMap<TimelineOperationId, Vec<u8>>,
+) -> Result<()> {
+    let reader = PackReader::from_slice(pack_data, index_data)?;
+    if reader.list_ids().len() != expected.len() {
+        return Err(HeddleError::InvalidObject(
+            "new timeline pack entry count differs from canonical operations".to_string(),
+        ));
+    }
+    for (id, expected_bytes) in expected {
+        match reader.get_object(&timeline_pack_id(id))? {
+            Some((ObjectType::TimelineOperation, bytes))
+                if &bytes == expected_bytes && TimelineOperationId::for_bytes(&bytes) == *id => {}
+            _ => {
+                return Err(HeddleError::InvalidObject(format!(
+                    "new timeline pack failed canonical verification for operation {}",
+                    id.short()
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn merge_loose_operations(
+    canonical_operations: &mut BTreeMap<TimelineOperationId, Vec<u8>>,
+    loose_operations: Vec<(TimelineOperationId, Vec<u8>)>,
+) -> Result<()> {
+    for (id, bytes) in loose_operations {
+        if let Some(packed_bytes) = canonical_operations.get(&id)
+            && packed_bytes != &bytes
+        {
+            return Err(HeddleError::InvalidObject(format!(
+                "loose and packed timeline operation {} differ",
+                id.short()
+            )));
+        }
+        canonical_operations.insert(id, bytes);
+    }
+    Ok(())
+}
+
+fn verify_canonical_operations(
+    packs: &TimelinePackSet,
+    expected: &BTreeMap<TimelineOperationId, Vec<u8>>,
+) -> Result<()> {
+    for (id, expected_bytes) in expected {
+        let actual_bytes = packs.read_operation(id)?.ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "new timeline pack does not resolve operation {}",
+                id.short()
+            ))
+        })?;
+        if &actual_bytes != expected_bytes {
+            return Err(HeddleError::InvalidObject(format!(
+                "new timeline pack changed canonical bytes for operation {}",
+                id.short()
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn retire_old_packs(old_pack_files: &[(PathBuf, PathBuf)], new_pack_name: &str) -> Result<()> {
+    for (pack_path, index_path) in old_pack_files {
+        if pack_path.file_stem().and_then(|stem| stem.to_str()) == Some(new_pack_name) {
+            continue;
+        }
+        remove_file_ignore_missing(pack_path)?;
+        remove_file_ignore_missing(index_path)?;
+    }
+    Ok(())
+}
+
+fn remove_file_ignore_missing(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err.into()),
+    }
+}
+
+pub(crate) fn timeline_pack_id(id: &TimelineOperationId) -> PackObjectId {
+    PackObjectId::Hash(ContentHash::from_bytes(*id.as_bytes()))
+}
+
+fn timeline_id_from_pack_id(id: PackObjectId) -> Result<TimelineOperationId> {
+    match id {
+        PackObjectId::Hash(hash) => Ok(TimelineOperationId::from_bytes(*hash.as_bytes())),
+        PackObjectId::StateId(_) => Err(HeddleError::InvalidObject(
+            "timeline pack contains a state-id entry".to_string(),
+        )),
+    }
+}
+
+fn paired_pack_paths(packs_dir: &Path) -> Result<Vec<(PathBuf, PathBuf)>> {
+    let entries = match fs::read_dir(packs_dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(err) => return Err(err.into()),
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        let pack_path = entry?.path();
+        if pack_path
+            .extension()
+            .is_some_and(|extension| extension == "pack")
+        {
+            let index_path = pack_path.with_extension("idx");
+            if index_path.is_file() {
+                paths.push((pack_path, index_path));
+            }
+        }
+    }
+    paths.sort();
+    Ok(paths)
+}

--- a/crates/repo/src/timeline_store.rs
+++ b/crates/repo/src/timeline_store.rs
@@ -5,6 +5,7 @@ use std::{
     fs,
     fs::OpenOptions,
     path::{Path, PathBuf},
+    sync::RwLock,
 };
 
 use objects::{
@@ -15,15 +16,17 @@ use objects::{
         StateId, TimelineBranchId, TimelineCodecError, TimelineCursorMoveReason,
         TimelineOperationEnvelope, TimelineOperationId, TimelineStepId,
     },
+    store::recover_pack_install_intents,
 };
 use serde::{Deserialize, Serialize};
 
-use crate::thread_manifest::encode_thread_segment;
+use crate::{thread_manifest::encode_thread_segment, timeline_pack::TimelinePackSet};
 
 pub const TIMELINE_MATERIALIZATION_RECOVERY_SCHEMA_VERSION: u16 = 1;
 pub const TIMELINE_OPERATION_INDEX_SCHEMA_VERSION: u16 = 1;
 const TIMELINE_DIR: &str = "timeline";
 const OPS_DIR: &str = "ops";
+const PACKS_DIR: &str = "packs";
 const INDEXES_DIR: &str = "indexes";
 const VIEWS_DIR: &str = "views";
 const SYNC_DIR: &str = "sync";
@@ -85,14 +88,18 @@ impl TimelineMaterializationRecoveryRecord {
 pub struct TimelineStore {
     root: PathBuf,
     lock: RepoLock,
+    packs: RwLock<TimelinePackSet>,
 }
 
 impl TimelineStore {
     /// Open or create the timeline store under `<heddle_dir>/timeline`.
     pub fn open(heddle_dir: impl AsRef<Path>) -> Result<Self> {
         let root = heddle_dir.as_ref().join(TIMELINE_DIR);
+        fs::create_dir_all(root.join(PACKS_DIR))?;
+        recover_pack_install_intents(&root.join(PACKS_DIR))?;
         let store = Self {
             lock: RepoLock::at(root.join(LOCK_FILE)),
+            packs: RwLock::new(TimelinePackSet::open(root.join(PACKS_DIR))?),
             root,
         };
         store.init()?;
@@ -107,6 +114,7 @@ impl TimelineStore {
     /// Ensure the timeline layout exists.
     pub fn init(&self) -> Result<()> {
         fs::create_dir_all(self.ops_dir())?;
+        fs::create_dir_all(self.packs_dir())?;
         fs::create_dir_all(self.root.join(INDEXES_DIR))?;
         fs::create_dir_all(self.root.join(VIEWS_DIR))?;
         fs::create_dir_all(self.root.join(SYNC_DIR))?;
@@ -158,7 +166,11 @@ impl TimelineStore {
         let _guard = self.lock.read().map_err(timeline_lock_error)?;
         match fs::read(path) {
             Ok(bytes) => Ok(Some(bytes)),
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                let mut packs = self.packs.write().map_err(timeline_pack_lock_error)?;
+                packs.reload_if_disk_changed()?;
+                packs.read_operation(id)
+            }
             Err(err) => Err(err.into()),
         }
     }
@@ -187,6 +199,106 @@ impl TimelineStore {
         let path = self.operation_index_path();
         let _guard = self.lock.read().map_err(timeline_lock_error)?;
         read_operation_index_unlocked(&path)
+    }
+
+    pub(crate) fn canonical_operation_ids(&self) -> Result<Vec<TimelineOperationId>> {
+        let _guard = self.lock.read().map_err(timeline_lock_error)?;
+        let mut operation_ids = self
+            .loose_operation_paths()?
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect::<Vec<_>>();
+        let mut packs = self.packs.write().map_err(timeline_pack_lock_error)?;
+        packs.reload_if_disk_changed()?;
+        operation_ids.extend(packs.operation_ids());
+        operation_ids.sort();
+        operation_ids.dedup();
+        Ok(operation_ids)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn loose_operation_ids(&self) -> Result<Vec<TimelineOperationId>> {
+        let _guard = self.lock.read().map_err(timeline_lock_error)?;
+        Ok(self
+            .loose_operation_paths()?
+            .into_iter()
+            .map(|(id, _)| id)
+            .collect())
+    }
+
+    /// Number of loose canonical timeline-operation files.
+    pub fn loose_operation_count(&self) -> Result<u64> {
+        let _guard = self.lock.read().map_err(timeline_lock_error)?;
+        u64::try_from(self.loose_operation_paths()?.len()).map_err(|_| {
+            HeddleError::InvalidObject("timeline operation count exceeds u64".to_string())
+        })
+    }
+
+    /// Consolidate every canonical timeline operation into one pack.
+    pub fn pack_operations(&self, aggressive: bool) -> Result<(u64, u64)> {
+        let _guard = self.lock.write().map_err(timeline_lock_error)?;
+        let loose_operations = self.read_loose_operations()?;
+        let mut packs = self.packs.write().map_err(timeline_pack_lock_error)?;
+        packs.consolidate(loose_operations, aggressive)
+    }
+
+    /// Remove loose operations only when an identical packed copy resolves.
+    pub fn prune_loose_operations(&self) -> Result<(u64, u64)> {
+        let _guard = self.lock.write().map_err(timeline_lock_error)?;
+        let loose_paths = self.loose_operation_paths()?;
+        let mut packs = self.packs.write().map_err(timeline_pack_lock_error)?;
+        packs.reload()?;
+        let mut removed = 0u64;
+        let mut bytes_freed = 0u64;
+        for (id, path) in loose_paths {
+            let loose_bytes = match fs::read(&path) {
+                Ok(bytes) => bytes,
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(err.into()),
+            };
+            if packs.read_operation(&id)?.as_deref() != Some(loose_bytes.as_slice()) {
+                continue;
+            }
+            let len = fs::metadata(&path)?.len();
+            match fs::remove_file(&path) {
+                Ok(()) => {
+                    removed += 1;
+                    bytes_freed += len;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+        remove_empty_operation_shards(&self.ops_dir())?;
+        Ok((removed, bytes_freed))
+    }
+
+    /// Remove timeline `.pack` files that have no matching index.
+    pub fn prune_unpaired_packs(&self) -> Result<(u64, u64)> {
+        let _guard = self.lock.write().map_err(timeline_lock_error)?;
+        let mut removed = 0u64;
+        let mut bytes_freed = 0u64;
+        for entry in fs::read_dir(self.packs_dir())? {
+            let path = entry?.path();
+            if !path.is_file()
+                || !path
+                    .extension()
+                    .is_some_and(|extension| extension == "pack")
+                || path.with_extension("idx").is_file()
+            {
+                continue;
+            }
+            let len = fs::metadata(&path)?.len();
+            match fs::remove_file(path) {
+                Ok(()) => {
+                    removed += 1;
+                    bytes_freed += len;
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+        Ok((removed, bytes_freed))
     }
 
     pub(crate) fn write_operation_index(
@@ -307,6 +419,36 @@ impl TimelineStore {
         self.root.join(OPS_DIR)
     }
 
+    fn loose_operation_paths(&self) -> Result<Vec<(TimelineOperationId, PathBuf)>> {
+        let mut paths = Vec::new();
+        collect_loose_operation_paths(&self.ops_dir(), &mut paths)?;
+        paths.sort_by_key(|(id, _)| *id);
+        Ok(paths)
+    }
+
+    fn read_loose_operations(&self) -> Result<Vec<(TimelineOperationId, Vec<u8>)>> {
+        self.loose_operation_paths()?
+            .into_iter()
+            .map(|(id, path)| {
+                let bytes = fs::read(path)?;
+                let computed_id = TimelineOperationId::for_bytes(&bytes);
+                if computed_id != id {
+                    return Err(HeddleError::InvalidObject(format!(
+                        "loose timeline operation id mismatch: expected {}, decoded {}",
+                        id.short(),
+                        computed_id.short()
+                    )));
+                }
+                TimelineOperationEnvelope::decode(&bytes).map_err(timeline_codec_error)?;
+                Ok((id, bytes))
+            })
+            .collect()
+    }
+
+    fn packs_dir(&self) -> PathBuf {
+        self.root.join(PACKS_DIR)
+    }
+
     fn operation_index_path(&self) -> PathBuf {
         self.root.join(INDEXES_DIR).join(OPERATION_INDEX_FILE)
     }
@@ -354,6 +496,84 @@ fn write_operation_index_unlocked(
     Ok(())
 }
 
+fn collect_loose_operation_paths(
+    dir: &Path,
+    paths: &mut Vec<(TimelineOperationId, PathBuf)>,
+) -> Result<()> {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(err) => return Err(err.into()),
+    };
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            collect_loose_operation_paths(&path, paths)?;
+        } else if file_type.is_file()
+            && path
+                .extension()
+                .is_some_and(|extension| extension == "msgpack")
+        {
+            paths.push((operation_id_from_path(&path)?, path));
+        }
+    }
+    Ok(())
+}
+
+fn operation_id_from_path(path: &Path) -> Result<TimelineOperationId> {
+    let prefix = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "timeline operation path has no shard prefix: {}",
+                path.display()
+            ))
+        })?;
+    let rest = path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "timeline operation path has no file stem: {}",
+                path.display()
+            ))
+        })?;
+    let raw = hex::decode(format!("{prefix}{rest}")).map_err(|err| {
+        HeddleError::InvalidObject(format!(
+            "timeline operation path has invalid id '{}': {err}",
+            path.display()
+        ))
+    })?;
+    TimelineOperationId::try_from_slice(&raw).map_err(|err| {
+        HeddleError::InvalidObject(format!(
+            "timeline operation path has invalid id length '{}': {err}",
+            path.display()
+        ))
+    })
+}
+
+fn remove_empty_operation_shards(ops_dir: &Path) -> Result<()> {
+    for entry in fs::read_dir(ops_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if fs::read_dir(&path)?.next().is_none() {
+            match fs::remove_dir(path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+    }
+    Ok(())
+}
+
 fn timeline_codec_error(err: TimelineCodecError) -> HeddleError {
     HeddleError::InvalidObject(err.to_string())
 }
@@ -362,8 +582,16 @@ fn timeline_lock_error(err: objects::lock::LockError) -> HeddleError {
     HeddleError::InvalidObject(format!("acquire timeline store lock: {err}"))
 }
 
+fn timeline_pack_lock_error<T>(_: std::sync::PoisonError<T>) -> HeddleError {
+    HeddleError::InvalidObject("acquire timeline pack index lock".to_string())
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt;
+
     use objects::object::{
         BranchCreatedV1, StateId, TimelineBranchId, TimelineBranchReason, TimelineOperationBodyV1,
         TimelineOperationEnvelope, TimelineStepId,
@@ -385,6 +613,23 @@ mod tests {
             }),
             Vec::new(),
         )
+    }
+
+    fn directory_sizes(path: &Path) -> (u64, u64) {
+        let metadata = std::fs::metadata(path).unwrap();
+        let mut apparent = metadata.len();
+        #[cfg(unix)]
+        let mut allocated = metadata.blocks() * 512;
+        #[cfg(not(unix))]
+        let mut allocated = apparent;
+        if metadata.is_dir() {
+            for entry in std::fs::read_dir(path).unwrap() {
+                let (entry_apparent, entry_allocated) = directory_sizes(&entry.unwrap().path());
+                apparent += entry_apparent;
+                allocated += entry_allocated;
+            }
+        }
+        (apparent, allocated)
     }
 
     #[test]
@@ -424,6 +669,131 @@ mod tests {
 
         assert_eq!(store.write_operation(&sample_envelope()).unwrap(), id);
         assert_eq!(store.read_operation_index().unwrap(), Some(vec![id]));
+    }
+
+    #[test]
+    fn timeline_store_fails_open_on_corrupt_paired_pack() {
+        let temp = TempDir::new().unwrap();
+        let heddle_dir = temp.path().join(".heddle");
+        let store = TimelineStore::open(&heddle_dir).unwrap();
+        std::fs::write(store.packs_dir().join("corrupt.pack"), b"not a pack").unwrap();
+        std::fs::write(store.packs_dir().join("corrupt.idx"), b"not an index").unwrap();
+        drop(store);
+
+        assert!(TimelineStore::open(&heddle_dir).is_err());
+    }
+
+    #[test]
+    fn timeline_store_prunes_only_unpaired_pack_files() {
+        let temp = TempDir::new().unwrap();
+        let store = TimelineStore::open(temp.path().join(".heddle")).unwrap();
+        std::fs::write(store.packs_dir().join("orphan.pack"), b"orphan").unwrap();
+        std::fs::write(store.packs_dir().join("index-only.idx"), b"index").unwrap();
+
+        assert_eq!(store.prune_unpaired_packs().unwrap(), (1, 6));
+        assert!(!store.packs_dir().join("orphan.pack").exists());
+        assert!(store.packs_dir().join("index-only.idx").exists());
+    }
+
+    #[test]
+    fn timeline_repack_carries_forward_existing_packed_operations() {
+        let temp = TempDir::new().unwrap();
+        let store = TimelineStore::open(temp.path().join(".heddle")).unwrap();
+        let first = sample_envelope();
+        let first_id = store.write_operation(&first).unwrap();
+        let first_bytes = first.encode().unwrap();
+        store.pack_operations(false).unwrap();
+        store.prune_loose_operations().unwrap();
+
+        let second = TimelineOperationEnvelope::new(
+            TimelineOperationBodyV1::BranchCreated(BranchCreatedV1 {
+                thread: "main".to_string(),
+                branch_id: TimelineBranchId::new("tlb-second"),
+                parent_branch_id: Some(TimelineBranchId::new("tlb-child")),
+                from_step_id: Some(TimelineStepId::new("tls-root")),
+                from_state: StateId::from_bytes([1; 32]),
+                reason: TimelineBranchReason::FanOut,
+                created_at_ms: 1_700_000_000_001,
+            }),
+            Vec::new(),
+        );
+        let second_id = store.write_operation(&second).unwrap();
+        let second_bytes = second.encode().unwrap();
+
+        assert_eq!(store.pack_operations(true).unwrap().0, 2);
+        assert_eq!(store.prune_loose_operations().unwrap().0, 1);
+        assert_eq!(
+            store.read_operation_bytes(&first_id).unwrap(),
+            Some(first_bytes)
+        );
+        assert_eq!(
+            store.read_operation_bytes(&second_id).unwrap(),
+            Some(second_bytes)
+        );
+    }
+
+    #[test]
+    fn packing_1000_branches_preserves_ids_bytes_and_removes_block_slack() {
+        let temp = TempDir::new().unwrap();
+        let heddle_dir = temp.path().join(".heddle");
+        let store = TimelineStore::open(&heddle_dir).unwrap();
+        let mut expected = BTreeMap::new();
+        for ordinal in 0..1_000 {
+            let envelope = TimelineOperationEnvelope::new(
+                TimelineOperationBodyV1::BranchCreated(BranchCreatedV1 {
+                    thread: "main".to_string(),
+                    branch_id: TimelineBranchId::new(format!("tlb-{ordinal:04}")),
+                    parent_branch_id: None,
+                    from_step_id: None,
+                    from_state: StateId::from_bytes([1; 32]),
+                    reason: TimelineBranchReason::FanOut,
+                    created_at_ms: ordinal,
+                }),
+                Vec::new(),
+            );
+            let bytes = envelope.encode().unwrap();
+            let id = TimelineOperationId::for_bytes(&bytes);
+            let path = store.operation_path(&id);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(path, &bytes).unwrap();
+            expected.insert(id, bytes);
+        }
+        store
+            .write_operation_index(&expected.keys().copied().collect::<Vec<_>>())
+            .unwrap();
+        let (before_apparent, before_allocated) = directory_sizes(store.root());
+
+        let (packed, _) = store.pack_operations(false).unwrap();
+        assert_eq!(packed, 1_000);
+        let (pruned, _) = store.prune_loose_operations().unwrap();
+        assert_eq!(pruned, 1_000);
+        let (after_apparent, after_allocated) = directory_sizes(store.root());
+        drop(store);
+        let store = TimelineStore::open(&heddle_dir).unwrap();
+        assert_eq!(
+            store.canonical_operation_ids().unwrap(),
+            expected.keys().copied().collect::<Vec<_>>()
+        );
+
+        for (id, expected_bytes) in &expected {
+            assert!(!store.operation_path(id).exists());
+            let packed_bytes = store.read_operation_bytes(id).unwrap().unwrap();
+            assert_eq!(&packed_bytes, expected_bytes);
+            assert_eq!(TimelineOperationId::for_bytes(&packed_bytes), *id);
+        }
+        assert_eq!(
+            crate::TimelineView::rebuild(&store)
+                .unwrap()
+                .branch_count("main"),
+            1_000
+        );
+        assert_eq!(store.pack_operations(false).unwrap(), (0, 0));
+        assert_eq!(store.prune_loose_operations().unwrap(), (0, 0));
+        println!(
+            "1000-branch canonical store: apparent {before_apparent} -> {after_apparent} bytes; allocated {before_allocated} -> {after_allocated} bytes"
+        );
+        #[cfg(unix)]
+        assert!(after_allocated < before_allocated / 2);
     }
 
     #[test]

--- a/crates/repo/src/timeline_view.rs
+++ b/crates/repo/src/timeline_view.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Rebuildable derived views over canonical agent timeline operations.
 
-use std::{
-    collections::{BTreeMap, BTreeSet},
-    fs,
-    path::Path,
-};
+use std::collections::{BTreeMap, BTreeSet};
 
 use objects::{
     error::{HeddleError, Result},
@@ -679,10 +675,7 @@ fn read_timeline_operation_records_by_id(
 }
 
 fn read_timeline_operation_ids(store: &TimelineStore) -> Result<Vec<TimelineOperationId>> {
-    let mut canonical_ids = Vec::new();
-    collect_operation_ids(&store.root().join("ops"), &mut canonical_ids)?;
-    canonical_ids.sort();
-    canonical_ids.dedup();
+    let canonical_ids = store.canonical_operation_ids()?;
 
     let canonical_set = canonical_ids.iter().copied().collect::<BTreeSet<_>>();
     let indexed_operation_ids = store
@@ -703,62 +696,6 @@ fn read_timeline_operation_ids(store: &TimelineStore) -> Result<Vec<TimelineOper
         store.write_operation_index(&operation_ids)?;
     }
     Ok(operation_ids)
-}
-
-fn collect_operation_ids(dir: &Path, ids: &mut Vec<TimelineOperationId>) -> Result<()> {
-    match fs::read_dir(dir) {
-        Ok(entries) => {
-            for entry in entries {
-                let entry = entry?;
-                let path = entry.path();
-                let file_type = entry.file_type()?;
-                if file_type.is_dir() {
-                    collect_operation_ids(&path, ids)?;
-                } else if file_type.is_file()
-                    && path.extension().is_some_and(|ext| ext == "msgpack")
-                {
-                    ids.push(operation_id_from_path(&path)?);
-                }
-            }
-            Ok(())
-        }
-        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(err) => Err(err.into()),
-    }
-}
-
-fn operation_id_from_path(path: &Path) -> Result<TimelineOperationId> {
-    let prefix = path
-        .parent()
-        .and_then(Path::file_name)
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            HeddleError::InvalidObject(format!(
-                "timeline operation path has no shard prefix: {}",
-                path.display()
-            ))
-        })?;
-    let rest = path
-        .file_stem()
-        .and_then(|name| name.to_str())
-        .ok_or_else(|| {
-            HeddleError::InvalidObject(format!(
-                "timeline operation path has no file stem: {}",
-                path.display()
-            ))
-        })?;
-    let raw = hex::decode(format!("{prefix}{rest}")).map_err(|err| {
-        HeddleError::InvalidObject(format!(
-            "timeline operation path has invalid id '{}': {err}",
-            path.display()
-        ))
-    })?;
-    TimelineOperationId::try_from_slice(&raw).map_err(|err| {
-        HeddleError::InvalidObject(format!(
-            "timeline operation path has invalid id length '{}': {err}",
-            path.display()
-        ))
-    })
 }
 
 fn rebuild_timeline_view_from_ids(
@@ -907,9 +844,12 @@ fn push_unique_operation(target: &mut Vec<TimelineOperationId>, id: TimelineOper
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{
-        BranchCreatedV1, NativeToolCallRefV1, TimelineToolPayloadMetadata, ToolCallFinishedV1,
-        ToolCallStartedV1,
+    use objects::{
+        object::{
+            BranchCreatedV1, NativeToolCallRefV1, TimelineToolPayloadMetadata, ToolCallFinishedV1,
+            ToolCallStartedV1,
+        },
+        store::{CompressionConfig, PackBuilder, pack::ObjectType},
     };
     use tempfile::TempDir;
 
@@ -944,6 +884,38 @@ mod tests {
         let temp = TempDir::new().unwrap();
         let store = TimelineStore::open(temp.path().join(".heddle")).unwrap();
         (temp, store)
+    }
+
+    fn install_operation_pack(store: &TimelineStore, id: TimelineOperationId, bytes: Vec<u8>) {
+        let mut builder = PackBuilder::new(CompressionConfig::disabled());
+        builder.add_id(
+            crate::timeline_pack::timeline_pack_id(&id),
+            ObjectType::TimelineOperation,
+            bytes,
+        );
+        let (pack_data, index_data, _) = builder.build().unwrap();
+        std::fs::write(store.root().join("packs/fixture.pack"), pack_data).unwrap();
+        std::fs::write(store.root().join("packs/fixture.idx"), index_data).unwrap();
+    }
+
+    fn read_timeline_operation_ids_loose_only(
+        store: &TimelineStore,
+    ) -> Result<Vec<TimelineOperationId>> {
+        let mut canonical_ids = store.loose_operation_ids()?;
+        canonical_ids.sort();
+        canonical_ids.dedup();
+
+        let canonical_set = canonical_ids.iter().copied().collect::<BTreeSet<_>>();
+        let indexed_operation_ids = store
+            .read_operation_index()
+            .unwrap_or(None)
+            .unwrap_or_default();
+        let mut operation_ids = indexed_operation_ids.clone();
+        operation_ids.retain(|id| canonical_set.contains(id));
+        if indexed_operation_ids != operation_ids {
+            store.write_operation_index(&operation_ids)?;
+        }
+        Ok(operation_ids)
     }
 
     fn write_main_two_steps(store: &TimelineStore) {
@@ -1084,6 +1056,52 @@ mod tests {
         assert_eq!(first.payload_summary.as_deref(), Some("created src/lib.rs"));
         assert_eq!(first.operation_ids.len(), 2);
         assert_eq!(first.labels, vec![TimelineLabel::RepoReversible]);
+    }
+
+    #[test]
+    fn pack_aware_rebuild_closes_loose_only_silent_omission() {
+        let (_temp, store) = temp_store();
+        let envelope = TimelineOperationEnvelope::new(
+            TimelineOperationBodyV1::BranchCreated(BranchCreatedV1 {
+                thread: "main".to_string(),
+                branch_id: branch("tlb-packed"),
+                parent_branch_id: None,
+                from_step_id: None,
+                from_state: state(0),
+                reason: TimelineBranchReason::ExplicitFork,
+                created_at_ms: 1,
+            }),
+            Vec::new(),
+        );
+        let id = store.write_operation(&envelope).unwrap();
+        let canonical_bytes = store.read_operation_bytes(&id).unwrap().unwrap();
+        install_operation_pack(&store, id, canonical_bytes.clone());
+        std::fs::remove_file(store.operation_path(&id)).unwrap();
+
+        let loose_only_ids = read_timeline_operation_ids_loose_only(&store).unwrap();
+        let loose_only_view = rebuild_timeline_view_from_ids(&store, &loose_only_ids).unwrap();
+        println!(
+            "non-pack-aware rebuild: indexed=1 resolved={} branches={} (silently omitted {})",
+            loose_only_view.operation_ids().len(),
+            loose_only_view.branch_count("main"),
+            id.short()
+        );
+        assert!(loose_only_view.operation_ids().is_empty());
+        assert_eq!(store.read_operation_index().unwrap(), Some(Vec::new()));
+
+        let pack_aware_view = TimelineView::rebuild(&store).unwrap();
+        let packed_bytes = store.read_operation_bytes(&id).unwrap().unwrap();
+        println!(
+            "pack-aware rebuild: resolved={} branches={} id={} canonical_bytes_identical={}",
+            pack_aware_view.operation_ids().len(),
+            pack_aware_view.branch_count("main"),
+            id.short(),
+            packed_bytes == canonical_bytes
+        );
+        assert_eq!(pack_aware_view.operation_ids(), &[id]);
+        assert_eq!(pack_aware_view.branch_count("main"), 1);
+        assert_eq!(packed_bytes, canonical_bytes);
+        assert_eq!(TimelineOperationId::for_bytes(&packed_bytes), id);
     }
 
     #[test]

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3417,7 +3417,7 @@ report redacted blobs the collector refused to touch; `consolidated_mirror_loose
 counts loose legacy Bridge Mirror objects packed into the mirror's own pack):
 
 ```json
-{"output_kind": "gc", "action": "gc", "status": "ok", "dry_run": false, "prune": false, "packed_count": 1, "bytes_saved": 0, "pruned_loose": 0, "bytes_freed": 0, "unpaired_packs_pruned": 0, "pack_install_intents_completed": 0, "pack_install_intents_aborted": 0, "pack_install_metrics": {"installs_ok": 0, "installs_err": 0, "recover_completed": 0, "recover_aborted": 0, "recover_skipped_in_progress": 0, "recover_quarantined": 0}, "pinned_redactions": 0, "preserved_redactions": 0, "pruned_git_mapping_entries": 0, "consolidated_mirror_loose": 0}
+{"output_kind": "gc", "action": "gc", "status": "ok", "dry_run": false, "prune": false, "packed_count": 1, "bytes_saved": 0, "pruned_loose": 0, "bytes_freed": 0, "timeline_packed_count": 0, "timeline_bytes_saved": 0, "timeline_pruned_loose": 0, "timeline_bytes_freed": 0, "timeline_unpaired_packs_pruned": 0, "unpaired_packs_pruned": 0, "pack_install_intents_completed": 0, "pack_install_intents_aborted": 0, "pack_install_metrics": {"installs_ok": 0, "installs_err": 0, "recover_completed": 0, "recover_aborted": 0, "recover_skipped_in_progress": 0, "recover_quarantined": 0}, "pinned_redactions": 0, "preserved_redactions": 0, "pruned_git_mapping_entries": 0, "consolidated_mirror_loose": 0}
 ```
 
 `heddle redact purge apply|list --output json` emit (each carries `output_kind`

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7381,7 +7381,7 @@ report redacted blobs the collector refused to touch; `consolidated_mirror_loose
 counts loose legacy Bridge Mirror objects packed into the mirror's own pack):
 
 ```json
-{"output_kind": "gc", "action": "gc", "status": "ok", "dry_run": false, "prune": false, "packed_count": 1, "bytes_saved": 0, "pruned_loose": 0, "bytes_freed": 0, "unpaired_packs_pruned": 0, "pack_install_intents_completed": 0, "pack_install_intents_aborted": 0, "pack_install_metrics": {"installs_ok": 0, "installs_err": 0, "recover_completed": 0, "recover_aborted": 0, "recover_skipped_in_progress": 0, "recover_quarantined": 0}, "pinned_redactions": 0, "preserved_redactions": 0, "pruned_git_mapping_entries": 0, "consolidated_mirror_loose": 0}
+{"output_kind": "gc", "action": "gc", "status": "ok", "dry_run": false, "prune": false, "packed_count": 1, "bytes_saved": 0, "pruned_loose": 0, "bytes_freed": 0, "timeline_packed_count": 0, "timeline_bytes_saved": 0, "timeline_pruned_loose": 0, "timeline_bytes_freed": 0, "timeline_unpaired_packs_pruned": 0, "unpaired_packs_pruned": 0, "pack_install_intents_completed": 0, "pack_install_intents_aborted": 0, "pack_install_metrics": {"installs_ok": 0, "installs_err": 0, "recover_completed": 0, "recover_aborted": 0, "recover_skipped_in_progress": 0, "recover_quarantined": 0}, "pinned_redactions": 0, "preserved_redactions": 0, "pruned_git_mapping_entries": 0, "consolidated_mirror_loose": 0}
 ```
 
 `heddle redact purge apply|list --output json` emit (each carries `output_kind`


### PR DESCRIPTION
## Summary

- store canonical timeline operations in the existing Heddle pack container under a domain-separated `timeline/packs` directory
- make operation lookup and timeline-view rebuild pack-aware before reclaiming any loose operation
- verify the candidate pack, installed pack, canonical bytes, and content-derived IDs before and after retiring older representations
- pack and reclaim timeline operations during `maintenance gc`, with explicit JSON accounting and idempotent consolidation

## Closes

Closes #1177

## Test evidence

- exact affected-package CI `cargo build --locked ... --tests --bin heddle --bin heddle-fuse-worker` (dev profile): passed
- exact affected-package CI `cargo clippy --locked ... --lib --bins --tests --examples -- -D warnings` (dev profile): passed
- exact affected-package CI `cargo test --locked ...`: passed, including 638 `heddle-repo` unit tests and 871 CLI integration tests (19 ignored by the normal lane)
- exact Git-overlay/native feature-contract checks for `heddle-repo` and `heddle-cli`: passed
- exact ignored fault suites: CLI 6/6 and timeline materialization 2/2 passed
- negative proof: loose-only rebuild reported `indexed=1 resolved=0 branches=0` and silently omitted `tl-h65f85amk80gw3b`; pack-aware rebuild reported `resolved=1 branches=1`, the same ID, and `canonical_bytes_identical=true`
- 1,000-branch unit fixture: every pre-pack ID and canonical byte sequence resolved after pack/prune/reopen; allocated bytes fell from 5,206,016 to 397,312
- real CLI fixture with 1,001 operations: `du -s -B1 .heddle/timeline` fell from 5,640,192 to 864,256 bytes; `du -s -B1 --apparent-size .heddle/timeline` changed from 788,427 to 806,263 bytes; loose operation count fell from 1,001 to 0 and a second GC was a no-op
- `rustfmt +nightly --edition 2024 --config skip_children=true` on touched Rust files only and `git diff --check`: passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1179"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788149121&installation_model_id=21489&pr_number=1179&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1179&signature=d2690df8c03159d92ebbb2a878ac659557ba6f9aaceeea8532663349d82495e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->