### PR TITLE
perf(repo): make 100k status scale with changed paths

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -610,7 +610,7 @@ impl UserConfig {
             .fsmonitor
             .mode
             .or_else(|| repo_config.map(|config| config.worktree.fsmonitor.mode))
-            .unwrap_or(FsMonitorMode::Off);
+            .unwrap_or_default();
         if let Ok(value) = std::env::var("HEDDLE_FSMONITOR")
             && let Some(parsed) = FsMonitorMode::parse(&value)
         {
@@ -874,6 +874,14 @@ mod tests {
         let options = config.worktree_status_options(Some(&repo));
 
         assert_eq!(options.fsmonitor.mode, FsMonitorMode::Watchman);
+    }
+
+    #[test]
+    fn user_worktree_status_options_default_to_auto() {
+        let config = UserConfig::default();
+        let options = config.worktree_status_options(None);
+
+        assert_eq!(options.fsmonitor.mode, FsMonitorMode::Auto);
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -267,7 +267,7 @@ pub async fn cmd_snapshot(
     // not fail the command. `capture` is a Heddle parent/state change —
     // the call frequency jj's `update_intent_to_add` is designed for.
     if git_overlay {
-        match repo.current_state() {
+        match repo.current_state_for_worktree_status() {
             Ok(Some(state)) => {
                 let bridge = GitProjection::new(&repo);
                 if let Err(err) = bridge.update_intent_to_add(&state.state_id) {
@@ -432,13 +432,13 @@ fn nothing_to_capture_advice() -> RecoveryAdvice {
 }
 
 fn capture_has_worktree_changes(repo: &Repository) -> Result<bool> {
-    if repo.current_state()?.is_none()
+    if repo.current_state_for_worktree_status()?.is_none()
         && let Some(status) = repo.git_overlay_worktree_status()?
     {
         return Ok(!status.is_clean());
     }
-    let tree = match repo.current_state()? {
-        Some(state) => repo.require_tree(&state.tree)?,
+    let tree = match repo.current_state_for_worktree_status()? {
+        Some(state) => repo.require_tree_for_worktree_status(&state.tree)?,
         None => Tree::new(),
     };
     let status = repo.compare_worktree_cached_with_options(
@@ -573,7 +573,7 @@ pub(crate) fn ensure_current_state(
     user_config: &UserConfig,
     intent: Option<String>,
 ) -> Result<StateId> {
-    if let Some(state) = repo.current_state()? {
+    if let Some(state) = repo.current_state_for_worktree_status()? {
         return Ok(state.state_id);
     }
 

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -48,6 +48,8 @@ fn emit_status_worktree_profile(profile: Option<&WorktreeCompareProfile>) {
         return;
     };
     let fields = [
+        ProfileField::boolean("changed_path_mode", profile.scan_mode == "changed_paths"),
+        ProfileField::boolean("fallback_scan", profile.scan_mode == "fallback_scan"),
         ProfileField::millis("index_load_ms", profile.index_load_ms),
         ProfileField::millis("index_snapshot_load_ms", profile.index_snapshot_load_ms),
         ProfileField::millis("index_journal_replay_ms", profile.index_journal_replay_ms),
@@ -82,7 +84,13 @@ fn emit_status_worktree_profile(profile: Option<&WorktreeCompareProfile>) {
     ];
     match profile_mode() {
         ProfileMode::Off | ProfileMode::Jsonl => emit_profile("status worktree detail", &fields),
-        ProfileMode::Human => emit_profile("status worktree", &fields),
+        ProfileMode::Human => {
+            emit_profile("status worktree", &fields);
+            eprintln!("  scan_mode: {}", profile.scan_mode);
+            if let Some(reason) = &profile.fallback_reason {
+                eprintln!("  fallback_reason: {reason}");
+            }
+        }
     }
 }
 

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -73,6 +73,17 @@ pub(crate) fn thread_manager(repo: &Repository) -> ThreadManager {
     ThreadManager::new(repo.heddle_dir())
 }
 
+fn remove_thread_checkout(path: &Path) -> Result<()> {
+    let monitor_guard = path
+        .join(".heddle")
+        .is_dir()
+        .then(|| repo::shutdown_local_monitor_helper(path))
+        .transpose()?;
+    remove_path_recursively(path)?;
+    drop(monitor_guard);
+    Ok(())
+}
+
 pub(crate) fn current_thread_ref_state_with_presence(
     repo: &Repository,
     thread: &Thread,
@@ -1304,7 +1315,7 @@ fn cmd_thread_promote(
             existing_has_heddle,
             same_existing_dir(existing, &target),
         ) {
-            remove_path_recursively(existing)?;
+            remove_thread_checkout(existing)?;
         }
     }
 
@@ -1451,7 +1462,7 @@ pub(crate) fn drop_thread_silent(
         // point. After unmount it should be an empty directory we
         // can safely rmdir; if the unmount failed `remove_path_recursively`
         // will also fail and the user gets a clear error.
-        remove_path_recursively(&thread.execution_path)?;
+        remove_thread_checkout(&thread.execution_path)?;
     }
     // Drop the manifest sidecar last — it has no on-disk dependencies
     // and a leftover would surface as a phantom entry in
@@ -1991,7 +2002,7 @@ fn apply_thread_drop(repo: &Repository, manager: &ThreadManager, thread: &Thread
         }
     }
     if plan.remove_execution_path {
-        remove_path_recursively(&thread.execution_path)?;
+        remove_thread_checkout(&thread.execution_path)?;
     }
     if plan.remove_manifest {
         repo::thread_manifest::remove_thread_manifest_dir(repo.heddle_dir(), &thread.thread)?;

--- a/crates/cli/src/cli/commands/undo_apply/mod.rs
+++ b/crates/cli/src/cli/commands/undo_apply/mod.rs
@@ -307,7 +307,12 @@ impl<'a> EntrySteps<'_, 'a> {
 
     /// Re-materialize the currently attached thread at `target`, preserving its
     /// attached HEAD. No-op when undo/redo is replaying a different thread's ref.
-    fn restore_active_thread_worktree(&mut self, name: &str, target: StateId) -> HeddleResult<()> {
+    fn restore_active_thread_worktree(
+        &mut self,
+        name: &str,
+        target: StateId,
+        materialized: StateId,
+    ) -> HeddleResult<()> {
         let repo = self.repo();
         let head_ref = repo.head_ref()?;
         let Head::Attached { thread } = &head_ref else {
@@ -317,9 +322,9 @@ impl<'a> EntrySteps<'_, 'a> {
             return Ok(());
         }
         self.step_nonatomic(
-            move || Ok((repo.head()?, repo.head_ref()?)),
+            move || Ok((Some(materialized), repo.head_ref()?)),
             move |(prev_state, prev_head_ref)| restore_head(repo, prev_state, &prev_head_ref),
-            move || repo.fast_forward_attached_without_record_discard_local(&target),
+            move || repo.restore_worktree_state_only(&target, Some(&materialized)),
         )
     }
 
@@ -707,6 +712,7 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         OpRecord::ThreadUpdate {
             name,
             old_state,
+            new_state,
             manager_snapshots,
             ..
         } => {
@@ -717,7 +723,7 @@ fn apply_undo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
                 steps.delete_thread(name.as_str())?;
             } else {
                 steps.set_thread(name.as_str(), *old_state)?;
-                steps.restore_active_thread_worktree(name.as_str(), *old_state)?;
+                steps.restore_active_thread_worktree(name.as_str(), *old_state, *new_state)?;
             }
             if let Some(snapshots) = manager_snapshots.as_ref() {
                 if !snapshots.old_records.is_empty() || !snapshots.new_records.is_empty() {
@@ -914,12 +920,13 @@ fn apply_redo_entry(steps: &mut EntrySteps, entry: &OpEntry) -> HeddleResult<()>
         }
         OpRecord::ThreadUpdate {
             name,
+            old_state,
             new_state,
             manager_snapshots,
             ..
         } => {
             steps.set_thread(name.as_str(), *new_state)?;
-            steps.restore_active_thread_worktree(name.as_str(), *new_state)?;
+            steps.restore_active_thread_worktree(name.as_str(), *new_state, *old_state)?;
             if let Some(snapshots) = manager_snapshots.as_ref() {
                 if !snapshots.old_records.is_empty() || !snapshots.new_records.is_empty() {
                     steps.restore_thread_record_set(

--- a/crates/cli/src/hosted_runtime/hosted/provider_pull.rs
+++ b/crates/cli/src/hosted_runtime/hosted/provider_pull.rs
@@ -1876,7 +1876,13 @@ mod tests {
             .iter()
             .copied()
             .enumerate()
-            .map(|(index, id)| (parsed_index.find(&id).unwrap(), index, id))
+            .map(|(index, id)| {
+                (
+                    parsed_index.find(&id).unwrap().expect("fixture id indexed"),
+                    index,
+                    id,
+                )
+            })
             .collect::<Vec<_>>();
         ordered.sort_unstable_by_key(|(offset, _, _)| *offset);
 
@@ -2066,6 +2072,7 @@ mod tests {
             PackIndex::from_bytes(&fixture.source_index)
                 .unwrap()
                 .ids()
+                .unwrap()
                 .len()
         );
         println!(

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -127,9 +127,9 @@ pub fn emit_profile(command: &'static str, fields: &[ProfileField]) {
     let duration_ms = fields
         .iter()
         .filter(|field| matches!(field.unit, ProfileMetricUnit::Milliseconds))
-        .map(|field| match field.value {
-            ProfileMetricScalar::Number(value) => u64::try_from(value).unwrap_or(u64::MAX),
-            ProfileMetricScalar::Boolean(_) => unreachable!("filtered to millisecond metrics"),
+        .filter_map(|field| match field.value {
+            ProfileMetricScalar::Number(value) => Some(u64::try_from(value).unwrap_or(u64::MAX)),
+            ProfileMetricScalar::Boolean(_) => None,
         })
         .max()
         .unwrap_or(0);

--- a/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
@@ -90,6 +90,17 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
                 observed_opens.max
             ));
         }
+        if result.path_count > 0 {
+            let repository_open = result.metric(|sample| sample.repository_open_ms);
+            if repository_open.p95 > 2.0 {
+                failures.push(format!(
+                    "repository-open latency gate: {} @ {} paths p95 {:.3} ms > 2.000 ms",
+                    result.kind.name(),
+                    result.path_count,
+                    repository_open.p95
+                ));
+            }
+        }
         if let Some(contract) = baseline
             .cases
             .iter()
@@ -125,10 +136,30 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
     if let Some(clean_100k) = find(results, CaseKind::StatusClean, 100_000) {
         let dirs = clean_100k.counter(|counters| counters.directories_scanned);
         let hashes = clean_100k.counter(|counters| counters.files_hashed);
-        if dirs.p95 > 10.0 || hashes.p95 > 1.0 {
+        if dirs.p95 > 10.0 || hashes.max > 0.0 {
             failures.push(format!(
-                "warm structural gate: clean status @ 100k dirs p95 {:.0} (<=10), files hashed p95 {:.0} (<=1)",
-                dirs.p95, hashes.p95
+                "warm structural gate: clean status @ 100k dirs p95 {:.0} (<=10), files hashed max {:.0} (=0)",
+                dirs.p95, hashes.max
+            ));
+        }
+    }
+    if let Some(dirty_100k) = find(results, CaseKind::StatusDirty, 100_000) {
+        let dirs = dirty_100k.counter(|counters| counters.directories_scanned);
+        let hashes = dirty_100k.counter(|counters| counters.files_hashed);
+        if dirs.p95 > 12.0 || hashes.max > 1.0 {
+            failures.push(format!(
+                "warm structural gate: one-path status @ 100k dirs p95 {:.0} (<=12), files hashed max {:.0} (<=1)",
+                dirs.p95, hashes.max
+            ));
+        }
+    }
+    if let Some(capture_100k) = find(results, CaseKind::CaptureOne, 100_000) {
+        let dirs = capture_100k.counter(|counters| counters.directories_scanned);
+        let hashes = capture_100k.counter(|counters| counters.files_hashed);
+        if dirs.p95 > 20.0 || hashes.max > 1.0 {
+            failures.push(format!(
+                "warm structural gate: one-path capture @ 100k dirs p95 {:.0} (<=20), files hashed max {:.0} (<=1)",
+                dirs.p95, hashes.max
             ));
         }
     }

--- a/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
@@ -18,6 +18,8 @@ pub(super) enum NegativeControl {
     None,
     Latency,
     FullScan,
+    SubtreeSkip,
+    EagerPackIndex,
     DuplicateOpen,
 }
 
@@ -26,6 +28,8 @@ impl NegativeControl {
         match env::var("HEDDLE_PERF_NEGATIVE_CONTROL").as_deref() {
             Ok("latency") => Self::Latency,
             Ok("full-scan") => Self::FullScan,
+            Ok("subtree-skip") => Self::SubtreeSkip,
+            Ok("eager-pack-index") => Self::EagerPackIndex,
             Ok("duplicate-open") => Self::DuplicateOpen,
             Ok(value) => panic!("unknown HEDDLE_PERF_NEGATIVE_CONTROL `{value}`"),
             Err(_) => Self::None,
@@ -77,6 +81,18 @@ pub(super) struct Sample {
     pub profile_total_ms: f64,
     pub startup_ms: f64,
     pub warm_repository_ms: f64,
+    pub repository_open_ms: f64,
+    pub current_state_ms: f64,
+    pub verification_ms: f64,
+    pub worktree_status_ms: f64,
+    pub thread_summary_ms: f64,
+    pub snapshot_ms: f64,
+    pub snapshot_tree_walk_ms: f64,
+    pub snapshot_blob_prep_ms: f64,
+    pub snapshot_blob_write_ms: f64,
+    pub snapshot_tree_write_ms: f64,
+    pub snapshot_state_ref_oplog_ms: f64,
+    pub snapshot_thread_metadata_ms: f64,
     pub monitor_ms: f64,
     pub rendering_ms: f64,
     pub network_ms: f64,
@@ -102,6 +118,18 @@ impl Sample {
         self.profile_total_ms += other.profile_total_ms;
         self.startup_ms += other.startup_ms;
         self.warm_repository_ms += other.warm_repository_ms;
+        self.repository_open_ms += other.repository_open_ms;
+        self.current_state_ms += other.current_state_ms;
+        self.verification_ms += other.verification_ms;
+        self.worktree_status_ms += other.worktree_status_ms;
+        self.thread_summary_ms += other.thread_summary_ms;
+        self.snapshot_ms += other.snapshot_ms;
+        self.snapshot_tree_walk_ms += other.snapshot_tree_walk_ms;
+        self.snapshot_blob_prep_ms += other.snapshot_blob_prep_ms;
+        self.snapshot_blob_write_ms += other.snapshot_blob_write_ms;
+        self.snapshot_tree_write_ms += other.snapshot_tree_write_ms;
+        self.snapshot_state_ref_oplog_ms += other.snapshot_state_ref_oplog_ms;
+        self.snapshot_thread_metadata_ms += other.snapshot_thread_metadata_ms;
         self.monitor_ms += other.monitor_ms;
         self.rendering_ms += other.rendering_ms;
         self.network_ms += other.network_ms;
@@ -147,7 +175,7 @@ impl CaseResult {
     pub(super) fn print(&self) {
         let wall = self.metric(|sample| sample.wall_ms);
         println!(
-            "RESULT case={} mode={} paths={} samples={} wall_ms={} total_ms={} startup_ms={} warm_repo_ms={} monitor_ms={} render_ms={} network_ms={}",
+            "RESULT case={} mode={} paths={} samples={} wall_ms={} total_ms={} startup_ms={} warm_repo_ms={} repo_open_ms={} current_state_ms={} verification_ms={} worktree_status_ms={} thread_summary_ms={} snapshot_ms={} snapshot_tree_walk_ms={} snapshot_blob_prep_ms={} snapshot_blob_write_ms={} snapshot_tree_write_ms={} snapshot_state_ref_oplog_ms={} snapshot_thread_metadata_ms={} monitor_ms={} render_ms={} network_ms={}",
             self.kind.name(),
             if self.path_count == 0 {
                 "cold_process"
@@ -160,6 +188,18 @@ impl CaseResult {
             self.metric(|sample| sample.profile_total_ms),
             self.metric(|sample| sample.startup_ms),
             self.metric(|sample| sample.warm_repository_ms),
+            self.metric(|sample| sample.repository_open_ms),
+            self.metric(|sample| sample.current_state_ms),
+            self.metric(|sample| sample.verification_ms),
+            self.metric(|sample| sample.worktree_status_ms),
+            self.metric(|sample| sample.thread_summary_ms),
+            self.metric(|sample| sample.snapshot_ms),
+            self.metric(|sample| sample.snapshot_tree_walk_ms),
+            self.metric(|sample| sample.snapshot_blob_prep_ms),
+            self.metric(|sample| sample.snapshot_blob_write_ms),
+            self.metric(|sample| sample.snapshot_tree_write_ms),
+            self.metric(|sample| sample.snapshot_state_ref_oplog_ms),
+            self.metric(|sample| sample.snapshot_thread_metadata_ms),
             self.metric(|sample| sample.monitor_ms),
             self.metric(|sample| sample.rendering_ms),
             self.metric(|sample| sample.network_ms),
@@ -256,11 +296,15 @@ fn run_profiled(binary: &Path, args: &[&str], cwd: &Path, negative: NegativeCont
     if negative == NegativeControl::Latency {
         std::thread::sleep(Duration::from_millis(50));
     }
-    let output = base_command(binary, cwd)
-        .env("HEDDLE_PROFILE", "jsonl")
-        .args(args)
-        .output()
-        .expect("run profiled command");
+    let mut command = base_command(binary, cwd);
+    command.env("HEDDLE_PROFILE", "jsonl");
+    if negative == NegativeControl::SubtreeSkip {
+        command.env("HEDDLE_PERF_DISABLE_SUBTREE_SKIP", "1");
+    }
+    if negative == NegativeControl::EagerPackIndex {
+        command.env("HEDDLE_PERF_FORCE_EAGER_PACK_INDEX", "1");
+    }
+    let output = command.args(args).output().expect("run profiled command");
     let wall_ms = start.elapsed().as_secs_f64() * 1_000.0;
     assert!(
         output.status.success(),

--- a/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
@@ -16,6 +16,27 @@ pub(super) fn sample_from_trace(wall_ms: f64, trace: &Value) -> Sample {
         profile_total_ms: total_ms,
         startup_ms: (wall_ms - command_body_ms).max(0.0),
         warm_repository_ms: status_repo + capture_repo,
+        repository_open_ms: phase_metric(trace, "status repo open", "repo_open_ms"),
+        current_state_ms: phase_metric(trace, "status current state", "current_state_ms"),
+        verification_ms: phase_metric(trace, "status verification", "verification_ms"),
+        worktree_status_ms: phase_metric(trace, "status worktree status", "worktree_status_ms")
+            + phase_metric(trace, "capture phases", "worktree_status_ms"),
+        thread_summary_ms: phase_metric(trace, "status thread summary", "thread_summary_ms"),
+        snapshot_ms: phase_metric(trace, "capture phases", "snapshot_ms"),
+        snapshot_tree_walk_ms: phase_metric(trace, "capture phases", "snapshot_tree_walk_ms"),
+        snapshot_blob_prep_ms: phase_metric(trace, "capture phases", "snapshot_blob_prep_ms"),
+        snapshot_blob_write_ms: phase_metric(trace, "capture phases", "snapshot_blob_write_ms"),
+        snapshot_tree_write_ms: phase_metric(trace, "capture phases", "snapshot_tree_write_ms"),
+        snapshot_state_ref_oplog_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_state_ref_oplog_ms",
+        ),
+        snapshot_thread_metadata_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_thread_metadata_ms",
+        ),
         monitor_ms: phase_metric(trace, "structural counters", "monitor_startup_ms"),
         rendering_ms: phase_metric(trace, "status render", "render_ms")
             + phase_metric(trace, "capture phases", "render_ms"),

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1705,6 +1705,7 @@ fn test_undo_thread_refresh_restores_base_state() {
     };
 
     heddle_must_succeed(&["thread", "refresh", "feature"], temp.path());
+    let feature_tip_after_refresh = head_short(temp.path());
     assert_eq!(
         std::fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
         "feature\n",
@@ -1768,6 +1769,27 @@ fn test_undo_thread_refresh_restores_base_state() {
         restored.current_state.as_deref(),
         Some(current_before_refresh.as_str()),
         "undo of refresh must restore the manager record's current_state too"
+    );
+
+    heddle_must_succeed(&["undo", "--redo"], temp.path());
+    let feature_ref = repo
+        .refs()
+        .get_thread(&ThreadName::new("feature"))
+        .unwrap()
+        .expect("feature ref survives refresh redo")
+        .short();
+    assert_eq!(
+        feature_ref, feature_tip_after_refresh,
+        "redo of refresh must restore the refreshed feature ref"
+    );
+    assert!(
+        temp.path().join("main.txt").exists(),
+        "redo of refresh on the checked-out thread must restore files introduced by refresh"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("feature.txt")).unwrap(),
+        "feature\n",
+        "redo of refresh must preserve the feature worktree content"
     );
 }
 

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -646,6 +646,7 @@ fn decode_native_pack(pack_data: &[u8], index_data: &[u8]) -> Vec<ObjectData> {
     let reader = objects::store::PackReader::from_slice(pack_data, index_data).unwrap();
     reader
         .list_ids()
+        .unwrap()
         .into_iter()
         .map(|id| {
             let (obj_type, data) = reader.get_object(&id).unwrap().unwrap();

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -2093,22 +2093,44 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
     let (git_worktree_status_result, git_index) = load_git_overlay_status_and_index_plan(repo);
     let git_overlay_status_ms = git_overlay_status_start.elapsed().as_millis();
 
+    let native_worktree_status_start = Instant::now();
+    let (worktree_status_result, native_worktree_profile) =
+        if repo.capability() == RepositoryCapability::GitOverlay {
+            (git_worktree_status_result, None)
+        } else {
+            match current_state.as_ref() {
+                Some(state) => {
+                    match repo
+                        .require_tree_for_worktree_status(&state.tree)
+                        .and_then(|tree| {
+                            repo.compare_worktree_cached_profiled_with_options(
+                                &tree,
+                                &opts.worktree_status_options,
+                            )
+                        }) {
+                        Ok((status, profile)) => (Ok(Some(status)), Some(profile)),
+                        Err(error) => (Err(error), None),
+                    }
+                }
+                None => (Ok(Some(WorktreeStatus::default())), None),
+            }
+        };
+    let native_worktree_status_ms = native_worktree_status_start.elapsed().as_millis();
+
     let verification_start = Instant::now();
-    let verification_health = build_repository_verification_health_with_worktree_status(
-        repo,
-        &git_worktree_status_result,
-    );
+    let verification_health =
+        build_repository_verification_health_with_worktree_status(repo, &worktree_status_result);
     let trust = build_repository_verification_state_with_worktree_status_and_machine_contract(
         repo,
         verification_health.clone(),
-        &git_worktree_status_result,
+        &worktree_status_result,
         &opts.machine_contract_input,
     );
     let verification_ms = verification_start.elapsed().as_millis();
     let remote_tracking =
         remote_tracking.map(|remote| remote_tracking_with_verification_action(remote, &trust));
 
-    let git_worktree_status = git_worktree_status_result.unwrap_or(None);
+    let worktree_status = worktree_status_result.unwrap_or(None);
 
     let git_index_ms = 0;
 
@@ -2116,7 +2138,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
     let git_clean_mapping_blocker = matches!(
         trust.status.as_str(),
         "needs_import" | "needs_reconcile" | "git_branch_advanced"
-    ) && git_worktree_status
+    ) && worktree_status
         .as_ref()
         .is_some_and(WorktreeStatus::is_clean);
     let git_backed_mapping = trust.mapping_state == "git_backed";
@@ -2124,14 +2146,22 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
     let worktree_status_start = Instant::now();
     let (changes, worktree_profile) = if git_clean_mapping_blocker {
         (ChangesInfo::default(), None)
-    } else if let Some(status) = git_worktree_status.as_ref()
+    } else if let Some(profile) = native_worktree_profile {
+        (
+            worktree_status
+                .as_ref()
+                .map(changes_from_worktree_status)
+                .unwrap_or_default(),
+            Some(profile),
+        )
+    } else if let Some(status) = worktree_status.as_ref()
         && !status.is_clean()
         && trust.status != "needs_checkpoint"
     {
         (changes_from_worktree_status(status), None)
     } else if git_backed_mapping {
         (
-            git_worktree_status
+            worktree_status
                 .as_ref()
                 .map(changes_from_worktree_status)
                 .unwrap_or_default(),
@@ -2142,7 +2172,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
         let (status, profile) = repo
             .compare_worktree_cached_profiled_with_options(&tree, &opts.worktree_status_options)?;
         (changes_from_worktree_status(&status), Some(profile))
-    } else if let Some(status) = git_worktree_status {
+    } else if let Some(status) = worktree_status {
         (changes_from_worktree_status(&status), None)
     } else {
         let tree = objects::object::Tree::new();
@@ -2153,7 +2183,8 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
         changes.deleted.clear();
         (changes, Some(profile))
     };
-    let worktree_status_ms = worktree_status_start.elapsed().as_millis();
+    let worktree_status_ms =
+        native_worktree_status_ms + worktree_status_start.elapsed().as_millis();
 
     if opts.detail.short_path() {
         return Ok(build_short_path_report(ShortPathInputs {

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -1595,6 +1595,12 @@ fn collect_status_submodules(
         && !is_synthetic_root(state)
     {
         let tree = repo.require_tree(&state.tree)?;
+        if let Some(cached) = repo.cached_gitlinks_for_tree(&tree) {
+            return Ok(cached
+                .into_iter()
+                .map(|(path, commit)| SubmoduleInfo { path, commit })
+                .collect());
+        }
         collect_tree_submodules(repo, &tree, "", &mut submodules)?;
     } else if let Some(git) = repo.git_overlay_sley_repository()? {
         let head = git.head_state().map_err(|error| {

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -505,7 +505,11 @@ pub fn build_repository_verification_health_with_worktree_status(
     match current_branch_tip(repo) {
         Ok(Some(tip))
             if !tip.history_imported
-                && repo.current_state().ok().flatten().is_some()
+                && repo
+                    .current_state_for_worktree_status()
+                    .ok()
+                    .flatten()
+                    .is_some()
                 && import_hint
                     .as_ref()
                     .is_some_and(import_guidance_includes_active_branch) =>
@@ -706,8 +710,8 @@ pub fn build_repository_verification_health_with_worktree_status(
                 }
             }
             if !head_mapping_is_git_backed(&checks)
-                && let Ok(Some(state)) = repo.current_state()
-                && let Ok(tree) = repo.require_tree(&state.tree)
+                && let Ok(Some(state)) = repo.current_state_for_worktree_status()
+                && let Ok(tree) = repo.require_tree_for_worktree_status(&state.tree)
                 && let Ok(status) = repo.compare_worktree_cached_with_options(
                     &tree,
                     &core_worktree_status_options(repo),
@@ -1137,10 +1141,10 @@ fn core_worktree_status_options(repo: &Repository) -> repo::WorktreeStatusOption
 /// only supplied a git-overlay walk (`Ok(None)` on native repos) so the
 /// native verification path can still report uncaptured edits honestly.
 fn native_worktree_status(repo: &Repository) -> Result<Option<WorktreeStatus>> {
-    let Some(state) = repo.current_state()? else {
+    let Some(state) = repo.current_state_for_worktree_status()? else {
         return Ok(Some(WorktreeStatus::default()));
     };
-    let tree = repo.require_tree(&state.tree)?;
+    let tree = repo.require_tree_for_worktree_status(&state.tree)?;
     repo.compare_worktree_cached_with_options(&tree, &core_worktree_status_options(repo))
         .map(Some)
 }
@@ -1161,10 +1165,10 @@ pub(crate) fn git_default_remote_name_from_repo(repo: &SleyRepository) -> Option
 }
 
 fn heddle_worktree_is_clean(repo: &Repository) -> bool {
-    let Ok(Some(state)) = repo.current_state() else {
+    let Ok(Some(state)) = repo.current_state_for_worktree_status() else {
         return false;
     };
-    let Ok(tree) = repo.require_tree(&state.tree) else {
+    let Ok(tree) = repo.require_tree_for_worktree_status(&state.tree) else {
         return false;
     };
     repo.compare_worktree_cached_with_options(&tree, &core_worktree_status_options(repo))
@@ -1594,7 +1598,7 @@ fn collect_status_submodules(
     if let Some(state) = state
         && !is_synthetic_root(state)
     {
-        let tree = repo.require_tree(&state.tree)?;
+        let tree = repo.require_tree_for_worktree_status(&state.tree)?;
         if let Some(cached) = repo.cached_gitlinks_for_tree(&tree) {
             return Ok(cached
                 .into_iter()
@@ -2062,7 +2066,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
     let body_start = Instant::now();
 
     let current_state_start = Instant::now();
-    let current_state = repo.current_state()?;
+    let current_state = repo.current_state_for_worktree_status()?;
     let current_state_ms = current_state_start.elapsed().as_millis();
 
     let operation_start = Instant::now();
@@ -2134,7 +2138,7 @@ pub fn status(ctx: &ExecutionContext, opts: StatusOptions) -> Result<StatusRepor
             None,
         )
     } else if let Some(ref state) = current_state {
-        let tree = repo.require_tree(&state.tree)?;
+        let tree = repo.require_tree_for_worktree_status(&state.tree)?;
         let (status, profile) = repo
             .compare_worktree_cached_profiled_with_options(&tree, &opts.worktree_status_options)?;
         (changes_from_worktree_status(&status), Some(profile))

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -1381,9 +1381,10 @@ mod tests {
                 let index = PackIndex::from_bytes(&std::fs::read(index_path).unwrap()).unwrap();
                 index
                     .ids()
+                    .unwrap()
                     .into_iter()
                     .filter(|id| {
-                        let offset = index.find(id).unwrap() as usize;
+                        let offset = index.find(id).unwrap().expect("indexed fixture id") as usize;
                         decode_tagged_entry_header(&pack[offset..])
                             .is_ok_and(|header| header.obj_type == ObjectType::Delta)
                     })

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -215,7 +215,7 @@ impl FsStore {
 /// both apply the same checksum validation and report the same
 /// installed ids regardless of how the bytes reach the store.
 fn validate_and_list_pack(reader: &crate::store::pack::PackReader) -> Result<Vec<PackObjectId>> {
-    let ids = reader.list_ids();
+    let ids = reader.list_ids()?;
     for id in &ids {
         let Some((obj_type, data)) = reader.get_object_bytes(id)? else {
             continue;
@@ -333,13 +333,7 @@ impl FsStore {
             && obj_type == ObjectType::Blob
         {
             trace!("Found blob in packfile");
-            // Step 2: skip the BLAKE3 re-hash. The pack reader already
-            // located this entry by its content-addressed key in the
-            // pack index — anything served here either matches or
-            // means the pack itself is corrupted in ways a per-read
-            // hash check can't recover from cleanly. For multi-MB
-            // blobs the verify was the dominant tail of the cold
-            // read (~3GB/s × 10MB ≈ 3.3ms per call).
+            validate_blob_bytes(&data, *hash)?;
             let blob = Blob::new(data);
             heddle_perf_contract::record_object_decode();
             self.cache_recent_blob(*hash, &blob);
@@ -509,6 +503,7 @@ impl FsStore {
             && let Some((obj_type, data)) = manager.get_hashed_object(hash)?
             && obj_type == ObjectType::Tree
         {
+            validate_tree_serialized(&data, *hash)?;
             return Ok(Some(data));
         }
 
@@ -615,6 +610,7 @@ impl ObjectStore for FsStore {
             && let Some((obj_type, data)) = manager.get_hashed_object_bytes(hash)?
             && obj_type == crate::store::pack::ObjectType::Blob
         {
+            validate_blob_bytes(data.as_ref(), *hash)?;
             return Ok(Some(data));
         }
         Ok(self

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -494,9 +494,10 @@ fn count_pack_deltas(store: &FsStore) -> usize {
             let index = PackIndex::from_bytes(&std::fs::read(index_path).unwrap()).unwrap();
             index
                 .ids()
+                .unwrap()
                 .into_iter()
                 .filter(|id| {
-                    let offset = index.find(id).unwrap() as usize;
+                    let offset = index.find(id).unwrap().unwrap() as usize;
                     decode_tagged_entry_header(&pack[offset..])
                         .is_ok_and(|header| header.obj_type == PackObjectType::Delta)
                 })

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -640,7 +640,7 @@ pub trait ObjectStore: Send + Sync {
     }
     fn install_pack(&self, pack_data: &[u8], index_data: &[u8]) -> Result<Vec<pack::PackObjectId>> {
         let reader = pack::PackReader::from_slice(pack_data, index_data)?;
-        let ids = reader.list_ids();
+        let ids = reader.list_ids()?;
         for id in &ids {
             let Some((obj_type, data)) = reader.get_object(id)? else {
                 continue;

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -2,8 +2,10 @@
 
 use std::{
     collections::HashMap,
+    fs,
     ops::Deref,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use serde::{Deserialize, Serialize};
@@ -12,7 +14,7 @@ use crate::{
     object::{ContentHash, StateId},
     store::{
         HeddleError, Result,
-        pack::{ObjectType, PackManager, PackObjectId, PackReader},
+        pack::{ObjectType, PackManager, PackObjectId},
     },
 };
 
@@ -80,25 +82,21 @@ impl SnapshotCommitArtifact {
 #[doc(hidden)]
 pub struct SnapshotPackManager {
     format: PackManager,
-    snapshot_commits: Vec<SnapshotCommitDescriptor>,
-    snapshot_commits_by_state: HashMap<StateId, SnapshotCommitDescriptor>,
-    snapshot_commit_index_error: Option<String>,
+    snapshot_commit_index: OnceLock<std::result::Result<SnapshotCommitIndex, String>>,
+}
+
+struct SnapshotCommitIndex {
+    descriptors: Vec<SnapshotCommitDescriptor>,
+    by_state: HashMap<StateId, SnapshotCommitDescriptor>,
 }
 
 impl SnapshotPackManager {
-    /// Open the format manager and build the objects-owned snapshot index.
+    /// Open the format manager. The objects-owned snapshot index is built on
+    /// its first query so ordinary repository opens do not decode every pack.
     pub fn new(packs_dir: PathBuf) -> Self {
-        let format = PackManager::new(packs_dir);
-        let ((snapshot_commits, snapshot_commits_by_state), snapshot_commit_index_error) =
-            match Self::index_snapshot_commits(&format) {
-                Ok(index) => (index, None),
-                Err(error) => ((Vec::new(), HashMap::new()), Some(error.to_string())),
-            };
         Self {
-            format,
-            snapshot_commits,
-            snapshot_commits_by_state,
-            snapshot_commit_index_error,
+            format: PackManager::new(packs_dir),
+            snapshot_commit_index: OnceLock::new(),
         }
     }
 
@@ -106,11 +104,8 @@ impl SnapshotPackManager {
     pub fn reload(&mut self) -> Result<()> {
         let mut format = PackManager::new(self.format.packs_dir().to_path_buf());
         format.reload()?;
-        let (snapshot_commits, snapshot_commits_by_state) = Self::index_snapshot_commits(&format)?;
         self.format = format;
-        self.snapshot_commits = snapshot_commits;
-        self.snapshot_commits_by_state = snapshot_commits_by_state;
-        self.snapshot_commit_index_error = None;
+        self.snapshot_commit_index = OnceLock::new();
         Ok(())
     }
 
@@ -132,34 +127,34 @@ impl SnapshotPackManager {
         {
             return Ok(());
         }
-        let descriptors = Self::snapshot_commit_descriptors_for_pack(&pack_path, &index_path)?;
         self.format.add_pack(pack_path, index_path)?;
-        for descriptor in descriptors {
-            self.snapshot_commits_by_state
-                .insert(descriptor.artifact.state, descriptor.clone());
-            self.snapshot_commits.push(descriptor);
-        }
+        self.snapshot_commit_index = OnceLock::new();
         Ok(())
     }
 
     pub(crate) fn snapshot_commit_descriptors(&self) -> Result<Vec<SnapshotCommitDescriptor>> {
-        self.ensure_snapshot_commit_index_valid()?;
-        Ok(self.snapshot_commits.clone())
+        Ok(self.snapshot_commit_index()?.descriptors.clone())
     }
 
     pub(crate) fn snapshot_commit_descriptor_for_state(
         &self,
         state: &StateId,
     ) -> Result<Option<SnapshotCommitDescriptor>> {
-        self.ensure_snapshot_commit_index_valid()?;
-        Ok(self.snapshot_commits_by_state.get(state).cloned())
+        Ok(self.snapshot_commit_index()?.by_state.get(state).cloned())
     }
 
-    fn ensure_snapshot_commit_index_valid(&self) -> Result<()> {
-        if let Some(error) = &self.snapshot_commit_index_error {
-            return Err(HeddleError::InvalidObject(error.clone()));
+    fn snapshot_commit_index(&self) -> Result<&SnapshotCommitIndex> {
+        match self.snapshot_commit_index.get_or_init(|| {
+            Self::index_snapshot_commits(&self.format)
+                .map(|(descriptors, by_state)| SnapshotCommitIndex {
+                    descriptors,
+                    by_state,
+                })
+                .map_err(|error| error.to_string())
+        }) {
+            Ok(index) => Ok(index),
+            Err(error) => Err(HeddleError::InvalidObject(error.clone())),
         }
-        Ok(())
     }
 
     fn index_snapshot_commits(
@@ -170,8 +165,8 @@ impl SnapshotPackManager {
     )> {
         let mut descriptors = Vec::new();
         let mut by_state = HashMap::new();
-        for (pack_path, index_path) in format.pack_file_paths() {
-            for descriptor in Self::snapshot_commit_descriptors_for_pack(pack_path, index_path)? {
+        for (pack_path, _) in format.pack_file_paths() {
+            for descriptor in Self::snapshot_commit_descriptors_for_pack(format, pack_path)? {
                 by_state.insert(descriptor.artifact.state, descriptor.clone());
                 descriptors.push(descriptor);
             }
@@ -180,28 +175,28 @@ impl SnapshotPackManager {
     }
 
     fn snapshot_commit_descriptors_for_pack(
+        format: &PackManager,
         pack_path: &Path,
-        index_path: &Path,
     ) -> Result<Vec<SnapshotCommitDescriptor>> {
-        let reader = PackReader::open(pack_path, index_path)?;
+        let artifact_ids = snapshot_commit_marker_ids(pack_path)?;
+        if artifact_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let object_ids = format.list_ids_from_pack(pack_path)?;
         let mut descriptors = Vec::new();
-        let object_ids = reader.list_ids();
-        for id in &object_ids {
-            let Some((ObjectType::SnapshotCommit, bytes)) = reader.get_object(id)? else {
-                continue;
-            };
-            let PackObjectId::Hash(expected) = id else {
+        for expected in artifact_ids {
+            let id = PackObjectId::Hash(expected);
+            let Some((ObjectType::SnapshotCommit, bytes)) =
+                format.get_object_from_pack(pack_path, &id)?
+            else {
                 continue;
             };
             let artifact: SnapshotCommitArtifact = rmp_serde::from_slice(&bytes)?;
             artifact.validate()?;
-            if artifact.id() != *expected {
+            if artifact.id() != expected {
                 return Err(HeddleError::InvalidObject(
                     "snapshot commit artifact address mismatch".to_string(),
                 ));
-            }
-            if !snapshot_commit_marker_path(pack_path, expected).exists() {
-                continue;
             }
             descriptors.push(SnapshotCommitDescriptor {
                 artifact,
@@ -216,6 +211,30 @@ impl SnapshotPackManager {
         }
         Ok(descriptors)
     }
+}
+
+fn snapshot_commit_marker_ids(pack_path: &Path) -> Result<Vec<ContentHash>> {
+    let Some(parent) = pack_path.parent() else {
+        return Ok(Vec::new());
+    };
+    let stem = pack_path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default();
+    let prefix = format!("{stem}.snapshot-commit-");
+    let mut ids = Vec::new();
+    for entry in fs::read_dir(parent)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some(suffix) = name.to_str().and_then(|name| name.strip_prefix(&prefix)) else {
+            continue;
+        };
+        if let Ok(id) = ContentHash::from_hex(suffix) {
+            ids.push(id);
+        }
+    }
+    ids.sort_unstable();
+    Ok(ids)
 }
 
 impl Deref for SnapshotPackManager {
@@ -320,7 +339,17 @@ mod tests {
     }
 
     #[test]
-    fn repeated_state_descriptor_lookup_stays_on_incremental_index_after_many_snapshots() {
+    fn unmarked_pack_does_not_open_or_enumerate_its_index_for_recovery() {
+        let temp = TempDir::new().unwrap();
+        fs::write(temp.path().join("ordinary.pack"), b"not opened").unwrap();
+        fs::write(temp.path().join("ordinary.idx"), b"not opened").unwrap();
+
+        let manager = SnapshotPackManager::new(temp.path().to_path_buf());
+        assert!(manager.snapshot_commit_descriptors().unwrap().is_empty());
+    }
+
+    #[test]
+    fn repeated_state_descriptor_lookup_stays_on_lazy_index_after_many_snapshots() {
         let temp = TempDir::new().unwrap();
         let mut manager = SnapshotPackManager::new(temp.path().to_path_buf());
         let mut states = Vec::new();
@@ -330,7 +359,9 @@ mod tests {
             states.push(state);
         }
         assert_eq!(manager.pack_count(), 128);
+        assert!(manager.snapshot_commit_index.get().is_none());
         assert_eq!(manager.snapshot_commit_descriptors().unwrap().len(), 128);
+        assert!(manager.snapshot_commit_index.get().is_some());
 
         let started = Instant::now();
         for iteration in 0..100_000 {
@@ -338,7 +369,7 @@ mod tests {
             let descriptor = manager
                 .snapshot_commit_descriptor_for_state(&state)
                 .unwrap()
-                .expect("every incrementally installed snapshot is indexed");
+                .expect("every installed snapshot is indexed");
             assert_eq!(descriptor.artifact.state, state);
         }
         eprintln!(

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -5,6 +5,7 @@ use std::{
     collections::HashMap,
     fs,
     path::{Path, PathBuf},
+    sync::{OnceLock, RwLock},
 };
 
 use tracing::{debug, instrument, trace};
@@ -23,23 +24,81 @@ use crate::{
 pub struct PackManager {
     packs_dir: PathBuf,
     packs: Vec<CachedPack>,
-    object_locations: HashMap<PackObjectId, usize>,
+    object_locations: RwLock<ObjectLocationIndex>,
+    eager_object_locations: bool,
+}
+
+#[derive(Default)]
+struct ObjectLocationIndex {
+    locations: HashMap<PackObjectId, usize>,
+    complete: bool,
 }
 
 struct CachedPack {
     pack_path: PathBuf,
     index_path: PathBuf,
-    reader: PackReader<'static>,
+    reader: OnceLock<Option<PackReader<'static>>>,
+}
+
+impl CachedPack {
+    fn discovered(pack_path: PathBuf, index_path: PathBuf) -> Self {
+        Self {
+            pack_path,
+            index_path,
+            reader: OnceLock::new(),
+        }
+    }
+
+    fn validated(pack_path: PathBuf, index_path: PathBuf, reader: PackReader<'static>) -> Self {
+        Self {
+            pack_path,
+            index_path,
+            reader: OnceLock::from(Some(reader)),
+        }
+    }
+
+    fn reader(&self) -> Option<&PackReader<'static>> {
+        self.reader
+            .get_or_init(
+                || match PackReader::open_lazy(&self.pack_path, &self.index_path) {
+                    Ok(reader) => Some(reader),
+                    Err(error) => {
+                        debug!(pack = ?self.pack_path, %error, "Failed to open pack");
+                        None
+                    }
+                },
+            )
+            .as_ref()
+    }
+
+    fn verified_reader(&self) -> Option<&PackReader<'static>> {
+        self.reader
+            .get_or_init(
+                || match PackReader::open(&self.pack_path, &self.index_path) {
+                    Ok(reader) => Some(reader),
+                    Err(error) => {
+                        debug!(pack = ?self.pack_path, %error, "Failed to open pack");
+                        None
+                    }
+                },
+            )
+            .as_ref()
+    }
 }
 
 impl PackManager {
     pub fn new(packs_dir: PathBuf) -> Self {
+        Self::new_with_index_mode(packs_dir, force_eager_pack_index())
+    }
+
+    fn new_with_index_mode(packs_dir: PathBuf, eager_object_locations: bool) -> Self {
         let packs = Self::load_packs(&packs_dir).unwrap_or_default();
-        let object_locations = Self::index_object_locations(&packs);
+        let object_locations = Self::initial_object_locations(&packs, eager_object_locations);
         Self {
             packs_dir,
             packs,
-            object_locations,
+            object_locations: RwLock::new(object_locations),
+            eager_object_locations,
         }
     }
 
@@ -69,42 +128,82 @@ impl PackManager {
     }
 
     fn load_packs(packs_dir: &Path) -> Result<Vec<CachedPack>> {
-        let mut cached_packs = Vec::new();
-
-        for (pack_path, index_path) in Self::discover_pack_paths(packs_dir)? {
-            match PackReader::open(&pack_path, &index_path) {
-                Ok(reader) => cached_packs.push(CachedPack {
-                    pack_path,
-                    index_path,
-                    reader,
-                }),
-                Err(error) => {
-                    debug!("Failed to open pack {:?}: {}", pack_path, error);
-                }
-            }
-        }
-
-        Ok(cached_packs)
+        Ok(Self::discover_pack_paths(packs_dir)?
+            .into_iter()
+            .map(|(pack_path, index_path)| CachedPack::discovered(pack_path, index_path))
+            .collect())
     }
 
     pub fn reload(&mut self) -> Result<()> {
-        let packs = Self::load_packs(&self.packs_dir)?;
-        let object_locations = Self::index_object_locations(&packs);
-        self.packs = packs;
-        self.object_locations = object_locations;
+        self.packs = Self::load_packs(&self.packs_dir)?;
+        self.reset_object_locations();
         Ok(())
     }
 
-    fn index_object_locations(packs: &[CachedPack]) -> HashMap<PackObjectId, usize> {
+    fn initial_object_locations(packs: &[CachedPack], eager: bool) -> ObjectLocationIndex {
+        if !eager {
+            return ObjectLocationIndex::default();
+        }
         let mut locations = HashMap::new();
         for (pack_index, pack) in packs.iter().enumerate() {
-            for id in pack.reader.list_ids() {
+            let Some(reader) = pack.verified_reader() else {
+                continue;
+            };
+            let Ok(ids) = reader.list_ids() else {
+                continue;
+            };
+            for id in ids {
                 // Preserve the historical first-pack-wins lookup behavior for
                 // duplicate immutable objects.
                 locations.entry(id).or_insert(pack_index);
             }
         }
-        locations
+        ObjectLocationIndex {
+            locations,
+            complete: true,
+        }
+    }
+
+    fn reset_object_locations(&mut self) {
+        self.object_locations = RwLock::new(Self::initial_object_locations(
+            &self.packs,
+            self.eager_object_locations,
+        ));
+    }
+
+    fn object_location(&self, id: &PackObjectId) -> Result<Option<usize>> {
+        {
+            let index = self
+                .object_locations
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(location) = index.locations.get(id) {
+                return Ok(Some(*location));
+            }
+            if index.complete {
+                return Ok(None);
+            }
+        }
+
+        let mut index = self
+            .object_locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if !index.complete {
+            for (pack_index, pack) in self.packs.iter().enumerate() {
+                let Some(reader) = pack.reader() else {
+                    continue;
+                };
+                let Ok(ids) = reader.list_ids() else {
+                    continue;
+                };
+                for object_id in ids {
+                    index.locations.entry(object_id).or_insert(pack_index);
+                }
+            }
+            index.complete = true;
+        }
+        Ok(index.locations.get(id).copied())
     }
 
     /// Add a complete pack/index pair to the in-memory format index.
@@ -112,16 +211,20 @@ impl PackManager {
         if self.packs.iter().any(|pack| pack.pack_path == pack_path) {
             return Ok(());
         }
-        let cached = CachedPack {
-            reader: PackReader::open(&pack_path, &index_path)?,
-            pack_path,
-            index_path,
-        };
+        let reader = PackReader::open(&pack_path, &index_path)?;
+        let ids = reader.list_ids()?;
         let pack_index = self.packs.len();
-        for id in cached.reader.list_ids() {
-            self.object_locations.entry(id).or_insert(pack_index);
-        }
+        let cached = CachedPack::validated(pack_path, index_path, reader);
         self.packs.push(cached);
+        let mut index = self
+            .object_locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if index.complete {
+            for id in ids {
+                index.locations.entry(id).or_insert(pack_index);
+            }
+        }
         Ok(())
     }
 
@@ -154,15 +257,47 @@ impl PackManager {
     }
 
     pub fn get_object(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Vec<u8>)>> {
-        let Some(pack_index) = self.object_locations.get(id).copied() else {
+        let Some(pack_index) = self.object_location(id)? else {
             trace!("Object not found in any pack");
             return Ok(None);
         };
-        let object = self.packs[pack_index].reader.get_object(id)?;
+        let Some(reader) = self.packs[pack_index].reader() else {
+            return Ok(None);
+        };
+        let object = reader.get_object(id)?;
         if object.is_some() {
             trace!("Found object in pack");
         }
         Ok(object)
+    }
+
+    /// Read `id` from one specific discovered pack without building the
+    /// cross-pack location index. The record identity remains validated by
+    /// [`PackReader`]; object-domain consumers must validate decoded content.
+    pub fn get_object_from_pack(
+        &self,
+        pack_path: &Path,
+        id: &PackObjectId,
+    ) -> Result<Option<(ObjectType, Vec<u8>)>> {
+        let Some(pack) = self.packs.iter().find(|pack| pack.pack_path == pack_path) else {
+            return Ok(None);
+        };
+        let Some(reader) = pack.reader() else {
+            return Ok(None);
+        };
+        reader.get_object(id)
+    }
+
+    /// List the identities in one specific pack without building the
+    /// cross-pack location index.
+    pub fn list_ids_from_pack(&self, pack_path: &Path) -> Result<Vec<PackObjectId>> {
+        let Some(pack) = self.packs.iter().find(|pack| pack.pack_path == pack_path) else {
+            return Ok(Vec::new());
+        };
+        let Some(reader) = pack.reader() else {
+            return Ok(Vec::new());
+        };
+        reader.list_ids()
     }
 
     #[instrument(skip(self), fields(hash = %hash.short()))]
@@ -179,15 +314,18 @@ impl PackManager {
         hash: &ContentHash,
     ) -> Result<Option<(ObjectType, bytes::Bytes)>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_locations.get(&id).copied() else {
+        let Some(pack_index) = self.object_location(&id)? else {
             return Ok(None);
         };
-        self.packs[pack_index].reader.get_object_bytes(&id)
+        let Some(reader) = self.packs[pack_index].reader() else {
+            return Ok(None);
+        };
+        reader.get_object_bytes(&id)
     }
 
     pub fn has_object(&self, hash: &ContentHash) -> bool {
-        self.object_locations
-            .contains_key(&PackObjectId::Hash(*hash))
+        self.object_location(&PackObjectId::Hash(*hash))
+            .is_ok_and(|location| location.is_some())
     }
 
     /// Look up the uncompressed size of `hash` across all loaded
@@ -195,21 +333,27 @@ impl PackManager {
     /// when the object isn't in any loaded pack.
     pub fn get_hashed_object_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_locations.get(&id).copied() else {
+        let Some(pack_index) = self.object_location(&id)? else {
             return Ok(None);
         };
-        self.packs[pack_index].reader.get_hashed_object_size(hash)
+        let Some(reader) = self.packs[pack_index].reader() else {
+            return Ok(None);
+        };
+        reader.get_hashed_object_size(hash)
     }
 
     pub fn has_object_id(&self, id: &PackObjectId) -> bool {
-        self.object_locations.contains_key(id)
+        self.object_location(id)
+            .is_ok_and(|location| location.is_some())
     }
 
     /// List all object hashes across all packs.
     pub fn list_all_hashes(&self) -> Result<Vec<ContentHash>> {
         let mut hashes = Vec::new();
         for pack in &self.packs {
-            hashes.extend(pack.reader.list_hashes());
+            if let Some(reader) = pack.reader() {
+                hashes.extend(reader.list_hashes()?);
+            }
         }
         Ok(hashes)
     }
@@ -217,7 +361,9 @@ impl PackManager {
     pub fn list_all_ids(&self) -> Result<Vec<PackObjectId>> {
         let mut ids = Vec::new();
         for pack in &self.packs {
-            ids.extend(pack.reader.list_ids());
+            if let Some(reader) = pack.reader() {
+                ids.extend(reader.list_ids()?);
+            }
         }
         Ok(ids)
     }
@@ -239,57 +385,11 @@ impl PackManager {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use heddle_format::compression::CompressionConfig;
-    use tempfile::TempDir;
-
-    use super::PackManager;
-    use crate::{
-        object::ContentHash,
-        store::pack::{ObjectType, PackBuilder},
-    };
-
-    fn write_pack(
-        root: &std::path::Path,
-        ordinal: usize,
-    ) -> (std::path::PathBuf, std::path::PathBuf, ContentHash) {
-        let payload = format!("pack-object-{ordinal}").into_bytes();
-        let object_id = ContentHash::compute(&payload);
-        let mut builder = PackBuilder::new(CompressionConfig {
-            max_delta_size: 0,
-            ..CompressionConfig::default()
-        });
-        builder.add(object_id, ObjectType::Blob, payload);
-        let (pack_data, index_data, _) = builder.build().unwrap();
-        let pack_path = root.join(format!("format-{ordinal:03}.pack"));
-        let index_path = root.join(format!("format-{ordinal:03}.idx"));
-        std::fs::write(&pack_path, pack_data).unwrap();
-        std::fs::write(&index_path, index_data).unwrap();
-        (pack_path, index_path, object_id)
-    }
-
-    #[test]
-    fn object_locator_tracks_incremental_and_reloaded_packs() {
-        let temp = TempDir::new().unwrap();
-        let mut manager = PackManager::new(temp.path().to_path_buf());
-        for ordinal in 0..8 {
-            let (pack_path, index_path, _) = write_pack(temp.path(), ordinal);
-            manager.add_pack(pack_path, index_path).unwrap();
-        }
-
-        let ids = manager.list_all_ids().unwrap();
-        assert_eq!(ids.len(), 8);
-        for id in &ids {
-            assert!(manager.has_object_id(id));
-            assert!(manager.get_object(id).unwrap().is_some());
-        }
-
-        let reloaded = PackManager::new(temp.path().to_path_buf());
-        assert_eq!(reloaded.pack_count(), 8);
-        for id in &ids {
-            assert!(reloaded.has_object_id(id));
-            assert!(reloaded.get_object(id).unwrap().is_some());
-        }
-    }
+fn force_eager_pack_index() -> bool {
+    std::env::var("HEDDLE_PERF_FORCE_EAGER_PACK_INDEX")
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
 }
+
+#[cfg(test)]
+#[path = "manager_tests.rs"]
+mod tests;

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -308,10 +308,13 @@ impl PackManager {
     /// Look up the logical object type without decoding the object payload.
     pub fn get_hashed_object_type(&self, hash: &ContentHash) -> Result<Option<ObjectType>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_locations.get(&id).copied() else {
+        let Some(pack_index) = self.object_location(&id)? else {
             return Ok(None);
         };
-        self.packs[pack_index].reader.get_hashed_object_type(hash)
+        let Some(reader) = self.packs[pack_index].reader() else {
+            return Ok(None);
+        };
+        reader.get_hashed_object_type(hash)
     }
 
     /// Zero-copy variant of `get_hashed_object`. Returns

--- a/crates/pack/src/store/pack/manager_tests.rs
+++ b/crates/pack/src/store/pack/manager_tests.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use heddle_format::compression::CompressionConfig;
+use tempfile::TempDir;
+
+use super::PackManager;
+use crate::{
+    object::ContentHash,
+    store::pack::{ObjectType, PackBuilder},
+};
+
+fn write_pack(
+    root: &std::path::Path,
+    ordinal: usize,
+) -> (std::path::PathBuf, std::path::PathBuf, ContentHash) {
+    let payload = format!("pack-object-{ordinal}").into_bytes();
+    let object_id = ContentHash::compute(&payload);
+    let mut builder = PackBuilder::new(CompressionConfig {
+        max_delta_size: 0,
+        ..CompressionConfig::default()
+    });
+    builder.add(object_id, ObjectType::Blob, payload);
+    let (pack_data, index_data, _) = builder.build().unwrap();
+    let pack_path = root.join(format!("format-{ordinal:03}.pack"));
+    let index_path = root.join(format!("format-{ordinal:03}.idx"));
+    std::fs::write(&pack_path, pack_data).unwrap();
+    std::fs::write(&index_path, index_data).unwrap();
+    (pack_path, index_path, object_id)
+}
+
+fn cached_location_count(manager: &PackManager) -> usize {
+    manager.object_locations.read().unwrap().locations.len()
+}
+
+#[test]
+fn object_locator_is_lazy_for_incremental_and_reloaded_packs() {
+    let temp = TempDir::new().unwrap();
+    let mut manager = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
+    for ordinal in 0..8 {
+        let (pack_path, index_path, _) = write_pack(temp.path(), ordinal);
+        manager.add_pack(pack_path, index_path).unwrap();
+    }
+
+    let ids = manager.list_all_ids().unwrap();
+    assert_eq!(ids.len(), 8);
+    assert_eq!(cached_location_count(&manager), 0);
+    for id in &ids {
+        assert!(manager.has_object_id(id));
+        assert!(manager.get_object(id).unwrap().is_some());
+    }
+    assert_eq!(cached_location_count(&manager), 8);
+
+    let reloaded = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
+    assert_eq!(reloaded.pack_count(), 8);
+    assert_eq!(cached_location_count(&reloaded), 0);
+    assert!(
+        reloaded
+            .packs
+            .iter()
+            .all(|pack| pack.reader.get().is_none())
+    );
+    for id in &ids {
+        assert!(reloaded.has_object_id(id));
+        assert!(reloaded.get_object(id).unwrap().is_some());
+    }
+}
+
+#[test]
+fn adding_a_pack_extends_a_completed_lazy_index() {
+    let temp = TempDir::new().unwrap();
+    let mut manager = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
+    let (pack_path, index_path, id) = write_pack(temp.path(), 1);
+
+    assert!(!manager.has_object(&id));
+    assert_eq!(cached_location_count(&manager), 0);
+    manager.add_pack(pack_path, index_path).unwrap();
+    assert_eq!(cached_location_count(&manager), 1);
+    assert!(manager.has_object(&id));
+    assert!(manager.get_hashed_object(&id).unwrap().is_some());
+}

--- a/crates/pack/src/store/pack/mod.rs
+++ b/crates/pack/src/store/pack/mod.rs
@@ -24,7 +24,8 @@ pub use shared::{
     PACK_CHECKSUM_LEN, PackContainerSpec, PackEntryHeader, PackObjectId, PackObjectRecord,
     append_container_checksum, compress_pack_payload, decode_tagged_entry_header,
     decompress_pack_payload, encode_tagged_entry, encode_tagged_entry_parts, has_zstd_magic,
-    try_decode_tagged_entry_header, verify_container, write_container_header,
+    try_decode_tagged_entry_header, verify_container, verify_container_layout,
+    write_container_header,
 };
 pub use streaming_builder::{StreamingPackBuilder, SyncData};
 

--- a/crates/pack/src/store/pack/pack_index.rs
+++ b/crates/pack/src/store/pack/pack_index.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pack index for fast object lookup within packfiles.
 
+use bytes::Bytes;
+
 use crate::store::{
     Result,
     pack::{
@@ -11,7 +13,7 @@ use crate::store::{
 
 pub(super) const INDEX_MAGIC: &[u8; 4] = b"LMI\0";
 pub(super) const INDEX_VERSION: u32 = 2;
-const MIN_INDEX_ENTRY_LEN: usize = 17 + 8;
+const INDEX_ENTRY_LEN: usize = 33 + 8;
 
 /// Entry in the pack index.
 #[derive(Debug, Clone, Copy)]
@@ -24,6 +26,14 @@ pub struct IndexEntry {
 #[derive(Debug)]
 pub struct PackIndex {
     entries: Vec<IndexEntry>,
+    encoded: Option<EncodedIndex>,
+}
+
+#[derive(Debug)]
+struct EncodedIndex {
+    data: Bytes,
+    entries_start: usize,
+    count: usize,
 }
 
 impl PackIndex {
@@ -31,29 +41,50 @@ impl PackIndex {
     pub fn new() -> Self {
         Self {
             entries: Vec::new(),
+            encoded: None,
         }
     }
 
     /// Add an entry.
     pub fn add(&mut self, id: PackObjectId, offset: u64) {
+        debug_assert!(self.encoded.is_none());
         self.entries.push(IndexEntry { id, offset });
     }
 
     /// Sort entries by hash for binary search.
     pub fn sort(&mut self) {
+        debug_assert!(self.encoded.is_none());
         self.entries.sort_by_key(|e| e.id);
     }
 
     /// Find an entry by hash.
-    pub fn find(&self, id: &PackObjectId) -> Option<u64> {
-        self.entries
-            .binary_search_by_key(id, |e| e.id)
-            .ok()
-            .map(|idx| self.entries[idx].offset)
+    pub fn find(&self, id: &PackObjectId) -> Result<Option<u64>> {
+        let Some(encoded) = &self.encoded else {
+            return Ok(self
+                .entries
+                .binary_search_by_key(id, |entry| entry.id)
+                .ok()
+                .map(|index| self.entries[index].offset));
+        };
+        let mut low = 0;
+        let mut high = encoded.count;
+        while low < high {
+            let middle = low + (high - low) / 2;
+            let entry = encoded.entry(middle)?;
+            match entry.id.cmp(id) {
+                std::cmp::Ordering::Less => low = middle + 1,
+                std::cmp::Ordering::Greater => high = middle,
+                std::cmp::Ordering::Equal => return Ok(Some(entry.offset)),
+            }
+        }
+        Ok(None)
     }
 
     /// Serialize to bytes.
     pub fn to_bytes(&self) -> Vec<u8> {
+        if let Some(encoded) = &self.encoded {
+            return encoded.data.to_vec();
+        }
         let mut result = Vec::new();
         index_header().write_vec(&mut result, self.entries.len() as u64);
         for entry in &self.entries {
@@ -65,9 +96,13 @@ impl PackIndex {
 
     /// Deserialize from bytes.
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
-        let header = index_header().verify(data)?;
+        Self::from_owned_bytes(Bytes::copy_from_slice(data))
+    }
+
+    pub fn from_owned_bytes(data: Bytes) -> Result<Self> {
+        let header = index_header().verify(&data)?;
         let count = header.count;
-        let max_entries = ((data.len() - header.header_len) / MIN_INDEX_ENTRY_LEN) as u64;
+        let max_entries = ((data.len() - header.header_len) / INDEX_ENTRY_LEN) as u64;
         if count > max_entries {
             return Err(crate::store::StoreError::InvalidObject(format!(
                 "Index entry count {} exceeds available data capacity {}",
@@ -79,30 +114,41 @@ impl PackIndex {
                 "Index entry count exceeds platform limits".to_string(),
             )
         })?;
-        let mut entries = Vec::with_capacity(count);
-        let mut pos = header.header_len;
-        for _ in 0..count {
-            let (id, id_len) = PackObjectId::decode_tagged(&data[pos..])?;
-            pos += id_len;
-            if pos + 8 > data.len() {
-                return Err(crate::store::StoreError::InvalidObject(
-                    "Index data truncated".to_string(),
-                ));
-            }
-            let offset = u64::from_be_bytes(data[pos..pos + 8].try_into().map_err(|_| {
-                crate::store::StoreError::InvalidObject("Invalid offset length".to_string())
-            })?);
-            entries.push(IndexEntry { id, offset });
-            pos += 8;
-        }
-        Ok(Self { entries })
+        Ok(Self {
+            entries: Vec::new(),
+            encoded: Some(EncodedIndex {
+                data,
+                entries_start: header.header_len,
+                count,
+            }),
+        })
+    }
+}
+
+impl EncodedIndex {
+    fn entry(&self, index: usize) -> Result<IndexEntry> {
+        let start = self.entries_start + index * INDEX_ENTRY_LEN;
+        let end = start + INDEX_ENTRY_LEN;
+        let bytes = self.data.get(start..end).ok_or_else(|| {
+            crate::store::StoreError::InvalidObject("Index data truncated".to_string())
+        })?;
+        let (id, id_len) = PackObjectId::decode_tagged(bytes)?;
+        let offset = u64::from_be_bytes(bytes[id_len..].try_into().map_err(|_| {
+            crate::store::StoreError::InvalidObject("Invalid offset length".to_string())
+        })?);
+        Ok(IndexEntry { id, offset })
     }
 }
 
 impl PackIndex {
     /// Return all ids in this index.
-    pub fn ids(&self) -> Vec<PackObjectId> {
-        self.entries.iter().map(|e| e.id).collect()
+    pub fn ids(&self) -> Result<Vec<PackObjectId>> {
+        if let Some(encoded) = &self.encoded {
+            return (0..encoded.count)
+                .map(|index| encoded.entry(index).map(|entry| entry.id))
+                .collect();
+        }
+        Ok(self.entries.iter().map(|entry| entry.id).collect())
     }
 }
 

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -9,7 +9,8 @@ use heddle_format::delta::{DeltaDecoder, MAX_DELTA_OUTPUT_SIZE};
 use super::{
     ObjectType, PackObjectId, PackObjectRecord, append_container_checksum,
     decode_tagged_entry_header, decompress_pack_payload, has_zstd_magic, pack_container_spec,
-    pack_index::PackIndex, varint, verify_container, write_container_header,
+    pack_index::PackIndex, varint, verify_container, verify_container_layout,
+    write_container_header,
 };
 use crate::{
     object::ContentHash,
@@ -94,10 +95,26 @@ impl PackReader<'static> {
     /// to benefit (the same threshold the loose-blob path uses for
     /// its own mmap decision); read-into-heap otherwise.
     pub fn open(pack_path: &Path, index_path: &Path) -> Result<Self> {
+        Self::open_with_verification(pack_path, index_path, true)
+    }
+
+    pub(super) fn open_lazy(pack_path: &Path, index_path: &Path) -> Result<Self> {
+        Self::open_with_verification(pack_path, index_path, false)
+    }
+
+    fn open_with_verification(
+        pack_path: &Path,
+        index_path: &Path,
+        verify_checksum: bool,
+    ) -> Result<Self> {
         let pack_bytes = read_file_bytes_for_pack(pack_path)?;
-        let index_data = std::fs::read(index_path)?;
-        let (_, _, content_end) = verify_container(&pack_bytes, pack_container_spec())?;
-        let index = PackIndex::from_bytes(&index_data)?;
+        let index_data = read_file_bytes_for_pack(index_path)?;
+        let (_, _, content_end) = if verify_checksum {
+            verify_container(&pack_bytes, pack_container_spec())?
+        } else {
+            verify_container_layout(&pack_bytes, pack_container_spec())?
+        };
+        let index = PackIndex::from_owned_bytes(index_data)?;
         Ok(Self {
             data: PackData::Owned(pack_bytes),
             index,
@@ -129,22 +146,23 @@ impl<'a> PackReader<'a> {
     }
 
     /// List all object ids in this pack.
-    pub fn list_ids(&self) -> Vec<PackObjectId> {
+    pub fn list_ids(&self) -> Result<Vec<PackObjectId>> {
         self.index.ids()
     }
 
-    pub fn list_hashes(&self) -> Vec<ContentHash> {
-        self.list_ids()
+    pub fn list_hashes(&self) -> Result<Vec<ContentHash>> {
+        Ok(self
+            .list_ids()?
             .into_iter()
             .filter_map(|id| match id {
                 PackObjectId::Hash(hash) => Some(hash),
                 PackObjectId::StateId(_) => None,
             })
-            .collect()
+            .collect())
     }
 
-    pub fn has_object(&self, id: &PackObjectId) -> bool {
-        self.index.find(id).is_some()
+    pub fn has_object(&self, id: &PackObjectId) -> Result<bool> {
+        Ok(self.index.find(id)?.is_some())
     }
 
     /// Copy a validated subset of non-delta encoded entries into a standalone
@@ -176,7 +194,7 @@ impl<'a> PackReader<'a> {
         let mut index = PackIndex::new();
         let mut encoded_bytes_copied = 0u64;
         for (expected_id, expected_type, expected_size) in expected {
-            let Some(offset) = self.index.find(expected_id) else {
+            let Some(offset) = self.index.find(expected_id)? else {
                 return Ok(None);
             };
             let offset = checked_index_offset(offset)?;
@@ -246,7 +264,7 @@ impl<'a> PackReader<'a> {
     /// surfaced via the consumer-side hash verify (see
     /// `FsStore::loose_blob_path` for the blob equivalent).
     pub fn get_object(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Vec<u8>)>> {
-        let offset = match self.index.find(id) {
+        let offset = match self.index.find(id)? {
             Some(offset) => checked_index_offset(offset)?,
             None => return Ok(None),
         };
@@ -270,7 +288,7 @@ impl<'a> PackReader<'a> {
     /// between the mount and vanilla FS at the 1 MB+ tier is the
     /// per-blob memcpy this method eliminates.
     pub fn get_object_bytes(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Bytes)>> {
-        let Some(offset) = self.index.find(id) else {
+        let Some(offset) = self.index.find(id)? else {
             return Ok(None);
         };
         let offset = checked_index_offset(offset)?;
@@ -331,7 +349,7 @@ impl<'a> PackReader<'a> {
     /// listing hot path so the fallback is acceptable.
     pub fn get_hashed_object_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(offset) = self.index.find(&id) else {
+        let Some(offset) = self.index.find(&id)? else {
             return Ok(None);
         };
         let offset = checked_index_offset(offset)?;
@@ -455,7 +473,7 @@ impl<'a> PackReader<'a> {
         let base_hash = Self::require_delta_base_hash(base_id)?;
         let base_offset = self
             .index
-            .find(&PackObjectId::Hash(base_hash))
+            .find(&PackObjectId::Hash(base_hash))?
             .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
         let base_offset = checked_index_offset(base_offset)?;
         let base_record = self.read_record_at_depth(base_offset, depth + 1)?;

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -287,7 +287,7 @@ impl<'a> PackReader<'a> {
     /// `Ok(None)`.
     pub fn get_hashed_object_type(&self, hash: &ContentHash) -> Result<Option<ObjectType>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(offset) = self.index.find(&id) else {
+        let Some(offset) = self.index.find(&id)? else {
             return Ok(None);
         };
         self.read_object_type_at_depth(&id, checked_index_offset(offset)?, 0)
@@ -418,7 +418,7 @@ impl<'a> PackReader<'a> {
         let base_id = PackObjectId::Hash(base_hash);
         let base_offset = self
             .index
-            .find(&base_id)
+            .find(&base_id)?
             .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
         self.read_object_type_at_depth(&base_id, checked_index_offset(base_offset)?, depth + 1)
     }

--- a/crates/pack/src/store/pack/pack_tests.rs
+++ b/crates/pack/src/store/pack/pack_tests.rs
@@ -73,7 +73,13 @@ fn test_pack_index_header_codec_matches_legacy_bytes() {
     let encoded = PackIndex::new().to_bytes();
 
     assert_eq!(encoded, legacy);
-    assert!(PackIndex::from_bytes(&legacy).unwrap().ids().is_empty());
+    assert!(
+        PackIndex::from_bytes(&legacy)
+            .unwrap()
+            .ids()
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[test]
@@ -88,19 +94,27 @@ fn test_pack_index_roundtrip() {
     let restored = PackIndex::from_bytes(&bytes).expect("Failed to deserialize index");
 
     assert_eq!(
-        restored.find(&PackObjectId::Hash(create_test_hash(1))),
+        restored
+            .find(&PackObjectId::Hash(create_test_hash(1)))
+            .unwrap(),
         Some(100)
     );
     assert_eq!(
-        restored.find(&PackObjectId::Hash(create_test_hash(2))),
+        restored
+            .find(&PackObjectId::Hash(create_test_hash(2)))
+            .unwrap(),
         Some(200)
     );
     assert_eq!(
-        restored.find(&PackObjectId::StateId(StateId::from_bytes([3; 32]))),
+        restored
+            .find(&PackObjectId::StateId(StateId::from_bytes([3; 32])))
+            .unwrap(),
         Some(300)
     );
     assert_eq!(
-        restored.find(&PackObjectId::Hash(create_test_hash(4))),
+        restored
+            .find(&PackObjectId::Hash(create_test_hash(4)))
+            .unwrap(),
         None
     );
 }
@@ -576,9 +590,11 @@ fn stale_index_swapped_offsets_surfaces_as_invalid_object() {
     let original_index = PackIndex::from_bytes(&index_data).unwrap();
     let offset_a = original_index
         .find(&PackObjectId::Hash(hash_a))
+        .unwrap()
         .expect("index has A");
     let offset_b = original_index
         .find(&PackObjectId::Hash(hash_b))
+        .unwrap()
         .expect("index has B");
     assert_ne!(offset_a, offset_b);
     let mut stale = PackIndex::new();

--- a/crates/pack/src/store/pack/shared.rs
+++ b/crates/pack/src/store/pack/shared.rs
@@ -107,6 +107,14 @@ pub fn verify_container(data: &[u8], spec: PackContainerSpec) -> Result<(u64, us
     Ok((header.count, header.header_len, header.content_end))
 }
 
+pub fn verify_container_layout(
+    data: &[u8],
+    spec: PackContainerSpec,
+) -> Result<(u64, usize, usize)> {
+    let header = pack_container_header(spec).verify_layout(data)?;
+    Ok((header.count, header.header_len, header.content_end))
+}
+
 pub fn append_container_checksum(buf: &mut Vec<u8>) {
     HeaderChecksum::Blake3Trailer.append(buf);
 }

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -887,7 +887,7 @@ mod tests {
         assert_eq!(stats.object_count, 0);
         // PackReader can parse the empty pack and reports zero objects.
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
-        assert!(reader.list_ids().is_empty());
+        assert!(reader.list_ids().unwrap().is_empty());
         // Bucket dir was removed.
         assert!(
             !bucket_dir.exists(),
@@ -907,7 +907,7 @@ mod tests {
         assert_eq!(stats.object_count, 1);
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
         let id = PackObjectId::Hash(hash);
-        assert!(reader.has_object(&id));
+        assert!(reader.has_object(&id).unwrap());
         let (got_type, got_data) = reader.get_object(&id).unwrap().unwrap();
         assert_eq!(got_type, ObjectType::Blob);
         assert_eq!(got_data, payload);
@@ -1004,7 +1004,7 @@ mod tests {
         assert_eq!(stats.object_count, 10_000);
 
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
-        assert_eq!(reader.list_ids().len(), 10_000);
+        assert_eq!(reader.list_ids().unwrap().len(), 10_000);
         // Spot-check ten across the range.
         for i in [0, 1, 99, 1234, 5_000, 9_999] {
             let id = PackObjectId::Hash(hashes[i]);
@@ -1049,7 +1049,7 @@ mod tests {
         assert_eq!(stats.object_count, TOTAL_BUCKETS as u64);
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
         for id in ids {
-            assert!(reader.has_object(&id), "missing id {id:?}");
+            assert!(reader.has_object(&id).unwrap(), "missing id {id:?}");
         }
     }
 
@@ -1106,8 +1106,8 @@ mod tests {
         // Same set of ids in the same sorted order — that's the
         // contract for binary search to work.
         assert_eq!(
-            streaming_reader.list_ids(),
-            classic_reader.list_ids(),
+            streaming_reader.list_ids().unwrap(),
+            classic_reader.list_ids().unwrap(),
             "streaming and classic indices should report the same id sequence"
         );
         // Spot-check that each id resolves to a payload that matches
@@ -1158,7 +1158,7 @@ mod tests {
         let count = u64::from_be_bytes(pack_data[8..16].try_into().unwrap());
         assert_eq!(count, 7);
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
-        assert_eq!(reader.list_ids().len(), 7);
+        assert_eq!(reader.list_ids().unwrap().len(), 7);
     }
 
     #[test]
@@ -1195,8 +1195,8 @@ mod tests {
         assert_eq!(stats.object_count, 2);
         assert_eq!(u64::from_be_bytes(pack_data[8..16].try_into().unwrap()), 2);
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
-        assert!(reader.has_object(&PackObjectId::Hash(hash)));
-        assert!(reader.has_object(&PackObjectId::Hash(second_hash)));
+        assert!(reader.has_object(&PackObjectId::Hash(hash)).unwrap());
+        assert!(reader.has_object(&PackObjectId::Hash(second_hash)).unwrap());
     }
 
     #[test]
@@ -1519,7 +1519,7 @@ mod tests {
         }
         let (pack_data, index_data, _) = finalize_cursor(b, &idx_path);
         let reader = PackReader::from_bytes(pack_data, index_data).unwrap();
-        let mut got = reader.list_ids();
+        let mut got = reader.list_ids().unwrap();
         // PackReader's list_ids returns index order — should already be
         // sorted because we sort on finalize.
         let mut sorted = got.clone();

--- a/crates/pack/src/store/pack/versioned_header.rs
+++ b/crates/pack/src/store/pack/versioned_header.rs
@@ -48,6 +48,13 @@ impl VersionedHeader {
     }
 
     pub fn verify(self, data: &[u8]) -> Result<VerifiedHeader> {
+        let header = self.verify_layout(data)?;
+        self.checksum
+            .verify(data, header.content_end, self.checksum_mismatch)?;
+        Ok(header)
+    }
+
+    pub fn verify_layout(self, data: &[u8]) -> Result<VerifiedHeader> {
         let trailer_len = self.checksum.trailer_len();
         if data.len() < VERSIONED_HEADER_LEN + trailer_len {
             return Err(StoreError::InvalidObject(self.too_short.to_string()));
@@ -65,9 +72,6 @@ impl VersionedHeader {
         }
 
         let content_end = data.len() - trailer_len;
-        self.checksum
-            .verify(data, content_end, self.checksum_mismatch)?;
-
         let count = u64::from_be_bytes([
             data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
         ]);

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -8,7 +8,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::mpsc::{self, Receiver},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use ignore::WalkBuilder;
@@ -89,6 +89,8 @@ struct WatchmanMonitor;
 /// The mount daemon ships with its own protocol version (v2) on a
 /// separate endpoint file — see `crates/repo/src/daemon/mount.rs`.
 const HELPER_PROTOCOL_VERSION: u32 = 1;
+const HELPER_START_POLL_MS: u64 = 5;
+const HELPER_START_POLLS: usize = 400;
 /// Query result and persisted state for one compare run.
 #[derive(Debug, Default)]
 pub(crate) struct ChangeMonitorSession {
@@ -347,6 +349,7 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
         pid: Some(std::process::id()),
     };
     persist_endpoint(&endpoint_path, &endpoint)?;
+    remove_starting_helper_if_owned(&state_path, std::process::id());
 
     let mut server = LocalMonitorServer::new(repo_root.to_path_buf(), state_path)?;
     let result = run_local_monitor_helper_loop(&listener, &mut server);
@@ -371,6 +374,9 @@ impl DaemonHandler for LocalMonitorServer {
     }
 
     fn on_tick(&mut self, idle_for: std::time::Duration) -> IdleDecision {
+        if self.shutdown_requested {
+            return IdleDecision::Exit;
+        }
         // fsmonitor drains pending notify events between accepts so
         // the change cursor stays current even when no CLI is
         // querying. Errors here historically propagated; preserve
@@ -418,6 +424,7 @@ struct LocalMonitorServer {
     last_activity: Instant,
     event_rx: Receiver<notify::Result<Event>>,
     _watcher: RecommendedWatcher,
+    shutdown_requested: bool,
 }
 
 impl LocalMonitorServer {
@@ -453,6 +460,7 @@ impl LocalMonitorServer {
             last_activity: Instant::now(),
             event_rx,
             _watcher: watcher,
+            shutdown_requested: false,
         })
     }
 
@@ -684,6 +692,32 @@ fn helper_lifetime_lock_path(state_path: &Path) -> PathBuf {
     state_path.with_file_name("monitor-helper-lifetime.lock")
 }
 
+fn helper_starting_path(state_path: &Path) -> PathBuf {
+    state_path.with_file_name("monitor-helper-starting")
+}
+
+fn load_starting_helper_pid(state_path: &Path) -> Option<u32> {
+    fs::read_to_string(helper_starting_path(state_path))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+fn persist_starting_helper_pid(state_path: &Path, pid: u32) -> Result<(), HeddleError> {
+    objects::fs_atomic::write_file_atomic(
+        &helper_starting_path(state_path),
+        format!("{pid}\n").as_bytes(),
+    )?;
+    Ok(())
+}
+
+fn remove_starting_helper_if_owned(state_path: &Path, pid: u32) {
+    if load_starting_helper_pid(state_path) == Some(pid) {
+        let _ = fs::remove_file(helper_starting_path(state_path));
+    }
+}
+
 fn try_local_helper_query(
     repo_root: &Path,
     state_path: &Path,
@@ -777,7 +811,9 @@ fn try_local_helper_refresh(repo_root: &Path, state_path: &Path) -> Result<bool,
 }
 
 fn try_spawn_local_helper(repo_root: &Path, state_path: &Path) -> Result<bool, HeddleError> {
-    try_spawn_local_helper_with(state_path, || spawn_local_helper_background(repo_root))
+    try_spawn_local_helper_with(state_path, || {
+        spawn_local_helper_background(repo_root, state_path)
+    })
 }
 
 fn try_spawn_local_helper_with(
@@ -854,11 +890,11 @@ fn retire_failed_helper_endpoint(
     Ok(())
 }
 
-fn spawn_local_helper_background(repo_root: &Path) -> Result<(), HeddleError> {
+fn spawn_local_helper_background(repo_root: &Path, state_path: &Path) -> Result<(), HeddleError> {
     let current_exe = std::env::current_exe()
         .map_err(|error| HeddleError::Config(format!("locate heddle executable: {error}")))?;
     let helper = local_helper_binary_for_executable(&current_exe);
-    if let Err(error) = Command::new(helper)
+    let mut child = match Command::new(helper)
         .arg("--repo-root")
         .arg(repo_root)
         .stdin(Stdio::null())
@@ -866,7 +902,24 @@ fn spawn_local_helper_background(repo_root: &Path) -> Result<(), HeddleError> {
         .stderr(Stdio::null())
         .spawn()
     {
-        warn!(%error, root = %repo_root.display(), "Failed to spawn local monitor helper");
+        Ok(child) => child,
+        Err(error) => {
+            warn!(%error, root = %repo_root.display(), "Failed to spawn local monitor helper");
+            return Ok(());
+        }
+    };
+    let pid = child.id();
+    if let Err(error) = persist_starting_helper_pid(state_path, pid) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
+    if crate::daemon::load_endpoint(&helper_endpoint_path(state_path))
+        .ok()
+        .and_then(|endpoint| endpoint.pid)
+        == Some(pid)
+    {
+        remove_starting_helper_if_owned(state_path, pid);
     }
     Ok(())
 }
@@ -900,6 +953,18 @@ fn handle_local_helper_request(
         "query" => server.query(request.since.as_deref()),
         "refresh" => server.refresh(),
         "baseline" => server.establish_baseline(request.since.as_deref()),
+        "shutdown" => {
+            server.shutdown_requested = true;
+            Ok(MonitorHelperResponse {
+                version: HELPER_PROTOCOL_VERSION,
+                ok: true,
+                status: "disabled".to_string(),
+                reason: Some("shutdown".to_string()),
+                clock: None,
+                changed_paths: Vec::new(),
+                error: None,
+            })
+        }
         command => Err(HeddleError::Config(format!(
             "unknown helper command: {command}"
         ))),
@@ -917,6 +982,90 @@ fn handle_local_helper_request(
             error: Some(error.to_string()),
         },
     }
+}
+
+/// Proof that no native change-monitor helper can create files beneath a
+/// worktree while its checkout directory is being removed.
+pub struct LocalMonitorShutdownGuard {
+    _start_lease: objects::lock::WriteLockGuard,
+    _lifetime_lease: objects::lock::WriteLockGuard,
+}
+
+/// Stop and drain the native change monitor for `repo_root`.
+///
+/// The returned guard keeps both the startup and lifetime locks held. Callers
+/// removing the worktree must retain it until recursive removal completes.
+pub fn shutdown_local_monitor_helper(
+    repo_root: &Path,
+) -> Result<LocalMonitorShutdownGuard, HeddleError> {
+    let state_path = repo_root.join(".heddle/state/fsmonitor.toml");
+    let start_lease = objects::lock::RepoLock::at(helper_start_lock_path(&state_path)).write()?;
+    let endpoint_path = helper_endpoint_path(&state_path);
+
+    let mut endpoint = crate::daemon::load_endpoint(&endpoint_path).ok();
+    if endpoint.is_none()
+        && let Some(starting_pid) = load_starting_helper_pid(&state_path)
+    {
+        for _ in 0..HELPER_START_POLLS {
+            endpoint = crate::daemon::load_endpoint(&endpoint_path).ok();
+            if endpoint.is_some() || !pid_alive(starting_pid) {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(HELPER_START_POLL_MS));
+        }
+        if endpoint.is_none() && pid_alive(starting_pid) {
+            return Err(HeddleError::Config(format!(
+                "native monitor helper {starting_pid} did not finish starting before teardown"
+            )));
+        }
+        remove_starting_helper_if_owned(&state_path, starting_pid);
+    }
+
+    if let Some(endpoint) = endpoint {
+        let response: MonitorHelperResponse = send_json_request(
+            &endpoint,
+            &MonitorHelperRequest {
+                version: HELPER_PROTOCOL_VERSION,
+                command: "shutdown".to_string(),
+                since: None,
+            },
+        )?;
+        if !response.ok {
+            return Err(HeddleError::Config(
+                response
+                    .error
+                    .unwrap_or_else(|| "native monitor refused shutdown".to_string()),
+            ));
+        }
+    }
+
+    let lifetime_lock = objects::lock::RepoLock::at(helper_lifetime_lock_path(&state_path));
+    let mut lifetime_lease = None;
+    for _ in 0..HELPER_START_POLLS {
+        if let Some(lease) = lifetime_lock.try_write()? {
+            lifetime_lease = Some(lease);
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(HELPER_START_POLL_MS));
+    }
+    let lifetime_lease = lifetime_lease.ok_or_else(|| {
+        HeddleError::Config("native monitor helper did not drain before teardown".to_string())
+    })?;
+
+    remove_endpoint(&endpoint_path);
+    let _ = fs::remove_file(helper_starting_path(&state_path));
+    for artifact in [&state_path, &snapshot_path(&state_path)] {
+        match fs::remove_file(artifact) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(HeddleError::Io(error)),
+        }
+    }
+
+    Ok(LocalMonitorShutdownGuard {
+        _start_lease: start_lease,
+        _lifetime_lease: lifetime_lease,
+    })
 }
 
 fn change_monitor_session_from_helper_response(
@@ -1214,7 +1363,8 @@ mod tests {
 
     use super::{
         HELPER_HOST, HELPER_PROTOCOL_VERSION, helper_endpoint_path,
-        local_helper_binary_for_executable, subtree_has_changes, try_spawn_local_helper_with,
+        local_helper_binary_for_executable, shutdown_local_monitor_helper, subtree_has_changes,
+        try_spawn_local_helper_with,
     };
     use crate::{DirectoryCacheEntry, WorktreeIndex};
 
@@ -1297,6 +1447,43 @@ mod tests {
         assert!(
             started.elapsed() < std::time::Duration::from_millis(100),
             "cold spawn should return immediately instead of polling"
+        );
+    }
+
+    #[test]
+    fn shutdown_drains_native_watcher_before_checkout_removal() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        std::fs::write(checkout.join("tracked.txt"), b"tracked\n").unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        let endpoint_path = helper_endpoint_path(&state_path);
+        let helper_root = checkout.clone();
+        let helper = thread::spawn(move || super::run_local_monitor_helper(&helper_root));
+
+        for _ in 0..400 {
+            if endpoint_path.exists() {
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            endpoint_path.exists(),
+            "native helper endpoint should appear"
+        );
+
+        let shutdown = shutdown_local_monitor_helper(&checkout).unwrap();
+        assert!(
+            !endpoint_path.exists(),
+            "shutdown should remove the helper endpoint"
+        );
+        objects::fs_ops::remove_path_recursively(&checkout).unwrap();
+        drop(shutdown);
+
+        helper.join().unwrap().unwrap();
+        assert!(
+            !checkout.exists(),
+            "a drained watcher must not recreate its checkout"
         );
     }
 

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -78,7 +78,6 @@ struct MonitorHelperResponse {
 
 trait ChangeMonitorBackend {
     fn prepare(repo_root: &Path, state_path: PathBuf) -> ChangeMonitorSession;
-    fn persist_current_cursor(repo_root: &Path, state_path: PathBuf) -> Result<(), HeddleError>;
 }
 
 struct LocalMonitor;
@@ -90,9 +89,6 @@ struct WatchmanMonitor;
 /// The mount daemon ships with its own protocol version (v2) on a
 /// separate endpoint file — see `crates/repo/src/daemon/mount.rs`.
 const HELPER_PROTOCOL_VERSION: u32 = 1;
-const HELPER_SPAWN_RETRIES: usize = 10;
-const HELPER_SPAWN_RETRY_DELAY_MS: u64 = 50;
-
 /// Query result and persisted state for one compare run.
 #[derive(Debug, Default)]
 pub(crate) struct ChangeMonitorSession {
@@ -100,6 +96,8 @@ pub(crate) struct ChangeMonitorSession {
     next_cursor: Option<String>,
     state_path: PathBuf,
     pending_snapshot: Option<MonitorSnapshotState>,
+    repo_root: PathBuf,
+    establish_baseline: bool,
     pub(crate) backend: Option<&'static str>,
     pub(crate) reason: Option<String>,
     pub(crate) status: MonitorStatus,
@@ -112,6 +110,7 @@ impl ChangeMonitorSession {
         match settings.mode {
             FsMonitorMode::Off => Self {
                 state_path,
+                repo_root: repo_root.to_path_buf(),
                 reason: Some("disabled".to_string()),
                 status: MonitorStatus::Disabled,
                 ..Self::default()
@@ -119,16 +118,19 @@ impl ChangeMonitorSession {
             FsMonitorMode::Native => try_local_helper_query(repo_root, &state_path)
                 .unwrap_or(None)
                 .unwrap_or_else(|| LocalMonitor::prepare(repo_root, state_path)),
-            FsMonitorMode::Auto => {
-                let session = try_local_helper_query(repo_root, &state_path)
+            FsMonitorMode::Auto if native_backend_supported() => {
+                try_local_helper_query(repo_root, &state_path)
                     .unwrap_or(None)
-                    .unwrap_or_else(|| LocalMonitor::prepare(repo_root, state_path.clone()));
-                if session.status != MonitorStatus::Disabled {
-                    session
-                } else {
-                    WatchmanMonitor::prepare(repo_root, state_path)
-                }
+                    .unwrap_or_else(|| LocalMonitor::prepare(repo_root, state_path))
             }
+            FsMonitorMode::Auto => Self {
+                state_path,
+                repo_root: repo_root.to_path_buf(),
+                backend: Some("off"),
+                reason: Some("native_unsupported_platform".to_string()),
+                status: MonitorStatus::Disabled,
+                ..Self::default()
+            },
             FsMonitorMode::Watchman => WatchmanMonitor::prepare(repo_root, state_path),
         }
     }
@@ -139,12 +141,64 @@ impl ChangeMonitorSession {
             .map_or(0, |paths| paths.len() as u64)
     }
 
+    pub(crate) fn changed_directory_keys(&self) -> BTreeSet<String> {
+        let mut directories = BTreeSet::from([String::new()]);
+        let Some(changed_paths) = &self.changed_paths else {
+            return directories;
+        };
+        for changed in changed_paths {
+            let mut current = Path::new(changed).parent();
+            while let Some(path) = current {
+                directories.insert(cache_key(path));
+                current = path.parent();
+            }
+            directories.insert(changed.clone());
+        }
+        directories
+    }
+
+    pub(crate) fn path_may_have_changed(&self, rel_path: &Path) -> bool {
+        if self.status != MonitorStatus::Usable {
+            return true;
+        }
+        let Some(changed_paths) = &self.changed_paths else {
+            return true;
+        };
+        if changed_paths.contains(".heddleignore") {
+            return true;
+        }
+        let key = cache_key(rel_path);
+        changed_paths.iter().any(|changed| {
+            changed == &key
+                || changed
+                    .strip_prefix(&key)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+                || key
+                    .strip_prefix(changed)
+                    .is_some_and(|suffix| suffix.starts_with('/'))
+        })
+    }
+
+    pub(crate) fn can_filter_directory_children(
+        &self,
+        rel_path: &Path,
+        index: &WorktreeIndex,
+    ) -> bool {
+        !subtree_skip_disabled()
+            && self.status == MonitorStatus::Usable
+            && self.changed_paths.is_some()
+            && index.get_directory(&cache_key(rel_path)).is_some()
+    }
+
     pub(crate) fn can_skip_directory(
         &self,
         rel_path: &Path,
         tree: Option<&Tree>,
         index: &WorktreeIndex,
     ) -> bool {
+        if subtree_skip_disabled() {
+            return false;
+        }
         if self.status != MonitorStatus::Usable {
             return false;
         }
@@ -152,6 +206,9 @@ impl ChangeMonitorSession {
             Some(paths) => paths,
             None => return false,
         };
+        if changed_paths.contains(".heddleignore") {
+            return false;
+        }
         let tree = match tree {
             Some(tree) => tree,
             None => return false,
@@ -170,9 +227,19 @@ impl ChangeMonitorSession {
         !subtree_has_changes(changed_paths, &dir_key)
     }
 
-    pub(crate) fn persist(&self) -> Result<(), HeddleError> {
+    pub(crate) fn persist(&self, worktree_clean: bool) -> Result<(), HeddleError> {
+        if !worktree_clean {
+            return Ok(());
+        }
         if let Some(snapshot) = &self.pending_snapshot {
             persist_snapshot(&snapshot_path(&self.state_path), snapshot)?;
+        }
+        if self.establish_baseline {
+            return try_establish_local_helper_baseline(
+                &self.repo_root,
+                &self.state_path,
+                self.next_cursor.as_deref(),
+            );
         }
         let Some(cursor) = &self.next_cursor else {
             return Ok(());
@@ -197,6 +264,27 @@ impl ChangeMonitorSession {
                 .unwrap_or_default(),
         }
     }
+
+    #[cfg(test)]
+    pub(crate) fn test_usable(repo_root: &Path, changed_paths: BTreeSet<String>) -> Self {
+        Self {
+            changed_paths: Some(changed_paths),
+            state_path: repo_root.join(".heddle/state/fsmonitor.toml"),
+            repo_root: repo_root.to_path_buf(),
+            backend: Some("test"),
+            status: MonitorStatus::Usable,
+            ..Self::default()
+        }
+    }
+}
+
+fn subtree_skip_disabled() -> bool {
+    std::env::var("HEDDLE_PERF_DISABLE_SUBTREE_SKIP")
+        .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+}
+
+const fn native_backend_supported() -> bool {
+    cfg!(target_os = "linux")
 }
 
 /// Rebuild the native change-monitor snapshot + cursor sidecars from a full
@@ -233,35 +321,6 @@ pub(crate) fn rebuild_local_monitor_snapshot(
             };
             persist_snapshot(&snapshot_path(&state_path), &snapshot)?;
             persist_cursor(&state_path, &next_generation.to_string())
-        }
-    }
-}
-
-pub(crate) fn persist_current_monitor_cursor(
-    repo_root: &Path,
-    settings: FsMonitorSettings,
-) -> Result<(), HeddleError> {
-    match settings.mode {
-        FsMonitorMode::Off => Ok(()),
-        FsMonitorMode::Native => {
-            let state_path = repo_root.join(".heddle/state").join("fsmonitor.toml");
-            if try_local_helper_refresh(repo_root, &state_path)? {
-                Ok(())
-            } else {
-                LocalMonitor::persist_current_cursor(repo_root, state_path)
-            }
-        }
-        FsMonitorMode::Auto => {
-            let state_path = repo_root.join(".heddle/state").join("fsmonitor.toml");
-            if try_local_helper_refresh(repo_root, &state_path)? {
-                Ok(())
-            } else {
-                LocalMonitor::persist_current_cursor(repo_root, state_path)
-            }
-        }
-        FsMonitorMode::Watchman => {
-            let state_path = repo_root.join(".heddle/state").join("fsmonitor.toml");
-            WatchmanMonitor::persist_current_cursor(repo_root, state_path)
         }
     }
 }
@@ -330,25 +389,20 @@ impl ChangeMonitorBackend for LocalMonitor {
         // the status hot path: without a live watcher we cannot produce a
         // reliable changed-paths set, so return a session that simply never
         // skips directories (`can_skip_directory` requires `Usable`).
-        // `Disabled` also lets `FsMonitorMode::Auto` fall through to
-        // Watchman. See docs/perf/cli-core-loop-todo.md.
-        let _ = repo_root;
+        // Once that correct fallback scan completes, attempt a non-blocking
+        // baseline handshake with the watcher that was spawned by `prepare`.
+        // If the endpoint is not ready yet, or the watcher observed a change
+        // during the scan, no cursor is advanced and the next command safely
+        // falls back again.
         ChangeMonitorSession {
             state_path,
+            repo_root: repo_root.to_path_buf(),
+            establish_baseline: true,
             backend: Some("native"),
             reason: Some("helper_unavailable_no_full_scan".to_string()),
             status: MonitorStatus::Disabled,
             ..ChangeMonitorSession::default()
         }
-    }
-
-    fn persist_current_cursor(repo_root: &Path, state_path: PathBuf) -> Result<(), HeddleError> {
-        // Same policy as `prepare`: do not full-tree scan just to advance a
-        // cursor when the helper is down. A no-op keeps status cheap; the
-        // helper's own `refresh` path still rebuilds snapshots under the
-        // long-lived watcher.
-        let _ = (repo_root, state_path);
-        Ok(())
     }
 }
 
@@ -381,8 +435,12 @@ impl LocalMonitorServer {
         watcher
             .watch(&repo_root, RecursiveMode::Recursive)
             .map_err(|error| HeddleError::Config(format!("watch repo root: {error}")))?;
-        let current_cursor = snapshot.generation.saturating_add(1);
-        persist_cursor(&state_path, &current_cursor.to_string())?;
+        let persisted_cursor = load_cursor_state(&state_path)
+            .clock
+            .and_then(|clock| clock.parse::<u64>().ok())
+            .unwrap_or_default();
+        let helper_restarted = persisted_cursor > 0;
+        let current_cursor = snapshot.generation.max(persisted_cursor).saturating_add(1);
         Ok(Self {
             repo_root,
             state_path,
@@ -391,7 +449,7 @@ impl LocalMonitorServer {
             current_cursor,
             startup_cursor: current_cursor,
             recent_changes: BTreeMap::new(),
-            desync_reason: None,
+            desync_reason: helper_restarted.then(|| "helper_restart".to_string()),
             last_activity: Instant::now(),
             event_rx,
             _watcher: watcher,
@@ -462,6 +520,43 @@ impl LocalMonitorServer {
         })
     }
 
+    fn establish_baseline(
+        &mut self,
+        expected_cursor: Option<&str>,
+    ) -> Result<MonitorHelperResponse, HeddleError> {
+        self.drain_events()?;
+        let expected = expected_cursor.and_then(|cursor| cursor.parse::<u64>().ok());
+        let stable = expected.map_or_else(
+            || self.recent_changes.is_empty(),
+            |cursor| cursor == self.current_cursor,
+        );
+        if !stable {
+            return Ok(MonitorHelperResponse {
+                version: HELPER_PROTOCOL_VERSION,
+                ok: true,
+                status: "fresh_instance".to_string(),
+                reason: Some("changes_during_baseline".to_string()),
+                clock: Some(self.current_cursor.to_string()),
+                changed_paths: Vec::new(),
+                error: None,
+            });
+        }
+
+        self.startup_cursor = self.current_cursor;
+        self.recent_changes.clear();
+        self.desync_reason = None;
+        persist_cursor(&self.state_path, &self.current_cursor.to_string())?;
+        Ok(MonitorHelperResponse {
+            version: HELPER_PROTOCOL_VERSION,
+            ok: true,
+            status: "usable".to_string(),
+            reason: None,
+            clock: Some(self.current_cursor.to_string()),
+            changed_paths: Vec::new(),
+            error: None,
+        })
+    }
+
     fn drain_events(&mut self) -> Result<(), HeddleError> {
         while let Ok(result) = self.event_rx.try_recv() {
             match result {
@@ -477,6 +572,11 @@ impl LocalMonitorServer {
 
     fn apply_event(&mut self, event: Event) {
         if should_ignore_event_kind(&event.kind) {
+            return;
+        }
+        if matches!(event.kind, EventKind::Any | EventKind::Other) || event.paths.is_empty() {
+            self.desync_reason = Some("overflow_or_dropped_event".to_string());
+            self.recent_changes.clear();
             return;
         }
         for changed_path in normalized_event_paths(&self.repo_root, &event) {
@@ -497,6 +597,8 @@ impl ChangeMonitorBackend for WatchmanMonitor {
                 next_cursor: result.clock,
                 state_path,
                 pending_snapshot: None,
+                repo_root: repo_root.to_path_buf(),
+                establish_baseline: false,
                 backend: Some("watchman"),
                 reason: result.reason,
                 status: result.status,
@@ -512,20 +614,6 @@ impl ChangeMonitorBackend for WatchmanMonitor {
                 }
             }
         }
-    }
-
-    fn persist_current_cursor(repo_root: &Path, state_path: PathBuf) -> Result<(), HeddleError> {
-        let watch_project = run_watchman_json(&[
-            Value::String("watch-project".to_string()),
-            Value::String(repo_root.display().to_string()),
-        ])?;
-        let watch = required_string(&watch_project, "watch")?;
-        let clock_response =
-            run_watchman_json(&[Value::String("clock".to_string()), Value::String(watch)])?;
-        let Some(clock) = optional_string(&clock_response, "clock") else {
-            return Ok(());
-        };
-        persist_cursor(&state_path, &clock)
     }
 }
 
@@ -595,17 +683,13 @@ fn try_local_helper_query(
     let endpoint = match crate::daemon::load_endpoint(&endpoint_path) {
         Ok(endpoint) => endpoint,
         Err(HeddleError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-            if !try_spawn_local_helper(repo_root, state_path)? {
-                return Ok(None);
-            }
-            crate::daemon::load_endpoint(&endpoint_path)?
+            let _ = try_spawn_local_helper(repo_root, state_path)?;
+            return Ok(None);
         }
         Err(error) => {
             warn!(%error, path = %endpoint_path.display(), "Ignoring unreadable monitor helper endpoint");
-            if !try_spawn_local_helper(repo_root, state_path)? {
-                return Ok(None);
-            }
-            crate::daemon::load_endpoint(&endpoint_path)?
+            let _ = try_spawn_local_helper(repo_root, state_path)?;
+            return Ok(None);
         }
     };
     let response: MonitorHelperResponse = match send_json_request(
@@ -626,6 +710,7 @@ fn try_local_helper_query(
     };
 
     Ok(Some(change_monitor_session_from_helper_response(
+        repo_root.to_path_buf(),
         state_path.to_path_buf(),
         &endpoint,
         response,
@@ -709,15 +794,38 @@ fn try_spawn_local_helper_with(
         spawn()?;
     }
 
-    for _ in 0..HELPER_SPAWN_RETRIES {
-        if endpoint_is_current_and_live(&endpoint_path) {
-            return Ok(true);
+    Ok(endpoint_is_current_and_live(&endpoint_path))
+}
+
+fn try_establish_local_helper_baseline(
+    repo_root: &Path,
+    state_path: &Path,
+    expected_cursor: Option<&str>,
+) -> Result<(), HeddleError> {
+    let endpoint_path = helper_endpoint_path(state_path);
+    let endpoint = match crate::daemon::load_endpoint(&endpoint_path) {
+        Ok(endpoint) => endpoint,
+        Err(_) => {
+            let _ = try_spawn_local_helper(repo_root, state_path)?;
+            return Ok(());
         }
-        std::thread::sleep(std::time::Duration::from_millis(
-            HELPER_SPAWN_RETRY_DELAY_MS,
+    };
+    let response: MonitorHelperResponse = send_json_request(
+        &endpoint,
+        &MonitorHelperRequest {
+            version: HELPER_PROTOCOL_VERSION,
+            command: "baseline".to_string(),
+            since: expected_cursor.map(str::to_string),
+        },
+    )?;
+    if !response.ok {
+        return Err(HeddleError::Config(
+            response
+                .error
+                .unwrap_or_else(|| "native monitor baseline failed".to_string()),
         ));
     }
-    Ok(endpoint_is_current_and_live(&endpoint_path))
+    Ok(())
 }
 
 fn endpoint_is_current_and_live(path: &Path) -> bool {
@@ -782,6 +890,7 @@ fn handle_local_helper_request(
     let result = match request.command.as_str() {
         "query" => server.query(request.since.as_deref()),
         "refresh" => server.refresh(),
+        "baseline" => server.establish_baseline(request.since.as_deref()),
         command => Err(HeddleError::Config(format!(
             "unknown helper command: {command}"
         ))),
@@ -802,6 +911,7 @@ fn handle_local_helper_request(
 }
 
 fn change_monitor_session_from_helper_response(
+    repo_root: PathBuf,
     state_path: PathBuf,
     endpoint: &EndpointState,
     response: MonitorHelperResponse,
@@ -827,6 +937,8 @@ fn change_monitor_session_from_helper_response(
         next_cursor: response.clock,
         state_path,
         pending_snapshot: None,
+        repo_root,
+        establish_baseline: status != MonitorStatus::Usable,
         backend: Some("native-helper"),
         reason: response.reason,
         status,
@@ -1164,6 +1276,59 @@ mod tests {
 
         assert!(threads.into_iter().all(|thread| thread.join().unwrap()));
         assert_eq!(spawns.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn cold_start_never_polls_for_worker_readiness() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join(".heddle/state/fsmonitor.toml");
+        let started = std::time::Instant::now();
+        let ready = try_spawn_local_helper_with(&state_path, || Ok(())).unwrap();
+        assert!(!ready);
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(100),
+            "cold spawn should return immediately instead of polling"
+        );
+    }
+
+    #[test]
+    fn overflow_and_missing_cursor_force_fresh_instance() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join(".heddle/state/fsmonitor.toml");
+        let mut server =
+            super::LocalMonitorServer::new(temp.path().to_path_buf(), state_path).unwrap();
+
+        let missing = server.query(None).unwrap();
+        assert_eq!(missing.status, "fresh_instance");
+
+        let cursor = server.current_cursor.to_string();
+        server.apply_event(notify::Event::new(notify::EventKind::Other));
+        let overflow = server.query(Some(&cursor)).unwrap();
+        assert_eq!(overflow.status, "fresh_instance");
+        assert_eq!(
+            overflow.reason.as_deref(),
+            Some("overflow_or_dropped_event")
+        );
+        assert!(overflow.changed_paths.is_empty());
+    }
+
+    #[test]
+    fn helper_restart_invalidates_a_durable_cursor() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join(".heddle/state/fsmonitor.toml");
+        super::persist_cursor(&state_path, "7").unwrap();
+
+        let mut restarted =
+            super::LocalMonitorServer::new(temp.path().to_path_buf(), state_path).unwrap();
+        let response = restarted.query(Some("7")).unwrap();
+
+        assert_eq!(response.status, "fresh_instance");
+        assert_eq!(response.reason.as_deref(), Some("helper_restart"));
+    }
+
+    #[test]
+    fn auto_native_backend_is_explicitly_platform_gated() {
+        assert_eq!(super::native_backend_supported(), cfg!(target_os = "linux"));
     }
 
     #[cfg(unix)]

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -574,12 +574,21 @@ impl LocalMonitorServer {
         if should_ignore_event_kind(&event.kind) {
             return;
         }
-        if matches!(event.kind, EventKind::Any | EventKind::Other) || event.paths.is_empty() {
+        if event.paths.is_empty() {
             self.desync_reason = Some("overflow_or_dropped_event".to_string());
             self.recent_changes.clear();
             return;
         }
-        for changed_path in normalized_event_paths(&self.repo_root, &event) {
+        let changed_paths = normalized_event_paths(&self.repo_root, &event);
+        if changed_paths.is_empty() {
+            return;
+        }
+        if matches!(event.kind, EventKind::Any | EventKind::Other) {
+            self.desync_reason = Some("overflow_or_dropped_event".to_string());
+            self.recent_changes.clear();
+            return;
+        }
+        for changed_path in changed_paths {
             self.current_cursor = self.current_cursor.saturating_add(1);
             self.recent_changes
                 .insert(changed_path, self.current_cursor);
@@ -1310,6 +1319,24 @@ mod tests {
             Some("overflow_or_dropped_event")
         );
         assert!(overflow.changed_paths.is_empty());
+    }
+
+    #[test]
+    fn internal_other_events_do_not_desync_the_worktree_monitor() {
+        let temp = TempDir::new().unwrap();
+        let state_path = temp.path().join(".heddle/state/fsmonitor.toml");
+        let mut server =
+            super::LocalMonitorServer::new(temp.path().to_path_buf(), state_path).unwrap();
+        let cursor = server.current_cursor.to_string();
+        server.apply_event(
+            notify::Event::new(notify::EventKind::Other)
+                .add_path(temp.path().join(".heddle/state/index.bin")),
+        );
+
+        let response = server.query(Some(&cursor)).unwrap();
+
+        assert_eq!(response.status, "usable");
+        assert!(response.changed_paths.is_empty());
     }
 
     #[test]

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -104,7 +104,10 @@ pub use collaboration_store::{
     CollaborationWriteOutcome,
 };
 pub use ephemeral_thread::{CollapsedThread, collapse_expired_ephemeral_threads};
-pub use fsmonitor::{ChangeMonitorReport, run_local_monitor_helper};
+pub use fsmonitor::{
+    ChangeMonitorReport, LocalMonitorShutdownGuard, run_local_monitor_helper,
+    shutdown_local_monitor_helper,
+};
 pub use git_ref_name::{
     GitRefContentNamespace, GitRefKind, GitRefName, GitRefNamespace, ParsedGitRef,
     REMOTE_NAME_FOR_LOCAL_GIT_REPO, is_reserved_git_remote_name,

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -563,7 +563,7 @@ mod tests {
         let config = RepoConfig::default();
 
         assert_eq!(config.worktree.ignore, vec![".heddle".to_string()]);
-        assert_eq!(config.worktree.fsmonitor.mode, crate::FsMonitorMode::Off);
+        assert_eq!(config.worktree.fsmonitor.mode, crate::FsMonitorMode::Auto);
         assert_eq!(
             config.repository.source_authority,
             RepositorySourceAuthority::Native

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -124,6 +124,9 @@ mod repository_tree;
 pub(crate) mod repository_worktree_apply;
 #[path = "repository_worktree_status.rs"]
 mod repository_worktree_status;
+#[cfg(test)]
+#[path = "status_monitor_tests.rs"]
+mod status_monitor_tests;
 #[path = "status_tracked_refresh.rs"]
 mod status_tracked_refresh;
 #[path = "status_untracked_scan.rs"]

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -583,14 +583,17 @@ impl SnapshotMutation<'_> {
     ) -> Result<(Tree, TreeBuildProfile, BTreeMap<String, ManifestFile>)> {
         let baseline_tree = match self.prev_head {
             Some(prev_head) => {
-                let state = self
-                    .repo
-                    .store
-                    .get_state(&prev_head)?
-                    .ok_or(HeddleError::StateNotFound(prev_head))?;
-                Some(self.repo.store.get_tree(&state.tree)?.ok_or_else(|| {
-                    HeddleError::NotFound(format!("tree {} (for state {})", state.tree, prev_head))
-                })?)
+                let state = self.repo.state_for_worktree_status(&prev_head)?;
+                Some(
+                    self.repo
+                        .require_tree_for_worktree_status(&state.tree)
+                        .map_err(|error| {
+                            HeddleError::NotFound(format!(
+                                "tree {} (for state {}): {error}",
+                                state.tree, prev_head
+                            ))
+                        })?,
+                )
             }
             None => None,
         };

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -17,7 +17,9 @@ use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result, repository_tree::TreeBuildProfile};
 use crate::{
+    WorktreeIndex,
     atomic::{AtomicMutation, RewindLedger, StagedCommit, Tx, execute, execute_reconstructible},
+    fsmonitor::{ChangeMonitorSession, MonitorStatus},
     thread_manifest::ManifestFile,
     worktree_ignore::WorktreeIgnoreMatcher,
     worktree_walk::{
@@ -79,7 +81,18 @@ mod contention_retry_tests {
             },
         )]);
         let cutoff = mtime_ns.min(ctime_ns);
-        let policy = SnapshotFingerprintPolicy::new(dir.path(), &files, cutoff);
+        let policy = SnapshotFingerprintPolicy::new(
+            dir.path(),
+            &files,
+            cutoff,
+            crate::WorktreeIndex::new(),
+            crate::fsmonitor::ChangeMonitorSession::prepare(
+                dir.path(),
+                crate::FsMonitorSettings {
+                    mode: crate::FsMonitorMode::Off,
+                },
+            ),
+        );
         let entry = WalkEntry {
             path: &path,
             name: "tracked",
@@ -624,6 +637,8 @@ struct SnapshotFingerprintPolicy<'a> {
     walk_root: &'a std::path::Path,
     files: &'a BTreeMap<String, ManifestFile>,
     racy_cutoff_ns: i64,
+    index: WorktreeIndex,
+    monitor: ChangeMonitorSession,
 }
 
 impl<'a> SnapshotFingerprintPolicy<'a> {
@@ -631,11 +646,15 @@ impl<'a> SnapshotFingerprintPolicy<'a> {
         walk_root: &'a std::path::Path,
         files: &'a BTreeMap<String, ManifestFile>,
         racy_cutoff_ns: i64,
+        index: WorktreeIndex,
+        monitor: ChangeMonitorSession,
     ) -> Self {
         Self {
             walk_root,
             files,
             racy_cutoff_ns,
+            index,
+            monitor,
         }
     }
 
@@ -661,6 +680,42 @@ impl<'a> SnapshotFingerprintPolicy<'a> {
 impl WorktreeWalkPolicy for SnapshotFingerprintPolicy<'_> {
     type DirectoryState = SnapshotFingerprintState;
     type Output = SnapshotFingerprintOutput;
+
+    fn reuse_tree_entry_before_metadata(
+        &mut self,
+        rel_path: &std::path::Path,
+        tree_entry: &TreeEntry,
+        state: &mut Self::DirectoryState,
+    ) -> Result<bool> {
+        let Some(tree_hash) = tree_entry.tree_hash() else {
+            return Ok(false);
+        };
+        let key = crate::worktree_walk::cache_key(rel_path);
+        let reusable = !self.monitor.path_may_have_changed(rel_path)
+            && self
+                .index
+                .get_directory(&key)
+                .is_some_and(|entry| entry.clean_tree_hash == Some(tree_hash));
+        if reusable {
+            state.entries.push(tree_entry.clone());
+        }
+        Ok(reusable)
+    }
+
+    fn skip_directory_before_enumeration(
+        &mut self,
+        rel_path: &std::path::Path,
+        _metadata: &std::fs::Metadata,
+        tree: Option<&Tree>,
+    ) -> Result<Option<Self::Output>> {
+        let Some(tree) = tree else {
+            return Ok(None);
+        };
+        Ok(self
+            .monitor
+            .can_skip_directory(rel_path, Some(tree), &self.index)
+            .then(|| SnapshotFingerprintOutput { tree: tree.clone() }))
+    }
 
     fn enter_directory(
         &mut self,
@@ -915,7 +970,23 @@ impl Repository {
         let nested_exclusions = self.nested_thread_worktree_exclusions(&self.root)?;
         let ignore_matcher = WorktreeIgnoreMatcher::new(&patterns)
             .with_nested_worktree_exclusions(nested_exclusions);
-        let mut policy = SnapshotFingerprintPolicy::new(&self.root, files, racy_cutoff_ns);
+        let monitor = ChangeMonitorSession::prepare(
+            self.root(),
+            crate::FsMonitorSettings::from(self.config.worktree.fsmonitor),
+        );
+        let index_path = self.root.join(".heddle/state/index.bin");
+        let index = if monitor.status == MonitorStatus::Usable {
+            WorktreeIndex::load_hot_profiled_for_directories(
+                &index_path,
+                &monitor.changed_directory_keys(),
+            )
+        } else {
+            WorktreeIndex::load_profiled(&index_path)
+        }
+        .map(|(index, _)| index)
+        .unwrap_or_default();
+        let mut policy =
+            SnapshotFingerprintPolicy::new(&self.root, files, racy_cutoff_ns, index, monitor);
         Ok(
             walk_worktree(self, &self.root, &ignore_matcher, Some(tree), &mut policy)?
                 .tree
@@ -1090,6 +1161,9 @@ impl Repository {
             reconcile_snapshot_ref(self, &head, &execution.state, committed_tip)?;
             execution.profile.ref_publish_ms = ref_publish_started.elapsed().as_millis();
             refresh_materialized_thread_manifest(self, &head, &execution.state, &execution.tree);
+            if let Err(error) = self.compare_worktree_cached_detailed(&execution.tree) {
+                tracing::warn!(%error, "Captured state, but could not refresh worktree monitor/index baseline");
+            }
             return Ok(execution);
         }
     }

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -755,6 +755,10 @@ fn compare_worktree_cached_treats_materialized_gitlink_as_clean_leaf() {
     assert!(status.added.is_empty(), "added={:?}", status.added);
     assert!(status.deleted.is_empty(), "deleted={:?}", status.deleted);
     assert_eq!(
+        repo.cached_gitlinks_for_tree(&tree),
+        Some(vec![("vendor".to_string(), target.to_string())])
+    );
+    assert_eq!(
         fs::read(temp_dir.path().join("vendor")).expect("gitlink placeholder"),
         gitlink_placeholder_bytes(&target)
     );
@@ -1903,6 +1907,8 @@ fn test_maintenance_run_builds_commit_graph_and_worktree_index() {
 
     let graph_path = temp_dir.path().join(".heddle/state/commit-graph.bin");
     let index_path = temp_dir.path().join(".heddle/state/index.bin");
+    let _ = fs::remove_file(&index_path);
+    let _ = fs::remove_file(temp_dir.path().join(".heddle/state/index.journal"));
     assert!(!graph_path.exists());
     assert!(!index_path.exists());
 

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -22,7 +22,7 @@ use super::{
 };
 use crate::{
     FsMonitorSettings, WorktreeIndex, WorktreeStatusOptions,
-    fsmonitor::ChangeMonitorSession,
+    fsmonitor::{ChangeMonitorSession, MonitorStatus},
     thread_manifest::ManifestFile,
     worktree_ignore::WorktreeIgnoreMatcher,
     worktree_index::{WorktreeIndexLoadStats, WorktreeIndexSaveStats},
@@ -34,6 +34,8 @@ use crate::{
 
 #[derive(Debug, Clone, Default)]
 pub struct WorktreeCompareProfile {
+    pub scan_mode: String,
+    pub fallback_reason: Option<String>,
     pub index_load_ms: u128,
     pub index_snapshot_load_ms: u128,
     pub index_journal_replay_ms: u128,
@@ -202,7 +204,24 @@ impl Repository {
     ) -> Result<TreeBuildOutput> {
         let ignore_matcher =
             WorktreeIgnoreMatcher::new(patterns).with_nested_worktree_exclusions(nested_exclusions);
-        let mut policy = TreeBuildPolicy::new(self, dir, stat_cache);
+        let incremental_state = (dir == self.root() && baseline_tree.is_some()).then(|| {
+            let monitor = ChangeMonitorSession::prepare(
+                self.root(),
+                self.default_worktree_status_options().fsmonitor,
+            );
+            let index = if monitor.status == MonitorStatus::Usable {
+                WorktreeIndex::load_hot_profiled_for_directories(
+                    &self.worktree_index_path(),
+                    &monitor.changed_directory_keys(),
+                )
+            } else {
+                WorktreeIndex::load_profiled(&self.worktree_index_path())
+            }
+            .map(|(index, _)| index)
+            .unwrap_or_default();
+            (index, monitor)
+        });
+        let mut policy = TreeBuildPolicy::new(self, dir, stat_cache, incremental_state);
         let mut output = walk_worktree(self, dir, &ignore_matcher, baseline_tree, &mut policy)?;
 
         // Flush every newly-seen blob as a single packfile. Stores
@@ -223,6 +242,23 @@ impl Repository {
     /// Compare the worktree against a tree using the persisted binary index.
     pub fn compare_worktree_cached(&self, tree: &Tree) -> Result<WorktreeStatus> {
         self.compare_worktree_cached_with_options(tree, &self.default_worktree_status_options())
+    }
+
+    /// Return the complete gitlink summary cached for `tree`, when the hot
+    /// index proves that its root directory summary was built from that tree.
+    pub fn cached_gitlinks_for_tree(&self, tree: &Tree) -> Option<Vec<(String, String)>> {
+        let (index, _) = WorktreeIndex::load_hot_profiled_for_directories(
+            &self.worktree_index_path(),
+            &std::collections::BTreeSet::from([String::new()]),
+        )
+        .ok()?;
+        (index.gitlinks_tree() == Some(tree.hash())).then(|| {
+            index
+                .gitlinks()
+                .iter()
+                .map(|(path, target)| (path.clone(), target.clone()))
+                .collect()
+        })
     }
 
     pub fn compare_worktree_cached_detailed(&self, tree: &Tree) -> Result<WorktreeStatusDetailed> {
@@ -275,24 +311,46 @@ impl Repository {
         options: &WorktreeStatusOptions,
     ) -> Result<(WorktreeStatusDetailed, WorktreeCompareProfile)> {
         let index_path = self.worktree_index_path();
+        let index_existed = index_path.exists();
+        let mut index_invalidation_reason = None;
+        let monitor_prepare_start = Instant::now();
+        let monitor = ChangeMonitorSession::prepare(self.root(), options.fsmonitor);
+        let monitor_prepare_ms = monitor_prepare_start.elapsed().as_millis();
         let load_start = Instant::now();
-        let (mut index, load_stats) = match WorktreeIndex::load_profiled(&index_path) {
+        let index_result = if monitor.status == MonitorStatus::Usable {
+            WorktreeIndex::load_hot_profiled_for_directories(
+                &index_path,
+                &monitor.changed_directory_keys(),
+            )
+        } else {
+            WorktreeIndex::load_profiled(&index_path)
+        };
+        let (mut index, load_stats) = match index_result {
             Ok(result) => result,
             Err(error) => {
+                index_invalidation_reason = Some(match &error {
+                    crate::worktree_index::IndexError::VersionMismatch { .. } => {
+                        "index_version_changed"
+                    }
+                    crate::worktree_index::IndexError::ChecksumMismatch
+                    | crate::worktree_index::IndexError::InvalidFormat(_)
+                    | crate::worktree_index::IndexError::InvalidUtf8(_) => "index_corrupt",
+                    crate::worktree_index::IndexError::Io(_) => "index_io_error",
+                });
                 warn!(path = %index_path.display(), %error, "Ignoring unreadable worktree index");
                 (WorktreeIndex::new(), WorktreeIndexLoadStats::default())
             }
         };
+        if !index_existed {
+            index_invalidation_reason = Some("missing_index");
+        }
         let index_load_ms = load_start.elapsed().as_millis();
-
-        let monitor_prepare_start = Instant::now();
-        let monitor = ChangeMonitorSession::prepare(self.root(), options.fsmonitor);
-        let monitor_prepare_ms = monitor_prepare_start.elapsed().as_millis();
 
         let patterns = self.ignore_patterns()?;
         let nested_exclusions = self.nested_thread_worktree_exclusions(self.root())?;
         let ignore_matcher = WorktreeIgnoreMatcher::new(&patterns)
             .with_nested_worktree_exclusions(nested_exclusions);
+        let changed_path_mode = monitor.can_filter_directory_children(Path::new(""), &index);
         let compare_start = Instant::now();
         let (status, stats) = compare_worktree_with_index_detailed(
             self,
@@ -304,23 +362,23 @@ impl Repository {
         let compare_ms = compare_start.elapsed().as_millis();
 
         let save_start = Instant::now();
-        let (index_save_ms, save_stats) = if index.is_dirty() {
+        let (index_save_ms, save_stats, index_persisted) = if index.is_dirty() {
             match index.save_profiled(&index_path) {
                 Ok(stats) => {
                     index.mark_clean();
-                    (save_start.elapsed().as_millis(), stats)
+                    (save_start.elapsed().as_millis(), stats, true)
                 }
                 Err(error) => {
                     warn!(path = %index_path.display(), %error, "Failed to persist worktree index");
-                    (0, WorktreeIndexSaveStats::default())
+                    (0, WorktreeIndexSaveStats::default(), false)
                 }
             }
         } else {
-            (0, WorktreeIndexSaveStats::default())
+            (0, WorktreeIndexSaveStats::default(), true)
         };
 
         let persist_start = Instant::now();
-        if let Err(error) = monitor.persist() {
+        if index_persisted && let Err(error) = monitor.persist(status.is_clean()) {
             warn!(path = %self.root().display(), %error, "Failed to persist monitor state");
         }
         let monitor_persist_ms = persist_start.elapsed().as_millis();
@@ -369,9 +427,22 @@ impl Repository {
             "Worktree compare complete"
         );
 
+        let fallback_reason = (!changed_path_mode).then(|| {
+            index_invalidation_reason
+                .map(str::to_string)
+                .or_else(|| monitor.reason.clone())
+                .unwrap_or_else(|| "missing_index_baseline".to_string())
+        });
+
         Ok((
             status,
             WorktreeCompareProfile {
+                scan_mode: if changed_path_mode {
+                    "changed_paths".to_string()
+                } else {
+                    "fallback_scan".to_string()
+                },
+                fallback_reason,
                 index_load_ms,
                 index_snapshot_load_ms: load_stats.snapshot_load_ms,
                 index_journal_replay_ms: load_stats.journal_replay_ms,
@@ -436,7 +507,6 @@ impl Repository {
     ) -> Result<crate::ChangeMonitorReport> {
         let session = ChangeMonitorSession::prepare(self.root(), options.fsmonitor);
         let report = session.report();
-        session.persist()?;
         Ok(report)
     }
 }
@@ -458,6 +528,7 @@ struct TreeBuildPolicy<'a> {
     /// their hash reused — no `read + hash + put_blob` cycle. Tracked
     /// in `stat_cache_hits` for diagnostics.
     stat_cache: Option<&'a crate::thread_manifest::ThreadManifest>,
+    incremental_state: Option<(WorktreeIndex, ChangeMonitorSession)>,
     stat_cache_hits: u64,
     /// Blobs encountered during the walk that aren't already in the
     /// store. Drained once at the end of the walk into a single
@@ -474,11 +545,13 @@ impl<'a> TreeBuildPolicy<'a> {
         repo: &'a Repository,
         walk_root: &'a Path,
         stat_cache: Option<&'a crate::thread_manifest::ThreadManifest>,
+        incremental_state: Option<(WorktreeIndex, ChangeMonitorSession)>,
     ) -> Self {
         Self {
             repo,
             walk_root,
             stat_cache,
+            incremental_state,
             stat_cache_hits: 0,
             pending_blobs: Vec::new(),
             seen: HashSet::new(),
@@ -491,7 +564,6 @@ impl<'a> TreeBuildPolicy<'a> {
     /// match is exact; `None` otherwise. The caller falls back to
     /// the read-and-hash path.
     fn lookup_stat_cache_hash(&self, entry: &WalkEntry<'_>) -> Option<ContentHash> {
-        let cache = self.stat_cache?;
         let rel = entry.path.strip_prefix(self.walk_root).ok()?;
         // Manifest keys use forward-slash separators (cross-platform
         // by construction; see `populate_manifest_from_tree`).
@@ -505,22 +577,39 @@ impl<'a> TreeBuildPolicy<'a> {
             }
             rel_str.push_str(s.to_str()?);
         }
-        let cached = cache.files.get(&rel_str)?;
-        let (size, inode, mtime_ns, ctime_ns, mode) =
-            crate::stat_signature::stat_signature(entry.path, &entry.metadata);
-        let stat = crate::thread_manifest::ManifestFile {
-            hash: cached.hash,
-            size,
-            inode,
-            mtime_ns,
-            ctime_ns,
-            mode,
-        };
-        if stat.matches(cached) {
-            Some(cached.hash)
-        } else {
-            None
+        if let Some(cached) = self.stat_cache.and_then(|cache| cache.files.get(&rel_str)) {
+            let (size, inode, mtime_ns, ctime_ns, mode) =
+                crate::stat_signature::stat_signature(entry.path, &entry.metadata);
+            let stat = crate::thread_manifest::ManifestFile {
+                hash: cached.hash,
+                size,
+                inode,
+                mtime_ns,
+                ctime_ns,
+                mode,
+            };
+            if stat.matches(cached) {
+                return Some(cached.hash);
+            }
         }
+        let cached = self
+            .incremental_state
+            .as_ref()
+            .and_then(|(index, _)| index.fresh_entry(&rel_str, &entry.metadata))?;
+        Some(cached.hash)
+    }
+
+    fn monitor_proves_unchanged(&self, entry: &WalkEntry<'_>) -> bool {
+        let Some((index, monitor)) = &self.incremental_state else {
+            return false;
+        };
+        entry.path.strip_prefix(self.walk_root).is_ok_and(|path| {
+            let parent = path.parent().unwrap_or_else(|| Path::new(""));
+            index
+                .get_directory(&crate::worktree_walk::cache_key(parent))
+                .is_some()
+                && !monitor.path_may_have_changed(path)
+        })
     }
 
     /// Push a blob into the pending pack if it's not already in the
@@ -574,6 +663,51 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
     type DirectoryState = TreeBuildState;
     type Output = TreeBuildOutput;
 
+    fn reuse_tree_entry_before_metadata(
+        &mut self,
+        rel_path: &Path,
+        tree_entry: &TreeEntry,
+        state: &mut Self::DirectoryState,
+    ) -> Result<bool> {
+        let Some(tree_hash) = tree_entry.tree_hash() else {
+            return Ok(false);
+        };
+        let Some((index, monitor)) = &self.incremental_state else {
+            return Ok(false);
+        };
+        let key = crate::worktree_walk::cache_key(rel_path);
+        let reusable = !monitor.path_may_have_changed(rel_path)
+            && index
+                .get_directory(&key)
+                .is_some_and(|entry| entry.clean_tree_hash == Some(tree_hash));
+        if reusable {
+            state.entries.push(tree_entry.clone());
+            state.profile.dir_count += 1;
+        }
+        Ok(reusable)
+    }
+
+    fn skip_directory_before_enumeration(
+        &mut self,
+        rel_path: &Path,
+        _metadata: &fs::Metadata,
+        tree: Option<&Tree>,
+    ) -> Result<Option<Self::Output>> {
+        let Some((index, monitor)) = &self.incremental_state else {
+            return Ok(None);
+        };
+        let Some(tree) = tree else {
+            return Ok(None);
+        };
+        Ok(monitor
+            .can_skip_directory(rel_path, Some(tree), index)
+            .then(|| TreeBuildOutput {
+                tree: tree.clone(),
+                profile: TreeBuildProfile::default(),
+                revalidation_files: BTreeMap::new(),
+            }))
+    }
+
     fn enter_directory(
         &mut self,
         _directory: &WalkDirectory<'_>,
@@ -589,6 +723,16 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         state: &mut Self::DirectoryState,
     ) -> Result<()> {
         trace!(file = %entry.path.display(), size = entry.metadata.len(), "Processing file");
+
+        if self.monitor_proves_unchanged(&entry)
+            && let Some(tree_entry) = tree_entry
+            && let Some(hash) = tree_entry.blob_hash()
+        {
+            self.record_revalidation_file(&entry, hash, state)?;
+            state.profile.file_count += 1;
+            state.entries.push(tree_entry.clone());
+            return Ok(());
+        }
 
         if let Some(target) = tree_entry.and_then(TreeEntry::gitlink_target) {
             let read_start = Instant::now();
@@ -667,9 +811,17 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
     fn visit_symlink(
         &mut self,
         entry: WalkEntry<'_>,
-        _tree_entry: Option<&TreeEntry>,
+        tree_entry: Option<&TreeEntry>,
         state: &mut Self::DirectoryState,
     ) -> Result<()> {
+        if self.monitor_proves_unchanged(&entry)
+            && let Some(tree_entry) = tree_entry
+            && let Some(hash) = tree_entry.symlink_hash()
+        {
+            self.record_revalidation_file(&entry, hash, state)?;
+            state.entries.push(tree_entry.clone());
+            return Ok(());
+        }
         let target = fs::read_link(entry.path)?;
         // Validate symlink escape against the *walk root*, not
         // `repo.root()`. When `capture_thread_from_disk` builds a

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -245,24 +245,30 @@ impl Repository {
     }
 
     pub fn require_tree_for_worktree_status(&self, hash: &ContentHash) -> Result<Tree> {
-        if let Ok((index, _)) = WorktreeIndex::load_hot_profiled_for_directories(
-            &self.worktree_index_path(),
-            &std::collections::BTreeSet::from([String::new()]),
-        ) && let Some(tree) = index.clean_tree("", hash)
+        let cache_path = self.root().join(".heddle/state/worktree-current-tree.bin");
+        if let Ok(bytes) = fs::read(&cache_path)
+            && let Ok(tree) = rmp_serde::from_slice::<Tree>(&bytes)
+            && tree.validate().is_ok()
+            && tree.hash() == *hash
         {
-            return Ok(tree.clone());
+            return Ok(tree);
         }
-        self.require_tree(hash)
+        let tree = self.require_tree(hash)?;
+        if let Ok(bytes) = rmp_serde::to_vec_named(&tree)
+            && let Err(error) = objects::fs_atomic::write_file_atomic(&cache_path, &bytes)
+        {
+            warn!(path = %cache_path.display(), %error, "Could not refresh worktree tree cache");
+        }
+        Ok(tree)
     }
 
     pub fn state_for_worktree_status(&self, id: &StateId) -> Result<State> {
-        let cache_path = self
-            .root()
-            .join(".heddle/state/worktree-current-state.bin");
+        let cache_path = self.root().join(".heddle/state/worktree-current-state.bin");
         if let Ok(bytes) = fs::read(&cache_path)
-            && let Ok(state) = rmp_serde::from_slice::<State>(&bytes)
+            && let Ok(mut state) = rmp_serde::from_slice::<State>(&bytes)
             && state.id() == *id
         {
+            state.state_id = *id;
             return Ok(state);
         }
         let state = self
@@ -286,18 +292,9 @@ impl Repository {
     /// Return the complete gitlink summary cached for `tree`, when the hot
     /// index proves that its root directory summary was built from that tree.
     pub fn cached_gitlinks_for_tree(&self, tree: &Tree) -> Option<Vec<(String, String)>> {
-        let (index, _) = WorktreeIndex::load_hot_profiled_for_directories(
-            &self.worktree_index_path(),
-            &std::collections::BTreeSet::from([String::new()]),
-        )
-        .ok()?;
-        (index.gitlinks_tree() == Some(tree.hash())).then(|| {
-            index
-                .gitlinks()
-                .iter()
-                .map(|(path, target)| (path.clone(), target.clone()))
-                .collect()
-        })
+        let (root, gitlinks) =
+            WorktreeIndex::load_hot_gitlinks_summary(&self.worktree_index_path()).ok()??;
+        (root == tree.hash()).then_some(gitlinks)
     }
 
     pub fn compare_worktree_cached_detailed(&self, tree: &Tree) -> Result<WorktreeStatusDetailed> {
@@ -651,6 +648,14 @@ impl<'a> TreeBuildPolicy<'a> {
         })
     }
 
+    fn changed_path_mode(&self) -> bool {
+        self.incremental_state
+            .as_ref()
+            .is_some_and(|(index, monitor)| {
+                monitor.status == MonitorStatus::Usable && index.get_directory("").is_some()
+            })
+    }
+
     /// Push a blob into the pending pack if it's not already in the
     /// store and not already queued. The hash is always the canonical
     /// blob hash — caller passes a precomputed one to avoid hashing
@@ -659,7 +664,7 @@ impl<'a> TreeBuildPolicy<'a> {
         if self.seen.contains(&hash) {
             return Ok(());
         }
-        if self.repo.store.has_blob_locally(&hash)? {
+        if !self.changed_path_mode() && self.repo.store.has_blob_locally(&hash)? {
             self.seen.insert(hash);
             return Ok(());
         }
@@ -808,7 +813,8 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         // since materialise time. Skips the read+hash entirely for
         // unchanged files — the dominant cost on a "one file edited
         // in a big repo" capture.
-        if let Some(hash) = self.lookup_stat_cache_hash(&entry)
+        if !self.changed_path_mode()
+            && let Some(hash) = self.lookup_stat_cache_hash(&entry)
             && self.repo.store.has_blob_locally(&hash)?
         {
             self.record_revalidation_file(&entry, hash, state)?;

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use objects::{
-    object::{Blob, ContentHash, Tree, TreeEntry},
+    object::{Blob, ContentHash, State, StateId, Tree, TreeEntry},
     store::ObjectStore,
     util::gitlink_placeholder_bytes,
     worktree::WorktreeStatus,
@@ -242,6 +242,45 @@ impl Repository {
     /// Compare the worktree against a tree using the persisted binary index.
     pub fn compare_worktree_cached(&self, tree: &Tree) -> Result<WorktreeStatus> {
         self.compare_worktree_cached_with_options(tree, &self.default_worktree_status_options())
+    }
+
+    pub fn require_tree_for_worktree_status(&self, hash: &ContentHash) -> Result<Tree> {
+        if let Ok((index, _)) = WorktreeIndex::load_hot_profiled_for_directories(
+            &self.worktree_index_path(),
+            &std::collections::BTreeSet::from([String::new()]),
+        ) && let Some(tree) = index.clean_tree("", hash)
+        {
+            return Ok(tree.clone());
+        }
+        self.require_tree(hash)
+    }
+
+    pub fn state_for_worktree_status(&self, id: &StateId) -> Result<State> {
+        let cache_path = self
+            .root()
+            .join(".heddle/state/worktree-current-state.bin");
+        if let Ok(bytes) = fs::read(&cache_path)
+            && let Ok(state) = rmp_serde::from_slice::<State>(&bytes)
+            && state.id() == *id
+        {
+            return Ok(state);
+        }
+        let state = self
+            .store()
+            .get_state(id)?
+            .ok_or(HeddleError::StateNotFound(*id))?;
+        if let Ok(bytes) = rmp_serde::to_vec_named(&state)
+            && let Err(error) = objects::fs_atomic::write_file_atomic(&cache_path, &bytes)
+        {
+            warn!(path = %cache_path.display(), %error, "Could not refresh worktree state cache");
+        }
+        Ok(state)
+    }
+
+    pub fn current_state_for_worktree_status(&self) -> Result<Option<State>> {
+        self.head()?
+            .map(|id| self.state_for_worktree_status(&id))
+            .transpose()
     }
 
     /// Return the complete gitlink summary cached for `tree`, when the hot

--- a/crates/repo/src/repository_worktree_apply.rs
+++ b/crates/repo/src/repository_worktree_apply.rs
@@ -22,8 +22,7 @@ use super::{
     repository_materialization::{MaterializedTree, WorktreeWriteOp},
 };
 use crate::{
-    FsMonitorSettings, WorktreeIndex,
-    fsmonitor::persist_current_monitor_cursor,
+    WorktreeIndex,
     worktree_index::{DirectoryCacheEntry, WorktreeIndexLoadStats, WorktreeIndexSaveStats},
     worktree_walk::{build_cached_entry, cache_key},
 };
@@ -777,9 +776,9 @@ impl Repository {
     }
 
     fn refresh_fsmonitor_after_incremental_apply(&self) {
-        let settings = FsMonitorSettings::from(self.config.worktree.fsmonitor);
-        if let Err(error) = persist_current_monitor_cursor(self.root(), settings) {
-            warn!(root = %self.root().display(), %error, "Failed to refresh monitor cursor after incremental apply");
+        let cursor = self.root.join(".heddle/state").join("fsmonitor.toml");
+        if let Err(error) = self.remove_if_exists(&cursor) {
+            warn!(root = %self.root().display(), %error, "Failed to invalidate monitor cursor after worktree apply");
         }
     }
 

--- a/crates/repo/src/status_monitor_tests.rs
+++ b/crates/repo/src/status_monitor_tests.rs
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::BTreeSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use objects::object::Tree;
+use tempfile::TempDir;
+
+use super::{
+    Repository,
+    repository_worktree_status::{WorktreeStatusDetailed, compare_worktree_with_index_detailed},
+};
+use crate::{
+    FsMonitorMode, FsMonitorSettings, WorktreeIndex, fsmonitor::ChangeMonitorSession,
+    worktree_ignore::WorktreeIgnoreMatcher,
+};
+
+fn flat(status: WorktreeStatusDetailed) -> objects::worktree::WorktreeStatus {
+    let mut status = status.into_flat_status();
+    status.modified.sort();
+    status.added.sort();
+    status.deleted.sort();
+    status
+}
+
+fn compare_with(
+    repo: &Repository,
+    tree: &Tree,
+    index: &WorktreeIndex,
+    monitor: &ChangeMonitorSession,
+) -> objects::worktree::WorktreeStatus {
+    let mut index = index.clone();
+    let matcher = WorktreeIgnoreMatcher::new(&repo.ignore_patterns().unwrap());
+    let (status, _) =
+        compare_worktree_with_index_detailed(repo, tree, &matcher, &mut index, monitor).unwrap();
+    flat(status)
+}
+
+fn assert_monitor_matches_full(
+    repo: &Repository,
+    tree: &Tree,
+    index: &WorktreeIndex,
+    changed: &BTreeSet<String>,
+) {
+    let monitored = ChangeMonitorSession::test_usable(repo.root(), changed.clone());
+    let full = ChangeMonitorSession::prepare(
+        repo.root(),
+        FsMonitorSettings {
+            mode: FsMonitorMode::Off,
+        },
+    );
+    let monitored = compare_with(repo, tree, index, &monitored);
+    let full = compare_with(repo, tree, index, &full);
+    assert_eq!(monitored.modified, full.modified);
+    assert_eq!(monitored.added, full.added);
+    assert_eq!(monitored.deleted, full.deleted);
+}
+
+fn seed_repo() -> (TempDir, Repository, Tree, WorktreeIndex) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    for directory in ["src", "tests", "nested/deep"] {
+        fs::create_dir_all(temp.path().join(directory)).unwrap();
+    }
+    for (path, contents) in [
+        ("src/a.txt", "a"),
+        ("src/b.txt", "b"),
+        ("tests/status.txt", "status"),
+        ("nested/deep/value.txt", "value"),
+    ] {
+        fs::write(temp.path().join(path), contents).unwrap();
+    }
+    let state = repo.snapshot(Some("seed".to_string()), None).unwrap();
+    let tree = repo.require_tree(&state.tree).unwrap();
+    repo.compare_worktree_cached_with_options(
+        &tree,
+        &crate::WorktreeStatusOptions {
+            fsmonitor: FsMonitorSettings {
+                mode: FsMonitorMode::Off,
+            },
+        },
+    )
+    .unwrap();
+    let index = WorktreeIndex::load(&temp.path().join(".heddle/state/index.bin")).unwrap();
+    (temp, repo, tree, index)
+}
+
+#[test]
+fn monitor_and_full_scan_match_randomized_mutation_sequences() {
+    let (temp, repo, tree, index) = seed_repo();
+    let mut changed = BTreeSet::new();
+    let mut seed = 0x5eed_u64;
+
+    for step in 0..32 {
+        seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+        let slot = (seed % 8) as usize;
+        let path = format!("random/file-{slot}.txt");
+        fs::create_dir_all(temp.path().join("random")).unwrap();
+        match (seed >> 8) % 4 {
+            0 | 1 => {
+                fs::write(temp.path().join(&path), format!("generation {step}\n")).unwrap();
+                changed.insert(path);
+            }
+            2 if temp.path().join(&path).exists() => {
+                fs::remove_file(temp.path().join(&path)).unwrap();
+                changed.insert(path);
+            }
+            _ => {
+                let renamed = format!("random/renamed-{step}.txt");
+                if temp.path().join(&path).exists() {
+                    fs::rename(temp.path().join(&path), temp.path().join(&renamed)).unwrap();
+                    changed.insert(path);
+                    changed.insert(renamed);
+                }
+            }
+        }
+        assert_monitor_matches_full(&repo, &tree, &index, &changed);
+    }
+
+    fs::write(temp.path().join("src/a.txt"), "edited").unwrap();
+    changed.insert("src/a.txt".to_string());
+    assert_monitor_matches_full(&repo, &tree, &index, &changed);
+
+    fs::rename(
+        temp.path().join("nested"),
+        temp.path().join("renamed-nested"),
+    )
+    .unwrap();
+    changed.insert("nested".to_string());
+    changed.insert("renamed-nested".to_string());
+    assert_monitor_matches_full(&repo, &tree, &index, &changed);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{PermissionsExt, symlink};
+        let path = temp.path().join("src/b.txt");
+        let mut permissions = fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&path, permissions).unwrap();
+        changed.insert("src/b.txt".to_string());
+        symlink(Path::new("a.txt"), temp.path().join("src/link.txt")).unwrap();
+        changed.insert("src/link.txt".to_string());
+        assert_monitor_matches_full(&repo, &tree, &index, &changed);
+    }
+}
+
+#[test]
+fn ignore_rule_transitions_force_the_same_safe_result_as_a_full_scan() {
+    let (temp, repo, tree, index) = seed_repo();
+    fs::create_dir_all(temp.path().join("ignored")).unwrap();
+    fs::write(temp.path().join("ignored/value.txt"), "ignored").unwrap();
+    fs::write(temp.path().join(".heddleignore"), "ignored/\n").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".heddleignore".to_string()]),
+    );
+
+    fs::write(temp.path().join(".heddleignore"), "").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".heddleignore".to_string()]),
+    );
+
+    fs::write(temp.path().join(".heddleignore"), "ignored/\n").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".heddleignore".to_string()]),
+    );
+}
+
+#[test]
+fn missing_or_cursor_lagging_index_never_reports_false_clean() {
+    let (temp, repo, tree, mut index) = seed_repo();
+    fs::write(temp.path().join("src/a.txt"), "changed after cursor").unwrap();
+
+    let cursor_ahead = ChangeMonitorSession::test_usable(repo.root(), BTreeSet::new());
+    let from_missing_index = compare_with(&repo, &tree, &WorktreeIndex::new(), &cursor_ahead);
+    assert_eq!(
+        from_missing_index.modified,
+        vec![PathBuf::from("src/a.txt")]
+    );
+
+    let event_not_committed =
+        ChangeMonitorSession::test_usable(repo.root(), BTreeSet::from(["src/a.txt".to_string()]));
+    let matcher = WorktreeIgnoreMatcher::new(&repo.ignore_patterns().unwrap());
+    let _ = compare_worktree_with_index_detailed(
+        &repo,
+        &tree,
+        &matcher,
+        &mut index,
+        &event_not_committed,
+    )
+    .unwrap();
+    let index_path = temp.path().join(".heddle/state/index.bin");
+    index.save(&index_path).unwrap();
+    let (reloaded_index, _) = WorktreeIndex::load_hot_profiled_for_directories(
+        &index_path,
+        &event_not_committed.changed_directory_keys(),
+    )
+    .unwrap();
+    let replayed_event = compare_with(&repo, &tree, &reloaded_index, &event_not_committed);
+    assert_eq!(replayed_event.modified, vec![PathBuf::from("src/a.txt")]);
+}

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -36,6 +36,10 @@ pub(crate) fn refresh_tracked_paths(
     status: &mut WorktreeStatusDetailed,
     stats: &mut WorktreeCompareStats,
 ) -> Result<BTreeSet<String>> {
+    index.set_gitlinks_tree(tree.hash());
+    if !monitor.can_filter_directory_children(Path::new(""), index) {
+        index.clear_gitlinks();
+    }
     let mut dirty_directories = BTreeSet::new();
     let mut ctx = TrackedRefreshContext {
         repo,
@@ -88,7 +92,15 @@ fn refresh_tracked_directory(
     let mut subtree_clean = true;
     for entry in tree.entries() {
         let child_rel_path = join_relative_path(rel_path, entry.name());
+        if ctx
+            .monitor
+            .can_filter_directory_children(rel_path, ctx.index)
+            && !ctx.monitor.path_may_have_changed(&child_rel_path)
+        {
+            continue;
+        }
         let child_key = child_key(dir_key, entry.name());
+        ctx.index.remove_gitlinks_at_or_below(&child_key);
         let child_clean = match entry.entry_type() {
             EntryType::Blob => refresh_tracked_file(ctx, &child_rel_path, &child_key, entry)?,
             EntryType::Symlink => refresh_tracked_symlink(ctx, &child_rel_path, &child_key, entry)?,
@@ -99,7 +111,13 @@ fn refresh_tracked_directory(
                 })?;
                 refresh_tracked_directory(ctx, &child_rel_path, &child_key, &subtree)?
             }
-            EntryType::Gitlink => false,
+            EntryType::Gitlink => {
+                if let Some(target) = entry.gitlink_target() {
+                    ctx.index
+                        .insert_gitlink(child_key.clone(), target.to_string());
+                }
+                false
+            }
             // Native child-spool edge: not materialized to the worktree in
             // this phase, so it never makes the tracked tree dirty.
             EntryType::Spoollink => true,
@@ -115,6 +133,11 @@ fn refresh_tracked_file(
     key: &str,
     tree_entry: &TreeEntry,
 ) -> Result<bool> {
+    if index_has_parent_baseline(ctx.index, rel_path)
+        && !ctx.monitor.path_may_have_changed(rel_path)
+    {
+        return Ok(true);
+    }
     let path = ctx.repo.root().join(rel_path);
     let metadata = match fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
@@ -164,6 +187,11 @@ fn refresh_tracked_symlink(
     key: &str,
     tree_entry: &TreeEntry,
 ) -> Result<bool> {
+    if index_has_parent_baseline(ctx.index, rel_path)
+        && !ctx.monitor.path_may_have_changed(rel_path)
+    {
+        return Ok(true);
+    }
     let path = ctx.repo.root().join(rel_path);
     let metadata = match fs::symlink_metadata(&path) {
         Ok(metadata) => metadata,
@@ -214,6 +242,13 @@ fn compute_and_cache_file(
         index.insert(key.to_string(), cached);
     }
     Ok(hash)
+}
+
+fn index_has_parent_baseline(index: &WorktreeIndex, rel_path: &Path) -> bool {
+    let parent = rel_path.parent().unwrap_or_else(|| Path::new(""));
+    index
+        .get_directory(&parent.to_string_lossy().replace('\\', "/"))
+        .is_some()
 }
 
 fn compute_and_cache_symlink(

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -58,6 +58,8 @@ fn refresh_tracked_directory(
     dir_key: &str,
     tree: &Tree,
 ) -> Result<bool> {
+    ctx.index
+        .insert_clean_tree(dir_key.to_string(), tree.clone());
     let dir_path = if dir_key.is_empty() {
         ctx.repo.root().to_path_buf()
     } else {
@@ -106,9 +108,13 @@ fn refresh_tracked_directory(
             EntryType::Symlink => refresh_tracked_symlink(ctx, &child_rel_path, &child_key, entry)?,
             EntryType::Tree => {
                 let tree_hash = entry.require_content_hash();
-                let subtree = ctx.repo.store().get_tree(&tree_hash)?.ok_or_else(|| {
-                    objects::error::HeddleError::NotFound(format!("tree {}", tree_hash))
-                })?;
+                let subtree = if let Some(tree) = ctx.index.clean_tree(&child_key, &tree_hash) {
+                    tree.clone()
+                } else {
+                    ctx.repo.store().get_tree(&tree_hash)?.ok_or_else(|| {
+                        objects::error::HeddleError::NotFound(format!("tree {}", tree_hash))
+                    })?
+                };
                 refresh_tracked_directory(ctx, &child_rel_path, &child_key, &subtree)?
             }
             EntryType::Gitlink => {

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -157,9 +157,18 @@ fn scan_directory(
                 let child_tree = match tree_entry {
                     Some(tree_entry) if tree_entry.entry_type() == EntryType::Tree => {
                         let tree_hash = tree_entry.require_content_hash();
-                        Some(ctx.repo.store().get_tree(&tree_hash)?.ok_or_else(|| {
-                            objects::error::HeddleError::NotFound(format!("tree {}", tree_hash))
-                        })?)
+                        Some(
+                            if let Some(tree) = ctx.index.clean_tree(&child_key, &tree_hash) {
+                                tree.clone()
+                            } else {
+                                ctx.repo.store().get_tree(&tree_hash)?.ok_or_else(|| {
+                                    objects::error::HeddleError::NotFound(format!(
+                                        "tree {}",
+                                        tree_hash
+                                    ))
+                                })?
+                            },
+                        )
                     }
                     _ => None,
                 };

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -127,6 +127,15 @@ fn scan_directory(
             continue;
         }
 
+        let child_rel_path = join_relative_path(rel_path, &entry.name);
+        if ctx
+            .monitor
+            .can_filter_directory_children(rel_path, ctx.index)
+            && !ctx.monitor.path_may_have_changed(&child_rel_path)
+        {
+            continue;
+        }
+
         while next_tree_entry < tree_entries.len()
             && tree_entries[next_tree_entry].name() < entry.name.as_str()
         {
@@ -140,7 +149,6 @@ fn scan_directory(
             next_tree_entry += 1;
         }
 
-        let child_rel_path = join_relative_path(rel_path, &entry.name);
         let child_key = cache_key(&child_rel_path);
 
         match entry.kind {

--- a/crates/repo/src/timeline_pack.rs
+++ b/crates/repo/src/timeline_pack.rs
@@ -58,7 +58,7 @@ impl TimelinePackSet {
         for (pack_path, index_path) in paired_pack_paths(&self.packs_dir)? {
             let reader = PackReader::open(&pack_path, &index_path)?;
             let pack_index = packs.len();
-            for id in reader.list_ids() {
+            for id in reader.list_ids()? {
                 let operation_id = timeline_id_from_pack_id(id)?;
                 operation_locations
                     .entry(operation_id)
@@ -180,7 +180,7 @@ fn verify_candidate_pack(
     expected: &BTreeMap<TimelineOperationId, Vec<u8>>,
 ) -> Result<()> {
     let reader = PackReader::from_slice(pack_data, index_data)?;
-    if reader.list_ids().len() != expected.len() {
+    if reader.list_ids()?.len() != expected.len() {
         return Err(HeddleError::InvalidObject(
             "new timeline pack entry count differs from canonical operations".to_string(),
         ));

--- a/crates/repo/src/worktree_index.rs
+++ b/crates/repo/src/worktree_index.rs
@@ -68,7 +68,7 @@ use std::{
     path::Path,
 };
 
-use objects::object::ContentHash;
+use objects::object::{ContentHash, Tree};
 use thiserror::Error;
 
 #[path = "worktree_index_storage.rs"]
@@ -301,6 +301,7 @@ pub struct WorktreeIndex {
     untracked_directories: BTreeMap<String, UntrackedDirectoryCacheEntry>,
     gitlinks: BTreeMap<String, String>,
     gitlinks_tree: Option<ContentHash>,
+    clean_trees: BTreeMap<String, Tree>,
     dirty: bool,
     pending_ops: Vec<JournalOp>,
     last_journal_bytes: u64,
@@ -318,6 +319,7 @@ impl WorktreeIndex {
             untracked_directories: BTreeMap::new(),
             gitlinks: BTreeMap::new(),
             gitlinks_tree: None,
+            clean_trees: BTreeMap::new(),
             dirty: false,
             pending_ops: Vec::new(),
             last_journal_bytes: 0,
@@ -542,6 +544,16 @@ impl WorktreeIndex {
 
     pub(crate) fn set_gitlinks_tree(&mut self, tree: ContentHash) {
         self.gitlinks_tree = Some(tree);
+    }
+
+    pub(crate) fn insert_clean_tree(&mut self, path: String, tree: Tree) {
+        self.clean_trees.insert(path, tree);
+    }
+
+    pub(crate) fn clean_tree(&self, path: &str, expected: &ContentHash) -> Option<&Tree> {
+        self.clean_trees
+            .get(path)
+            .filter(|tree| tree.hash() == *expected)
     }
 
     pub(crate) fn insert_gitlink(&mut self, path: String, target: String) {

--- a/crates/repo/src/worktree_index.rs
+++ b/crates/repo/src/worktree_index.rs
@@ -5,15 +5,22 @@
 //! offering faster load/save compared to TOML while maintaining
 //! debuggability via the `dump()` function.
 //!
-//! ## Binary Format (Version 5)
+//! ## Binary Format (Version 6)
 //!
 //! ```text
-//! Header (24 bytes):
+//! Header (40 bytes):
 //!   - magic: "HDLEIDX\0" (8 bytes)
 //!   - version: u32 (4 bytes)
 //!   - file_entry_count: u32 (4 bytes)
 //!   - directory_entry_count: u32 (4 bytes) [new in v2]
 //!   - untracked_directory_entry_count: u32 (4 bytes) [new in v5]
+//!   - gitlink_summary_count: u32 (4 bytes) [new in v6]
+//!   - hot_section_len: u64 (8 bytes) [new in v6]
+//!   - hot_section_checksum: u32 (4 bytes) [new in v6]
+//!
+//! Directory and untracked-directory entries come first as the independently
+//! checksummed hot section. File entries follow and are loaded only by callers
+//! that need a full index.
 //!
 //! File Entries (variable):
 //!   - type: u8 (1 byte: 0x01 = file)
@@ -55,7 +62,11 @@
 //!   - checksum: u32 (CRC32 of all entries)
 //! ```
 
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::Path,
+};
 
 use objects::object::ContentHash;
 use thiserror::Error;
@@ -74,13 +85,14 @@ pub(crate) const MAX_JOURNAL_BYTES_BEFORE_COMPACT: u64 = 256 * 1024;
 pub(crate) const MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT: u128 = 16;
 
 /// Current format version.
-pub(crate) const INDEX_VERSION: u32 = 5;
+pub(crate) const INDEX_VERSION: u32 = 6;
 
 /// Size of the v4 fixed header (magic + version + file_count + dir_count).
 pub(crate) const HEADER_SIZE_V4: usize = 8 + 4 + 4 + 4;
 
 /// Size of the v5 fixed header (magic + version + file_count + dir_count + untracked_count).
 pub(crate) const HEADER_SIZE_V5: usize = HEADER_SIZE_V4 + 4;
+pub(crate) const HEADER_SIZE_V6: usize = HEADER_SIZE_V5 + 4 + 8 + 4;
 
 /// Index errors.
 #[derive(Debug, Error)]
@@ -287,11 +299,14 @@ pub struct WorktreeIndex {
     entries: BTreeMap<String, IndexEntry>,
     directories: BTreeMap<String, DirectoryCacheEntry>,
     untracked_directories: BTreeMap<String, UntrackedDirectoryCacheEntry>,
+    gitlinks: BTreeMap<String, String>,
+    gitlinks_tree: Option<ContentHash>,
     dirty: bool,
     pending_ops: Vec<JournalOp>,
     last_journal_bytes: u64,
     last_journal_ops: usize,
     last_journal_replay_ms: u128,
+    hot_loaded: bool,
 }
 
 impl WorktreeIndex {
@@ -301,11 +316,14 @@ impl WorktreeIndex {
             entries: BTreeMap::new(),
             directories: BTreeMap::new(),
             untracked_directories: BTreeMap::new(),
+            gitlinks: BTreeMap::new(),
+            gitlinks_tree: None,
             dirty: false,
             pending_ops: Vec::new(),
             last_journal_bytes: 0,
             last_journal_ops: 0,
             last_journal_replay_ms: 0,
+            hot_loaded: false,
         }
     }
 
@@ -316,6 +334,13 @@ impl WorktreeIndex {
 
     pub fn load_profiled(path: &Path) -> Result<(Self, WorktreeIndexLoadStats), IndexError> {
         storage::load_profiled(path)
+    }
+
+    pub(crate) fn load_hot_profiled_for_directories(
+        path: &Path,
+        directories: &BTreeSet<String>,
+    ) -> Result<(Self, WorktreeIndexLoadStats), IndexError> {
+        storage::load_hot_profiled_for_directories(path, directories)
     }
 
     /// Save the index to a binary file.
@@ -507,6 +532,55 @@ impl WorktreeIndex {
         removed_any
     }
 
+    pub(crate) fn gitlinks(&self) -> &BTreeMap<String, String> {
+        &self.gitlinks
+    }
+
+    pub(crate) fn gitlinks_tree(&self) -> Option<ContentHash> {
+        self.gitlinks_tree
+    }
+
+    pub(crate) fn set_gitlinks_tree(&mut self, tree: ContentHash) {
+        self.gitlinks_tree = Some(tree);
+    }
+
+    pub(crate) fn insert_gitlink(&mut self, path: String, target: String) {
+        if self.gitlinks.get(&path) != Some(&target) {
+            self.gitlinks.insert(path.clone(), target.clone());
+            self.pending_ops
+                .push(JournalOp::UpsertGitlink { path, target });
+            self.dirty = true;
+        }
+    }
+
+    pub(crate) fn remove_gitlinks_at_or_below(&mut self, path: &str) -> bool {
+        let mut keys = Vec::new();
+        if self.gitlinks.remove(path).is_some() {
+            keys.push(path.to_string());
+        }
+        keys.extend(remove_prefixed_range(
+            &mut self.gitlinks,
+            &descendant_range_start(path),
+        ));
+        for key in &keys {
+            self.pending_ops
+                .push(JournalOp::RemoveGitlink { path: key.clone() });
+        }
+        if !keys.is_empty() {
+            self.dirty = true;
+        }
+        !keys.is_empty()
+    }
+
+    pub(crate) fn clear_gitlinks(&mut self) {
+        let keys = self.gitlinks.keys().cloned().collect::<Vec<_>>();
+        for path in keys {
+            self.gitlinks.remove(&path);
+            self.pending_ops.push(JournalOp::RemoveGitlink { path });
+            self.dirty = true;
+        }
+    }
+
     /// Returns true if index contents changed since load/new.
     pub fn is_dirty(&self) -> bool {
         self.dirty
@@ -534,6 +608,10 @@ impl WorktreeIndex {
 
     pub(crate) fn last_journal_replay_ms(&self) -> u128 {
         self.last_journal_replay_ms
+    }
+
+    pub(crate) fn is_hot_loaded(&self) -> bool {
+        self.hot_loaded
     }
 
     fn remove_matching_paths(&mut self, path: &str, remove_file_at_path: bool) -> bool {

--- a/crates/repo/src/worktree_index.rs
+++ b/crates/repo/src/worktree_index.rs
@@ -76,6 +76,8 @@ mod worktree_index_storage;
 
 use self::worktree_index_storage::{self as storage, JournalOp};
 
+pub(crate) type GitlinkSummary = (ContentHash, Vec<(String, String)>);
+
 /// Magic bytes for the index file format.
 pub(crate) const INDEX_MAGIC: &[u8; 8] = b"HDLEIDX\x00";
 pub(crate) const JOURNAL_MAGIC: &[u8; 8] = b"HDLEJNL\x00";
@@ -345,6 +347,12 @@ impl WorktreeIndex {
         storage::load_hot_profiled_for_directories(path, directories)
     }
 
+    pub(crate) fn load_hot_gitlinks_summary(
+        path: &Path,
+    ) -> Result<Option<GitlinkSummary>, IndexError> {
+        storage::load_hot_gitlinks_summary(path)
+    }
+
     /// Save the index to a binary file.
     pub fn save(&self, path: &Path) -> Result<(), IndexError> {
         storage::save_profiled(self, path).map(|_| ())
@@ -534,12 +542,9 @@ impl WorktreeIndex {
         removed_any
     }
 
+    #[cfg(test)]
     pub(crate) fn gitlinks(&self) -> &BTreeMap<String, String> {
         &self.gitlinks
-    }
-
-    pub(crate) fn gitlinks_tree(&self) -> Option<ContentHash> {
-        self.gitlinks_tree
     }
 
     pub(crate) fn set_gitlinks_tree(&mut self, tree: ContentHash) {

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     fs::{self, File, OpenOptions},
     io::{Read, Seek, Write},
     path::Path,
@@ -11,15 +11,17 @@ use objects::object::ContentHash;
 use tracing::{debug, warn};
 
 use super::{
-    DirectoryCacheEntry, HEADER_SIZE_V4, HEADER_SIZE_V5, INDEX_MAGIC, INDEX_VERSION, IndexEntry,
-    IndexEntryKind, IndexError, MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT, UntrackedDirectoryCacheEntry,
-    WorktreeIndex, WorktreeIndexLoadStats, WorktreeIndexSaveStats,
+    DirectoryCacheEntry, HEADER_SIZE_V4, HEADER_SIZE_V5, HEADER_SIZE_V6, INDEX_MAGIC,
+    INDEX_VERSION, IndexEntry, IndexEntryKind, IndexError, MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT,
+    UntrackedDirectoryCacheEntry, WorktreeIndex, WorktreeIndexLoadStats, WorktreeIndexSaveStats,
 };
 
 const JOURNAL_MAGIC: &[u8; 8] = super::JOURNAL_MAGIC;
 const JOURNAL_VERSION: u32 = super::JOURNAL_VERSION;
 const MAX_JOURNAL_OPS_BEFORE_COMPACT: usize = super::MAX_JOURNAL_OPS_BEFORE_COMPACT;
 const MAX_JOURNAL_BYTES_BEFORE_COMPACT: u64 = super::MAX_JOURNAL_BYTES_BEFORE_COMPACT;
+const HOT_RECORD_MAGIC: &[u8; 8] = b"HDLEHOT\0";
+const HOT_RECORD_VERSION: u32 = 1;
 
 fn read_u32_be(bytes: &[u8], context: &str) -> Result<u32, IndexError> {
     let array = read_be_at::<4>(bytes, context)?;
@@ -50,6 +52,7 @@ enum IndexEntryType {
     File = 0x01,
     Directory = 0x02,
     UntrackedDirectory = 0x03,
+    Gitlink = 0x04,
 }
 
 impl IndexEntryType {
@@ -58,6 +61,7 @@ impl IndexEntryType {
             0x01 => Some(Self::File),
             0x02 => Some(Self::Directory),
             0x03 => Some(Self::UntrackedDirectory),
+            0x04 => Some(Self::Gitlink),
             _ => None,
         }
     }
@@ -90,6 +94,13 @@ pub(crate) enum JournalOp {
     RemoveUntrackedDirectory {
         path: String,
     },
+    UpsertGitlink {
+        path: String,
+        target: String,
+    },
+    RemoveGitlink {
+        path: String,
+    },
 }
 
 pub(crate) fn load(path: &Path) -> Result<WorktreeIndex, IndexError> {
@@ -98,6 +109,69 @@ pub(crate) fn load(path: &Path) -> Result<WorktreeIndex, IndexError> {
 
 pub(crate) fn load_profiled(
     path: &Path,
+) -> Result<(WorktreeIndex, WorktreeIndexLoadStats), IndexError> {
+    load_profiled_inner(path, false)
+}
+
+pub(crate) fn load_hot_profiled_for_directories(
+    path: &Path,
+    directory_keys: &BTreeSet<String>,
+) -> Result<(WorktreeIndex, WorktreeIndexLoadStats), IndexError> {
+    let mut stats = WorktreeIndexLoadStats::default();
+    if !path.exists() {
+        return Ok((WorktreeIndex::new(), stats));
+    }
+    let load_start = Instant::now();
+    let mut snapshot = File::open(path)?;
+    let mut header = [0_u8; 12];
+    snapshot.read_exact(&mut header)?;
+    if &header[..8] != INDEX_MAGIC {
+        return Err(IndexError::InvalidFormat("missing magic bytes".to_string()));
+    }
+    let version = read_u32_be(&header[8..12], "index version")?;
+    if version != INDEX_VERSION {
+        return Err(IndexError::VersionMismatch {
+            expected: INDEX_VERSION,
+            got: version,
+        });
+    }
+
+    let mut index = WorktreeIndex::new();
+    index.hot_loaded = true;
+    for key in directory_keys {
+        if let Some((directory, untracked, bytes)) = load_hot_directory_record(path, key)? {
+            stats.snapshot_bytes = stats.snapshot_bytes.saturating_add(bytes);
+            if let Some(directory) = directory {
+                index.directories.insert(key.clone(), directory);
+            }
+            if let Some(untracked) = untracked {
+                index.untracked_directories.insert(key.clone(), untracked);
+            }
+        }
+    }
+
+    let gitlinks_valid = load_hot_gitlinks(path, &mut index, &mut stats)?;
+    if !gitlinks_valid {
+        index.directories.remove("");
+    }
+    stats.snapshot_load_ms = load_start.elapsed().as_millis();
+
+    let journal_path = journal_path(path);
+    if journal_path.exists() {
+        stats.journal_bytes = journal_path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+        let replay_start = Instant::now();
+        stats.journal_ops = apply_journal(&mut index, &journal_path)?;
+        stats.journal_replay_ms = replay_start.elapsed().as_millis();
+    }
+    index.dirty = false;
+    index.pending_ops.clear();
+    index.set_last_load_stats(&stats);
+    Ok((index, stats))
+}
+
+fn load_profiled_inner(
+    path: &Path,
+    hot_only: bool,
 ) -> Result<(WorktreeIndex, WorktreeIndexLoadStats), IndexError> {
     let mut stats = WorktreeIndexLoadStats::default();
     if !path.exists() {
@@ -130,7 +204,8 @@ pub(crate) fn load_profiled(
         2 if file_size >= HEADER_SIZE_V4 as u64 + 4 => load_v2(&mut file, file_size),
         3 if file_size >= HEADER_SIZE_V4 as u64 + 4 => load_v3(&mut file, file_size),
         4 if file_size >= HEADER_SIZE_V4 as u64 + 4 => load_v4(&mut file, file_size),
-        5 if file_size >= HEADER_SIZE_V5 as u64 + 4 => load_v5(&mut file, file_size),
+        5 if !hot_only && file_size >= HEADER_SIZE_V5 as u64 + 4 => load_v5(&mut file, file_size),
+        6 if file_size >= HEADER_SIZE_V6 as u64 + 4 => load_v6(&mut file, file_size, hot_only),
         v => Err(IndexError::VersionMismatch {
             expected: INDEX_VERSION,
             got: v,
@@ -151,13 +226,7 @@ pub(crate) fn load_profiled(
                 op_count
             }
             Err(error) => {
-                stats.journal_replay_ms = replay_start.elapsed().as_millis();
-                warn!(
-                    journal_path = %journal_path.display(),
-                    %error,
-                    "Ignoring unreadable worktree index journal"
-                );
-                0
+                return Err(error);
             }
         }
     } else {
@@ -193,6 +262,8 @@ pub(crate) fn save_profiled(
         return Ok(stats);
     }
 
+    write_hot_sidecars(index, path)?;
+
     let journal_path = journal_path(path);
     let journal_exists = journal_path.exists();
     let journal_len = journal_path
@@ -201,11 +272,13 @@ pub(crate) fn save_profiled(
         .unwrap_or(0);
     let compact_reason = if !path.exists() {
         Some("missing_snapshot")
-    } else if index.pending_ops.len() > MAX_JOURNAL_OPS_BEFORE_COMPACT {
+    } else if !index.is_hot_loaded() && index.pending_ops.len() > MAX_JOURNAL_OPS_BEFORE_COMPACT {
         Some("pending_ops")
-    } else if journal_len > MAX_JOURNAL_BYTES_BEFORE_COMPACT {
+    } else if !index.is_hot_loaded() && journal_len > MAX_JOURNAL_BYTES_BEFORE_COMPACT {
         Some("journal_bytes")
-    } else if index.last_journal_replay_ms() > MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT {
+    } else if !index.is_hot_loaded()
+        && index.last_journal_replay_ms() > MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT
+    {
         Some("replay_ms")
     } else {
         None
@@ -267,6 +340,7 @@ pub(crate) fn save_snapshot_profiled(
 ) -> Result<WorktreeIndexSaveStats, IndexError> {
     let journal_path = journal_path(path);
     let write_start = Instant::now();
+    write_hot_sidecars(index, path)?;
     write_snapshot(index, path)?;
     let snapshot_write_ms = write_start.elapsed().as_millis();
     let snapshot_bytes = path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
@@ -376,11 +450,14 @@ fn load_v1(file: &mut File, file_size: u64) -> Result<WorktreeIndex, IndexError>
         entries,
         directories: BTreeMap::new(),
         untracked_directories: BTreeMap::new(),
+        gitlinks: BTreeMap::new(),
+        gitlinks_tree: None,
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
         last_journal_ops: 0,
         last_journal_replay_ms: 0,
+        hot_loaded: false,
     })
 }
 
@@ -398,6 +475,111 @@ fn load_v4(file: &mut File, file_size: u64) -> Result<WorktreeIndex, IndexError>
 
 fn load_v5(file: &mut File, file_size: u64) -> Result<WorktreeIndex, IndexError> {
     load_compact_versioned_with_untracked(file, file_size)
+}
+
+fn load_v6(file: &mut File, file_size: u64, hot_only: bool) -> Result<WorktreeIndex, IndexError> {
+    file.seek(std::io::SeekFrom::Start(0))?;
+    let mut header = [0u8; HEADER_SIZE_V6];
+    file.read_exact(&mut header)?;
+    let file_count = read_u32_be(&header[12..16], "index file count")?;
+    let dir_count = read_u32_be(&header[16..20], "index directory count")?;
+    let untracked_count = read_u32_be(&header[20..24], "index untracked directory count")?;
+    let gitlink_count = read_u32_be(&header[24..28], "index gitlink count")?;
+    let hot_len = read_u64_be(&header[28..36], "index hot section length")?;
+    let hot_checksum = read_u32_be(&header[36..40], "index hot section checksum")?;
+    let data_len = file_size
+        .checked_sub(HEADER_SIZE_V6 as u64 + 4)
+        .ok_or_else(|| IndexError::InvalidFormat("truncated v6 index".to_string()))?;
+    if hot_len > data_len {
+        return Err(IndexError::InvalidFormat(
+            "hot section exceeds index data".to_string(),
+        ));
+    }
+
+    let mut hot_data = vec![0_u8; hot_len as usize];
+    file.read_exact(&mut hot_data)?;
+    if crc32(&hot_data) != hot_checksum {
+        return Err(IndexError::ChecksumMismatch);
+    }
+    let mut directories = BTreeMap::new();
+    let mut untracked_directories = BTreeMap::new();
+    let mut gitlinks = BTreeMap::new();
+    let mut offset = 0;
+    for _ in 0..dir_count {
+        offset = expect_entry_type(&hot_data, offset, IndexEntryType::Directory)?;
+        offset = read_compact_directory_entry(&hot_data, offset, &mut directories)?;
+    }
+    for _ in 0..untracked_count {
+        offset = expect_entry_type(&hot_data, offset, IndexEntryType::UntrackedDirectory)?;
+        offset = read_untracked_directory_entry(&hot_data, offset, &mut untracked_directories)?;
+    }
+    for _ in 0..gitlink_count {
+        offset = expect_entry_type(&hot_data, offset, IndexEntryType::Gitlink)?;
+        let path = read_string(&hot_data, &mut offset)?;
+        let target = read_string(&hot_data, &mut offset)?;
+        gitlinks.insert(path, target);
+    }
+    if offset != hot_data.len() {
+        return Err(IndexError::InvalidFormat(
+            "trailing bytes in hot index section".to_string(),
+        ));
+    }
+
+    let mut entries = BTreeMap::new();
+    if !hot_only {
+        let file_data_len = data_len - hot_len;
+        let mut file_data = vec![0_u8; file_data_len as usize];
+        file.read_exact(&mut file_data)?;
+        let mut file_offset = 0;
+        for _ in 0..file_count {
+            file_offset = expect_entry_type(&file_data, file_offset, IndexEntryType::File)?;
+            file_offset = read_file_entry(&file_data, file_offset, &mut entries)?;
+        }
+        if file_offset != file_data.len() {
+            return Err(IndexError::InvalidFormat(
+                "trailing bytes in file index section".to_string(),
+            ));
+        }
+        let mut checksum_bytes = [0_u8; 4];
+        file.read_exact(&mut checksum_bytes)?;
+        let mut all_data = hot_data.clone();
+        all_data.extend_from_slice(&file_data);
+        if crc32(&all_data) != u32::from_be_bytes(checksum_bytes) {
+            return Err(IndexError::ChecksumMismatch);
+        }
+    }
+
+    Ok(WorktreeIndex {
+        entries,
+        directories,
+        untracked_directories,
+        gitlinks,
+        gitlinks_tree: None,
+        dirty: false,
+        pending_ops: Vec::new(),
+        last_journal_bytes: 0,
+        last_journal_ops: 0,
+        last_journal_replay_ms: 0,
+        hot_loaded: hot_only,
+    })
+}
+
+fn expect_entry_type(
+    data: &[u8],
+    offset: usize,
+    expected: IndexEntryType,
+) -> Result<usize, IndexError> {
+    let Some(value) = data.get(offset).copied() else {
+        return Err(IndexError::InvalidFormat(
+            "truncated entry type".to_string(),
+        ));
+    };
+    if IndexEntryType::from_u8(value) != Some(expected) {
+        return Err(IndexError::InvalidFormat(format!(
+            "unexpected index entry type {value}"
+        )));
+    }
+    Ok(offset + 1)
 }
 
 fn load_compact_versioned_with_untracked(
@@ -509,11 +691,14 @@ fn load_compact_versioned_with_untracked(
         entries,
         directories,
         untracked_directories,
+        gitlinks: BTreeMap::new(),
+        gitlinks_tree: None,
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
         last_journal_ops: 0,
         last_journal_replay_ms: 0,
+        hot_loaded: false,
     })
 }
 
@@ -602,11 +787,14 @@ fn load_legacy_versioned(
         entries,
         directories,
         untracked_directories: BTreeMap::new(),
+        gitlinks: BTreeMap::new(),
+        gitlinks_tree: None,
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
         last_journal_ops: 0,
         last_journal_replay_ms: 0,
+        hot_loaded: false,
     })
 }
 
@@ -684,11 +872,14 @@ fn load_compact_versioned(file: &mut File, file_size: u64) -> Result<WorktreeInd
         entries,
         directories,
         untracked_directories: BTreeMap::new(),
+        gitlinks: BTreeMap::new(),
+        gitlinks_tree: None,
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
         last_journal_ops: 0,
         last_journal_replay_ms: 0,
+        hot_loaded: false,
     })
 }
 
@@ -927,41 +1118,232 @@ fn read_untracked_directory_entry(
     Ok(offset)
 }
 
+fn hot_sidecar_dir(snapshot_path: &Path) -> std::path::PathBuf {
+    snapshot_path.with_extension("hot")
+}
+
+fn hot_directory_record_path(snapshot_path: &Path, key: &str) -> std::path::PathBuf {
+    let hash = ContentHash::compute_typed("worktree-index-hot-path", key.as_bytes());
+    hot_sidecar_dir(snapshot_path).join(format!("{hash}.bin"))
+}
+
+fn hot_gitlinks_path(snapshot_path: &Path) -> std::path::PathBuf {
+    hot_sidecar_dir(snapshot_path).join("gitlinks.bin")
+}
+
+fn write_reconstructible_atomic(path: &Path, bytes: &[u8]) -> Result<(), IndexError> {
+    let parent = path.parent().unwrap_or(Path::new("."));
+    fs::create_dir_all(parent)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+    temporary.write_all(bytes)?;
+    temporary.flush()?;
+    let (_file, temporary_path) = temporary
+        .keep()
+        .map_err(|error| IndexError::Io(error.error))?;
+    match fs::rename(&temporary_path, path) {
+        Ok(()) => Ok(()),
+        Err(_error) if path.exists() => {
+            fs::remove_file(path)?;
+            fs::rename(temporary_path, path)?;
+            Ok(())
+        }
+        Err(error) => Err(IndexError::Io(error)),
+    }
+}
+
+fn frame_hot_record(mut body: Vec<u8>) -> Vec<u8> {
+    let checksum = crc32(&body);
+    body.extend_from_slice(&checksum.to_be_bytes());
+    body
+}
+
+fn verified_hot_body(bytes: &[u8]) -> Option<&[u8]> {
+    let body_len = bytes.len().checked_sub(4)?;
+    let stored = u32::from_be_bytes(bytes[body_len..].try_into().ok()?);
+    (crc32(&bytes[..body_len]) == stored).then_some(&bytes[..body_len])
+}
+
+fn write_hot_sidecars(index: &WorktreeIndex, snapshot_path: &Path) -> Result<(), IndexError> {
+    let keys = index
+        .directories
+        .keys()
+        .chain(index.untracked_directories.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for key in keys {
+        let mut body = Vec::new();
+        body.extend_from_slice(HOT_RECORD_MAGIC);
+        body.extend_from_slice(&HOT_RECORD_VERSION.to_be_bytes());
+        write_string(&mut body, &key)?;
+        let directory = index.directories.get(&key);
+        body.push(u8::from(directory.is_some()));
+        if let Some(directory) = directory {
+            write_directory_entry_payload(&mut body, directory)?;
+        }
+        let untracked = index.untracked_directories.get(&key);
+        body.push(u8::from(untracked.is_some()));
+        if let Some(untracked) = untracked {
+            write_untracked_directory_entry_payload(&mut body, untracked)?;
+        }
+        write_reconstructible_atomic(
+            &hot_directory_record_path(snapshot_path, &key),
+            &frame_hot_record(body),
+        )?;
+    }
+
+    let mut body = Vec::new();
+    body.extend_from_slice(HOT_RECORD_MAGIC);
+    body.extend_from_slice(&HOT_RECORD_VERSION.to_be_bytes());
+    let root_tree_hash = index.gitlinks_tree;
+    body.push(u8::from(root_tree_hash.is_some()));
+    body.extend_from_slice(
+        root_tree_hash
+            .as_ref()
+            .map(ContentHash::as_bytes)
+            .unwrap_or(&[0_u8; 32]),
+    );
+    body.extend_from_slice(&(index.gitlinks.len() as u32).to_be_bytes());
+    for (path, target) in &index.gitlinks {
+        write_string(&mut body, path)?;
+        write_string(&mut body, target)?;
+    }
+    write_reconstructible_atomic(&hot_gitlinks_path(snapshot_path), &frame_hot_record(body))
+}
+
+type HotDirectoryRecord = (
+    Option<DirectoryCacheEntry>,
+    Option<UntrackedDirectoryCacheEntry>,
+    u64,
+);
+
+fn load_hot_directory_record(
+    snapshot_path: &Path,
+    expected_key: &str,
+) -> Result<Option<HotDirectoryRecord>, IndexError> {
+    let bytes = match fs::read(hot_directory_record_path(snapshot_path, expected_key)) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(IndexError::Io(error)),
+    };
+    let Some(body) = verified_hot_body(&bytes) else {
+        return Ok(None);
+    };
+    if body.len() < 12 || &body[..8] != HOT_RECORD_MAGIC {
+        return Ok(None);
+    }
+    if read_u32_be(&body[8..12], "hot record version")? != HOT_RECORD_VERSION {
+        return Ok(None);
+    }
+    let mut offset = 12;
+    let key = read_string(body, &mut offset)?;
+    if key != expected_key {
+        return Ok(None);
+    }
+    let Some(has_directory) = body.get(offset).copied() else {
+        return Ok(None);
+    };
+    offset += 1;
+    let directory = if has_directory != 0 {
+        Some(read_directory_entry_payload(body, &mut offset)?)
+    } else {
+        None
+    };
+    let Some(has_untracked) = body.get(offset).copied() else {
+        return Ok(None);
+    };
+    offset += 1;
+    let untracked = if has_untracked != 0 {
+        Some(read_untracked_directory_entry_payload(body, &mut offset)?)
+    } else {
+        None
+    };
+    if offset != body.len() {
+        return Ok(None);
+    }
+    Ok(Some((directory, untracked, bytes.len() as u64)))
+}
+
+fn load_hot_gitlinks(
+    snapshot_path: &Path,
+    index: &mut WorktreeIndex,
+    stats: &mut WorktreeIndexLoadStats,
+) -> Result<bool, IndexError> {
+    let bytes = match fs::read(hot_gitlinks_path(snapshot_path)) {
+        Ok(bytes) => bytes,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(IndexError::Io(error)),
+    };
+    stats.snapshot_bytes = stats.snapshot_bytes.saturating_add(bytes.len() as u64);
+    let Some(body) = verified_hot_body(&bytes) else {
+        return Ok(false);
+    };
+    if body.len() < 12 + 1 + 32 + 4 || &body[..8] != HOT_RECORD_MAGIC {
+        return Ok(false);
+    }
+    if read_u32_be(&body[8..12], "hot gitlink version")? != HOT_RECORD_VERSION {
+        return Ok(false);
+    }
+    let mut offset = 12;
+    let has_root = body[offset] != 0;
+    offset += 1;
+    let root_hash = if has_root {
+        let mut hash = [0_u8; 32];
+        hash.copy_from_slice(&body[offset..offset + 32]);
+        Some(ContentHash::from_bytes(hash))
+    } else {
+        None
+    };
+    offset += 32;
+    if root_hash.is_none() {
+        return Ok(false);
+    }
+    index.gitlinks_tree = root_hash;
+    let count = read_u32_be(&body[offset..], "hot gitlink count")?;
+    offset += 4;
+    for _ in 0..count {
+        let path = read_string(body, &mut offset)?;
+        let target = read_string(body, &mut offset)?;
+        index.gitlinks.insert(path, target);
+    }
+    Ok(offset == body.len())
+}
+
 fn write_snapshot(index: &WorktreeIndex, path: &Path) -> Result<(), IndexError> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
 
-    let mut entry_data = Vec::new();
+    let mut hot_data = Vec::new();
+    let mut file_data = Vec::new();
 
     for (path, entry) in &index.entries {
         let path_bytes = path.as_bytes();
-        entry_data.reserve_exact(1 + 4 + path_bytes.len() + 32 + 8 + 8 + 4 + 1 + 1);
+        file_data.reserve_exact(1 + 4 + path_bytes.len() + 32 + 8 + 8 + 4 + 1 + 1);
 
-        entry_data.push(IndexEntryType::File.to_u8());
-        entry_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
-        entry_data.extend_from_slice(path_bytes);
-        entry_data.extend_from_slice(entry.hash.as_bytes());
-        entry_data.extend_from_slice(&entry.size.to_be_bytes());
-        entry_data.extend_from_slice(&entry.modified_sec.to_be_bytes());
-        entry_data.extend_from_slice(&entry.modified_nsec.to_be_bytes());
-        entry_data.push(if entry.executable { 1 } else { 0 });
-        entry_data.push(entry.kind.to_u8());
+        file_data.push(IndexEntryType::File.to_u8());
+        file_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
+        file_data.extend_from_slice(path_bytes);
+        file_data.extend_from_slice(entry.hash.as_bytes());
+        file_data.extend_from_slice(&entry.size.to_be_bytes());
+        file_data.extend_from_slice(&entry.modified_sec.to_be_bytes());
+        file_data.extend_from_slice(&entry.modified_nsec.to_be_bytes());
+        file_data.push(if entry.executable { 1 } else { 0 });
+        file_data.push(entry.kind.to_u8());
     }
 
     for (path, dir) in &index.directories {
         let path_bytes = path.as_bytes();
-        entry_data.reserve_exact(1 + 4 + path_bytes.len() + 8 + 4 + 4 + 32 + 1 + 32);
+        hot_data.reserve_exact(1 + 4 + path_bytes.len() + 8 + 4 + 4 + 32 + 1 + 32);
 
-        entry_data.push(IndexEntryType::Directory.to_u8());
-        entry_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
-        entry_data.extend_from_slice(path_bytes);
-        entry_data.extend_from_slice(&dir.mtime_sec.to_be_bytes());
-        entry_data.extend_from_slice(&dir.mtime_nsec.to_be_bytes());
-        entry_data.extend_from_slice(&dir.child_count.to_be_bytes());
-        entry_data.extend_from_slice(dir.child_digest.as_bytes());
-        entry_data.push(u8::from(dir.clean_tree_hash.is_some()));
-        entry_data.extend_from_slice(
+        hot_data.push(IndexEntryType::Directory.to_u8());
+        hot_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
+        hot_data.extend_from_slice(path_bytes);
+        hot_data.extend_from_slice(&dir.mtime_sec.to_be_bytes());
+        hot_data.extend_from_slice(&dir.mtime_nsec.to_be_bytes());
+        hot_data.extend_from_slice(&dir.child_count.to_be_bytes());
+        hot_data.extend_from_slice(dir.child_digest.as_bytes());
+        hot_data.push(u8::from(dir.clean_tree_hash.is_some()));
+        hot_data.extend_from_slice(
             dir.clean_tree_hash
                 .as_ref()
                 .map(ContentHash::as_bytes)
@@ -971,30 +1353,45 @@ fn write_snapshot(index: &WorktreeIndex, path: &Path) -> Result<(), IndexError> 
 
     for (path, dir) in &index.untracked_directories {
         let path_bytes = path.as_bytes();
-        entry_data.push(IndexEntryType::UntrackedDirectory.to_u8());
-        entry_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
-        entry_data.extend_from_slice(path_bytes);
-        write_untracked_directory_entry_payload(&mut entry_data, dir)?;
+        hot_data.push(IndexEntryType::UntrackedDirectory.to_u8());
+        hot_data.extend_from_slice(&(path_bytes.len() as u32).to_be_bytes());
+        hot_data.extend_from_slice(path_bytes);
+        write_untracked_directory_entry_payload(&mut hot_data, dir)?;
     }
 
+    for (path, target) in &index.gitlinks {
+        hot_data.push(IndexEntryType::Gitlink.to_u8());
+        write_string(&mut hot_data, path)?;
+        write_string(&mut hot_data, target)?;
+    }
+
+    let mut entry_data = hot_data.clone();
+    entry_data.extend_from_slice(&file_data);
     let checksum = crc32(&entry_data);
 
-    let mut file_data = Vec::with_capacity(HEADER_SIZE_V5 + entry_data.len() + 4);
-    file_data.extend_from_slice(INDEX_MAGIC);
-    file_data.extend_from_slice(&INDEX_VERSION.to_be_bytes());
-    file_data.extend_from_slice(&(index.entries.len() as u32).to_be_bytes());
-    file_data.extend_from_slice(&(index.directories.len() as u32).to_be_bytes());
-    file_data.extend_from_slice(&(index.untracked_directories.len() as u32).to_be_bytes());
-    file_data.extend_from_slice(&entry_data);
-    file_data.extend_from_slice(&checksum.to_be_bytes());
+    let mut encoded = Vec::with_capacity(HEADER_SIZE_V6 + entry_data.len() + 4);
+    encoded.extend_from_slice(INDEX_MAGIC);
+    encoded.extend_from_slice(&INDEX_VERSION.to_be_bytes());
+    encoded.extend_from_slice(&(index.entries.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&(index.directories.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&(index.untracked_directories.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&(index.gitlinks.len() as u32).to_be_bytes());
+    encoded.extend_from_slice(&(hot_data.len() as u64).to_be_bytes());
+    encoded.extend_from_slice(&crc32(&hot_data).to_be_bytes());
+    encoded.extend_from_slice(&entry_data);
+    encoded.extend_from_slice(&checksum.to_be_bytes());
 
     let mut temp_file = tempfile::NamedTempFile::new_in(path.parent().unwrap_or(Path::new(".")))?;
-    temp_file.write_all(&file_data)?;
+    temp_file.write_all(&encoded)?;
     temp_file.flush()?;
+    temp_file.as_file().sync_all()?;
     let (_file, temp_path) = temp_file
         .keep()
         .map_err(|error| IndexError::Io(error.error))?;
     fs::rename(&temp_path, path)?;
+    if let Some(parent) = path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
 
     Ok(())
 }
@@ -1004,6 +1401,7 @@ fn append_journal(index: &WorktreeIndex, journal_path: &Path) -> Result<(), Inde
         fs::create_dir_all(parent)?;
     }
 
+    let journal_existed = journal_path.exists();
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -1020,6 +1418,10 @@ fn append_journal(index: &WorktreeIndex, journal_path: &Path) -> Result<(), Inde
     file.write_all(&crc32(&payload).to_be_bytes())?;
     file.write_all(&payload)?;
     file.flush()?;
+    file.sync_data()?;
+    if !journal_existed && let Some(parent) = journal_path.parent() {
+        File::open(parent)?.sync_all()?;
+    }
     Ok(())
 }
 
@@ -1072,11 +1474,8 @@ fn apply_journal(index: &mut WorktreeIndex, journal_path: &Path) -> Result<usize
         }
 
         if crc32(&payload) != expected_checksum {
-            warn!(
-                journal_path = %journal_path.display(),
-                "Stopping worktree index journal replay at corrupt frame"
-            );
-            break;
+            warn!(journal_path = %journal_path.display(), "Rejecting corrupt worktree index journal");
+            return Err(IndexError::ChecksumMismatch);
         }
 
         let ops = deserialize_journal_ops(&payload)?;
@@ -1100,6 +1499,12 @@ fn apply_journal(index: &mut WorktreeIndex, journal_path: &Path) -> Result<usize
                 }
                 JournalOp::RemoveUntrackedDirectory { path } => {
                     let _ = index.untracked_directories.remove(&path);
+                }
+                JournalOp::UpsertGitlink { path, target } => {
+                    index.gitlinks.insert(path, target);
+                }
+                JournalOp::RemoveGitlink { path } => {
+                    let _ = index.gitlinks.remove(&path);
                 }
             }
         }
@@ -1320,6 +1725,15 @@ fn write_journal_op(writer: &mut impl Write, op: &JournalOp) -> Result<(), Index
             writer.write_all(&[0x06])?;
             write_string(writer, path)?;
         }
+        JournalOp::UpsertGitlink { path, target } => {
+            writer.write_all(&[0x07])?;
+            write_string(writer, path)?;
+            write_string(writer, target)?;
+        }
+        JournalOp::RemoveGitlink { path } => {
+            writer.write_all(&[0x08])?;
+            write_string(writer, path)?;
+        }
     }
     Ok(())
 }
@@ -1367,6 +1781,15 @@ fn deserialize_journal_ops(payload: &[u8]) -> Result<Vec<JournalOp>, IndexError>
             0x06 => {
                 let path = read_string(payload, &mut offset)?;
                 ops.push(JournalOp::RemoveUntrackedDirectory { path });
+            }
+            0x07 => {
+                let path = read_string(payload, &mut offset)?;
+                let target = read_string(payload, &mut offset)?;
+                ops.push(JournalOp::UpsertGitlink { path, target });
+            }
+            0x08 => {
+                let path = read_string(payload, &mut offset)?;
+                ops.push(JournalOp::RemoveGitlink { path });
             }
             _ => {
                 return Err(IndexError::InvalidFormat(
@@ -1430,7 +1853,7 @@ mod tests {
     ) {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(INDEX_MAGIC);
-        bytes.extend_from_slice(&INDEX_VERSION.to_be_bytes());
+        bytes.extend_from_slice(&5_u32.to_be_bytes());
         bytes.extend_from_slice(&file_count.to_be_bytes());
         bytes.extend_from_slice(&dir_count.to_be_bytes());
         bytes.extend_from_slice(&untracked_dir_count.to_be_bytes());
@@ -1490,7 +1913,7 @@ mod tests {
     }
 
     #[test]
-    fn v5_snapshot_round_trips_untracked_directories() {
+    fn v6_snapshot_round_trips_untracked_directories() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("index.bin");
 
@@ -1508,7 +1931,7 @@ mod tests {
         assert_eq!(loaded.untracked_directory_len(), 1);
         let entry = loaded
             .get_untracked_directory("scratch")
-            .expect("untracked directory entry should survive v5 roundtrip");
+            .expect("untracked directory entry should survive v6 roundtrip");
         assert_eq!(
             entry.added_paths,
             vec!["nested/one.txt".to_string(), "nested/two.txt".to_string()]
@@ -1517,6 +1940,69 @@ mod tests {
             entry.ignore_fingerprint,
             sample_untracked_directory_entry().ignore_fingerprint
         );
+    }
+
+    #[test]
+    fn v6_hot_load_reads_directory_proofs_without_file_table() {
+        let temp = TempDir::new().unwrap();
+        let path = temp.path().join("index.bin");
+        let mut index = WorktreeIndex::new();
+        for name in ["a.txt", "b.txt"] {
+            index.insert(name.to_string(), sample_file_entry(name));
+        }
+        let root_hash = ContentHash::compute_typed("tree", b"root");
+        index.insert_directory(
+            String::new(),
+            DirectoryCacheEntry {
+                mtime_sec: 1,
+                mtime_nsec: 2,
+                child_count: 2,
+                child_digest: ContentHash::compute_typed("dirnames", b"a.txt\0b.txt"),
+                clean_tree_hash: Some(root_hash),
+            },
+        );
+        index.insert_directory(
+            "unchanged-sibling".to_string(),
+            DirectoryCacheEntry {
+                mtime_sec: 3,
+                mtime_nsec: 4,
+                child_count: 0,
+                child_digest: ContentHash::compute_typed("dirnames", b""),
+                clean_tree_hash: Some(ContentHash::compute_typed("tree", b"sibling")),
+            },
+        );
+        index.set_gitlinks_tree(root_hash);
+        index.insert_gitlink(
+            "vendor/library".to_string(),
+            "0123456789012345678901234567890123456789".to_string(),
+        );
+        save_snapshot_profiled(&index, &path).unwrap();
+
+        let (hot, _) = load_hot_profiled_for_directories(
+            &path,
+            &BTreeSet::from([String::new()]),
+        )
+        .unwrap();
+        assert_eq!(hot.len(), 0);
+        assert_eq!(hot.directory_len(), 1);
+        assert!(hot.get_directory("unchanged-sibling").is_none());
+        assert_eq!(
+            hot.gitlinks().get("vendor/library").map(String::as_str),
+            Some("0123456789012345678901234567890123456789")
+        );
+        assert!(hot.is_hot_loaded());
+        let (full, _) = load_profiled(&path).unwrap();
+        assert_eq!(full.len(), 2);
+        assert_eq!(full.directory_len(), 2);
+        assert!(!full.is_hot_loaded());
+
+        fs::write(hot_directory_record_path(&path, ""), b"corrupt").unwrap();
+        let (self_healed, _) = load_hot_profiled_for_directories(
+            &path,
+            &BTreeSet::from([String::new()]),
+        )
+        .unwrap();
+        assert!(self_healed.get_directory("").is_none());
     }
 
     #[test]
@@ -1547,7 +2033,7 @@ mod tests {
     }
 
     #[test]
-    fn journal_replay_preserves_good_frames_before_corrupt_tail() {
+    fn journal_checksum_corruption_invalidates_the_whole_index() {
         let temp = TempDir::new().unwrap();
         let path = temp.path().join("index.bin");
         let journal_path = journal_path(&path);
@@ -1575,11 +2061,9 @@ mod tests {
         journal[second_frame_start + 4] ^= 0xFF;
         fs::write(&journal_path, journal).unwrap();
 
-        let (loaded, stats) = load_profiled(&path).unwrap();
-
-        assert!(loaded.get("base.txt").is_some());
-        assert!(loaded.get("good.txt").is_some());
-        assert!(loaded.get("tail.txt").is_none());
-        assert_eq!(stats.journal_ops, 1);
+        assert!(matches!(
+            load_profiled(&path),
+            Err(IndexError::ChecksumMismatch)
+        ));
     }
 }

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -11,9 +11,10 @@ use objects::object::ContentHash;
 use tracing::{debug, warn};
 
 use super::{
-    DirectoryCacheEntry, HEADER_SIZE_V4, HEADER_SIZE_V5, HEADER_SIZE_V6, INDEX_MAGIC,
-    INDEX_VERSION, IndexEntry, IndexEntryKind, IndexError, MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT,
-    UntrackedDirectoryCacheEntry, WorktreeIndex, WorktreeIndexLoadStats, WorktreeIndexSaveStats,
+    DirectoryCacheEntry, GitlinkSummary, HEADER_SIZE_V4, HEADER_SIZE_V5, HEADER_SIZE_V6,
+    INDEX_MAGIC, INDEX_VERSION, IndexEntry, IndexEntryKind, IndexError,
+    MAX_JOURNAL_REPLAY_MS_BEFORE_COMPACT, UntrackedDirectoryCacheEntry, WorktreeIndex,
+    WorktreeIndexLoadStats, WorktreeIndexSaveStats,
 };
 
 const JOURNAL_MAGIC: &[u8; 8] = super::JOURNAL_MAGIC;
@@ -140,7 +141,7 @@ pub(crate) fn load_hot_profiled_for_directories(
     index.hot_loaded = true;
     for key in directory_keys {
         if let Some((directory, untracked, clean_tree, bytes)) =
-            load_hot_directory_record(path, key)?
+            load_hot_directory_record(path, key, !key.is_empty())?
         {
             stats.snapshot_bytes = stats.snapshot_bytes.saturating_add(bytes);
             if let Some(directory) = directory {
@@ -163,7 +164,10 @@ pub(crate) fn load_hot_profiled_for_directories(
 
     let journal_path = journal_path(path);
     if journal_path.exists() {
-        stats.journal_bytes = journal_path.metadata().map(|metadata| metadata.len()).unwrap_or(0);
+        stats.journal_bytes = journal_path
+            .metadata()
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
         let replay_start = Instant::now();
         stats.journal_ops = apply_journal(&mut index, &journal_path)?;
         stats.journal_replay_ms = replay_start.elapsed().as_millis();
@@ -172,6 +176,18 @@ pub(crate) fn load_hot_profiled_for_directories(
     index.pending_ops.clear();
     index.set_last_load_stats(&stats);
     Ok((index, stats))
+}
+
+pub(crate) fn load_hot_gitlinks_summary(path: &Path) -> Result<Option<GitlinkSummary>, IndexError> {
+    let mut index = WorktreeIndex::new();
+    let mut stats = WorktreeIndexLoadStats::default();
+    if !load_hot_gitlinks(path, &mut index, &mut stats)? {
+        return Ok(None);
+    }
+    let Some(root) = index.gitlinks_tree else {
+        return Ok(None);
+    };
+    Ok(Some((root, index.gitlinks.into_iter().collect())))
 }
 
 fn load_profiled_inner(
@@ -1238,6 +1254,7 @@ type HotDirectoryRecord = (
 fn load_hot_directory_record(
     snapshot_path: &Path,
     expected_key: &str,
+    decode_clean_tree: bool,
 ) -> Result<Option<HotDirectoryRecord>, IndexError> {
     let bytes = match fs::read(hot_directory_record_path(snapshot_path, expected_key)) {
         Ok(bytes) => bytes,
@@ -1287,10 +1304,16 @@ fn load_hot_directory_record(
             .checked_add(len)
             .filter(|end| *end <= body.len())
             .ok_or_else(|| IndexError::InvalidFormat("truncated hot tree".to_string()))?;
-        let tree = rmp_serde::from_slice(&body[offset..end])
-            .map_err(|error| IndexError::InvalidFormat(error.to_string()))?;
+        let tree = if decode_clean_tree {
+            Some(
+                rmp_serde::from_slice(&body[offset..end])
+                    .map_err(|error| IndexError::InvalidFormat(error.to_string()))?,
+            )
+        } else {
+            None
+        };
         offset = end;
-        Some(tree)
+        tree
     } else {
         None
     };
@@ -2015,11 +2038,8 @@ mod tests {
         );
         save_snapshot_profiled(&index, &path).unwrap();
 
-        let (hot, _) = load_hot_profiled_for_directories(
-            &path,
-            &BTreeSet::from([String::new()]),
-        )
-        .unwrap();
+        let (hot, _) =
+            load_hot_profiled_for_directories(&path, &BTreeSet::from([String::new()])).unwrap();
         assert_eq!(hot.len(), 0);
         assert_eq!(hot.directory_len(), 1);
         assert!(hot.get_directory("unchanged-sibling").is_none());
@@ -2034,11 +2054,8 @@ mod tests {
         assert!(!full.is_hot_loaded());
 
         fs::write(hot_directory_record_path(&path, ""), b"corrupt").unwrap();
-        let (self_healed, _) = load_hot_profiled_for_directories(
-            &path,
-            &BTreeSet::from([String::new()]),
-        )
-        .unwrap();
+        let (self_healed, _) =
+            load_hot_profiled_for_directories(&path, &BTreeSet::from([String::new()])).unwrap();
         assert!(self_healed.get_directory("").is_none());
     }
 

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -139,13 +139,18 @@ pub(crate) fn load_hot_profiled_for_directories(
     let mut index = WorktreeIndex::new();
     index.hot_loaded = true;
     for key in directory_keys {
-        if let Some((directory, untracked, bytes)) = load_hot_directory_record(path, key)? {
+        if let Some((directory, untracked, clean_tree, bytes)) =
+            load_hot_directory_record(path, key)?
+        {
             stats.snapshot_bytes = stats.snapshot_bytes.saturating_add(bytes);
             if let Some(directory) = directory {
                 index.directories.insert(key.clone(), directory);
             }
             if let Some(untracked) = untracked {
                 index.untracked_directories.insert(key.clone(), untracked);
+            }
+            if let Some(clean_tree) = clean_tree {
+                index.clean_trees.insert(key.clone(), clean_tree);
             }
         }
     }
@@ -452,6 +457,7 @@ fn load_v1(file: &mut File, file_size: u64) -> Result<WorktreeIndex, IndexError>
         untracked_directories: BTreeMap::new(),
         gitlinks: BTreeMap::new(),
         gitlinks_tree: None,
+        clean_trees: BTreeMap::new(),
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
@@ -555,6 +561,7 @@ fn load_v6(file: &mut File, file_size: u64, hot_only: bool) -> Result<WorktreeIn
         untracked_directories,
         gitlinks,
         gitlinks_tree: None,
+        clean_trees: BTreeMap::new(),
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
@@ -693,6 +700,7 @@ fn load_compact_versioned_with_untracked(
         untracked_directories,
         gitlinks: BTreeMap::new(),
         gitlinks_tree: None,
+        clean_trees: BTreeMap::new(),
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
@@ -789,6 +797,7 @@ fn load_legacy_versioned(
         untracked_directories: BTreeMap::new(),
         gitlinks: BTreeMap::new(),
         gitlinks_tree: None,
+        clean_trees: BTreeMap::new(),
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
@@ -874,6 +883,7 @@ fn load_compact_versioned(file: &mut File, file_size: u64) -> Result<WorktreeInd
         untracked_directories: BTreeMap::new(),
         gitlinks: BTreeMap::new(),
         gitlinks_tree: None,
+        clean_trees: BTreeMap::new(),
         dirty: false,
         pending_ops: Vec::new(),
         last_journal_bytes: 0,
@@ -1185,6 +1195,14 @@ fn write_hot_sidecars(index: &WorktreeIndex, snapshot_path: &Path) -> Result<(),
         if let Some(untracked) = untracked {
             write_untracked_directory_entry_payload(&mut body, untracked)?;
         }
+        let clean_tree = index.clean_trees.get(&key);
+        body.push(u8::from(clean_tree.is_some()));
+        if let Some(clean_tree) = clean_tree {
+            let encoded = rmp_serde::to_vec_named(clean_tree)
+                .map_err(|error| IndexError::InvalidFormat(error.to_string()))?;
+            body.extend_from_slice(&(encoded.len() as u32).to_be_bytes());
+            body.extend_from_slice(&encoded);
+        }
         write_reconstructible_atomic(
             &hot_directory_record_path(snapshot_path, &key),
             &frame_hot_record(body),
@@ -1213,6 +1231,7 @@ fn write_hot_sidecars(index: &WorktreeIndex, snapshot_path: &Path) -> Result<(),
 type HotDirectoryRecord = (
     Option<DirectoryCacheEntry>,
     Option<UntrackedDirectoryCacheEntry>,
+    Option<objects::object::Tree>,
     u64,
 );
 
@@ -1257,10 +1276,28 @@ fn load_hot_directory_record(
     } else {
         None
     };
+    let Some(has_tree) = body.get(offset).copied() else {
+        return Ok(None);
+    };
+    offset += 1;
+    let clean_tree = if has_tree != 0 {
+        let len = read_u32_be(&body[offset..], "hot tree length")? as usize;
+        offset += 4;
+        let end = offset
+            .checked_add(len)
+            .filter(|end| *end <= body.len())
+            .ok_or_else(|| IndexError::InvalidFormat("truncated hot tree".to_string()))?;
+        let tree = rmp_serde::from_slice(&body[offset..end])
+            .map_err(|error| IndexError::InvalidFormat(error.to_string()))?;
+        offset = end;
+        Some(tree)
+    } else {
+        None
+    };
     if offset != body.len() {
         return Ok(None);
     }
-    Ok(Some((directory, untracked, bytes.len() as u64)))
+    Ok(Some((directory, untracked, clean_tree, bytes.len() as u64)))
 }
 
 fn load_hot_gitlinks(

--- a/crates/repo/src/worktree_status_options.rs
+++ b/crates/repo/src/worktree_status_options.rs
@@ -4,11 +4,10 @@
 use serde::{Deserialize, Serialize};
 
 /// Optional fsmonitor backend selection for worktree status hot paths.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FsMonitorMode {
     /// Disable fsmonitor integration.
-    #[default]
     Off,
     /// Auto-detect a supported backend at runtime.
     Auto,
@@ -16,6 +15,12 @@ pub enum FsMonitorMode {
     Native,
     /// Use the Watchman CLI backend when available.
     Watchman,
+}
+
+impl Default for FsMonitorMode {
+    fn default() -> Self {
+        Self::Auto
+    }
 }
 
 impl FsMonitorMode {

--- a/crates/repo/src/worktree_status_options.rs
+++ b/crates/repo/src/worktree_status_options.rs
@@ -4,23 +4,18 @@
 use serde::{Deserialize, Serialize};
 
 /// Optional fsmonitor backend selection for worktree status hot paths.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum FsMonitorMode {
     /// Disable fsmonitor integration.
     Off,
     /// Auto-detect a supported backend at runtime.
+    #[default]
     Auto,
     /// Use Heddle's local native backend.
     Native,
     /// Use the Watchman CLI backend when available.
     Watchman,
-}
-
-impl Default for FsMonitorMode {
-    fn default() -> Self {
-        Self::Auto
-    }
 }
 
 impl FsMonitorMode {

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -81,6 +81,15 @@ pub(crate) trait WorktreeWalkPolicy {
         tree: Option<&Tree>,
     ) -> Result<Self::DirectoryState>;
 
+    fn reuse_tree_entry_before_metadata(
+        &mut self,
+        _rel_path: &Path,
+        _tree_entry: &TreeEntry,
+        _state: &mut Self::DirectoryState,
+    ) -> Result<bool> {
+        Ok(false)
+    }
+
     fn visit_file(
         &mut self,
         entry: WalkEntry<'_>,
@@ -225,6 +234,17 @@ fn walk_directory<P: WorktreeWalkPolicy>(
                 .filter(|entry| entry.name() == name);
             if tree_entry.is_some() {
                 next_tree_entry += 1;
+            }
+
+            if let Some(tree_entry) = tree_entry
+                && policy.reuse_tree_entry_before_metadata(
+                    &directory.rel_path.join(name),
+                    tree_entry,
+                    &mut state,
+                )?
+            {
+                pop_key_component(&mut entry_key, location.key);
+                continue;
             }
 
             let metadata = match &entry.metadata {

--- a/crates/wire/src/native_pack.rs
+++ b/crates/wire/src/native_pack.rs
@@ -932,13 +932,13 @@ mod tests {
         assert_eq!(stats.object_count, wanted.len());
         assert!(stats.encoded_bytes_copied > 0);
         let reused = PackReader::open(&bundle.pack_path, &bundle.index_path).unwrap();
-        let mut reused_ids = reused.list_ids();
+        let mut reused_ids = reused.list_ids().unwrap();
         reused_ids.sort();
         let mut wanted_ids = vec![blob.0, tree.0, state.0];
         wanted_ids.sort();
         assert_eq!(reused_ids, wanted_ids);
-        assert!(!reused.has_object(&attachment_id));
-        assert!(!reused.has_object(&artifact_id));
+        assert!(!reused.has_object(&attachment_id).unwrap());
+        assert!(!reused.has_object(&artifact_id).unwrap());
 
         for path in [&bundle.pack_path, &bundle.index_path] {
             let expected_wire_bytes = std::fs::read(path).unwrap();

--- a/crates/wire/src/provider_pack.rs
+++ b/crates/wire/src/provider_pack.rs
@@ -155,7 +155,7 @@ impl ProviderPackSpool {
             .iter()
             .map(|extent| extent.objects.len())
             .sum::<usize>();
-        if reader.list_ids().len() != expected_objects {
+        if reader.list_ids()?.len() != expected_objects {
             return Err(ProtocolError::InvalidState(
                 "provider pack index does not match its manifest".to_string(),
             ));
@@ -560,8 +560,14 @@ mod tests {
     fn split_manifest() -> (ProviderPackManifest, Vec<Vec<u8>>, Vec<u8>, Vec<u8>) {
         let (pack, index, ids) = source_pack();
         let parsed_index = PackIndex::from_bytes(&index).unwrap();
-        let first = parsed_index.find(&ids[0]).unwrap();
-        let second = parsed_index.find(&ids[1]).unwrap();
+        let first = parsed_index
+            .find(&ids[0])
+            .unwrap()
+            .expect("first fixture object indexed");
+        let second = parsed_index
+            .find(&ids[1])
+            .unwrap()
+            .expect("second fixture object indexed");
         let (first_id, first_offset, second_id, second_offset) = if first < second {
             (ids[0], first, ids[1], second)
         } else {

--- a/docs/perf/cli-core-loop-baseline.json
+++ b/docs/perf/cli-core-loop-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "heddle-cli-core-loop-baseline/v2",
-  "recorded_at": "2026-08-03",
+  "recorded_at": "2026-08-04",
   "sample_count": 20,
   "profiles": [
     {
@@ -69,13 +69,13 @@
     },
     {
       "name": "local-calibration",
-      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 56669328 bytes",
+      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 58037072 bytes",
       "cases": [
         {
           "case": "version",
           "paths": 0,
           "target_p95_ms": 20.0,
-          "measured_p95_ms": 1.564,
+          "measured_p95_ms": 1.498,
           "gate_p95_ms": 20.0,
           "disposition": "target"
         },
@@ -83,7 +83,7 @@
           "case": "help",
           "paths": 0,
           "target_p95_ms": 20.0,
-          "measured_p95_ms": 4.951,
+          "measured_p95_ms": 4.903,
           "gate_p95_ms": 20.0,
           "disposition": "target"
         },
@@ -91,31 +91,31 @@
           "case": "status_clean",
           "paths": 100000,
           "target_p95_ms": 50.0,
-          "measured_p95_ms": 218.697,
-          "gate_p95_ms": 241.0,
-          "disposition": "local baseline + 10% noise; 168.697 ms above target"
+          "measured_p95_ms": 73.271,
+          "gate_p95_ms": 81.0,
+          "disposition": "local lazy-pack baseline + 10% noise; 23.271 ms above target"
         },
         {
           "case": "status_one_dirty",
           "paths": 100000,
           "target_p95_ms": 75.0,
-          "measured_p95_ms": 415.569,
-          "gate_p95_ms": 458.0,
-          "disposition": "local baseline + 10% noise; 340.569 ms above target"
+          "measured_p95_ms": 78.619,
+          "gate_p95_ms": 87.0,
+          "disposition": "local lazy-pack baseline + 10% noise; 3.619 ms above target"
         },
         {
           "case": "capture_one",
           "paths": 100000,
           "target_p95_ms": 100.0,
-          "measured_p95_ms": 2436.937,
-          "gate_p95_ms": 2681.0,
-          "disposition": "local baseline + 10% noise; 2336.937 ms above target"
+          "measured_p95_ms": 971.053,
+          "gate_p95_ms": 1069.0,
+          "disposition": "local lazy-pack baseline + 10% noise; 871.053 ms above target"
         }
       ],
       "scale_cases": [
         {
           "case": "status_clean",
-          "measured_wall_ratio": 6.712,
+          "measured_wall_ratio": 6.976,
           "gate_wall_ratio": 7.4,
           "measured_directory_ratio": 1.0,
           "gate_directory_ratio": 3.0,
@@ -123,11 +123,11 @@
         },
         {
           "case": "status_one_dirty",
-          "measured_wall_ratio": 7.755,
-          "gate_wall_ratio": 8.55,
-          "measured_directory_ratio": 9.824,
-          "gate_directory_ratio": 10.0,
-          "disposition": "local wall and directory ratchets; gaps remain for Instant Heddle"
+          "measured_wall_ratio": 7.096,
+          "gate_wall_ratio": 8.0,
+          "measured_directory_ratio": 1.0,
+          "gate_directory_ratio": 3.0,
+          "disposition": "local wall-time ratchet; structural directory invariant enforced"
         }
       ]
     }

--- a/docs/perf/cli-core-loop.md
+++ b/docs/perf/cli-core-loop.md
@@ -56,8 +56,9 @@ cargo test --release -p heddle-cli --test cli_integration \
 Compilation happens before the test process starts. The harness also reports
 fixture construction (`SETUP`) separately, before starting any command sample.
 It prints the runner fingerprint and p50/p95/p99/max for end-to-end wall time,
-profile total, process startup, warm repository work, monitor startup,
-rendering, and network work. Structural counters use the same percentiles.
+profile total, process startup, warm repository work, repository open,
+verification, worktree status, snapshot subphases, monitor startup, rendering,
+and network work. Structural counters use the same percentiles.
 
 Wave 0 covers `--version`, `help`, clean status, one-dirty-path status, and a
 one-path capture. Repository fixtures contain 10k and 100k paths. Version and
@@ -72,14 +73,39 @@ the dedicated release workflow runs it on a controlled runner. Absolute bands
 already met use the product target. Missed bands use a baseline ratchet and keep
 the target gap explicit.
 
-The three repeatable negative controls are:
+The repeatable negative controls are:
 
 ```sh
 HEDDLE_PERF_NEGATIVE_CONTROL=latency HEDDLE_PERF_SAMPLES=5 <command-above>
 HEDDLE_PERF_NEGATIVE_CONTROL=full-scan HEDDLE_PERF_SAMPLES=5 <command-above>
+HEDDLE_PERF_NEGATIVE_CONTROL=subtree-skip HEDDLE_PERF_SAMPLES=5 <command-above>
+HEDDLE_PERF_NEGATIVE_CONTROL=eager-pack-index HEDDLE_PERF_SAMPLES=5 <command-above>
 HEDDLE_PERF_NEGATIVE_CONTROL=duplicate-open HEDDLE_PERF_SAMPLES=5 <command-above>
 ```
 
 They respectively inject 50 ms into the timed window, disable the monitor and
-remove the warm index before every sample, and execute a second repository open
-inside each sample. Each invocation must fail with `PERF GATE RED`.
+remove the warm index before every sample, deliberately disable subtree and
+unchanged-child skips while retaining the warm index, eagerly build the global
+packed-object location map during every repository open, and execute a second
+repository open inside each sample. Each invocation must fail with `PERF GATE
+RED`. The eager-index control is pinned by the warm repository-open p95 gate
+(2 ms), not only by the aggregate wall-time band.
+
+## 2026-08-04 local calibration
+
+The 20-sample local release run after lazy pack lookup measured the following
+100k-path p95 values. The previous column is the prior recorded local
+calibration; the gate column is the new baseline plus roughly 10% noise and is
+strictly tighter than the previous gate.
+
+| Case | Previous p95 | Lazy-pack p95 | New gate | Product target |
+|---|---:|---:|---:|---:|
+| Clean status | 218.697 ms | 73.271 ms | 81 ms | 50 ms |
+| One-path status | 415.569 ms | 78.619 ms | 87 ms | 75 ms |
+| One-path capture | 2436.937 ms | 971.053 ms | 1069 ms | 100 ms |
+
+Repository open measured 0 ms at both 10k and 100k. At 100k the clean,
+one-path status, and one-path capture cases scanned 2, 6, and 16 directories
+respectively and hashed 0, at most 1, and 1 files. The local 10k-to-100k
+wall-ratio gates are 7.4x (clean, unchanged) and 8.0x (one path, tightened
+from 8.55x); both retain a 3x directory-ratio ceiling.


### PR DESCRIPTION
Closes #1220.

## What changed

- make `PackManager` discover pack/index paths at repository open without opening every pack or enumerating every object
- build and cache the cross-pack object-location map on first general packed-object lookup; extend an already-built map when a pack is added
- keep pack-specific snapshot recovery lazy, with marker-first discovery and content-address validation at the object-domain boundary
- retain the #1220 native-monitor changed-path scanner, subtree proofs, hot worktree-index/state caches, and profile counters
- add `eager-pack-index` as a repeatable release-harness negative control and pin it with a 2 ms repository-open p95 gate

Packed-object correctness is covered across reopened packs, incremental pack addition, snapshot artifact recovery, corrupt/swapped indexes, and the existing pack/object/repository suites.

## #1219 release harness

20 samples, local calibration runner, 100k paths:

| Case | Previous p95 | Lazy-pack calibrated p95 | Ratcheted gate | Product target |
|---|---:|---:|---:|---:|
| Warm clean status | 218.697 ms | 73.271 ms | 81 ms | 50 ms |
| One-path status | 415.569 ms | 78.619 ms | 87 ms | 75 ms |
| One-path capture | 2436.937 ms | 971.053 ms | 1069 ms | 100 ms |

The confirmation run was green at 79.557 / 83.871 / 992.578 ms p95. Repository-open p95 was 0 ms. At 100k, clean status, one-path status, and one-path capture scanned 2 / 6 / 16 directories and hashed 0 / at most 1 / 1 files. The 10k-to-100k status ratio gates remain 7.4x clean and 8.0x one-path; no gate was loosened.

After the conflict-free rebase onto current `main`, the affected release target rebuilt successfully. Subsequent local timing attempts ran while the shared host was saturated (md2 reached 100% utilization with 229–450 MB/s unrelated writes and CPU reached 97%), so those noisy capture samples were not used to recalibrate or loosen the committed gates. Structural counters and repository-open timing remained unchanged.

## Negative control

`HEDDLE_PERF_NEGATIVE_CONTROL=eager-pack-index HEDDLE_PERF_SAMPLES=5` exits red as required:

- warm clean status p95: 93.996 ms, above the 81 ms aggregate gate
- repository-open p95: 15 ms, above the 2 ms direct gate
- clean 10k-to-100k ratio: 9.044x, above the 7.4x scale gate

## Verification

- `cargo test -p heddle-pack -p heddle-objects -p heddle-repo` (73 pack, 171 object-store, 623 repository tests passed; expected ignores only)
- full CLI integration suite (889 passed, 19 ignored)
- `cargo clippy -p heddle-pack -p heddle-objects -p heddle-repo -p heddle-core -p heddle-cli --tests -- -D warnings`
- `git diff --check`
- touched Rust files pass formatting; repository-wide `cargo fmt --all -- --check` still reports the pre-existing formatting difference in `crates/cli/tests/ts_types_in_sync.rs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788410563&installation_model_id=21489&pr_number=1231&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1231&signature=7c96ad9a0070ee860aa951ee03e74c0bbfd13d2ad36979669a219ba091970c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->