### PR TITLE
perf(clone): consume refs from clone bootstrap

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1571,52 +1571,114 @@ async fn clone_network_connected(
         println!("Connected to {}", addr);
     }
 
-    let remote_refs = client
-        .list_refs_with_revision_addresses(repo_path)
-        .await?
-        .into_iter()
-        .filter(|entry| entry.is_thread)
-        .collect::<Vec<_>>();
-    let track_name = select_hosted_clone_thread(
-        thread.as_deref(),
-        remote_refs.iter().map(|entry| entry.name.as_str()),
-        repo_path,
-    )?;
-    let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
-        .is_some_and(|address| address.starts_with("git:"));
-
     let mut cleanup = CloneDestinationCleanup::new(local_path);
-
-    // Create the local directory only after TLS/auth prevalidation and remote
-    // ref discovery. Git-backed hosted refs need `.git` present before
-    // Repository::init so the destination is opened as Git-overlay and accepts
-    // the Git lane transfers during pull.
-    fs::create_dir_all(local_path)?;
-    if git_overlay_clone {
-        SleyRepository::init(local_path).map_err(anyhow::Error::msg)?;
-    }
-
-    // Initialize the local repository only after TLS/auth prevalidation.
-    let local_repo = Repository::init(local_path)?;
-    let origin_url = hosted_clone_origin_url(&endpoint_spec, repo_path);
-    if git_overlay_clone {
-        configure_git_overlay_origin(local_path, &origin_url)?;
-    }
     let materialization = if lazy {
         PullMaterialization::Lazy
     } else {
         PullMaterialization::Full
     };
