### PR TITLE
fix(pull): materialize remote threads as managed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ recorded here. Hosted-product work (Postgres, Biscuit, the web app,
 GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 `HeddleCo/tapestry` repos.
 
+## Unreleased
+
+### Fixed
+
+- **Native pull preserves managed threads.** Pulling a pushed managed thread
+  into a clone now restores its thread metadata, so `thread list` exposes its
+  integration target and `land` reaches the real merge verdict instead of
+  diagnosing the pulled ref as Git damage.
+
 ## 0.11.0 - 2026-07-31
 
 ### Breaking

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -26,7 +26,7 @@ use objects::{
     store::ObjectStore,
 };
 use refs::Head;
-use repo::{Repository, RepositoryCapability};
+use repo::{Repository, RepositoryCapability, SyncedThreadMetadata, ThreadManager};
 use serde::Serialize;
 use sley::{
     ConfigEdit, ConfigEditPlan, ConfigEditScope, HeadUpdateOptions, RefChange, ReferenceTarget,
@@ -908,6 +908,8 @@ async fn pull_local(
         .context(format!("Thread {} not found in source", remote_thread))?;
 
     let objects_copied = source.fetch_state(repo, &state_id)? + source.fetch_markers(repo)?;
+    let pulled_thread_metadata =
+        ThreadManager::new(source.source().heddle_dir()).find_record_by_thread(remote_thread)?;
 
     let track_to_update = local_thread.unwrap_or(remote_thread);
     let track_tn = ThreadName::new(track_to_update);
@@ -945,6 +947,7 @@ async fn pull_local(
     } else {
         repo.set_thread_recorded(&track_tn, &state_id)?;
     }
+    save_pulled_thread_metadata(repo, track_to_update, &state_id, pulled_thread_metadata)?;
     if let Some(remote_name) = configured_remote_name {
         repo.set_remote_thread_recorded(remote_name, &ThreadName::new(remote_thread), &state_id)?;
     }
@@ -1057,6 +1060,20 @@ async fn pull_network_connected(
             let track_to_update = options.local_thread.unwrap_or(options.remote_thread);
             let mut changed = false;
             if let Some(final_state_id) = final_state_id {
+                let pulled_thread_metadata = if options.local_thread.is_some() {
+                    Some(
+                        client
+                            .get_thread_metadata(
+                                repo,
+                                repo_path,
+                                options.remote_thread,
+                                final_state_id,
+                            )
+                            .await?,
+                    )
+                } else {
+                    None
+                };
                 let track_tn = ThreadName::new(track_to_update);
                 let pre_target = repo.refs().get_thread(&track_tn)?;
                 let pre_target_str = pre_target.as_ref().map(|s| s.to_string());
@@ -1089,6 +1106,12 @@ async fn pull_network_connected(
                         repo.set_thread_recorded(&track_tn, &final_state_id)?;
                     }
                 }
+                save_pulled_thread_metadata(
+                    repo,
+                    track_to_update,
+                    &final_state_id,
+                    pulled_thread_metadata,
+                )?;
             }
             // Read path for hosted discussions (heddle discuss): materialize any
             // new hosted CollaborationService discussions/turns for the pulled
@@ -1160,6 +1183,23 @@ async fn pull_network_connected(
         }
     }
 
+    Ok(())
+}
+
+fn save_pulled_thread_metadata(
+    repo: &Repository,
+    local_thread: &str,
+    pulled_state: &StateId,
+    metadata: Option<SyncedThreadMetadata>,
+) -> Result<()> {
+    let Some(mut metadata) = metadata else {
+        return Ok(());
+    };
+    metadata.id = local_thread.to_string();
+    metadata.thread = local_thread.to_string();
+    metadata.current_state = Some(pulled_state.short());
+    metadata.shared_target_dir = None;
+    ThreadManager::new(repo.heddle_dir()).save_record(&metadata)?;
     Ok(())
 }
 

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -292,6 +292,13 @@ impl HostedRoutes<'_> {
         CheckMergeEligibilityResponse
     );
     unary_method!(
+        get_thread,
+        "WorkflowService",
+        "GetThread",
+        GetThreadRequest,
+        ThreadSummary
+    );
+    unary_method!(
         list_thread_approvals,
         "WorkflowService",
         "ListThreadApprovals",

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -25,6 +25,7 @@ mod state_review;
 mod sync;
 #[cfg(test)]
 mod test_https;
+mod thread_metadata;
 mod user;
 
 #[cfg(test)]

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -9,8 +9,8 @@ use std::{
 };
 
 use api::heddle::api::v1alpha1::{
-    ConfidenceBand as ProtoConfidenceBand, GetBlobRequest, GitCheckpointTransfer, GitLaneTransfer,
-    GitObjectAlgorithm, GitObjectId as ProtoGitObjectId, GitPackTransfer,
+    ConfidenceBand as ProtoConfidenceBand, GetBlobRequest, GetThreadRequest, GitCheckpointTransfer,
+    GitLaneTransfer, GitObjectAlgorithm, GitObjectId as ProtoGitObjectId, GitPackTransfer,
     GitRefKind as ProtoGitRefKind, GitRefUpdateTransfer,
     IntegrationPolicyStatus as ProtoIntegrationPolicyStatus, ListRefsRequest,
     ObjectAvailabilityStatus, ObjectDescriptor, PackChunk, PackStreamKind, PartialFetchStatus,
@@ -296,6 +296,40 @@ impl HostedClient {
                 })
             })
             .collect()
