### PR TITLE
Fix ~/.heddle config dir shadowing repo discovery

### DIFF
--- a/crates/cli-contract/src/cli/commands/doctor_docs.rs
+++ b/crates/cli-contract/src/cli/commands/doctor_docs.rs
@@ -352,7 +352,7 @@ fn walk_markdown(repo_root: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result
 fn find_repo_root(start: &Path) -> Option<PathBuf> {
     let mut current = start.to_path_buf();
     loop {
-        if current.join(".git").exists() || current.join(".heddle").exists() {
+        if current.join(".git").exists() || repo::is_heddle_repository_root(&current) {
             return Some(current);
         }
         if !current.pop() {

--- a/crates/cli-contract/src/cli/commands/doctor_schemas.rs
+++ b/crates/cli-contract/src/cli/commands/doctor_schemas.rs
@@ -659,13 +659,13 @@ pub fn documented_samples_with_bound_verbs(doc: &str, verbs: &[&str]) -> Vec<(Va
     core_documented_samples_with_bound_verbs(doc, verbs)
 }
 
-/// Walk parents of `start` until we find a directory containing a
-/// `.heddle/` or `.git/` folder. Same heuristic as
+/// Walk parents of `start` until we find a directory containing repository
+/// metadata in `.heddle/` or `.git/`. Same heuristic as
 /// [`super::doctor_docs::find_repo_root`] but kept private to this
 /// module to avoid a doc-only intermodule coupling.
 fn find_repo_root(start: &Path) -> Option<PathBuf> {
     for ancestor in start.ancestors() {
-        if ancestor.join(".heddle").exists() || ancestor.join(".git").exists() {
+        if repo::is_heddle_repository_root(ancestor) || ancestor.join(".git").exists() {
             return Some(ancestor.to_path_buf());
         }
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -860,11 +860,9 @@ async fn async_main() -> Result<()> {
 /// `Repository::open` create a sidecar before adopt preflight completes.
 fn recovery_target_has_existing_metadata(command: &Commands, start: &Path) -> bool {
     if matches!(command, Commands::Adopt(_)) {
-        return start.join(".heddle").is_dir();
+        return repo::is_heddle_repository_root(start);
     }
-    start
-        .ancestors()
-        .any(|ancestor| ancestor.join(".heddle").is_dir())
+    repo::discover_heddle_root(start).is_some()
 }
 
 fn is_harness_relay_invocation(command: &Commands) -> bool {

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -387,6 +387,98 @@ fn test_cli_init_creates_repository() {
 }
 
 #[test]
+fn test_cli_init_under_home_ignores_user_config_directory() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let user_config_dir = home.join(".heddle");
+    std::fs::create_dir_all(user_config_dir.join("session")).unwrap();
+    std::fs::create_dir_all(user_config_dir.join("locks")).unwrap();
+    std::fs::write(user_config_dir.join("credentials.toml"), "").unwrap();
+    std::fs::write(user_config_dir.join("device-identity.toml"), "").unwrap();
+    std::fs::write(user_config_dir.join("config.toml"), "").unwrap();
+
+    let repo = home.join("anywhere/new-repo");
+    std::fs::create_dir_all(&repo).unwrap();
+    let home_env = home.to_str().expect("home path is utf8");
+
+    let init = heddle_output_with_env(&["init"], Some(&repo), &[("HOME", home_env)])
+        .expect("invoke init under HOME");
+    assert!(
+        init.status.success(),
+        "init under HOME with ~/.heddle user config must succeed: {}",
+        std::str::from_utf8(&init.stderr).unwrap()
+    );
+    assert!(repo.join(".heddle/objects").is_dir());
+
+    let status = heddle_output_with_env(
+        &["status", "--output", "json"],
+        Some(&repo),
+        &[("HOME", home_env)],
+    )
+    .expect("invoke status in initialized repo");
+    assert!(
+        status.status.success(),
+        "status under HOME after init must succeed: {}",
+        std::str::from_utf8(&status.stderr).unwrap()
+    );
+
+    std::fs::write(repo.join("tracked.txt"), "captured under HOME\n").unwrap();
+    let capture = heddle_output_with_env(
+        &["capture", "-m", "capture under HOME"],
+        Some(&repo),
+        &[("HOME", home_env)],
+    )
+    .expect("invoke capture in initialized repo");
+    assert!(
+        capture.status.success(),
+        "capture under HOME after init must succeed: {}",
+        std::str::from_utf8(&capture.stderr).unwrap()
+    );
+}
+
+#[test]
+fn test_cli_discovery_does_not_skip_a_genuinely_malformed_repository() {
+    let temp = TempDir::new().unwrap();
+    let outer = temp.path().join("outer");
+    Repository::init_default(&outer).unwrap();
+    let broken = outer.join("broken");
+    Repository::init_default(&broken).unwrap();
+    let broken_config = broken.join(".heddle/config.toml");
+    std::fs::write(&broken_config, "[repository\n").unwrap();
+    let nested = broken.join("src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let output = heddle_output(&["status"], Some(&nested)).expect("invoke status in broken repo");
+    assert!(
+        !output.status.success(),
+        "discovery must not skip the broken inner repository and open the valid outer repository"
+    );
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(
+        stderr.contains(&broken_config.display().to_string()),
+        "error must identify the malformed repository config: {stderr}"
+    );
+}
+
+#[test]
+fn test_discovery_under_home_finds_nearest_real_repository() {
+    let temp = TempDir::new().unwrap();
+    let home = temp.path().join("home");
+    let user_config_dir = home.join(".heddle");
+    std::fs::create_dir_all(user_config_dir.join("session")).unwrap();
+    std::fs::write(user_config_dir.join("credentials.toml"), "").unwrap();
+    std::fs::write(user_config_dir.join("config.toml"), "").unwrap();
+
+    let real_root = home.join("projects/real-repo");
+    Repository::init_default(&real_root).unwrap();
+    let nested = real_root.join("src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let discovered = Repository::open(&nested).expect("discover real repository under HOME");
+    assert_eq!(discovered.root(), real_root);
+}
+
+#[test]
 fn test_cli_init_honors_global_repo_path() {
     let temp = TempDir::new().unwrap();
     let cwd = temp.path().join("cwd");

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -143,8 +143,8 @@ pub use repository::{
     SnapshotExecution, SnapshotProfile, SpoolFacet, ThreadCaptureOutcome, TreeBuildProfile,
     TrustedKey, UntrackedSet, UntrackedSubtree, WarmCanonicalStoreStats, WorktreeCompareProfile,
     WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct, discover_heddle_root,
-    find_merge_base, is_major_rewrite, is_synthetic_root, open_git_repository_at_root,
-    query_history_from_source,
+    find_merge_base, is_heddle_repository_root, is_major_rewrite, is_synthetic_root,
+    open_git_repository_at_root, query_history_from_source,
 };
 #[cfg(feature = "git-overlay")]
 pub use repository::{GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitOverlayShortStatus};

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -132,6 +132,7 @@ mod status_untracked_scan;
 const GIT_CHECKPOINTS_FILE: &str = "git-checkpoints.json";
 const GIT_CHECKPOINT_INTENT_FILE: &str = "git-checkpoint-intent.json";
 const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[".heddle/"];
+const HEDDLE_REPOSITORY_MEMBERS: &[&str] = &["HEAD", "objects", "objectstore", "oplog", "refs"];
 
 fn git_discovery_across_filesystem() -> bool {
     std::env::var("GIT_DISCOVERY_ACROSS_FILESYSTEM")
@@ -186,9 +187,23 @@ fn bounded_ancestor_paths_with_device(
     ancestors
 }
 
-/// Find the nearest Heddle sidecar without allowing Git discovery to claim the
-/// path first. The walk follows Git's filesystem-boundary policy and honors
-/// `GIT_DISCOVERY_ACROSS_FILESYSTEM`.
+/// Return whether `root/.heddle` contains repository-specific metadata.
+///
+/// The user configuration directory is also named `.heddle`, so the directory
+/// name alone is not a repository marker. This is only a discovery probe, not
+/// full validation: once a candidate is found, [`Repository::open`] still
+/// validates it and reports malformed repository metadata loudly.
+pub fn is_heddle_repository_root(root: &Path) -> bool {
+    let heddle_dir = root.join(".heddle");
+    heddle_dir.is_dir()
+        && HEDDLE_REPOSITORY_MEMBERS
+            .iter()
+            .any(|member| fs::symlink_metadata(heddle_dir.join(member)).is_ok())
+}
+
+/// Find the nearest Heddle repository sidecar without allowing Git discovery
+/// to claim the path first. The walk follows Git's filesystem-boundary policy
+/// and honors `GIT_DISCOVERY_ACROSS_FILESYSTEM`.
 pub fn discover_heddle_root(start: &Path) -> Option<PathBuf> {
     let absolute = if start.is_absolute() {
         start.to_path_buf()
@@ -198,7 +213,7 @@ pub fn discover_heddle_root(start: &Path) -> Option<PathBuf> {
     let start = absolute.canonicalize().unwrap_or(absolute);
     bounded_ancestor_paths(&start)
         .into_iter()
-        .find(|path| path.join(".heddle").is_dir())
+        .find(|path| is_heddle_repository_root(path))
 }
 
 /// Open only the Git repository rooted at `root`; never inherit an ancestor.
@@ -1042,7 +1057,7 @@ impl Repository {
             }
             let heddle_path = dir.join(".heddle");
 
-            if heddle_path.is_dir() {
+            if is_heddle_repository_root(dir) {
                 let pointer_path = heddle_path.join("objectstore");
                 let objects_dir = heddle_path.join("objects");
                 if !pointer_path.is_file() && !objects_dir.is_dir() {

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -427,24 +427,28 @@ fn test_open_finds_repo() {
 }
 
 #[test]
-fn test_open_rejects_bogus_ancestor_metadata_and_reports_matched_root() {
+fn test_open_ignores_config_only_ancestor_metadata() {
     let temp_dir = TempDir::new().unwrap();
-    let bogus_root = temp_dir.path().canonicalize().unwrap();
-    fs::create_dir_all(bogus_root.join(".heddle/bootstrap-op-id")).unwrap();
-    let nested = bogus_root.join("projects/demo");
+    let home = temp_dir.path().canonicalize().unwrap();
+    fs::create_dir_all(home.join(".heddle/session")).unwrap();
+    fs::create_dir_all(home.join(".heddle/locks")).unwrap();
+    fs::write(home.join(".heddle/credentials.toml"), "").unwrap();
+    fs::write(home.join(".heddle/device-identity.toml"), "").unwrap();
+    fs::write(home.join(".heddle/config.toml"), "").unwrap();
+    let nested = home.join("projects/demo");
     fs::create_dir_all(&nested).unwrap();
 
     let error = match Repository::open(&nested) {
-        Ok(_) => panic!("bogus .heddle metadata must not be accepted as a repository"),
+        Ok(_) => panic!("a path without repository metadata must not open"),
         Err(error) => error,
     };
 
     match error {
         HeddleError::RepositoryNotFound(path) => assert_eq!(
-            path, bogus_root,
-            "the error must identify the ancestor containing bogus .heddle metadata",
+            path, nested,
+            "the config-only ancestor must not be accepted as a repository marker",
         ),
-        other => panic!("expected repository-not-found for bogus metadata, got {other}"),
+        other => panic!("expected repository-not-found for requested path, got {other}"),
     }
 }
 


### PR DESCRIPTION
## Summary

- Treat an ancestor as a Heddle repository only when its `.heddle` directory contains repository-specific members (`HEAD`, `objects`, `objectstore`, `oplog`, or `refs`) instead of accepting the directory name alone (`crates/repo/src/repository.rs:135`, `crates/repo/src/repository.rs:190`).
- Use that structural probe in repository opening, startup recovery, and the doctor commands, so user config directories are skipped without changing the config or credential layout (`crates/repo/src/repository.rs:1060`, `crates/cli/src/main.rs:861`).
- Keep validation terminal after a real repository candidate is found. A malformed inner repository still reports its own bad config and is not skipped in favor of an outer repository (`crates/cli/tests/cli_integration/basics.rs:440`).
- The `/home/scratch` workaround is no longer needed for this marker collision: the full 893-test CLI integration suite passes with `TMPDIR` beneath a config-only `.heddle` ancestor.

## Closes

Closes #1180

## Test evidence

- Regression before fix: `test_cli_init_under_home_ignores_user_config_directory` failed with `repository not found at .../home`.
- Regression after fix: the same test passes through `init`, `status`, and `capture` (`crates/cli/tests/cli_integration/basics.rs:390`).
- Falsification: temporarily restoring the old name-only startup probe made that exact regression fail again; restoring the structural probe made it pass.
- Negative coverage passes: a malformed nested repository errors on its own `.heddle/config.toml`, and discovery beneath HOME selects the nearest real repository (`crates/cli/tests/cli_integration/basics.rs:440`, `crates/cli/tests/cli_integration/basics.rs:464`).
- `TMPDIR=/home/scratch/heddle-1180-poisoned.WSVIgQ/tmp cargo test -p heddle-cli --test cli_integration --quiet`: 874 passed, 0 failed, 19 ignored.
- `TMPDIR=/home/scratch cargo test -p heddle-repo`: 613 passed, 0 failed, 4 ignored across unit and integration targets.
- `TMPDIR=/home/scratch cargo test -p heddle-cli-contract --quiet`: 124 passed, 0 failed.
- `TMPDIR=/home/scratch cargo build --workspace`: passed.
- `TMPDIR=/home/scratch cargo clippy --workspace --all-targets -- -D warnings`: passed.
- `rustfmt +nightly --check --edition 2024` on touched Rust files and `git diff --check`: passed.
- Full workspace run had one load-sensitive performance threshold miss (`snapshot small repo` 2.286s versus 2s); the exact test passed immediately in isolation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788153529&installation_model_id=21489&pr_number=1182&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1182&signature=b6805e6fc5fe3e5893c5565e2876a5585ade6d37534082c180d40eba6473df9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->