### PR TITLE
feat(cli): export opt-in OTLP command traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **Opt-in CLI OpenTelemetry traces.** Default `heddle` builds can export
+  privacy-bounded command and profile-phase spans to a configured OTLP
+  collector, and hosted Iroh request preludes carry W3C trace context for
+  coordinated end-to-end traces with Weft. Export remains dormant when no
+  endpoint is configured.
+
 - **Public hosted repo-event subscription client.** Rust consumers can connect
   through Heddle's standard credential and verified native transport, subscribe
   with the API-owned request/event types, and resume from the last delivered

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,29 +308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00bdb5da18dac48ca2cc7cd4a98e533e8635a58e2361d13a1a4ee3888e0d72f1"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43103168cc76fe62678a375e722fc9cb3a0146159ac5828bc4f0dfd755c2224c"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,15 +741,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "cmov"
@@ -1317,12 +1285,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,12 +1647,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -4248,6 +4204,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.9.5",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4924,63 +4881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror 2.0.18",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror 2.0.18",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5195,6 +5095,7 @@ checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -5207,7 +5108,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -5369,7 +5269,6 @@ version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -5434,7 +5333,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,11 +81,11 @@ prost-reflect = "0.16"
 prost-types = "0.14"
 protoc-bin-vendored = "3"
 opentelemetry = "0.32"
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-client", "reqwest-rustls", "trace", "metrics"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["http-proto", "reqwest-blocking-client", "trace", "metrics"] }
 opentelemetry_sdk = "0.32"
 rand = "0.10"
 regex-lite = "0.1"
-reqwest = { version = "0.13.4", default-features = false, features = ["json", "rustls-no-provider"] }
+reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls-no-provider"] }
 rmp-serde = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
 rustls = { version = "0.23", default-features = false, features = ["ring", "logging", "std", "tls12"] }

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ export RUST_BACKTRACE=1
 
 Heddle records the agent model string verbatim and echoes it back in attribution output (for example the `Agent:` line of `heddle log --verbose`). If the coding agent reports a model id with a bracketed suffix — such as `claude-opus-4-8[1m]` — heddle preserves the suffix as-is; it does not add or interpret it. The suffix is supplied by the agent harness to distinguish a model variant (for Claude models the bracketed tag denotes the context-window variant), so set `HEDDLE_AGENT_MODEL` to whatever identifier you want recorded.
 
+Optional OpenTelemetry command tracing, its privacy boundary, and pilot
+collector wiring are documented in [CLI trace export](docs/telemetry.md).
+
 ## Repository layout
 
 This repository is a Cargo workspace. The OSS crates live under `crates/`:

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -26,6 +26,9 @@ tracing.workspace = true
 tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 
+[dev-dependencies]
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
+
 [features]
 observability = [
     "dep:opentelemetry",

--- a/crates/cli-shared/src/logging/mod.rs
+++ b/crates/cli-shared/src/logging/mod.rs
@@ -24,16 +24,22 @@
 //! ```
 
 use std::io::{self, IsTerminal};
+#[cfg(feature = "observability")]
+use std::time::Duration;
 
+mod trace;
 #[cfg(feature = "observability")]
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
 #[cfg(feature = "observability")]
 use opentelemetry_otlp::WithExportConfig;
 #[cfg(feature = "observability")]
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider, trace::SdkTracerProvider};
+pub use trace::{CommandTrace, record_phase_span, trace_export_enabled};
 use tracing::Level;
+#[cfg(feature = "observability")]
+use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::{
-    EnvFilter, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
+    EnvFilter, Layer as _, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
 };
 
 use crate::config::UserConfig;
