### PR TITLE
perf(semantic): gate cached parse reuse

### DIFF
--- a/crates/semantic/src/analysis/analysis_classify.rs
+++ b/crates/semantic/src/analysis/analysis_classify.rs
@@ -46,16 +46,16 @@ pub fn classify_modification_with_confidence(
     let old_parsed = ParsedFile::parse(old_content, language);
     let new_parsed = ParsedFile::parse(new_content, language);
 
-    classify_parse_result(
-        old_content,
-        new_content,
-        old_parsed.as_ref(),
-        new_parsed.as_ref(),
-        token_sim.value,
-    )
+    match (old_parsed.as_ref(), new_parsed.as_ref()) {
+        (Some(old_ast), Some(new_ast)) => {
+            classify_with_parsed(old_content, new_content, old_ast, new_ast)
+        }
+        _ => classify_without_ast(old_content, new_content, token_sim.value),
+    }
 }
 
-pub(crate) fn classify_modification_with_parsed(
+/// Classify a modification using ASTs already parsed by the caller.
+pub(crate) fn classify_with_parsed(
     old_content: &str,
     new_content: &str,
     old_ast: &ParsedFile,
@@ -105,24 +105,6 @@ fn classify_common_prefix(old_content: &str, new_content: &str) -> TokenSimilari
     TokenSimilarityCheck {
         value: token_sim,
         result: None,
-    }
-}
-
-fn classify_parse_result(
-    old_content: &str,
-    new_content: &str,
-    old_parsed: Option<&ParsedFile>,
-    new_parsed: Option<&ParsedFile>,
-    token_sim: f64,
-) -> ClassificationResult {
-    match (old_parsed, new_parsed) {
-        (Some(old_ast), Some(new_ast)) => {
-            classify_with_ast(old_content, new_content, old_ast, new_ast)
-        }
-        _ => {
-            // Parse failed — fall back to token-level heuristics (lower confidence).
-            classify_without_ast(old_content, new_content, token_sim)
-        }
     }
 }
 
@@ -345,14 +327,36 @@ mod tests {
 
     #[test]
     fn test_classify_with_parsed_matches_direct_classifier() {
-        let old = "use std::io;\n\nfn compute() -> i32 {\n    1\n}\n";
-        let new = "use std::io;\nuse std::fs;\n\nfn compute() -> i32 {\n    1\n}\n";
-        let old_ast = ParsedFile::parse(old, Language::Rust).expect("old Rust should parse");
-        let new_ast = ParsedFile::parse(new, Language::Rust).expect("new Rust should parse");
+        let fixtures = [
+            (
+                "formatting",
+                "fn compute() -> i32 { 1 }\n",
+                "fn compute() -> i32 {\n    1\n}\n",
+            ),
+            (
+                "comments",
+                "// before\nfn compute() -> i32 { 1 }\n",
+                "// after\nfn compute() -> i32 { 1 }\n",
+            ),
+            (
+                "imports",
+                "use std::io;\n\nfn compute() -> i32 {\n    1\n}\n",
+                "use std::io;\nuse std::fs;\n\nfn compute() -> i32 {\n    1\n}\n",
+            ),
+            (
+                "logic",
+                "fn compute(input: i32) -> i32 { input + 1 }\n",
+                "fn compute(input: i32) -> i32 { input * 2 }\n",
+            ),
+        ];
 
-        let direct = classify_modification_with_confidence(Path::new("test.rs"), old, new);
-        let cached = classify_modification_with_parsed(old, new, &old_ast, &new_ast);
+        for (name, old, new) in fixtures {
+            let old_ast = ParsedFile::parse(old, Language::Rust).expect("old Rust should parse");
+            let new_ast = ParsedFile::parse(new, Language::Rust).expect("new Rust should parse");
+            let direct = classify_modification_with_confidence(Path::new("test.rs"), old, new);
+            let cached = classify_with_parsed(old, new, &old_ast, &new_ast);
 
-        assert_eq!(cached, direct);
+            assert_eq!(cached, direct, "classification drift for {name}");
+        }
     }
 }

--- a/crates/semantic/src/analysis/hot_spots.rs
+++ b/crates/semantic/src/analysis/hot_spots.rs
@@ -474,6 +474,8 @@ fn _state_anchor(_: &State) {}
 
 #[cfg(test)]
 mod tests {
+    use std::fmt::Write as _;
+
     use objects::{
         object::{Attribution, Principal, State, StateId, Tree, TreeEntry},
         store::InMemoryStore,
@@ -535,6 +537,71 @@ mod tests {
         let id_c = state_c.state_id;
 
         (id_c, store)
+    }
+
+    fn build_semantic_benchmark_chain(
+        state_count: usize,
+        functions_per_file: usize,
+    ) -> (StateId, InMemoryStore) {
+        assert!(state_count >= 2);
+        let store = InMemoryStore::new();
+        let mut parent = None;
+
+        for state_index in 0..state_count {
+            let mut source = String::new();
+            for function_index in 0..functions_per_file {
+                writeln!(
+                    source,
+                    "fn compute_{function_index}() -> usize {{ {state_index} + {function_index} }}"
+                )
+                .expect("writing Rust fixture to String should succeed");
+            }
+            let blob = store
+                .put_blob(&objects::object::Blob::from_slice(source.as_bytes()))
+                .unwrap();
+            let tree = store
+                .put_tree(&Tree::from_entries(vec![
+                    TreeEntry::file("lib.rs".to_string(), blob, false).unwrap(),
+                ]))
+                .unwrap();
+            let state = State::new(
+                tree,
+                parent.into_iter().collect(),
+                Attribution::human(principal("benchmark")),
+            );
+            store.put_state(&state).unwrap();
+            parent = Some(state.state_id);
+        }
+
+        (parent.expect("benchmark chain has a head"), store)
+    }
+
+    #[test]
+    #[ignore = "semantic hot-spots benchmark; run explicitly with --release --ignored --nocapture"]
+    fn semantic_hot_spots_parse_reuse_benchmark() {
+        const STATE_COUNT: usize = 201;
+        const FUNCTIONS_PER_FILE: usize = 100;
+
+        let (head, store) = build_semantic_benchmark_chain(STATE_COUNT, FUNCTIONS_PER_FILE);
+        SemanticParseCache::shared().clear();
+        crate::parser::reset_parse_count();
+
+        let started = Instant::now();
+        let report = analyze_hot_spots(&store, head, &HotSpotParams::default()).unwrap();
+        let elapsed = started.elapsed();
+        let parse_count = crate::parser::parse_count();
+        let state_pairs = STATE_COUNT - 1;
+
+        println!(
+            "semantic hot-spots bench state_pairs={state_pairs} unique_contents={STATE_COUNT} tree_sitter_parses={parse_count} parses_per_unique_content={:.2} elapsed_ms={:.3}",
+            parse_count as f64 / STATE_COUNT as f64,
+            elapsed.as_secs_f64() * 1_000.0,
+        );
+        assert_eq!(report.states_walked, state_pairs);
+        assert_eq!(
+            parse_count, STATE_COUNT,
+            "hot-spots must parse each unique content once across adjacent state pairs"
+        );
     }
 
     #[test]

--- a/crates/semantic/src/analysis/mod.rs
+++ b/crates/semantic/src/analysis/mod.rs
@@ -15,7 +15,7 @@ mod analysis_tests;
 pub use analysis_aggregate::{
     AggregateKind, AggregatedChange, AggregationResult, aggregate_changes,
 };
-pub(crate) use analysis_classify::classify_modification_with_parsed;
+pub(crate) use analysis_classify::classify_with_parsed;
 pub use analysis_classify::{classify_modification, classify_modification_with_confidence};
 pub use analysis_functions::detect_function_changes;
 pub(crate) use analysis_functions::detect_function_changes_with_parsed;

--- a/crates/semantic/src/diff/diff_engine.rs
+++ b/crates/semantic/src/diff/diff_engine.rs
@@ -356,7 +356,13 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::Cell, path::Path};
+    use std::{
+        cell::Cell,
+        collections::HashMap,
+        fmt::Write as _,
+        path::{Path, PathBuf},
+        time::Instant,
+    };
 
     use objects::object::{DiffKind, FileChangeSet};
 
@@ -567,6 +573,71 @@ mod tests {
             parse_count, 2,
             "one modified file has two unique contents and each must reach tree-sitter once"
         );
+    }
+
+    #[test]
+    #[ignore = "semantic diff benchmark; run explicitly with --release --ignored --nocapture"]
+    fn semantic_diff_parse_reuse_benchmark() {
+        const CHANGED_FILES: usize = 100;
+        const FUNCTIONS_PER_FILE: usize = 100;
+
+        let mut file_changes = FileChangeSet::new();
+        let mut contents = HashMap::new();
+        for file_index in 0..CHANGED_FILES {
+            let path = PathBuf::from(format!("file_{file_index:03}.rs"));
+            file_changes.push((path.to_string_lossy().into_owned(), DiffKind::Modified).into());
+            contents.insert(
+                path,
+                (
+                    semantic_diff_benchmark_source(file_index, 1, FUNCTIONS_PER_FILE),
+                    semantic_diff_benchmark_source(file_index, 2, FUNCTIONS_PER_FILE),
+                ),
+            );
+        }
+
+        let cache = SemanticParseCache::new(CHANGED_FILES * 2);
+        crate::parser::reset_parse_count();
+        let started = Instant::now();
+        let result = SemanticEngine::new(
+            file_changes,
+            |path| Ok(contents.get(path).map(|(old, _)| old.clone())),
+            |path| Ok(contents.get(path).map(|(_, new)| new.clone())),
+            &SemanticDiffOptions::default(),
+            &cache,
+        )
+        .full()
+        .expect("semantic diff benchmark should succeed");
+        let elapsed = started.elapsed();
+        let parse_count = crate::parser::parse_count();
+        let unique_contents = CHANGED_FILES * 2;
+
+        println!(
+            "semantic diff parse bench changed_files={CHANGED_FILES} functions_per_file={FUNCTIONS_PER_FILE} unique_contents={unique_contents} tree_sitter_parses={parse_count} parses_per_unique_content={:.2} elapsed_ms={:.3}",
+            parse_count as f64 / unique_contents as f64,
+            elapsed.as_secs_f64() * 1_000.0,
+        );
+        assert!(!result.changes.is_empty());
+        assert_eq!(
+            parse_count, unique_contents,
+            "diff must parse each unique old/new content once"
+        );
+    }
+
+    fn semantic_diff_benchmark_source(
+        file_index: usize,
+        revision: usize,
+        function_count: usize,
+    ) -> String {
+        let mut source = String::new();
+        let operator = if revision == 1 { "+" } else { "*" };
+        for function_index in 0..function_count {
+            writeln!(
+                source,
+                "fn compute_{file_index}_{function_index}(input: usize) -> usize {{ input {operator} ({file_index} + {function_index}) }}"
+            )
+            .expect("writing Rust fixture to String should succeed");
+        }
+        source
     }
 
     #[test]

--- a/crates/semantic/src/diff/diff_engine.rs
+++ b/crates/semantic/src/diff/diff_engine.rs
@@ -535,6 +535,9 @@ mod tests {
         let cache = SemanticParseCache::default();
         cache.clear();
         let options = SemanticDiffOptions::default();
+        let expected =
+            crate::analysis::classify_modification_with_confidence(Path::new("lib.rs"), old, new);
+        crate::parser::reset_parse_count();
 
         let engine = SemanticEngine::new(
             file_changes,
@@ -545,8 +548,7 @@ mod tests {
         );
 
         let result = engine.full().expect("semantic diff should succeed");
-        let expected =
-            crate::analysis::classify_modification_with_confidence(Path::new("lib.rs"), old, new);
+        let parse_count = crate::parser::parse_count();
 
         assert!(result.changes.iter().any(|change| matches!(
             change,
@@ -561,6 +563,10 @@ mod tests {
                 && confidence == &Some(expected.2)
         )));
         assert_eq!(cache.stats().stores, 2);
+        assert_eq!(
+            parse_count, 2,
+            "one modified file has two unique contents and each must reach tree-sitter once"
+        );
     }
 
     #[test]

--- a/crates/semantic/src/diff/diff_support.rs
+++ b/crates/semantic/src/diff/diff_support.rs
@@ -12,9 +12,9 @@ use objects::object::{DiffKind, FileChange, FileChangeSet, SemanticChange};
 use super::{diff_options::SemanticDiffOptions, diff_types::SemanticFallbackReason};
 use crate::{
     analysis::{
-        AggregationResult, classify_modification_with_confidence,
-        classify_modification_with_parsed, detect_file_renames,
-        detect_function_changes_with_parsed, detect_import_changes_with_parsed,
+        AggregationResult, classify_modification_with_confidence, classify_with_parsed,
+        detect_file_renames, detect_function_changes_with_parsed,
+        detect_import_changes_with_parsed,
     },
     parser::ParsedFile,
 };
@@ -290,12 +290,9 @@ fn push_modified_change(
                             .and_then(|value| value.as_deref()),
                     )
             }) {
-                Some((old_parsed, new_parsed)) => classify_modification_with_parsed(
-                    old_content,
-                    new_content,
-                    old_parsed,
-                    new_parsed,
-                ),
+                Some((old_parsed, new_parsed)) => {
+                    classify_with_parsed(old_content, new_content, old_parsed, new_parsed)
+                }
                 None => {
                     classify_modification_with_confidence(&change.path, old_content, new_content)
                 }

--- a/crates/semantic/src/diff/diff_tests.rs
+++ b/crates/semantic/src/diff/diff_tests.rs
@@ -1025,7 +1025,16 @@ fn semantic_large_diff_benchmark_matrix() {
         },
     ];
 
+    let filter = std::env::var("HEDDLE_SEMANTIC_BENCH_FILTER").ok();
+    let mut matched_rows = 0usize;
     for row in rows {
+        if filter
+            .as_deref()
+            .is_some_and(|filter| !row.name.contains(filter))
+        {
+            continue;
+        }
+        matched_rows += 1;
         let store = InMemoryStore::new();
         let fixture = build_semantic_bench_fixture(&store, &row.fixture);
         let cache = SemanticParseCache::new(1024);
@@ -1075,6 +1084,10 @@ fn semantic_large_diff_benchmark_matrix() {
             result.fallback_reasons
         );
     }
+    assert!(
+        matched_rows > 0,
+        "semantic benchmark filter matched no rows"
+    );
 }
 
 struct BenchFixtureData {

--- a/crates/semantic/src/parser/mod.rs
+++ b/crates/semantic/src/parser/mod.rs
@@ -16,5 +16,7 @@ pub use comment_walk::{is_comment_node, walk_non_comment_leaves};
 pub use parser_core::ParsedFile;
 pub use parser_deps::extract_dependencies;
 pub use parser_language::Language;
+#[cfg(test)]
+pub(crate) use parser_pool::{parse_count, reset_parse_count};
 pub use parser_types::{FunctionDef, Import, ImportKind};
 pub use syntax_index::{FunctionRef, ImportRef, SyntaxIndex};

--- a/crates/semantic/src/parser/parser_pool.rs
+++ b/crates/semantic/src/parser/parser_pool.rs
@@ -6,12 +6,27 @@ use std::{
     collections::{HashMap, hash_map::Entry},
 };
 
+#[cfg(test)]
+use std::cell::Cell;
+
 use tree_sitter::{Parser, Tree as TSTree};
 
 use super::parser_language::Language;
 
 thread_local! {
     static PARSERS: RefCell<HashMap<Language, Parser>> = RefCell::new(HashMap::new());
+    #[cfg(test)]
+    static PARSE_COUNT: Cell<usize> = const { Cell::new(0) };
+}
+
+#[cfg(test)]
+pub(crate) fn reset_parse_count() {
+    PARSE_COUNT.set(0);
+}
+
+#[cfg(test)]
+pub(crate) fn parse_count() -> usize {
+    PARSE_COUNT.get()
 }
 
 /// Parse a complete document with the pooled parser for `language`.
@@ -32,6 +47,8 @@ pub(super) fn parse_fresh(source: &[u8], language: Language) -> Option<TSTree> {
             }
         };
         parser.reset();
