### PR TITLE
Fix opaque land blocker and no-op sync recovery loop

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -7606,6 +7606,12 @@
               },
               "type": "array"
             },
+            "capture_reason": {
+              "type": "string"
+            },
+            "capture_status": {
+              "type": "string"
+            },
             "captured": {
               "type": "boolean"
             },
@@ -7665,6 +7671,8 @@
           "required": [
             "status",
             "captured",
+            "capture_status",
+            "capture_reason",
             "checks",
             "integration",
             "freshness",
@@ -7879,6 +7887,12 @@
           },
           "type": "array"
         },
+        "capture_reason": {
+          "type": "string"
+        },
+        "capture_status": {
+          "type": "string"
+        },
         "captured": {
           "type": "boolean"
         },
@@ -8007,6 +8021,8 @@
         "blockers",
         "warnings",
         "captured",
+        "capture_status",
+        "capture_reason",
         "readiness",
         "report",
         "verification",
@@ -18306,6 +18322,113 @@
           ],
           "type": "object"
         },
+        "LandBlockerCheckSchema": {
+          "enum": [
+            "thread_state",
+            "merge_preview",
+            "auto_land_confidence",
+            "verification_summary",
+            "freshness",
+            "integration_preview"
+          ],
+          "type": "string"
+        },
+        "LandBlockerCodeSchema": {
+          "enum": [
+            "thread_state_blocked",
+            "merge_conflicts",
+            "auto_land_confidence_below_threshold",
+            "verification_tests_failed",
+            "thread_stale",
+            "integration_preview_blocked"
+          ],
+          "type": "string"
+        },
+        "LandBlockerDetailSchema": {
+          "properties": {
+            "check": {
+              "$ref": "#/$defs/LandBlockerCheckSchema",
+              "description": "Eligibility check that produced the blocker."
+            },
+            "code": {
+              "$ref": "#/$defs/LandBlockerCodeSchema",
+              "description": "Stable condition code for machine branching."
+            },
+            "message": {
+              "description": "Human explanation of the observed condition.",
+              "type": "string"
+            },
+            "paths": {
+              "description": "Concrete affected paths; empty for non-path conditions.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "state_context": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LandBlockerStateContextSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "code",
+            "check",
+            "message",
+            "paths"
+          ],
+          "type": "object"
+        },
+        "LandBlockerStateContextSchema": {
+          "properties": {
+            "conflict_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "integration_policy_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "integration_policy_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "merge_relation": {
+              "type": "string"
+            },
+            "recorded_state_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recorded_thread_state": {
+              "type": "string"
+            },
+            "thread_tip_state_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "recorded_thread_state",
+            "merge_relation",
+            "conflict_count"
+          ],
+          "type": "object"
+        },
         "SiblingRestackFailureSchema": {
           "properties": {
             "message": {
@@ -18326,6 +18449,12 @@
       "properties": {
         "action": {
           "type": "string"
+        },
+        "blocker_details": {
+          "items": {
+            "$ref": "#/$defs/LandBlockerDetailSchema"
+          },
+          "type": "array"
         },
         "blockers": {
           "items": {
@@ -18503,6 +18632,7 @@
         "integrated",
         "performed_steps",
         "skipped_steps",
+        "blocker_details",
         "chosen_path",
         "siblings_restacked",
         "siblings_restack_failed",
@@ -18545,6 +18675,12 @@
         },
         "LandBatchPeerSchema": {
           "properties": {
+            "blocker_details": {
+              "items": {
+                "$ref": "#/$defs/LandBlockerDetailSchema"
+              },
+              "type": "array"
+            },
             "blockers": {
               "items": {
                 "type": "string"
@@ -18620,8 +18756,116 @@
             "siblings_restacked",
             "siblings_restack_failed",
             "blockers",
+            "blocker_details",
             "warnings",
             "recovery_commands"
+          ],
+          "type": "object"
+        },
+        "LandBlockerCheckSchema": {
+          "enum": [
+            "thread_state",
+            "merge_preview",
+            "auto_land_confidence",
+            "verification_summary",
+            "freshness",
+            "integration_preview"
+          ],
+          "type": "string"
+        },
+        "LandBlockerCodeSchema": {
+          "enum": [
+            "thread_state_blocked",
+            "merge_conflicts",
+            "auto_land_confidence_below_threshold",
+            "verification_tests_failed",
+            "thread_stale",
+            "integration_preview_blocked"
+          ],
+          "type": "string"
+        },
+        "LandBlockerDetailSchema": {
+          "properties": {
+            "check": {
+              "$ref": "#/$defs/LandBlockerCheckSchema",
+              "description": "Eligibility check that produced the blocker."
+            },
+            "code": {
+              "$ref": "#/$defs/LandBlockerCodeSchema",
+              "description": "Stable condition code for machine branching."
+            },
+            "message": {
+              "description": "Human explanation of the observed condition.",
+              "type": "string"
+            },
+            "paths": {
+              "description": "Concrete affected paths; empty for non-path conditions.",
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "state_context": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/LandBlockerStateContextSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          },
+          "required": [
+            "code",
+            "check",
+            "message",
+            "paths"
+          ],
+          "type": "object"
+        },
+        "LandBlockerStateContextSchema": {
+          "properties": {
+            "conflict_count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "integration_policy_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "integration_policy_status": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "merge_relation": {
+              "type": "string"
+            },
+            "recorded_state_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recorded_thread_state": {
+              "type": "string"
+            },
+            "thread_tip_state_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "recorded_thread_state",
+            "merge_relation",
+            "conflict_count"
           ],
           "type": "object"
         },
@@ -23022,6 +23266,12 @@
               },
               "type": "array"
             },
+            "capture_reason": {
+              "type": "string"
+            },
+            "capture_status": {
+              "type": "string"
+            },
             "captured": {
               "type": "boolean"
             },
@@ -23081,6 +23331,8 @@
           "required": [
             "status",
             "captured",
+            "capture_status",
+            "capture_reason",
             "checks",
             "integration",
             "freshness",
@@ -23295,6 +23547,12 @@
           },
           "type": "array"
         },
+        "capture_reason": {
+          "type": "string"
+        },
+        "capture_status": {
+          "type": "string"
+        },
         "captured": {
           "type": "boolean"
         },
@@ -23423,6 +23681,8 @@
         "blockers",
         "warnings",
         "captured",
+        "capture_status",
+        "capture_reason",
         "readiness",
         "report",
         "verification",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -281,6 +281,8 @@ export interface AgentProvenanceShowSchema {
 export interface AgentReadySchema {
   action: string;
   blockers: string[];
+  capture_reason: string;
+  capture_status: string;
   captured: boolean;
   captured_state?: string | null;
   idempotency_status?: string | null;
@@ -1240,6 +1242,7 @@ export interface IntegrationUpgradeSchema {
 }
 
 export interface LandBatchPeerSchema {
+  blocker_details: LandBlockerDetailSchema[];
   blockers: string[];
   captured: boolean;
   checkpointed: boolean;
@@ -1274,8 +1277,35 @@ export interface LandBatchSchema {
   verification: RepositoryVerificationStateSchema | null;
 }
 
+export type LandBlockerCheckSchema = "thread_state" | "merge_preview" | "auto_land_confidence" | "verification_summary" | "freshness" | "integration_preview";
+
+export type LandBlockerCodeSchema = "thread_state_blocked" | "merge_conflicts" | "auto_land_confidence_below_threshold" | "verification_tests_failed" | "thread_stale" | "integration_preview_blocked";
+
+export interface LandBlockerDetailSchema {
+  /** Eligibility check that produced the blocker. */
+  check: LandBlockerCheckSchema;
+  /** Stable condition code for machine branching. */
+  code: LandBlockerCodeSchema;
+  /** Human explanation of the observed condition. */
+  message: string;
+  /** Concrete affected paths; empty for non-path conditions. */
+  paths: string[];
+  state_context?: LandBlockerStateContextSchema | null;
+}
+
+export interface LandBlockerStateContextSchema {
+  conflict_count: number;
+  integration_policy_reason?: string | null;
+  integration_policy_status?: string | null;
+  merge_relation: string;
+  recorded_state_id?: string | null;
+  recorded_thread_state: string;
+  thread_tip_state_id?: string | null;
+}
+
 export interface LandSchema {
   action: string;
+  blocker_details: LandBlockerDetailSchema[];
   blockers?: string[] | null;
   captured: boolean;
   checkpointed: boolean;
@@ -1645,6 +1675,8 @@ export interface ReadyChecksSchema {
 
 export interface ReadyReadinessSchema {
   blockers: string[];
+  capture_reason: string;
+  capture_status: string;
   captured: boolean;
   captured_state?: string | null;
   changed_path_count: number;
@@ -1663,6 +1695,8 @@ export interface ReadyReadinessSchema {
 export interface ReadySchema {
   action: string;
   blockers: string[];
+  capture_reason: string;
+  capture_status: string;
   captured: boolean;
   captured_state?: string | null;
   idempotency_status?: string | null;

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -1323,6 +1323,8 @@ pub struct ReadySchema {
     pub recommended_action_template: Option<ActionTemplateSchema>,
     pub captured: bool,
     pub captured_state: Option<String>,
+    pub capture_status: String,
+    pub capture_reason: String,
     pub thread_state: Option<String>,
     pub readiness: ReadyReadinessSchema,
     pub report: Value,
@@ -1335,6 +1337,8 @@ pub struct ReadyReadinessSchema {
     pub status: String,
     pub captured: bool,
     pub captured_state: Option<String>,
+    pub capture_status: String,
+    pub capture_reason: String,
     pub checks: ReadyChecksSchema,
     pub integration: String,
     pub freshness: String,
@@ -1384,9 +1388,56 @@ pub struct LandSchema {
     pub performed_steps: Vec<String>,
     pub skipped_steps: Vec<String>,
     pub merge_state: Option<String>,
+    pub blocker_details: Vec<LandBlockerDetailSchema>,
     pub chosen_path: String,
     pub siblings_restacked: Vec<String>,
     pub siblings_restack_failed: Vec<SiblingRestackFailureSchema>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LandBlockerDetailSchema {
+    /// Stable condition code for machine branching.
+    pub code: LandBlockerCodeSchema,
+    /// Eligibility check that produced the blocker.
+    pub check: LandBlockerCheckSchema,
+    /// Human explanation of the observed condition.
+    pub message: String,
+    /// Concrete affected paths; empty for non-path conditions.
+    pub paths: Vec<String>,
+    pub state_context: Option<LandBlockerStateContextSchema>,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LandBlockerCodeSchema {
+    ThreadStateBlocked,
+    MergeConflicts,
+    AutoLandConfidenceBelowThreshold,
+    VerificationTestsFailed,
+    ThreadStale,
+    IntegrationPreviewBlocked,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum LandBlockerCheckSchema {
+    ThreadState,
+    MergePreview,
+    AutoLandConfidence,
+    VerificationSummary,
+    Freshness,
+    IntegrationPreview,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct LandBlockerStateContextSchema {
+    pub recorded_thread_state: String,
+    pub recorded_state_id: Option<String>,
+    pub thread_tip_state_id: Option<String>,
+    pub integration_policy_status: Option<String>,
+    pub integration_policy_reason: Option<String>,
+    pub merge_relation: String,
+    pub conflict_count: usize,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -1408,6 +1459,7 @@ pub struct LandBatchPeerSchema {
     pub siblings_restacked: Vec<String>,
     pub siblings_restack_failed: Vec<SiblingRestackFailureSchema>,
     pub blockers: Vec<String>,
+    pub blocker_details: Vec<LandBlockerDetailSchema>,
     pub warnings: Vec<String>,
     pub primary_command: Option<String>,
     pub recovery_commands: Vec<String>,
@@ -3658,7 +3710,14 @@ mod tests {
         );
 
         let required = required_fields(&schema);
-        for stable_field in ["blockers", "warnings", "readiness", "verification"] {
+        for stable_field in [
+            "blockers",
+            "warnings",
+            "capture_status",
+            "capture_reason",
+            "readiness",
+            "verification",
+        ] {
             assert!(
                 required.contains(&stable_field),
                 "ready schema must require `{stable_field}` because ready JSON always emits the stable field set: {schema}"
@@ -3667,6 +3726,20 @@ mod tests {
         assert!(
             properties.contains_key("captured_state"),
             "ready schema should document captured_state even though schemars models nullable Option fields as optional"
+        );
+    }
+
+    #[test]
+    fn land_schema_requires_structured_blocker_details() {
+        let schema = schema_for_verb("land").expect("land schema");
+        let properties = schema
+            .get("properties")
+            .and_then(|properties| properties.as_object())
+            .expect("land schema has properties");
+        assert!(properties.contains_key("blocker_details"), "{schema}");
+        assert!(
+            required_fields(&schema).contains(&"blocker_details"),
+            "land always emits the machine-readable blocker detail array: {schema}"
         );
     }
 

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -62,6 +62,8 @@ struct ReadyReadinessSummary {
     status: String,
     captured: bool,
     captured_state: Option<String>,
+    capture_status: String,
+    capture_reason: String,
     checks: ReadyChecksSummary,
     integration: String,
     freshness: String,
@@ -82,7 +84,32 @@ struct ReadyChecksSummary {
 }
 
 impl ReadyOutput {
+    fn capture_status(&self) -> (&'static str, &'static str) {
+        if self.captured {
+            (
+                "captured",
+                "worktree changes were captured during this ready invocation",
+            )
+        } else if ready_blocked_by_missing_intent(self) {
+            (
+                "required",
+                "the worktree has uncaptured changes and capture intent is missing",
+            )
+        } else if !self.trust.verified && self.report.merge_relation == "blocked" {
+            (
+                "not_checked",
+                "repository verification blocked capture evaluation",
+            )
+        } else {
+            (
+                "not_needed",
+                "the worktree already matches the current Heddle state",
+            )
+        }
+    }
+
     fn readiness_summary(&self) -> ReadyReadinessSummary {
+        let (capture_status, capture_reason) = self.capture_status();
         let checks = ready_checks_summary(self);
         let integration = ready_integration_summary(&self.report);
         let freshness = ready_freshness_summary(&self.report);
@@ -96,6 +123,8 @@ impl ReadyOutput {
             status: ready_status_summary(&self.report),
             captured: self.captured,
             captured_state: self.captured_state.clone(),
+            capture_status: capture_status.to_string(),
+            capture_reason: capture_reason.to_string(),
             checks,
             integration,
             freshness,
@@ -128,7 +157,8 @@ impl Serialize for ReadyOutput {
         let verification = serde_json::to_value(&self.trust).map_err(S::Error::custom)?;
         let readiness = self.readiness_summary();
 
-        let mut state = serializer.serialize_struct("ReadyOutput", 18)?;
+        let (capture_status, capture_reason) = self.capture_status();
+        let mut state = serializer.serialize_struct("ReadyOutput", 20)?;
         state.serialize_field("output_kind", "ready")?;
         state.serialize_field("status", &self.operator.status)?;
         state.serialize_field("action", &self.operator.action)?;
@@ -141,6 +171,8 @@ impl Serialize for ReadyOutput {
         state.serialize_field("recommended_action_template", &recommended_action_template)?;
         state.serialize_field("captured", &self.captured)?;
         state.serialize_field("captured_state", &self.captured_state)?;
+        state.serialize_field("capture_status", capture_status)?;
+        state.serialize_field("capture_reason", capture_reason)?;
         state.serialize_field("thread_state", &self.thread_state)?;
         state.serialize_field("readiness", &readiness)?;
         state.serialize_field("report", &self.report)?;
@@ -830,7 +862,7 @@ fn write_preview_report(output: &ReadyOutput, recommended_action: Option<&str>) 
     );
     println!(
         "  {}",
-        style::field("captured", &ready_captured_label(&summary))
+        style::field("capture", &ready_capture_label(&summary))
     );
     println!(
         "  {}",
@@ -911,11 +943,14 @@ fn ready_merge_type_summary(report: &ThreadPreviewReport) -> String {
     core_ready_merge_type_summary(&report.merge_relation)
 }
 
-fn ready_captured_label(summary: &ReadyReadinessSummary) -> String {
-    match summary.captured_state.as_deref() {
-        Some(state) => format!("yes (state {})", style::state_id(state)),
-        None if summary.captured => "yes".to_string(),
-        None => "no".to_string(),
+fn ready_capture_label(summary: &ReadyReadinessSummary) -> String {
+    match (
+        summary.capture_status.as_str(),
+        summary.captured_state.as_deref(),
+    ) {
+        ("captured", Some(state)) => format!("captured (state {})", style::state_id(state)),
+        ("captured", None) => "captured".to_string(),
+        (status, _) => format!("{} ({})", status.replace('_', " "), summary.capture_reason),
     }
 }
 

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -8,7 +8,6 @@ use heddle_core::{
     integrated_land_next_action as core_integrated_land_next_action,
     integration_blocker_recommended_action as core_integration_blocker_recommended_action,
     integration_blockers as core_integration_blockers,
-    land_blockers_for_preview as core_land_blockers_for_preview,
     land_checkpoint_message as core_land_checkpoint_message,
     land_performed_steps as core_land_performed_steps,
     land_skipped_steps as core_land_skipped_steps, land_text_step as core_land_text_step,
@@ -25,7 +24,10 @@ use objects::{
     store::ObjectStore,
 };
 use oplog::{OpBatch, OpLogBackend, OpRecord};
-use repo::{Repository, Thread, ThreadIntegrationPolicy, thread_flag};
+use repo::{
+    Repository, THREAD_STATE_BLOCKER_PREFIX, Thread, ThreadIntegrationPolicy, ThreadState,
+    thread_flag,
+};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -104,6 +106,7 @@ struct LandOutput {
     performed_steps: Vec<String>,
     skipped_steps: Vec<String>,
     merge_state: Option<String>,
+    blocker_details: Vec<LandBlockerDetail>,
     #[serde(default)]
     siblings_restacked: Vec<String>,
     #[serde(default)]
@@ -112,6 +115,49 @@ struct LandOutput {
     #[serde(rename = "verification")]
     trust: RepositoryVerificationState,
     chosen_path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LandBlockerDetail {
+    code: LandBlockerCode,
+    check: LandBlockerCheck,
+    message: String,
+    paths: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state_context: Option<LandBlockerStateContext>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LandBlockerCode {
+    ThreadStateBlocked,
+    MergeConflicts,
+    AutoLandConfidenceBelowThreshold,
+    VerificationTestsFailed,
+    ThreadStale,
+    IntegrationPreviewBlocked,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum LandBlockerCheck {
+    ThreadState,
+    MergePreview,
+    AutoLandConfidence,
+    VerificationSummary,
+    Freshness,
+    IntegrationPreview,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct LandBlockerStateContext {
+    recorded_thread_state: String,
+    recorded_state_id: Option<String>,
+    thread_tip_state_id: Option<String>,
+    integration_policy_status: Option<String>,
+    integration_policy_reason: Option<String>,
+    merge_relation: String,
+    conflict_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -130,6 +176,7 @@ struct MultiLandPeerResult {
     siblings_restack_failed: Vec<SiblingRestackFailure>,
     #[serde(default)]
     blockers: Vec<String>,
+    blocker_details: Vec<LandBlockerDetail>,
     #[serde(default)]
     warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -460,6 +507,9 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         let preview = build_thread_preview_report(&repo, &mut refreshed_thread, true)?;
         let stale_blockers = non_staleness_blockers(&preview.blockers);
         if preview.conflict_count == 0 && !stale_blockers.is_empty() {
+            let blocker_details =
+                land_blocker_details(&repo, &refreshed_thread, &preview, &stale_blockers)?;
+            let rendered_blockers = blocker_messages(&blocker_details);
             update_integration_policy(
                 &repo,
                 &refreshed_thread.id,
@@ -480,7 +530,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                             "Thread '{}' must be synced manually",
                             refreshed_thread.id
                         ),
-                        blockers: land_blockers_for_preview(&preview, &stale_blockers),
+                        blockers: rendered_blockers,
                         warnings: Vec::new(),
                         next_action: Some(format!(
                             "heddle sync {}",
@@ -498,6 +548,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                     synced: false,
                     integrated: false,
                     merge_state: None,
+                    blocker_details,
                     siblings_restacked: Vec::new(),
                     siblings_restack_failed: Vec::new(),
                     trust: build_repository_verification_state(&repo),
@@ -530,6 +581,9 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                     "land sync produced conflicts requiring manual resolution",
                 )?;
                 let recommended_action = scoped_resolve_list_command(&refreshed_thread);
+                let blocker_details =
+                    land_blocker_details(&repo, &refreshed_thread, &preview, &stale_blockers)?;
+                let rendered_blockers = blocker_messages(&blocker_details);
                 return write_land_output(
                     cli,
                     &repo,
@@ -541,7 +595,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                                 "Thread '{}' has merge conflicts to resolve",
                                 refreshed_thread.id
                             ),
-                            blockers: land_blockers_for_preview(&preview, &stale_blockers),
+                            blockers: rendered_blockers,
                             warnings: Vec::new(),
                             next_action: Some(recommended_action.clone()),
                             recommended_action: Some(recommended_action),
@@ -553,6 +607,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                         synced: false,
                         integrated: false,
                         merge_state: None,
+                        blocker_details,
                         siblings_restacked: Vec::new(),
                         siblings_restack_failed: Vec::new(),
                         trust: build_repository_verification_state(&repo),
@@ -727,6 +782,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                 synced,
                 integrated: true,
                 merge_state: Some(merge_state),
+                blocker_details: Vec::new(),
                 siblings_restacked: sibling_restack.restacked,
                 siblings_restack_failed: sibling_restack.failed,
                 trust,
@@ -741,7 +797,10 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         );
     }
     if preview.conflict_count > 0 || !integration_blockers.is_empty() {
-        let reason = integration_blockers
+        let blocker_details =
+            land_blocker_details(&repo, &merge_thread, &preview, &integration_blockers)?;
+        let rendered_blockers = blocker_messages(&blocker_details);
+        let policy_reason = integration_blockers
             .first()
             .cloned()
             .unwrap_or_else(|| "integration requires manual review".to_string());
@@ -754,7 +813,15 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             && policy_recovery_action.is_none()
             && materialize_land_conflict_for_thread(&repo, &merge_thread)?
         {
-            update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
+            update_integration_policy(
+                &repo,
+                &merge_thread.id,
+                "blocked",
+                format!(
+                    "{} path conflict(s) need manual resolution",
+                    preview.conflict_count
+                ),
+            )?;
             let recommended_action = scoped_resolve_list_command(&merge_thread);
             return write_land_output(
                 cli,
@@ -767,7 +834,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                             "Thread '{}' has merge conflicts to resolve",
                             merge_thread.id
                         ),
-                        blockers: land_blockers_for_preview(&preview, &integration_blockers),
+                        blockers: rendered_blockers.clone(),
                         warnings: preview_warnings.clone(),
                         next_action: Some(recommended_action.clone()),
                         recommended_action: Some(recommended_action),
@@ -779,6 +846,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                     synced: false,
                     integrated: false,
                     merge_state: None,
+                    blocker_details: blocker_details.clone(),
                     siblings_restacked: Vec::new(),
                     siblings_restack_failed: Vec::new(),
                     trust: build_repository_verification_state(&repo),
@@ -788,14 +856,14 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                 },
             );
         }
-        // Never fall back to `preview.recommended_action` here: this is the
-        // pre-merge bail, so a preview-originated `resolve` breadcrumb could
-        // die with `no_merge_in_progress`, and the preview's own land
-        // recommendation would self-loop this very command. When materializing
-        // was not possible, drive the operator through the explicit sync path.
-        let recommended_action = policy_recovery_action
-            .unwrap_or_else(|| format!("heddle sync {}", thread_flag(&merge_thread.id)));
-        update_integration_policy(&repo, &merge_thread.id, "blocked", &reason)?;
+        // A current thread's persisted lifecycle/policy blocker cannot be
+        // changed by sync: sync's selected path is necessarily `no_op`. Only
+        // emit a command when the blocker classifier knows it can change the
+        // condition (currently confidence / failing-test policy recapture).
+        let recommended_action = policy_recovery_action;
+        if merge_thread.state != ThreadState::Blocked {
+            update_integration_policy(&repo, &merge_thread.id, "blocked", policy_reason)?;
+        }
         return write_land_output(
             cli,
             &repo,
@@ -804,10 +872,10 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                     status: "blocked".to_string(),
                     action: OperatorAction::Land,
                     message: format!("Thread '{}' is not eligible for auto-land", merge_thread.id),
-                    blockers: land_blockers_for_preview(&preview, &integration_blockers),
+                    blockers: rendered_blockers,
                     warnings: preview_warnings.clone(),
-                    next_action: Some(recommended_action.clone()),
-                    recommended_action: Some(recommended_action),
+                    next_action: recommended_action.clone(),
+                    recommended_action,
                 },
                 thread: merge_thread.id.clone(),
                 captured,
@@ -816,6 +884,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
                 synced,
                 integrated: false,
                 merge_state: None,
+                blocker_details,
                 siblings_restacked: Vec::new(),
                 siblings_restack_failed: Vec::new(),
                 trust: build_repository_verification_state(&repo),
@@ -992,6 +1061,16 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     );
     let sibling_restack =
         apply_sibling_restack_after_land(&repo, &merge_thread, cli, integrated, &mut operator);
+    let blocker_details = if integrated {
+        Vec::new()
+    } else {
+        land_blocker_details(
+            &repo,
+            &merge_thread,
+            &preview,
+            &merge_output.operator.blockers,
+        )?
+    };
 
     write_land_output(
         cli,
@@ -1005,6 +1084,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             synced,
             integrated,
             merge_state: merge_output.merge_state.clone(),
+            blocker_details,
             siblings_restacked: sibling_restack.restacked,
             siblings_restack_failed: sibling_restack.failed,
             trust,
@@ -1765,11 +1845,153 @@ pub(crate) fn recovery_scope_checkout(
     core_recovery_scope_checkout(&thread.execution_path, current_checkout)
 }
 
-fn land_blockers_for_preview(
+fn land_blocker_details(
+    repo: &Repository,
+    thread: &Thread,
     preview: &super::merge::ThreadPreviewReport,
     blockers: &[String],
-) -> Vec<String> {
-    core_land_blockers_for_preview(preview, blockers)
+) -> Result<Vec<LandBlockerDetail>> {
+    let mut details = Vec::new();
+    if let Some(detail) = thread_state_blocker_detail(repo, thread, preview)? {
+        details.push(detail);
+    }
+    if preview.conflict_count > 0 {
+        details.push(LandBlockerDetail {
+            code: LandBlockerCode::MergeConflicts,
+            check: LandBlockerCheck::MergePreview,
+            message: format!(
+                "merge preview check failed: {} conflicting path(s): {}",
+                preview.conflict_count,
+                preview.conflicts.join(", ")
+            ),
+            paths: preview.conflicts.clone(),
+            state_context: None,
+        });
+    }
+    details.extend(auto_land_blocker_details(repo, thread));
+    for blocker in blockers {
+        let known = blocker.starts_with(THREAD_STATE_BLOCKER_PREFIX)
+            || blocker.starts_with("confidence ")
+            || blocker == "verification summary reports failing tests"
+            || (preview.conflict_count > 0
+                && (blocker.contains("path conflict(s) need manual resolution")
+                    || blocker.starts_with("conflict: ")));
+        if known {
+            continue;
+        }
+        let (code, check) = if blocker.contains(" is stale against ") {
+            (LandBlockerCode::ThreadStale, LandBlockerCheck::Freshness)
+        } else {
+            (
+                LandBlockerCode::IntegrationPreviewBlocked,
+                LandBlockerCheck::IntegrationPreview,
+            )
+        };
+        details.push(LandBlockerDetail {
+            code,
+            check,
+            message: blocker.clone(),
+            paths: Vec::new(),
+            state_context: None,
+        });
+    }
+
+    Ok(details)
+}
+
+fn thread_state_blocker_detail(
+    repo: &Repository,
+    thread: &Thread,
+    preview: &super::merge::ThreadPreviewReport,
+) -> Result<Option<LandBlockerDetail>> {
+    if thread.state != ThreadState::Blocked {
+        return Ok(None);
+    }
+    let thread_tip_state_id = repo
+        .refs()
+        .get_thread(&ThreadName::new(&thread.thread))?
+        .map(|state| state.short());
+    let id_context = match (
+        thread.current_state.as_deref(),
+        thread_tip_state_id.as_deref(),
+    ) {
+        (Some(recorded), Some(tip)) if recorded != tip => {
+            format!("recorded state {recorded} differs from thread tip {tip}")
+        }
+        (Some(recorded), Some(_)) => {
+            format!("recorded state and thread tip both resolve to {recorded}")
+        }
+        (None, Some(tip)) => format!("no state is recorded while the thread tip is {tip}"),
+        (Some(recorded), None) => {
+            format!("recorded state is {recorded} but the thread has no readable tip")
+        }
+        (None, None) => "neither a recorded state nor a thread tip is available".to_string(),
+    };
+    let policy_status = thread
+        .integration_policy_result
+        .status
+        .as_deref()
+        .unwrap_or("not recorded");
+    let policy_reason = thread
+        .integration_policy_result
+        .reason
+        .as_deref()
+        .unwrap_or("no reason recorded");
+    Ok(Some(LandBlockerDetail {
+        code: LandBlockerCode::ThreadStateBlocked,
+        check: LandBlockerCheck::ThreadState,
+        message: format!(
+            "thread state check failed: recorded lifecycle state is 'blocked' (integration policy status '{policy_status}', reason '{policy_reason}'); {id_context}; current merge preview is {} with {} conflict(s)",
+            preview.merge_relation, preview.conflict_count
+        ),
+        paths: Vec::new(),
+        state_context: Some(LandBlockerStateContext {
+            recorded_thread_state: thread.state.to_string(),
+            recorded_state_id: thread.current_state.clone(),
+            thread_tip_state_id,
+            integration_policy_status: thread.integration_policy_result.status.clone(),
+            integration_policy_reason: thread.integration_policy_result.reason.clone(),
+            merge_relation: preview.merge_relation.clone(),
+            conflict_count: preview.conflict_count,
+        }),
+    }))
+}
+
+fn auto_land_blocker_details(repo: &Repository, thread: &Thread) -> Vec<LandBlockerDetail> {
+    let policy = auto_land_policy_input(repo, thread);
+    let mut details = Vec::new();
+    if policy.agent_authored
+        && let Some(confidence) = policy.confidence
+        && confidence < heddle_core::AUTO_LAND_CONFIDENCE_THRESHOLD
+    {
+        details.push(LandBlockerDetail {
+            code: LandBlockerCode::AutoLandConfidenceBelowThreshold,
+            check: LandBlockerCheck::AutoLandConfidence,
+            message: format!(
+                "auto-land confidence check failed: {confidence:.2} is below the {:.2} threshold",
+                heddle_core::AUTO_LAND_CONFIDENCE_THRESHOLD
+            ),
+            paths: Vec::new(),
+            state_context: None,
+        });
+    }
+    if matches!(policy.tests_passed, Some(false)) {
+        details.push(LandBlockerDetail {
+            code: LandBlockerCode::VerificationTestsFailed,
+            check: LandBlockerCheck::VerificationSummary,
+            message: "verification summary check failed: tests_passed is false".to_string(),
+            paths: Vec::new(),
+            state_context: None,
+        });
+    }
+    details
+}
+
+fn blocker_messages(details: &[LandBlockerDetail]) -> Vec<String> {
+    details
+        .iter()
+        .map(|detail| detail.message.clone())
+        .collect()
 }
 
 fn land_warnings_for_preview(preview: &super::merge::ThreadPreviewReport) -> Vec<String> {
@@ -1896,6 +2118,7 @@ fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Resul
                     siblings_restacked: output.siblings_restacked.clone(),
                     siblings_restack_failed: output.siblings_restack_failed.clone(),
                     blockers: output.operator.blockers.clone(),
+                    blocker_details: output.blocker_details.clone(),
                     warnings: output.operator.warnings.clone(),
                     recovery_commands: primary_command.iter().cloned().collect(),
                     primary_command,
@@ -1939,7 +2162,7 @@ fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Resul
                 println!(
                     "  {}",
                     style::field(
-                        "up to date",
+                        "not performed",
                         &output
                             .skipped_steps
                             .iter()
@@ -1986,6 +2209,21 @@ fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Resul
             .or(output.operator.next_action.as_ref())
         {
             print_next(next);
+        } else if output.operator.status == "blocked" {
+            println!();
+            if output
+                .blocker_details
+                .iter()
+                .any(|detail| detail.code == LandBlockerCode::ThreadStateBlocked)
+            {
+                println!(
+                    "No automatic recovery command is available: sync is already current and cannot change the recorded blocked thread state."
+                );
+            } else {
+                println!(
+                    "No automatic recovery command is available for the blocking condition above."
+                );
+            }
         }
     }
     fail_if_blocked_operator_status(&output.operator.status)
@@ -2899,6 +3137,7 @@ fn multi_land_error_peer(thread: &str, error: &anyhow::Error) -> MultiLandPeerRe
         siblings_restacked: Vec::new(),
         siblings_restack_failed: Vec::new(),
         blockers,
+        blocker_details: Vec::new(),
         warnings,
         primary_command,
         recovery_commands,

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use repo::{Repository, ThreadIntegrationPolicy, ThreadManager, ThreadState};
 use serde_json::Value;
 use tempfile::TempDir;
 
@@ -48,6 +49,30 @@ fn setup_managed_thread(name: &str) -> (TempDir, TempDir, String) {
         .expect("start should report execution_path")
         .to_string();
     (main, checkout, execution_path)
+}
+
+fn setup_current_blocked_thread(name: &str) -> (TempDir, TempDir, String) {
+    let (main, checkout_owner, execution_path) = setup_managed_thread(name);
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout)).unwrap();
+
+    let repo = Repository::open(main.path()).unwrap();
+    let manager = ThreadManager::new(repo.heddle_dir());
+    let mut thread = manager
+        .load(name)
+        .unwrap()
+        .expect("managed thread should have a record");
+    thread.state = ThreadState::Blocked;
+    thread.current_state = Some(thread.base_state.clone());
+    thread.integration_policy_result = ThreadIntegrationPolicy {
+        status: Some("blocked".to_string()),
+        reason: Some("Thread needs attention before integration".to_string()),
+        ..ThreadIntegrationPolicy::default()
+    };
+    manager.save(&thread).unwrap();
+
+    (main, checkout_owner, execution_path)
 }
 
 fn assert_no_banned_next_actions(value: &Value) {
@@ -204,6 +229,96 @@ fn ready_clean_stale_managed_thread_refreshes_and_surfaces_land() {
     );
     assert_eq!(shown["freshness"], "current", "{shown}");
     assert_no_banned_next_actions(&shown);
+
+    drop(checkout_owner);
+}
+
+#[test]
+fn land_blocker_payload_names_thread_state_condition() {
+    let (main, checkout_owner, _execution_path) =
+        setup_current_blocked_thread("feature/blocked-state-payload");
+
+    let land = json(
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/blocked-state-payload",
+        ],
+        main.path(),
+    );
+
+    assert_eq!(
+        land["status"], "blocked",
+        "land must preserve the gate: {land}"
+    );
+    assert!(
+        land["blockers"].as_array().is_some_and(|blockers| {
+            blockers.iter().any(|blocker| {
+                blocker
+                    .as_str()
+                    .is_some_and(|message| message.contains("thread state check"))
+            })
+        }),
+        "human blockers must name the failed check: {land}"
+    );
+    let detail = &land["blocker_details"][0];
+    assert_eq!(detail["code"], "thread_state_blocked", "{land}");
+    assert_eq!(detail["check"], "thread_state", "{land}");
+    assert_eq!(detail["paths"], serde_json::json!([]), "{land}");
+    assert_eq!(
+        detail["state_context"]["recorded_thread_state"], "blocked",
+        "{land}"
+    );
+    assert_ne!(
+        detail["state_context"]["recorded_state_id"],
+        detail["state_context"]["thread_tip_state_id"],
+        "the fixture must preserve the state-id mismatch from #1185: {land}"
+    );
+    assert_eq!(
+        detail["state_context"]["merge_relation"], "fast_forward",
+        "{land}"
+    );
+    assert_eq!(detail["state_context"]["conflict_count"], 0, "{land}");
+
+    drop(checkout_owner);
+}
+
+#[test]
+fn land_never_recommends_no_op_sync_for_current_thread_state_blocker() {
+    let (main, checkout_owner, _execution_path) =
+        setup_current_blocked_thread("feature/blocked-state-no-sync");
+
+    let sync = json(
+        &[
+            "--output",
+            "json",
+            "sync",
+            "--thread",
+            "feature/blocked-state-no-sync",
+        ],
+        main.path(),
+    );
+    assert_eq!(
+        sync["chosen_path"], "no_op",
+        "fixture must hit the no-op path: {sync}"
+    );
+
+    let land = json(
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/blocked-state-no-sync",
+        ],
+        main.path(),
+    );
+    assert_eq!(land["status"], "blocked", "{land}");
+    assert_eq!(land["next_action"], Value::Null, "{land}");
+    assert_eq!(land["recommended_action"], Value::Null, "{land}");
+    assert_eq!(land["blocker_details"][0]["code"], "thread_state_blocked");
 
     drop(checkout_owner);
 }

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -5493,7 +5493,7 @@ fn ready_text_names_ready_and_already_ready_noop_states() {
     for field in [
         "thread:",
         "status:",
-        "captured:",
+        "capture:",
         "checks:",
         "integration:",
         "freshness:",
@@ -5509,7 +5509,9 @@ fn ready_text_names_ready_and_already_ready_noop_states() {
     }
     assert!(
         first_stdout.contains("checks: completed (readiness preview ran)")
-            && first_stdout.contains("captured: no")
+            && first_stdout.contains(
+                "capture: not needed (the worktree already matches the current Heddle state)"
+            )
             && first_stdout.contains("freshness: n/a (no integration target configured)")
             && first_stdout.contains("merge type: n/a (no integration target configured)")
             && first_stdout.contains("conflicts: 0")
@@ -5570,7 +5572,7 @@ fn ready_capture_is_visible_and_carries_confidence() {
     assert!(text.status.success(), "ready should succeed");
     let stdout = String::from_utf8_lossy(&text.stdout);
     assert!(
-        stdout.contains("captured: yes (state hs-"),
+        stdout.contains("capture: captured (state hs-"),
         "ready text should explicitly name the captured state when it saves work: {stdout}"
     );
 
@@ -5590,6 +5592,8 @@ fn ready_capture_is_visible_and_carries_confidence() {
     assert_schema_declares_runtime_top_level(&["ready"], &json);
     assert_eq!(json["output_kind"], "ready");
     assert_eq!(json["captured"], true);
+    assert_eq!(json["capture_status"], "captured");
+    assert_eq!(json["readiness"]["capture_status"], "captured");
     assert!(
         json["captured_state"]
             .as_str()
@@ -5617,9 +5621,11 @@ fn ready_refuses_dirty_capture_without_intent() {
     assert_eq!(ready["status"], "blocked");
     assert_eq!(ready["captured"], false);
     assert_eq!(ready["captured_state"], serde_json::Value::Null);
+    assert_eq!(ready["capture_status"], "required");
     assert_eq!(ready["blockers"].as_array().unwrap().len(), 1);
     assert_eq!(ready["warnings"], serde_json::json!([]));
     assert_eq!(ready["readiness"]["captured"], false);
+    assert_eq!(ready["readiness"]["capture_status"], "required");
     assert_eq!(
         ready["readiness"]["captured_state"],
         serde_json::Value::Null
@@ -5683,6 +5689,7 @@ fn ready_plain_git_refuses_before_initializing_heddle() {
     assert_eq!(ready["output_kind"], "ready");
     assert_eq!(ready["verification"]["status"], "needs_init");
     assert_eq!(ready["captured"], false);
+    assert_eq!(ready["capture_status"], "not_checked");
     assert!(
         ready["recommended_action"]
             .as_str()

--- a/crates/core/src/workflow.rs
+++ b/crates/core/src/workflow.rs
@@ -296,7 +296,7 @@ pub fn land_text_step(step: &str) -> String {
         "sync(current)" => "already refreshed".to_string(),
         "merge(blocked)" => "merge blocked".to_string(),
         "checkpoint(not needed)" => "no Git commit needed".to_string(),
-        "checkpoint(not reached)" => "Git commit not reached".to_string(),
+        "checkpoint(not reached)" => "Git commit skipped because merge did not run".to_string(),
         other => other.to_string(),
     }
 }
@@ -839,6 +839,10 @@ mod tests {
     fn land_text_scope_and_manual_review() {
         assert_eq!(land_text_step("capture"), "saved");
         assert_eq!(land_text_step("merge(blocked)"), "merge blocked");
+        assert_eq!(
+            land_text_step("checkpoint(not reached)"),
+            "Git commit skipped because merge did not run"
+        );
         assert!(is_manual_review_blocker("Heavy-impact change: Cargo.lock"));
         assert!(!is_manual_review_blocker("stale"));
         assert_eq!(

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -169,8 +169,8 @@ pub use stack_snapshot::{
 pub use stash::{StashEntry, StashId, StashManager};
 pub use state_attachments::StateAttachmentKind;
 pub use thread_advice::{
-    RecommendedAction, ThreadAdvice, describe_thread_advice, describe_thread_advice_with_initial,
-    shell_quote, thread_flag,
+    RecommendedAction, THREAD_STATE_BLOCKER_PREFIX, ThreadAdvice, describe_thread_advice,
+    describe_thread_advice_with_initial, shell_quote, thread_flag,
 };
 pub use thread_model::{
     ConfidenceBand, EphemeralMarker, ThreadConfidenceSummary, ThreadFreshness, ThreadId,

--- a/crates/repo/src/thread_advice.rs
+++ b/crates/repo/src/thread_advice.rs
@@ -5,6 +5,12 @@ use serde::Serialize;
 
 use crate::{Thread, ThreadFreshness, ThreadState};
 
+/// Stable prefix for the human rendering of the persisted thread-state gate.
+/// Machine consumers must use the structured blocker code emitted by `land`;
+/// this prefix only lets internal renderers recognize and enrich the matching
+/// human message without comparing the old opaque sentence.
+pub const THREAD_STATE_BLOCKER_PREFIX: &str = "thread state check failed:";
+
 /// Shell-quote an argument for inclusion in a recommended-command string so a
 /// value containing whitespace or shell metacharacters yields a runnable
 /// command (and tokenizes correctly through the CLI's next_action validator).
@@ -188,15 +194,11 @@ pub fn describe_thread_advice_with_initial(
             preview_paths(&thread.heavy_impact_paths)
         ));
         RecommendedAction::Review
-    } else if conflicts > 0 || thread.state == ThreadState::Blocked {
-        if conflicts > 0 {
-            blockers.push(format!(
-                "{} path conflict(s) need manual resolution",
-                conflicts
-            ));
-        } else if blockers.is_empty() {
-            blockers.push("Thread needs attention before integration".to_string());
-        }
+    } else if conflicts > 0 {
+        blockers.push(format!(
+            "{} path conflict(s) need manual resolution",
+            conflicts
+        ));
         // `land` — not `resolve --list`. This is a metadata-only function; it
         // is always called from non-materialized contexts (status passes
         // conflicts=0, the only conflicts>0 caller is the merge dry-run
@@ -206,6 +208,25 @@ pub fn describe_thread_advice_with_initial(
         // `continue`) or re-reports the specific blocker with its own
         // recommendation. (heddle#464 close-the-class.)
         RecommendedAction::Land
+    } else if thread.state == ThreadState::Blocked {
+        let policy_status = thread
+            .integration_policy_result
+            .status
+            .as_deref()
+            .unwrap_or("not recorded");
+        let policy_reason = thread
+            .integration_policy_result
+            .reason
+            .as_deref()
+            .unwrap_or("no reason recorded");
+        blockers.push(format!(
+            "{THREAD_STATE_BLOCKER_PREFIX} recorded lifecycle state is 'blocked' (integration policy status '{policy_status}', reason '{policy_reason}')"
+        ));
+        // No generic command is known to change a persisted Blocked state.
+        // `land` reports the state/ref/preview mismatch in structured form;
+        // `sync` is deliberately not suggested because a current thread makes
+        // that command a no-op (heddle#1185).
+        RecommendedAction::Review
     } else if thread.state == ThreadState::Ready
         && thread.integration_policy_result.status.as_deref() == Some("previewed")
     {
@@ -279,17 +300,17 @@ mod tests {
         .expect("thread fixture should deserialize")
     }
 
-    // heddle#464 close-the-class: `describe_thread_advice` is metadata-only —
-    // it is never called from a context that has materialized a merge (status
-    // passes conflicts=0; the lone conflicts>0 caller is the dry-run merge
-    // preview). So it must never emit `heddle resolve --list`, which would die
-    // with `no_merge_in_progress`. A blocked thread re-drives through `land`.
+    // A persisted Blocked lifecycle state is itself the failed check. There is
+    // no generic command that can safely clear it, so advice must name the
+    // recorded condition and stop instead of entering a land/sync loop.
     #[test]
-    fn blocked_thread_recommends_land_not_dead_resolve_breadcrumb() {
+    fn blocked_thread_names_recorded_state_without_guessing_recovery() {
         let advice = describe_thread_advice(&thread_json("blocked"), false, 0, false);
         assert_eq!(advice.thread_health, "blocked");
-        assert_ne!(advice.recommended_action, "heddle resolve --list");
-        assert_eq!(advice.recommended_action, "heddle land --thread feature/x");
+        assert_eq!(advice.recommended_action, "");
+        assert_eq!(advice.blockers.len(), 1);
+        assert!(advice.blockers[0].starts_with(THREAD_STATE_BLOCKER_PREFIX));
+        assert!(advice.blockers[0].contains("recorded lifecycle state is 'blocked'"));
     }
 
     // Even when a preview reports conflicts, the merge is a dry run with no


### PR DESCRIPTION
## Summary

- replace the opaque blocked-thread `land` refusal with typed blocker details that name the failed check, recorded lifecycle/policy state, state-id mismatch, merge relation, conflict count, and affected paths
- remove the `sync` fallback when no known command can change the blocker, closing the current-thread `land` -> no-op `sync` loop
- clarify that `ready.captured` reports work captured by that invocation, add `capture_status` / `capture_reason`, and explain skipped Git checkpoint telemetry

## Closes

Closes #1185

## Test evidence

- GitHub PR checks: all applicable checks passed, including Quality, Feature contracts, CLI fault injection, Postgres integration, Linux FUSE, Windows ProjFS, and macOS FSKit
- `cargo build --locked --workspace --tests --bin heddle --bin heddle-fuse-worker`
- `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings`
- `cargo test --locked --workspace`
- `bash scripts/check-default-cli-contracts.sh`
- `cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd`
- `cargo check --locked -p heddle-repo --no-default-features --features native,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd`
- `next_action_contract::land_blocker_payload_names_thread_state_condition`: passes with the fix; fails with the implementation commit reversed on the old `Thread needs attention before integration` payload
- `next_action_contract::land_never_recommends_no_op_sync_for_current_thread_state_blocker`: passes with the fix; fails with the implementation commit reversed because `land.next_action` is again `heddle sync ...` after `sync.chosen_path` was established as `no_op`