@@ -76,16 +82,27 @@ pub struct LoggingGuard {
 }
 
 impl LoggingGuard {
-    pub fn shutdown(self) {
+    pub fn shutdown(mut self) {
+        self.shutdown_inner();
+    }
+
+    fn shutdown_inner(&mut self) {
         #[cfg(feature = "observability")]
         {
-            if let Some(meter_provider) = self.meter_provider {
-                let _ = meter_provider.shutdown();
+            if let Some(meter_provider) = self.meter_provider.take() {
+                let _ = meter_provider.shutdown_with_timeout(Duration::from_millis(250));
             }
-            if let Some(tracer_provider) = self.tracer_provider {
-                let _ = tracer_provider.shutdown();
+            if let Some(tracer_provider) = self.tracer_provider.take() {
+                let _ = tracer_provider.shutdown_with_timeout(Duration::from_millis(250));
             }
+            trace::set_trace_export_enabled(false);
         }
+    }
+}
+
+impl Drop for LoggingGuard {
+    fn drop(&mut self) {
+        self.shutdown_inner();
     }
 }
 
@@ -225,7 +242,6 @@ impl LoggingConfig {
 #[cfg(feature = "observability")]
 impl OtelConfig {
     fn from_logging_config(config: &LoggingConfig) -> Self {
-        let shared_endpoint = config.otel_endpoint.clone();
         Self {
             service_name: config
                 .otel_service_name
@@ -234,8 +250,11 @@ impl OtelConfig {
             trace_endpoint: config
                 .otel_traces_endpoint
                 .clone()
-                .or_else(|| shared_endpoint.clone()),
-            metrics_endpoint: config.otel_metrics_endpoint.clone().or(shared_endpoint),
+                .or_else(|| signal_endpoint(config.otel_endpoint.as_deref(), "v1/traces")),
+            metrics_endpoint: config
+                .otel_metrics_endpoint
+                .clone()
+                .or_else(|| signal_endpoint(config.otel_endpoint.as_deref(), "v1/metrics")),
         }
     }
 
@@ -249,6 +268,11 @@ impl OtelConfig {
             .with_attributes([KeyValue::new("service.name", self.service_name.clone())])
             .build()
     }
+}
+
+#[cfg(feature = "observability")]
+fn signal_endpoint(base: Option<&str>, signal_path: &str) -> Option<String> {
+    base.map(|endpoint| format!("{}/{signal_path}", endpoint.trim_end_matches('/')))
 }
 
 /// Initialize the global tracing subscriber.
@@ -273,14 +297,17 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
         FmtSpan::NONE
     };
     let telemetry = init_otel(&config);
-    let registry = tracing_subscriber::registry().with(env_filter);
+    let registry = tracing_subscriber::registry();
 
     #[cfg(feature = "observability")]
     let init_result = match (config.format, telemetry.tracer_provider.as_ref()) {
         (LogFormat::Text, Some(provider)) => registry
             .with(
                 tracing_opentelemetry::layer()
-                    .with_tracer(provider.tracer(telemetry.service_name.clone())),
+                    .with_tracer(provider.tracer(telemetry.service_name.clone()))
+                    .with_filter(filter_fn(|metadata| {
+                        metadata.target() == trace::TELEMETRY_TARGET
+                    })),
             )
             .with(
                 tracing_subscriber::fmt::layer()
@@ -291,7 +318,8 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
                     .with_span_events(span_events)
-                    .with_ansi(io::stderr().is_terminal()),
+                    .with_ansi(io::stderr().is_terminal())
+                    .with_filter(env_filter),
             )
             .try_init(),
         (LogFormat::Text, None) => registry
@@ -304,13 +332,17 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
                     .with_span_events(span_events)
-                    .with_ansi(io::stderr().is_terminal()),
+                    .with_ansi(io::stderr().is_terminal())
+                    .with_filter(env_filter),
             )
             .try_init(),
         (LogFormat::Json, Some(provider)) => registry
             .with(
                 tracing_opentelemetry::layer()
-                    .with_tracer(provider.tracer(telemetry.service_name.clone())),
+                    .with_tracer(provider.tracer(telemetry.service_name.clone()))
+                    .with_filter(filter_fn(|metadata| {
+                        metadata.target() == trace::TELEMETRY_TARGET
+                    })),
             )
             .with(
                 tracing_subscriber::fmt::layer()
@@ -321,7 +353,8 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_thread_ids(config.include_thread_ids)
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
-                    .with_span_events(span_events),
+                    .with_span_events(span_events)
+                    .with_filter(env_filter),
             )
             .try_init(),
         (LogFormat::Json, None) => registry
@@ -334,7 +367,8 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_thread_ids(config.include_thread_ids)
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
-                    .with_span_events(span_events),
+                    .with_span_events(span_events)
+                    .with_filter(env_filter),
             )
             .try_init(),
     };
@@ -351,7 +385,8 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
                     .with_span_events(span_events)
-                    .with_ansi(io::stderr().is_terminal()),
+                    .with_ansi(io::stderr().is_terminal())
+                    .with_filter(env_filter),
             )
             .try_init(),
         LogFormat::Json => registry
@@ -364,7 +399,8 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
                     .with_thread_ids(config.include_thread_ids)
                     .with_file(config.include_location)
                     .with_line_number(config.include_location)
-                    .with_span_events(span_events),
+                    .with_span_events(span_events)
+                    .with_filter(env_filter),
             )
             .try_init(),
     };
@@ -426,6 +462,8 @@ struct TelemetryInit {
     tracer_provider: Option<SdkTracerProvider>,
     #[cfg(feature = "observability")]
     service_name: String,
+    #[cfg(all(test, feature = "observability"))]
+    network_client_initialized: bool,
 }
 
 #[cfg(feature = "observability")]
@@ -436,6 +474,8 @@ fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
             guard: LoggingGuard::default(),
             tracer_provider: None,
             service_name: config.service_name,
+            #[cfg(all(test, feature = "observability"))]
+            network_client_initialized: false,
         };
     }
 
@@ -457,6 +497,7 @@ fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
         global::set_tracer_provider(provider.clone());
         Some(provider)
     });
+    trace::set_trace_export_enabled(tracer_provider.is_some());
 
     let meter_provider = config.metrics_endpoint.as_ref().and_then(|endpoint| {
         let exporter = opentelemetry_otlp::MetricExporter::builder()
@@ -483,6 +524,9 @@ fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
         },
         tracer_provider,
         service_name: config.service_name,
+        #[cfg(all(test, feature = "observability"))]
+        network_client_initialized: config.trace_endpoint.is_some()
+            || config.metrics_endpoint.is_some(),
     }
 }
 
@@ -495,6 +539,13 @@ fn init_otel(_logging: &LoggingConfig) -> TelemetryInit {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "observability")]
+    use opentelemetry::trace::TracerProvider as _;
+    #[cfg(feature = "observability")]
+    use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SimpleSpanProcessor};
+    #[cfg(feature = "observability")]
+    use tracing_subscriber::layer::SubscriberExt as _;
+
     use super::*;
 
     #[test]
