### PR TITLE
perf(clone): replace per-op fsync with verified durability commit

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1794,7 +1794,10 @@ async fn clone_network_connected(
         // then may refs/HEAD become visible; the intent is cleared last.
         durability.commit()?;
         if durability.barrier_count() != 1 {
-            anyhow::bail!("clone durability commit executed more than once");
+            return Err(HeddleError::InvalidObject(
+                "clone durability commit executed more than once".to_string(),
+            )
+            .into());
         }
         client
             .publish_clone_markers(&local_repo, repo_path, &result.checkpoint)
@@ -2006,7 +2009,10 @@ async fn recover_interrupted_clone_connected(
     }
     durability.commit()?;
     if durability.barrier_count() != 1 {
-        anyhow::bail!("clone recovery durability commit executed more than once");
+        return Err(HeddleError::InvalidObject(
+            "clone recovery durability commit executed more than once".to_string(),
+        )
+        .into());
     }
     client
         .publish_clone_markers(&repo, &intent.repository, &result.checkpoint)

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -33,6 +33,8 @@ use heddle_git_projection::git_core::{
     clone_url_to_bare, copy_local_repo_to_bare, open_repo, set_reference, write_head_symref,
 };
 use ingest::ImportOptions;
+#[cfg(feature = "client")]
+use objects::fs_atomic::CloneDurabilityBatch;
 use objects::{
     Progress,
     error::{HeddleError, Result as HeddleResult},
@@ -41,6 +43,8 @@ use objects::{
     sync::LockExt,
 };
 use refs::Head;
+#[cfg(feature = "client")]
+use repo::clone_intent::CloneIntent;
 use repo::{BlobHydrator, Repository};
 use serde::Serialize;
 #[cfg(feature = "client")]
@@ -1572,6 +1576,18 @@ async fn clone_network_connected(
     }
 
     let mut cleanup = CloneDestinationCleanup::new(local_path);
+    let intent = CloneIntent {
+        origin: hosted_clone_origin_url(&endpoint_spec, repo_path),
+        endpoint: endpoint_spec.clone(),
+        repository: repo_path.to_string(),
+        thread: thread.clone(),
+        depth,
+        lazy,
+    };
+    intent.create(local_path)?;
+    // Failures after the durable intent are resumable and must remain on disk.
+    cleanup.disarm();
+    let durability = CloneDurabilityBatch::begin(local_path);
     let materialization = if lazy {
         PullMaterialization::Lazy
     } else {
@@ -1614,19 +1630,19 @@ async fn clone_network_connected(
                     SleyRepository::init(local_path)
                         .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
                 }
-                let repo = Repository::init(local_path).map_err(wire::ProtocolError::from)?;
+                let repo = Repository::init_clone(local_path).map_err(wire::ProtocolError::from)?;
                 folded_refs = Some(refs.refs);
                 Ok(repo)
             },
         )
         .await;
-    let (result, local_repo, remote_refs) = match folded {
+    let (mut result, local_repo, remote_refs) = match folded {
         Ok((result, local_repo)) => (
             result,
             local_repo,
             folded_refs.context("folded clone response is missing its refs")?,
         ),
-        Err(error) if !local_path.join(".heddle").exists() && !local_path.join(".git").exists() => {
+        Err(error) if folded_refs.is_none() && !local_path.join(".git").exists() => {
             let remote_refs = client
                 .list_refs_with_revision_addresses(repo_path)
                 .await?
@@ -1644,13 +1660,12 @@ async fn clone_network_connected(
             if git_overlay_clone {
                 SleyRepository::init(local_path).map_err(anyhow::Error::msg)?;
             }
-            let local_repo = Repository::init(local_path)?;
+            let local_repo = Repository::init_clone(local_path)?;
             let result = client
-                .pull_with_depth_and_materialization(
+                .repair_clone_with_depth_and_materialization(
                     &local_repo,
                     repo_path,
                     &track_name,
-                    Some(&track_name),
                     depth,
                     materialization,
                 )
@@ -1679,34 +1694,49 @@ async fn clone_network_connected(
     if git_overlay_clone {
         configure_git_overlay_origin(local_path, &origin_url)?;
     }
-    let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
-        .context("decode hosted clone bootstrap")?;
-    let bootstrap = if result.success {
-        bootstrap
-            .as_ref()
-            .map(|metadata| metadata.resolve(&local_repo, result.final_state))
-            .transpose()
-            .context("resolve hosted clone bootstrap")?
-    } else {
-        None
-    };
     if result.success {
-        let final_state = result.final_state;
-        if let Some(state) = final_state {
-            local_repo.set_thread_recorded(&ThreadName::new(&track_name), &state)?;
+        objects::fault_inject::maybe_panic_at("clone_after_fetch_before_verify");
+        let mut final_state = result
+            .final_state
+            .context("hosted clone completed without a final state")?;
+        if let Err(first_error) = verify_hosted_clone(&local_repo, final_state, depth, lazy) {
+            local_repo.store().discard_corrupt_clone_packs()?;
+            result = client
+                .repair_clone_with_depth_and_materialization(
+                    &local_repo,
+                    repo_path,
+                    &track_name,
+                    depth,
+                    materialization,
+                )
+                .await
+                .map_err(|repair| {
+                    anyhow!(
+                        "clone verification failed ({first_error}); targeted repair failed ({repair})"
+                    )
+                })?;
+            if !result.success {
+                anyhow::bail!(
+                    "clone verification failed ({first_error}); targeted repair was rejected: {}",
+                    result.error.as_deref().unwrap_or("unknown remote error")
+                );
+            }
+            final_state = result
+                .final_state
+                .context("targeted clone repair completed without a final state")?;
+            verify_hosted_clone(&local_repo, final_state, depth, lazy)
+                .context("clone remained incomplete after targeted remote repair")?;
         }
-        // Lazy clone: persist the hydrator metadata so future
-        // `Repository::open` calls (in any process) can reconstruct
-        // the on-read hydrator. Without this, lazy clones would only
-        // hydrate inside the single `cmd_clone` process — every
-        // subsequent `heddle <verb>` would surface MissingObject on
-        // any blob read.
+
+        let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
+            .context("decode hosted clone bootstrap")?
+            .as_ref()
+            .map(|metadata| metadata.resolve(&local_repo, Some(final_state)))
+            .transpose()
+            .context("resolve hosted clone bootstrap")?;
+
         if lazy {
             use repo::lazy_hydrator::LazyHydratorConfig;
-            // Persist the original `host:port` spec (not `addr.to_string()`,
-            // which is a resolved IP). The hydrator re-resolves DNS on
-            // every process start so a future LB rotation doesn't pin us
-            // to a stale IP.
             let cfg = LazyHydratorConfig::hosted(
                 endpoint_spec.clone(),
                 repo_path,
@@ -1715,16 +1745,9 @@ async fn clone_network_connected(
             );
             cfg.save(local_repo.heddle_dir())
                 .context("failed to persist lazy-hydrator.toml")?;
-        } else if git_overlay_clone {
-            finish_hosted_git_overlay_checkout(&local_repo, &track_name)
-                .context("failed to finish hosted Git-overlay checkout")?;
-            configure_git_overlay_origin_tracking(local_path, &track_name)?;
-        } else if let Some(state) = final_state {
-            local_repo
-                .goto_from_materialized_state(&state, None)
-                .context("failed to materialize hosted clone worktree")?;
         }
         configure_hosted_clone_origin(&local_repo, &endpoint_spec, repo_path)?;
+
         // Read path for hosted discussions (heddle discuss): materialize the
         // hosted CollaborationService discussions for the cloned head into the
         // local op-log so `discuss list` / `discuss show` see them. Best-effort:
@@ -1765,6 +1788,41 @@ async fn clone_network_connected(
                 eprintln!("{} context sync skipped: {error:#}", style::warn_marker());
             }
         }
+
+        // Ordering invariant: the reachable object closure is hash-complete;
+        // one whole-filesystem barrier commits all direct clone data; only
+        // then may refs/HEAD become visible; the intent is cleared last.
+        durability.commit()?;
+        if durability.barrier_count() != 1 {
+            anyhow::bail!("clone durability commit executed more than once");
+        }
+        client
+            .publish_clone_markers(&local_repo, repo_path, &result.checkpoint)
+            .await?;
+        local_repo.set_thread_recorded(&ThreadName::new(&track_name), &final_state)?;
+        // Lazy clone: persist the hydrator metadata so future
+        // `Repository::open` calls (in any process) can reconstruct
+        // the on-read hydrator. Without this, lazy clones would only
+        // hydrate inside the single `cmd_clone` process — every
+        // subsequent `heddle <verb>` would surface MissingObject on
+        // any blob read.
+        if lazy {
+            local_repo.refs().write_head(&Head::Attached {
+                thread: ThreadName::new(&track_name),
+            })?;
+        } else if git_overlay_clone {
+            finish_hosted_git_overlay_checkout(&local_repo, &track_name)
+                .context("failed to finish hosted Git-overlay checkout")?;
+            configure_git_overlay_origin_tracking(local_path, &track_name)?;
+        } else {
+            local_repo
+                .goto_from_materialized_state(&final_state, None)
+                .context("failed to materialize hosted clone worktree")?;
+            local_repo.refs().write_head(&Head::Attached {
+                thread: ThreadName::new(&track_name),
+            })?;
+        }
+        CloneIntent::clear(local_path)?;
         if should_output_json(cli, Some(local_repo.config())) {
             let output = heddle_clone_output(
                 origin_url.clone(),
@@ -1772,7 +1830,7 @@ async fn clone_network_connected(
                 track_name.clone(),
                 local_repo.capability_label(),
                 None,
-                final_state.map(|state| state.to_string()),
+                Some(final_state.to_string()),
                 Some(build_repository_verification_state(&local_repo)),
             );
             crate::cli::render::write_json_stdout(&output)?;
@@ -1785,12 +1843,10 @@ async fn clone_network_connected(
                 style::bold(&local_path.display().to_string()),
                 style::dim(&depth_info)
             );
-            if let Some(state) = final_state {
-                println!(
-                    "  {}",
-                    style::field("state", &style::state_id(&state.to_string()))
-                );
-            }
+            println!(
+                "  {}",
+                style::field("state", &style::state_id(&final_state.to_string()))
+            );
         }
     } else {
         let err = result.error.unwrap_or_else(|| "Unknown error".to_string());
@@ -1799,8 +1855,201 @@ async fn clone_network_connected(
         )));
     }
 
-    cleanup.disarm();
     Ok(())
+}
+
+#[cfg(feature = "client")]
+pub async fn recover_interrupted_clone(cli: &Cli, start: &Path) -> Result<bool> {
+    use crate::{
+        client::{HostedAuthMode, HostedSession},
+        config::UserConfig,
+    };
+
+    let Some(root) = repo::clone_intent::find_clone_intent_root(start) else {
+        return Ok(false);
+    };
+    let intent = CloneIntent::load(&root)?
+        .context("clone intent disappeared while recovery was starting")?;
+    let target = RemoteTarget::parse(&intent.origin).map_err(anyhow::Error::msg)?;
+    let RemoteTarget::Network { addr, .. } = target else {
+        anyhow::bail!(
+            "clone intent origin is not a hosted remote: {}",
+            intent.origin
+        );
+    };
+    let user_config = UserConfig::load_default()?;
+    let server_key = credential_key_from_remote_url(&intent.origin);
+    let session =
+        HostedSession::build(&user_config, server_key, HostedAuthMode::CredentialFallback)?;
+    let mut client = session.connect(addr).await?;
+    let recovered = recover_interrupted_clone_connected(cli, &root, &intent, &mut client).await;
+    client.close().await;
+    recovered?;
+    Ok(true)
+}
+
+#[cfg(feature = "client")]
+async fn recover_interrupted_clone_connected(
+    _cli: &Cli,
+    root: &Path,
+    intent: &CloneIntent,
+    client: &mut HostedClient,
+) -> Result<()> {
+    let durability = CloneDurabilityBatch::begin(root);
+    let repo = Repository::init_clone(root)?;
+    let remote_refs = client
+        .list_refs_with_revision_addresses(&intent.repository)
+        .await?;
+    let track_name = select_hosted_clone_thread(
+        intent.thread.as_deref(),
+        remote_refs
+            .iter()
+            .filter(|entry| entry.is_thread)
+            .map(|entry| entry.name.as_str()),
+        &intent.repository,
+    )?;
+    let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
+        .is_some_and(|address| address.starts_with("git:"));
+    if git_overlay_clone && !root.join(".git").exists() {
+        SleyRepository::init(root).map_err(anyhow::Error::msg)?;
+    }
+    let materialization = if intent.lazy {
+        PullMaterialization::Lazy
+    } else {
+        PullMaterialization::Full
+    };
+    let mut result = client
+        .repair_clone_with_depth_and_materialization(
+            &repo,
+            &intent.repository,
+            &track_name,
+            intent.depth,
+            materialization,
+        )
+        .await?;
+    if !result.success {
+        anyhow::bail!(
+            "clone repair failed: {}",
+            result.error.as_deref().unwrap_or("unknown remote error")
+        );
+    }
+    let mut final_state = result
+        .final_state
+        .context("clone repair completed without a final state")?;
+    if verify_hosted_clone(&repo, final_state, intent.depth, intent.lazy).is_err() {
+        repo.store().discard_corrupt_clone_packs()?;
+        result = client
+            .repair_clone_with_depth_and_materialization(
+                &repo,
+                &intent.repository,
+                &track_name,
+                intent.depth,
+                materialization,
+            )
+            .await?;
+        if !result.success {
+            anyhow::bail!(
+                "clone repair retry failed: {}",
+                result.error.as_deref().unwrap_or("unknown remote error")
+            );
+        }
+        final_state = result
+            .final_state
+            .context("clone repair retry completed without a final state")?;
+        verify_hosted_clone(&repo, final_state, intent.depth, intent.lazy)?;
+    }
+
+    if intent.lazy {
+        use repo::lazy_hydrator::LazyHydratorConfig;
+        LazyHydratorConfig::hosted(
+            intent.endpoint.clone(),
+            &intent.repository,
+            &track_name,
+            &track_name,
+        )
+        .save(repo.heddle_dir())?;
+    }
+    configure_hosted_clone_origin(&repo, &intent.endpoint, &intent.repository)?;
+    let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)?
+        .as_ref()
+        .map(|metadata| metadata.resolve(&repo, Some(final_state)))
+        .transpose()?;
+    if let Err(error) = crate::client::discussion_sync::pull_discussions(
+        &repo,
+        client,
+        &intent.repository,
+        bootstrap
+            .as_ref()
+            .map(|metadata| metadata.discussions.as_slice()),
+    )
+    .await
+    {
+        eprintln!(
+            "{} discussion sync skipped during clone recovery: {error:#}",
+            style::warn_marker()
+        );
+    }
+    if let Err(error) = crate::client::context_sync::pull_context(
+        &repo,
+        client,
+        &intent.repository,
+        bootstrap
+            .as_ref()
+            .map(|metadata| metadata.context.as_slice()),
+    )
+    .await
+    {
+        eprintln!(
+            "{} context sync skipped during clone recovery: {error:#}",
+            style::warn_marker()
+        );
+    }
+    durability.commit()?;
+    if durability.barrier_count() != 1 {
+        anyhow::bail!("clone recovery durability commit executed more than once");
+    }
+    client
+        .publish_clone_markers(&repo, &intent.repository, &result.checkpoint)
+        .await?;
+    repo.set_thread_recorded(&ThreadName::new(&track_name), &final_state)?;
+    if intent.lazy {
+        repo.refs().write_head(&Head::Attached {
+            thread: ThreadName::new(&track_name),
+        })?;
+    } else if git_overlay_clone {
+        finish_hosted_git_overlay_checkout(&repo, &track_name)?;
+        configure_git_overlay_origin(root, &intent.origin)?;
+        configure_git_overlay_origin_tracking(root, &track_name)?;
+    } else {
+        repo.goto_from_materialized_state(&final_state, None)?;
+        repo.refs().write_head(&Head::Attached {
+            thread: ThreadName::new(&track_name),
+        })?;
+    }
+    CloneIntent::clear(root)?;
+    Ok(())
+}
+
+#[cfg(feature = "client")]
+fn verify_hosted_clone(
+    repo: &Repository,
+    final_state: objects::object::StateId,
+    depth: Option<u32>,
+    lazy: bool,
+) -> Result<usize> {
+    let options = wire::StateClosureOptions {
+        depth,
+        exclude_states: Vec::new(),
+    };
+    if lazy {
+        wire::enumerate_state_closure_plan_with_options(repo.store(), final_state, options)
+            .map(|objects| objects.len())
+            .map_err(anyhow::Error::new)
+    } else {
+        wire::enumerate_state_closure_with_options(repo.store(), final_state, options)
+            .map(|objects| objects.len())
+            .map_err(anyhow::Error::new)
+    }
 }
 
 /// Recursive MONOREPO clone (Spool epic P9, weft#358).

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -87,6 +87,8 @@ pub use agent_cmd::{
     agent_api_schema, cmd_agent_capture, cmd_agent_heartbeat, cmd_agent_list, cmd_agent_ready,
     cmd_agent_release, cmd_agent_reserve,
 };
+#[cfg(feature = "client")]
+pub use clone::recover_interrupted_clone;
 pub use clone::{
     CLONE_CONNECTION_OUTPUT_KIND, CLONE_OUTPUT_KIND, GitOverlayBlobHydrator, cmd_clone,
     register_git_overlay_factory,

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -60,6 +60,7 @@ struct PullOptions<'a> {
     depth: Option<u32>,
     target_state: Option<StateId>,
     materialization: PullMaterialization,
+    publish_refs: bool,
 }
 
 const PULL_BOOTSTRAP_LINE_PREFIX: &str = "heddle-pull-bootstrap-v1:";
@@ -1138,6 +1139,7 @@ impl HostedClient {
                 depth: None,
                 target_state: None,
                 materialization: PullMaterialization::Full,
+                publish_refs: true,
             },
         )
         .await
@@ -1159,6 +1161,7 @@ impl HostedClient {
                 depth: None,
                 target_state: None,
                 materialization: PullMaterialization::Full,
+                publish_refs: true,
             },
         )
         .await
@@ -1181,6 +1184,7 @@ impl HostedClient {
                 depth: None,
                 target_state: None,
                 materialization: PullMaterialization::Lazy,
+                publish_refs: true,
             },
         )
         .await
@@ -1204,6 +1208,30 @@ impl HostedClient {
                 depth,
                 target_state: None,
                 materialization,
+                publish_refs: true,
+            },
+        )
+        .await
+    }
+
+    pub(crate) async fn repair_clone_with_depth_and_materialization(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        depth: Option<u32>,
+        materialization: PullMaterialization,
+    ) -> Result<PullComplete, ProtocolError> {
+        self.pull_with_options(
+            repo,
+            repo_path,
+            remote_thread,
+            PullOptions {
+                local_thread: None,
+                depth,
+                target_state: None,
+                materialization,
+                publish_refs: false,
             },
         )
         .await
@@ -1234,6 +1262,7 @@ impl HostedClient {
                     depth,
                     target_state: None,
                     materialization,
+                    publish_refs: false,
                 },
                 Some(Box::new(initialize)),
             )
@@ -1279,6 +1308,7 @@ impl HostedClient {
                 depth: None,
                 target_state: Some(target_state),
                 materialization: PullMaterialization::Full,
+                publish_refs: true,
             },
         )
         .await