-    let result = client
-        .pull_with_depth_and_materialization(
-            &local_repo,
+    let mut folded_refs = None;
+    let folded = client
+        .clone_pull_with_depth_and_materialization(
             repo_path,
-            &track_name,
-            Some(&track_name),
+            thread.as_deref(),
             depth,
             materialization,
+            |ready| {
+                let checkpoint = ready
+                    .transfer
+                    .as_ref()
+                    .map(|transfer| transfer.checkpoint.as_slice())
+                    .unwrap_or_default();
+                let refs = crate::hosted_runtime::hosted::decode_pull_refs(checkpoint)?
+                    .ok_or_else(|| {
+                        wire::ProtocolError::InvalidState(
+                            "server does not advertise folded clone refs".to_string(),
+                        )
+                    })?;
+                let track_name = select_hosted_clone_thread(
+                    thread.as_deref(),
+                    refs.refs
+                        .iter()
+                        .filter(|entry| entry.is_thread)
+                        .map(|entry| entry.name.as_str()),
+                    repo_path,
+                )
+                .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
+                let git_overlay_clone =
+                    hosted_clone_thread_revision_address(&refs.refs, &track_name)
+                        .is_some_and(|address| address.starts_with("git:"));
+                fs::create_dir_all(local_path)
+                    .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
+                if git_overlay_clone {
+                    SleyRepository::init(local_path)
+                        .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
+                }
+                let repo = Repository::init(local_path).map_err(wire::ProtocolError::from)?;
+                folded_refs = Some(refs.refs);
+                Ok(repo)
+            },
         )
-        .await?;
+        .await;
+    let (result, local_repo, remote_refs) = match folded {
+        Ok((result, local_repo)) => (
+            result,
+            local_repo,
+            folded_refs.context("folded clone response is missing its refs")?,
+        ),
+        Err(error) if !local_path.join(".heddle").exists() && !local_path.join(".git").exists() => {
+            let remote_refs = client
+                .list_refs_with_revision_addresses(repo_path)
+                .await?
+                .into_iter()
+                .filter(|entry| entry.is_thread)
+                .collect::<Vec<_>>();
+            let track_name = select_hosted_clone_thread(
+                thread.as_deref(),
+                remote_refs.iter().map(|entry| entry.name.as_str()),
+                repo_path,
+            )?;
+            let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
+                .is_some_and(|address| address.starts_with("git:"));
+            fs::create_dir_all(local_path)?;
+            if git_overlay_clone {
+                SleyRepository::init(local_path).map_err(anyhow::Error::msg)?;
+            }
+            let local_repo = Repository::init(local_path)?;
+            let result = client
+                .pull_with_depth_and_materialization(
+                    &local_repo,
+                    repo_path,
+                    &track_name,
+                    Some(&track_name),
+                    depth,
+                    materialization,
+                )
+                .await
+                .map_err(|fallback| {
+                    let error = format!(
+                        "folded clone bootstrap failed ({error}); ListRefs fallback failed ({fallback})"
+                    );
+                    anyhow!(RecoveryAdvice::network_clone_failed(&error, local_path))
+                })?;
+            (result, local_repo, remote_refs)
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let track_name = select_hosted_clone_thread(
+        thread.as_deref(),
+        remote_refs
+            .iter()
+            .filter(|entry| entry.is_thread)
+            .map(|entry| entry.name.as_str()),
+        repo_path,
+    )?;
+    let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
+        .is_some_and(|address| address.starts_with("git:"));
+    let origin_url = hosted_clone_origin_url(&endpoint_spec, repo_path);
+    if git_overlay_clone {
+        configure_git_overlay_origin(local_path, &origin_url)?;
+    }
     let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
         .context("decode hosted clone bootstrap")?;
     let bootstrap = if result.success {

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -62,7 +62,7 @@ pub use methods::HostedRoutes;
 use prost::Message;
 pub use session::{HostedAuthMode, HostedSession};
 pub use sync::HostedRefEntry;
-pub(crate) use sync::decode_pull_bootstrap;
+pub(crate) use sync::{decode_pull_bootstrap, decode_pull_refs};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct RenewableAuthorityCredential {

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -14,8 +14,8 @@ use api::heddle::api::v1alpha1::{
     GitRefKind as ProtoGitRefKind, GitRefUpdateTransfer,
     IntegrationPolicyStatus as ProtoIntegrationPolicyStatus, ListRefsRequest,
     ObjectAvailabilityStatus, ObjectDescriptor, PackChunk, PackStreamKind, PartialFetchStatus,
-    ProviderPlanChallenge, PullClientFrame, PullRequest, PullServerFrame, PushClientFrame,
-    PushRequest, PushServerFrame, RedactionTransfer, StateAttachmentTransfer,
+    ProviderPlanChallenge, PullClientFrame, PullReady, PullRequest, PullServerFrame,
+    PushClientFrame, PushRequest, PushServerFrame, RedactionTransfer, StateAttachmentTransfer,
     StateVisibilityTransfer, StreamOpeningProof, ThreadConfidenceSummary,
     ThreadFreshness as ProtoThreadFreshness, ThreadIntegrationPolicy, ThreadMetadata,
     ThreadMode as ProtoThreadMode, ThreadVerificationSummary, TransportMode, UpdateRefRequest,
@@ -63,12 +63,21 @@ struct PullOptions<'a> {
 }
 
 const PULL_BOOTSTRAP_LINE_PREFIX: &str = "heddle-pull-bootstrap-v1:";
+const PULL_REFS_LINE_PREFIX: &str = "heddle-pull-refs-v1:";
+const PULL_CLONE_BOOTSTRAP_THREAD_PREFIX: &str = "heddle-clone-bootstrap-v1:";
 type PullBootstrapPayload = (
     bool,
     Vec<Discussion>,
     bool,
     Vec<(ContextTarget, ContextBlob)>,
 );
+type PullRefsPayload = (
+    String,
+    Option<Vec<u8>>,
+    Vec<(String, Vec<u8>, bool, String)>,
+);
+type PullRepositoryInitializer<'a> =
+    Box<dyn FnOnce(&PullReady) -> Result<Repository, ProtocolError> + 'a>;
 
 #[derive(Debug, Clone)]
 pub(crate) struct PullBootstrapMetadata {
@@ -82,6 +91,11 @@ pub(crate) struct PullBootstrapMetadata {
 pub(crate) struct ResolvedPullBootstrapMetadata {
     pub discussions: Vec<Discussion>,
     pub context: Vec<(ContextTarget, ContextBlob)>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct PullBootstrapRefs {
+    pub refs: Vec<HostedRefEntry>,
 }
 
 impl PullBootstrapMetadata {
@@ -139,6 +153,56 @@ pub(crate) fn decode_pull_bootstrap(
         context_from_pack,
         context,
     }))
+}
+
+pub(crate) fn decode_pull_refs(
+    checkpoint: &[u8],
+) -> Result<Option<PullBootstrapRefs>, ProtocolError> {
+    let checkpoint = std::str::from_utf8(checkpoint)
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    let Some(payload) = checkpoint
+        .lines()
+        .find_map(|line| line.strip_prefix(PULL_REFS_LINE_PREFIX))
+    else {
+        return Ok(None);
+    };
+    let payload = payload
+        .split_once('\t')
+        .map(|(payload, _)| payload)
+        .ok_or_else(|| {
+            ProtocolError::InvalidState("decode pull refs: missing sentinel state".to_string())
+        })?;
+    let payload = hex::decode(payload)
+        .map_err(|error| ProtocolError::InvalidState(format!("decode pull refs: {error}")))?;
+    let (_head_thread, head_state, refs): PullRefsPayload = rmp_serde::from_slice(&payload)
+        .map_err(|error| ProtocolError::InvalidState(format!("decode pull refs: {error}")))?;
+    let head_state = head_state
+        .map(|value| decode_bootstrap_state_id(value, "head state"))
+        .transpose()?;
+    let refs = refs
+        .into_iter()
+        .map(|(name, state_id, is_thread, revision_address)| {
+            let state_id = decode_bootstrap_state_id(state_id, "ref state")?;
+            Ok(HostedRefEntry {
+                name,
+                state_id,
+                is_thread,
+                revision_address,
+            })
+        })
+        .collect::<Result<Vec<_>, ProtocolError>>()?;
+    let _ = head_state;
+    Ok(Some(PullBootstrapRefs { refs }))
+}
+
+fn decode_bootstrap_state_id(value: Vec<u8>, field: &str) -> Result<StateId, ProtocolError> {
+    let value: [u8; 32] = value.try_into().map_err(|value: Vec<u8>| {
+        ProtocolError::InvalidState(format!(
+            "decode pull refs {field}: expected 32 bytes, got {}",
+            value.len()
+        ))
+    })?;
+    Ok(StateId::from_bytes(value))
 }
 
 fn discussions_from_pull_pack(
@@ -1145,6 +1209,41 @@ impl HostedClient {
         .await
     }
 
+    pub async fn clone_pull_with_depth_and_materialization<F>(
+        &mut self,
+        repo_path: &str,
+        requested_thread: Option<&str>,
+        depth: Option<u32>,
+        materialization: PullMaterialization,
+        initialize: F,
+    ) -> Result<(PullComplete, Repository), ProtocolError>
+    where
+        F: FnOnce(&PullReady) -> Result<Repository, ProtocolError>,
+    {
+        let remote_thread = format!(
+            "{PULL_CLONE_BOOTSTRAP_THREAD_PREFIX}{}",
+            requested_thread.unwrap_or_default()
+        );
+        let (exchange, repo) = self
+            .pull_exchange_inner(
+                None,
+                repo_path,
+                &remote_thread,
+                PullOptions {
+                    local_thread: None,
+                    depth,
+                    target_state: None,
+                    materialization,
+                },
+                Some(Box::new(initialize)),
+            )
+            .await?;
+        let repo = repo.ok_or_else(|| {
+            ProtocolError::InvalidState("clone pull did not initialize its repository".to_string())
+        })?;
+        Ok((exchange.result, repo))
+    }
+
     pub async fn pull_with_depth(
         &mut self,
         repo: &Repository,
@@ -1276,6 +1375,19 @@ impl HostedClient {
         remote_thread: &str,
         options: PullOptions<'_>,
     ) -> Result<PullExchange, ProtocolError> {
+        self.pull_exchange_inner(Some(repo), repo_path, remote_thread, options, None)
+            .await
+            .map(|(exchange, _)| exchange)
+    }
+
+    async fn pull_exchange_inner<'a>(
+        &mut self,
+        initial_repo: Option<&Repository>,
+        repo_path: &str,
+        remote_thread: &str,
+        options: PullOptions<'_>,
+        initializer: Option<PullRepositoryInitializer<'a>>,
+    ) -> Result<(PullExchange, Option<Repository>), ProtocolError> {
         let exchange_start = Instant::now();
         let mut exclude_states = Vec::new();
         // Whether the head comes from an explicit `--local-thread` or is
@@ -1288,17 +1400,23 @@ impl HostedClient {
         // incomplete repo. Both branches therefore share the same completeness
         // gate; when it refuses, we fall back to the correct (slower)
         // empty-exclude full pull.
-        let advertised_head = if let Some(local_thread) = options.local_thread {
-            locally_complete_local_thread_head(repo, local_thread, options.target_state)?
+        let advertised_head = if let Some(repo) = initial_repo {
+            if let Some(local_thread) = options.local_thread {
+                locally_complete_local_thread_head(repo, local_thread, options.target_state)?
+            } else {
+                locally_complete_pull_head(repo, remote_thread, options.target_state)?
+            }
         } else {
-            locally_complete_pull_head(repo, remote_thread, options.target_state)?
+            None
         };
         if let Some(head) = advertised_head {
             exclude_states.push(head);
         }
         let allow_partial_fetch = options.materialization.allows_partial_fetch();
-        let fresh_full_pull =
-            supports_compact_full_pull(repo, allow_partial_fetch, &exclude_states)?;
+        let fresh_full_pull = match initial_repo {
+            Some(repo) => supports_compact_full_pull(repo, allow_partial_fetch, &exclude_states)?,
+            None => !allow_partial_fetch,
+        };
 
         let transfer_id = pull_transfer_id(
             repo_path,
@@ -1331,7 +1449,9 @@ impl HostedClient {
                     0,
                     false,
                 )),
-                partial_fetch_status: partial_fetch_status_for_repo(repo),
+                partial_fetch_status: initial_repo
+                    .map(partial_fetch_status_for_repo)
+                    .unwrap_or(PartialFetchStatus::Disabled as i32),
                 allow_partial_fetch,
                 fresh_full_pull,
                 target_revision_address: options
@@ -1386,6 +1506,17 @@ impl HostedClient {
             ready_wait: exchange_start.elapsed(),
             ..PullProfile::default()
         };
+        let owned_repo = match initial_repo {
+            Some(_) => None,
+            None => Some(initializer.ok_or_else(|| {
+                ProtocolError::InvalidState(
+                    "pull is missing its repository initializer".to_string(),
+                )
+            })?(&ready)?),
+        };
+        let repo = initial_repo.or(owned_repo.as_ref()).ok_or_else(|| {
+            ProtocolError::InvalidState("pull repository initialization failed".to_string())
+        })?;
         let remote_state = super::helpers::parse_proto_state_id(ready.remote_state)?
             .ok_or_else(|| ProtocolError::InvalidState("missing remote state".to_string()))?;
         let advertised_object_count = ready.objects_to_fetch.len();
@@ -1773,11 +1904,60 @@ impl HostedClient {
                         }
                         profile.metadata_sync = metadata_start.elapsed();
                         profile.objects_received = received;
-                        return Ok(PullExchange {
+                        return Ok((
+                            PullExchange {
+                                result: PullComplete {
+                                    success: true,
+                                    final_state,
+                                    error: None,
+                                    transfer_id: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| transfer.transfer_id.clone())
+                                        .unwrap_or_default(),
+                                    transport_mode: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| {
+                                            transport_mode_name(transfer.transport_mode)
+                                        })
+                                        .unwrap_or("native-pack")
+                                        .to_string(),
+                                    resume_offset: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| transfer.resume_offset)
+                                        .unwrap_or_default(),
+                                    chunk_index: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| transfer.chunk_index)
+                                        .unwrap_or_default(),
+                                    checkpoint: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| transfer.checkpoint.clone())
+                                        .unwrap_or_default(),
+                                    is_complete: complete
+                                        .transfer
+                                        .as_ref()
+                                        .map(|transfer| transfer.is_complete)
+                                        .unwrap_or(false),
+                                },
+                                object_count: received,
+                                profile,
+                            },
+                            owned_repo,
+                        ));
+                    }
+
+                    profile.objects_received = received;
+                    return Ok((
+                        PullExchange {
                             result: PullComplete {
-                                success: true,
+                                success: false,
                                 final_state,
-                                error: None,
+                                error: (!complete.error.is_empty()).then_some(complete.error),
                                 transfer_id: complete
                                     .transfer
                                     .as_ref()
@@ -1812,50 +1992,9 @@ impl HostedClient {
                             },
                             object_count: received,
                             profile,
-                        });
-                    }
-
-                    profile.objects_received = received;
-                    return Ok(PullExchange {
-                        result: PullComplete {
-                            success: false,
-                            final_state,
-                            error: (!complete.error.is_empty()).then_some(complete.error),
-                            transfer_id: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transfer.transfer_id.clone())
-                                .unwrap_or_default(),
-                            transport_mode: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transport_mode_name(transfer.transport_mode))
-                                .unwrap_or("native-pack")
-                                .to_string(),
-                            resume_offset: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transfer.resume_offset)
-                                .unwrap_or_default(),
-                            chunk_index: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transfer.chunk_index)
-                                .unwrap_or_default(),
-                            checkpoint: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transfer.checkpoint.clone())
-                                .unwrap_or_default(),
-                            is_complete: complete
-                                .transfer
-                                .as_ref()
-                                .map(|transfer| transfer.is_complete)
-                                .unwrap_or(false),
                         },
-                        object_count: received,
-                        profile,
-                    });
+                        owned_repo,
+                    ));
                 }
                 _ => {}
             }