@@ -538,5 +589,61 @@ mod tests {
         assert!(!is_truthy("off"));
         assert!(!is_truthy(""));
         assert!(!is_truthy("random"));
+    }
+
+    #[cfg(feature = "observability")]
+    #[test]
+    fn endpoint_gate_is_network_dormant_and_command_spans_export_when_enabled() {
+        let shared = LoggingConfig {
+            otel_endpoint: Some("http://collector:4318/".to_string()),
+            ..LoggingConfig::default()
+        };
+        let resolved = OtelConfig::from_logging_config(&shared);
+        assert_eq!(
+            resolved.trace_endpoint.as_deref(),
+            Some("http://collector:4318/v1/traces")
+        );
+
+        let telemetry = init_otel(&LoggingConfig::default());
+        assert!(telemetry.tracer_provider.is_none());
+        assert!(!telemetry.network_client_initialized);
+        drop(telemetry);
+
+        let exporter = InMemorySpanExporter::default();
+        let provider = SdkTracerProvider::builder()
+            .with_span_processor(SimpleSpanProcessor::new(exporter.clone()))
+            .build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("heddle-test")));
+        trace::set_trace_export_enabled(true);
+        tracing::subscriber::with_default(subscriber, || {
+            let mut command = CommandTrace::start("status", std::time::Instant::now())
+                .expect("test trace export is enabled");
+            command
+                .span()
+                .in_scope(|| record_phase_span("status repo open", 7));
+            command.finish(0);
+            drop(command);
+        });
+        trace::set_trace_export_enabled(false);
+
+        let spans = exporter.get_finished_spans().expect("read exported spans");
+        assert_eq!(spans.len(), 2);
+        let command = spans
+            .iter()
+            .find(|span| span.name == "heddle.command")
+            .expect("command span exported");
+        let phase = spans
+            .iter()
+            .find(|span| span.name == "heddle.phase")
+            .expect("phase span exported");
+        assert_eq!(phase.parent_span_id, command.span_context.span_id());
+        assert!(command.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "command.status" && attribute.value.to_string() == "ok"
+        }));
+        assert!(phase.attributes.iter().any(|attribute| {
+            attribute.key.as_str() == "phase.name"
+                && attribute.value.to_string() == "status repo open"
+        }));
     }
 }

