### PR TITLE
perf(cli): gate hosted endpoint close drain

### DIFF
--- a/.github/workflows/perf-core-loop.yml
+++ b/.github/workflows/perf-core-loop.yml
@@ -64,12 +64,28 @@ jobs:
           /usr/bin/time -f 'release_test_compile elapsed=%e user=%U sys=%S max_rss_kb=%M' \
             cargo test --locked --release -p heddle-cli --test cli_integration \
               --no-run 2>&1 | tee -a release-compile.txt
+          /usr/bin/time -f 'release_hosted_close_compile elapsed=%e user=%U sys=%S max_rss_kb=%M' \
+            cargo test --locked --release -p heddle-cli --lib \
+              --no-run 2>&1 | tee -a release-compile.txt
 
       - name: Enforce instant core-loop contract
         run: |
           set -o pipefail
           cargo test --locked --release -p heddle-cli --test cli_integration \
             core_loop_release_contract -- --ignored --nocapture 2>&1 | tee core-loop-contract.txt
+
+      - name: Enforce hosted endpoint close contract
+        run: |
+          set -o pipefail
+          RUST_LOG=iroh=error cargo test --locked --release -p heddle-cli --lib \
+            hosted_endpoint_close_release_contract -- --ignored --nocapture \
+            2>&1 | tee hosted-close-contract.txt
+          if grep -Fq 'Endpoint dropped without calling `Endpoint::close`' \
+            hosted-close-contract.txt; then
+            echo 'HOSTED_CLOSE_LEAK_GUARD red: endpoint was dropped ungracefully'
+            exit 1
+          fi
+          echo 'HOSTED_CLOSE_LEAK_GUARD green'
 
       - name: Publish contract summary
         if: always()
@@ -83,6 +99,13 @@ jobs:
             grep -E '^(RUNNER|SETUP|RESULT|COUNTERS|BASELINE|BAND|SCALE|GATES|PERF GATE)' \
               core-loop-contract.txt 2>/dev/null || true
             echo '```'
+            echo
+            echo '## Hosted endpoint close release contract'
+            echo
+            echo '```text'
+            grep -E '^(HOSTED_CLOSE|HOSTED CLOSE GATE)' \
+              hosted-close-contract.txt 2>/dev/null || true
+            echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload release evidence
@@ -93,6 +116,7 @@ jobs:
           path: |
             release-compile.txt
             core-loop-contract.txt
+            hosted-close-contract.txt
 
       - name: sccache stats
         if: always()

--- a/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -1,4 +1,5 @@
 use std::{
+    env,
     net::Ipv4Addr,
     time::{Duration, Instant},
 };
@@ -13,6 +14,14 @@ use iroh::{Endpoint, RelayMode, endpoint::presets};
 use n0_watcher::Watcher;
 
 use super::{DescriptorKeyring, VerifiedEndpointDescriptor, connection::HostedConnection};
