### PR TITLE
fix(cli): detect Codex capture model attribution

### DIFF
--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -44,7 +44,9 @@ use wire::{
 mod claude_hook;
 mod probe;
 
-use self::probe::{HarnessProbeInput, HarnessProbeResult, probe_harness_actor};
+use self::probe::{
+    HarnessProbeInput, HarnessProbeResult, codex_session_probe_metadata, probe_harness_actor,
+};
 use crate::{
     cli::{
         Cli,
@@ -69,15 +71,17 @@ pub(crate) fn probe_current_process_harness(
     current_model: Option<String>,
     current_policy: Option<String>,
 ) -> Result<HarnessProbeResult> {
+    let env_hints = harness_env_hints();
+    let probe_metadata = codex_session_probe_metadata(&env_hints);
     probe_harness_actor(&HarnessProbeInput {
         argv: detected_harness_argv().or_else(|| Some(std::env::args().collect())),
-        env_hints: harness_env_hints(),
+        env_hints,
         explicit_harness: None,
         explicit_provider: None,
         explicit_model: None,
         explicit_thinking_level: None,
         explicit_policy: None,
-        probe_metadata: BTreeMap::new(),
+        probe_metadata,
         current_provider,
         current_model,
         current_policy,

--- a/crates/cli/src/harness/probe/codex.rs
+++ b/crates/cli/src/harness/probe/codex.rs
@@ -1,6 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+};
+
 use anyhow::Result;
 use heddle_core::HarnessKind;
+use serde_json::Value;
 
 use super::{
     HarnessActorProbe, HarnessAttachHints, HarnessProbeInput, HarnessProbeResult, ProbeSource,
@@ -8,6 +16,102 @@ use super::{
 };
 
 pub(crate) struct CodexProbe;
+
+/// Resolve the effective model from the durable rollout for the Codex thread
+/// that launched this command. Missing or mismatched session evidence stays
+/// empty so attribution never turns a provider-only detection into a guess.
+pub(crate) fn codex_session_probe_metadata(
+    env_hints: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let Some(thread_id) = env_hints.get("CODEX_THREAD_ID") else {
+        return BTreeMap::new();
+    };
+    let Some(codex_home) = codex_home(env_hints) else {
+        return BTreeMap::new();
+    };
+    let Some(path) = codex_rollout_path(&codex_home, thread_id) else {
+        return BTreeMap::new();
+    };
+    read_codex_session_metadata(&path, thread_id).unwrap_or_default()
+}
+
+fn codex_home(env_hints: &BTreeMap<String, String>) -> Option<PathBuf> {
+    env_hints
+        .get("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("CODEX_HOME").map(PathBuf::from))
+        .or_else(|| std::env::var_os("HOME").map(|home| Path::new(&home).join(".codex")))
+        .or_else(|| std::env::var_os("USERPROFILE").map(|home| Path::new(&home).join(".codex")))
+}
+
+fn codex_rollout_path(codex_home: &Path, thread_id: &str) -> Option<PathBuf> {
+    ingest::transcript::locator::codex_sessions(codex_home, None)
+        .ok()?
+        .into_iter()
+        .rev()
+        .find(|path| {
+            path.file_stem()
+                .and_then(|stem| stem.to_str())
+                .is_some_and(|stem| stem.ends_with(thread_id))
+        })
+}
+
+fn read_codex_session_metadata(
+    path: &Path,
+    thread_id: &str,
+) -> std::io::Result<BTreeMap<String, String>> {
+    let reader = BufReader::new(File::open(path)?);
+    let mut matched_session = false;
+    let mut metadata = BTreeMap::new();
+
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            continue;
+        };
+        let Ok(event) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let payload = event.get("payload").and_then(Value::as_object);
+        match event.get("type").and_then(Value::as_str) {
+            Some("session_meta") => {
+                matched_session = payload
+                    .and_then(|payload| payload.get("id"))
+                    .and_then(Value::as_str)
+                    == Some(thread_id);
+                if let Some(provider) = payload
+                    .and_then(|payload| payload.get("model_provider"))
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    metadata.insert("model_provider".to_string(), provider.to_string());
+                }
+            }
+            Some("turn_context") => {
+                if let Some(model) = payload
+                    .and_then(|payload| payload.get("model"))
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    metadata.insert("model".to_string(), model.to_string());
+                }
+                if let Some(effort) = payload
+                    .and_then(|payload| payload.get("effort"))
+                    .and_then(Value::as_str)
+                    .filter(|value| !value.trim().is_empty())
+                {
+                    metadata.insert("model_reasoning_effort".to_string(), effort.to_string());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if matched_session {
+        Ok(metadata)
+    } else {
+        Ok(BTreeMap::new())
+    }
+}
 
 impl HarnessActorProbe for CodexProbe {
     fn harness_name(&self) -> &'static str {
@@ -105,5 +209,54 @@ impl HarnessActorProbe for CodexProbe {
             probe_source: Some(probe_source.as_str().to_string()),
             ..HarnessProbeResult::default()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_thread_resolves_latest_model_from_its_rollout() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let thread_id = "019fbc09-7051-79e1-b13c-3a55b72fa811";
+        let session_dir = temp.path().join("sessions/2026/08/01");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join(format!("rollout-2026-08-01T08-36-03-{thread_id}.jsonl")),
+            format!(
+                concat!(
+                    "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"model_provider\":\"openai\"}}}}\n",
+                    "{{\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-terra\",\"effort\":\"medium\"}}}}\n",
+                    "{{\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\",\"effort\":\"high\"}}}}\n"
+                ),
+                thread_id
+            ),
+        )
+        .unwrap();
+
+        let env_hints = BTreeMap::from([
+            ("CODEX_THREAD_ID".to_string(), thread_id.to_string()),
+            ("CODEX_HOME".to_string(), temp.path().display().to_string()),
+        ]);
+
+        let metadata = codex_session_probe_metadata(&env_hints);
+        assert_eq!(
+            metadata.get("model_provider").map(String::as_str),
+            Some("openai")
+        );
+        assert_eq!(
+            metadata.get("model").map(String::as_str),
+            Some("gpt-5.6-sol")
+        );
+        assert_eq!(
+            metadata.get("model_reasoning_effort").map(String::as_str),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn codex_session_metadata_requires_a_thread_marker() {
+        assert!(codex_session_probe_metadata(&BTreeMap::new()).is_empty());
     }
 }

--- a/crates/cli/src/harness/probe/mod.rs
+++ b/crates/cli/src/harness/probe/mod.rs
@@ -12,7 +12,7 @@ mod codex;
 mod opencode;
 
 pub(crate) use claude_code::ClaudeCodeProbe;
-pub(crate) use codex::CodexProbe;
+pub(crate) use codex::{CodexProbe, codex_session_probe_metadata};
 pub(crate) use opencode::OpenCodeProbe;
 
 #[derive(Debug, Clone, Default)]

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -2008,6 +2008,86 @@ fn capture_json_reports_recorded_confidence_principal_and_agent() {
 }
 
 #[test]
+fn capture_auto_detects_codex_model_without_fabricating_plain_shell_agent() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let agent_env = [
+        "CODEX_THREAD_ID",
+        "CODEX_CI",
+        "CODEX_SANDBOX",
+        "CODEX_HOME",
+        "HEDDLE_AGENT_PROVIDER",
+        "HEDDLE_AGENT_MODEL",
+        "CLAUDECODE",
+        "CLAUDE_MODEL",
+        "ANTHROPIC_MODEL",
+    ];
+    let capture = |message: &str, envs: &[(&str, &str)]| {
+        let output = heddle_output_with_env_removed(
+            &["capture", "-m", message, "--output", "json"],
+            Some(temp.path()),
+            envs,
+            &agent_env,
+        )
+        .unwrap();
+        assert!(
+            output.status.success(),
+            "capture failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    };
+    let latest_agent = || {
+        let output = heddle_output_with_env_removed(
+            &["log", "--output", "json"],
+            Some(temp.path()),
+            &[],
+            &agent_env,
+        )
+        .unwrap();
+        assert!(output.status.success());
+        let log: Value = serde_json::from_slice(&output.stdout).unwrap();
+        log["states"][0]["agent"].clone()
+    };
+
+    let codex_home = temp.path().join("codex-home");
+    let session_dir = codex_home.join("sessions/2026/08/01");
+    let thread_id = "019fbc09-7051-79e1-b13c-3a55b72fa811";
+    std::fs::create_dir_all(&session_dir).unwrap();
+    std::fs::write(
+        session_dir.join(format!("rollout-2026-08-01T08-36-03-{thread_id}.jsonl")),
+        format!(
+            concat!(
+                "{{\"type\":\"session_meta\",\"payload\":{{\"id\":\"{}\",\"model_provider\":\"openai\"}}}}\n",
+                "{{\"type\":\"turn_context\",\"payload\":{{\"model\":\"gpt-5.6-sol\",\"effort\":\"high\"}}}}\n"
+            ),
+            thread_id
+        ),
+    )
+    .unwrap();
+
+    std::fs::write(temp.path().join("codex.txt"), "codex work\n").unwrap();
+    capture(
+        "codex save",
+        &[
+            ("CODEX_THREAD_ID", thread_id),
+            ("CODEX_HOME", codex_home.to_str().unwrap()),
+        ],
+    );
+    assert_eq!(latest_agent(), "openai/gpt-5.6-sol");
+
+    std::fs::write(temp.path().join("plain.txt"), "plain shell work\n").unwrap();
+    capture("plain shell save", &[]);
+    assert_eq!(latest_agent(), Value::Null);
+
+    std::fs::write(temp.path().join("claude.txt"), "claude work\n").unwrap();
+    capture(
+        "claude save",
+        &[("CLAUDECODE", "1"), ("CLAUDE_MODEL", "claude-fable-5")],
+    );
+    assert_eq!(latest_agent(), "anthropic/claude-fable-5");
+}
+
+#[test]
 fn git_overlay_commit_without_capture_uses_typed_recovery() {
     let temp = TempDir::new().unwrap();
     init_git_repo_for_json_contract(temp.path(), "main");


### PR DESCRIPTION
## Summary

- Enrich the current-process harness probe with Codex's durable session metadata before attribution resolution (`crates/cli/src/harness/mod.rs:68`).
- Use `CODEX_THREAD_ID` to select the matching rollout, require its `session_meta.id` to agree, and read the latest effective `turn_context.model` rather than guessing from a default (`crates/cli/src/harness/probe/codex.rs:20`, `crates/cli/src/harness/probe/codex.rs:47`, `crates/cli/src/harness/probe/codex.rs:59`).
- Preserve null attribution when there is no thread/session model evidence, and cover Codex, no-marker, and existing Claude detection through real capture/log assertions (`crates/cli/tests/cli_integration/oss_cli_polish.rs:2010`).

## Closes

Closes #1184

## Test evidence

- `TMPDIR=/home/scratch rustfmt +nightly --edition 2024` on the four touched Rust files.
- `TMPDIR=/home/scratch cargo build -p heddle-cli --bin heddle` — passed.
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib` — 587 passed.
- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration` — 875 passed, 19 ignored, 0 failed.
- Final focused rerun: `cargo test -p heddle-cli --test cli_integration oss_cli_polish::capture_auto_detects_codex_model_without_fabricating_plain_shell_agent -- --exact` — passed.
- Live bwrap Codex fixture under `/home/scratch/heddle-1184-codex-5QYYco`: `heddle log --output json` recorded `openai/gpt-5.6-sol`; an `env -i` capture recorded `agent: null`; the Claude control recorded `anthropic/claude-fable-5`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788159104&installation_model_id=21489&pr_number=1190&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1190&signature=69c0764dee970696820058dddc774ac1f7dfbd2c7241a072e4fb9b84a3b561e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->