### PR TITLE
docs: add WebTransport re-evaluation note to ADR 0049

### DIFF
--- a/docs/adr/0049-iroh-hosted-transport-and-weft-browser-relay.md
+++ b/docs/adr/0049-iroh-hosted-transport-and-weft-browser-relay.md
@@ -84,3 +84,14 @@ and Weft implementation concerns. Using browser WebTransport would create a
 second transport implementation instead of exercising Iroh's relay path. One
 Iroh call interface preserves locality while keeping the public protobuf contract
 independent of its transport.
+
+## Revisit trigger
+
+The browser leg uses a secure WebSocket to a Weft relay rather than
+WebTransport because, as of mid-2026, Cloudflare Workers and Durable Objects
+terminate inbound WebSockets and inbound HTTP/3 request/response traffic, but
+not WebTransport. This is a Cloudflare capability constraint, not a transport
+preference. Re-evaluate WebTransport—which maps more directly to Iroh's QUIC
+bidirectional streams—if Cloudflare adds WebTransport termination to Workers
+and Durable Objects. See Cloudflare Workers' [Protocols](https://developers.cloudflare.com/workers/reference/protocols/)
+documentation.


### PR DESCRIPTION
## Summary
Adds a WebTransport re-evaluation note to ADR 0049.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788364603&installation_model_id=21489&pr_number=1213&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1213&signature=9587c5244c1cb680914841e763d3868d9a610415fc599600b48d6ce820828397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->