### PR TITLE
build(cli): feature-gate OTLP telemetry export

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -334,6 +334,8 @@ jobs:
       - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
 
       - uses: mozilla-actions/sccache-action@v0.0.9
 
@@ -353,6 +355,15 @@ jobs:
           cargo check --locked -p heddle-repo --no-default-features --features native,zstd
           cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd
           cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd
+
+      - name: Telemetry build, clippy, and tests
+        run: |
+          set -euo pipefail
+          cargo build --locked -p heddle-cli --features telemetry --tests --bin heddle
+          cargo clippy --locked -p heddle-cli -p heddle-cli-shared \
+            --features heddle-cli/telemetry --lib --bins --tests --examples -- -D warnings
+          cargo test --locked -p heddle-cli -p heddle-cli-shared \
+            --features heddle-cli/telemetry
 
       - name: sccache stats
         run: sccache --show-stats

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -30,7 +30,7 @@ tracing-subscriber.workspace = true
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [features]
-observability = [
+telemetry = [
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",

--- a/crates/cli-shared/src/logging/mod.rs
+++ b/crates/cli-shared/src/logging/mod.rs
@@ -24,19 +24,19 @@
 //! ```
 
 use std::io::{self, IsTerminal};
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use std::time::Duration;
 
 mod trace;
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use opentelemetry::{KeyValue, global, trace::TracerProvider as _};
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use opentelemetry_otlp::WithExportConfig;
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use opentelemetry_sdk::{Resource, metrics::SdkMeterProvider, trace::SdkTracerProvider};
 pub use trace::{CommandTrace, record_phase_span, trace_export_enabled};
 use tracing::Level;
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use tracing_subscriber::filter::filter_fn;
 use tracing_subscriber::{
     EnvFilter, Layer as _, fmt::format::FmtSpan, layer::SubscriberExt, util::SubscriberInitExt,
@@ -75,9 +75,9 @@ pub struct LoggingConfig {
 
 #[derive(Debug, Default)]
 pub struct LoggingGuard {
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     tracer_provider: Option<SdkTracerProvider>,
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     meter_provider: Option<SdkMeterProvider>,
 }
 
@@ -87,7 +87,7 @@ impl LoggingGuard {
     }
 
     fn shutdown_inner(&mut self) {
-        #[cfg(feature = "observability")]
+        #[cfg(feature = "telemetry")]
         {
             if let Some(meter_provider) = self.meter_provider.take() {
                 let _ = meter_provider.shutdown_with_timeout(Duration::from_millis(250));
@@ -106,7 +106,7 @@ impl Drop for LoggingGuard {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 #[derive(Debug, Clone)]
 struct OtelConfig {
     service_name: String,
@@ -239,7 +239,7 @@ impl LoggingConfig {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 impl OtelConfig {
     fn from_logging_config(config: &LoggingConfig) -> Self {
         Self {
@@ -262,7 +262,6 @@ impl OtelConfig {
         self.trace_endpoint.is_some() || self.metrics_endpoint.is_some()
     }
 
-    #[cfg(feature = "observability")]
     fn resource(&self) -> Resource {
         Resource::builder_empty()
             .with_attributes([KeyValue::new("service.name", self.service_name.clone())])
@@ -270,7 +269,7 @@ impl OtelConfig {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 fn signal_endpoint(base: Option<&str>, signal_path: &str) -> Option<String> {
     base.map(|endpoint| format!("{}/{signal_path}", endpoint.trim_end_matches('/')))
 }
@@ -299,7 +298,7 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
     let telemetry = init_otel(&config);
     let registry = tracing_subscriber::registry();
 
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     let init_result = match (config.format, telemetry.tracer_provider.as_ref()) {
         (LogFormat::Text, Some(provider)) => registry
             .with(
@@ -373,7 +372,7 @@ pub fn init_logging(config: LoggingConfig) -> LoggingGuard {
             .try_init(),
     };
 
-    #[cfg(not(feature = "observability"))]
+    #[cfg(not(feature = "telemetry"))]
     let init_result = match config.format {
         LogFormat::Text => registry
             .with(
@@ -458,15 +457,15 @@ macro_rules! log_repo_event {
 
 struct TelemetryInit {
     guard: LoggingGuard,
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     tracer_provider: Option<SdkTracerProvider>,
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     service_name: String,
-    #[cfg(all(test, feature = "observability"))]
+    #[cfg(all(test, feature = "telemetry"))]
     network_client_initialized: bool,
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
     let config = OtelConfig::from_logging_config(logging);
     if !config.enabled() {
@@ -474,7 +473,7 @@ fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
             guard: LoggingGuard::default(),
             tracer_provider: None,
             service_name: config.service_name,
-            #[cfg(all(test, feature = "observability"))]
+            #[cfg(all(test, feature = "telemetry"))]
             network_client_initialized: false,
         };
     }
@@ -524,13 +523,13 @@ fn init_otel(logging: &LoggingConfig) -> TelemetryInit {
         },
         tracer_provider,
         service_name: config.service_name,
-        #[cfg(all(test, feature = "observability"))]
+        #[cfg(all(test, feature = "telemetry"))]
         network_client_initialized: config.trace_endpoint.is_some()
             || config.metrics_endpoint.is_some(),
     }
 }
 
-#[cfg(not(feature = "observability"))]
+#[cfg(not(feature = "telemetry"))]
 fn init_otel(_logging: &LoggingConfig) -> TelemetryInit {
     TelemetryInit {
         guard: LoggingGuard::default(),
@@ -539,11 +538,11 @@ fn init_otel(_logging: &LoggingConfig) -> TelemetryInit {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use opentelemetry::trace::TracerProvider as _;
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use opentelemetry_sdk::trace::{InMemorySpanExporter, SdkTracerProvider, SimpleSpanProcessor};
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
@@ -591,7 +590,7 @@ mod tests {
         assert!(!is_truthy("random"));
     }
 
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     #[test]
     fn endpoint_gate_is_network_dormant_and_command_spans_export_when_enabled() {
         let shared = LoggingConfig {

--- a/crates/cli-shared/src/logging/trace.rs
+++ b/crates/cli-shared/src/logging/trace.rs
@@ -12,7 +12,7 @@ pub(super) const TELEMETRY_TARGET: &str = "heddle_telemetry";
 
 static TRACE_EXPORT_ENABLED: AtomicBool = AtomicBool::new(false);
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 pub(super) fn set_trace_export_enabled(enabled: bool) {
     TRACE_EXPORT_ENABLED.store(enabled, Ordering::Release);
 }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -143,9 +143,6 @@ mount = { path = "../mount", package = "heddle-mount", version = "0.11", optiona
 # fallback (`nfsserve` + `tokio` async-trait). The OSS feature
 # subsets that explicitly want a slim build (`--no-default-features
 # --features git-overlay,...`) opt out the same way they do today.
-# `observability` compiles OTLP support into shipped binaries, but runtime
-# initialization remains endpoint-gated: without an OTLP endpoint there is no
-# provider, exporter, background worker, or telemetry network client.
 default = [
     "git-overlay",
     "native",
@@ -154,7 +151,6 @@ default = [
     "semantic",
     "zstd",
     "client",
-    "observability",
 ]
 local = []
 # Repository mode features. At least one must be enabled. The default
@@ -200,8 +196,11 @@ semantic = [
     "repo/tree-sitter-symbols",
 ]
 semantic-extended = ["semantic", "heddle-core/semantic-extended", "semantic?/extended-languages"]
-observability = [
-    "cli-shared/observability",
+# `telemetry` compiles OTLP support into the CLI. It stays opt-in so the
+# default binary does not carry the exporter and HTTP/TLS dependency stack.
+# Runtime initialization remains endpoint-gated when the feature is enabled.
+telemetry = [
+    "cli-shared/telemetry",
     "dep:opentelemetry",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry_sdk",

--- a/crates/cli/src/hosted_runtime/hosted/context.rs
+++ b/crates/cli/src/hosted_runtime/hosted/context.rs
@@ -12,12 +12,12 @@ use api::{
 };
 use cli_shared::ClientConfig;
 use crypto::{Ed25519Signer, Signer as _};
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use opentelemetry::propagation::{Injector, TextMapPropagator};
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use opentelemetry_sdk::propagation::TraceContextPropagator;
 use prost_types::Timestamp;
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 use tracing_opentelemetry::OpenTelemetrySpanExt as _;
 
 use super::{HostedError, Result};
@@ -305,14 +305,14 @@ impl CallContextFactory {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 #[derive(Default)]
 struct TraceHeaders {
     traceparent: Option<String>,
     tracestate: Option<String>,
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 impl Injector for TraceHeaders {
     fn set(&mut self, key: &str, value: String) {
         match key {
@@ -323,7 +323,7 @@ impl Injector for TraceHeaders {
     }
 }
 
-#[cfg(feature = "observability")]
+#[cfg(feature = "telemetry")]
 fn active_trace_context() -> Option<TraceContext> {
     let context = tracing::Span::current().context();
     let mut headers = TraceHeaders::default();
@@ -335,7 +335,7 @@ fn active_trace_context() -> Option<TraceContext> {
     })
 }
 
-#[cfg(not(feature = "observability"))]
+#[cfg(not(feature = "telemetry"))]
 fn active_trace_context() -> Option<TraceContext> {
     None
 }
@@ -414,14 +414,14 @@ fn deadline(timeout: Duration) -> Result<Timestamp> {
 mod tests {
     use api::UNARY_SIGNING_V1_FIXTURE_JSON;
     use crypto::Signer as _;
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use opentelemetry::trace::{TraceContextExt as _, TracerProvider as _};
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use opentelemetry_sdk::trace::SdkTracerProvider;
     use serde::Deserialize;
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use tracing_opentelemetry::OpenTelemetrySpanExt as _;
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     use tracing_subscriber::layer::SubscriberExt as _;
 
     use super::*;
@@ -444,7 +444,7 @@ mod tests {
         assert!(context.trace.is_none());
     }
 
-    #[cfg(feature = "observability")]
+    #[cfg(feature = "telemetry")]
     #[test]
     fn active_span_traceparent_is_carried_in_the_iroh_request_prelude() {
         let provider = SdkTracerProvider::builder().build();

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -346,6 +346,7 @@ mod state_id_acceptance;
 mod stdout_stderr_split;
 #[path = "cli_integration/submodule_status.rs"]
 mod submodule_status;
+#[cfg(feature = "telemetry")]
 #[path = "cli_integration/telemetry.rs"]
 mod telemetry;
 #[path = "cli_integration/thread_cleanup.rs"]

--- a/docs/migrations/0.11-hosted-runtime.md
+++ b/docs/migrations/0.11-hosted-runtime.md
@@ -58,7 +58,7 @@ Weft can replace every `git = "https://github.com/HeddleCo/heddle"` dependency
 with the corresponding crates.io requirement:
 
 ```toml
-cli-shared = { package = "heddle-cli-shared", version = "0.11", features = ["observability"] }
+cli-shared = { package = "heddle-cli-shared", version = "0.11", features = ["telemetry"] }
 crypto = { package = "heddle-crypto", version = "0.11" }
 objects = { package = "heddle-objects", version = "0.11", features = ["async-source"] }
 oplog = { package = "heddle-oplog", version = "0.11", default-features = false }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1,10 +1,17 @@
 # CLI trace export
 
-Heddle can export command traces to an OpenTelemetry collector. Export is off
-by default: unless a trace endpoint is configured, Heddle does not construct a
-tracer provider, exporter, or telemetry network client.
+Heddle can export command traces to an OpenTelemetry collector. The default
+CLI build does not include the OTLP exporter. Build it explicitly with:
 
-Opt in for one shell with the collector's OTLP/HTTP base endpoint:
+```sh
+cargo build -p heddle-cli --features telemetry
+```
+
+In a telemetry build, export remains off at runtime unless a trace endpoint is
+configured. Without one, Heddle does not construct a tracer provider, exporter,
+or telemetry network client.
+
+Then opt in for one shell with the collector's OTLP/HTTP base endpoint:
 
 ```sh
 export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318

--- a/scripts/check-cli-dep-count.sh
+++ b/scripts/check-cli-dep-count.sh
@@ -10,13 +10,14 @@
 # that nobody notices until a cold build is slow again.
 #
 # This script counts the `heddle-cli` crate's transitive dependency closure
-# (default features, normal edges only — the same method the audit doc uses)
+# (default features, normal edges only)
 # and FAILS if the live count exceeds baseline + slack. We persist only the
 # count, not the full dep set, so on a regression the failure message points
 # the author at `cargo tree` to find the new subtree.
 #
-# It uses `cargo metadata` only — no crate build — so it is cheap enough to
-# run on every PR.
+# It uses `cargo tree` plus dependency-free workspace metadata — no crate build
+# — so it is cheap enough to run on every PR. Selecting the CLI package keeps
+# dev-only features from unrelated workspace targets out of the normal graph.
 #
 # Knobs:
 #   HEDDLE_CLI_DEP_BASELINE_FILE — path to the baseline JSON
@@ -38,62 +39,49 @@ if [[ ! -f "$BASELINE_FILE" ]]; then
   exit 1
 fi
 
-# Resolve the dependency graph from the workspace root so the active
-# Cargo.lock is used. Write to a temp file (not a pipe) because the python
-# below is itself fed on stdin via a heredoc — stdin is not available for the
-# metadata payload.
-META_FILE="$(mktemp)"
-trap 'rm -f "$META_FILE"' EXIT
-(cd "$WORKSPACE_ROOT" && cargo metadata --format-version 1 --quiet) >"$META_FILE"
+PACKAGE_NAME="$(
+  python3 -c 'import json, sys; print(json.load(open(sys.argv[1])).get("package", "heddle-cli"))' \
+    "$BASELINE_FILE"
+)"
 
-# Single python pass: read the baseline JSON, walk the cli closure over normal
-# edges (default features), compare against baseline + slack. Exit non-zero on
-# regression. Keeps the graph-walk identical to docs/CLI_DEP_AUDIT_2026-05-12.md.
-BASELINE_FILE="$BASELINE_FILE" META_FILE="$META_FILE" python3 - <<'PY'
+# Resolve the package-scoped normal graph from the workspace root so the active
+# Cargo.lock is used. Full-workspace metadata unifies dev-only features from
+# every member into shared dependencies and can count test server stacks in the
+# production CLI closure.
+TREE_FILE="$(mktemp)"
+WORKSPACE_META_FILE="$(mktemp)"
+trap 'rm -f "$TREE_FILE" "$WORKSPACE_META_FILE"' EXIT
+(cd "$WORKSPACE_ROOT" && cargo tree --locked --package "$PACKAGE_NAME" \
+  --edges normal --prefix none --format '{p}') >"$TREE_FILE"
+(cd "$WORKSPACE_ROOT" && cargo metadata --format-version 1 --no-deps \
+  --locked --quiet) >"$WORKSPACE_META_FILE"
+
+# Single python pass: read the baseline JSON and package-scoped tree, compare
+# the unique external crate names against baseline + slack, and exit non-zero
+# on regression.
+BASELINE_FILE="$BASELINE_FILE" TREE_FILE="$TREE_FILE" \
+WORKSPACE_META_FILE="$WORKSPACE_META_FILE" python3 - <<'PY'
 import json
 import os
 import sys
 
-with open(os.environ["META_FILE"]) as f:
-    meta = json.load(f)
-
 with open(os.environ["BASELINE_FILE"]) as f:
     base = json.load(f)
+
+with open(os.environ["WORKSPACE_META_FILE"]) as f:
+    workspace_meta = json.load(f)
 
 pkg_name = base.get("package", "heddle-cli")
 baseline = int(base["baseline"])
 slack = int(base.get("slack", 0))
 ceiling = baseline + slack
 
-# Workspace members (source is None) are not counted as external deps.
-ws = {p["name"] for p in meta["packages"] if p["source"] is None}
-node_by_id = {n["id"]: n for n in meta["resolve"]["nodes"]}
-pkg_by_id = {p["id"]: p for p in meta["packages"]}
-
-try:
-    cli_id = next(
-        p["id"]
-        for p in meta["packages"]
-        if p["name"] == pkg_name and p["source"] is None
-    )
-except StopIteration:
-    print(f"error: workspace package {pkg_name!r} not found in cargo metadata", file=sys.stderr)
-    sys.exit(1)
-
-# Reachable closure over normal (non-dev, non-build) edges only.
-seen, stack = set(), [cli_id]
-while stack:
-    nid = stack.pop()
-    if nid in seen:
-        continue
-    seen.add(nid)
-    for d in node_by_id[nid]["deps"]:
-        # dep_kinds entry with kind == None is a normal (runtime) edge.
-        if not any(k.get("kind") is None for k in d.get("dep_kinds", [])):
-            continue
-        stack.append(d["pkg"])
-
-external = {pkg_by_id[i]["name"] for i in seen if pkg_by_id[i]["name"] not in ws}
+# `cargo tree --prefix none --format '{p}'` starts each line with the package
+# name. Count names, not versions, to preserve the audit's metric.
+workspace_names = {package["name"] for package in workspace_meta["packages"]}
+with open(os.environ["TREE_FILE"]) as f:
+    tree_names = {line.split(maxsplit=1)[0] for line in f if line.strip()}
+external = tree_names - workspace_names
 count = len(external)
 
 print(f"{pkg_name} transitive deps (default features): {count}")

--- a/scripts/cli-dep-count-baseline.json
+++ b/scripts/cli-dep-count-baseline.json
@@ -1,9 +1,9 @@
 {
-  "_comment": "Post-gix-removal transitive-dependency baseline for the heddle-cli crate (default features). Tracked by scripts/check-cli-dep-count.sh, wired into .github/workflows/audit.yml. See docs/CLI_DEP_AUDIT_2026-05-12.md for the audit method and the dep-reduction plan (IMPROVEMENT_PLAN section 8, P4: gix removal cut a ~277-dep subtree). The gate FAILS if the live count exceeds baseline + slack; raise the baseline (with justification) only when a dep addition is deliberate.",
+  "_comment": "Package-scoped post-gix-removal transitive-dependency baseline for the heddle-cli crate (default features, normal edges only). Tracked by scripts/check-cli-dep-count.sh and wired into .github/workflows/audit.yml. The gate FAILS if the live count exceeds baseline + slack; raise the baseline (with justification) only when a dependency addition is deliberate.",
   "package": "heddle-cli",
   "features": "default",
-  "baseline": 506,
+  "baseline": 408,
   "slack": 10,
-  "measured_at": "2026-07-27",
-  "measured_against": "integrate/iroh-cutover at 40d3bc35; the deliberate strict native Iroh transport adds the endpoint, DNS, relay, netwatch, and cryptography dependency subtrees"
+  "measured_at": "2026-08-04",
+  "measured_against": "task/1226 after OTLP export moved behind the opt-in telemetry feature; package-scoped cargo tree avoids workspace dev-feature unification"
 }


### PR DESCRIPTION
## Summary

- move the CLI OTLP exporter, tracer provider, and OpenTelemetry dependencies behind a non-default `telemetry` feature while keeping the `CallContext` trace wire field available in every build
- document the exact telemetry build command and retain endpoint/config runtime opt-in for telemetry-enabled binaries
- exercise the default and telemetry feature graphs in CI, including clippy and the real-command OTLP integration coverage
- correct the #604 dependency gate to count the package-scoped normal graph instead of workspace feature-unified metadata, then tighten its baseline from 506 to 408; the pre-change gate result was 526 and the default graph now reports 408 with no OpenTelemetry dependencies

Closes #1226.
Refs #1221, #1222, #604, and #1218.

## Testing

- `TMPDIR=/home/scratch bash scripts/check-cli-dep-count.sh` (408 <= 418; pre-change: 526 > 516)
- default `cargo tree` normal graph checked for absence of `opentelemetry`, `opentelemetry-otlp`, `opentelemetry_sdk`, and `tracing-opentelemetry`
- `cargo check --locked -p heddle-cli`
- `cargo check --locked -p heddle-cli --features telemetry`
- `cargo clippy --locked -p heddle-cli -p heddle-cli-shared --lib --bins --tests --examples -- -D warnings`
- `cargo clippy --locked -p heddle-cli -p heddle-cli-shared --lib --bins --tests --examples --features heddle-cli/telemetry -- -D warnings`
- full `heddle-cli` and `heddle-cli-shared` test suites for both default and `heddle-cli/telemetry` graphs
- telemetry endpoint-gate negative control plus in-memory exporter command-span test
- real-command OTLP HTTP collector integration test under `telemetry`
- telemetry trace-context propagation test
- default CLI build and `heddle --version`; initialized-repository status behavior covered by the CLI integration suite
- `rustfmt +nightly --edition 2024 --check` on touched Rust files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788402762&installation_model_id=21489&pr_number=1227&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1227&signature=d8c00e7b40215c92f1e7803be631c7fe9ebc6b4fffbf1ab875fcbea0443d53b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->