### PR TITLE
fix: normalize legacy Git tree modes on import

### DIFF
--- a/crates/ingest/src/git_walk.rs
+++ b/crates/ingest/src/git_walk.rs
@@ -547,10 +547,11 @@ impl GitSource {
         for entry in entries {
             let kind = match entry.mode {
                 0o040000 => TreeChildKind::Tree,
-                0o100644 => TreeChildKind::Blob { executable: false },
-                0o100755 => TreeChildKind::Blob { executable: true },
                 0o120000 => TreeChildKind::Symlink,
                 0o160000 => TreeChildKind::Gitlink,
+                mode if mode & 0o170000 == 0o100000 => TreeChildKind::Blob {
+                    executable: mode & 0o111 != 0,
+                },
                 mode => {
                     return Err(IngestError::Git(format!(
                         "tree entry {} has unsupported mode {:o}",

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -1447,6 +1447,52 @@ mod tests {
         git_output(path, &["update-ref", "refs/heads/main", &commit], None);
     }
 
+    fn append_git_oid(tree: &mut Vec<u8>, sha: &str) {
+        for pair in sha.as_bytes().chunks_exact(2) {
+            let hex = std::str::from_utf8(pair).expect("Git object id is ASCII");
+            tree.push(u8::from_str_radix(hex, 16).expect("Git object id is hexadecimal"));
+        }
+    }
+
+    fn seed_raw_tree_repo(path: &Path, entries: &[(&str, &str)]) {
+        let status = Command::new("git")
+            .args(["init", "-q", "--initial-branch=main"])
+            .current_dir(path)
+            .env("GIT_CONFIG_GLOBAL", "/dev/null")
+            .env("GIT_CONFIG_SYSTEM", "/dev/null")
+            .status()
+            .expect("git init");
+        assert!(status.success(), "git init failed");
+
+        // Build the raw tree body instead of using `git mktree`: mktree
+        // canonicalizes these historical modes before writing the object.
+        let mut tree_body = Vec::new();
+        for (mode, name) in entries {
+            let blob = git_output(
+                path,
+                &["hash-object", "-w", "--stdin"],
+                Some(format!("{name}\n").as_bytes()),
+            );
+            tree_body.extend_from_slice(format!("{mode} {name}\0").as_bytes());
+            append_git_oid(&mut tree_body, &blob);
+        }
+        let tree = git_output(
+            path,
+            &["hash-object", "--literally", "-w", "-t", "tree", "--stdin"],
+            Some(&tree_body),
+        );
+        let commit = git_output(path, &["commit-tree", &tree, "-m", "legacy modes"], None);
+        git_output(path, &["update-ref", "refs/heads/main", &commit], None);
+    }
+
+    fn seed_noncanonical_mode_repo(path: &Path) {
+        seed_raw_tree_repo(path, &[("100664", "legacy.txt"), ("100775", "run.sh")]);
+    }
+
+    fn seed_unknown_mode_repo(path: &Path) {
+        seed_raw_tree_repo(path, &[("140000", "unknown")]);
+    }
+
     #[test]
     fn imports_commits_refs_and_tag_end_to_end() {
         let gitdir = TempDir::new().unwrap();
@@ -1675,6 +1721,62 @@ mod tests {
             "error explains conversion: {message}"
         );
         assert!(message.contains("--lossy"), "error names opt-in: {message}");
+    }
+
+    #[test]
+    fn import_git_into_normalizes_noncanonical_regular_file_modes() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_noncanonical_mode_repo(gitdir.path());
+
+        let (stats, _map) =
+            import_git_into(gitdir.path(), heddledir.path()).expect("legacy modes import");
+        assert_eq!(stats.commits_imported, 1);
+
+        let repo = repo::Repository::open(heddledir.path()).unwrap();
+        let main = repo
+            .refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .expect("main thread");
+        let state = repo.store().get_state(&main).unwrap().expect("main state");
+        let tree = repo
+            .store()
+            .get_tree(&state.tree)
+            .unwrap()
+            .expect("root tree");
+
+        assert_eq!(
+            tree.get("legacy.txt")
+                .expect("legacy file")
+                .mode()
+                .to_unix_mode(),
+            0o100644,
+            "100664 must normalize to Git's 100644"
+        );
+        assert_eq!(
+            tree.get("run.sh")
+                .expect("executable file")
+                .mode()
+                .to_unix_mode(),
+            0o100755,
+            "100775 must normalize to Git's 100755"
+        );
+    }
+
+    #[test]
+    fn import_git_into_rejects_unknown_tree_modes() {
+        let gitdir = TempDir::new().unwrap();
+        let heddledir = TempDir::new().unwrap();
+        seed_unknown_mode_repo(gitdir.path());
+
+        let error = import_git_into(gitdir.path(), heddledir.path())
+            .expect_err("unknown tree mode must fail");
+        let message = error.to_string();
+        assert!(
+            message.contains("unsupported mode 140000"),
+            "error should identify the unknown mode: {message}"
+        );
     }
 
     #[test]

--- a/crates/repo/src/git_overlay_object_source.rs
+++ b/crates/repo/src/git_overlay_object_source.rs
@@ -128,11 +128,11 @@ impl ExternalObjectSource for GitOverlayObjectSource {
                         .ok_or_else(|| missing_mapping("tree", &child.oid, &git_sha))?;
                     TreeEntry::directory(name, parse_hash(&mapped)?)
                 }
-                0o100644 | 0o100755 => {
+                mode if mode & 0o170000 == 0o100000 => {
                     let mapped = self
                         .heddle_for_git(&child.oid, KIND_BLOB)?
                         .ok_or_else(|| missing_mapping("blob", &child.oid, &git_sha))?;
-                    TreeEntry::file(name, parse_hash(&mapped)?, child.mode == 0o100755)
+                    TreeEntry::file(name, parse_hash(&mapped)?, mode & 0o111 != 0)
                 }
                 0o120000 => {
                     let mapped = self


### PR DESCRIPTION
## Summary

- Normalize legacy regular-file modes in Git tree imports by mapping executable-bit-bearing modes to `100755` and all other regular-file modes to `100644`.
- Preserve existing handling for directories (`40000`), symlinks (`120000`), gitlinks (`160000`), and canonical file modes.
- Add a raw Git tree fixture covering `100664 -> 100644` and `100775 -> 100755`, unblocking historical `git.git` initial-commit adoption (`2b5bfdf7`).




Closes #1233

## Test evidence

- Red first, before the parser change: `TMPDIR=/home/scratch cargo test -p heddle-ingest import_git_into_normalizes_noncanonical_regular_file_modes -- --nocapture` failed with `tree entry legacy.txt has unsupported mode 100664`.
- Green: `TMPDIR=/home/scratch HEDDLE_CONFIG=/dev/null cargo test --locked -p heddle-ingest -p heddle-repo` — `heddle-ingest`: 203 passed, 1 ignored; `heddle-repo`: 625 passed, 2 ignored.
- Green: `TMPDIR=/home/scratch cargo build --locked -p heddle-cli -p heddle-cli-contract -p heddle-cli-render -p heddle-core -p heddle-git-projection -p heddle-ingest --tests --bin heddle --bin heddle-fuse-worker`.
- Green: `TMPDIR=/home/scratch cargo clippy --locked -p heddle-cli -p heddle-cli-contract -p heddle-cli-render -p heddle-core -p heddle-git-projection -p heddle-ingest --lib --bins --tests --examples -- -D warnings`.
- Exact affected-package test command reproduced one unrelated host-dependent `diff_and_status::test_native_status_warms_helper_for_second_run` failure in `core_functionality` (92 passed, 1 failed); the isolated rerun passed (`1 passed; 92 filtered out`).
- Canonical tree, gitlink, and non-canonical-mode differential tests pass. `git diff --check` and targeted rustfmt checks pass. Full workspace fmt still reports the pre-existing unrelated difference at `crates/cli/tests/ts_types_in_sync.rs:34`.