@@ -1301,6 +1331,7 @@ impl HostedClient {
                 depth: None,
                 target_state: Some(target_state),
                 materialization: PullMaterialization::Lazy,
+                publish_refs: true,
             },
         )
         .await
@@ -1349,6 +1380,7 @@ impl HostedClient {
                     depth: None,
                     target_state: Some(target_state),
                     materialization: PullMaterialization::Full,
+                    publish_refs: true,
                 },
             )
             .await?;
@@ -1893,14 +1925,16 @@ impl HostedClient {
                         } else if final_state.is_some() {
                             let _ = repo.clear_all_missing_blobs()?;
                         }
-                        let synced_markers = complete
-                            .transfer
-                            .as_ref()
-                            .map(|transfer| apply_marker_snapshot(repo, &transfer.checkpoint))
-                            .transpose()?
-                            .unwrap_or(false);
-                        if !synced_markers {
-                            self.sync_local_markers(repo, repo_path).await?;
+                        if options.publish_refs {
+                            let synced_markers = complete
+                                .transfer
+                                .as_ref()
+                                .map(|transfer| apply_marker_snapshot(repo, &transfer.checkpoint))
+                                .transpose()?
+                                .unwrap_or(false);
+                            if !synced_markers {
+                                self.sync_local_markers(repo, repo_path).await?;
+                            }
                         }
                         profile.metadata_sync = metadata_start.elapsed();
                         profile.objects_received = received;
@@ -2079,6 +2113,18 @@ impl HostedClient {
                 )?,
                 None => repo.create_marker_recorded(&marker_name, &marker.state_id)?,
             }
