### PR TITLE
perf(hosted): consume clone bootstrap metadata

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1617,6 +1617,17 @@ async fn clone_network_connected(
             materialization,
         )
         .await?;
+    let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
+        .context("decode hosted clone bootstrap")?;
+    let bootstrap = if result.success {
+        bootstrap
+            .as_ref()
+            .map(|metadata| metadata.resolve(&local_repo, result.final_state))
+            .transpose()
+            .context("resolve hosted clone bootstrap")?
+    } else {
+        None
+    };
     if result.success {
         let final_state = result.final_state;
         if let Some(state) = final_state {
@@ -1656,7 +1667,15 @@ async fn clone_network_connected(
         // hosted CollaborationService discussions for the cloned head into the
         // local op-log so `discuss list` / `discuss show` see them. Best-effort:
         // a fetch hiccup warns rather than failing an otherwise-good clone.
-        match crate::client::discussion_sync::pull_discussions(&local_repo, client, repo_path).await
+        match crate::client::discussion_sync::pull_discussions(
+            &local_repo,
+            client,
+            repo_path,
+            bootstrap
+                .as_ref()
+                .map(|metadata| metadata.discussions.as_slice()),
+        )
+        .await
         {
             Ok(_) => {}
             Err(error) => {
@@ -1669,7 +1688,16 @@ async fn clone_network_connected(
         // Read path for hosted context annotations (heddle context): materialize
         // the hosted head's annotations into the local Context attachment so
         // `context list` sees them. Best-effort, mirroring discussions.
-        match crate::client::context_sync::pull_context(&local_repo, client, repo_path).await {
+        match crate::client::context_sync::pull_context(
+            &local_repo,
+            client,
+            repo_path,
+            bootstrap
+                .as_ref()
+                .map(|metadata| metadata.context.as_slice()),
+        )
+        .await
+        {
             Ok(_) => {}
             Err(error) => {
                 eprintln!("{} context sync skipped: {error:#}", style::warn_marker());

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1050,6 +1050,17 @@ async fn pull_network_connected(
             },
         )
         .await?;
+    let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
+        .context("decode hosted pull bootstrap")?;
+    let bootstrap = if result.success {
+        bootstrap
+            .as_ref()
+            .map(|metadata| metadata.resolve(repo, result.final_state))
+            .transpose()
+            .context("resolve hosted pull bootstrap")?
+    } else {
+        None
+    };
 
     // Keep typed StateId for ref/worktree I/O; map string fields for pure parse.
     let final_state_id = result.final_state;
@@ -1120,7 +1131,16 @@ async fn pull_network_connected(
             // new hosted CollaborationService discussions/turns for the pulled
             // head into the local op-log. Best-effort — a fetch hiccup warns
             // rather than failing the pull.
-            match crate::client::discussion_sync::pull_discussions(repo, client, repo_path).await {
+            match crate::client::discussion_sync::pull_discussions(
+                repo,
+                client,
+                repo_path,
+                bootstrap
+                    .as_ref()
+                    .map(|metadata| metadata.discussions.as_slice()),
+            )
+            .await
+            {
                 Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} discussion(s) from {}",
@@ -1137,7 +1157,16 @@ async fn pull_network_connected(
                 }
             }
             // Read path for hosted context annotations — same seam as discussions.
-            match crate::client::context_sync::pull_context(repo, client, repo_path).await {
+            match crate::client::context_sync::pull_context(
+                repo,
+                client,
+                repo_path,
+                bootstrap
+                    .as_ref()
+                    .map(|metadata| metadata.context.as_slice()),
+            )
+            .await
+            {
                 Ok(count) if count > 0 && !should_output_json(options.cli, Some(repo.config())) => {
                     println!(
                         "{} synced {count} annotation(s) from {}",

--- a/crates/cli/src/client/context_sync.rs
+++ b/crates/cli/src/client/context_sync.rs
@@ -732,6 +732,7 @@ pub async fn pull_context(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
+    bootstrap: Option<&[(ContextTarget, ContextBlob)]>,
 ) -> Result<usize> {
     let Some(head_id) = repo.head().context("resolve repository head")? else {
         return Ok(0);
@@ -744,11 +745,6 @@ pub async fn pull_context(
         return Ok(0);
     };
 
-    let server = list_server_targets(client, repo_path).await?;
-    if server.is_empty() {
-        return Ok(0);
-    }
-
     let user_config = crate::config::UserConfig::load_default().unwrap_or_default();
     let self_local_attr = crate::cli::commands::snapshot::resolve_attribution(repo, &user_config)
         .ok()
@@ -758,8 +754,42 @@ pub async fn pull_context(
     let heddle_dir = repo.heddle_dir().to_path_buf();
     let mut mirror = load_mirror(&heddle_dir)?;
     let mut changed = 0usize;
+    if let Some(entries) = bootstrap {
+        for (target, blob) in entries {
+            for annotation in &blob.annotations {
+                if annotation.status == AnnotationStatus::Superseded {
+                    continue;
+                }
+                let result = pull_one_annotation(
+                    repo,
+                    repo_path,
+                    &head_state,
+                    target,
+                    annotation,
+                    self_local_attr.as_deref(),
+                    username.as_deref(),
+                    &mut mirror,
+                );
+                save_mirror(&heddle_dir, &mirror)?;
+                match result {
+                    Ok(true) => changed += 1,
+                    Ok(false) => {}
+                    Err(error) => {
+                        eprintln!(
+                            "{} hosted context {}: {error:#}",
+                            crate::cli::style::warn_marker(),
+                            annotation.annotation_id
+                        );
+                    }
+                }
+            }
+        }
+        return Ok(changed);
+    }
+
+    let server = list_server_targets(client, repo_path).await?;
     for (target, annotation) in server {
-        let result = pull_one(
+        let result = pull_one_rpc(
             repo,
             client,
             repo_path,
@@ -788,7 +818,7 @@ pub async fn pull_context(
 }
 
 #[allow(clippy::too_many_arguments)]
-async fn pull_one(
+async fn pull_one_rpc(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
@@ -799,9 +829,42 @@ async fn pull_one(
     username: Option<&str>,
     mirror: &mut HostedContextMirror,
 ) -> Result<bool> {
-    let local_id =
-        local_id_for_server(mirror, repo_path, &server.id).unwrap_or_else(|| server.id.clone());
     let server_revs = fetch_history(client, repo_path, &server.id).await?;
+    let annotation = Annotation {
+        annotation_id: server.id.clone(),
+        scope: scope_from_proto(server.scope.as_ref()),
+        status: status_from_proto(server.status),
+        revisions: server_revs,
+        supersedes_annotation_id: server.supersedes_annotation_id.clone(),
+        supersedes_rewrite_pct: server.supersedes_rewrite_pct,
+        visibility: objects::object::VisibilityTier::default(),
+        resolved_from_discussion: None,
+    };
+    pull_one_annotation(
+        repo,
+        repo_path,
+        head_state,
+        target,
+        &annotation,
+        self_local_attr,
+        username,
+        mirror,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn pull_one_annotation(
+    repo: &Repository,
+    repo_path: &str,
+    head_state: &State,
+    target: &ContextTarget,
+    server: &Annotation,
+    self_local_attr: Option<&str>,
+    username: Option<&str>,
+    mirror: &mut HostedContextMirror,
+) -> Result<bool> {
+    let local_id = local_id_for_server(mirror, repo_path, &server.annotation_id)
+        .unwrap_or_else(|| server.annotation_id.clone());
 
     let context_root = context_root_for_state(repo, head_state)?;
     let mut blob = match &context_root {
@@ -829,7 +892,7 @@ async fn pull_one(
 
     let (new_revisions, new_links) = reconcile_revisions_pull(
         &existing_revisions,
-        &server_revs,
+        &server.revisions,
         &existing_links,
         self_local_attr,
         username,
@@ -837,20 +900,19 @@ async fn pull_one(
 
     {
         let entry = get_or_create_entry(mirror, repo_path, &local_id);
-        entry.server_id = server.id.clone();
+        entry.server_id = server.annotation_id.clone();
         entry.revision_links = new_links;
     }
 
-    let new_status = status_from_proto(server.status);
     let changed = match existing_index {
         Some(index) => {
             let annotation = &mut blob.annotations[index];
             let differs = annotation.revisions != new_revisions
-                || annotation.status != new_status
+                || annotation.status != server.status
                 || annotation.supersedes_annotation_id != server.supersedes_annotation_id
                 || annotation.supersedes_rewrite_pct != server.supersedes_rewrite_pct;
             annotation.revisions = new_revisions;
-            annotation.status = new_status;
+            annotation.status = server.status;
             annotation.supersedes_annotation_id = server.supersedes_annotation_id.clone();
             annotation.supersedes_rewrite_pct = server.supersedes_rewrite_pct;
             differs
@@ -858,13 +920,13 @@ async fn pull_one(
         None => {
             blob.annotations.push(Annotation {
                 annotation_id: local_id.clone(),
-                scope: scope_from_proto(server.scope.as_ref()),
-                status: new_status,
+                scope: server.scope.clone(),
+                status: server.status,
                 revisions: new_revisions,
                 supersedes_annotation_id: server.supersedes_annotation_id.clone(),
                 supersedes_rewrite_pct: server.supersedes_rewrite_pct,
-                visibility: objects::object::VisibilityTier::default(),
-                resolved_from_discussion: None,
+                visibility: server.visibility.clone(),
+                resolved_from_discussion: server.resolved_from_discussion.clone(),
             });
             true
         }

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -10,9 +10,9 @@
 //!   symbol-anchored discussion turns *we authored* to the server via the
 //!   caller-authenticated `OpenDiscussion` / `AppendTurn` RPCs (enforce-mode
 //!   signed). #549 rejects attachments in the pack, so they cannot ride it.
-//! * **Pull/clone (read path):** after a successful clone/pull, `ListByState`
-//!   the head state's discussions and materialize any turns we do not already
-//!   hold into the local op-log so `discuss list` / `discuss show` see them.
+//! * **Pull/clone (read path):** after a successful clone/pull, consume the
+//!   pull bootstrap's discussions when present, falling back to `ListByState`
+//!   for older servers, and materialize unseen turns into the local op-log.
 //!
 //! ## Turn identity
 //!
@@ -74,8 +74,9 @@ use objects::{
     fs_atomic::write_file_atomic,
     object::{
         Attribution, CollabOpId, CollaborationAnchor, CollaborationIdempotencyKey,
-        CollaborationOperationBodyV1, CollaborationOperationEnvelope, DiscussionRecordId,
-        DiscussionTurnV1, MaterializedDiscussion, Principal, StateId, VisibilityTier,
+        CollaborationOperationBodyV1, CollaborationOperationEnvelope, Discussion,
+        DiscussionRecordId, DiscussionTurnV1, MaterializedDiscussion, Principal, StateId,
+        VisibilityTier,
     },
     store::ObjectStore,
 };
@@ -431,6 +432,7 @@ pub async fn pull_discussions(
     repo: &Repository,
     client: &mut HostedClient,
     repo_path: &str,
+    bootstrap: Option<&[Discussion]>,
 ) -> Result<usize> {
     // Hosted discussions arrive as server-minted `Discussions` state-attachments
     // on the pulled objects. Those are the transport form of what we
@@ -454,10 +456,17 @@ pub async fn pull_discussions(
     };
     let change_id = state.change_id;
 
-    let hosted = client
-        .list_discussions_by_state(repo_path, change_id, "all")
-        .await
-        .context("list hosted discussions")?;
+    let hosted = match bootstrap {
+        Some(discussions) => discussions
+            .iter()
+            .cloned()
+            .map(hosted_discussion_from_bootstrap)
+            .collect(),
+        None => client
+            .list_discussions_by_state(repo_path, change_id, "all")
+            .await
+            .context("list hosted discussions")?,
+    };
     if hosted.is_empty() {
         return Ok(0);
     }
@@ -495,6 +504,26 @@ pub async fn pull_discussions(
     }
 
     Ok(changed)
+}
+
+fn hosted_discussion_from_bootstrap(discussion: Discussion) -> HostedDiscussion {
+    HostedDiscussion {
+        id: discussion.id,
+        file: discussion.anchor.file,
+        symbol: discussion.anchor.symbol,
+        opened_against_state: Some(discussion.opened_against_state),
+        visibility: discussion.visibility.as_str().to_string(),
+        turns: discussion
+            .turns
+            .into_iter()
+            .map(|turn| HostedDiscussionTurn {
+                author_name: turn.author.name,
+                author_email: turn.author.email,
+                body: turn.body,
+                posted_at_secs: turn.posted_at,
+            })
+            .collect(),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -62,6 +62,7 @@ pub use methods::HostedRoutes;
 use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
 pub use sync::HostedRefEntry;
+pub(crate) use sync::decode_pull_bootstrap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RenewableAuthorityCredential {

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -24,7 +24,10 @@ use api::heddle::api::v1alpha1::{
 };
 use objects::{
     Progress,
-    object::{ContentHash, MarkerName, StateId, ThreadName},
+    object::{
+        AnnotationStatus, ContentHash, ContextBlob, ContextTarget, Discussion, DiscussionsBlob,
+        MarkerName, StateAttachmentBody, StateAttachmentKind, StateId, ThreadName,
+    },
     store::{AnyStore, ObjectStore, PackObjectId, SnapshotCommitDescriptor},
 };
 use repo::{
@@ -57,6 +60,140 @@ struct PullOptions<'a> {
     depth: Option<u32>,
     target_state: Option<StateId>,
     materialization: PullMaterialization,
+}
+
+const PULL_BOOTSTRAP_LINE_PREFIX: &str = "heddle-pull-bootstrap-v1:";
+type PullBootstrapPayload = (
+    bool,
+    Vec<Discussion>,
+    bool,
+    Vec<(ContextTarget, ContextBlob)>,
+);
+
+#[derive(Debug, Clone)]
+pub(crate) struct PullBootstrapMetadata {
+    discussions_from_pack: bool,
+    pub discussions: Vec<Discussion>,
+    context_from_pack: bool,
+    pub context: Vec<(ContextTarget, ContextBlob)>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ResolvedPullBootstrapMetadata {
+    pub discussions: Vec<Discussion>,
+    pub context: Vec<(ContextTarget, ContextBlob)>,
+}
+
+impl PullBootstrapMetadata {
+    pub(crate) fn resolve(
+        &self,
+        repo: &Repository,
+        state_id: Option<StateId>,
+    ) -> Result<ResolvedPullBootstrapMetadata, ProtocolError> {
+        let state_id = state_id.ok_or_else(|| {
+            ProtocolError::InvalidState("pull bootstrap is missing its final state".to_string())
+        })?;
+        let discussions = if self.discussions_from_pack {
+            discussions_from_pull_pack(repo, state_id)?
+        } else {
+            self.discussions.clone()
+        };
+        let context = if self.context_from_pack {
+            context_from_pull_pack(repo, state_id)?
+        } else {
+            self.context.clone()
+        };
+        Ok(ResolvedPullBootstrapMetadata {
+            discussions,
+            context,
+        })
+    }
+}
+
+pub(crate) fn decode_pull_bootstrap(
+    checkpoint: &[u8],
+) -> Result<Option<PullBootstrapMetadata>, ProtocolError> {
+    let checkpoint = std::str::from_utf8(checkpoint)
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    let Some(payload) = checkpoint
+        .lines()
+        .find_map(|line| line.strip_prefix(PULL_BOOTSTRAP_LINE_PREFIX))
+    else {
+        return Ok(None);
+    };
+    let payload = payload
+        .split_once('\t')
+        .map(|(payload, _)| payload)
+        .ok_or_else(|| {
+            ProtocolError::InvalidState("decode pull bootstrap: missing sentinel state".to_string())
+        })?;
+    let payload = hex::decode(payload)
+        .map_err(|error| ProtocolError::InvalidState(format!("decode pull bootstrap: {error}")))?;
+    let (discussions_from_pack, discussions, context_from_pack, context): PullBootstrapPayload =
+        rmp_serde::from_slice(&payload).map_err(|error| {
+            ProtocolError::InvalidState(format!("decode pull bootstrap: {error}"))
+        })?;
+    Ok(Some(PullBootstrapMetadata {
+        discussions_from_pack,
+        discussions,
+        context_from_pack,
+        context,
+    }))
+}
+
+fn discussions_from_pull_pack(
+    repo: &Repository,
+    state_id: StateId,
+) -> Result<Vec<Discussion>, ProtocolError> {
+    let Some(attachment) =
+        repo.latest_state_attachment(&state_id, StateAttachmentKind::Discussions)?
+    else {
+        return Err(ProtocolError::InvalidState(
+            "pull bootstrap advertised packed discussions but the attachment is missing"
+                .to_string(),
+        ));
+    };
+    let StateAttachmentBody::Discussions(hash) = attachment.body else {
+        return Err(ProtocolError::InvalidState(
+            "packed discussions attachment has the wrong kind".to_string(),
+        ));
+    };
+    let blob = repo.store().get_blob(&hash)?.ok_or_else(|| {
+        ProtocolError::InvalidState(format!(
+            "packed discussions attachment references missing blob {hash}"
+        ))
+    })?;
+    DiscussionsBlob::decode(blob.content())
+        .map(|blob| blob.discussions)
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))
+}
+
+fn context_from_pull_pack(
+    repo: &Repository,
+    state_id: StateId,
+) -> Result<Vec<(ContextTarget, ContextBlob)>, ProtocolError> {
+    let Some(attachment) = repo.latest_state_attachment(&state_id, StateAttachmentKind::Context)?
+    else {
+        return Err(ProtocolError::InvalidState(
+            "pull bootstrap advertised packed context but the attachment is missing".to_string(),
+        ));
+    };
+    let StateAttachmentBody::Context(root) = attachment.body else {
+        return Err(ProtocolError::InvalidState(
+            "packed context attachment has the wrong kind".to_string(),
+        ));
+    };
+    let mut entries = repo
+        .list_context_entries(&root, None)?
+        .into_iter()
+        .map(|entry| (entry.target, entry.blob))
+        .collect::<Vec<_>>();
+    for (_, blob) in &mut entries {
+        blob.annotations
+            .retain(|annotation| annotation.status == AnnotationStatus::Active);
+    }
+    entries.retain(|(_, blob)| !blob.annotations.is_empty());
+    Ok(entries)
 }
 
 struct PullWantPlan {
@@ -2349,22 +2486,178 @@ fn apply_marker_snapshot(repo: &Repository, checkpoint: &[u8]) -> Result<bool, P
         };
         let state_id =
             StateId::parse(state_id).map_err(|err| ProtocolError::InvalidState(err.to_string()))?;
-        if !repo.store().has_state(&state_id)? {
-            continue;
-        }
-        let name = MarkerName::from(name);
-        match repo.refs().get_marker(&name)? {
-            Some(existing) if existing == state_id => {}
-            Some(existing) => repo.set_marker_recorded_cas(
-                &name,
-                refs::RefExpectation::Value(existing),
-                &state_id,
-            )?,
-            None => repo.create_marker_recorded(&name, &state_id)?,
-        }
+        apply_marker_entry(repo, name, state_id)?;
     }
 
     Ok(true)
+}
+
+fn apply_marker_entry(
+    repo: &Repository,
+    name: &str,
+    state_id: StateId,
+) -> Result<(), ProtocolError> {
+    if !repo.store().has_state(&state_id)? {
+        return Ok(());
+    }
+    let name = MarkerName::from(name);
+    match repo.refs().get_marker(&name)? {
+        Some(existing) if existing == state_id => {}
+        Some(existing) => {
+            repo.set_marker_recorded_cas(&name, refs::RefExpectation::Value(existing), &state_id)?
+        }
+        None => repo.create_marker_recorded(&name, &state_id)?,
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod pull_bootstrap_tests {
+    use chrono::Utc;
+    use objects::object::{
+        Annotation, AnnotationKind, AnnotationScope, Attribution, Blob, DiscussionResolution,
+        DiscussionTurn, Principal, StateAttachment, SymbolAnchor, VisibilityTier,
+    };
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn bootstrap_decoder_accepts_structured_empty_metadata_and_old_server_falls_back() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("README.md"), "bootstrap\n").expect("write fixture");
+        let snapshot = repo
+            .snapshot(Some("bootstrap marker".to_string()), None)
+            .expect("snapshot");
+        let payload = rmp_serde::to_vec_named(&(
+            true,
+            Vec::<Discussion>::new(),
+            true,
+            Vec::<(ContextTarget, ContextBlob)>::new(),
+        ))
+        .expect("encode server-compatible pull bootstrap");
+        let checkpoint = format!(
+            "heddle-markers-v1\nrelease\t{}\n{PULL_BOOTSTRAP_LINE_PREFIX}{}\t{}\n",
+            snapshot.state_id.to_string_full(),
+            hex::encode(payload),
+            StateId::from_bytes([0; 32]).to_string_full()
+        );
+
+        let decoded = decode_pull_bootstrap(checkpoint.as_bytes())
+            .expect("decode pull bootstrap")
+            .expect("new-server header must select bootstrap metadata");
+        assert!(decoded.discussions.is_empty());
+        assert!(decoded.context.is_empty());
+        assert!(
+            apply_marker_snapshot(&repo, checkpoint.as_bytes())
+                .expect("the legacy marker parser accepts the additive ASCII line")
+        );
+        assert_eq!(
+            repo.refs()
+                .get_marker(&MarkerName::from("release"))
+                .expect("read marker"),
+            Some(snapshot.state_id)
+        );
+        assert!(
+            decode_pull_bootstrap(b"heddle-markers-v1\n")
+                .expect("legacy checkpoint is valid")
+                .is_none(),
+            "an old server must retain the unary metadata fallback"
+        );
+    }
+
+    #[test]
+    fn malformed_advertised_bootstrap_fails_loud() {
+        let error = decode_pull_bootstrap(
+            format!(
+                "heddle-markers-v1\nheddle-pull-bootstrap-v1:not-hex\t{}\n",
+                StateId::from_bytes([0; 32]).to_string_full()
+            )
+            .as_bytes(),
+        )
+        .expect_err("advertised but malformed metadata must not silently fall back");
+        assert!(error.to_string().contains("decode pull bootstrap"));
+    }
+
+    #[test]
+    fn packed_bootstrap_resolves_the_same_discussion_and_context_domain_content() {
+        let temp = TempDir::new().expect("temp repo");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        std::fs::write(temp.path().join("lib.rs"), "pub fn run() {}\n").expect("write source");
+        let snapshot = repo
+            .snapshot(Some("seed".to_string()), None)
+            .expect("snapshot");
+        let principal = Principal::new("Ada", "ada@example.com");
+        let discussion = Discussion {
+            id: "discussion-1".to_string(),
+            anchor: SymbolAnchor::new("lib.rs", "run"),
+            opened_against_state: snapshot.state_id,
+            opened_at: 1_700_000_000,
+            thread_ref: None,
+            turns: vec![DiscussionTurn {
+                author: principal.clone(),
+                body: "keep this invariant".to_string(),
+                posted_at: 1_700_000_001,
+            }],
+            resolution: DiscussionResolution::Open,
+            body_changed_since_open: false,
+            orphaned: false,
+            visibility: VisibilityTier::Public,
+            resolved_annotation_id: None,
+        };
+        let discussions_blob = DiscussionsBlob::new(vec![discussion.clone()]);
+        let discussions_hash = repo
+            .store()
+            .put_blob(&Blob::from(
+                discussions_blob.encode().expect("encode discussions"),
+            ))
+            .expect("store discussions");
+        repo.put_state_attachment(&StateAttachment {
+            state_id: snapshot.state_id,
+            body: StateAttachmentBody::Discussions(discussions_hash),
+            attribution: Attribution::human(principal.clone()),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach discussions");
+
+        let target = ContextTarget::file("lib.rs").expect("context target");
+        let annotation = Annotation::new(
+            AnnotationScope::File,
+            AnnotationKind::Invariant,
+            "run remains public".to_string(),
+            vec!["contract".to_string()],
+            principal.to_string(),
+            1_700_000_002,
+            None,
+            Some(snapshot.state_id),
+        );
+        let context_blob = ContextBlob::new(vec![annotation.clone()]);
+        let context_root = repo
+            .set_context_blob(None, &target, &context_blob)
+            .expect("store context");
+        repo.put_state_attachment(&StateAttachment {
+            state_id: snapshot.state_id,
+            body: StateAttachmentBody::Context(context_root),
+            attribution: Attribution::human(principal),
+            created_at: Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach context");
+
+        let resolved = PullBootstrapMetadata {
+            discussions_from_pack: true,
+            discussions: Vec::new(),
+            context_from_pack: true,
+            context: Vec::new(),
+        }
+        .resolve(&repo, Some(snapshot.state_id))
+        .expect("resolve packed bootstrap");
+
+        assert_eq!(resolved.discussions, vec![discussion]);
+        assert_eq!(resolved.context, vec![(target, context_blob)]);
+    }
 }
 
 fn state_id_string_to_bytes(s: &str) -> Vec<u8> {


### PR DESCRIPTION
## Summary

- Decode and resolve the additive pull-bootstrap metadata after the native pack is installed, then feed the same discussion/context reconciliation paths without issuing unary reads.
- Apply the seam to hosted clone and ordinary hosted pull.
- Preserve compatibility in both directions: malformed advertised metadata fails loud, while a missing extension from an older server falls back to ListByState, ListContext, and GetContextHistory.
- Preserve legacy marker parsing by treating the versioned bootstrap extension as an ignorable valid marker line for older clients.

Pairs with HeddleCo/weft#1041.

## Test evidence

Pilot A/B used both release-built sides against org/rnd/shuttle with the weft #1025 Tempo spans and statement-shape counters. The demonstrated-red run reverted this client fold while retaining the new server.

| Path | RPCs | server wall | statement-shape queries | SQL wall |
|---|---:|---:|---:|---:|
| Red ListByState | 1 | 1,358.361 ms | 10 | 466.566 ms |
| Red ListContext | 1 | 1,763.678 ms | 12 | 469.860 ms |
| Red GetContextHistory | 1 | 2,033.249 ms | 13 | 636.779 ms |
| Red total | 3 | 5,155.288 ms | 35 | 1,573.205 ms |
| Folded post-pull total | 0 | 0 ms | 0 | 0 ms |

The 20 ms post-pull metadata band passes at 0 ms. Total client wall was 25.17 s red versus 3.99 s folded. The consolidated server bootstrap measured 728.237 ms inside Pull and introduced no post-pull round trip.

Differential content was byte-identical after canonical JSON sorting: discussions SHA-256 f56e251458e1b1f0f903c6d1bf1962f6f9b0bbe5caced67bd43358d56e68e4b1 (0 items), context SHA-256 0214edd6581d3ac1c81b2631b17e9bcc284b834a48618b45794ab97785651b92 (1 active item). Both clones reported clean at hs-v64whfx1kb8vqd1.

- Default CLI build, clippy, full tests, and default CLI contract script: pass.
- No-default git-overlay/native/client/semantic/zstd checks: pass.
- Telemetry build, clippy, heddle-cli + heddle-cli-shared tests: pass.
- Pull bootstrap fallback, legacy parser, malformed payload, and packed-domain differential tests: pass.
- Nightly rustfmt on touched Rust files and git diff --check: pass.

Refs HeddleCo/weft#1026
Refs HeddleCo/weft#1024

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788427958&installation_model_id=21489&pr_number=1235&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1235&signature=f7f14f853dcc0e1a15ebc1818abbd1517a4c735587d5e6ea034f6bee7a2e080c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->