### PR TITLE
ci: run GitHub-hosted jobs on Blacksmith

### DIFF
--- a/.github/workflows/api-capability-sync.yml
+++ b/.github/workflows/api-capability-sync.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
       - run: python3 api-capabilities/test_verify_sync.py

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   criterion:
     name: Criterion suite
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 240
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -36,7 +36,7 @@ env:
 jobs:
   facade-render-free:
     name: Facade render-free
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 5
 
     steps:
@@ -60,7 +60,7 @@ jobs:
   #   package_names_csv — selected workspace packages, including reverse dependents.
   changes:
     name: Detect changed paths
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     outputs:
       rust: ${{ steps.decide.outputs.rust }}
@@ -469,7 +469,7 @@ jobs:
       - feature-contracts
       - postgres-tests
     if: ${{ always() }}
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404-arm
     timeout-minutes: 5
     steps:
       - name: Require every extracted quality gate
@@ -592,7 +592,7 @@ jobs:
     name: FUSE mount smoke (Linux)
     needs: changes
     if: needs.changes.outputs.mount == 'true'
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/unwrap-inventory.yml
+++ b/.github/workflows/unwrap-inventory.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   unwrap-inventory:
     name: unwrap-inventory
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 45
     continue-on-error: true
 


### PR DESCRIPTION
## Summary

- Move every exact `runs-on: ubuntu-latest` workflow job to an existing Blacksmith runner so CI can start despite the GitHub-hosted Actions minutes/spending limit.
- `blacksmith-2vcpu-ubuntu-2404` (2-vCPU x64): facade-render-free, changed-path detection, API capability sync, and unwrap inventory.
- `blacksmith-4vcpu-ubuntu-2404-arm` (4-vCPU ARM): the Rust `Check & test` gate.
- `blacksmith-4vcpu-ubuntu-2404` (4-vCPU x64): Criterion benchmarks and the FUSE smoke job, matching their Linux/FUSE requirements.
- This PR's own `ubuntu-latest` checks may fail until the workflow change is merged (chicken-and-egg); an admin merge may be required.

## Closes

Direct CI maintenance request; no tracking issue number was supplied.

## Test evidence

- `git diff --check` passed.
- Verified no exact `runs-on: ubuntu-latest` entries remain under `.github/workflows/`.
- Verified the diff contains only `runs-on` line changes (4 files, 7 replacements).
- `actionlint` was unavailable in the local environment; no Rust tests were needed for runner-only changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788446235&installation_model_id=21489&pr_number=1237&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1237&signature=ec2f7298278d30b028958792f06a26d7651e879a448f0552ec38e54c7b25674c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->