### PR TITLE
fix(auth): honor HEDDLE_CREDENTIAL across auth introspection

### DIFF
--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -23,7 +23,8 @@ use super::{
         effective_pop_public_key_hex,
     },
     hosted::{
-        HostedAuthMode, HostedClient, HostedError, HostedSession, operation_id::ClientOperationId,
+        HostedAuthMode, HostedClient, HostedError, HostedSession, ResolvedHostedCredential,
+        operation_id::ClientOperationId, resolve_hosted_credential,
     },
 };
 
@@ -226,21 +227,24 @@ fn cmd_auth_derive_agent(
         bail!("--ttl must be greater than zero seconds");
     }
     let ttl_secs = i64::try_from(ttl_secs).context("--ttl is too large")?;
-    let parent = credentials::get_server_credential(server)?
+    let parent = resolve_hosted_credential(Some(server))?;
+    let parent_token = parent
+        .token
+        .as_ref()
         .ok_or_else(|| anyhow::anyhow!(HostedRecoveryAdvice::auth_required(server)))?;
-    let private_key_pem = parent.private_key_pem.as_deref().ok_or_else(|| {
+    let private_key_pem = parent.proof_key_pem.as_deref().ok_or_else(|| {
         anyhow::anyhow!(
-            "stored credential for {server} has no device proof key; run `heddle auth login --server {server}` first"
+            "active credential for {server} has no device proof key; run `heddle auth login --server {server}` first"
         )
     })?;
     let signer = Ed25519Signer::from_pem(private_key_pem)
-        .map_err(|error| anyhow::anyhow!("stored device proof key is invalid: {error}"))?;
-    let metadata = headless_token_metadata(&parent.token)?;
+        .map_err(|error| anyhow::anyhow!("active device proof key is invalid: {error}"))?;
+    let metadata = headless_token_metadata(&parent_token.id)?;
     if !metadata
         .proof_public_key_hex
         .eq_ignore_ascii_case(&hex::encode(signer.public_key()))
     {
-        bail!("stored device proof key does not match the parent Biscuit");
+        bail!("active device proof key does not match the parent Biscuit");
     }
 
     let now = chrono::Utc::now();
@@ -263,11 +267,11 @@ fn cmd_auth_derive_agent(
     let agent_id = agent_id.unwrap_or_else(|| format!("agent-{}", uuid::Uuid::new_v4()));
     let allowed_operations = resolve_agent_operations(template, requested_operations)?;
     let declared_scopes = parse_agent_scopes(scopes)?;
-    validate_scope_narrowing(&parent.token, &declared_scopes)?;
+    validate_scope_narrowing(&parent_token.id, &declared_scopes)?;
     let child_signer = Ed25519Signer::generate()
         .map_err(|error| anyhow::anyhow!("failed to generate child proof key: {error}"))?;
     let child_token = attenuate_for_agent(
-        &parent.token,
+        &parent_token.id,
         AgentAttenuation {
             agent_id: agent_id.clone(),
             expires_at,
@@ -313,6 +317,7 @@ fn cmd_auth_derive_agent(
         };
         credential_file::write_credential_file(out, &verified)?;
         println!("Agent credential {agent_id} written to {}.", out.display());
+        println!("Parent source: {}", parent.source.label());
         if let Some(template) = template {
             println!("Template: {} ceiling", template.as_str());
         }
@@ -329,7 +334,7 @@ fn cmd_auth_derive_agent(
         server,
         ServerCredential {
             token: child_token,
-            subject: parent.subject,
+            subject: parent.subject.unwrap_or(metadata.subject),
             device_id: None,
             credential_id: None,
             private_key_pem: Some(child_private_key_pem),
@@ -338,6 +343,7 @@ fn cmd_auth_derive_agent(
     )?;
 
     println!("Derived and installed agent token {agent_id} for {server}.");
+    println!("Parent source: {}", parent.source.label());
     println!("Expires: {expires_at}");
     if let Some(template) = template {
         println!("Template: {} ceiling", template.as_str());
@@ -795,7 +801,7 @@ fn cmd_auth_status(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     // Report through the SAME precedence the runtime authenticates with, so
     // `auth status` reflects what a hosted op would actually use — including a
     // `HEDDLE_CREDENTIAL` that overrides the keystore.
-    let resolved = crate::hosted_runtime::hosted::resolve_hosted_credential(Some(&server))?;
+    let resolved = resolve_hosted_credential(Some(&server))?;
     let output = auth_status_output(&server, &resolved);
     if ctx.should_output_json(None) {
         println!("{}", serde_json::to_string(&output)?);
@@ -831,10 +837,7 @@ fn cmd_auth_status(ctx: &dyn CliContext, server: Option<&str>) -> Result<()> {
     Ok(())
 }
 
-fn auth_status_output(
-    server: &str,
-    resolved: &crate::hosted_runtime::hosted::ResolvedHostedCredential,
-) -> AuthStatusOutput {
+fn auth_status_output(server: &str, resolved: &ResolvedHostedCredential) -> AuthStatusOutput {
     let source = resolved.source.label();
     if resolved.token.is_some() {
         let proof_key_available = resolved
@@ -898,10 +901,14 @@ async fn cmd_create_service_token(
         );
     }
 
-    // Select and validate the exact stored bearer + matching device proof key
+    // Select and validate the exact active bearer + matching device proof key
     // before generating the new service-account key.
     let user_config = UserConfig::load_default()?;
-    let session = HostedSession::build_stored_credential(&user_config, &server)?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.clone()),
+        HostedAuthMode::CredentialFallback,
+    )?;
     let mut auth_client = session.connect(([127, 0, 0, 1], 0).into()).await?;
     let result = create_service_token_connected(
         ctx,

--- a/crates/cli/src/hosted_runtime/hosted/session.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session.rs
@@ -3,9 +3,8 @@
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
-use cli_shared::{ClientConfig, UserConfig, credentials};
-use crypto::{Ed25519Signer, Signer};
-use wire::{AuthToken, ProtocolError};
+use cli_shared::{ClientConfig, UserConfig};
+use wire::ProtocolError;
 
 use super::{
     HostedClient, RenewableAuthorityCredential, credential::server_keys_match,
@@ -23,27 +22,6 @@ pub struct HostedSession {
 }
 
 impl HostedSession {
-    pub fn build_stored_credential(user_config: &UserConfig, server_key: &str) -> Result<Self> {
-        let credential = credentials::get_server_credential(server_key)?.ok_or_else(|| {
-            anyhow::anyhow!(weft_client_shim::HostedRecoveryAdvice::auth_required(
-                server_key
-            ))
-        })?;
-        let proof_key = validated_stored_proof_key(&credential, server_key)?;
-        let authenticated_principal = validated_authenticated_principal(&credential)?;
-        let renewable_authority_credential = RenewableAuthorityCredential::from_stored(&credential);
-        let token = AuthToken::new(credential.token, "credential-store");
-        let config = user_config
-            .hosted_runtime_config(Some(token))?
-            .with_server_key(server_key.to_string())
-            .with_auth_proof_key_pem(proof_key)
-            .with_authenticated_principal(authenticated_principal);
-        Ok(Self {
-            config,
-            renewable_authority_credential,
-        })
-    }
-
     pub fn build(
         user_config: &UserConfig,
         server_key: Option<String>,
@@ -53,7 +31,7 @@ impl HostedSession {
             token,
             mut credential_proof_key,
             renewable_authority_credential,
-            stored_credential_subject,
+            resolved_credential_subject,
         ) = match mode {
             HostedAuthMode::Unauthenticated => (None, None, None, None),
             HostedAuthMode::CredentialFallback => {
@@ -91,12 +69,12 @@ impl HostedSession {
             })?;
             let subject = crate::hosted_runtime::device_flow::authenticated_subject(&token.id)
                 .context("reading the hosted bearer token's authenticated principal")?;
-            if stored_credential_subject
+            if resolved_credential_subject
                 .as_deref()
                 .is_some_and(|stored| stored != subject.as_str())
             {
                 anyhow::bail!(
-                    "stored credential subject does not match the bearer token's authenticated principal"
+                    "resolved credential subject does not match the bearer token's authenticated principal"
                 );
             }
             config = config.with_authenticated_principal(format!("principal:{subject}"));
@@ -175,37 +153,6 @@ impl HostedClient {
             .connect(addr)
             .await?)
     }
-}
-
-fn validated_authenticated_principal(credential: &credentials::ServerCredential) -> Result<String> {
-    let subject = crate::hosted_runtime::device_flow::authenticated_subject(&credential.token)
-        .context("reading the stored credential's authenticated principal")?;
-    if subject != credential.subject {
-        anyhow::bail!(
-            "stored credential subject does not match the bearer token's authenticated principal"
-        );
-    }
-    Ok(format!("principal:{subject}"))
-}
-
-fn validated_stored_proof_key(
-    credential: &credentials::ServerCredential,
-    server_key: &str,
-) -> Result<String> {
-    let pem = credential.private_key_pem.as_deref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "stored credential for {server_key} has no device proof key; run `heddle auth login --server {server_key}` first"
-        )
-    })?;
-    let signer = Ed25519Signer::from_pem(pem)
-        .map_err(|error| anyhow::anyhow!("stored device proof key is invalid: {error}"))?;
-    let token_key =
-        crate::hosted_runtime::device_flow::effective_pop_public_key_hex(&credential.token)
-            .context("reading the stored credential's effective proof key")?;
-    if !token_key.eq_ignore_ascii_case(&hex::encode(signer.public_key())) {
-        anyhow::bail!("stored device proof key does not match the credential Biscuit");
-    }
-    Ok(pem.to_string())
 }
 
 fn shared_device_proof_key(server_key: &str, token: &str) -> Result<Option<String>> {

--- a/crates/cli/src/hosted_runtime/whoami.rs
+++ b/crates/cli/src/hosted_runtime/whoami.rs
@@ -1,7 +1,7 @@
 //! `heddle whoami` — machine-readable acting-identity introspection.
 //!
-//! Where `auth status` reports only the locally-stored credential state,
-//! `whoami` resolves the *acting* identity: it calls `IdentityService.WhoAmI`
+//! Like `auth status`, `whoami` resolves the credential the hosted runtime
+//! would actually use. It then calls `IdentityService.WhoAmI`
 //! on the server for the authoritative principal/staff/service-account markers
 //! and directly-held resource roles, and reads the local Biscuit for the token
 //! kind, resource scopes, operation ceiling, and TTL that the delegation chain
@@ -10,22 +10,26 @@
 //! unreachable.
 
 use anyhow::{Context, Result};
-use cli_shared::{UserConfig, credentials};
+use cli_shared::UserConfig;
 use crypto::Ed25519Signer;
 use serde::Serialize;
 use weft_client_shim::CliContext;
 
 use super::{
     auth::{headless_token_metadata, resolve_server},
-    hosted::HostedSession,
+    hosted::{HostedAuthMode, HostedSession, ResolvedHostedCredential, resolve_hosted_credential},
 };
 
 #[derive(Debug, Serialize)]
 struct WhoamiOutput {
     output_kind: &'static str,
     server: String,
-    /// A usable credential is stored locally for this server.
+    /// A usable credential resolves for this server.
     authenticated: bool,
+    /// Credential origin: `env:<path>`, `keystore`, or `none`.
+    source: String,
+    /// Locally verified subject, present even when the server is unreachable.
+    subject: Option<String>,
     /// The server answered `WhoAmI` — the acting identity below is authoritative.
     reachable: bool,
     /// `root` (full-authority device/human token), `agent` (an offline-derived,
@@ -90,11 +94,44 @@ pub async fn cmd_whoami(ctx: &dyn CliContext, server: Option<String>) -> Result<
 }
 
 async fn resolve_whoami(server: &str) -> Result<WhoamiOutput> {
-    let Some(credential) = credentials::get_server_credential(server)? else {
+    let resolved = resolve_hosted_credential(Some(server))?;
+    let mut output = resolve_local_whoami(server, &resolved)?;
+    if !output.authenticated {
+        return Ok(output);
+    }
+
+    // Server round trip for the authoritative identity. Failure (unreachable,
+    // rejected, or missing proof key) degrades to a local-only answer rather
+    // than erroring — `reachable` records which case this is.
+    output.identity = fetch_identity(server).await.ok();
+    output.reachable = output.identity.is_some();
+    if output
+        .identity
+        .as_ref()
+        .is_some_and(|identity| identity.is_service_account)
+    {
+        output.token_kind = Some("service-account".to_string());
+    }
+    output.recommended_action = if !output.proof_key_available {
+        Some(format!("heddle auth login --server {server}"))
+    } else if !output.reachable {
+        Some(format!(
+            "server did not answer WhoAmI; check connectivity to {server} or re-run `heddle auth login --server {server}`"
+        ))
+    } else {
+        None
+    };
+    Ok(output)
+}
+
+fn resolve_local_whoami(server: &str, resolved: &ResolvedHostedCredential) -> Result<WhoamiOutput> {
+    let Some(token) = resolved.token.as_ref() else {
         return Ok(WhoamiOutput {
             output_kind: "whoami",
             server: server.to_string(),
             authenticated: false,
+            source: resolved.source.label(),
+            subject: None,
             reachable: false,
             token_kind: None,
             scopes: Vec::new(),
@@ -107,21 +144,21 @@ async fn resolve_whoami(server: &str) -> Result<WhoamiOutput> {
         });
     };
 
-    let proof_key_available = credential
-        .private_key_pem
+    let proof_key_available = resolved
+        .proof_key_pem
         .as_deref()
         .is_some_and(|pem| Ed25519Signer::from_pem(pem).is_ok());
 
     // Local Biscuit introspection — works with no server round trip.
-    let metadata = headless_token_metadata(&credential.token)
-        .context("reading the stored credential's Biscuit")?;
-    let scopes = token_resource_scopes(&credential.token)
+    let metadata =
+        headless_token_metadata(&token.id).context("reading the active credential's Biscuit")?;
+    let scopes = token_resource_scopes(&token.id)
         .context("reading the token's resource scopes")?
         .into_iter()
         .map(|(kind, path)| format!("{kind}:{path}"))
         .collect::<Vec<_>>();
-    let operation_ceiling = token_operation_ceiling(&credential.token)
-        .context("reading the token's operation ceiling")?;
+    let operation_ceiling =
+        token_operation_ceiling(&token.id).context("reading the token's operation ceiling")?;
     let expires_at = metadata.expires_at.clone();
     let ttl_seconds_remaining = expires_at.as_deref().and_then(|value| {
         chrono::DateTime::parse_from_rfc3339(value)
@@ -129,53 +166,42 @@ async fn resolve_whoami(server: &str) -> Result<WhoamiOutput> {
             .map(|expiry| (expiry.with_timezone(&chrono::Utc) - chrono::Utc::now()).num_seconds())
     });
 
-    // Server round trip for the authoritative identity. Failure (unreachable,
-    // rejected, or missing proof key) degrades to a local-only answer rather
-    // than erroring — `reachable` records which case this is.
-    let identity = fetch_identity(server).await.ok();
-    let reachable = identity.is_some();
-
-    let token_kind = Some(
-        if identity.as_ref().is_some_and(|id| id.is_service_account) {
-            "service-account"
-        } else if metadata.is_derived {
-            "agent"
-        } else {
-            "root"
-        }
-        .to_string(),
-    );
+    let token_kind = Some(if metadata.is_derived { "agent" } else { "root" }.to_string());
 
     let recommended_action = if !proof_key_available {
         Some(format!("heddle auth login --server {server}"))
-    } else if !reachable {
+    } else {
         Some(format!(
             "server did not answer WhoAmI; check connectivity to {server} or re-run `heddle auth login --server {server}`"
         ))
-    } else {
-        None
     };
 
     Ok(WhoamiOutput {
         output_kind: "whoami",
         server: server.to_string(),
         authenticated: true,
-        reachable,
+        source: resolved.source.label(),
+        subject: resolved.subject.clone(),
+        reachable: false,
         token_kind,
         scopes,
         operation_ceiling,
         expires_at,
         ttl_seconds_remaining,
         proof_key_available,
-        identity,
+        identity: None,
         recommended_action,
     })
 }
 
 async fn fetch_identity(server: &str) -> Result<WhoamiIdentity> {
     let user_config = UserConfig::load_default()?;
-    let session = HostedSession::build_stored_credential(&user_config, server)
-        .map_err(|error| anyhow::anyhow!(error))?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.to_string()),
+        HostedAuthMode::CredentialFallback,
+    )
+    .map_err(|error| anyhow::anyhow!(error))?;
     let mut client = session
         .connect(([127, 0, 0, 1], 0).into())
         .await
@@ -322,8 +348,11 @@ fn print_human(output: &WhoamiOutput) {
         }
         return;
     }
+    println!("Source:        {}", output.source);
+    if let Some(subject) = &output.subject {
+        println!("Subject:       {subject}");
+    }
     if let Some(identity) = &output.identity {
-        println!("Subject:       {}", identity.subject);
         if identity.actor_subject != identity.subject && !identity.actor_subject.is_empty() {
             println!("Acting as:     {}", identity.actor_subject);
         }

--- a/crates/cli/tests/auth_credential_env.rs
+++ b/crates/cli/tests/auth_credential_env.rs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "client")]
+
+use std::{path::Path, process::Command};
+
+use biscuit_auth::KeyPair;
+use crypto::{Ed25519Signer, Signer};
+use serde_json::Value;
+use tempfile::TempDir;
+
+const SERVER: &str = "127.0.0.1:9";
+
+fn write_env_credential(path: &Path) {
+    let signer = Ed25519Signer::generate().expect("proof key");
+    let expires_at = chrono::Utc::now() + chrono::Duration::hours(2);
+    let token = biscuit_auth::Biscuit::builder()
+        .fact(r#"user("env-agent")"#)
+        .expect("user fact")
+        .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+        .expect("proof-key fact")
+        .fact(format!("expires_at({})", expires_at.to_rfc3339()).as_str())
+        .expect("expiry fact")
+        .check(format!("check if time($now), $now < {}", expires_at.to_rfc3339()).as_str())
+        .expect("expiry check")
+        .build(&KeyPair::new())
+        .expect("build credential token")
+        .to_base64()
+        .expect("encode credential token");
+    let credential = serde_json::json!({
+        "format": "heddle-credential",
+        "version": 1,
+        "server": SERVER,
+        "kind": "device",
+        "subject": "env-agent",
+        "token": token,
+        "proof_key_pem": signer.to_pem().expect("proof PEM"),
+        "expires_at": expires_at.to_rfc3339(),
+        "credential_id": null,
+    });
+    std::fs::write(
+        path,
+        serde_json::to_vec(&credential).expect("serialize credential"),
+    )
+    .expect("write credential fixture");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+            .expect("restrict credential fixture");
+    }
+}
+
+fn run_json(home: &Path, credential: Option<&Path>, args: &[&str]) -> Value {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    command
+        .arg("--output")
+        .arg("json")
+        .args(args)
+        .current_dir(home)
+        .env("HOME", home)
+        .env("HEDDLE_HOME", home)
+        .env_remove("HEDDLE_CONFIG");
+    match credential {
+        Some(path) => {
+            command.env("HEDDLE_CREDENTIAL", path);
+        }
+        None => {
+            command.env_remove("HEDDLE_CREDENTIAL");
+        }
+    }
+    let output = command.output().expect("run heddle");
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "command did not emit JSON: {error}; stdout={}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+fn run_derive(home: &Path, credential: Option<&Path>, out: &Path) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    command
+        .args([
+            "auth",
+            "derive-agent",
+            "--server",
+            SERVER,
+            "--agent-id",
+            "child-agent",
+            "--out",
+        ])
+        .arg(out)
+        .current_dir(home)
+        .env("HOME", home)
+        .env("HEDDLE_HOME", home)
+        .env_remove("HEDDLE_CONFIG");
+    match credential {
+        Some(path) => {
+            command.env("HEDDLE_CREDENTIAL", path);
+        }
+        None => {
+            command.env_remove("HEDDLE_CREDENTIAL");
+        }
+    }
+    command.output().expect("run derive-agent")
+}
+
+#[test]
+fn auth_family_agrees_for_env_only_and_absent_credentials() {
+    let home = TempDir::new().expect("isolated Heddle home");
+    let credential_path = home.path().join("headless.hcred");
+    write_env_credential(&credential_path);
+    assert!(
+        !home.path().join("credentials.toml").exists(),
+        "the positive case must start with no keystore entry",
+    );
+
+    let status_with_env = run_json(
+        home.path(),
+        Some(&credential_path),
+        &["auth", "status", "--server", SERVER],
+    );
+    let whoami_with_env = run_json(
+        home.path(),
+        Some(&credential_path),
+        &["whoami", "--server", SERVER],
+    );
+    assert_eq!(status_with_env["authenticated"], true);
+    assert_eq!(whoami_with_env["authenticated"], true);
+    assert_eq!(
+        status_with_env["authenticated"],
+        whoami_with_env["authenticated"]
+    );
+    assert_eq!(status_with_env["subject"], "env-agent");
+    assert_eq!(whoami_with_env["subject"], "env-agent");
+    let expected_source = format!("env:{}", credential_path.display());
+    assert_eq!(status_with_env["source"], expected_source);
+    assert_eq!(whoami_with_env["source"], expected_source);
+
+    let derived_path = home.path().join("derived.hcred");
+    let derive_with_env = run_derive(home.path(), Some(&credential_path), &derived_path);
+    assert!(
+        derive_with_env.status.success(),
+        "derive-agent rejected the env credential: stdout={} stderr={}",
+        String::from_utf8_lossy(&derive_with_env.stdout),
+        String::from_utf8_lossy(&derive_with_env.stderr),
+    );
+    assert!(
+        derived_path.is_file(),
+        "derive-agent should write its child credential"
+    );
+    assert!(
+        String::from_utf8_lossy(&derive_with_env.stdout).contains(&expected_source),
+        "derive-agent should identify the parent credential source",
+    );
+    assert!(
+        !home.path().join("credentials.toml").exists(),
+        "deriving to --out must not populate the empty keystore",
+    );
+
+    let status_without_env = run_json(home.path(), None, &["auth", "status", "--server", SERVER]);
+    let whoami_without_env = run_json(home.path(), None, &["whoami", "--server", SERVER]);
+    assert_eq!(status_without_env["authenticated"], false);
+    assert_eq!(whoami_without_env["authenticated"], false);
+    assert_eq!(
+        status_without_env["authenticated"],
+        whoami_without_env["authenticated"]
+    );
+    assert_eq!(status_without_env["source"], "none");
+    assert_eq!(whoami_without_env["source"], "none");
+
+    let absent_child = home.path().join("absent-child.hcred");
+    let derive_without_env = run_derive(home.path(), None, &absent_child);
+    assert!(!derive_without_env.status.success());
+    assert!(
+        String::from_utf8_lossy(&derive_without_env.stderr).contains("Not authenticated"),
+        "derive-agent should report the absent credential without exposing credential material",
+    );
+    assert!(!absent_child.exists());
+}


### PR DESCRIPTION
## Summary

- Route `whoami`, `auth derive-agent`, and `auth create-service-token` through the existing hosted credential resolver/session path (`HEDDLE_CREDENTIAL` → keystore → unauthenticated); `auth status` was already using it.
- Report the resolved source and locally verified subject from `whoami`, including when the server is unreachable, and report the parent source from `auth derive-agent`.
- Remove the obsolete stored-only hosted session constructor and add real-binary env-only, env-unset, and `auth status`/`whoami` agreement coverage.
- File scope: `crates/cli/src/hosted_runtime/{auth.rs,whoami.rs,hosted/session.rs}` and `crates/cli/tests/auth_credential_env.rs`.

## Closes

Closes #1187

## Test evidence

- `TMPDIR=/home/scratch rustfmt +nightly --edition 2024` on the four touched Rust files
- `TMPDIR=/home/scratch cargo test -p heddle-cli --test auth_credential_env` (1 passed)
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib hosted_runtime::auth::tests` (22 passed)
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib hosted_runtime::hosted::credential::tests` (5 passed)
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib` (585 passed)
- `TMPDIR=/home/scratch cargo clippy -p heddle-cli --all-targets -- -D warnings`
- Env-only/no-keystore regression: `auth status` and `whoami` both return `authenticated: true`, source `env:<fixture path>`, subject `env-agent`; `auth derive-agent --out` succeeds and names the env parent source.
- Env-unset/no-keystore negative regression: `auth status` and `whoami` both return `authenticated: false`, source `none`; `auth derive-agent --out` fails with `Not authenticated` and writes no child credential.
- No test prints or logs token or proof-key material.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1189"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788158456&installation_model_id=21489&pr_number=1189&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1189&signature=1c4fefdd27f8ffb190310fde7c736078963ba338c9303e42a5c13b7d9837b440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->