@@ -2578,6 +2717,53 @@ mod pull_bootstrap_tests {
         )
         .expect_err("advertised but malformed metadata must not silently fall back");
         assert!(error.to_string().contains("decode pull bootstrap"));
+    }
+
+    #[test]
+    fn folded_refs_decode_identically_and_old_server_selects_fallback() {
+        let main = StateId::from_bytes([7; 32]);
+        let release = StateId::from_bytes([8; 32]);
+        let payload: PullRefsPayload = (
+            "main".to_string(),
+            Some(main.as_bytes().to_vec()),
+            vec![
+                (
+                    "main".to_string(),
+                    main.as_bytes().to_vec(),
+                    true,
+                    "git:0123456789abcdef".to_string(),
+                ),
+                (
+                    "release".to_string(),
+                    release.as_bytes().to_vec(),
+                    false,
+                    RevisionAddress::heddle(release).to_string(),
+                ),
+            ],
+        );
+        let checkpoint = format!(
+            "{PULL_REFS_LINE_PREFIX}{}\t{}\n",
+            hex::encode(rmp_serde::to_vec_named(&payload).expect("encode refs fixture")),
+            StateId::from_bytes([0; 32]).to_string_full(),
+        );
+
+        let decoded = decode_pull_refs(checkpoint.as_bytes())
+            .expect("decode folded refs")
+            .expect("new server advertises refs");
+        assert_eq!(decoded.refs.len(), 2);
+        assert_eq!(decoded.refs[0].name, "main");
+        assert_eq!(decoded.refs[0].state_id, main);
+        assert!(decoded.refs[0].is_thread);
+        assert_eq!(decoded.refs[0].revision_address, "git:0123456789abcdef");
+        assert_eq!(decoded.refs[1].name, "release");
+        assert_eq!(decoded.refs[1].state_id, release);
+        assert!(!decoded.refs[1].is_thread);
+        assert!(
+            decode_pull_refs(b"heddle-markers-v1\n")
+                .expect("old-server checkpoint remains valid")
+                .is_none(),
+            "absence of folded refs must select the standalone ListRefs fallback"
+        );
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration/clone_output_contract.rs
+++ b/crates/cli/tests/cli_integration/clone_output_contract.rs
@@ -17,12 +17,13 @@ mod fixture {
 
     use api::{
         HOSTED_ALPN_V1,
-        framing::encode_failure_response,
+        framing::{decode_request_prelude, encode_failure_response},
         heddle::api::v1alpha1::{
             CallFailure, CallFailureCode, EndpointDescriptor, SignedEndpointDescriptor,
         },
         signing::endpoint_descriptor_bytes,
     };
+    use biscuit_auth::KeyPair;
     use crypto::{Ed25519Signer, Signer};
     use iroh::{Endpoint, RelayMode, endpoint::presets};
     use prost::Message;
@@ -41,7 +42,7 @@ mod fixture {
     #[test]
     fn clone_json_peer_disconnect_after_connection_emits_structured_error() {
         let temp = TempDir::new().expect("create clone contract fixture root");
-        let (endpoint_id, direct_address, iroh_thread) = disconnecting_iroh_server();
+        let (endpoint_id, direct_address, iroh_thread) = disconnecting_iroh_server(None);
         let signer = Ed25519Signer::generate().expect("generate descriptor signer");
         let descriptor = signed_descriptor(&endpoint_id, &direct_address, &signer);
         let https = TestHttpsServer::start(HashMap::from([(
@@ -108,7 +109,95 @@ mod fixture {
         assert!(!destination.exists());
     }
 
-    fn disconnecting_iroh_server() -> (String, String, thread::JoinHandle<()>) {
+    #[test]
+    fn authenticated_clone_starts_with_folded_pull_instead_of_list_refs() {
+        const PULL: &str = "/heddle.api.v1alpha1.RepoSyncService/Pull";
+
+        let temp = TempDir::new().expect("create folded clone fixture root");
+        let (endpoint_id, direct_address, iroh_thread) = disconnecting_iroh_server(Some(PULL));
+        let signer = Ed25519Signer::generate().expect("generate descriptor signer");
+        let descriptor = signed_descriptor(&endpoint_id, &direct_address, &signer);
+        let https = TestHttpsServer::start(HashMap::from([(
+            DESCRIPTOR_PATH.to_string(),
+            VecDeque::from([descriptor]),
+        )]));
+        let certificate = temp.path().join("descriptor-ca.pem");
+        std::fs::write(&certificate, &https.certificate_pem).expect("write descriptor test CA");
+        let credential = temp.path().join("clone-test.hcred");
+        write_test_credential(&credential, &https.authority);
+        let destination = temp.path().join("clone");
+        let remote = format!("heddle://{}/owner/repo", https.authority);
+        let descriptor_public_key = hex::encode(signer.public_key());
+        let heddle_home = temp.path().join("heddle-home");
+
+        let output = heddle_output_with_env(
+            &[
+                "clone",
+                &remote,
+                destination.to_str().expect("UTF-8 destination"),
+            ],
+            Some(temp.path()),
+            &[
+                (
+                    "HEDDLE_REMOTE_TLS_CA_CERT",
+                    certificate.to_str().expect("UTF-8 CA path"),
+                ),
+                ("HEDDLE_REMOTE_IROH_DESCRIPTOR_KEY_ID", "clone-test-key"),
+                (
+                    "HEDDLE_REMOTE_IROH_DESCRIPTOR_PUBLIC_KEY",
+                    &descriptor_public_key,
+                ),
+                ("HEDDLE_HOME", heddle_home.to_str().expect("UTF-8 home")),
+                (
+                    "HEDDLE_CREDENTIAL",
+                    credential.to_str().expect("UTF-8 credential path"),
+                ),
+            ],
+        )
+        .expect("invoke authenticated clone against route fixture");
+
+        iroh_thread.join().expect("route-check Iroh server exits");
+        assert!(
+            !output.status.success(),
+            "fixture terminates the folded Pull"
+        );
+        assert!(!destination.exists());
+    }
+
+    fn write_test_credential(path: &std::path::Path, server: &str) {
+        let signer = Ed25519Signer::generate().expect("generate credential proof key");
+        let token = biscuit_auth::Biscuit::builder()
+            .fact(r#"user("clone-test")"#)
+            .expect("credential subject fact")
+            .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+            .expect("credential proof-key fact")
+            .build(&KeyPair::new())
+            .expect("mint test credential")
+            .to_base64()
+            .expect("encode test credential");
+        let encoded = serde_json::to_vec_pretty(&serde_json::json!({
+            "format": "heddle-credential",
+            "version": 1,
+            "server": server,
+            "kind": "device",
+            "subject": "clone-test",
+            "token": token,
+            "proof_key_pem": signer.to_pem().expect("encode credential proof key"),
+            "credential_id": null,
+        }))
+        .expect("encode credential file");
+        std::fs::write(path, encoded).expect("write credential file");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+                .expect("restrict credential file permissions");
+        }
+    }
+
+    fn disconnecting_iroh_server(
+        expected_method: Option<&'static str>,
+    ) -> (String, String, thread::JoinHandle<()>) {
         let (ready_tx, ready_rx) = mpsc::sync_channel(1);
         let thread = thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
@@ -136,7 +225,35 @@ mod fixture {
 
                 let incoming = endpoint.accept().await.expect("accept clone connection");
                 let connection = incoming.await.expect("complete clone connection");
-                let (mut send, _recv) = connection.accept_bi().await.expect("accept ListRefs RPC");
+                let (mut send, mut recv) = connection
+                    .accept_bi()
+                    .await
+                    .expect("accept initial Pull RPC");
+                let mut request = vec![0_u8; 70 * 1024];
+                let mut received = 0;
+                let method = loop {
+                    let read = recv
+                        .read(&mut request[received..])
+                        .await
+                        .expect("read clone request prelude")
+                        .expect("clone request ended before its prelude");
+                    received += read;
+                    if let Some((prelude, _)) = decode_request_prelude(&request[..received])
+                        .expect("decode request prelude")
+                    {
+                        break prelude.method.to_string();
+                    }
+                    assert!(
+                        received < request.len(),
+                        "clone request prelude is oversized"
+                    );
+                };
+                if let Some(expected_method) = expected_method {
+                    assert_eq!(
+                        method, expected_method,
+                        "an authenticated clone must start with folded Pull, not ListRefs"
+                    );
+                }
                 let failure = encode_failure_response(&CallFailure {
                     code: CallFailureCode::Unavailable as i32,
                     message: "Broken pipe".to_string(),


### PR DESCRIPTION
## Summary

- consume the versioned ref snapshot from the clone Pull `Ready` checkpoint, eliminating the standalone `ListRefs` RPC against an updated server
- initialize native versus Git-overlay storage only after folded refs arrive, then continue the same Pull stream
- fall back to standalone `ListRefs` plus the existing Pull flow when an older server does not advertise folded refs
- assert on the authenticated wire that clone's first RPC is `RepoSyncService/Pull`

Paired server change: HeddleCo/weft#1044

## Closes

Refs HeddleCo/weft#1027
Refs HeddleCo/weft#1024

## Test evidence

- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli`
  - clone and hosted sync tests pass; the only local failure is the unrelated Codex harness-model assertion expecting `gpt-5.3-codex` while this runner injects `gpt-5.6-sol`
  - the isolated test passes when run with its declared harness model: `HEDDLE_AGENT_PROVIDER=openai HEDDLE_AGENT_MODEL=gpt-5.3-codex`
- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli --test cli_integration clone_output_contract::fixture::authenticated_clone_starts_with_folded_pull_instead_of_list_refs -- --exact --nocapture`
- native and Git-overlay no-default-feature checks pass
- telemetry build, clippy, and tests pass through the same environment-only harness assertion described above
- `TMPDIR=/home/scratch cargo clippy --locked -p heddle-cli --lib --bins --tests --examples -- -D warnings`
- `TMPDIR=/home/scratch bash scripts/check-default-cli-contracts.sh`
- nightly rustfmt applied to every touched Rust file