+
+const HOSTED_ENDPOINT_CLOSE_P95_BUDGET: Duration = Duration::from_millis(20);
+const DEFAULT_CLOSE_SAMPLE_COUNT: usize = 20;
+
+fn require_release_build() {
+    #[cfg(debug_assertions)]
+    panic!("hosted endpoint close contract must run with --release");
+}
 
 fn verified_descriptor(
     endpoint_id: iroh::EndpointId,
@@ -50,12 +59,29 @@ fn verified_descriptor(
 }
 
 #[tokio::test]
-#[ignore = "manual five-sample loopback transport measurement"]
-async fn measure_loopback_transport_setup_and_close() {
+#[ignore = "release-only hosted endpoint close performance contract"]
+async fn hosted_endpoint_close_release_contract() {
+    require_release_build();
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
         .with_test_writer()
         .try_init();
+    let sample_count = env::var("HEDDLE_HOSTED_CLOSE_SAMPLES")
+        .map(|value| {
+            value
+                .parse::<usize>()
+                .expect("sample count must be an integer")
+        })
+        .unwrap_or(DEFAULT_CLOSE_SAMPLE_COUNT);
+    assert!(
+        sample_count >= 5,
+        "close contract requires at least 5 samples"
+    );
+    let negative_control = match env::var("HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL").as_deref() {
+        Ok("latency") => true,
+        Ok(value) => panic!("unknown HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL `{value}`"),
+        Err(_) => false,
+    };
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
         .relay_mode(RelayMode::Disabled)
@@ -75,7 +101,7 @@ async fn measure_loopback_transport_setup_and_close() {
         server.addr().ip_addrs().map(ToString::to_string).collect(),
     );
     let server_task = tokio::spawn(async move {
-        for _ in 0..5 {
+        for _ in 0..sample_count {
             let connection = server
                 .accept()
                 .await
@@ -87,23 +113,52 @@ async fn measure_loopback_transport_setup_and_close() {
         server.close().await;
     });
 
-    for sample in 1..=5 {
-        let started = Instant::now();
+    let mut close_ms = Vec::with_capacity(sample_count);
+    for _ in 0..sample_count {
         let connection =
             HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
                 .await
                 .unwrap();
-        let setup = started.elapsed();
+        let endpoint_observer = connection.endpoint.clone();
+        let close_started = Instant::now();
+        if negative_control {
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
         connection.close().await;
-        let total = started.elapsed();
-        println!(
-            "LOOPBACK sample={sample} setup_ms={:.3} close_ms={:.3} total_ms={:.3}",
-            setup.as_secs_f64() * 1_000.0,
-            (total - setup).as_secs_f64() * 1_000.0,
-            total.as_secs_f64() * 1_000.0,
+        close_ms.push(close_started.elapsed().as_secs_f64() * 1_000.0);
+        assert!(
+            endpoint_observer.is_closed(),
+            "successful hosted teardown must close the endpoint before drop"
         );
+        drop(connection);
+        drop(endpoint_observer);
     }
     server_task.await.unwrap();
+
+    close_ms.sort_by(f64::total_cmp);
+    let middle = close_ms.len() / 2;
+    let median = if close_ms.len().is_multiple_of(2) {
+        (close_ms[middle - 1] + close_ms[middle]) / 2.0
+    } else {
+        close_ms[middle]
+    };
+    let p95 = percentile_ms(&close_ms, 95);
+    let min = close_ms[0];
+    let max = close_ms[close_ms.len() - 1];
+    let budget_ms = HOSTED_ENDPOINT_CLOSE_P95_BUDGET.as_secs_f64() * 1_000.0;
+    println!(
+        "HOSTED_CLOSE samples={sample_count} median_ms={median:.3} p95_ms={p95:.3} min_ms={min:.3} max_ms={max:.3} budget_p95_ms={budget_ms:.3} negative_control={negative_control}"
+    );
+    assert!(
+        p95 <= budget_ms,
+        "HOSTED CLOSE GATE RED: p95 {p95:.3} ms > {budget_ms:.3} ms budget"
+    );
+    println!("HOSTED_CLOSE_GATES green");
+}
+
+fn percentile_ms(sorted_values: &[f64], percentile: usize) -> f64 {
+    let rank = (sorted_values.len() * percentile).div_ceil(100);
+    sorted_values[rank.saturating_sub(1)]
 }
 
 #[tokio::test]

--- a/docs/perf/hosted-endpoint-close.md
+++ b/docs/perf/hosted-endpoint-close.md
@@ -1,0 +1,69 @@
+# Hosted Endpoint Close Performance
+
+Hosted operations explicitly close their QUIC connection and then await
+`Endpoint::close()` at their shared teardown boundary. The await is required:
+skipping it reproduces `Endpoint dropped without calling Endpoint::close` and
+an ungraceful abort. This document records the release-mode cost and its
+executable budget so the earlier debug-build number is not treated as shipped
+latency.
+
+## Release measurement
+
+Measured on 2026-08-04 at `fb5d4b7c` using rustc 1.97.0's optimized release
+profile on Linux x86_64 (AMD Ryzen 7 7700, 8 cores/16 threads). Each sample
+established a loopback connection over the hosted ALPN through
+`HostedConnection::connect_verified`; endpoint setup and compilation were
+outside the timed window. The timer covered only the shared hosted-operation
+teardown. Twenty control samples closed the QUIC connection but temporarily
+skipped the endpoint-close await, with each sample isolated in a fresh test
+process so its intentional ungraceful abort could not contaminate the next
+connection.
+
+| teardown | samples | median | p95 | min-max |
+| --- | ---: | ---: | ---: | ---: |
+| graceful `Endpoint::close().await` | 20 | 0.3965 ms | 0.694 ms | 0.354-0.779 ms |
+| control: skip endpoint-close await | 20 | 0.0020 ms | 0.003 ms | 0.002-0.003 ms |
+
+The median release drain attributable to the await was approximately 0.3945
+ms, not the 0.87 seconds observed in the historical debug build. All 20 control
+runs emitted the #1143 ungraceful-abort error. A non-isolated control also made
+the following connection time out, further confirming that skipping the await
+is not a viable optimization.
+
+## Budget and decision
+
+The release contract is **p95 <= 20 ms** for the isolated endpoint close. Law 7
+in #1218 requires an executable latency gate; its smallest fixed-work product
+band is the 20 ms p95 budget for cold metadata commands. Hosted completion is
+otherwise expressed relative to RTT plus fixed server work, so client endpoint
+drain is gated as fixed local work rather than folded into an unstable total
+push, pull, or clone duration.
+
+The measured p95 has about 29x headroom under that budget. The graceful close
+therefore stays unchanged: adding a timeout or another teardown path would add
+complexity to save less than one millisecond while risking the real leak and
+spurious error fixed by #1143/#1151.
+
+## Executable contract
+
+The dedicated release workflow runs:
+
+```sh
+TMPDIR=/home/scratch cargo test --locked --release -p heddle-cli --lib \
+  hosted_endpoint_close_release_contract -- --ignored --nocapture
+```
+
+The test takes 20 samples, prints median/p95/min/max, asserts p95 is within 20
+ms, and asserts that the endpoint is closed before each successful hosted
+connection is dropped. The workflow also enables Iroh error logs and fails if
+the literal #1143 `Endpoint dropped without calling Endpoint::close` message
+appears. The test refuses to run as a debug-build gate.
+
+The repeatable negative control adds 25 ms inside the measured close window and
+must fail with `HOSTED CLOSE GATE RED`:
+
+```sh
+TMPDIR=/home/scratch HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL=latency \
+  cargo test --locked --release -p heddle-cli --lib \
+  hosted_endpoint_close_release_contract -- --ignored --nocapture
+```


### PR DESCRIPTION
## Summary

- measure the shared hosted-operation `Endpoint::close().await` boundary in an optimized release build against a temporary control that closes the QUIC connection but skips only the endpoint-close await
- keep graceful teardown unchanged: the measured release drain is sub-millisecond and does not justify a timeout or second lifecycle path
- add a release-only 20 ms p95 regression contract to the #1219 controlled workflow, including a structural closed-endpoint assertion and a literal #1143 ungraceful-abort log guard
- document the measurement, budget rationale, negative control, and no-fix decision

Closes #1159
Refs #1218, especially law 7 (latency budgets are executable contracts) and the hosted RTT-plus-fixed-work model.

## Test evidence

### Release measurement and temporary skip-await control

Measured on Linux x86_64 (AMD Ryzen 7 7700, 8 cores/16 threads), rustc 1.97.0, optimized release profile, 20 samples per arm. Compilation and connection setup were outside the timed window; the timer isolated the shared hosted teardown boundary.

| teardown | samples | median | p95 | min-max |
| --- | ---: | ---: | ---: | ---: |
| graceful `Endpoint::close().await` | 20 | 0.3965 ms | 0.694 ms | 0.354-0.779 ms |
| temporary control: skip endpoint-close await | 20 | 0.0020 ms | 0.003 ms | 0.002-0.003 ms |

The median release drain attributable to the await is approximately **0.3945 ms**, not the historical debug-build +0.87 s. The skip-await control emitted `Endpoint dropped without calling Endpoint::close. Aborting ungracefully.` in all 20 isolated runs. A non-isolated control also contaminated the next hosted connection and made it time out, so the control was kept measurement-only and removed before commit.

### Budget and decision

The executable budget is **p95 <= 20 ms** for isolated client endpoint drain. #1218 uses 20 ms as its smallest fixed-work p95 band (cold version/help), while hosted completion is RTT plus fixed server/client work. Endpoint drain is fixed client work, so it must fit within that smallest band rather than inherit total-operation network variance.

Measured p95 has approximately 29x headroom. The correct outcome is no teardown change: keep graceful close and avoid timeout/concurrency complexity that would save less than one millisecond while risking #1143.

### Release gate: green

```text
TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1159-target \
RUST_LOG=iroh=error cargo test --locked --release -p heddle-cli --lib \
  hosted_endpoint_close_release_contract -- --ignored --nocapture

HOSTED_CLOSE samples=20 median_ms=0.193 p95_ms=0.268 min_ms=0.184 max_ms=0.394 budget_p95_ms=20.000 negative_control=false
HOSTED_CLOSE_GATES green
HOSTED_CLOSE_LEAK_GUARD green
```

The test asserts `Endpoint::is_closed()` before every successful hosted connection is dropped. With Iroh error logging enabled, the transcript contains no `Endpoint dropped without calling Endpoint::close` or `Aborting ungracefully` warning.

### Proven-red negative control

```text
TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1159-target \
HEDDLE_HOSTED_CLOSE_NEGATIVE_CONTROL=latency \
cargo test --locked --release -p heddle-cli --lib \
  hosted_endpoint_close_release_contract -- --ignored --nocapture

HOSTED_CLOSE samples=20 median_ms=26.213 p95_ms=26.413 min_ms=26.070 max_ms=26.490 budget_p95_ms=20.000 negative_control=true
HOSTED CLOSE GATE RED: p95 26.413 ms > 20.000 ms budget
negative_control_rc=101
```

The injection adds 25 ms inside the measured drain window; it is not a configurable production budget. The hard-coded 20 ms gate was not loosened.

### Correctness and static checks

- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli --lib hosted_runtime::hosted::connection_path_tests -- --nocapture` — direct, direct-only, and signed-relay fallback passed; release contract ignored in debug
- explicit debug invocation of the ignored gate exited 101 with `hosted endpoint close contract must run with --release`
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1159-target cargo clippy --locked -p heddle-cli --lib --tests -- -D warnings` — passed
- `rustfmt +nightly --edition 2024 --check crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs` — passed
- `git diff --check` — passed

Local release verification used a task-specific Cargo target because the in-flight #1220 repo/pack work briefly contaminated the shared target cache with an incompatible artifact; the isolated build passed the same boundary cleanly. No `cargo clean` was run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788410675&installation_model_id=21489&pr_number=1232&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1232&signature=c59f4675bc8ed6fc385b16c2cb5bc769c8f5528402f70370dbdc4c494a8d1699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->