### PR TITLE
feat(client): expose hosted repo event subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+### Added
+
+- **Public hosted repo-event subscription client.** Rust consumers can connect
+  through Heddle's standard credential and verified native transport, subscribe
+  with the API-owned request/event types, and resume from the last delivered
+  event ID after an explicit disconnect error.
+
 ### Fixed
 
 - **Native pull preserves managed threads.** Pulling a pushed managed thread

--- a/crates/cli/examples/repo_events.rs
+++ b/crates/cli/examples/repo_events.rs
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use cli::client::repo_events::{RepoEventClient, SubscribeRepoEventsRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut arguments = std::env::args().skip(1);
+    let server = arguments
+        .next()
+        .ok_or("usage: repo_events <server> <repo-id> [after-event-id]")?;
+    let repo_id = arguments
+        .next()
+        .ok_or("usage: repo_events <server> <repo-id> [after-event-id]")?;
+    let after_event_id = arguments.next().as_deref().unwrap_or("0").parse::<i64>()?;
+
+    let client = RepoEventClient::connect(&server).await?;
+    let mut events = client
+        .subscribe(SubscribeRepoEventsRequest {
+            repo_id,
+            thread: String::new(),
+            after_event_id,
+            event_types: Vec::new(),
+        })
+        .await?;
+    let event = events.next().await?;
+    println!(
+        "{}",
+        serde_json::json!({
+            "event_id": event.event_id,
+            "repo_id": event.repo_id,
+            "event_type": event.event_type,
+            "thread": event.thread,
+            "ref_name": event.ref_name,
+            "is_thread": event.is_thread,
+            "actor_subject": event.actor_subject,
+            "payload_json": event.payload_json,
+        })
+    );
+    client.close().await;
+    Ok(())
+}

--- a/crates/cli/src/client/mod.rs
+++ b/crates/cli/src/client/mod.rs
@@ -12,6 +12,8 @@ pub mod discussion_sync;
 pub mod human_signature;
 pub mod local_sync;
 #[cfg(feature = "client")]
+pub mod repo_events;
+#[cfg(feature = "client")]
 pub mod review_sync;
 
 pub use cli_shared::ClientConfig;

