### PR TITLE
Expose measured delta-search policy by pack path

### DIFF
--- a/crates/cli/src/bin/heddle-ingest.rs
+++ b/crates/cli/src/bin/heddle-ingest.rs
@@ -220,7 +220,10 @@ fn run_import(
     let (stats, _map) = import_git_into_scoped_with_options(
         git_path,
         heddle_path,
-        ImportOptions { lossy },
+        ImportOptions {
+            lossy,
+            ..ImportOptions::default()
+        },
         ImportScope::refs(refs.to_vec()),
     )?;
     let r = &stats.refs_seen;

--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -207,7 +207,10 @@ fn import_ingest_for_adopt(
     let (stats, _map) = import_git_into_scoped_with_options_and_progress(
         repo.root(),
         repo.root(),
-        ImportOptions::default(),
+        ImportOptions {
+            delta_search: repo.config().storage.delta_search.import,
+            ..ImportOptions::default()
+        },
         scope,
         Some(&mut on_commit),
     )

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -581,7 +581,10 @@ fn finish_git_overlay_clone(
     let (stats, _map) = ingest::import_git_into_scoped_with_options_and_progress(
         local_path,
         local_path,
-        ImportOptions::default(),
+        ImportOptions {
+            delta_search: repo.config().storage.delta_search.import,
+            ..ImportOptions::default()
+        },
         scope,
         Some(&mut on_commit),
     )

--- a/crates/cli/src/cli/commands/gc.rs
+++ b/crates/cli/src/cli/commands/gc.rs
@@ -107,7 +107,8 @@ pub fn cmd_gc(cli: &Cli, prune: bool, aggressive: bool, dry_run: bool) -> Result
             );
         }
     } else {
-        let (packed_count, bytes_saved) = repo.store().pack_objects(aggressive)?;
+        let delta_search = aggressive || repo.config().storage.delta_search.gc;
+        let (packed_count, bytes_saved) = repo.store().pack_objects(delta_search)?;
         summary.packed_count = packed_count;
         summary.bytes_saved = bytes_saved;
 

--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -473,7 +473,10 @@ fn run_git_import(
     };
     let mut progress = ImportProgress::start(cli, repo, &scope, &source_label);
     progress.begin_commit_import();
-    let import_options = ImportOptions { lossy };
+    let import_options = ImportOptions {
+        lossy,
+        delta_search: repo.config().storage.delta_search.import,
+    };
     let mut on_commit = |event| progress.commit_tick(event);
     let source_path = resolved
         .as_ref()

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -454,7 +454,10 @@ fn pull_git_overlay(
     let (stats, mapping) = ingest::import_git_into_scoped_with_options_and_progress(
         repo.root(),
         repo.root(),
-        ingest::ImportOptions::default(),
+        ingest::ImportOptions {
+            delta_search: repo.config().storage.delta_search.import,
+            ..ingest::ImportOptions::default()
+        },
         ingest::ImportScope::refs(vec![staging_ref.clone()]),
         Some(&mut on_import),
     )

--- a/crates/cli/tests/commit_conformance.rs
+++ b/crates/cli/tests/commit_conformance.rs
@@ -49,7 +49,7 @@ fn ingest_into_git_projection(
     source: &Path,
 ) -> Result<(), String> {
     let target = test_support::heddle_repo(git_projection).root();
-    ingest::import_git_into_with_options(source, target, ingest::ImportOptions { lossy: false })
+    ingest::import_git_into_with_options(source, target, ingest::ImportOptions::default())
         .map_err(|error| error.to_string())?;
     test_support::stage_ingest_source_in_mirror(git_projection, source, &[])
         .map_err(|error| error.to_string())?;

--- a/crates/cli/tests/git_projection_engine_integration.rs
+++ b/crates/cli/tests/git_projection_engine_integration.rs
@@ -1085,7 +1085,10 @@ fn import_all_default_fails_on_cached_lossy_commit_from_prior_run() {
     let first = import_all_with_options(
         &mut first_git_projection,
         Some(git_path),
-        ingest::ImportOptions { lossy: true },
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
     )
     .expect("initial lossy Git import succeeds");
     assert_eq!(first.lossy_entries.len(), 1);
@@ -1112,7 +1115,10 @@ fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
     import_all_with_options(
         &mut first_git_projection,
         Some(git_path),
-        ingest::ImportOptions { lossy: true },
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
     )
     .expect("initial lossy Git import succeeds");
 
@@ -1120,7 +1126,10 @@ fn import_all_lossy_reports_cached_lossy_commit_from_prior_run() {
     let second = import_all_with_options(
         &mut rerun_git_projection,
         Some(git_path),
-        ingest::ImportOptions { lossy: true },
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
     )
     .expect("lossy git_projection rerun reports ingest-cached lossy entries");
 
@@ -1174,7 +1183,10 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
             let (first, map) = import_git_into_with_options(
                 git_path,
                 heddle_temp.path(),
-                ImportOptions { lossy: true },
+                ImportOptions {
+                    lossy: true,
+                    ..ImportOptions::default()
+                },
             )
             .expect("initial lossy ingest import succeeds");
             drop(map);
@@ -1191,7 +1203,10 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
             let first = import_all_with_options(
                 &mut first_git_projection,
                 Some(git_path),
-                ingest::ImportOptions { lossy: true },
+                ingest::ImportOptions {
+                    lossy: true,
+                    ..ingest::ImportOptions::default()
+                },
             )
             .expect("initial lossy Git import succeeds");
             assert_eq!(first.lossy_entries.len(), 1);
@@ -1456,7 +1471,10 @@ fn import_all_lossy_clean_repo_reports_no_lossy_entries() {
     let stats = import_all_with_options(
         &mut git_projection,
         Some(git_repo.workdir().expect("workdir").as_path()),
-        ingest::ImportOptions { lossy: true },
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
     )
     .expect("clean repo imports with lossy flag too");
 
@@ -1502,7 +1520,10 @@ fn git_import_lossy_state_carries_canonical_git_lossy_marker() {
     let stats = import_all_with_options(
         &mut git_projection,
         Some(git_temp.path()),
-        ingest::ImportOptions { lossy: true },
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
     )
     .expect("lossy Git import succeeds");
     assert_eq!(stats.lossy_entries.len(), 1);
@@ -1525,9 +1546,15 @@ fn ingest_lossy_state_carries_canonical_git_lossy_marker() {
     let git_path = git_temp.path();
 
     let heddle_temp = TempDir::new().expect("heddle temp");
-    let (stats, map) =
-        import_git_into_with_options(git_path, heddle_temp.path(), ImportOptions { lossy: true })
-            .expect("lossy ingest succeeds");
+    let (stats, map) = import_git_into_with_options(
+        git_path,
+        heddle_temp.path(),
+        ImportOptions {
+            lossy: true,
+            ..ImportOptions::default()
+        },
+    )
+    .expect("lossy ingest succeeds");
     drop(map);
     assert_eq!(stats.lossy_entries.len(), 1);
 
@@ -1553,9 +1580,15 @@ fn export_mints_lossy_ingest_state_from_raw_metadata() {
     let git_path = git_temp.path();
 
     let heddle_temp = TempDir::new().expect("heddle temp");
-    let (stats, map) =
-        import_git_into_with_options(git_path, heddle_temp.path(), ImportOptions { lossy: true })
-            .expect("lossy ingest succeeds");
+    let (stats, map) = import_git_into_with_options(
+        git_path,
+        heddle_temp.path(),
+        ImportOptions {
+            lossy: true,
+            ..ImportOptions::default()
+        },
+    )
+    .expect("lossy ingest succeeds");
     drop(map);
     assert_eq!(stats.lossy_entries.len(), 1);
 

--- a/crates/cli/tests/roundtrip_fidelity.rs
+++ b/crates/cli/tests/roundtrip_fidelity.rs
@@ -32,8 +32,15 @@ fn ingest_into_bridge(
     lossy: bool,
 ) -> Result<(), String> {
     let target = test_support::heddle_repo(bridge).root();
-    ingest::import_git_into_with_options(source, target, ingest::ImportOptions { lossy })
-        .map_err(|error| error.to_string())?;
+    ingest::import_git_into_with_options(
+        source,
+        target,
+        ingest::ImportOptions {
+            lossy,
+            ..ingest::ImportOptions::default()
+        },
+    )
+    .map_err(|error| error.to_string())?;
     test_support::stage_ingest_source_in_mirror(bridge, source, &[])
         .map_err(|error| error.to_string())?;
     test_support::build_existing_mapping(bridge, Some(source)).map_err(|error| error.to_string())

--- a/crates/ingest/src/import_options.rs
+++ b/crates/ingest/src/import_options.rs
@@ -10,6 +10,9 @@ pub struct ImportOptions {
     /// When true, the importer restores the historical drop/convert behavior
     /// and records every affected entry in the import summary.
     pub lossy: bool,
+    /// Use the classic buffered pack builder and its sliding-window delta
+    /// search instead of the bounded-memory streaming builder.
+    pub delta_search: bool,
 }
 
 use serde::{Deserialize, Serialize};

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -25,7 +25,7 @@ use objects::{
     object::{Blob, ContentHash, Tree, TreeEntry},
     store::{
         CompressionConfig, ObjectStore,
-        pack::{ObjectType as PackObjectType, PackObjectId, StreamingPackBuilder, SyncData},
+        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId, StreamingPackBuilder},
     },
     util::{GitTreeNameClassification, GitTreeNameLossyAction, classify_git_tree_name},
 };
@@ -336,9 +336,9 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             });
         }
 
-        // Translate each commit into a streaming native pack: tree first,
-        // then state. Importing a git repo creates thousands of objects;
-        // writing them as loose files means thousands of durable renames.
+        // Translate each commit into one native pack: tree first, then state.
+        // Importing a git repo creates thousands of objects; writing them as
+        // loose files means thousands of durable renames.
         //
         // We use [`StreamingPackBuilder`] so the pack data streams to a
         // single staging file on disk while the index entries are
@@ -347,11 +347,9 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
         // repo size, modulo the largest single object's compressed
         // payload (limited by the non-streaming zstd API).
         //
-        // Delta search is disabled (`max_delta_size = 0`): the
-        // previous delta-enabled experiment was slower than loose
-        // writes on real Heddle history, and `StreamingPackBuilder`
-        // can't do delta encoding anyway (it'd need random access to
-        // recently-written objects).
+        // The default remains the bounded-memory streaming builder. The
+        // repository's import delta-search policy opts into `PackBuilder`,
+        // which retains the full object set so it can search recent bases.
         let staging_dir = self.pack_staging_dir.clone().unwrap_or_else(|| {
             std::env::temp_dir().join(format!("heddle-ingest-{}", std::process::id()))
         });
@@ -393,29 +391,12 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             for (git_sha, _) in &descriptor_commits {
                 self.map.remove_commit(git_sha)?;
             }
-            let pack_file = std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .open(&pack_path)
-                .map_err(|e| {
-                    IngestError::Other(format!(
-                        "opening pack staging file {}: {e}",
-                        pack_path.display()
-                    ))
-                })?;
-            let compression = CompressionConfig {
-                max_delta_size: 0,
-                ..CompressionConfig::default()
-            };
-            let builder = StreamingPackBuilder::new(
-                pack_file,
-                index_path.clone(),
-                compression,
-                bucket_dir.clone(),
-            )
-            .map_err(IngestError::from)?;
+            let builder = ImportPackBuilder::new(
+                &pack_path,
+                &index_path,
+                &bucket_dir,
+                self.options.delta_search,
+            )?;
             let mut packed = PackedImport::new(self.git, self.map, builder, self.options.clone())
                 .repair_mapped_objects(repair_mapped_objects);
             let mut last_log = 0usize;
@@ -452,8 +433,7 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             }
             let stats = packed.stats;
             if stats.object_count > 0 {
-                let (_file, _) = packed.builder.finalize()?;
-                self.store.install_pack_streaming(&pack_path, &index_path)?;
+                packed.builder.finish(self.store, &pack_path, &index_path)?;
             } else {
                 // No objects to install — drop the empty staging file.
                 let _ = std::fs::remove_file(&pack_path);
@@ -544,10 +524,160 @@ struct PackedImportStats {
     lossy_entries: Vec<LossyImportEntry>,
 }
 
-struct PackedImport<'a, W: std::io::Write + std::io::Read + std::io::Seek + SyncData> {
+trait ImportPackSink {
+    fn add(
+        &mut self,
+        hash: ContentHash,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()>;
+
+    fn add_id(
+        &mut self,
+        id: PackObjectId,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()>;
+}
+
+impl<W> ImportPackSink for StreamingPackBuilder<W>
+where
+    W: std::io::Write + std::io::Read + std::io::Seek + objects::store::SyncData,
+{
+    fn add(
+        &mut self,
+        hash: ContentHash,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        StreamingPackBuilder::add(self, hash, obj_type, data).map_err(IngestError::from)
+    }
+
+    fn add_id(
+        &mut self,
+        id: PackObjectId,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        StreamingPackBuilder::add_id(self, id, obj_type, data).map_err(IngestError::from)
+    }
+}
+
+impl ImportPackSink for PackBuilder {
+    fn add(
+        &mut self,
+        hash: ContentHash,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        PackBuilder::add(self, hash, obj_type, data);
+        Ok(())
+    }
+
+    fn add_id(
+        &mut self,
+        id: PackObjectId,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        PackBuilder::add_id(self, id, obj_type, data);
+        Ok(())
+    }
+}
+
+enum ImportPackBuilder {
+    Streaming(StreamingPackBuilder<std::fs::File>),
+    DeltaSearch(PackBuilder),
+}
+
+impl ImportPackBuilder {
+    fn new(
+        pack_path: &Path,
+        index_path: &Path,
+        bucket_dir: &Path,
+        delta_search: bool,
+    ) -> crate::Result<Self> {
+        if delta_search {
+            return Ok(Self::DeltaSearch(PackBuilder::new(
+                CompressionConfig::default(),
+            )));
+        }
+
+        let pack_file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(pack_path)
+            .map_err(|error| {
+                IngestError::Other(format!(
+                    "opening pack staging file {}: {error}",
+                    pack_path.display()
+                ))
+            })?;
+        let compression = CompressionConfig {
+            max_delta_size: 0,
+            ..CompressionConfig::default()
+        };
+        let builder = StreamingPackBuilder::new(
+            pack_file,
+            index_path.to_path_buf(),
+            compression,
+            bucket_dir.to_path_buf(),
+        )?;
+        Ok(Self::Streaming(builder))
+    }
+
+    fn finish<S: ObjectStore>(
+        self,
+        store: &S,
+        pack_path: &Path,
+        index_path: &Path,
+    ) -> crate::Result<()> {
+        match self {
+            Self::Streaming(builder) => {
+                let (_file, _) = builder.finalize()?;
+                store.install_pack_streaming(pack_path, index_path)?;
+            }
+            Self::DeltaSearch(builder) => {
+                let (pack, index, _) = builder.build()?;
+                store.install_pack(&pack, &index)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ImportPackSink for ImportPackBuilder {
+    fn add(
+        &mut self,
+        hash: ContentHash,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        match self {
+            Self::Streaming(builder) => ImportPackSink::add(builder, hash, obj_type, data),
+            Self::DeltaSearch(builder) => ImportPackSink::add(builder, hash, obj_type, data),
+        }
+    }
+
+    fn add_id(
+        &mut self,
+        id: PackObjectId,
+        obj_type: PackObjectType,
+        data: Vec<u8>,
+    ) -> crate::Result<()> {
+        match self {
+            Self::Streaming(builder) => ImportPackSink::add_id(builder, id, obj_type, data),
+            Self::DeltaSearch(builder) => ImportPackSink::add_id(builder, id, obj_type, data),
+        }
+    }
+}
+
+struct PackedImport<'a, B: ImportPackSink> {
     git: &'a GitSource,
     map: &'a mut ShaMap,
-    builder: StreamingPackBuilder<W>,
+    builder: B,
     stats: PackedImportStats,
     options: ImportOptions,
     emit_objects: bool,
@@ -556,13 +686,8 @@ struct PackedImport<'a, W: std::io::Write + std::io::Read + std::io::Seek + Sync
     materialized_blobs: HashSet<String>,
 }
 
-impl<'a, W: std::io::Write + std::io::Read + std::io::Seek + SyncData> PackedImport<'a, W> {
-    fn new(
-        git: &'a GitSource,
-        map: &'a mut ShaMap,
-        builder: StreamingPackBuilder<W>,
-        options: ImportOptions,
-    ) -> Self {
+impl<'a, B: ImportPackSink> PackedImport<'a, B> {
+    fn new(git: &'a GitSource, map: &'a mut ShaMap, builder: B, options: ImportOptions) -> Self {
         Self {
             git,
             map,
@@ -898,9 +1023,9 @@ pub fn import_git_into_scoped_with_options_and_progress(
     let map_path = repo.heddle_dir().join("ingest").join("sha_map.sqlite");
     let mut map = ShaMap::open(&map_path)?;
 
-    // Stage the streaming pack file inside `.heddle/ingest/staging/` so
-    // the final `rename(2)` into `.heddle/objects/packs/` lands on the
-    // same filesystem (atomic move, no copy).
+    // Stage streaming packs inside `.heddle/ingest/staging/` so the final
+    // `rename(2)` into `.heddle/packs/` lands on the same filesystem.
+    // Delta-search imports use the buffered builder and install from memory.
     let staging_dir = repo.heddle_dir().join("ingest").join("staging");
 
     // `run` is `async`, but the local `RefManager`/`OpLog` futures are
@@ -1146,7 +1271,10 @@ mod tests {
 
     use objects::{
         object::{EntryType, FileMode, ThreadName},
-        store::InMemoryStore,
+        store::{
+            FsStore, InMemoryStore,
+            pack::{ObjectType, PackIndex, decode_tagged_entry_header},
+        },
     };
     use refs::refs::RefManager;
     use tempfile::TempDir;
@@ -1216,6 +1344,52 @@ mod tests {
             "160000,0808080808080808080808080808080808080808,vendor",
         ]);
         run(&["commit", "-q", "-m", "add gitlink"]);
+    }
+
+    fn seed_delta_repo(path: &Path) {
+        let run = |args: &[&str]| {
+            let status = Command::new("git")
+                .args(args)
+                .current_dir(path)
+                .env("GIT_AUTHOR_NAME", "Test")
+                .env("GIT_AUTHOR_EMAIL", "test@example.com")
+                .env("GIT_COMMITTER_NAME", "Test")
+                .env("GIT_COMMITTER_EMAIL", "test@example.com")
+                .env("GIT_CONFIG_GLOBAL", "/dev/null")
+                .env("GIT_CONFIG_SYSTEM", "/dev/null")
+                .status()
+                .expect("git cmd");
+            assert!(status.success(), "git {:?} failed", args);
+        };
+        run(&["init", "-q", "--initial-branch=main"]);
+        for version in 0..12 {
+            let mut payload = vec![b'a'; 8 * 1024];
+            payload[version * 31] = b'A' + version as u8;
+            std::fs::write(path.join("history.txt"), payload).unwrap();
+            run(&["add", "history.txt"]);
+            run(&["commit", "-q", "-m", &format!("version {version}")]);
+        }
+    }
+
+    fn count_pack_deltas(store: &FsStore) -> usize {
+        let manager = store.pack_manager().read().unwrap();
+        manager
+            .pack_file_paths()
+            .into_iter()
+            .map(|(pack_path, index_path)| {
+                let pack = std::fs::read(pack_path).unwrap();
+                let index = PackIndex::from_bytes(&std::fs::read(index_path).unwrap()).unwrap();
+                index
+                    .ids()
+                    .into_iter()
+                    .filter(|id| {
+                        let offset = index.find(id).unwrap() as usize;
+                        decode_tagged_entry_header(&pack[offset..])
+                            .is_ok_and(|header| header.obj_type == ObjectType::Delta)
+                    })
+                    .count()
+            })
+            .sum()
     }
 
     fn git_output(path: &Path, args: &[&str], stdin: Option<&[u8]>) -> String {
@@ -1302,6 +1476,59 @@ mod tests {
             refs.get_thread(&ThreadName::new("feature/x"))
                 .unwrap()
                 .is_some()
+        );
+    }
+
+    #[test]
+    fn delta_search_enabled_import_reconstructs_byte_exact_with_zero_blake3_failures() {
+        let gitdir = TempDir::new().unwrap();
+        let streaming_dir = TempDir::new().unwrap();
+        let delta_dir = TempDir::new().unwrap();
+        seed_delta_repo(gitdir.path());
+
+        import_git_into_with_options(
+            gitdir.path(),
+            streaming_dir.path(),
+            ImportOptions::default(),
+        )
+        .expect("streaming import");
+        import_git_into_with_options(
+            gitdir.path(),
+            delta_dir.path(),
+            ImportOptions {
+                delta_search: true,
+                ..ImportOptions::default()
+            },
+        )
+        .expect("delta import");
+
+        let streaming_store = FsStore::new(streaming_dir.path().join(".heddle"));
+        let delta_store = FsStore::new(delta_dir.path().join(".heddle"));
+        assert_eq!(
+            count_pack_deltas(&streaming_store),
+            0,
+            "off must preserve the zero-delta streaming pack"
+        );
+        assert!(
+            count_pack_deltas(&delta_store) > 0,
+            "on must emit delta entries"
+        );
+
+        let hashes = delta_store.list_blobs().unwrap();
+        assert!(!hashes.is_empty());
+        let mut blake3_failures = 0;
+        for hash in hashes {
+            let blob = delta_store
+                .get_blob(&hash)
+                .unwrap()
+                .expect("imported blob must reconstruct");
+            if ContentHash::compute_typed("blob", blob.content()) != hash {
+                blake3_failures += 1;
+            }
+        }
+        assert_eq!(
+            blake3_failures, 0,
+            "delta-enabled import must have 0 BLAKE3 reconstruction failures"
         );
     }
 
@@ -1458,7 +1685,10 @@ mod tests {
         let (stats, _map) = import_git_into_with_options(
             gitdir.path(),
             heddledir.path(),
-            ImportOptions { lossy: true },
+            ImportOptions {
+                lossy: true,
+                ..ImportOptions::default()
+            },
         )
         .expect("lossy import converts invalid UTF-8 name");
         let converted_name = "bad\u{fffd}name";
@@ -1478,7 +1708,10 @@ mod tests {
         let (first, map) = import_git_into_with_options(
             gitdir.path(),
             heddledir.path(),
-            ImportOptions { lossy: true },
+            ImportOptions {
+                lossy: true,
+                ..ImportOptions::default()
+            },
         )
         .expect("initial lossy import succeeds");
         drop(map);
@@ -1508,7 +1741,10 @@ mod tests {
         let (_first, map) = import_git_into_with_options(
             gitdir.path(),
             heddledir.path(),
-            ImportOptions { lossy: true },
+            ImportOptions {
+                lossy: true,
+                ..ImportOptions::default()
+            },
         )
         .expect("initial lossy import succeeds");
         drop(map);
@@ -1516,7 +1752,10 @@ mod tests {
         let (second, _map) = import_git_into_with_options(
             gitdir.path(),
             heddledir.path(),
-            ImportOptions { lossy: true },
+            ImportOptions {
+                lossy: true,
+                ..ImportOptions::default()
+            },
         )
         .expect("lossy rerun reports persisted lossy entries");
 
@@ -1534,7 +1773,10 @@ mod tests {
         let (stats, _map) = import_git_into_with_options(
             gitdir.path(),
             heddledir.path(),
-            ImportOptions { lossy: true },
+            ImportOptions {
+                lossy: true,
+                ..ImportOptions::default()
+            },
         )
         .expect("clean lossy import succeeds");
 

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -1237,8 +1237,8 @@ impl ObjectStore for FsStore {
     }
 
     #[instrument(skip(self))]
-    fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {
-        self.pack_objects_impl(aggressive)
+    fn pack_objects(&self, delta_search: bool) -> Result<(u64, u64)> {
+        self.pack_objects_impl(delta_search)
     }
 
     #[instrument(skip(self), fields(id = ?id))]

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -114,7 +114,9 @@ impl FsStore {
             <Self as ObjectStore>::has_state(self, &state.id())?
         };
         let mut compression = self.compression;
-        compression.max_delta_size = 0;
+        if !self.snapshot_delta_search {
+            compression.max_delta_size = 0;
+        }
         let mut builder = PackBuilder::new(compression);
         let mut staged_blobs = Vec::with_capacity(blobs.len());
 
@@ -241,7 +243,9 @@ impl FsStore {
         // `pack_objects_impl` keeps the full delta search; this
         // path only optimizes durability + write throughput.
         let mut compression = self.compression;
-        compression.max_delta_size = 0;
+        if !self.snapshot_delta_search {
+            compression.max_delta_size = 0;
+        }
         let mut builder = PackBuilder::new(compression);
         let mut staged: Vec<(ContentHash, Vec<u8>)> = Vec::with_capacity(blobs.len());
         for (hash, data) in blobs {
@@ -297,7 +301,7 @@ impl FsStore {
     /// started with. Running GC again over an already-consolidated store
     /// is a no-op (nothing loose, one pack already covers everything).
     ///
-    pub(super) fn pack_objects_impl(&self, aggressive: bool) -> Result<(u64, u64)> {
+    pub(super) fn pack_objects_impl(&self, delta_search: bool) -> Result<(u64, u64)> {
         let loose_blobs = list_hashes_from_dir(&blobs_dir(&self.root))?;
         let loose_trees = list_hashes_from_dir(&trees_dir(&self.root))?;
 
@@ -328,17 +332,14 @@ impl FsStore {
         }
 
         // Consolidation packs every object that's already packed plus the
-        // loose ones. The default path SKIPS the sliding-window delta
-        // search: it runs across the full payloads of every object and on
-        // a large native store (tens of MB across thousands of objects)
-        // costs minutes for a near-zero size win, because the carried-
-        // forward objects are already zstd-compressed. `--aggressive`
-        // opts back into the full delta search for the rare "shrink the
-        // pack at all costs" case. This mirrors the snapshot hot path
-        // (`put_blobs_packed_impl`), which disables delta for the same
-        // reason.
+        // loose ones. The default path skips the sliding-window delta search
+        // to keep foreground GC latency bounded: it searches the full payloads
+        // of every object and can turn a seconds-long consolidation into
+        // minutes. The caller resolves the repository's GC policy and the
+        // `--aggressive` override into the `delta_search` argument. This
+        // mirrors the snapshot hot path, whose policy is held by the store.
         let mut compression = self.compression;
-        if !aggressive {
+        if !delta_search {
             compression.max_delta_size = 0;
         }
         let mut builder = PackBuilder::new(compression);

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -236,6 +236,7 @@ where
 pub struct FsStore {
     pub(super) root: PathBuf,
     pub(super) compression: CompressionConfig,
+    pub(super) snapshot_delta_search: bool,
     pack_manager: RwLock<SnapshotPackManager>,
     pub(super) recent_blobs: RwLock<RecentObjectCache<ContentHash, Blob>>,
     pub(super) recent_trees: RwLock<RecentObjectCache<ContentHash, Tree>>,
@@ -269,6 +270,7 @@ pub struct FsStore {
 impl Clone for FsStore {
     fn clone(&self) -> Self {
         let mut cloned = Self::with_compression(&self.root, self.compression);
+        cloned.snapshot_delta_search = self.snapshot_delta_search;
         cloned.loose_object_write_mode = self.loose_object_write_mode;
         cloned.external_source = self.external_source.clone();
         cloned
@@ -285,6 +287,7 @@ impl FsStore {
         Self {
             root,
             compression: CompressionConfig::default(),
+            snapshot_delta_search: false,
             pack_manager: RwLock::new(pack_manager),
             recent_blobs: RwLock::new(RecentObjectCache::with_byte_budget(
                 RECENT_BLOB_CACHE_CAPACITY,
@@ -311,6 +314,7 @@ impl FsStore {
         Self {
             root,
             compression,
+            snapshot_delta_search: false,
             pack_manager: RwLock::new(pack_manager),
             recent_blobs: RwLock::new(RecentObjectCache::with_byte_budget(
                 RECENT_BLOB_CACHE_CAPACITY,
@@ -355,6 +359,11 @@ impl FsStore {
     /// Set the compression configuration.
     pub fn set_compression(&mut self, compression: CompressionConfig) {
         self.compression = compression;
+    }
+
+    /// Enable or disable sliding-window delta search for snapshot packs.
+    pub fn set_snapshot_delta_search(&mut self, enabled: bool) {
+        self.snapshot_delta_search = enabled;
     }
 
     pub fn loose_object_write_mode(&self) -> LooseObjectWriteMode {

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -16,7 +16,10 @@ use crate::{
     },
     store::{
         HeddleError, ObjectStore,
-        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
+        pack::{
+            ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId,
+            decode_tagged_entry_header,
+        },
     },
     sync::RwLockExt,
 };
@@ -479,6 +482,78 @@ fn count_packs(store: &FsStore) -> usize {
                 .count()
         })
         .unwrap_or(0)
+}
+
+fn count_pack_deltas(store: &FsStore) -> usize {
+    let manager = store.pack_manager().read().unwrap();
+    manager
+        .pack_file_paths()
+        .into_iter()
+        .map(|(pack_path, index_path)| {
+            let pack = std::fs::read(pack_path).unwrap();
+            let index = PackIndex::from_bytes(&std::fs::read(index_path).unwrap()).unwrap();
+            index
+                .ids()
+                .into_iter()
+                .filter(|id| {
+                    let offset = index.find(id).unwrap() as usize;
+                    decode_tagged_entry_header(&pack[offset..])
+                        .is_ok_and(|header| header.obj_type == PackObjectType::Delta)
+                })
+                .count()
+        })
+        .sum()
+}
+
+fn similar_blobs(count: usize) -> Vec<(ContentHash, Vec<u8>)> {
+    (0..count)
+        .map(|version| {
+            let mut data = vec![b'x'; 8 * 1024];
+            data[version * 31] = b'A' + version as u8;
+            let blob = Blob::from(data.clone());
+            (blob.hash(), data)
+        })
+        .collect()
+}
+
+#[test]
+fn snapshot_delta_search_policy_controls_pack_emission() {
+    let (_off_temp, off_store) = create_test_store();
+    let (_on_temp, mut on_store) = create_test_store();
+    let blobs = similar_blobs(12);
+
+    off_store.put_blobs_packed(blobs.clone()).unwrap();
+    on_store.set_snapshot_delta_search(true);
+    on_store.put_blobs_packed(blobs.clone()).unwrap();
+
+    assert_eq!(count_pack_deltas(&off_store), 0);
+    assert!(count_pack_deltas(&on_store) > 0);
+    for (hash, expected) in blobs {
+        let actual = on_store.get_blob(&hash).unwrap().unwrap();
+        assert_eq!(actual.content(), expected);
+    }
+}
+
+#[test]
+fn gc_delta_search_policy_controls_pack_emission() {
+    let (_off_temp, off_store) = create_test_store();
+    let (_on_temp, on_store) = create_test_store();
+    let blobs = similar_blobs(12);
+    for (_, data) in &blobs {
+        let blob = Blob::from(data.clone());
+        off_store.put_blob(&blob).unwrap();
+        on_store.put_blob(&blob).unwrap();
+    }
+
+    off_store.pack_objects(false).unwrap();
+    on_store.pack_objects(true).unwrap();
+
+    assert_eq!(count_pack_deltas(&off_store), 0);
+    assert!(count_pack_deltas(&on_store) > 0);
+    for (hash, expected) in blobs {
+        let actual = on_store.get_blob(&hash).unwrap().unwrap();
+        assert_eq!(actual.content(), expected);
+    }
 }
 
 fn count_loose_objects(store: &FsStore) -> usize {

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -248,8 +248,8 @@ impl ObjectStore for AnyStore {
     ) -> Result<Vec<pack::PackObjectId>> {
         any_store_dispatch!(self, install_pack_streaming(pack_path, index_path))
     }
-    fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {
-        any_store_dispatch!(self, pack_objects(aggressive))
+    fn pack_objects(&self, delta_search: bool) -> Result<(u64, u64)> {
+        any_store_dispatch!(self, pack_objects(delta_search))
     }
     fn prune_loose_objects(&self) -> Result<(u64, u64)> {
         any_store_dispatch!(self, prune_loose_objects())
@@ -706,8 +706,8 @@ pub trait ObjectStore: Send + Sync {
         Ok(ids)
     }
 
-    fn pack_objects(&self, aggressive: bool) -> Result<(u64, u64)> {
-        let _ = aggressive;
+    fn pack_objects(&self, delta_search: bool) -> Result<(u64, u64)> {
+        let _ = delta_search;
         Ok((0, 0))
     }
 

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -388,12 +388,29 @@ pub struct DisplayConfig {
 pub struct StorageConfig {
     #[serde(default)]
     pub filesystem: Option<FilesystemStorageConfig>,
+    #[serde(default)]
+    pub delta_search: DeltaSearchConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FilesystemStorageConfig {
     /// Path to the storage directory (relative to .heddle or absolute)
     pub path: Option<String>,
+}
+
+/// `[storage.delta_search]` policy for pack-producing paths.
+///
+/// Every path defaults off to preserve the bounded-memory import path and the
+/// latency-oriented snapshot and maintenance behavior. Operators can opt a
+/// path into the classic sliding-window search independently.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, Eq, PartialEq)]
+pub struct DeltaSearchConfig {
+    #[serde(default)]
+    pub import: bool,
+    #[serde(default)]
+    pub snapshot: bool,
+    #[serde(default)]
+    pub gc: bool,
 }
 
 fn default_hash_length() -> usize {
@@ -553,6 +570,7 @@ mod tests {
         );
         assert_eq!(config.output.format, None);
         assert!(config.policies.default_policy.is_none());
+        assert_eq!(config.storage.delta_search, DeltaSearchConfig::default());
     }
 
     #[test]
@@ -569,6 +587,30 @@ source_authority = "native"
         assert!(config.policies.default_policy.is_none());
         assert!(config.agent.provider.is_none());
         assert!(config.agent.model.is_none());
+        assert_eq!(config.storage.delta_search, DeltaSearchConfig::default());
+    }
+
+    #[test]
+    fn delta_search_paths_deserialize_independently() {
+        let toml = r#"
+[repository]
+version = 3
+source_authority = "native"
+[storage.delta_search]
+import = true
+snapshot = false
+gc = true
+"#;
+        let config: RepoConfig = toml::from_str(toml).expect("config should deserialize");
+
+        assert_eq!(
+            config.storage.delta_search,
+            DeltaSearchConfig {
+                import: true,
+                snapshot: false,
+                gc: true,
+            }
+        );
     }
 
     #[test]

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -841,7 +841,9 @@ impl Repository {
         heddle_dir: &Path,
         shared_overlay_source_root: Option<&Path>,
     ) -> Result<AnyStore> {
-        let store = AnyStore::Fs(FsStore::new(heddle_dir));
+        let mut fs_store = FsStore::new(heddle_dir);
+        fs_store.set_snapshot_delta_search(config.storage.delta_search.snapshot);
+        let store = AnyStore::Fs(fs_store);
         #[cfg(feature = "git-overlay")]
         let mut store = store;
         #[cfg(not(feature = "git-overlay"))]

--- a/docs/perf/delta-search-policy.md
+++ b/docs/perf/delta-search-policy.md
@@ -1,0 +1,113 @@
+# Delta-search policy and measurements
+
+Status: measured 2026-08-02 against Heddle `a37381633b0cacaa987bc2191fa48fd6c36955d9`.
+
+Heddle's classic pack builder can substantially reduce pack size by searching
+recent objects for delta bases. Import/adoption uses a streaming builder by
+default to bound memory, while snapshot packing and foreground GC prioritize
+latency. These paths therefore keep delta search off by default and expose
+independent repository settings:
+
+```toml
+[storage.delta_search]
+import = false
+snapshot = false
+gc = false
+```
+
+`import` applies to full Git import/adoption paths, including Git-backed clone,
+pull, and Git Projection import. Enabling it selects the buffered classic pack
+builder instead of the streaming builder. `snapshot` applies to packs created
+while capturing batches of new objects. `gc` applies to native-object packing
+during ordinary `heddle maintenance gc`; `--aggressive` continues to force
+delta search on regardless of the setting.
+
+For a repository that has not yet been adopted, run `heddle init`, set
+`storage.delta_search.import = true` in `.heddle/config.toml`, and then run
+`heddle adopt`.
+
+## Method
+
+The three repositories retained by the semantic-packing spike were measured at
+these exact revisions:
+
+| Corpus | Revision |
+| --- | --- |
+| ripgrep | `435f59fc4b43af3ab32f34d53fa34978f393fe52` |
+| fd | `41532d114e2ba565fb5367d606c111b29b96450c` |
+| cargo-deny | `bca0dde53651ee946720e4540b5ce2610bec8f06` |
+
+The release binary was built with `cargo build --release -p heddle-cli
+--features zstd`. Each import measurement used a fresh local clone and an
+already-initialized Heddle repository; `/usr/bin/time -v` wrapped only `heddle
+adopt`. Off/on runs were sequential, with order alternated by corpus to reduce
+systematic warm-cache bias. Filesystem caches were not dropped. These are
+single-run engineering measurements, so the ratios are policy signals rather
+than benchmark confidence intervals.
+
+For GC, one small capture was added after delta-off adoption so the store had
+multiple packs to consolidate. That prepared repository was copied byte for
+byte into the off/on cases before changing only
+`storage.delta_search.gc`. `/usr/bin/time -v` then wrapped ordinary,
+non-aggressive `heddle maintenance gc`. Pack bytes and entry types were read
+directly from the resulting LMPK v3 pack and index files. Pack size below
+excludes the index, whose size was identical between each off/on pair.
+
+## Import/adoption results
+
+| Corpus | Objects | Pack off -> on | Saved | Deltas off -> on | Wall off -> on | Slowdown | Peak RSS off -> on |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| ripgrep | 13,558 | 35.47 -> 11.70 MiB | 67.02% | 0 -> 11,189 | 26.90s -> 253.11s | 9.41x | 228.55 -> 354.36 MiB |
+| fd | 8,523 | 17.52 -> 5.79 MiB | 66.93% | 0 -> 6,470 | 24.92s -> 82.36s | 3.30x | 128.91 -> 173.77 MiB |
+| cargo-deny | 6,091 | 21.75 -> 10.98 MiB | 49.52% | 0 -> 5,428 | 8.14s -> 126.43s | 15.53x | 156.55 -> 819.97 MiB |
+
+Exact off/on pack byte counts were 37,191,867/12,265,464 for ripgrep,
+18,369,339/6,075,152 for fd, and 22,804,383/11,512,222 for cargo-deny.
+
+## Default-GC results
+
+| Corpus | Objects | Pack off -> on | Saved | Deltas off -> on | Wall off -> on | Slowdown | Peak RSS off -> on |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| ripgrep | 13,734 | 35.60 -> 12.08 MiB | 66.06% | 0 -> 11,364 | 2.71s -> 175.20s | 64.65x | 401.34 -> 366.59 MiB |
+| fd | 8,565 | 17.53 -> 5.85 MiB | 66.60% | 0 -> 6,516 | 1.08s -> 47.87s | 44.32x | 202.76 -> 181.70 MiB |
+| cargo-deny | 6,271 | 21.87 -> 11.13 MiB | 49.11% | 0 -> 5,601 | 1.46s -> 81.60s | 55.89x | 244.67 -> 782.77 MiB |
+
+Exact off/on pack byte counts were 37,330,288/12,669,574 for ripgrep,
+18,376,751/6,137,785 for fd, and 22,927,448/11,667,253 for cargo-deny.
+
+## Byte-exact reconstruction proof
+
+The negative case is named
+`delta_search_enabled_import_reconstructs_byte_exact_with_zero_blake3_failures`.
+It imports a deliberately delta-friendly Git history with the setting both off
+and on, inspects the packs to prove `0` versus `>0` delta entries, reconstructs
+every imported blob through `FsStore`, recomputes its typed BLAKE3 content
+identity, and requires exactly zero failures.
+
+The retained-corpus harness also loaded every object through `PackReader` and
+recomputed typed BLAKE3 identities for every blob. Delta-enabled import rebuilt
+28,172 objects and checked 11,397 blobs; delta-enabled GC rebuilt 28,570 objects
+and checked 11,789 blobs. Both paths had 0 reconstruction failures and 0 BLAKE3
+identity failures on every corpus. `heddle verify --output json` also reported
+`clean: true` for all three delta-enabled GC repositories.
+
+## Recommendation
+
+Keep import/adoption default-off. Saving 49.52-67.02% is valuable, but a
+3.30-15.53x hot-path slowdown and a cargo-deny peak of 819.97 MiB reject it as
+the general import policy. Operators who explicitly prefer stored size can opt
+in with `storage.delta_search.import`.
+
+Keep snapshot packing default-off and opt-in. Snapshot capture is latency
+sensitive, and it should not inherit the buffered import or whole-store search
+cost without a dedicated snapshot benchmark that justifies that change.
+
+Keep foreground default GC delta search off. The measured 44.32-64.65x slowdown
+would turn routine maintenance into an unexpectedly long operation. Preserve
+`--aggressive` as the explicit one-shot override and expose
+`storage.delta_search.gc` for repositories that accept that recurring cost.
+
+The right eventual default home is a background repack/consolidation job with
+resource controls and cancellation, where the 49.11-66.60% storage win is
+worthwhile and does not block adoption, capture, or foreground maintenance.
+Until that scheduler exists, all three synchronous paths remain opt-in.


### PR DESCRIPTION
## Summary

- Add independent `[storage.delta_search]` settings for `import`, `snapshot`, and `gc`, all default-off.
- Route opt-in imports through the classic buffered pack builder, apply the snapshot policy to snapshot packs, and let ordinary GC use its policy while preserving `--aggressive` as a force-on override.
- Document the corpus measurements and recommend background repack/consolidation as the eventual default home; synchronous import, snapshot, and foreground GC remain opt-in.

Import/adoption measurements (`/usr/bin/time -v`, release build with zstd):

| Corpus | Pack off -> on | Saved | Deltas off -> on | Wall off -> on | Peak RSS off -> on |
| --- | ---: | ---: | ---: | ---: | ---: |
| ripgrep | 35.47 -> 11.70 MiB | 67.02% | 0 -> 11,189 | 26.90s -> 253.11s | 228.55 -> 354.36 MiB |
| fd | 17.52 -> 5.79 MiB | 66.93% | 0 -> 6,470 | 24.92s -> 82.36s | 128.91 -> 173.77 MiB |
| cargo-deny | 21.75 -> 10.98 MiB | 49.52% | 0 -> 5,428 | 8.14s -> 126.43s | 156.55 -> 819.97 MiB |

Ordinary, non-aggressive GC measurements from byte-identical multi-pack seeds:

| Corpus | Pack off -> on | Saved | Deltas off -> on | Wall off -> on | Peak RSS off -> on |
| --- | ---: | ---: | ---: | ---: | ---: |
| ripgrep | 35.60 -> 12.08 MiB | 66.06% | 0 -> 11,364 | 2.71s -> 175.20s | 401.34 -> 366.59 MiB |
| fd | 17.53 -> 5.85 MiB | 66.60% | 0 -> 6,516 | 1.08s -> 47.87s | 202.76 -> 181.70 MiB |
| cargo-deny | 21.87 -> 11.13 MiB | 49.11% | 0 -> 5,601 | 1.46s -> 81.60s | 244.67 -> 782.77 MiB |

## Closes

Closes #1198

## Test evidence

- `cargo test -p heddle-repo -p heddle-ingest -p heddle-objects --features zstd --no-fail-fast`
- `cargo test -p heddle-cli --lib --features zstd --no-fail-fast` (594 passed)
- `cargo clippy -p heddle-objects -p heddle-repo -p heddle-ingest -p heddle-cli --all-targets --features zstd -- -D warnings`
- `rustfmt +nightly --edition 2024 --check --config skip_children=true` on touched Rust files
- `delta_search_enabled_import_reconstructs_byte_exact_with_zero_blake3_failures`: off emitted 0 deltas, on emitted deltas, every imported blob reconstructed through `FsStore`, 0 typed-BLAKE3 failures.
- Retained-corpus proof: delta-enabled import reconstructed 28,172 objects and checked 11,397 blob identities; delta-enabled GC reconstructed 28,570 objects and checked 11,789 blob identities. Both had 0 reconstruction failures and 0 BLAKE3 failures. `heddle verify --output json` reported `clean: true` for all delta-enabled GC outputs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1200"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788286856&installation_model_id=21489&pr_number=1200&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1200&signature=75025e64869db6c8583a35cdddf9293cbef5fdf93a27cd1e5b5626928893abf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->