+    }
+
+    /// Fetch and validate the managed record for a pulled hosted thread.
+    pub async fn get_thread_metadata(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        pulled_state: StateId,
+    ) -> Result<SyncedThreadMetadata, ProtocolError> {
+        let request = GetThreadRequest {
+            repo_path: super::helpers::repository_ref(repo_path),
+            name: remote_thread.to_string(),
+        };
+        let summary = match self.routes().get_thread(&request).await {
+            Ok(summary) => summary,
+            Err(error) => {
+                let error = hosted_to_protocol_error(error);
+                if matches!(
+                    error,
+                    ProtocolError::ObjectNotFound(_)
+                        | ProtocolError::RemoteFailure {
+                            code: wire::RemoteFailureCode::NotFound,
+                            ..
+                        }
+                ) {
+                    return Err(ProtocolError::InvalidState(format!(
+                        "hosted thread '{remote_thread}' has no managed metadata; no local thread was created"
+                    )));
+                }
+                return Err(error);
+            }
+        };
+        super::thread_metadata::from_summary(repo, remote_thread, pulled_state, summary)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/cli/src/hosted_runtime/hosted/thread_metadata.rs
+++ b/crates/cli/src/hosted_runtime/hosted/thread_metadata.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use api::heddle::api::v1alpha1::{
+    ConfidenceBand as ProtoConfidenceBand, IntegrationPolicyStatus as ProtoIntegrationPolicyStatus,
+    ThreadFreshness as ProtoThreadFreshness, ThreadMode as ProtoThreadMode, ThreadSummary,
+    thread_state::Kind as ProtoThreadState,
+};
+use objects::{object::StateId, store::ObjectStore};
+use repo::{Repository, SyncedThreadMetadata};
+use wire::ProtocolError;
+
+pub(super) fn from_summary(
+    repo: &Repository,
+    remote_thread: &str,
+    pulled_state: StateId,
+    summary: ThreadSummary,
+) -> Result<SyncedThreadMetadata, ProtocolError> {
+    if summary.name != remote_thread {
+        return Err(invalid_metadata(
+            remote_thread,
+            format!("was named '{}'", summary.name),
+        ));
+    }
+    let base_state = super::helpers::parse_proto_state_id(summary.base_state)?
+        .ok_or_else(|| invalid_metadata(remote_thread, "is missing its managed base state"))?;
+    let advertised_current = super::helpers::parse_proto_state_id(summary.current_state)?;
+    if advertised_current != Some(pulled_state) {
+        return Err(invalid_metadata(
+            remote_thread,
+            format!("does not match pulled state {pulled_state}"),
+        ));
+    }
+    let base_root = repo
+        .store()
+        .get_state(&base_state)?
+        .ok_or_else(|| {
+            invalid_metadata(
+                remote_thread,
+                format!("names base state {base_state}, which was not transferred"),
+            )
+        })?
+        .tree
+        .short();
+    let state = thread_state(remote_thread, summary.thread_state)?;
+    let now = chrono::Utc::now();
+
+    Ok(SyncedThreadMetadata {
+        id: remote_thread.to_string(),
+        thread: remote_thread.to_string(),
+        target_thread: summary.target_thread,
+        parent_thread: summary.parent_thread,
+        mode: thread_mode(remote_thread, summary.thread_mode)?,
+        state: state.clone(),
+        base_state: base_state.short(),
+        base_root,
+        current_state: Some(pulled_state.short()),
+        merged_state: (state == repo::ThreadState::Merged).then(|| pulled_state.short()),
+        task: summary.task,
+        changed_paths: summary.changed_paths,
+        impact_categories: impact_categories(remote_thread, summary.impact_categories)?,
+        heavy_impact_paths: summary.heavy_impact_paths,
+        promotion_suggested: summary.promotion_suggested,
+        freshness: freshness(summary.freshness),
+        verification_summary: verification_summary(summary.verification_summary),
+        confidence_summary: confidence_summary(summary.confidence_summary),
+        integration_policy_result: integration_policy(summary.integration_policy_result),
+        created_at: now,
+        updated_at: now,
+        ephemeral: None,
+        auto: false,
+        shared_target_dir: None,
+    })
+}
+
+fn invalid_metadata(remote_thread: &str, detail: impl std::fmt::Display) -> ProtocolError {
+    ProtocolError::InvalidState(format!("hosted thread '{remote_thread}' metadata {detail}"))
+}
+
+fn thread_state(remote_thread: &str, value: i32) -> Result<repo::ThreadState, ProtocolError> {
+    match ProtoThreadState::try_from(value).ok() {
+        Some(ProtoThreadState::ThreadStateDraft) => Ok(repo::ThreadState::Draft),
+        Some(ProtoThreadState::ThreadStateActive) => Ok(repo::ThreadState::Active),
+        Some(ProtoThreadState::ThreadStateReady) => Ok(repo::ThreadState::Ready),
+        Some(ProtoThreadState::ThreadStateBlocked) => Ok(repo::ThreadState::Blocked),
+        Some(ProtoThreadState::ThreadStateMerged) => Ok(repo::ThreadState::Merged),
+        Some(ProtoThreadState::ThreadStateAbandoned) => Ok(repo::ThreadState::Abandoned),
+        Some(ProtoThreadState::ThreadStatePromoted) => Ok(repo::ThreadState::Promoted),
+        _ => Err(invalid_metadata(
+            remote_thread,
+            "has no managed lifecycle state",
+        )),
+    }
+}
+
+fn thread_mode(remote_thread: &str, value: i32) -> Result<repo::ThreadMode, ProtocolError> {
+    match ProtoThreadMode::try_from(value).ok() {
+        Some(ProtoThreadMode::Materialized) => Ok(repo::ThreadMode::Materialized),
+        Some(ProtoThreadMode::Virtualized) => Ok(repo::ThreadMode::Virtualized),
+        Some(ProtoThreadMode::Solid) => Ok(repo::ThreadMode::Solid),
+        _ => Err(invalid_metadata(
+            remote_thread,
+            "has no managed workspace mode",
+        )),
+    }
+}
+
+fn freshness(value: i32) -> repo::ThreadFreshness {
+    match ProtoThreadFreshness::try_from(value).ok() {
+        Some(ProtoThreadFreshness::Current) => repo::ThreadFreshness::Current,
+        Some(ProtoThreadFreshness::Stale) => repo::ThreadFreshness::Stale,
+        _ => repo::ThreadFreshness::Unknown,
+    }
+}
+
+fn verification_summary(
+    value: Option<api::heddle::api::v1alpha1::ThreadVerificationSummary>,
+) -> repo::ThreadVerificationSummary {
+    value.map_or_else(repo::ThreadVerificationSummary::default, |summary| {
+        repo::ThreadVerificationSummary {
+            tests_passed: summary.tests_passed,
+            tests_failed: Some(summary.tests_failed),
+            coverage_pct: summary.coverage_pct,
+            lint_warnings: summary.lint_warnings,
+        }
+    })
+}
+
+fn confidence_summary(
+    value: Option<api::heddle::api::v1alpha1::ThreadConfidenceSummary>,
+) -> repo::ThreadConfidenceSummary {
+    value.map_or_else(repo::ThreadConfidenceSummary::default, |summary| {
+        repo::ThreadConfidenceSummary {
+            value: summary.value,
+            band: match ProtoConfidenceBand::try_from(summary.band).ok() {
+                Some(ProtoConfidenceBand::Low) => Some(repo::ConfidenceBand::Low),
+                Some(ProtoConfidenceBand::Medium) => Some(repo::ConfidenceBand::Medium),
+                Some(ProtoConfidenceBand::High) => Some(repo::ConfidenceBand::High),
+                _ => None,
+            },
+        }
+    })
+}
+
+fn integration_policy(
+    value: Option<api::heddle::api::v1alpha1::ThreadIntegrationPolicy>,
+) -> repo::ThreadIntegrationPolicy {
+    value.map_or_else(repo::ThreadIntegrationPolicy::default, |policy| {
+        repo::ThreadIntegrationPolicy {
+            status: match ProtoIntegrationPolicyStatus::try_from(policy.status).ok() {
+                Some(ProtoIntegrationPolicyStatus::Previewed) => Some("previewed".to_string()),
+                Some(ProtoIntegrationPolicyStatus::Current) => Some("current".to_string()),
+                Some(ProtoIntegrationPolicyStatus::Blocked) => Some("blocked".to_string()),
+                Some(ProtoIntegrationPolicyStatus::ManualResolved) => {
+                    Some("manual_resolved".to_string())
+                }
+                Some(ProtoIntegrationPolicyStatus::AutoIntegrated) => {
+                    Some("auto_integrated".to_string())
+                }
+                _ => None,
+            },
+            reason: (!policy.reason.is_empty()).then_some(policy.reason),
+            manual_resolution_state: None,
+            conflicts_resolved_manually: false,
+        }
+    })
+}
+
+fn impact_categories(
+    remote_thread: &str,
+    values: Vec<String>,
+) -> Result<Vec<repo::ThreadImpactCategory>, ProtocolError> {
+    values
+        .into_iter()
+        .map(|category| match category.as_str() {
+            "dependency_graph" => Ok(repo::ThreadImpactCategory::DependencyGraph),
+            "build_runtime_config" => Ok(repo::ThreadImpactCategory::BuildRuntimeConfig),
+            "generated_outputs" => Ok(repo::ThreadImpactCategory::GeneratedOutputs),
+            "repo_wide_refactor" => Ok(repo::ThreadImpactCategory::RepoWideRefactor),
+            "public_api_surface" => Ok(repo::ThreadImpactCategory::PublicApiSurface),
+            _ => Err(invalid_metadata(
+                remote_thread,
+                format!("has unknown impact category '{category}'"),
+            )),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use api::heddle::api::v1alpha1::{
+        ThreadFreshness as ProtoThreadFreshness, ThreadMode as ProtoThreadMode, ThreadSummary,
+        thread_state::Kind as ProtoThreadState,
+    };
+    use repo::Repository;
+    use tempfile::TempDir;
+
+    use super::from_summary;
+
+    #[test]
+    fn hosted_thread_summary_rehydrates_managed_metadata_at_pulled_tip() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+        let base = repo.snapshot(Some("base".to_string()), None).unwrap();
+        std::fs::write(temp.path().join("runner.txt"), "runner\n").unwrap();
+        let tip = repo.snapshot(Some("runner".to_string()), None).unwrap();
+        let summary = ThreadSummary {
+            name: "shuttle/runner".to_string(),
+            base_state: super::super::helpers::proto_state_id(base.state_id),
+            current_state: super::super::helpers::proto_state_id(tip.state_id),
+            target_thread: Some("main".to_string()),
+            task: Some("fixture runner".to_string()),
+            thread_mode: ProtoThreadMode::Solid as i32,
+            freshness: ProtoThreadFreshness::Current as i32,
+            thread_state: ProtoThreadState::ThreadStateReady as i32,
+            changed_paths: vec!["runner.txt".to_string()],
+            ..ThreadSummary::default()
+        };
+
+        let metadata = from_summary(&repo, "shuttle/runner", tip.state_id, summary).unwrap();
+        assert_eq!(metadata.thread, "shuttle/runner");
+        assert_eq!(metadata.target_thread.as_deref(), Some("main"));
+        assert_eq!(metadata.state, repo::ThreadState::Ready);
+        assert_eq!(metadata.current_state, Some(tip.state_id.short()));
+        assert_eq!(metadata.changed_paths, vec!["runner.txt"]);
+    }
+}

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use cli::remote::RemoteConfig;
 use objects::object::{MarkerName, ThreadName};
+use repo::ThreadManager;
 use sley::{ConfigEdit, ConfigEditPlan};
 
 use super::{git_overlay_fixtures::GitOverlayFixture, *};
@@ -846,6 +847,134 @@ fn test_cli_pull_local_side_thread_updates_ref_without_materializing_checkout() 
     assert_eq!(
         std::fs::read_to_string(target.path().join("source.txt")).unwrap(),
         "from source\n"
+    );
+}
+
+fn managed_thread_pull_fixture() -> (TempDir, std::path::PathBuf, TempDir, std::path::PathBuf) {
+    let source_root = TempDir::new().unwrap();
+    let source = source_root.path().join("source");
+    let runner = source_root.path().join("runner");
+    std::fs::create_dir(&source).unwrap();
+    heddle(&["init"], Some(&source)).unwrap();
+    std::fs::write(source.join("base.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "Base state"], Some(&source)).unwrap();
+    heddle(
+        &[
+            "start",
+            "shuttle/runner",
+            "--path",
+            runner.to_str().unwrap(),
+            "--task",
+            "fixture runner",
+        ],
+        Some(&source),
+    )
+    .unwrap();
+    std::fs::write(runner.join("runner.txt"), "runner change\n").unwrap();
+    heddle(&["capture", "-m", "Runner change"], Some(&runner)).unwrap();
+
+    let target_root = TempDir::new().unwrap();
+    let clone = target_root.path().join("clone");
+    heddle(
+        &["clone", source.to_str().unwrap(), clone.to_str().unwrap()],
+        None,
+    )
+    .unwrap();
+    (source_root, source, target_root, clone)
+}
+
+fn pull_managed_runner(source: &std::path::Path, clone: &std::path::Path) -> Value {
+    let output = heddle(
+        &[
+            "--output",
+            "json",
+            "pull",
+            source.to_str().unwrap(),
+            "--thread",
+            "shuttle/runner",
+            "--local-thread",
+            "shuttle/runner",
+        ],
+        Some(clone),
+    )
+    .expect("managed side-thread pull succeeds");
+    serde_json::from_str(&output).expect("pull JSON parses")
+}
+
+#[test]
+fn pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land() {
+    let (_source_root, source, _target_root, clone) = managed_thread_pull_fixture();
+    let pull = pull_managed_runner(&source, &clone);
+    assert_eq!(pull["thread"], "shuttle/runner", "{pull}");
+
+    let repo = Repository::open(&clone).unwrap();
+    let managed = ThreadManager::new(repo.heddle_dir())
+        .find_by_thread("shuttle/runner")
+        .unwrap()
+        .expect("pull must persist managed thread metadata");
+    assert_eq!(managed.target_thread.as_deref(), Some("main"));
+    assert_eq!(
+        managed.current_state,
+        repo.refs()
+            .get_thread(&ThreadName::new("shuttle/runner"))
+            .unwrap()
+            .map(|state| state.short())
+    );
+
+    let listed = heddle(&["thread", "list", "--output", "json"], Some(&clone)).unwrap();
+    let listed: Value = serde_json::from_str(&listed).unwrap();
+    let runner = listed["threads"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|thread| thread["name"] == "shuttle/runner")
+        .expect("thread list must show the pulled managed thread");
+    assert_eq!(runner["target_thread"], "main", "{listed}");
+
+    let landed = heddle(
+        &[
+            "land",
+            "--thread",
+            "shuttle/runner",
+            "-m",
+            "integrate runner",
+            "--output",
+            "json",
+        ],
+        Some(&clone),
+    )
+    .expect("land must reach a real merge verdict");
+    let landed: Value = serde_json::from_str(&landed).unwrap();
+    assert_eq!(landed["output_kind"], "land", "{landed}");
+    assert_eq!(landed["status"], "landed", "{landed}");
+}
+
+#[test]
+fn pull_created_ref_never_routes_cli_verbs_to_fsck_repair() {
+    let (_source_root, source, _target_root, clone) = managed_thread_pull_fixture();
+    pull_managed_runner(&source, &clone);
+
+    let verdict = heddle_output(
+        &[
+            "land",
+            "--thread",
+            "shuttle/runner",
+            "-m",
+            "integrate runner",
+            "--output",
+            "json",
+        ],
+        Some(&clone),
+    )
+    .expect("invoke land after pull");
+    let output = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&verdict.stdout),
+        String::from_utf8_lossy(&verdict.stderr)
+    );
+    assert!(
+        !output.contains("fsck repair") && !output.contains("imported_git_ref_not_managed_thread"),
+        "a CLI-created pull result must not be diagnosed as repository damage: {output}"
     );
 }
 


### PR DESCRIPTION
## Summary

- Preserve managed thread metadata when a native local pull materializes a remote thread under a local name.
- Fetch the hosted thread summary after native hosted transfer, validate that its name, tip, base, mode, and lifecycle describe the transferred state, and persist a localized managed record before returning success.
- Keep `land` eligibility unchanged. If an explicit hosted `--local-thread` pull cannot retrieve valid managed metadata, pull fails before publishing the local thread ref instead of creating an artifact later diagnosed as Git damage.
- Reproduced and manually verified with a local native fixture; the live pilot was not used or modified.

## Closes

Closes #1186

## Test evidence

- `rustfmt +nightly --edition 2024` on the six touched Rust files.
- `TMPDIR=/home/scratch cargo clippy -p heddle-cli --tests -- -D warnings` — passed.
- `env -u HEDDLE_AGENT_PROVIDER -u HEDDLE_AGENT_MODEL -u CODEX_THREAD_ID -u CODEX_MODEL -u OPENAI_MODEL TMPDIR=/home/scratch cargo test -p heddle-cli --quiet` — passed. The Codex session locator is removed so attribution-sensitive fixtures control their own model instead of inheriting the current rollout.
- `TMPDIR=/home/scratch cargo build -p heddle-cli` — passed and watched to completion.
- `cargo test -p heddle-cli --test cli_integration pulling_managed_thread_into_clone_registers_it_for_thread_list_and_land -- --nocapture` — passed by name.
- `cargo test -p heddle-cli --test cli_integration pull_created_ref_never_routes_cli_verbs_to_fsck_repair -- --nocapture` — passed by name.
- Falsification: temporarily removed the pull-side metadata lookup/save while retaining both tests. The first failed at `pull must persist managed thread metadata`; the second failed after `land` emitted `imported_git_ref_not_managed_thread` with `heddle fsck repair git --ref shuttle/runner --preview`. Restoring the implementation made both pass again.
- Manual local-native `clone -> pull -t shuttle/runner -l shuttle/runner -> thread list -> land`:

```text
Threads in Heddle native
Repository: Heddle native

Current
* main clean no dedicated checkout

Ready to merge
- shuttle/runner ahead no dedicated checkout
    sync: current
    next step: heddle ready --thread shuttle/runner
[ok] Landed thread 'shuttle/runner'
  thread: shuttle/runner
  landed: on parent
Workspace: verified
Next: heddle thread cleanup --merged --dry-run
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788185860&installation_model_id=21489&pr_number=1194&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1194&signature=a6a96d2bfd70a9c33afccd3772584244b59310f816e510c5f3f2548df46b4b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->