--- a/crates/cli/src/client/repo_events.rs
+++ b/crates/cli/src/client/repo_events.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Public native client for hosted repository events.
+//!
+//! Weft persists repository events and serves every event after
+//! [`SubscribeRepoEventsRequest::after_event_id`] before switching to live
+//! delivery. This client deliberately leaves reconnect timing to its caller:
+//! [`RepoEventSubscription::next`] never turns a dead stream into an indefinite
+//! wait. It returns [`RepoEventError::Disconnected`] or
+//! [`RepoEventError::Ended`], and [`RepoEventSubscription::resume_request`]
+//! carries the last received event ID into a new subscription.
+
+use api::heddle::api::v1alpha1::CallFailureCode;
+pub use api::heddle::api::v1alpha1::{RepoEvent, SubscribeRepoEventsRequest};
+use cli_shared::{RemoteTarget, UserConfig};
+
+pub use crate::hosted_runtime::hosted::HostedError;
+use crate::hosted_runtime::{HostedAuthMode, HostedClient, HostedSession, ServerStream};
+
+/// Failure to connect or receive hosted repository events.
+#[derive(Debug, thiserror::Error)]
+pub enum RepoEventError {
+    /// The supplied server is not a supported native hosted remote.
+    #[error("invalid hosted server URL: {0}")]
+    InvalidServer(String),
+    /// Event subscriptions are only available from hosted network servers.
+    #[error("repo-event subscriptions require a hosted network server")]
+    LocalServer,
+    /// Standard Heddle credential or transport configuration could not load.
+    #[error("failed to configure the hosted repo-event client: {0}")]
+    Configuration(String),
+    /// Descriptor discovery or the native Iroh connection failed.
+    #[error("failed to connect the hosted repo-event client: {0}")]
+    Connection(String),
+    /// The server refused the subscription, including authorization failures.
+    #[error("repo-event subscription was refused: {source}")]
+    Refused {
+        /// Typed hosted failure returned by the server.
+        #[source]
+        source: HostedError,
+    },
+    /// The underlying connection failed after the reported durable cursor.
+    #[error(
+        "repo-event stream disconnected after event {last_event_id}: {source}; reconnect and resume after event {last_event_id}"
+    )]
+    Disconnected {
+        /// Last event ID successfully returned to the caller.
+        last_event_id: i64,
+        /// Typed transport, framing, or remote failure.
+        #[source]
+        source: HostedError,
+    },
+    /// The server ended a stream that is defined to be long-lived.
+    #[error(
+        "repo-event stream ended after event {last_event_id}; reconnect and resume after event {last_event_id}"
+    )]
+    Ended {
+        /// Last event ID successfully returned to the caller.
+        last_event_id: i64,
+    },
+}
+
+impl RepoEventError {
+    /// Cursor that may be placed in `after_event_id` after a disconnect.
+    pub fn resume_after_event_id(&self) -> Option<i64> {
+        match self {
+            Self::Disconnected { last_event_id, .. } | Self::Ended { last_event_id } => {
+                Some(*last_event_id)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Authenticated native client for hosted repository-event subscriptions.
+pub struct RepoEventClient {
+    client: HostedClient,
+}
+
+impl RepoEventClient {
+    /// Connect using Heddle's standard credential resolution and descriptor trust.
+    ///
+    /// `server` accepts the same native network forms as a Heddle remote, such
+    /// as `heddle://host:8421/owner/repo` or
+    /// `https://host/owner/repo`. Credentials are resolved from the active
+    /// environment credential or Heddle's credential store.
+    pub async fn connect(server: &str) -> Result<Self, RepoEventError> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let target = RemoteTarget::parse_native(server).map_err(RepoEventError::InvalidServer)?;
+        let RemoteTarget::Network { addr, .. } = target else {
+            return Err(RepoEventError::LocalServer);
+        };
+        let server_key = cli_shared::remote::credential_key_from_remote_url(server);
+        let user_config = UserConfig::load_default()
+            .map_err(|error| RepoEventError::Configuration(error.to_string()))?;
+        let session =
+            HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)
+                .map_err(|error| RepoEventError::Configuration(error.to_string()))?;
+        let client = session
+            .connect(addr)
+            .await
+            .map_err(|error| RepoEventError::Connection(error.to_string()))?;
+        Ok(Self { client })
+    }
+
+    /// Subscribe with the API-owned request shape used on the wire.
+    ///
+    /// A positive `after_event_id` first replays persisted matching events
+    /// after that ID, then continues with live events. A non-positive cursor
+    /// replays the available matching history before live delivery.
+    pub async fn subscribe(
+        &self,
+        request: SubscribeRepoEventsRequest,
+    ) -> Result<RepoEventSubscription, RepoEventError> {
+        let last_event_id = request.after_event_id.max(0);
+        let stream = self
+            .client
+            .routes()
+            .subscribe_repo_events(&request)
+            .await
+            .map_err(|source| RepoEventError::Disconnected {
+                last_event_id,
+                source,
+            })?;
+        Ok(RepoEventSubscription {
+            request,
+            stream,
+            last_event_id,
+        })
+    }
+
+    /// Gracefully close the native connection.
+    pub async fn close(self) {
+        self.client.close().await;
+    }
+
+    #[cfg(test)]
+    fn from_hosted_client(client: HostedClient) -> Self {
+        Self { client }
+    }
+}
+
+/// One long-lived repository-event stream and its durable resume cursor.
+pub struct RepoEventSubscription {
+    request: SubscribeRepoEventsRequest,
+    stream: ServerStream<RepoEvent>,
+    last_event_id: i64,
+}
+
+impl RepoEventSubscription {
+    /// Receive the next wire event.
+    ///
+    /// Unlike a generic optional stream, clean EOF is an error because hosted
+    /// repository-event subscriptions are long-lived. A connection failure is
+    /// also returned immediately; neither case silently leaves a consumer
+    /// waiting on a dead channel.
+    pub async fn next(&mut self) -> Result<RepoEvent, RepoEventError> {
+        match self.stream.next().await {
+            Ok(Some(event)) => {
+                self.last_event_id = self.last_event_id.max(event.event_id);
+                Ok(event)
+            }
+            Ok(None) => Err(RepoEventError::Ended {
+                last_event_id: self.last_event_id,
+            }),
+            Err(source) if is_refusal(&source) => Err(RepoEventError::Refused { source }),
+            Err(source) => Err(RepoEventError::Disconnected {
+                last_event_id: self.last_event_id,
+                source,
+            }),
+        }
+    }
+
+    /// Last event ID successfully returned by [`Self::next`].
+    pub fn last_event_id(&self) -> i64 {
+        self.last_event_id
+    }
+
+    /// Clone the original wire request with its durable cursor advanced.
+    pub fn resume_request(&self) -> SubscribeRepoEventsRequest {
+        let mut request = self.request.clone();
+        request.after_event_id = self.last_event_id;
+        request
+    }
+}
+
+fn is_refusal(error: &HostedError) -> bool {
+    matches!(
+        error,
+        HostedError::Call {
+            code: CallFailureCode::Unauthenticated
+                | CallFailureCode::PermissionDenied
+                | CallFailureCode::NotFound,
+            ..
+        }
+    )
+}
+
+#[cfg(test)]
+#[path = "repo_events_tests.rs"]
+mod tests;

--- a/crates/cli/src/client/repo_events_tests.rs
+++ b/crates/cli/src/client/repo_events_tests.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{net::Ipv4Addr, time::Duration};
+
+use api::{
+    framing::{encode_stream_failure, encode_stream_message},
+    heddle::api::v1alpha1::{CallFailure, CallFailureCode},
+};
+use iroh::{Endpoint, RelayMode, endpoint::presets};
+use prost::Message as _;
+use tokio::sync::oneshot;
+
+use super::{RepoEvent, RepoEventClient, RepoEventError, SubscribeRepoEventsRequest};
+use crate::hosted_runtime::hosted::{CallContextFactory, HostedClient};
+
+fn request() -> SubscribeRepoEventsRequest {
+    SubscribeRepoEventsRequest {
+        repo_id: "00000000-0000-0000-0000-000000000001".to_string(),
+        thread: "main".to_string(),
+        after_event_id: 40,
+        event_types: vec!["ref.updated".to_string()],
+    }
+}
+
+async fn client_for(server: iroh::EndpointAddr) -> RepoEventClient {
+    let endpoint = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let hosted =
+        HostedClient::connect_addr_with_context(endpoint, server, CallContextFactory::default())
+            .await
+            .unwrap();
+    RepoEventClient::from_hosted_client(hosted)
+}
+
+async fn receive_request(connection: &iroh::endpoint::Connection) -> iroh::endpoint::SendStream {
+    let (send, mut recv) = connection.accept_bi().await.unwrap();
+    recv.read_to_end(64 * 1024).await.unwrap();
+    send
+}
+
+#[tokio::test]
+async fn killing_connection_mid_stream_returns_resumable_error_instead_of_hanging() {
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let (event_received_tx, event_received_rx) = oneshot::channel();
+    let server_addr = server.addr();
+    let server_task = tokio::spawn(async move {
+        let connection = server.accept().await.unwrap().await.unwrap();
+        let mut send = receive_request(&connection).await;
+        let event = RepoEvent {
+            event_id: 41,
+            repo_id: "00000000-0000-0000-0000-000000000001".to_string(),
+            event_type: "ref.updated".to_string(),
+            thread: "main".to_string(),
+            ..RepoEvent::default()
+        };
+        send.write_all(&encode_stream_message(&event.encode_to_vec()).unwrap())
+            .await
+            .unwrap();
+        event_received_rx.await.unwrap();
+        connection.close(42u32.into(), b"connection killed by test");
+        server.close().await;
+    });
+
+    let client = client_for(server_addr).await;
+    let mut subscription = client.subscribe(request()).await.unwrap();
+    let event = tokio::time::timeout(Duration::from_secs(2), subscription.next())
+        .await
+        .expect("live event must not hang")
+        .unwrap();
+    assert_eq!(event.event_id, 41);
+    event_received_tx.send(()).unwrap();
+
+    let error = tokio::time::timeout(Duration::from_secs(2), subscription.next())
+        .await
+        .expect("a killed connection must not silently hang")
+        .expect_err("a killed connection must be an explicit error");
+    assert!(matches!(
+        &error,
+        RepoEventError::Disconnected {
+            last_event_id: 41,
+            ..
+        }
+    ));
+    assert_eq!(error.resume_after_event_id(), Some(41));
+    assert_eq!(subscription.resume_request().after_event_id, 41);
+    server_task.await.unwrap();
+    client.close().await;
+}
+
+#[tokio::test]
+async fn unreadable_repository_subscription_is_refused() {
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let server_addr = server.addr();
+    let server_task = tokio::spawn(async move {
+        let connection = server.accept().await.unwrap().await.unwrap();
+        let mut send = receive_request(&connection).await;
+        let failure = CallFailure {
+            code: CallFailureCode::PermissionDenied as i32,
+            message: "access denied".to_string(),
+            error: None,
+        };
+        send.write_all(&encode_stream_failure(&failure).unwrap())
+            .await
+            .unwrap();
+        send.finish().unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let client = client_for(server_addr).await;
+    let mut subscription = client.subscribe(request()).await.unwrap();
+    let error = tokio::time::timeout(Duration::from_secs(2), subscription.next())
+        .await
+        .expect("permission denial must not look like an empty stream")
+        .expect_err("an unreadable repository must be refused");
+    assert!(matches!(
+        &error,
+        RepoEventError::Refused {
+            source: super::HostedError::Call {
+                code: CallFailureCode::PermissionDenied,
+                ..
+            }
+        }
+    ));
+    assert!(error.to_string().contains("subscription was refused"));
+    client.close().await;
+    server_task.await.unwrap();
+}

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -175,6 +175,7 @@ pub const SAFE_AGENT_OPERATIONS: &[&str] = &[
     "GetDiff",
     "GetSemanticHotSpots",
     "ListActions",
+    "SubscribeRepoEvents",
     // Context reads and writes.
     "ListContext",
     "GetContextHistory",
@@ -209,6 +210,7 @@ const TEMPLATE_READ_OPERATIONS: &[&str] = &[
     "GetDiff",
     "GetSemanticHotSpots",
     "ListActions",
+    "SubscribeRepoEvents",
     "ListContext",
     "GetContextHistory",
     "ListContextSuggestions",

--- a/crates/cli/src/hosted_runtime/hosted/context.rs
+++ b/crates/cli/src/hosted_runtime/hosted/context.rs
@@ -176,6 +176,16 @@ impl CallContextFactory {
         self.base(method, client_operation_id.into())
     }
 
+    pub(super) fn long_lived_streaming(
+        &self,
+        method: &str,
+        client_operation_id: impl Into<String>,
+    ) -> Result<CallContext> {
+        let mut context = self.streaming(method, client_operation_id)?;
+        context.deadline = None;
+        Ok(context)
+    }
+
     pub fn stream_opening_proof(
         &self,
         method: &str,
@@ -457,5 +467,16 @@ mod tests {
         );
         Ed25519Signer::verify_with_public_key(&canonical, signer.public_key(), &proof.signature)
             .unwrap();
+    }
+
+    #[test]
+    fn long_lived_streaming_context_has_no_rpc_deadline() {
+        let context = CallContextFactory::default()
+            .long_lived_streaming(
+                "/heddle.api.v1alpha1.RepositoryService/SubscribeRepoEvents",
+                "",
+            )
+            .unwrap();
+        assert!(context.deadline.is_none());
     }
 }

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -355,6 +355,18 @@ impl HostedRoutes<'_> {
             .await
     }
 
+    pub async fn subscribe_repo_events(
+        &self,
+        request: &SubscribeRepoEventsRequest,
+    ) -> Result<ServerStream<RepoEvent>> {
+        self.client
+            .call_long_lived_server_stream(
+                "/heddle.api.v1alpha1.RepositoryService/SubscribeRepoEvents",
+                request,
+            )
+            .await
+    }
+
     pub async fn push(
         &self,
         client_operation_id: impl Into<String>,
@@ -401,7 +413,7 @@ mod tests {
     };
 
     #[test]
-    fn shipped_native_inventory_is_43_unary_one_server_stream_and_two_bidi() {
+    fn shipped_native_inventory_is_43_unary_two_server_streams_and_two_bidi() {
         const ROUTES: &[MethodRoute] = &[
             MethodRoute::CollaborationServiceAppendTurn,
             MethodRoute::CollaborationServiceListByState,
@@ -443,6 +455,7 @@ mod tests {
             MethodRoute::RepositoryServiceListContextSuggestions,
             MethodRoute::RepositoryServiceReviseContext,
             MethodRoute::RepositoryServiceSetContext,
+            MethodRoute::RepositoryServiceSubscribeRepoEvents,
             MethodRoute::RepositoryServiceSupersedeContext,
             MethodRoute::StateReviewServiceSignState,
             MethodRoute::WorkflowServiceApproveThread,
@@ -459,7 +472,7 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(shipped.len(), 46);
+        assert_eq!(shipped.len(), 47);
         assert_eq!(
             shipped
                 .iter()
@@ -472,7 +485,7 @@ mod tests {
                 .iter()
                 .filter(|method| method.streaming == StreamingShape::ServerStreaming)
                 .count(),
-            1
+            2
         );
         assert_eq!(
             shipped

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -414,6 +414,19 @@ impl HostedClient {
         call::server_stream(self.connection.clone(), method, &context, request).await
     }
 
+    pub(super) async fn call_long_lived_server_stream<Request, Response>(
+        &self,
+        method: &str,
+        request: &Request,
+    ) -> Result<ServerStream<Response>>
+    where
+        Request: Message,
+        Response: Message + Default,
+    {
+        let context = self.context.long_lived_streaming(method, "")?;
+        call::server_stream(self.connection.clone(), method, &context, request).await
+    }
+
     pub async fn call_bidirectional<Request, Response>(
         &self,
         method: &str,

--- a/crates/cli/src/hosted_runtime/mod.rs
+++ b/crates/cli/src/hosted_runtime/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod whoami;
 
 pub(crate) use auth::cmd_auth;
 pub(crate) use hosted::{
-    HostedAuthMode, HostedClient, HostedSession, resolve_active_bearer, resolve_hosted_credential,
+    HostedAuthMode, HostedClient, HostedSession, ServerStream, resolve_active_bearer,
+    resolve_hosted_credential,
 };
 pub(crate) use websocket::connect_websocket;

--- a/docs/migrations/0.11-hosted-runtime.md
+++ b/docs/migrations/0.11-hosted-runtime.md
@@ -9,14 +9,16 @@ dependency or supported integration surface.
 | Before 0.11 | Heddle 0.11 owner |
 |---|---|
 | `heddle-client::credentials` store, schema, resolution, permissions, and atomic persistence | `heddle-cli-shared::credentials` |
-| Native hosted session, Iroh connection/runtime, provider-plan negotiation, bounded concurrent download, positional assembly, resume, verification, and fallback | private `heddle-cli::hosted_runtime` module |
+| Native hosted session, Iroh connection/runtime, provider-plan negotiation, bounded concurrent download, positional assembly, resume, verification, and fallback | private `heddle-cli::hosted_runtime` module, with the narrow supported repo-event surface at `heddle-cli::client::repo_events` |
 | Authentication device flow, `.hcred` verification, WebSocket status, and `whoami` command behavior | private `heddle-cli::hosted_runtime` module |
 | Public protocol types, method descriptors, canonical request/provider-plan signing bytes, and framing identities | `heddle-api` 0.2.1 |
 | Unused owner-authorization prototype and unused support/presence exports | removed; hosted/server policy stays in Weft |
 
 `heddle-api` does not gain a transport, credential store, downloader, Iroh
-dependency, or CLI policy. Consumers that need a protocol transport implement
-one against the API-owned method, framing, and signing contracts.
+dependency, or CLI policy. Consumers of hosted repository events use
+`heddle-cli::client::repo_events`; other consumers that need a protocol
+transport implement one against the API-owned method, framing, and signing
+contracts.
 
 The workspace intentionally remains on `heddle-api` 0.2.1. The relocated
 runtime uses only contracts already present in that release; the physical


### PR DESCRIPTION
## Summary

- Confirmed the transport gap described by the issue is already closed: `heddle-api` owns the `SubscribeRepoEventsRequest` / `RepoEvent` wire vocabulary and route descriptor, Heddle's private hosted runtime can already cross the verified descriptor + native Iroh transport, and Weft now serves `SubscribeRepoEvents` with durable catch-up before live delivery.
- Add the genuinely missing supported surface at `cli::client::repo_events`: standard Heddle credential resolution, the API-owned request/event types unchanged, a typed subscription, and an executable public-only example. This belongs in the client library; a second CLI/NDJSON command would add another output contract without being needed by Rust consumers.
- Make repository subscriptions genuinely long-lived by omitting the ordinary 30-second unary/finite-stream deadline for this route only. Disconnects and unexpected EOF fail loudly with the last delivered event ID; callers reconnect and pass `resume_request()` to replay persisted events after that cursor without a gap.
- Admit `SubscribeRepoEvents` to the read-only derived-agent operation ceiling so scoped agent credentials can use the new client API.

## Closes

Closes #1183

## Test evidence

- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib -- --nocapture` — 592 passed.
- `TMPDIR=/home/scratch cargo clippy -p heddle-cli --all-targets -- -D warnings` — passed.
- `TMPDIR=/home/scratch cargo build -p heddle-cli --all-targets` — passed.
- `TMPDIR=/home/scratch cargo check -p heddle-cli --no-default-features --features git-overlay,native,semantic,zstd --lib` — passed; emitted four existing unused/dead-code warnings in the slim feature set.
- `TMPDIR=/home/scratch rustfmt +nightly --edition 2024` on touched Rust files only, plus `git diff --check` — passed.
- Public-only real client: built and ran `crates/cli/examples/repo_events.rs` against the running TLS + native-Iroh Weft development stack. A subscription established at the current cursor received live event `81` with actor `heddle-1183-real-client` and payload `{"evidence":"heddle-1183-live-after-deadline-fix"}`. Reconnecting from cursor `79` replayed persisted event `80`, proving the documented resume path crosses the real transport.
- Connection-kill negative, by name: `killing_connection_mid_stream_returns_resumable_error_instead_of_hanging` closes the real Iroh connection after event `41`; `next()` returns `RepoEventError::Disconnected { last_event_id: 41, .. }` within two seconds and `resume_request().after_event_id == 41`.
- Authorization negative, by name: the public example used a root-signed, PoP-bound non-staff credential for a real user with no grant on `org/issue929-topology-d/protocol`; Weft returned `PERMISSION_DENIED: reader access required`, surfaced as `RepoEventError::Refused`. `unreadable_repository_subscription_is_refused` pins the typed client behavior.
- The temporary live events, no-read user/session, and credential files were removed after verification. No Weft source was modified.
- `RUSTDOCFLAGS='-D warnings' TMPDIR=/home/scratch cargo doc -p heddle-cli --no-deps` remains blocked by the pre-existing broken intra-doc link `objects::object::state_review::signing_payload` in `crates/cli/src/client/review_sync.rs:13`; this change does not touch that module.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788218469&installation_model_id=21489&pr_number=1195&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1195&signature=a295ac20f881da25d14769fe2972ea43fe7577df306559690bf9588962f29c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->