+        #[cfg(test)]
+        PARSE_COUNT.set(PARSE_COUNT.get() + 1);
         parser.parse(source, None)
     })
 }


### PR DESCRIPTION
## Summary

- complete the #885 hardening pass around the cache-first semantic diff path by routing the direct classifier through `classify_with_parsed`
- count actual `tree_sitter::Parser::parse` invocations in tests, so uncached parses cannot hide behind cache-store counters
- add focused release harnesses for a parse-heavy 100-file diff and a 200-pair `analyze_hot_spots` walk, plus filtering for the existing semantic benchmark matrix
- preserve classification kind, importance, and confidence across formatting, comments-only, imports-only, and logic fixtures
- improve #1218 performance law 5: compute each semantic parse once and retain the useful cached AST

## Testing

All timings are medians of 5 release runs with `TMPDIR=/home/scratch` on the same runner and target directory.

- Structural counter, single modified file: optimized path = 2 total tree-sitter calls for 2 unique old/new contents (1.00 per unique content). Reverting cache reuse made the gate red with `left: 4, right: 2`.
- Focused semantic diff, 100 changed files × 100 functions: 351.829 ms before → 235.098 ms after (**-33.2%**). Parse count: 400 → 200 total, or 4 → 2 per changed file and 2.00 → 1.00 per unique old/new content. The reverted path failed the structural assertion with `left: 400, right: 200`.
- Hot-spots shape, 200 adjacent state pairs / 201 unique contents: 262.947 ms before → 172.108 ms after (**-34.5%**). Parse count: 403 → 201, or 2.00 → 1.00 per unique content. The reverted path failed the gate with `left: 403, right: 201`.
- Existing 10k-repo / 100-changed semantic row: 53.285 ms before → 50.371 ms after (**-5.5%**).
- Correctness: cached and direct classifiers return identical `(ModificationKind, ChangeImportance, confidence)` tuples for formatting, comments-only, imports-only, and logic fixtures; the release semantic suite also covers file/function rename behavior.
- `TMPDIR=/home/scratch cargo test --release -p heddle-semantic` — 293 passed, 3 ignored benchmark gates
- `TMPDIR=/home/scratch cargo test --release -p heddle-semantic semantic_diff_parse_reuse_benchmark -- --ignored --nocapture`
- `TMPDIR=/home/scratch cargo test --release -p heddle-semantic semantic_hot_spots_parse_reuse_benchmark -- --ignored --nocapture`
- `TMPDIR=/home/scratch cargo clippy -p heddle-semantic --all-targets -- -D warnings`
- `cargo fmt -p heddle-semantic -- --check`

Closes #885
Refs #1218

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788398476&installation_model_id=21489&pr_number=1225&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1225&signature=5b0a8beaf9e8fa73d75624bfe5ea0b6ad0bf44ffb59d1965a4efb3263828890d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->