--- a/crates/cli-shared/src/logging/trace.rs
+++ b/crates/cli-shared/src/logging/trace.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Privacy-bounded command and phase tracing for the foreground CLI.
+
+use std::{
+    sync::atomic::{AtomicBool, Ordering},
+    time::Instant,
+};
+
+use tracing::{Span, field};
+
+pub(super) const TELEMETRY_TARGET: &str = "heddle_telemetry";
+
+static TRACE_EXPORT_ENABLED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(feature = "observability")]
+pub(super) fn set_trace_export_enabled(enabled: bool) {
+    TRACE_EXPORT_ENABLED.store(enabled, Ordering::Release);
+}
+
+/// Whether this process has an endpoint-backed trace provider.
+pub fn trace_export_enabled() -> bool {
+    TRACE_EXPORT_ENABLED.load(Ordering::Acquire)
+}
+
+/// One root span for a foreground CLI command.
+pub struct CommandTrace {
+    span: Span,
+    started: Instant,
+    finished: bool,
+}
+
+impl CommandTrace {
+    /// Start a command span only when trace export was explicitly enabled.
+    pub fn start(command: &str, started: Instant) -> Option<Self> {
+        trace_export_enabled().then(|| Self {
+            span: tracing::info_span!(
+                target: TELEMETRY_TARGET,
+                "heddle.command",
+                command.name = command,
+                command.status = field::Empty,
+                command.exit_code = field::Empty,
+                command.duration_ms = field::Empty,
+            ),
+            started,
+            finished: false,
+        })
+    }
+
+    pub fn span(&self) -> &Span {
+        &self.span
+    }
+
+    pub fn finish(&mut self, exit_code: i32) {
+        self.span.record(
+            "command.status",
+            if exit_code == 0 { "ok" } else { "error" },
+        );
+        self.span.record("command.exit_code", exit_code);
+        self.span.record(
+            "command.duration_ms",
+            u64::try_from(self.started.elapsed().as_millis()).unwrap_or(u64::MAX),
+        );
+        self.finished = true;
+    }
+}
+
+impl Drop for CommandTrace {
+    fn drop(&mut self) {
+        if !self.finished {
+            self.finish(1);
+        }
+    }
+}
+
+/// Record an already-measured profile phase as a child of the command span.
+pub fn record_phase_span(name: &'static str, duration_ms: u64) {
+    if !trace_export_enabled() {
+        return;
+    }
+    let span = tracing::info_span!(
+        target: TELEMETRY_TARGET,
+        "heddle.phase",
+        phase.name = name,
+        phase.duration_ms = duration_ms,
+    );
+    let _entered = span.enter();
+}

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -142,7 +142,19 @@ mount = { path = "../mount", package = "heddle-mount", version = "0.11", optiona
 # fallback (`nfsserve` + `tokio` async-trait). The OSS feature
 # subsets that explicitly want a slim build (`--no-default-features
 # --features git-overlay,...`) opt out the same way they do today.
-default = ["git-overlay", "native", "local", "mount", "semantic", "zstd", "client"]
+# `observability` compiles OTLP support into shipped binaries, but runtime
+# initialization remains endpoint-gated: without an OTLP endpoint there is no
+# provider, exporter, background worker, or telemetry network client.
+default = [
+    "git-overlay",
+    "native",
+    "local",
+    "mount",
+    "semantic",
+    "zstd",
+    "client",
+    "observability",
+]
 local = []
 # Repository mode features. At least one must be enabled. The default
 # build enables both modes plus the hosted `client`. Slimmer builds opt

--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::{
     cli::{AdoptArgs, Cli, should_output_json, style},
-    perf::{ProfileField, emit_profile, profile_enabled},
+    perf::{ProfileField, emit_profile, instrumentation_enabled},
 };
 
 #[derive(Debug, Serialize)]
@@ -114,7 +114,7 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
     drop(repo);
     let repo = Repository::open(&git_root)?;
     let verification_start = std::time::Instant::now();
-    let (trust, verification_profile) = if profile_enabled() {
+    let (trust, verification_profile) = if instrumentation_enabled() {
         let (trust, profile) = build_repository_verification_state_profiled(&repo);
         (trust, Some(profile))
     } else {

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -45,7 +45,7 @@ use crate::{
     attribution::clean_attribution_value,
     cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
     config::UserConfig,
-    perf::{ProfileField, emit_profile, profile_enabled},
+    perf::{ProfileField, emit_profile, instrumentation_enabled},
 };
 
 #[derive(Serialize)]
@@ -365,7 +365,7 @@ pub async fn cmd_snapshot(
         );
     }
 
-    if profile_enabled() {
+    if instrumentation_enabled() {
         emit_profile(
             "capture phases",
             &[

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -40,7 +40,7 @@ use super::{
 };
 use crate::{
     cli::{Cli, output_is_compact, should_output_json, style, worktree_status_options},
-    perf::{ProfileField, ProfileMode, emit_profile, profile_enabled, profile_mode},
+    perf::{ProfileField, ProfileMode, emit_profile, instrumentation_enabled, profile_mode},
 };
 
 fn emit_status_worktree_profile(profile: Option<&WorktreeCompareProfile>) {
@@ -81,9 +81,8 @@ fn emit_status_worktree_profile(profile: Option<&WorktreeCompareProfile>) {
         ),
     ];
     match profile_mode() {
-        ProfileMode::Off => {}
+        ProfileMode::Off | ProfileMode::Jsonl => emit_profile("status worktree detail", &fields),
         ProfileMode::Human => emit_profile("status worktree", &fields),
-        ProfileMode::Jsonl => emit_profile("status worktree detail", &fields),
     }
 }
 
@@ -182,7 +181,7 @@ fn render_fast_short_status(output: &FastShortStatusReport) {
 }
 
 fn emit_fast_short_status_profile(output: &FastShortStatusReport) {
-    if profile_enabled() {
+    if instrumentation_enabled() {
         emit_profile(
             "status fast short",
             &[
@@ -374,7 +373,7 @@ fn cli_coordination_status(status: CoordinationStatus) -> super::thread::Coordin
 }
 
 fn emit_status_profile(output: &StatusOutput) {
-    if !profile_enabled() {
+    if !instrumentation_enabled() {
         return;
     }
     emit_status_worktree_profile(output.profile.worktree_profile.as_ref());
@@ -402,9 +401,8 @@ fn emit_status_profile(output: &StatusOutput) {
         ProfileField::millis("build_total_ms", output.profile.build_total_ms),
     ];
     match profile_mode() {
-        ProfileMode::Off => {}
+        ProfileMode::Off | ProfileMode::Jsonl => emit_profile_status_jsonl_phases(output),
         ProfileMode::Human => emit_profile("status phases", &fields),
-        ProfileMode::Jsonl => emit_profile_status_jsonl_phases(output),
     }
 }
 
@@ -577,7 +575,7 @@ pub(crate) fn render_status(
     } else {
         render_long_status(output, cli.verbose > 0);
     }
-    if profile_enabled() {
+    if instrumentation_enabled() {
         emit_profile(
             "status render",
             &[ProfileField::duration("render_ms", render_start.elapsed())],

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -64,7 +64,7 @@ use super::{
 use crate::{
     cli::{Cli, ThreadListArgs, ThreadStartArgs, WorkspaceModeArg, should_output_json, style},
     config::{UserConfig, UserThreadWorkspaceMode},
-    perf::{ProfileField, ProfileMode, emit_profile, profile_enabled, profile_mode},
+    perf::{ProfileField, ProfileMode, emit_profile, instrumentation_enabled, profile_mode},
 };
 
 pub(crate) const DEFAULT_AVAILABLE_GIT_REF_LIMIT: usize = 5;
@@ -586,16 +586,14 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
         render_available_git_refs(&output.available_git_refs, cli.verbose > 0);
     }
 
-    if profile_enabled() {
+    if instrumentation_enabled() {
         let fields = [
             ProfileField::millis("collect_summaries_ms", collect_summaries_ms),
             ProfileField::millis("verification_ms", verification_ms),
             ProfileField::duration("command_body_ms", body_start.elapsed()),
         ];
         match profile_mode() {
-            ProfileMode::Off => {}
-            ProfileMode::Human => emit_profile("thread list phases", &fields),
-            ProfileMode::Jsonl => {
+            ProfileMode::Off | ProfileMode::Jsonl => {
                 emit_profile(
                     "thread list collect summaries",
                     &[ProfileField::millis(
@@ -615,6 +613,7 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
                     )],
                 );
             }
+            ProfileMode::Human => emit_profile("thread list phases", &fields),
         }
     }
 

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -14,7 +14,7 @@ use super::{RecoveryAdvice, action_line::print_next};
 use crate::{
     cli::{Cli, should_output_json, style},
     config::UserConfig,
-    perf::{ProfileField, ProfileMode, emit_profile, profile_enabled, profile_mode},
+    perf::{ProfileField, ProfileMode, emit_profile, instrumentation_enabled, profile_mode},
 };
 
 pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
@@ -33,7 +33,7 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
     // Open cost is paid either in the CLI shell (injected) or inside core
     // (facade open). Exactly one side owns it; sum keeps profile truthful.
     let repo_open_ms = prepared.repo_open_ms + output.profile.repo_open_ms;
-    if profile_enabled() {
+    if instrumentation_enabled() {
         let fields = [
             ProfileField::millis("plain_git_probe_ms", output.profile.plain_git_probe_ms),
             ProfileField::millis("repo_open_ms", repo_open_ms),
@@ -41,9 +41,7 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
             ProfileField::duration("command_body_ms", body_start.elapsed()),
         ];
         match profile_mode() {
-            ProfileMode::Off => {}
-            ProfileMode::Human => emit_profile("verify phases", &fields),
-            ProfileMode::Jsonl => {
+            ProfileMode::Off | ProfileMode::Jsonl => {
                 emit_profile(
                     "verify plain git probe",
                     &[ProfileField::millis(
@@ -70,6 +68,7 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
                     )],
                 );
             }
+            ProfileMode::Human => emit_profile("verify phases", &fields),
         }
     }
     // Config comes from the single open above — never re-open for JSON mode.

--- a/crates/cli/src/hosted_runtime/hosted/context.rs
+++ b/crates/cli/src/hosted_runtime/hosted/context.rs
@@ -12,7 +12,13 @@ use api::{
 };
 use cli_shared::ClientConfig;
 use crypto::{Ed25519Signer, Signer as _};
+#[cfg(feature = "observability")]
+use opentelemetry::propagation::{Injector, TextMapPropagator};
+#[cfg(feature = "observability")]
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use prost_types::Timestamp;
+#[cfg(feature = "observability")]
+use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use super::{HostedError, Result};
 
@@ -267,7 +273,7 @@ impl CallContextFactory {
             request_proof: None,
             human_verification: None,
             client_operation_id,
-            trace: self.trace.clone(),
+            trace: self.trace.clone().or_else(active_trace_context),
             bearer_grant_envelope: self.bearer_grant_envelope.clone(),
         })
     }
@@ -297,6 +303,41 @@ impl CallContextFactory {
             signature,
         }))
     }
+}
+
+#[cfg(feature = "observability")]
+#[derive(Default)]
+struct TraceHeaders {
+    traceparent: Option<String>,
+    tracestate: Option<String>,
+}
+
+#[cfg(feature = "observability")]
+impl Injector for TraceHeaders {
+    fn set(&mut self, key: &str, value: String) {
+        match key {
+            "traceparent" => self.traceparent = Some(value),
+            "tracestate" => self.tracestate = Some(value),
+            _ => {}
+        }
+    }
+}
+
+#[cfg(feature = "observability")]
+fn active_trace_context() -> Option<TraceContext> {
+    let context = tracing::Span::current().context();
+    let mut headers = TraceHeaders::default();
+    TraceContextPropagator::new().inject_context(&context, &mut headers);
+    Some(TraceContext {
+        traceparent: headers.traceparent?,
+        tracestate: headers.tracestate.unwrap_or_default(),
+        baggage: String::new(),
+    })
+}
+
+#[cfg(not(feature = "observability"))]
+fn active_trace_context() -> Option<TraceContext> {
+    None
 }
 
 /// A context plus the stable action data required for one human-verification retry.
@@ -373,7 +414,15 @@ fn deadline(timeout: Duration) -> Result<Timestamp> {
 mod tests {
     use api::UNARY_SIGNING_V1_FIXTURE_JSON;
     use crypto::Signer as _;
+    #[cfg(feature = "observability")]
+    use opentelemetry::trace::{TraceContextExt as _, TracerProvider as _};
+    #[cfg(feature = "observability")]
+    use opentelemetry_sdk::trace::SdkTracerProvider;
     use serde::Deserialize;
+    #[cfg(feature = "observability")]
+    use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+    #[cfg(feature = "observability")]
+    use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
 
@@ -385,6 +434,55 @@ mod tests {
         nonce_hex: String,
         request_hex: String,
         canonical_hex: String,
+    }
+
+    #[test]
+    fn tracing_off_omits_hosted_trace_context() {
+        let context = CallContextFactory::default()
+            .streaming("/heddle.api.v1alpha1.RepoSyncService/Pull", "off")
+            .unwrap();
+        assert!(context.trace.is_none());
+    }
+
+    #[cfg(feature = "observability")]
+    #[test]
+    fn active_span_traceparent_is_carried_in_the_iroh_request_prelude() {
+        let provider = SdkTracerProvider::builder().build();
+        let subscriber = tracing_subscriber::registry()
+            .with(tracing_opentelemetry::layer().with_tracer(provider.tracer("propagation-test")));
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!(
+                target: "heddle_telemetry",
+                "heddle.command",
+                command.name = "pull"
+            );
+            span.in_scope(|| {
+                let span_context = span.context();
+                let expected = span_context.span().span_context().clone();
+                let context = CallContextFactory::default()
+                    .streaming("/heddle.api.v1alpha1.RepoSyncService/Pull", "propagation")
+                    .unwrap();
+                let trace = context.trace.as_ref().expect("active trace is propagated");
+                let parts = trace.traceparent.split('-').collect::<Vec<_>>();
+                assert_eq!(parts.len(), 4);
+                assert_eq!(parts[0], "00");
+                assert_eq!(parts[1], expected.trace_id().to_string());
+                assert_eq!(parts[2], expected.span_id().to_string());
+                assert!(trace.baggage.is_empty());
+
+                let frame = api::framing::encode_request_prelude(
+                    "/heddle.api.v1alpha1.RepoSyncService/Pull",
+                    &context,
+                )
+                .unwrap();
+                let (decoded, consumed) = api::framing::decode_request_prelude(&frame)
+                    .unwrap()
+                    .expect("complete request prelude");
+                assert_eq!(consumed, frame.len());
+                assert_eq!(decoded.context.trace, context.trace);
+            });
+        });
+        provider.shutdown().unwrap();
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -45,7 +45,7 @@ use cli::{
     },
     config::UserConfig,
     exit::HeddleExitCode,
-    logging::{LoggingConfig, init_logging},
+    logging::{CommandTrace, LoggingConfig, LoggingGuard, init_logging},
     operation_id::{resolve_operation_id, run_local_idempotency_if_requested},
     perf::{ProfileField, emit_command_profile, profile_enabled},
 };
@@ -252,6 +252,12 @@ async fn async_main() -> Result<()> {
     };
     let telemetry = init_logging(logging);
     let logging_init_ms = logging_start.elapsed().as_millis();
+    let command_trace = CommandTrace::start(&command_name, total_start);
+    // The foreground runtime is deliberately single-threaded, so keeping this
+    // span entered across awaits cannot associate it with another task/thread.
+    let command_span_guard = command_trace
+        .as_ref()
+        .map(|trace| trace.span().clone().entered());
 
     debug!(
         command = command_name.as_str(),
@@ -268,34 +274,34 @@ async fn async_main() -> Result<()> {
     // Agents treat 64 as "fix your argv" and retry-with-mutation; 65 tells
     // them to fall back to a supported output mode (HeddleCo/heddle#648).
     if explicit_json_requested(&cli) && !command_contract.supports_json {
-        telemetry.shutdown();
         let err = anyhow::anyhow!(cli::cli::commands::RecoveryAdvice::json_unsupported(
             &command_name
         ));
         let code = HeddleExitCode::from_error(&err);
         print_error_with_hint(&cli, &err);
+        shutdown_command_telemetry(command_trace, command_span_guard, telemetry, code.into());
         std::process::exit(code.into());
     }
     if cli::cli::output_is_compact(&cli) && !command_contract.supports_json_compact {
-        telemetry.shutdown();
         let err = anyhow::anyhow!(
             cli::cli::commands::RecoveryAdvice::json_compact_unsupported(&command_name)
         );
         let code = HeddleExitCode::from_error(&err);
         print_error_with_hint(&cli, &err);
+        shutdown_command_telemetry(command_trace, command_span_guard, telemetry, code.into());
         std::process::exit(code.into());
     }
 
     match run_local_idempotency_if_requested(&cli, &command_name, command_supports_op_id) {
         Ok(true) => {
-            telemetry.shutdown();
+            shutdown_command_telemetry(command_trace, command_span_guard, telemetry, 0);
             return Ok(());
         }
         Ok(false) => {}
         Err(err) => {
-            telemetry.shutdown();
             let code = HeddleExitCode::from_error(&err);
             print_error_with_hint(&cli, &err);
+            shutdown_command_telemetry(command_trace, command_span_guard, telemetry, code.into());
             std::process::exit(code.into());
         }
     }
@@ -818,12 +824,12 @@ async fn async_main() -> Result<()> {
         "CLI command complete"
     );
 
+    let exit_status = match &result {
+        Ok(()) => 0,
+        Err(err) if !explicit_json_requested(&cli) && is_broken_pipe_error(err) => 0,
+        Err(err) => HeddleExitCode::from_error(err).into(),
+    };
     if profile {
-        let exit_status = match &result {
-            Ok(()) => 0,
-            Err(err) if !explicit_json_requested(&cli) && is_broken_pipe_error(err) => 0,
-            Err(err) => HeddleExitCode::from_error(err).into(),
-        };
         emit_command_profile(
             &command_name,
             exit_status,
@@ -836,7 +842,7 @@ async fn async_main() -> Result<()> {
         );
     }
 
-    telemetry.shutdown();
+    shutdown_command_telemetry(command_trace, command_span_guard, telemetry, exit_status);
     match result {
         Ok(()) => Ok(()),
         // Machine output must end in a terminal record or a structured error.
@@ -854,6 +860,20 @@ async fn async_main() -> Result<()> {
             std::process::exit(code.into());
         }
     }
+}
+
+fn shutdown_command_telemetry(
+    mut command_trace: Option<CommandTrace>,
+    command_span_guard: Option<tracing::span::EnteredSpan>,
+    telemetry: LoggingGuard,
+    exit_code: i32,
+) {
+    if let Some(trace) = command_trace.as_mut() {
+        trace.finish(exit_code);
+    }
+    drop(command_span_guard);
+    drop(command_trace);
+    telemetry.shutdown();
 }
 
 /// Check for an existing recovery target without opening or bootstrapping it.

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -10,6 +10,8 @@ use std::{cell::RefCell, collections::BTreeMap, time::Duration};
 
 use serde::Serialize;
 
+use crate::logging::{record_phase_span, trace_export_enabled};
+
 const PROFILE_SCHEMA: &str = "heddle-cli-profile/v1";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -101,7 +103,18 @@ pub fn profile_enabled() -> bool {
     profile_mode() != ProfileMode::Off
 }
 
-pub fn emit_profile(command: &str, fields: &[ProfileField]) {
+pub fn instrumentation_enabled() -> bool {
+    profile_enabled() || trace_export_enabled()
+}
+
+pub fn emit_profile(command: &'static str, fields: &[ProfileField]) {
+    let duration_ms = fields
+        .iter()
+        .filter(|field| matches!(field.unit, ProfileMetricUnit::Milliseconds))
+        .map(|field| u64::try_from(field.value).unwrap_or(u64::MAX))
+        .max()
+        .unwrap_or(0);
+    record_phase_span(command, duration_ms);
     match profile_mode() {
         ProfileMode::Off => {}
         ProfileMode::Human => emit_human_profile(command, fields),

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -346,6 +346,8 @@ mod state_id_acceptance;
 mod stdout_stderr_split;
 #[path = "cli_integration/submodule_status.rs"]
 mod submodule_status;
+#[path = "cli_integration/telemetry.rs"]
+mod telemetry;
 #[path = "cli_integration/thread_cleanup.rs"]
 mod thread_cleanup;
 #[path = "cli_integration/thread_default_current.rs"]

--- a/crates/cli/tests/cli_integration/telemetry.rs
+++ b/crates/cli/tests/cli_integration/telemetry.rs
@@ -64,6 +64,18 @@ fn opted_in_real_command_reaches_otlp_http_collector() {
             .any(|window| window == b"heddle.command"),
         "OTLP protobuf body should contain the command span name"
     );
+    assert!(
+        request[header_end..]
+            .windows(b"heddle.phase".len())
+            .any(|window| window == b"heddle.phase"),
+        "OTLP protobuf body should contain profile phase child spans"
+    );
+    assert!(
+        !request[header_end..]
+            .windows(repo.path().as_os_str().as_encoded_bytes().len())
+            .any(|window| window == repo.path().as_os_str().as_encoded_bytes()),
+        "OTLP protobuf body must not contain the repository path"
+    );
 }
 
 fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {

--- a/crates/cli/tests/cli_integration/telemetry.rs
+++ b/crates/cli/tests/cli_integration/telemetry.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+    thread,
+    time::Duration,
+};
+
+use super::*;
+
+const OTEL_ENV: &[&str] = &[
+    "OTEL_EXPORTER_OTLP_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+];
+
+#[test]
+fn opted_in_real_command_reaches_otlp_http_collector() {
+    let repo = TempDir::new().unwrap();
+    let init = heddle_output_with_env_removed(&["init"], Some(repo.path()), &[], OTEL_ENV).unwrap();
+    assert!(init.status.success());
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let endpoint = format!("http://{}", listener.local_addr().unwrap());
+    let (captured_tx, captured_rx) = mpsc::channel();
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("OTLP request");
+        stream
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .unwrap();
+        let request = read_http_request(&mut stream);
+        stream
+            .write_all(
+                b"HTTP/1.1 200 OK\r\ncontent-type: application/x-protobuf\r\ncontent-length: 0\r\nconnection: close\r\n\r\n",
+            )
+            .unwrap();
+        captured_tx.send(request).unwrap();
+    });
+
+    let output = heddle_output_with_env_removed(
+        &["--output", "json", "status"],
+        Some(repo.path()),
+        &[("OTEL_EXPORTER_OTLP_ENDPOINT", endpoint.as_str())],
+        OTEL_ENV,
+    )
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "status failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let request = captured_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("collector receives an export request");
+    server.join().unwrap();
+    let header_end = find_bytes(&request, b"\r\n\r\n").expect("HTTP headers") + 4;
+    let headers = String::from_utf8_lossy(&request[..header_end]);
+    assert!(headers.starts_with("POST /v1/traces HTTP/1.1"), "{headers}");
+    assert!(
+        request[header_end..]
+            .windows(b"heddle.command".len())
+            .any(|window| window == b"heddle.command"),
+        "OTLP protobuf body should contain the command span name"
+    );
+}
+
+fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 4096];
+    let header_end = loop {
+        let read = stream.read(&mut chunk).expect("read OTLP request headers");
+        assert_ne!(read, 0, "OTLP request ended before headers");
+        request.extend_from_slice(&chunk[..read]);
+        if let Some(index) = find_bytes(&request, b"\r\n\r\n") {
+            break index + 4;
+        }
+    };
+    let headers = String::from_utf8_lossy(&request[..header_end]);
+    let content_length = headers
+        .lines()
+        .find_map(|line| {
+            line.split_once(':').and_then(|(name, value)| {
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().unwrap())
+            })
+        })
+        .expect("OTLP request content-length");
+    while request.len() < header_end + content_length {
+        let read = stream.read(&mut chunk).expect("read OTLP request body");
+        assert_ne!(read, 0, "OTLP request body was truncated");
+        request.extend_from_slice(&chunk[..read]);
+    }
+    request
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,0 +1,42 @@
+# CLI trace export
+
+Heddle can export command traces to an OpenTelemetry collector. Export is off
+by default: unless a trace endpoint is configured, Heddle does not construct a
+tracer provider, exporter, or telemetry network client.
+
+Opt in for one shell with the collector's OTLP/HTTP base endpoint:
+
+```sh
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+heddle status
+```
+
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` takes precedence when both variables are
+set and, per the OTLP convention for signal-specific endpoints, should include
+the `/v1/traces` path. A persistent user configuration uses the same complete
+trace URL:
+
+```toml
+[logging]
+otel_traces_endpoint = "http://127.0.0.1:4318/v1/traces"
+```
+
+For the pilot observability stack under `workspace/obs`, set the endpoint to
+`http://<collector-host>:4318`; use `127.0.0.1` when Heddle runs on the same
+host as the collector.
+
+Each traced invocation emits a `heddle.command` span with the static command
+name, success/error status, numeric exit code, and duration. Existing
+`HEDDLE_PROFILE` timings are represented as `heddle.phase` child spans where
+the command already measures them. Heddle does not attach paths, argv, object
+IDs, remote URLs, environment values, or filenames. Hosted request context
+propagates W3C `traceparent` and `tracestate`; baggage is not collected or sent.
+
+Trace export is batched on a background worker. Process exit attempts a
+best-effort flush bounded to 250 milliseconds, so an unavailable collector
+cannot hold command completion indefinitely.
+
+The client-side spans and export are useful independently. End-to-end traces
+also require Weft to extract the propagated context from
+`CallContext.trace.traceparent` and `CallContext.trace.tracestate` in the Iroh
+request opening prelude and use it as the parent of its RPC lifecycle span.


### PR DESCRIPTION
## Summary

- Compile OpenTelemetry trace export into the default `heddle` build while keeping initialization endpoint-gated: no configured endpoint means no provider, exporter, background worker, or telemetry network client.
- Emit privacy-bounded `heddle.command` root spans plus existing profile measurements as `heddle.phase` children, using a background batch exporter and a best-effort 250 ms shutdown bound.
- Propagate the active command context through every hosted Iroh RPC opening prelude, and document opt-in, privacy, pilot collector wiring, and shutdown behavior.

Closes #1221. Relates to #1218 and the #1219 law-4 gate.

### On-wire contract and merge order

Every unary, server-streaming, and bidirectional hosted call is framed by `api::framing::encode_request_frame` / `encode_request_prelude`. The existing protobuf `CallContext.trace` field (field 7) carries `TraceContext`: `traceparent` is field 1 and contains the standard W3C string, `tracestate` is field 2, and `baggage` is field 3 and is always empty for automatically propagated CLI context. The client injects this context before the request body in the Iroh operation-stream opening prelude.

The Weft companion should extract `CallContext.trace.traceparent` and `CallContext.trace.tracestate` from that prelude and install them as the parent context of the #987 RPC lifecycle span. This PR can merge first: client export and local command/phase spans are useful independently. Linked end-to-end traces require both this client change and the Weft extraction change.

## Testing

- `cargo test -p heddle-cli-shared --features observability logging::tests` — 4 passed.
- `cargo test -p heddle-cli --lib hosted_runtime::hosted::context::tests` — 6 passed.
- `cargo test -p heddle-cli --test cli_integration telemetry::` — 1 passed; a real `heddle status` posted OTLP protobuf to `/v1/traces`, including command + phase span names and excluding the repository path.
- `cargo test -p heddle-cli --test cli_integration perf_trace::` — 4 passed.
- `cargo check -p heddle-cli --no-default-features --features git-overlay,native,semantic,zstd` — passed with four pre-existing feature-combination warnings.
- `cargo clippy -p heddle-cli --all-targets -- -D warnings` — passed.
- `rustfmt +nightly --edition 2024 --check <touched Rust files>` — passed.

### Negative-control evidence

The endpoint-gate test asserts `tracer_provider.is_none()` and `network_client_initialized == false` with default configuration. I temporarily forced `http://127.0.0.1:4318/v1/traces` as an unconditional fallback; the test went red with:

```text
assertion failed: telemetry.tracer_provider.is_none()
test result: FAILED. 0 passed; 1 failed
```

After reverting the forced endpoint, the same test passed.

### Default-build cost

Same-source debug builds measured 287,227,880 bytes without `observability` and 296,654,936 bytes with it: +9,427,056 bytes (+3.28%). With all OTLP endpoint variables removed, 60 `status --output json` runs measured 64.542 ms median without the feature and 65.345 ms median with default-compiled OTLP (+0.803 ms, +1.24%). No AWS-LC dependency was introduced; the blocking OTLP worker reuses the existing ring-backed Reqwest stack.

### Live collector bonus

A live command sent through the shared collector on `127.0.0.1:4318`; Tempo returned trace `1e026f81b4169729cdaa3ab030f9d8a2` with root service `heddle`, root span `heddle.command`, and 68 ms duration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1222"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788384197&installation_model_id=21489&pr_number=1222&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1222&signature=b4e9a5f22c856b1604bcdd61615c781a094f158ba0455a33ba1673b4372decd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->