### PR TITLE
perf(objects): classify packed enumeration from headers

### DIFF
--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -68,6 +68,11 @@ harness = false
 required-features = ["bench"]
 
 [[bench]]
+name = "object_enumeration"
+harness = false
+required-features = ["bench"]
+
+[[bench]]
 name = "tree_diff"
 harness = false
 required-features = ["bench"]

--- a/crates/objects/benches/object_enumeration.rs
+++ b/crates/objects/benches/object_enumeration.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Mixed loose/packed object-enumeration benchmark.
+//!
+//! Run: `cargo bench -p heddle-objects --bench object_enumeration --features bench`
+
+use std::{fs, hint::black_box, path::Path};
+
+use chrono::{TimeZone, Utc};
+use criterion::{Criterion, criterion_group, criterion_main};
+use heddle_format::compression::CompressionConfig;
+use objects::{
+    object::{Action, Attribution, ContentHash, Operation, Principal, StateId, Tree, TreeEntry},
+    store::{
+        FsStore, ObjectStore,
+        pack::{ObjectType, PackBuilder},
+    },
+};
+use tempfile::TempDir;
+
+const LOOSE_PER_TYPE: usize = 2_048;
+const PACKED_PER_TYPE: usize = 2_048;
+const BLOB_SIZE: usize = 1_024;
+
+struct EnumerationFixture {
+    _dir: TempDir,
+    store: FsStore,
+}
+
+fn write_loose_hash(root: &Path, kind: &str, hash: ContentHash) {
+    let hex = hash.to_hex();
+    let path = if kind == "actions" {
+        root.join(kind).join(format!("{hex}.action"))
+    } else {
+        root.join("objects")
+            .join(kind)
+            .join(&hex[..2])
+            .join(&hex[2..])
+    };
+    fs::create_dir_all(path.parent().unwrap()).unwrap();
+    fs::write(path, []).unwrap();
+}
+
+fn fixture_action(index: usize) -> Action {
+    Action::new(
+        None,
+        StateId::from_bytes([7; 32]),
+        Operation::Snapshot,
+        format!("enumeration fixture action {index}"),
+        Attribution::human(Principal::new("perf", "perf@heddle.local")),
+    )
+    .with_timestamp(Utc.timestamp_opt(index as i64, 0).unwrap())
+}
+
+fn build_fixture() -> EnumerationFixture {
+    let dir = TempDir::new().unwrap();
+    let store = FsStore::new(dir.path());
+    store.init().unwrap();
+
+    for index in 0..LOOSE_PER_TYPE {
+        let seed = index.to_le_bytes();
+        write_loose_hash(
+            dir.path(),
+            "blobs",
+            ContentHash::compute_typed("loose-blob", &seed),
+        );
+        write_loose_hash(
+            dir.path(),
+            "trees",
+            ContentHash::compute_typed("loose-tree", &seed),
+        );
+        write_loose_hash(
+            dir.path(),
+            "actions",
+            ContentHash::compute_typed("loose-action", &seed),
+        );
+    }
+
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    for index in 0..PACKED_PER_TYPE {
+        let mut blob = vec![0; BLOB_SIZE];
+        blob[..size_of::<usize>()].copy_from_slice(&index.to_le_bytes());
+        let blob_hash = ContentHash::compute_typed("blob", &blob);
+        builder.add(blob_hash, ObjectType::Blob, blob);
+
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file(format!("file-{index}.bin"), blob_hash, false).unwrap(),
+        ]);
+        builder.add(
+            tree.hash(),
+            ObjectType::Tree,
+            rmp_serde::to_vec(&tree).unwrap(),
+        );
+
+        let action = fixture_action(index);
+        builder.add(
+            *action.compute_id().as_hash(),
+            ObjectType::Action,
+            rmp_serde::to_vec(&action).unwrap(),
+        );
+    }
+    let (pack, index, _) = builder.build().unwrap();
+    store.install_pack(&pack, &index).unwrap();
+
+    EnumerationFixture { _dir: dir, store }
+}
+
+fn bench_object_enumeration(c: &mut Criterion) {
+    let fixture = build_fixture();
+    let expected_per_type = LOOSE_PER_TYPE + PACKED_PER_TYPE;
+    assert_eq!(fixture.store.list_blobs().unwrap().len(), expected_per_type);
+    assert_eq!(fixture.store.list_trees().unwrap().len(), expected_per_type);
+    assert_eq!(
+        fixture.store.list_actions().unwrap().len(),
+        expected_per_type
+    );
+
+    c.bench_function("object_enumeration/mixed_6144_loose_6144_packed", |b| {
+        b.iter(|| {
+            black_box(fixture.store.list_blobs().unwrap());
+            black_box(fixture.store.list_trees().unwrap());
+            black_box(fixture.store.list_actions().unwrap());
+        });
+    });
+}
+
+criterion_group!(benches, bench_object_enumeration);
+criterion_main!(benches);

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -2,6 +2,7 @@
 //! ObjectStore implementation for FsStore.
 
 use std::{
+    collections::HashSet,
     fs::{self, OpenOptions},
     path::{Path, PathBuf},
 };
