### PR TITLE
perf(cli): bypass relays for reachable direct Iroh peers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1097,6 +1097,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1971,6 +1985,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -2063,6 +2083,7 @@ dependencies = [
  "hyper-util",
  "ignore",
  "iroh-base",
+ "iroh-relay",
  "libc",
  "n0-watcher",
  "noq-udp",
@@ -3164,12 +3185,20 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "iroh-metrics-derive",
  "itoa",
  "n0-error",
  "portable-atomic",
+ "reqwest",
+ "rustls",
+ "rustls-platform-verifier",
  "ryu",
  "serde",
+ "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -3194,6 +3223,8 @@ dependencies = [
  "blake3",
  "bytes",
  "cfg_aliases",
+ "clap",
+ "dashmap",
  "data-encoding",
  "derive_more",
  "getrandom 0.4.3",
@@ -3214,17 +3245,28 @@ dependencies = [
  "pin-project",
  "postcard",
  "rand 0.10.2",
+ "rcgen",
+ "reloadable-state",
  "reqwest",
  "rustls",
+ "rustls-cert-file-reader",
+ "rustls-cert-reloadable-resolver",
  "rustls-pki-types",
  "serde",
  "serde_bytes",
+ "serde_json",
+ "sha1 0.11.0",
+ "simdutf8",
  "strum",
+ "time",
  "tokio",
  "tokio-rustls",
+ "tokio-rustls-acme",
  "tokio-util",
  "tokio-websockets",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "url",
  "webpki-roots 1.0.9",
  "ws_stream_wasm",
@@ -3836,6 +3878,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "slab",
  "sorted-index-buffer",
  "thiserror 2.0.18",
@@ -5097,6 +5140,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "reloadable-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc20ac1418988b60072d783c9f68e28a173fb63493c127952f6face3b40c6e0"
+
+[[package]]
+name = "reloadable-state"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3853ef78d45b50f8b989896304a85239539d39b7f866a000e8846b9b72d74ce8"
+dependencies = [
+ "arc-swap",
+ "reloadable-core",
+ "tokio",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5345,40 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-cert-file-reader"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb47c2a50fdfdaf95b0ac8b12620fc327da1fd4adbb30d0c56d866b005873ff"
+dependencies = [
+ "rustls-cert-read",
+ "rustls-pki-types",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "rustls-cert-read"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd46e8c5ae4de3345c4786a83f99ec7aff287209b9e26fa883c473aeb28f19d5"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-cert-reloadable-resolver"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe1baa8a3a1f05eaa9fc55aed4342867f70e5c170ea3bfed1b38c51a4857c0c8"
+dependencies = [
+ "futures-util",
+ "reloadable-state",
+ "rustls",
+ "rustls-cert-read",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6752,6 +6846,34 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls-acme"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1af8573b15fdad8d66da116198cd8fd8d87ff62a67c1c6c3df7f62da1170793f"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "log",
+ "num-bigint",
+ "pem",
+ "proc-macro2",
+ "rcgen",
+ "reqwest",
+ "ring",
+ "rustls",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-rustls",
+ "webpki-roots 1.0.9",
+ "x509-parser",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -248,6 +248,7 @@ mount = [
 criterion = "0.8"
 heddle-cli-render = { path = "../cli-render", version = "0.11", features = ["test-utils"] }
 hyper-util.workspace = true
+iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true
 prost-reflect.workspace = true
 proptest.workspace = true

--- a/crates/cli/src/hosted_runtime/hosted/bootstrap.rs
+++ b/crates/cli/src/hosted_runtime/hosted/bootstrap.rs
@@ -109,17 +109,27 @@ pub struct VerifiedEndpointDescriptor(EndpointDescriptor);
 
 impl VerifiedEndpointDescriptor {
     pub fn endpoint_addr(&self) -> Result<EndpointAddr> {
+        self.endpoint_addr_with_relays(true)
+    }
+
+    pub(super) fn direct_endpoint_addr(&self) -> Result<EndpointAddr> {
+        self.endpoint_addr_with_relays(false)
+    }
+
+    fn endpoint_addr_with_relays(&self, include_relays: bool) -> Result<EndpointAddr> {
         let endpoint_id: EndpointId = self
             .0
             .endpoint_id
             .parse()
             .map_err(|error| HostedError::InvalidDescriptor(format!("endpoint id: {error}")))?;
         let mut address = EndpointAddr::new(endpoint_id);
-        for relay in &self.0.relay_urls {
-            let relay: RelayUrl = relay
-                .parse()
-                .map_err(|error| HostedError::InvalidDescriptor(format!("relay URL: {error}")))?;
-            address = address.with_relay_url(relay);
+        if include_relays {
+            for relay in &self.0.relay_urls {
+                let relay: RelayUrl = relay.parse().map_err(|error| {
+                    HostedError::InvalidDescriptor(format!("relay URL: {error}"))
+                })?;
+                address = address.with_relay_url(relay);
+            }
         }
         for direct in &self.0.direct_addresses {
             let direct: SocketAddr = direct.parse().map_err(|error| {
@@ -235,6 +245,7 @@ async fn bootstrap_http_client(
     url: &str,
     config: &ClientConfig,
 ) -> Result<(Client, reqwest::Url, Option<HeaderValue>)> {
+    heddle_perf_contract::record_network_client_initialization();
     let mut builder = Client::builder()
         .timeout(Duration::from_secs(config.timeout_secs.max(1)))
         .redirect(Policy::none());

--- a/crates/cli/src/hosted_runtime/hosted/connection.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use api::heddle::api::v1alpha1::ProviderSource;
 use cli_shared::ClientConfig;
@@ -11,6 +11,8 @@ use tokio::sync::Mutex;
 use super::{
     HostedError, Result, VerifiedEndpointDescriptor, provider_transport::ProviderWebSocketTransport,
 };
+
+const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub(super) struct HostedConnection {
@@ -29,19 +31,38 @@ impl HostedConnection {
         heddle_perf_contract::record_network_client_initialization();
         let relays = descriptor.relay_urls()?;
         let address = descriptor.endpoint_addr()?;
+        let direct_address = descriptor.direct_endpoint_addr()?;
+
+        if direct_address.ip_addrs().next().is_some() {
+            let provider_transport = ProviderWebSocketTransport::new(config.clone());
+            let endpoint =
+                bind_endpoint(RelayMode::Disabled, Some(provider_transport.clone())).await?;
+            let direct = tokio::time::timeout(
+                DIRECT_CONNECT_TIMEOUT,
+                Self::connect_inner(endpoint, direct_address, Some(provider_transport)),
+            )
+            .await;
+            match direct {
+                Ok(Ok(connection)) => return Ok(connection),
+                Ok(Err(error)) if relays.is_empty() => return Err(error),
+                Err(error) if relays.is_empty() => return Err(HostedError::transport(error)),
+                Ok(Err(error)) => {
+                    tracing::debug!(%error, "signed direct addresses unavailable; enabling relays")
+                }
+                Err(_) => tracing::debug!(
+                    timeout_ms = DIRECT_CONNECT_TIMEOUT.as_millis(),
+                    "signed direct-address attempt timed out; enabling relays"
+                ),
+            }
+        }
+
         let relay_mode = if relays.is_empty() {
             RelayMode::Disabled
         } else {
             RelayMode::custom(relays)
         };
         let provider_transport = ProviderWebSocketTransport::new(config.clone());
-        let endpoint = Endpoint::builder(presets::Minimal)
-            .transport_config(transport_config())
-            .relay_mode(relay_mode)
-            .add_custom_transport(Arc::new(provider_transport.clone()))
-            .bind()
-            .await
-            .map_err(HostedError::transport)?;
+        let endpoint = bind_endpoint(relay_mode, Some(provider_transport.clone())).await?;
         Self::connect_inner(endpoint, address, Some(provider_transport)).await
     }
 
@@ -124,6 +145,19 @@ impl HostedConnection {
         self.connection.close(0u32.into(), b"Heddle client closed");
         self.endpoint.close().await;
     }
+}
+
+async fn bind_endpoint(
+    relay_mode: RelayMode,
+    provider_transport: Option<ProviderWebSocketTransport>,
+) -> Result<Endpoint> {
+    let mut builder = Endpoint::builder(presets::Minimal)
+        .transport_config(transport_config())
+        .relay_mode(relay_mode);
+    if let Some(provider_transport) = provider_transport {
+        builder = builder.add_custom_transport(Arc::new(provider_transport));
+    }
+    builder.bind().await.map_err(HostedError::transport)
 }
 
 impl Drop for HostedConnection {

--- a/crates/cli/src/hosted_runtime/hosted/connection.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection.rs
@@ -37,6 +37,10 @@ impl HostedConnection {
             let provider_transport = ProviderWebSocketTransport::new(config.clone());
             let endpoint =
                 bind_endpoint(RelayMode::Disabled, Some(provider_transport.clone())).await?;
+            if relays.is_empty() {
+                return Self::connect_inner(endpoint, direct_address, Some(provider_transport))
+                    .await;
+            }
             let direct = tokio::time::timeout(
                 DIRECT_CONNECT_TIMEOUT,
                 Self::connect_inner(endpoint, direct_address, Some(provider_transport)),
@@ -44,8 +48,6 @@ impl HostedConnection {
             .await;
             match direct {
                 Ok(Ok(connection)) => return Ok(connection),
-                Ok(Err(error)) if relays.is_empty() => return Err(error),
-                Err(error) if relays.is_empty() => return Err(HostedError::transport(error)),
                 Ok(Err(error)) => {
                     tracing::debug!(%error, "signed direct addresses unavailable; enabling relays")
                 }

--- a/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -1,0 +1,198 @@
+use std::{
+    net::Ipv4Addr,
+    time::{Duration, Instant},
+};
+
+use api::{
+    HOSTED_ALPN_V1,
+    heddle::api::v1alpha1::{EndpointDescriptor, SignedEndpointDescriptor},
+    signing::endpoint_descriptor_bytes,
+};
+use crypto::{Ed25519Signer, Signer};
+use iroh::{Endpoint, RelayMode, endpoint::presets};
+use n0_watcher::Watcher;
+
+use super::{DescriptorKeyring, VerifiedEndpointDescriptor, connection::HostedConnection};
+
+fn verified_descriptor(
+    endpoint_id: iroh::EndpointId,
+    relay_urls: Vec<String>,
+    direct_addresses: Vec<String>,
+) -> VerifiedEndpointDescriptor {
+    let signer = Ed25519Signer::generate().unwrap();
+    let now = chrono::Utc::now().timestamp_millis();
+    let descriptor = EndpointDescriptor {
+        version: 1,
+        endpoint_id: endpoint_id.to_string(),
+        relay_urls,
+        direct_addresses,
+        supported_alpns: vec![HOSTED_ALPN_V1.to_vec()],
+        issued_at_unix_millis: now - 1_000,
+        expires_at_unix_millis: now + 60_000,
+        rotation: None,
+    };
+    let signed = SignedEndpointDescriptor {
+        signature: signer
+            .sign(&endpoint_descriptor_bytes(&descriptor))
+            .unwrap(),
+        descriptor: Some(descriptor),
+        key_id: "test-key".to_string(),
+    };
+    let mut keys = DescriptorKeyring::default();
+    keys.insert(
+        "test-key",
+        signer.public_key().try_into().unwrap(),
+        i64::MIN,
+        i64::MAX,
+    )
+    .unwrap();
+    keys.verify(&signed, now).unwrap()
+}
+
+#[tokio::test]
+#[ignore = "manual five-sample loopback transport measurement"]
+async fn measure_loopback_transport_setup_and_close() {
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        vec![
+            "https://usw1-1.relay.n0.iroh.link.".to_string(),
+            "https://aps1-1.relay.n0.iroh.link.".to_string(),
+            "https://use1-1.relay.n0.iroh.link.".to_string(),
+            "https://euc1-1.relay.n0.iroh.link.".to_string(),
+        ],
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        for _ in 0..5 {
+            let connection = server
+                .accept()
+                .await
+                .expect("incoming connection")
+                .await
+                .unwrap();
+            connection.closed().await;
+        }
+        server.close().await;
+    });
+
+    for sample in 1..=5 {
+        let started = Instant::now();
+        let connection =
+            HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
+                .await
+                .unwrap();
+        let setup = started.elapsed();
+        connection.close().await;
+        let total = started.elapsed();
+        println!(
+            "LOOPBACK sample={sample} setup_ms={:.3} close_ms={:.3} total_ms={:.3}",
+            setup.as_secs_f64() * 1_000.0,
+            (total - setup).as_secs_f64() * 1_000.0,
+            total.as_secs_f64() * 1_000.0,
+        );
+    }
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn reachable_direct_address_never_initializes_advertised_relays() {
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        vec!["https://usw1-1.relay.n0.iroh.link.".to_string()],
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let connection =
+        HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
+            .await
+            .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert!(
+        connection.endpoint.home_relay_status().get().is_empty(),
+        "a reachable signed direct address must not initialize a relay transport"
+    );
+    connection.close().await;
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
+async fn unreachable_direct_address_falls_back_to_signed_relay() {
+    use iroh_relay::server::{RelayConfig as RelayServerConfig, Server, ServerConfig};
+
+    let mut relay_config = ServerConfig::default();
+    relay_config.relay = Some(RelayServerConfig::new((Ipv4Addr::LOCALHOST, 0)));
+    let relay = Server::spawn(relay_config).await.unwrap();
+    let relay_url: iroh::RelayUrl = format!("http://{}", relay.http_addr().unwrap())
+        .parse()
+        .unwrap();
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::custom([relay_url.clone()]))
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), server.online())
+        .await
+        .expect("server should register with the relay");
+    let descriptor = verified_descriptor(
+        server.id(),
+        vec![relay_url.to_string()],
+        vec!["127.0.0.1:9".to_string()],
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming relay connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let connection = tokio::time::timeout(
+        Duration::from_secs(5),
+        HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default()),
+    )
+    .await
+    .expect("relay fallback should connect")
+    .unwrap();
+    tokio::time::timeout(Duration::from_secs(5), connection.endpoint.online())
+        .await
+        .expect("client should register with the signed relay");
+    assert!(
+        !connection.endpoint.home_relay_status().get().is_empty(),
+        "relay fallback must initialize the signed relay transport"
+    );
+    connection.close().await;
+    server_task.await.unwrap();
+    drop(relay);
+}

--- a/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -146,6 +146,40 @@ async fn reachable_direct_address_never_initializes_advertised_relays() {
 }
 
 #[tokio::test]
+async fn direct_only_descriptor_uses_the_normal_connection_path() {
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        Vec::new(),
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming direct-only connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let connection =
+        HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
+            .await
+            .unwrap();
+    connection.close().await;
+    server_task.await.unwrap();
+}
+
+#[tokio::test]
 async fn unreachable_direct_address_falls_back_to_signed_relay() {
     use iroh_relay::server::{RelayConfig as RelayServerConfig, Server, ServerConfig};
 

--- a/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -52,6 +52,10 @@ fn verified_descriptor(
 #[tokio::test]
 #[ignore = "manual five-sample loopback transport measurement"]
 async fn measure_loopback_transport_setup_and_close() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
         .relay_mode(RelayMode::Disabled)

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -7,6 +7,8 @@ mod bootstrap;
 mod call;
 mod collaboration;
 mod connection;
+#[cfg(test)]
+mod connection_path_tests;
 mod content;
 mod context;
 mod credential;

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -127,7 +127,10 @@ pub fn emit_profile(command: &'static str, fields: &[ProfileField]) {
     let duration_ms = fields
         .iter()
         .filter(|field| matches!(field.unit, ProfileMetricUnit::Milliseconds))
-        .map(|field| u64::try_from(field.value).unwrap_or(u64::MAX))
+        .map(|field| match field.value {
+            ProfileMetricScalar::Number(value) => u64::try_from(value).unwrap_or(u64::MAX),
+            ProfileMetricScalar::Boolean(_) => unreachable!("filtered to millisecond metrics"),
+        })
         .max()
         .unwrap_or(0);
     record_phase_span(command, duration_ms);


### PR DESCRIPTION
## Summary

- attempt signed direct addresses with a relay-disabled Iroh endpoint before constructing any advertised relay transport; only build the relay-enabled endpoint after the bounded direct attempt fails
- preserve the normal connection deadline for direct-only descriptors and retain signed-relay fallback for genuinely unreachable direct peers
- keep endpoint and connection reuse inside HostedConnection, while making HTTP descriptor bootstrap participate in the #1219 network-initialization counter
- add direct, direct-only, relay-fallback, no-relay-state, and manual five-sample loopback transport coverage
- repair the #1219 ProfileMetricScalar conversion so the release performance gate builds on current main

Closes #1121
Refs #1218, especially law 4: local commands initialize no network.

## Testing

### Loopback transport setup

Original issue baseline against a loopback weft, five commands: 1028.8, 1035.0, 1030.3, 1029.6, 1033.3 ms, approximately 1031 ms fixed cost.

A fresh origin/main control at the hosted Iroh transport boundary was already fast after intervening dependency updates:

- setup: 8.198, 7.636, 7.674, 7.267, 7.268 ms; p50 7.636 ms
- setup plus close: 8.637, 7.910, 7.936, 7.550, 7.626 ms; p50 7.910 ms

This branch, using the same five-run boundary benchmark:

- setup: 8.297, 8.509, 8.005, 7.410, 7.380 ms; p50 8.005 ms
- setup plus close: 8.660, 8.734, 8.229, 7.616, 7.676 ms; p50 8.229 ms

The historical approximately 1031 ms floor is therefore absent on the current dependency base; this change makes the desired transport behavior explicit and regression-tested rather than claiming a fresh synthetic speedup over current main.

With RUST_LOG=iroh=debug, every loopback sample logged relay_url=None and skipping net_report, empty RelayMap. There were no usw1, aps1, use1, or euc1 dial events even though all four URLs were present in the signed descriptor.

### Law 4 / zero-network gate

Passed:

TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1121-target HEDDLE_PERF_SAMPLES=5 cargo test --release -p heddle-cli --test cli_integration core_loop_release_contract -- --ignored --nocapture

The final report was GATES green: latency, scale invariance, repository opens, zero network. Version, help, status clean and dirty, and capture at 10k and 100k paths all reported network_initialized=false.

Negative control: I temporarily forced an Iroh Endpoint build inside cmd_status. The same gate went red with four zero-network failures: status_clean and status_one_dirty at both 10k and 100k paths reported network_initialized=true. I removed the injection and restored the green gate before committing.

### Correctness

- cargo test -p heddle-cli --lib hosted_runtime::hosted::connection_path_tests -- --nocapture: 3 passed, 1 ignored manual measurement
- unreachable direct address test connects through an in-process signed relay and completes the online/status exchange
- cargo test -p heddle-cli --lib hosted_runtime::hosted -- --nocapture: 82 passed, 1 ignored
- cargo test -p heddle-cli --test cli_integration perf_trace -- --nocapture: 6 passed
- cargo clippy -p heddle-cli --lib --tests -- -D warnings: passed

cargo fmt --all -- --check still reports the pre-existing wrapping difference in crates/cli/tests/ts_types_in_sync.rs from origin/main; all files changed by this PR were formatted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1224"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788393123&installation_model_id=21489&pr_number=1224&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1224&signature=e5a07202437ea38beb31e06228f616805c36f6f0e5c51b9186f7c6c7d9a427d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->