### PR TITLE
test(discovery): harden poisoned ancestor boundary

### DIFF
--- a/crates/cli/tests/onboarding_contract.rs
+++ b/crates/cli/tests/onboarding_contract.rs
@@ -161,8 +161,11 @@ fn init_in_fresh_directory_does_not_write_to_ancestor_git_repository() {
     assert!(repo.join(".heddle").is_dir());
 }
 
+#[cfg(unix)]
 #[test]
-fn cwd_native_repository_wins_over_readable_ancestor_git_repository() {
+fn poisoned_ancestor_git_cannot_override_local_heddle_boundary_or_receive_writes() {
+    use std::os::unix::fs::PermissionsExt;
+
     let fixture = TempDir::new().unwrap();
     let outer = fixture.path().join("outer");
     let repo = outer.join("native");
@@ -170,11 +173,26 @@ fn cwd_native_repository_wins_over_readable_ancestor_git_repository() {
     fs::create_dir_all(&repo).unwrap();
     init_git(&outer);
     repo::Repository::init_default(&repo).unwrap();
+    let git_info = outer.join(".git/info");
+    let git_exclude = git_info.join("exclude");
+    fs::set_permissions(&git_exclude, fs::Permissions::from_mode(0o444)).unwrap();
+    fs::set_permissions(&git_info, fs::Permissions::from_mode(0o555)).unwrap();
+    let outside_before = snapshot_outside_repository(&outer, &repo);
 
-    let status = json(&heddle(&repo, &config, &["status", "--output", "json"]));
+    let output = heddle(&repo, &config, &["status", "--output", "json"]);
 
+    fs::set_permissions(&git_info, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(&git_exclude, fs::Permissions::from_mode(0o644)).unwrap();
+    let status = json(&output);
     assert_eq!(status["repository_capability"], "native-heddle");
     assert_eq!(status["storage_model"], "heddle-native");
+    assert_eq!(
+        snapshot_outside_repository(&outer, &repo),
+        outside_before,
+        "poisoned ancestor Git metadata must remain untouched"
+    );
+    assert!(!outer.join(".heddle").exists());
+    assert!(repo.join(".heddle").is_dir());
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Confirm #1147 was a real repository-boundary bug, not only an environment artifact: the pre-fix controlled fixture in #1158 used a valid ancestor Git repository and reproduced both the external `.git/info/exclude` write and the unreadable-sibling status failure.
- Keep the production fix already merged on current `main` via #1158: init opens Git only at the requested root, Heddle discovery wins at the nearest repository boundary, and ancestor walking is filesystem-bounded and fault-tolerant.
- Strengthen the local-boundary regression under the exact poisoned-ancestor name: make the valid ancestor `.git/info` and exclude file read-only, prove native status still resolves the local `.heddle`, snapshot all files outside the local repository before and after, and assert no ancestor `.heddle` appears.

## Closes

Closes #1147

## Test evidence

- Symptom 1 / clean init: a freshly built current-main CLI ran `heddle init probe` as native Heddle (`git_detected: false`), created no local `.git`, and left the sandbox-injected `/home/scratch/.git` tree hash unchanged.
- Symptom 2: under a valid ancestor Git worktree with an unreadable sibling, `heddle status` exited 0 and reported `native-heddle` / `heddle-native`.
- Poisoned-ancestor negative case: the valid ancestor `.git` was read-only during status; its before/after tree hashes were identical, no ancestor `.heddle` was created, and the local `.heddle` remained authoritative.
- `TMPDIR=/home/scratch cargo build --locked -p heddle-cli`
- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli --test onboarding_contract poisoned_ancestor_git_cannot_override_local_heddle_boundary_or_receive_writes -- --exact --nocapture` (1 passed)
- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli --test onboarding_contract` (10 passed)
- `TMPDIR=/home/scratch cargo clippy --locked -p heddle-cli --test onboarding_contract -- -D warnings`
- `rustfmt +nightly --edition 2024 --check crates/cli/tests/onboarding_contract.rs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788365562&installation_model_id=21489&pr_number=1214&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1214&signature=b9cbec0ce3a650591a12ef552443913eda6c963061c3c83b6ffacd9b3d0d89b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->