### PR TITLE
fix(auth): make device approval timeout actionable

### DIFF
--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -5,9 +5,9 @@ use std::{collections::BTreeSet, path::Path};
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
     CreateDeviceAuthorizationRequest, CreateServiceAccountRequest, DeviceAuthProof,
-    DeviceAuthorizationResponse, DeviceAuthorizationStatus, ExchangeDeviceAuthorizationRequest,
-    IssueServiceAccountCredentialRequest, MintBiscuitRequest, WaitForDeviceAuthorizationRequest,
-    mint_biscuit_request::Proof,
+    DeviceAuthorizationEvent, DeviceAuthorizationResponse, DeviceAuthorizationStatus,
+    ExchangeDeviceAuthorizationRequest, IssueServiceAccountCredentialRequest, MintBiscuitRequest,
+    WaitForDeviceAuthorizationRequest, mint_biscuit_request::Proof,
 };
 use cli_shared::{UserConfig, credentials, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer};
@@ -1173,17 +1173,17 @@ async fn poll_for_approval(
         .as_ref()
         .map(|t| t.seconds.max(0) as u64)
         .unwrap_or(0);
-    let deadline = std::time::Instant::now()
-        + std::time::Duration::from_secs(
-            expires_at_secs
-                .saturating_sub(
-                    std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_secs(),
-                )
-                .max(30),
-        );
+    let wait_budget = std::time::Duration::from_secs(
+        expires_at_secs
+            .saturating_sub(
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs(),
+            )
+            .max(30),
+    );
+    let deadline = std::time::Instant::now() + wait_budget;
 
     let mut events = client
         .routes()
@@ -1196,13 +1196,11 @@ async fn poll_for_approval(
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
-            bail!("Authorization timed out. Please try again.");
+            return Err(device_authorization_wait_timeout(wait_budget));
         }
 
-        let event = tokio::time::timeout(remaining, events.next())
-            .await
-            .map_err(|_| anyhow::anyhow!("Authorization timed out. Please try again."))?
-            .map_err(|error| anyhow::anyhow!("device authorization wait failed: {error}"))?;
+        let event =
+            wait_for_device_authorization_event(events.next(), remaining, wait_budget).await?;
 
         match event.map(|status| status.status()) {
             Some(DeviceAuthorizationStatus::Pending) => continue,
@@ -1227,6 +1225,45 @@ async fn poll_for_approval(
         }
         Err(error) => Err(anyhow::anyhow!("device authorization failed: {error}")),
     }
+}
+
+async fn wait_for_device_authorization_event(
+    event: impl std::future::Future<
+        Output = std::result::Result<Option<DeviceAuthorizationEvent>, HostedError>,
+    >,
+    remaining: std::time::Duration,
+    wait_budget: std::time::Duration,
+) -> Result<Option<DeviceAuthorizationEvent>> {
+    tokio::time::timeout(remaining, event)
+        .await
+        .map_err(|_| device_authorization_wait_timeout(wait_budget))?
+        .map_err(|error| device_authorization_wait_stream_error(error, wait_budget))
+}
+
+fn device_authorization_wait_timeout(wait_budget: std::time::Duration) -> anyhow::Error {
+    anyhow::anyhow!(
+        "device authorization approval wait exceeded its {}s authorization-expiry budget; please run `heddle auth login` again",
+        wait_budget.as_secs()
+    )
+}
+
+fn device_authorization_wait_stream_error(
+    error: HostedError,
+    wait_budget: std::time::Duration,
+) -> anyhow::Error {
+    if matches!(
+        error,
+        HostedError::Call {
+            code: api::heddle::api::v1alpha1::CallFailureCode::DeadlineExceeded,
+            ..
+        }
+    ) {
+        return anyhow::anyhow!(
+            "device authorization approval stream returned DeadlineExceeded before its {}s authorization-expiry budget elapsed: {error}",
+            wait_budget.as_secs()
+        );
+    }
+    anyhow::anyhow!("device authorization approval stream failed: {error}")
 }
 
 async fn mint_biscuit_with_device_auth(
@@ -1538,6 +1575,41 @@ mod tests {
             .is_err(),
             "signature must commit to the device code",
         );
+    }
+
+    #[tokio::test]
+    async fn device_authorization_timeout_names_stage_and_budget() {
+        let wait_budget = std::time::Duration::from_secs(42);
+        let error = wait_for_device_authorization_event(
+            std::future::pending::<
+                std::result::Result<Option<DeviceAuthorizationEvent>, HostedError>,
+            >(),
+            std::time::Duration::from_millis(1),
+            wait_budget,
+        )
+        .await
+        .expect_err("the deliberately stalled authorization wait must time out");
+
+        assert_eq!(
+            error.to_string(),
+            "device authorization approval wait exceeded its 42s authorization-expiry budget; please run `heddle auth login` again"
+        );
+    }
+
+    #[test]
+    fn early_remote_deadline_names_stage_and_budget() {
+        let error = device_authorization_wait_stream_error(
+            HostedError::Call {
+                code: api::heddle::api::v1alpha1::CallFailureCode::DeadlineExceeded,
+                message: "call deadline has elapsed".to_string(),
+                error: None,
+            },
+            std::time::Duration::from_secs(600),
+        );
+
+        assert!(error.to_string().contains(
+            "device authorization approval stream returned DeadlineExceeded before its 600s authorization-expiry budget elapsed"
+        ));
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -347,10 +347,9 @@ impl HostedRoutes<'_> {
         request: &WaitForDeviceAuthorizationRequest,
     ) -> Result<ServerStream<DeviceAuthorizationEvent>> {
         self.client
-            .call_server_stream(
+            .call_long_lived_server_stream(
                 "/heddle.api.v1alpha1.IdentityService/WaitForDeviceAuthorization",
                 request,
-                "",
             )
             .await
     }


### PR DESCRIPTION
## Summary

- re-examined #1164 against pilot weft `d84c22270c890909259d4a22db35e8a3eb13b269` (image `sha256:2a3badc22e4b58c11b122d70c06c922a49cca9aacc8723a9504290fc4fe43c29`), which contains weft#934
- reproduced the opaque 30-second `DeadlineExceeded` on current Heddle `main` in one live unapproved login attempt
- make `WaitForDeviceAuthorization` a long-lived stream bounded by the server-issued authorization expiry instead of the generic 30-second RPC deadline
- name the approval-wait stage and its exact authorization-expiry budget on both local timeout and premature remote `DeadlineExceeded`

The historical after-approval race was not independently reproduced: the pilot emitted `https://weft.poc.heddle.sh/auth/device`, whose port 443 endpoint was unreachable from this environment, so the live challenge could not be approved. No weft or pilot configuration was changed.

## Before / after evidence

Before (current `main`, live pilot, no approval): after 30 seconds the CLI exited 74 with:

```
Error: device authorization wait failed: hosted call failed with DeadlineExceeded: call deadline has elapsed
```

After this change, the same live flow remained in `Waiting for authorization...` beyond 50 seconds; it was then interrupted deliberately rather than waiting out the full authorization expiry.

A deliberately stalled 1 ms test wait now produces:

```
device authorization approval wait exceeded its 42s authorization-expiry budget; please run `heddle auth login` again
```

The separate early-remote-deadline path reports that `DeadlineExceeded` arrived before the configured authorization-expiry budget elapsed.

## Verification

- `rustfmt +nightly --edition 2024` on both touched Rust files
- `cargo build -p heddle-cli --bin heddle`
- `cargo test -p heddle-cli --lib` — 594 passed
- `cargo test -p heddle-cli --test auth_login` — passed
- both new focused timeout tests — passed
- `cargo clippy -p heddle-cli -- -D warnings` — passed
- `git diff --check` — passed

Closes #1164

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788236977&installation_model_id=21489&pr_number=1197&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1197&signature=3858dec54eb574278753e5d400655e5375895725db714f52ca0879dd99574264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->