+        }
+        Ok(())
+    }
+
+    pub(crate) async fn publish_clone_markers(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        checkpoint: &[u8],
+    ) -> Result<(), ProtocolError> {
+        if !apply_marker_snapshot(repo, checkpoint)? {
+            self.sync_local_markers(repo, repo_path).await?;
         }
         Ok(())
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -307,6 +307,14 @@ async fn async_main() -> Result<()> {
         std::process::exit(code.into());
     }
 
+    #[cfg(feature = "client")]
+    if command_contract.targets_current_repository
+        && !matches!(&cli.command, Commands::Init(_) | Commands::Clone(_))
+    {
+        let start = cli.repo.clone().unwrap_or(std::env::current_dir()?);
+        cli::cli::commands::recover_interrupted_clone(&cli, &start).await?;
+    }
+
     match run_local_idempotency_if_requested(&cli, &command_name, command_supports_op_id) {
         Ok(true) => {
             shutdown_command_telemetry(command_trace, command_span_guard, telemetry, 0);

--- a/crates/cli/tests/cli_integration/clone_output_contract.rs
+++ b/crates/cli/tests/cli_integration/clone_output_contract.rs
@@ -106,7 +106,14 @@ mod fixture {
                 .is_some_and(|message| message.contains("Broken pipe")),
             "error envelope must retain the peer disconnect: {error}"
         );
-        assert!(!destination.exists());
+        assert!(
+            repo::clone_intent::CloneIntent::path(&destination).is_file(),
+            "a connected interrupted clone retains its durable recovery intent"
+        );
+        assert!(matches!(
+            repo::Repository::open(&destination),
+            Err(repo::HeddleError::IncompleteClone(path)) if path == destination
+        ));
     }
 
     #[test]
@@ -161,7 +168,10 @@ mod fixture {
             !output.status.success(),
             "fixture terminates the folded Pull"
         );
-        assert!(!destination.exists());
+        assert!(
+            repo::clone_intent::CloneIntent::path(&destination).is_file(),
+            "folded-pull interruption must remain detectable and resumable"
+        );
     }
 
     fn write_test_credential(path: &std::path::Path, server: &str) {

--- a/crates/fs-prims/src/fs_atomic.rs
+++ b/crates/fs-prims/src/fs_atomic.rs
@@ -3,9 +3,104 @@ use std::{
     fs::{self, File, OpenOptions},
     io::{self, Write},
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
+
+#[derive(Default)]
+struct CloneDurabilityStats {
+    barriers: AtomicU64,
+    skipped: AtomicU64,
+}
+
+#[derive(Clone)]
+struct CloneDurabilityEntry {
+    root: PathBuf,
+    stats: Arc<CloneDurabilityStats>,
+}
+
+fn clone_durability_entries() -> &'static Mutex<Vec<CloneDurabilityEntry>> {
+    static ENTRIES: OnceLock<Mutex<Vec<CloneDurabilityEntry>>> = OnceLock::new();
+    ENTRIES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn deferred_clone_stats(path: &Path) -> Option<Arc<CloneDurabilityStats>> {
+    clone_durability_entries()
+        .lock()
+        .ok()?
+        .iter()
+        .rev()
+        .find(|entry| path.starts_with(&entry.root))
+        .map(|entry| Arc::clone(&entry.stats))
+}
+
+pub fn clone_write_is_deferred(path: &Path) -> bool {
+    deferred_clone_stats(path).is_some()
+}
+
+pub fn record_deferred_clone_barrier(path: &Path) {
+    if let Some(stats) = deferred_clone_stats(path) {
+        stats.skipped.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Path-scoped durability suppression for reconstructible clone writes.
+///
+/// The caller must first persist a clone-intent marker outside this scope and
+/// must call [`commit`](Self::commit) only after hash-verifying the fetched
+/// closure. Writes outside `root` retain their ordinary per-operation fsyncs.
+pub struct CloneDurabilityBatch {
+    root: PathBuf,
+    stats: Arc<CloneDurabilityStats>,
+}
+
+impl CloneDurabilityBatch {
+    pub fn begin(root: impl AsRef<Path>) -> Self {
+        let root = root.as_ref().to_path_buf();
+        let stats = Arc::new(CloneDurabilityStats::default());
+        clone_durability_entries()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(CloneDurabilityEntry {
+                root: root.clone(),
+                stats: Arc::clone(&stats),
+            });
+        Self { root, stats }
+    }
+
+    /// Flush every dirty file and directory on the destination filesystem in
+    /// one kernel barrier. Refs remain unpublished while this runs.
+    pub fn commit(&self) -> io::Result<()> {
+        sync_filesystem(&self.root)?;
+        self.stats.barriers.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+
+    pub fn barrier_count(&self) -> u64 {
+        self.stats.barriers.load(Ordering::Relaxed)
+    }
+
+    pub fn skipped_barrier_count(&self) -> u64 {
+        self.stats.skipped.load(Ordering::Relaxed)
+    }
+}
+
+impl Drop for CloneDurabilityBatch {
+    fn drop(&mut self) {
+        let mut entries = clone_durability_entries()
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if let Some(index) = entries
+            .iter()
+            .rposition(|entry| entry.root == self.root && Arc::ptr_eq(&entry.stats, &self.stats))
+        {
+            entries.remove(index);
+        }
+    }
+}
 
 #[derive(Clone, Copy)]
 enum AtomicWriteKind {
@@ -251,8 +346,7 @@ pub fn stage_temp_files_durable(files: &[(PathBuf, Vec<u8>)]) -> io::Result<()> 
     // Barrier pass: by now most files' writeback is already in flight (or done),
     // so each `sync_all` blocks only on the tail, not a cold synchronous flush.
     for (file, (temp_path, _)) in handles.iter().zip(files) {
-        file.sync_all()
-            .map_err(|err| enrich_write_error(temp_path, err))?;
+        sync_file(file, temp_path).map_err(|err| enrich_write_error(temp_path, err))?;
     }
     Ok(())
 }
@@ -287,8 +381,70 @@ pub fn sync_directory(_path: &Path) -> io::Result<()> {
 
 #[cfg(not(windows))]
 pub fn sync_directory(path: &Path) -> io::Result<()> {
+    if let Some(stats) = deferred_clone_stats(path) {
+        stats.skipped.fetch_add(1, Ordering::Relaxed);
+        return Ok(());
+    }
     let dir = OpenOptions::new().read(true).open(path)?;
     dir.sync_all()
+}
+
+/// Sync one file unless it belongs to an active clone durability batch.
+pub fn sync_file(file: &File, path: &Path) -> io::Result<()> {
+    if let Some(stats) = deferred_clone_stats(path) {
+        stats.skipped.fetch_add(1, Ordering::Relaxed);
+        return Ok(());
+    }
+    file.sync_all()
+}
+
+pub fn sync_file_data(file: &File, path: &Path) -> io::Result<()> {
+    if let Some(stats) = deferred_clone_stats(path) {
+        stats.skipped.fetch_add(1, Ordering::Relaxed);
+        return Ok(());
+    }
+    file.sync_data()
+}
+
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn sync_filesystem(path: &Path) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let file = OpenOptions::new().read(true).open(path)?;
+    // SAFETY: `file` owns a live descriptor for the duration of the call.
+    if unsafe { libc::syncfs(file.as_raw_fd()) } == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
+fn sync_filesystem(_path: &Path) -> io::Result<()> {
+    // `syncfs(2)` is Linux-specific. `sync(2)` is the closest portable Unix
+    // whole-filesystem commit primitive and avoids a barrier per clone object.
+    unsafe { libc::sync() };
+    Ok(())
+}
+
+#[cfg(windows)]
+fn sync_filesystem(path: &Path) -> io::Result<()> {
+    // Windows exposes no non-privileged `syncfs` equivalent. Keep one logical
+    // clone commit phase, flushing every clone file only after verification;
+    // directory metadata is covered by NTFS journaling (see `sync_directory`).
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_dir() {
+            sync_filesystem(&entry.path())?;
+        } else if file_type.is_file() {
+            OpenOptions::new()
+                .read(true)
+                .open(entry.path())?
+                .sync_all()?;
+        }
+    }
+    Ok(())
 }
 
 /// Collect missing path components (deepest-first) and the deepest pre-existing
@@ -556,7 +712,7 @@ fn stage_file_atomic_impl(
         kind.enforce_before_write(&file)?;
         before_write(&file, &tmp)?;
         file.write_all(bytes)?;
-        file.sync_all()?;
+        sync_file(&file, &tmp)?;
         Ok(())
     })();
 
@@ -670,8 +826,7 @@ fn fsync_file_data(path: &Path) -> io::Result<()> {
         .write(true)
         .open(path)
         .map_err(|e| enrich_fs_error(path, "opening", e))?;
-    file.sync_all()
-        .map_err(|e| enrich_fs_error(path, "syncing", e))
+    sync_file(&file, path).map_err(|e| enrich_fs_error(path, "syncing", e))
 }
 
 pub fn publish_file_durable(src: &Path, dst: &Path) -> io::Result<()> {

--- a/crates/object-model/src/error.rs
+++ b/crates/object-model/src/error.rs
@@ -166,6 +166,8 @@ pub enum HeddleError {
     RepositoryNotFound(std::path::PathBuf),
     #[error("repository already exists at {0}")]
     RepositoryExists(std::path::PathBuf),
+    #[error("repository clone at {0} is incomplete and must be repaired from its origin")]
+    IncompleteClone(std::path::PathBuf),
     #[error(
         "repository config at {path} uses repository format {found} but this binary supports {supported}; upgrade heddle or run `heddle migrate`"
     )]

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -1387,6 +1387,43 @@ impl ObjectStore for FsStore {
         self.prune_loose_objects_impl()
     }
 
+    fn discard_corrupt_clone_packs(&self) -> Result<usize> {
+        let packs = super::fs_paths::packs_dir(&self.root);
+        let mut removed = 0;
+        for entry in match fs::read_dir(&packs) {
+            Ok(entries) => entries,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+            Err(error) => return Err(error.into()),
+        } {
+            let path = entry?.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("pack") {
+                continue;
+            }
+            let index = path.with_extension("idx");
+            let valid = crate::store::pack::PackReader::open(&path, &index)
+                .and_then(|reader| {
+                    for id in reader.list_ids()? {
+                        let (kind, bytes) = reader.get_object(&id)?.ok_or_else(|| {
+                            HeddleError::InvalidObject(format!("pack index lost object {id:?}"))
+                        })?;
+                        validate_pack_entry(&id, kind, &bytes)?;
+                    }
+                    Ok(())
+                })
+                .is_ok();
+            if !valid {
+                let _ = fs::remove_file(&path);
+                let _ = fs::remove_file(&index);
+                removed += 1;
+            }
+        }
+        if removed > 0 {
+            self.reload_packs()?;
+            self.clear_recent_object_caches();
+        }
+        Ok(removed)
+    }
+
     #[instrument(skip(self))]
     fn begin_snapshot_write_batch(&self) -> Result<()> {
         self.begin_snapshot_write_batch_impl()

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -14,7 +14,8 @@ use std::{
 use crate::{
     error::HeddleError,
     fs_atomic::{
-        create_dir_all_durable, enrich_fs_error, enrich_rename_error, sync_directory, temp_path,
+        create_dir_all_durable, enrich_fs_error, enrich_rename_error, sync_directory, sync_file,
+        temp_path,
     },
     store::Result,
 };
@@ -101,7 +102,7 @@ pub(super) fn write_atomic(
             // before rename, then directory fsync after — so the file
             // is fully on disk and discoverable through the parent
             // directory before this returns.
-            AtomicWriteMode::Durable => file.sync_all()?,
+            AtomicWriteMode::Durable => sync_file(&file, &temp_path)?,
             // `BatchDirectorySync` keeps per-file content durability
             // (so a crash mid-batch can't leave a renamed-but-empty
             // file behind) but defers parent-directory fsyncs to
@@ -113,7 +114,13 @@ pub(super) fn write_atomic(
             // flush could leave a file that "exists" in the directory
             // but whose data blocks weren't flushed — exactly the
             // ACID violation we want to avoid for state/tree writes.
-            AtomicWriteMode::BatchDirectorySync => file.sync_data()?,
+            AtomicWriteMode::BatchDirectorySync => {
+                if crate::fs_atomic::clone_write_is_deferred(&temp_path) {
+                    crate::fs_atomic::record_deferred_clone_barrier(&temp_path);
+                } else {
+                    file.sync_data()?;
+                }
+            }
             // Cache-mirror writes: no fsync. Caller guards reads
             // with a hash check, so torn-write corruption is
             // recoverable (re-promote from the authoritative copy).

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -336,6 +336,34 @@ fn install_pack_streaming_publishes_via_durable_rename_and_loads_objects() {
 }
 
 #[test]
+fn interrupted_clone_discards_only_short_pack_and_accepts_remote_repair() {
+    let (_temp, store) = create_test_store();
+    let blob = Blob::from("authoritative remote clone payload");
+    let hash = blob.hash();
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(hash, PackObjectType::Blob, blob.content().to_vec());
+    let (pack_data, index_data, _) = builder.build().unwrap();
+    store.install_pack(&pack_data, &index_data).unwrap();
+
+    let pack_path = std::fs::read_dir(packs_dir(store.root()))
+        .unwrap()
+        .map(Result::unwrap)
+        .map(|entry| entry.path())
+        .find(|path| path.extension().and_then(|value| value.to_str()) == Some("pack"))
+        .unwrap();
+    std::fs::write(&pack_path, &pack_data[..pack_data.len() / 2]).unwrap();
+
+    assert_eq!(store.discard_corrupt_clone_packs().unwrap(), 1);
+    assert!(store.get_blob(&hash).unwrap().is_none());
+
+    // The incremental pull installs only the pair that contained the corrupt
+    // object. Reusing the authoritative bytes makes the object byte-identical.
+    store.install_pack(&pack_data, &index_data).unwrap();
+    let repaired = store.get_blob(&hash).unwrap().unwrap();
+    assert_eq!(repaired.content(), blob.content());
+}
+
+#[test]
 fn install_pack_rejects_hash_mismatch_without_partial_commit() {
     let (_temp, store) = create_test_store();
 

--- a/crates/objects/src/store/fs/pack_install_journal.rs
+++ b/crates/objects/src/store/fs/pack_install_journal.rs
@@ -43,7 +43,8 @@ use serde::{Deserialize, Serialize};
 use crate::{
     fault_inject,
     fs_atomic::{
-        create_dir_all_durable, publish_file_durable, sync_directory, temp_path, write_file_atomic,
+        create_dir_all_durable, publish_file_durable, sync_directory, sync_file, temp_path,
+        write_file_atomic,
     },
     lock::RepoLock,
     object::ContentHash,
@@ -1002,8 +1003,8 @@ fn stage_snapshot_pack_pair_durable(
     index.write_all(&index_data)?;
 
     let (pack_sync, index_sync) = thread::scope(|scope| {
-        let pack_sync = scope.spawn(move || pack.sync_all());
-        let index_sync = scope.spawn(move || index.sync_all());
+        let pack_sync = scope.spawn(move || sync_file(&pack, pack_path));
+        let index_sync = scope.spawn(move || sync_file(&index, index_path));
         (pack_sync.join(), index_sync.join())
     });
     pack_sync.map_err(|_| io::Error::other("snapshot pack sync worker panicked"))??;

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -254,6 +254,9 @@ impl ObjectStore for AnyStore {
     fn prune_loose_objects(&self) -> Result<(u64, u64)> {
         any_store_dispatch!(self, prune_loose_objects())
     }
+    fn discard_corrupt_clone_packs(&self) -> Result<usize> {
+        any_store_dispatch!(self, discard_corrupt_clone_packs())
+    }
     fn begin_snapshot_write_batch(&self) -> Result<()> {
         any_store_dispatch!(self, begin_snapshot_write_batch())
     }
@@ -713,6 +716,12 @@ pub trait ObjectStore: Send + Sync {
 
     fn prune_loose_objects(&self) -> Result<(u64, u64)> {
         Ok((0, 0))
+    }
+
+    /// Remove only pack/index pairs that fail checksum, index, or object-hash
+    /// validation so a clone repair pull advertises their objects as missing.
+    fn discard_corrupt_clone_packs(&self) -> Result<usize> {
+        Ok(0)
     }
 
     fn begin_snapshot_write_batch(&self) -> Result<()> {

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -24,7 +24,7 @@ use heddle_schema::op_record::{
 };
 use objects::{
     error::{HeddleError, Result},
-    fs_atomic::{create_dir_all_durable, sync_directory, temp_path, write_file_atomic},
+    fs_atomic::{create_dir_all_durable, sync_directory, sync_file, temp_path, write_file_atomic},
     fs_clone::{ReflinkOutcome, try_reflink},
 };
 
@@ -818,7 +818,7 @@ impl PackedOpLogIndex {
             },
         )?;
         if durable {
-            out.sync_all()?;
+            sync_file(&out, tmp)?;
         }
         Ok(footer)
     }

--- a/crates/repo/src/clone_intent.rs
+++ b/crates/repo/src/clone_intent.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Durable recovery record for an in-progress hosted clone.
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use objects::{
+    error::{HeddleError, Result},
+    fs_atomic::{create_private_dir_all, write_file_atomic},
+};
+use serde::{Deserialize, Serialize};
+
+pub const CLONE_INTENT_FILE: &str = "clone-intent.toml";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CloneIntent {
+    pub origin: String,
+    pub endpoint: String,
+    pub repository: String,
+    pub thread: Option<String>,
+    pub depth: Option<u32>,
+    pub lazy: bool,
+}
+
+impl CloneIntent {
+    pub fn path(root: &Path) -> PathBuf {
+        root.join(".heddle").join(CLONE_INTENT_FILE)
+    }
+
+    /// Persist the recovery authority before any reconstructible clone data.
+    pub fn create(&self, root: &Path) -> Result<()> {
+        let heddle_dir = root.join(".heddle");
+        create_private_dir_all(&heddle_dir)?;
+        let bytes = toml::to_string_pretty(self)?;
+        write_file_atomic(&Self::path(root), bytes.as_bytes())?;
+        Ok(())
+    }
+
+    pub fn load(root: &Path) -> Result<Option<Self>> {
+        let path = Self::path(root);
+        match fs::read_to_string(&path) {
+            Ok(contents) => toml::from_str(&contents)
+                .map(Some)
+                .map_err(|source| HeddleError::ConfigParse { path, source }),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    /// Remove the publication gate after verification, the data commit, and
+    /// ref/HEAD publication. A crash may conservatively resurrect the marker;
+    /// that only causes another idempotent verification/repair pass.
+    pub fn clear(root: &Path) -> Result<()> {
+        match fs::remove_file(Self::path(root)) {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error.into()),
+        }
+    }
+}
+
+pub fn find_clone_intent_root(start: &Path) -> Option<PathBuf> {
+    let start = start.canonicalize().ok()?;
+    start
+        .ancestors()
+        .find(|root| CloneIntent::path(root).is_file())
+        .map(Path::to_path_buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Repository;
+    use objects::{
+        fs_atomic::CloneDurabilityBatch,
+        object::{Attribution, Principal, State, ThreadName, Tree},
+        store::ObjectStore,
+    };
+    use refs::Head;
+
+    fn intent() -> CloneIntent {
+        CloneIntent {
+            origin: "heddle://127.0.0.1:8443/acme/demo".to_string(),
+            endpoint: "127.0.0.1:8443".to_string(),
+            repository: "acme/demo".to_string(),
+            thread: Some("main".to_string()),
+            depth: None,
+            lazy: false,
+        }
+    }
+
+    #[test]
+    fn clone_commit_is_one_barrier_and_marker_gates_publication() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path().join("clone");
+        intent().create(&root).unwrap();
+
+        let durability = CloneDurabilityBatch::begin(&root);
+        let repo = Repository::init_clone(&root).unwrap();
+        assert!(!repo.heddle_dir().join("HEAD").exists());
+        assert!(matches!(
+            Repository::open(&root),
+            Err(HeddleError::IncompleteClone(path)) if path == root
+        ));
+
+        let tree = Tree::new();
+        let tree_hash = repo.store().put_tree(&tree).unwrap();
+        let state = State::new(
+            tree_hash,
+            Vec::new(),
+            Attribution::human(Principal::new("Clone Test", "clone@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        wire::enumerate_state_closure(repo.store(), state.id()).unwrap();
+
+        durability.commit().unwrap();
+        assert_eq!(durability.barrier_count(), 1);
+        assert!(durability.skipped_barrier_count() > 10);
+
+        repo.set_thread_recorded(&ThreadName::from("main"), &state.id())
+            .unwrap();
+        repo.refs()
+            .write_head(&Head::Attached {
+                thread: ThreadName::from("main"),
+            })
+            .unwrap();
+        assert!(matches!(
+            Repository::open(&root),
+            Err(HeddleError::IncompleteClone(path)) if path == root
+        ));
+
+        CloneIntent::clear(&root).unwrap();
+        drop(durability);
+        let opened = Repository::open(&root).unwrap();
+        assert_eq!(opened.head().unwrap(), Some(state.id()));
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) fn test_state_id() -> objects::object::StateId {
 }
 
 pub mod atomic;
+pub mod clone_intent;
 mod collaboration_migration;
 mod collaboration_store;
 pub mod daemon;

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -882,6 +882,68 @@ impl Repository {
         Self::init_with_source_authority(path, RepositorySourceAuthority::Native)
     }
 
+    /// Build or resume the unpublished local skeleton for a hosted clone.
+    ///
+    /// A durable [`crate::clone_intent::CloneIntent`] must already exist. This
+    /// initializer deliberately creates no HEAD or thread ref: those are the
+    /// publication gate and are written only after the fetched closure passes
+    /// hash verification and its clone durability batch commits.
+    pub fn init_clone(path: impl AsRef<Path>) -> Result<Self> {
+        let root = path.as_ref().to_path_buf();
+        let heddle_dir = root.join(".heddle");
+        if crate::clone_intent::CloneIntent::load(&root)?.is_none() {
+            return Err(HeddleError::Config(format!(
+                "clone initialization at {} requires a durable clone intent",
+                root.display()
+            )));
+        }
+
+        objects::fs_atomic::create_private_dir_all(&heddle_dir)?;
+        let store = FsStore::new(&heddle_dir);
+        store.init()?;
+        let refs = RefManager::new(&heddle_dir);
+        refs.init()?;
+        let oplog = OpLog::new_unattributed(&heddle_dir);
+        oplog.init()?;
+
+        let config_path = heddle_dir.join("config.toml");
+        let config = match RepoConfig::load_for_repository(&config_path) {
+            Ok(config) => config,
+            Err(HeddleError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
+                let config = RepoConfig::default();
+                config.save(&config_path)?;
+                config
+            }
+            Err(error) => return Err(error),
+        };
+
+        let reconciler = std::sync::Arc::new(crate::atomic::OplogRefReconciler::new(
+            &heddle_dir,
+            compute_op_scope(&root),
+        ));
+        let committer = std::sync::Arc::new(crate::atomic::OplogRefCommitter::new(
+            &heddle_dir,
+            objects::object::Principal::new("<unknown>", ""),
+        ));
+        let refs = refs.with_reconciler(reconciler).with_committer(committer);
+        refs.init_reconcile_watermark()?;
+        let repo = Self {
+            root,
+            heddle_dir: heddle_dir.clone(),
+            capability: repository_capability_for_authority(config.repository.source_authority),
+            store: AnyStore::Fs(store),
+            refs,
+            oplog,
+            config,
+            shallow: RwLock::new(ShallowInfo::load(&heddle_dir)?),
+            blob_hydrator: RwLock::new(None),
+            git_overlay_repo: RwLock::new(None),
+            progress: RwLock::new(Progress::null()),
+        };
+        crate::migration::apply_pending(&repo)?;
+        Ok(repo)
+    }
+
     fn init_with_source_authority(
         path: impl AsRef<Path>,
         source_authority: RepositorySourceAuthority,
@@ -1062,6 +1124,10 @@ impl Repository {
                 discovered_git_root = Some(dir.to_path_buf());
             }
             let heddle_path = dir.join(".heddle");
+
+            if crate::clone_intent::CloneIntent::path(dir).is_file() {
+                return Err(HeddleError::IncompleteClone(dir.to_path_buf()));
+            }
 
             if is_heddle_repository_root(dir) {
                 let pointer_path = heddle_path.join("objectstore");

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -7,7 +7,10 @@ use std::{
     time::Instant,
 };
 
-use objects::object::ContentHash;
+use objects::{
+    fs_atomic::{sync_directory, sync_file, sync_file_data},
+    object::ContentHash,
+};
 use tracing::{debug, warn};
 
 use super::{
@@ -1444,13 +1447,13 @@ fn write_snapshot(index: &WorktreeIndex, path: &Path) -> Result<(), IndexError> 
     let mut temp_file = tempfile::NamedTempFile::new_in(path.parent().unwrap_or(Path::new(".")))?;
     temp_file.write_all(&encoded)?;
     temp_file.flush()?;
-    temp_file.as_file().sync_all()?;
+    sync_file(temp_file.as_file(), temp_file.path())?;
     let (_file, temp_path) = temp_file
         .keep()
         .map_err(|error| IndexError::Io(error.error))?;
     fs::rename(&temp_path, path)?;
     if let Some(parent) = path.parent() {
-        File::open(parent)?.sync_all()?;
+        sync_directory(parent)?;
     }
 
     Ok(())
@@ -1478,9 +1481,9 @@ fn append_journal(index: &WorktreeIndex, journal_path: &Path) -> Result<(), Inde
     file.write_all(&crc32(&payload).to_be_bytes())?;
     file.write_all(&payload)?;
     file.flush()?;
-    file.sync_data()?;
+    sync_file_data(&file, journal_path)?;
     if !journal_existed && let Some(parent) = journal_path.parent() {
-        File::open(parent)?.sync_all()?;
+        sync_directory(parent)?;
     }
     Ok(())
 }

--- a/crates/wire/src/native_pack.rs
+++ b/crates/wire/src/native_pack.rs
@@ -592,7 +592,7 @@ impl PackStreamSpool {
     fn close(&mut self) -> Result<()> {
         if let Some(mut file) = self.file.take() {
             file.flush()?;
-            file.sync_all()?;
+            objects::fs_atomic::sync_file(&file, &self.path)?;
         }
         Ok(())
     }

--- a/crates/wire/src/provider_pack.rs
+++ b/crates/wire/src/provider_pack.rs
@@ -145,7 +145,7 @@ impl ProviderPackSpool {
         let body_end = self.manifest.output_pack_length - PACK_TRAILER_LEN as u64;
         let trailer_digest = hash_file_prefix(&self.file, body_end)?;
         write_all_at(&self.file, &trailer_digest, body_end)?;
-        self.file.sync_all()?;
+        objects::fs_atomic::sync_file(&self.file, &self.pack_path)?;
         write_provider_index(&self.index_path, &self.manifest)?;
 
         let reader = PackReader::open(&self.pack_path, &self.index_path)?;
@@ -288,7 +288,7 @@ fn write_provider_index(path: &Path, manifest: &ProviderPackManifest) -> Result<
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
     file.write_all(&index.to_bytes())?;
     file.flush()?;
-    file.sync_all()?;
+    objects::fs_atomic::sync_file(&file, path)?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Persist a durable clone-intent marker before fetch, then initialize and write directly into the unpublished `.heddle` repository with clone-scoped per-operation durability suppression.
- Hash-walk the requested reachable closure before publication. Missing objects trigger the existing incremental pull; corrupt pack/index pairs are discarded selectively so only their objects are requested again.
- Recover an interrupted clone automatically when a CLI command opens it. The marker remains the publication gate, so `Repository::open` rejects partial state instead of presenting it as a repository.
- Preserve ordinary per-operation durability outside the clone root and after the clone batch ends.

The load-bearing commit order is explicit and tested: reachable closure hash-complete -> one filesystem durability commit -> publish refs/HEAD -> clear clone intent last. Therefore a cleared marker strictly implies that the referenced object data was complete and durable before publication.

## Test evidence

- Structural counter: `clone_commit_is_one_barrier_and_marker_gates_publication` asserts exactly 1 clone commit barrier while more than 10 former per-operation barriers are suppressed. Local `strace -f -e fsync,fdatasync,syncfs -c` on the 9-object baby repo dropped from 107 calls to 6 O(1) calls: 5 calls for the sole early durable intent marker and exactly 1 late `syncfs` commit.
- Wall time, localhost baby repo, debug build: documented before median 639 ms (617-948 ms); after median 140 ms across 7 runs (120-450 ms), a 4.6x median improvement.
- Recovery/negative case: fault-injected a crash at `clone_after_fetch_before_verify`, confirmed the marker remained, truncated the fetched pack to 32 bytes, and opened via `heddle status`. Open repaired from the remote incrementally, cleared the marker only after re-verification/commit, reproduced the authoritative pack SHA-256 `06594f12dfcf51af6b792b55ee024b4496d156b8ea8a1374dba50ca01bcd0cf3`, and passed `heddle fsck --full`.
- Automated recovery coverage: `interrupted_clone_discards_only_short_pack_and_accepts_remote_repair`, `clone_commit_is_one_barrier_and_marker_gates_publication`, and both connected-interruption clone output-contract tests pass.
- Blacksmith-equivalent local gates: strict affected-package clippy, the four repository/CLI feature-shape checks, `heddle-wire` tests, default CLI executable contracts, and focused clone/recovery suites pass. The affected-package aggregate run passed the CLI library and 889/889 non-ignored CLI integration tests; one load-sensitive fsmonitor warm-up assertion failed later in the run and passed immediately when rerun alone.

Closes #1239

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788460596&installation_model_id=21489&pr_number=1240&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1240&signature=e9ef3b2acb2a4c0dde846e02017037cc31c117bf72baadb87269733be97b6136"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->