@@ -104,6 +105,50 @@ fn validate_loaded_action(requested_id: &ActionId, action: Action) -> Result<Act
 fn validate_action_serialized(data: &[u8], id: ActionId) -> Result<Action> {
     let action: Action = rmp_serde::from_slice(data)?;
     validate_loaded_action(&id, action)
+}
+
+trait EnumerationCounter {
+    fn membership_check(&mut self);
+    fn header_read(&mut self);
+}
+
+struct NoopEnumerationCounter;
+
+impl EnumerationCounter for NoopEnumerationCounter {
+    fn membership_check(&mut self) {}
+    fn header_read(&mut self) {}
+}
+
+fn append_packed_hashes_with_counter(
+    hashes: &mut Vec<ContentHash>,
+    manager: &PackManager,
+    expected_type: ObjectType,
+    counter: &mut impl EnumerationCounter,
+) -> Result<()> {
+    let mut known: HashSet<_> = hashes.iter().copied().collect();
+    for id in manager.list_all_ids()? {
+        let PackObjectId::Hash(hash) = id else {
+            continue;
+        };
+        counter.membership_check();
+        if known.contains(&hash) {
+            continue;
+        }
+        counter.header_read();
+        if manager.get_hashed_object_type(&hash)? == Some(expected_type) {
+            known.insert(hash);
+            hashes.push(hash);
+        }
+    }
+    Ok(())
+}
+
+fn append_packed_hashes(
+    hashes: &mut Vec<ContentHash>,
+    manager: &PackManager,
+    expected_type: ObjectType,
+) -> Result<()> {
+    append_packed_hashes_with_counter(hashes, manager, expected_type, &mut NoopEnumerationCounter)
 }
 
 impl FsStore {
@@ -1178,7 +1223,7 @@ impl ObjectStore for FsStore {
     #[instrument(skip(self))]
     fn list_actions(&self) -> Result<Vec<ActionId>> {
         let dir = actions_dir(&self.root);
-        let mut actions = Vec::new();
+        let mut action_hashes = Vec::new();
         if dir.exists() {
             for entry in fs::read_dir(&dir)? {
                 let entry = entry?;
@@ -1187,21 +1232,17 @@ impl ObjectStore for FsStore {
                     && let Some(name_str) = name.to_str()
                     && let Ok(hash) = ContentHash::from_hex(name_str)
                 {
-                    actions.push(ActionId::from_hash(hash));
+                    action_hashes.push(hash);
                 }
             }
         }
         if let Ok(manager) = self.pack_manager().read() {
-            for id in manager.list_all_ids()? {
-                if let PackObjectId::Hash(hash) = id
-                    && !actions.iter().any(|action_id| action_id.as_hash() == &hash)
-                    && let Some((obj_type, _)) = manager.get_hashed_object(&hash)?
-                    && obj_type == ObjectType::Action
-                {
-                    actions.push(ActionId::from_hash(hash));
-                }
-            }
+            append_packed_hashes(&mut action_hashes, &manager, ObjectType::Action)?;
         }
+        let actions = action_hashes
+            .into_iter()
+            .map(ActionId::from_hash)
+            .collect::<Vec<_>>();
         debug!(count = actions.len(), "Listed actions");
         Ok(actions)
     }
@@ -1211,15 +1252,7 @@ impl ObjectStore for FsStore {
         let dir = blobs_dir(&self.root);
         let mut blobs = list_hashes_from_dir(&dir)?;
         if let Ok(manager) = self.pack_manager().read() {
-            for id in manager.list_all_ids()? {
-                if let PackObjectId::Hash(hash) = id
-                    && !blobs.contains(&hash)
-                    && let Some((obj_type, _)) = manager.get_hashed_object(&hash)?
-                    && obj_type == ObjectType::Blob
-                {
-                    blobs.push(hash);
-                }
-            }
+            append_packed_hashes(&mut blobs, &manager, ObjectType::Blob)?;
         }
         Ok(blobs)
     }
@@ -1229,15 +1262,7 @@ impl ObjectStore for FsStore {
         let dir = trees_dir(&self.root);
         let mut trees = list_hashes_from_dir(&dir)?;
         if let Ok(manager) = self.pack_manager().read() {
-            for id in manager.list_all_ids()? {
-                if let PackObjectId::Hash(hash) = id
-                    && !trees.contains(&hash)
-                    && let Some((obj_type, _)) = manager.get_hashed_object(&hash)?
-                    && obj_type == ObjectType::Tree
-                {
-                    trees.push(hash);
-                }
-            }
+            append_packed_hashes(&mut trees, &manager, ObjectType::Tree)?;
         }
         Ok(trees)
     }
@@ -1563,5 +1588,263 @@ mod state_attachment_tests {
             vec![attachment]
         );
         assert!(!rebuild_marker.exists());
+    }
+}
+
+#[cfg(test)]
+mod enumeration_tests {
+    use heddle_format::{compression::CompressionConfig, delta::DeltaEncoder};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::store::pack::{
+        PackBuilder, PackContainerSpec, PackIndex, append_container_checksum,
+        encode_tagged_entry_parts, write_container_header,
+    };
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+    struct TestEnumerationMetrics {
+        membership_checks: u64,
+        header_reads: u64,
+        full_object_decodes: u64,
+    }
+
+    impl EnumerationCounter for TestEnumerationMetrics {
+        fn membership_check(&mut self) {
+            self.membership_checks += 1;
+        }
+
+        fn header_read(&mut self) {
+            self.header_reads += 1;
+        }
+    }
+
+    fn install_pack_files(
+        dir: &TempDir,
+        name: &str,
+        pack_data: &[u8],
+        index_data: &[u8],
+    ) -> PackManager {
+        fs::write(dir.path().join(format!("{name}.pack")), pack_data).unwrap();
+        fs::write(dir.path().join(format!("{name}.idx")), index_data).unwrap();
+        PackManager::new(dir.path().to_path_buf())
+    }
+
+    fn raw_mixed_manager() -> (TempDir, PackManager, Vec<(ContentHash, ObjectType)>) {
+        let dir = TempDir::new().unwrap();
+        let objects = [
+            (ObjectType::Blob, b"packed blob".as_slice()),
+            (ObjectType::Tree, b"packed tree".as_slice()),
+            (ObjectType::Action, b"packed action".as_slice()),
+        ];
+        let mut builder = PackBuilder::new(CompressionConfig::disabled());
+        let mut classified = Vec::new();
+        for (obj_type, data) in objects {
+            let hash = ContentHash::compute_typed("enumeration-test", data);
+            builder.add(hash, obj_type, data.to_vec());
+            classified.push((hash, obj_type));
+        }
+        let (pack, index, _) = builder.build().unwrap();
+        let manager = install_pack_files(&dir, "mixed", &pack, &index);
+        (dir, manager, classified)
+    }
+
+    fn delta_chain_manager() -> (TempDir, PackManager, Vec<ContentHash>) {
+        const SPEC: PackContainerSpec = PackContainerSpec {
+            magic: b"LMPK",
+            version: 3,
+        };
+        let dir = TempDir::new().unwrap();
+        let base = b"delta-chain base payload ".repeat(64);
+        let mut middle = base.clone();
+        middle[200..208].copy_from_slice(b"middle!!");
+        let mut tip = middle.clone();
+        tip[900..908].copy_from_slice(b"tip!!!!!");
+        let bodies = [&base, &middle, &tip];
+        let hashes = bodies
+            .iter()
+            .map(|body| ContentHash::compute_typed("blob", body))
+            .collect::<Vec<_>>();
+        let middle_delta = DeltaEncoder::encode(&base, &middle);
+        let tip_delta = DeltaEncoder::encode(&middle, &tip);
+
+        let mut pack = Vec::new();
+        let mut index = PackIndex::new();
+        write_container_header(&mut pack, SPEC, 3);
+        for (position, payload) in [
+            base.as_slice(),
+            middle_delta.as_slice(),
+            tip_delta.as_slice(),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            index.add(PackObjectId::Hash(hashes[position]), pack.len() as u64);
+            let (stored_type, base_id) = if position == 0 {
+                (ObjectType::Blob, None)
+            } else {
+                (
+                    ObjectType::Delta,
+                    Some(PackObjectId::Hash(hashes[position - 1])),
+                )
+            };
+            encode_tagged_entry_parts(
+                &mut pack,
+                PackObjectId::Hash(hashes[position]),
+                stored_type,
+                bodies[position].len(),
+                base_id,
+                payload,
+            )
+            .unwrap();
+        }
+        index.sort();
+        append_container_checksum(&mut pack);
+        let manager = install_pack_files(&dir, "delta-chain", &pack, &index.to_bytes());
+        (dir, manager, hashes)
+    }
+
+    fn legacy_append_packed_hashes(
+        hashes: &mut Vec<ContentHash>,
+        manager: &PackManager,
+        expected_type: ObjectType,
+    ) -> Result<TestEnumerationMetrics> {
+        let mut metrics = TestEnumerationMetrics::default();
+        for id in manager.list_all_ids()? {
+            let PackObjectId::Hash(hash) = id else {
+                continue;
+            };
+            let mut already_listed = false;
+            for listed in hashes.iter() {
+                metrics.membership_checks += 1;
+                if listed == &hash {
+                    already_listed = true;
+                    break;
+                }
+            }
+            if already_listed {
+                continue;
+            }
+            metrics.full_object_decodes += 1;
+            if let Some((obj_type, _)) = manager.get_hashed_object(&hash)?
+                && obj_type == expected_type
+            {
+                hashes.push(hash);
+            }
+        }
+        Ok(metrics)
+    }
+
+    fn assert_new_matches_legacy(
+        label: &str,
+        manager: &PackManager,
+        loose: Vec<ContentHash>,
+        expected_type: ObjectType,
+    ) {
+        let mut new = loose.clone();
+        let mut new_metrics = TestEnumerationMetrics::default();
+        append_packed_hashes_with_counter(&mut new, manager, expected_type, &mut new_metrics)
+            .unwrap();
+        let mut legacy = loose;
+        legacy_append_packed_hashes(&mut legacy, manager, expected_type).unwrap();
+        assert_eq!(new, legacy, "fixture {label} changed output or ordering");
+        assert_eq!(new_metrics.full_object_decodes, 0, "fixture {label}");
+    }
+
+    #[test]
+    fn type_only_enumeration_matches_full_decode_across_fixture_set() {
+        let empty_dir = TempDir::new().unwrap();
+        let empty = PackManager::new(empty_dir.path().to_path_buf());
+        let loose_hash = ContentHash::compute(b"loose only");
+        assert_new_matches_legacy("loose-only", &empty, vec![loose_hash], ObjectType::Blob);
+
+        let (_raw_dir, raw, classified) = raw_mixed_manager();
+        for expected_type in [ObjectType::Blob, ObjectType::Tree, ObjectType::Action] {
+            assert_new_matches_legacy("packed-only", &raw, Vec::new(), expected_type);
+            assert_new_matches_legacy(
+                "mixed",
+                &raw,
+                vec![ContentHash::compute_typed("loose", &[expected_type as u8])],
+                expected_type,
+            );
+            let duplicate = classified
+                .iter()
+                .find_map(|(hash, obj_type)| (*obj_type == expected_type).then_some(*hash))
+                .unwrap();
+            assert_new_matches_legacy(
+                "duplicate-loose-packed",
+                &raw,
+                vec![duplicate],
+                expected_type,
+            );
+        }
+        for (hash, expected_type) in classified {
+            assert_eq!(
+                raw.get_hashed_object_type(&hash).unwrap(),
+                raw.get_hashed_object(&hash)
+                    .unwrap()
+                    .map(|(obj_type, _)| obj_type)
+            );
+            assert_eq!(
+                raw.get_hashed_object_type(&hash).unwrap(),
+                Some(expected_type)
+            );
+        }
+
+        let (_delta_dir, delta, delta_hashes) = delta_chain_manager();
+        assert_new_matches_legacy("two-link-delta-chain", &delta, Vec::new(), ObjectType::Blob);
+        for hash in delta_hashes {
+            assert_eq!(
+                delta.get_hashed_object_type(&hash).unwrap(),
+                Some(ObjectType::Blob)
+            );
+            assert_eq!(
+                delta.get_hashed_object_type(&hash).unwrap(),
+                delta
+                    .get_hashed_object(&hash)
+                    .unwrap()
+                    .map(|(obj_type, _)| obj_type)
+            );
+        }
+    }
+
+    #[test]
+    fn structural_counter_rejects_vec_scan_and_full_decode_negative_control() {
+        let (_dir, manager, _) = raw_mixed_manager();
+        let loose = (0..64u8)
+            .map(|byte| ContentHash::compute_typed("loose", &[byte]))
+            .collect::<Vec<_>>();
+        let packed_hashes = manager
+            .list_all_ids()
+            .unwrap()
+            .into_iter()
+            .filter(|id| matches!(id, PackObjectId::Hash(_)))
+            .count() as u64;
+
+        for expected_type in [ObjectType::Blob, ObjectType::Tree, ObjectType::Action] {
+            let mut optimized = loose.clone();
+            let mut optimized_metrics = TestEnumerationMetrics::default();
+            append_packed_hashes_with_counter(
+                &mut optimized,
+                &manager,
+                expected_type,
+                &mut optimized_metrics,
+            )
+            .unwrap();
+            assert_eq!(optimized_metrics.membership_checks, packed_hashes);
+            assert_eq!(optimized_metrics.header_reads, packed_hashes);
+            assert_eq!(optimized_metrics.full_object_decodes, 0);
+
+            let mut legacy = loose.clone();
+            let legacy_metrics =
+                legacy_append_packed_hashes(&mut legacy, &manager, expected_type).unwrap();
+            assert!(legacy_metrics.membership_checks >= loose.len() as u64 * packed_hashes);
+            assert_eq!(legacy_metrics.full_object_decodes, packed_hashes);
+            assert!(
+                !(legacy_metrics.membership_checks <= packed_hashes
+                    && legacy_metrics.full_object_decodes == 0),
+                "negative control unexpectedly passed the structural contract: {legacy_metrics:?}"
+            );
+        }
     }
 }

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -170,6 +170,15 @@ impl PackManager {
         self.get_object(&PackObjectId::Hash(*hash))
     }
 
+    /// Look up the logical object type without decoding the object payload.
+    pub fn get_hashed_object_type(&self, hash: &ContentHash) -> Result<Option<ObjectType>> {
+        let id = PackObjectId::Hash(*hash);
+        let Some(pack_index) = self.object_locations.get(&id).copied() else {
+            return Ok(None);
+        };
+        self.packs[pack_index].reader.get_hashed_object_type(hash)
+    }
+
     /// Zero-copy variant of `get_hashed_object`. Returns
     /// [`bytes::Bytes`] views into the underlying pack mmap when
     /// the entry is non-delta and stored uncompressed; falls back

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -260,6 +260,22 @@ impl<'a> PackReader<'a> {
         self.get_object(&PackObjectId::Hash(*hash))
     }
 
+    /// Read an object's logical type from pack headers without reading or
+    /// decoding its payload.
+    ///
+    /// Delta entries inherit the type of their base, so this follows only the
+    /// tagged base ids and headers until it reaches a non-delta entry. No
+    /// compressed or delta payload bytes are decoded. Missing hashes return
+    /// `Ok(None)`.
+    pub fn get_hashed_object_type(&self, hash: &ContentHash) -> Result<Option<ObjectType>> {
+        let id = PackObjectId::Hash(*hash);
+        let Some(offset) = self.index.find(&id) else {
+            return Ok(None);
+        };
+        self.read_object_type_at_depth(&id, checked_index_offset(offset)?, 0)
+            .map(Some)
+    }
+
     /// Zero-copy fast path: when the entry is non-delta and stored
     /// uncompressed, returns `Bytes::slice` into the pack's
     /// (mmap-backed) buffer — no allocation, no memcpy. Compressed
@@ -355,6 +371,38 @@ impl<'a> PackReader<'a> {
             return Ok(Some(uncompressed_size));
         }
         Ok(Some(uncompressed_size))
+    }
+
+    fn read_object_type_at_depth(
+        &self,
+        requested_id: &PackObjectId,
+        offset: usize,
+        depth: usize,
+    ) -> Result<ObjectType> {
+        if depth > MAX_DELTA_CHAIN_DEPTH {
+            return Err(StoreError::InvalidObject(format!(
+                "Delta chain depth {depth} exceeds max {MAX_DELTA_CHAIN_DEPTH}"
+            )));
+        }
+        if offset >= self.content_end {
+            return Err(StoreError::InvalidObject(
+                "Entry offset out of bounds".to_string(),
+            ));
+        }
+
+        let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+        verify_record_id_matches(requested_id, &header.id)?;
+        if header.obj_type != ObjectType::Delta {
+            return Ok(header.obj_type);
+        }
+
+        let base_hash = Self::require_delta_base_hash(header.delta_base)?;
+        let base_id = PackObjectId::Hash(base_hash);
+        let base_offset = self
+            .index
+            .find(&base_id)
+            .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
+        self.read_object_type_at_depth(&base_id, checked_index_offset(base_offset)?, depth + 1)
     }
 
     fn read_record_at_depth(&self, offset: usize, depth: usize) -> Result<PackObjectRecord> {


### PR DESCRIPTION
## Summary

- build one `HashSet` from the loose ids and share the O(1) membership/type-classification loop across `list_blobs`, `list_trees`, and `list_actions`
- add a minimal pack-reader/manager type-only accessor; delta entries follow tagged base headers to the logical type without decompressing or applying payloads
- preserve loose-first then pack-index ordering and first-pack-wins duplicate behavior
- add a focused mixed loose/packed object-enumeration benchmark

Closes #908
Refs #1218

## Test evidence

### Structural counter and negative control

`structural_counter_rejects_vec_scan_and_full_decode_negative_control` runs each of blobs, trees, and actions against 64 loose ids and 3 packed hash ids.

- optimized: 3 O(1) membership probes, 3 header reads, 0 full-object decodes per enumeration
- legacy `Vec` scan + `get_hashed_object`: at least 192 equality comparisons and 3 full-object decodes per enumeration
- the test asserts the optimized contract and asserts that the legacy negative control fails it

### Differential correctness

`type_only_enumeration_matches_full_decode_across_fixture_set` compares exact id vectors, including ordering, from the new path and the old full-decode path for:

- loose-only
- packed-only
- mixed loose + packed
- explicit duplicate loose + packed ids
- an explicit two-link delta chain
- Blob, Tree, and Action classifications

The type-only accessor is also compared object-by-object with full decode classification.

### Wall time

Command: `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-908-target cargo bench -p heddle-objects --bench object_enumeration --features bench -- --sample-size 10`

Fixture: 6,144 loose + 6,144 packed objects, evenly split across blobs/trees/actions; one benchmark iteration enumerates all three lists.

- before: 44.541 ms point estimate, 43.596-45.809 ms interval
- after: 13.005 ms point estimate, 12.888-13.181 ms interval
- delta: -70.604%, 3.42x faster, p < 0.05

### Verification

- `cargo test -p heddle-pack --features zstd`: 72 passed
- `cargo test -p heddle-objects --features zstd`: 171 unit + 1 integration passed
- `cargo clippy -p heddle-pack -p heddle-objects --all-targets --features heddle-pack/zstd,heddle-objects/zstd,heddle-objects/bench -- -D warnings`: passed
- package `cargo fmt --check`, debug build, and `git diff --check`: passed
- full `cargo test --workspace --features zstd` completed all earlier blocks cleanly, then hit one unrelated Codex-environment assertion in `agent_capture_and_ready_require_authenticated_writer_authority`: the ambient `CODEX_THREAD_ID` resolved this session model (`openai/gpt-5.6-sol`) instead of the fixtures explicit `openai/gpt-5.3-codex`; the exact test passes when rerun with `CODEX_THREAD_ID` removed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788409405&installation_model_id=21489&pr_number=1230&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1230&signature=532400ac7fb4a36145abc115fe9f387cbf4807c58e575b870bdc9293f943009f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->