### PR TITLE
fix(cli): make clone JSON disconnects terminal

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -67,7 +67,6 @@ fn main() -> Result<()> {
     }));
     match result {
         Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) if is_broken_pipe_error(&error) => Ok(()),
         Ok(Err(error)) => Err(error),
         Err(payload) if is_broken_pipe_panic(payload.as_ref()) => Ok(()),
         Err(payload) => std::panic::resume_unwind(payload),
@@ -822,7 +821,7 @@ async fn async_main() -> Result<()> {
     if profile {
         let exit_status = match &result {
             Ok(()) => 0,
-            Err(err) if is_broken_pipe_error(err) => 0,
+            Err(err) if !explicit_json_requested(&cli) && is_broken_pipe_error(err) => 0,
             Err(err) => HeddleExitCode::from_error(err).into(),
         };
         emit_command_profile(
@@ -840,7 +839,10 @@ async fn async_main() -> Result<()> {
     telemetry.shutdown();
     match result {
         Ok(()) => Ok(()),
-        Err(err) if is_broken_pipe_error(&err) => Ok(()),
+        // Machine output must end in a terminal record or a structured error.
+        // Never confuse a transport's BrokenPipe with a consumer closing
+        // stdout; JSON writers already handle the latter at the write site.
+        Err(err) if !explicit_json_requested(&cli) && is_broken_pipe_error(&err) => Ok(()),
         Err(err) => {
             let code = HeddleExitCode::from_error(&err);
             // OutcomeExit means the command already rendered its report
@@ -1028,7 +1030,6 @@ fn is_broken_pipe_error(error: &anyhow::Error) -> bool {
     error
         .downcast_ref::<std::io::Error>()
         .is_some_and(|io| io.kind() == std::io::ErrorKind::BrokenPipe)
-        || error.to_string().contains("Broken pipe")
 }
 
 fn is_broken_pipe_panic(payload: &(dyn Any + Send)) -> bool {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -266,6 +266,8 @@ mod basics;
 mod cli_help_consistency;
 #[path = "cli_integration/cli_premium_output.rs"]
 mod cli_premium_output;
+#[path = "cli_integration/clone_output_contract.rs"]
+mod clone_output_contract;
 #[path = "cli_integration/compact_output.rs"]
 mod compact_output;
 #[path = "cli_integration/context_recovery_advice.rs"]

--- a/crates/cli/tests/cli_integration/clone_output_contract.rs
+++ b/crates/cli/tests/cli_integration/clone_output_contract.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+#![cfg(feature = "client")]
+
+mod fixture {
+    use std::{
+        collections::{HashMap, VecDeque},
+        io::{Read, Write},
+        net::{TcpListener, TcpStream},
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    use api::{
+        HOSTED_ALPN_V1,
+        framing::encode_failure_response,
+        heddle::api::v1alpha1::{
+            CallFailure, CallFailureCode, EndpointDescriptor, SignedEndpointDescriptor,
+        },
+        signing::endpoint_descriptor_bytes,
+    };
+    use crypto::{Ed25519Signer, Signer};
+    use iroh::{Endpoint, RelayMode, endpoint::presets};
+    use prost::Message;
+    use rcgen::{CertifiedKey, generate_simple_self_signed};
+    use rustls::{
+        ServerConfig, ServerConnection, StreamOwned,
+        pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+    };
+    use serde_json::Value;
+    use tempfile::TempDir;
+
+    use super::super::heddle_output_with_env;
+
+    const DESCRIPTOR_PATH: &str = "/.well-known/heddle/iroh-endpoint";
+
+    #[test]
+    fn clone_json_peer_disconnect_after_connection_emits_structured_error() {
+        let temp = TempDir::new().expect("create clone contract fixture root");
+        let (endpoint_id, direct_address, iroh_thread) = disconnecting_iroh_server();
+        let signer = Ed25519Signer::generate().expect("generate descriptor signer");
+        let descriptor = signed_descriptor(&endpoint_id, &direct_address, &signer);
+        let https = TestHttpsServer::start(HashMap::from([(
+            DESCRIPTOR_PATH.to_string(),
+            VecDeque::from([descriptor]),
+        )]));
+        let certificate = temp.path().join("descriptor-ca.pem");
+        std::fs::write(&certificate, &https.certificate_pem).expect("write descriptor test CA");
+        let destination = temp.path().join("clone");
+        let remote = format!("heddle://{}/owner/repo", https.authority);
+        let descriptor_public_key = hex::encode(signer.public_key());
+        let heddle_home = temp.path().join("heddle-home");
+
+        let output = heddle_output_with_env(
+            &[
+                "--output",
+                "json",
+                "clone",
+                &remote,
+                destination.to_str().expect("UTF-8 destination"),
+            ],
+            Some(temp.path()),
+            &[
+                (
+                    "HEDDLE_REMOTE_TLS_CA_CERT",
+                    certificate.to_str().expect("UTF-8 CA path"),
+                ),
+                ("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID", "clone-test-key"),
+                (
+                    "HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY",
+                    &descriptor_public_key,
+                ),
+                ("HEDDLE_HOME", heddle_home.to_str().expect("UTF-8 home")),
+            ],
+        )
+        .expect("invoke clone against disconnecting fixture");
+
+        iroh_thread.join().expect("disconnecting Iroh server exits");
+        assert!(
+            !output.status.success(),
+            "mid-clone peer disconnect must exit non-zero\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert_eq!(output.status.code(), Some(75));
+        let records = String::from_utf8(output.stdout).expect("clone stdout is UTF-8");
+        let records = records
+            .lines()
+            .map(|line| serde_json::from_str::<Value>(line).expect("clone stdout record is JSON"))
+            .collect::<Vec<_>>();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0]["output_kind"], "clone_connection");
+        assert_eq!(records[0]["status"], "connected");
+
+        let error: Value = serde_json::from_slice(&output.stderr)
+            .expect("mid-clone disconnect must emit a structured JSON error");
+        assert_eq!(error["exit_code"], output.status.code().unwrap());
+        assert!(
+            error["error"]
+                .as_str()
+                .is_some_and(|message| message.contains("Broken pipe")),
+            "error envelope must retain the peer disconnect: {error}"
+        );
+        assert!(!destination.exists());
+    }
+
+    fn disconnecting_iroh_server() -> (String, String, thread::JoinHandle<()>) {
+        let (ready_tx, ready_rx) = mpsc::sync_channel(1);
+        let thread = thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("build Iroh fixture runtime");
+            runtime.block_on(async move {
+                let endpoint = Endpoint::builder(presets::Minimal)
+                    .alpns(vec![HOSTED_ALPN_V1.to_vec()])
+                    .relay_mode(RelayMode::Disabled)
+                    .bind_addr((std::net::Ipv4Addr::LOCALHOST, 0))
+                    .expect("bind Iroh fixture address")
+                    .bind()
+                    .await
+                    .expect("start Iroh fixture endpoint");
+                let address = endpoint.addr();
+                let direct = address
+                    .ip_addrs()
+                    .next()
+                    .expect("fixture endpoint has a direct address")
+                    .to_string();
+                ready_tx
+                    .send((endpoint.id().to_string(), direct))
+                    .expect("publish Iroh fixture address");
+
+                let incoming = endpoint.accept().await.expect("accept clone connection");
+                let connection = incoming.await.expect("complete clone connection");
+                let (mut send, _recv) = connection.accept_bi().await.expect("accept ListRefs RPC");
+                let failure = encode_failure_response(&CallFailure {
+                    code: CallFailureCode::Unavailable as i32,
+                    message: "Broken pipe".to_string(),
+                    error: None,
+                })
+                .expect("encode disconnect failure");
+                send.write_all(&failure)
+                    .await
+                    .expect("send disconnect failure");
+                send.finish().expect("finish disconnect response");
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                connection.close(1_u32.into(), b"Broken pipe");
+                connection.closed().await;
+                endpoint.close().await;
+            });
+        });
+        let (endpoint_id, direct_address) = ready_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("Iroh fixture starts");
+        (endpoint_id, direct_address, thread)
+    }
+
+    fn signed_descriptor(
+        endpoint_id: &str,
+        direct_address: &str,
+        signer: &Ed25519Signer,
+    ) -> Vec<u8> {
+        let now = chrono::Utc::now().timestamp_millis();
+        let descriptor = EndpointDescriptor {
+            version: 1,
+            endpoint_id: endpoint_id.to_string(),
+            relay_urls: Vec::new(),
+            direct_addresses: vec![direct_address.to_string()],
+            supported_alpns: vec![HOSTED_ALPN_V1.to_vec()],
+            issued_at_unix_millis: now - 1_000,
+            expires_at_unix_millis: now + 60_000,
+            rotation: None,
+        };
+        SignedEndpointDescriptor {
+            signature: signer
+                .sign(&endpoint_descriptor_bytes(&descriptor))
+                .expect("sign fixture endpoint descriptor"),
+            descriptor: Some(descriptor),
+            key_id: "clone-test-key".to_string(),
+        }
+        .encode_to_vec()
+    }
+
+    struct TestHttpsServer {
+        authority: String,
+        certificate_pem: String,
+        stop: Arc<AtomicBool>,
+        thread: Option<thread::JoinHandle<()>>,
+    }
+
+    impl TestHttpsServer {
+        fn start(routes: HashMap<String, VecDeque<Vec<u8>>>) -> Self {
+            let CertifiedKey { cert, signing_key } =
+                generate_simple_self_signed(vec!["127.0.0.1".to_string()])
+                    .expect("generate test TLS certificate");
+            let certificate_pem = cert.pem();
+            let private_key =
+                PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+            let tls = Arc::new(
+                ServerConfig::builder()
+                    .with_no_client_auth()
+                    .with_single_cert(vec![cert.der().clone()], private_key)
+                    .expect("configure test HTTPS server"),
+            );
+            let listener =
+                TcpListener::bind(("127.0.0.1", 0)).expect("bind endpoint descriptor HTTPS server");
+            listener
+                .set_nonblocking(true)
+                .expect("make endpoint descriptor listener nonblocking");
+            let authority = listener.local_addr().expect("HTTPS address").to_string();
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = Arc::clone(&stop);
+            let routes = Arc::new(Mutex::new(routes));
+            let thread = thread::spawn(move || {
+                while !thread_stop.load(Ordering::Acquire) {
+                    match listener.accept() {
+                        Ok((stream, _)) => {
+                            serve_https(stream, Arc::clone(&tls), Arc::clone(&routes))
+                        }
+                        Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                            thread::sleep(Duration::from_millis(2));
+                        }
+                        Err(error) => panic!("endpoint descriptor HTTPS accept failed: {error}"),
+                    }
+                }
+            });
+            Self {
+                authority,
+                certificate_pem,
+                stop,
+                thread: Some(thread),
+            }
+        }
+    }
+
+    impl Drop for TestHttpsServer {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::Release);
+            if let Some(thread) = self.thread.take() {
+                thread
+                    .join()
+                    .expect("endpoint descriptor HTTPS server exits");
+            }
+        }
+    }
+
+    fn serve_https(
+        stream: TcpStream,
+        tls: Arc<ServerConfig>,
+        routes: Arc<Mutex<HashMap<String, VecDeque<Vec<u8>>>>>,
+    ) {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set endpoint descriptor read timeout");
+        let connection = ServerConnection::new(tls).expect("create test TLS connection");
+        let mut stream = StreamOwned::new(connection, stream);
+        let mut request = Vec::new();
+        let mut chunk = [0_u8; 1024];
+        while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+            let count = match stream.read(&mut chunk) {
+                Ok(count) => count,
+                Err(_) => return,
+            };
+            if count == 0 {
+                return;
+            }
+            request.extend_from_slice(&chunk[..count]);
+        }
+        let request = String::from_utf8_lossy(&request);
+        let path = request
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .unwrap_or("/");
+        let body = routes
+            .lock()
+            .expect("lock endpoint descriptor routes")
+            .get_mut(path)
+            .and_then(VecDeque::pop_front)
+            .unwrap_or_default();
+        let status = if body.is_empty() {
+            "404 Not Found"
+        } else {
+            "200 OK"
+        };
+        let response = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: application/protobuf\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream
+            .write_all(response.as_bytes())
+            .and_then(|_| stream.write_all(&body))
+            .and_then(|_| stream.flush());
+    }
+}


### PR DESCRIPTION
## Summary

- Never classify a command failure as a harmless closed stdout pipe when `--output json` or `--output json-compact` was explicitly requested; machine invocations now reach the structured error renderer and retain their typed non-zero exit.
- Add a local signed-descriptor/Iroh fixture that emits `clone_connection`, fails the first clone RPC with an unavailable `Broken pipe`, and closes the connection. The test also proves no destination is created.
- Push and pull do not emit preliminary connection records; clone and recursive clone are the current intermediate-record paths. The guard is enforced at the shared command boundary, so all explicit JSON verbs receive the same protection.

## Closes

Closes #1193

## Test evidence

Before the fix, the named regression failed with exit 0:

```text
stdout: {"address":"127.0.0.1:42049","output_kind":"clone_connection","status":"connected"}
stderr:
destination: absent
```

After the fix, the same fixture exits 75:

```text
stdout: {"address":"127.0.0.1:38453","output_kind":"clone_connection","status":"connected"}
stderr: {"error":"remote failure (Unavailable): Broken pipe","exit_code":75,...,"kind":"runtime_error",...}
destination: absent
```

Successful clone remains unchanged: `test_cli_clone_local_attaches_head_to_cloned_thread` emits terminal `output_kind: "clone"`, creates and materializes the destination, attaches `HEAD`, and reports clean status.

- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration clone_json_peer_disconnect_after_connection_emits_structured_error`
- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration test_cli_clone_local_attaches_head_to_cloned_thread -- --nocapture`
- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration tolerate_closed_downstream_pipes -- --nocapture`
- `TMPDIR=/home/scratch cargo test -p heddle-cli --test cli_integration` — 886 passed, 0 failed, 19 ignored
- `TMPDIR=/home/scratch cargo test -p heddle-cli --lib --bins` — 594 passed, 0 failed
- `TMPDIR=/home/scratch cargo build -p heddle-cli`
- `TMPDIR=/home/scratch cargo clippy -p heddle-cli --tests -- -D warnings`
- `rustfmt +nightly --edition 2024 --check` on touched Rust files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788224652&installation_model_id=21489&pr_number=1196&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1196&signature=c9ff3501011d8e409b2d16d63893d61ca63756d66d32332e0e08ae604907cab5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->