### PR TITLE
fix(clone): adopt advertised git lane authority

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -43,9 +43,9 @@ use objects::{
     sync::LockExt,
 };
 use refs::Head;
-#[cfg(feature = "client")]
-use repo::clone_intent::CloneIntent;
 use repo::{BlobHydrator, Repository};
+#[cfg(feature = "client")]
+use repo::{RepositorySourceAuthority, clone_intent::CloneIntent};
 use serde::Serialize;
 #[cfg(feature = "client")]
 use sley::plumbing::sley_worktree;
@@ -1621,16 +1621,7 @@ async fn clone_network_connected(
                     repo_path,
                 )
                 .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
-                let git_overlay_clone =
-                    hosted_clone_thread_revision_address(&refs.refs, &track_name)
-                        .is_some_and(|address| address.starts_with("git:"));
-                fs::create_dir_all(local_path)
-                    .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
-                if git_overlay_clone {
-                    SleyRepository::init(local_path)
-                        .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
-                }
-                let repo = Repository::init_clone(local_path).map_err(wire::ProtocolError::from)?;
+                let repo = initialize_hosted_clone_repository(local_path, &refs.refs, &track_name)?;
                 folded_refs = Some(refs.refs);
                 Ok(repo)
             },
@@ -1654,13 +1645,8 @@ async fn clone_network_connected(
                 remote_refs.iter().map(|entry| entry.name.as_str()),
                 repo_path,
             )?;
-            let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
-                .is_some_and(|address| address.starts_with("git:"));
-            fs::create_dir_all(local_path)?;
-            if git_overlay_clone {
-                SleyRepository::init(local_path).map_err(anyhow::Error::msg)?;
-            }
-            let local_repo = Repository::init_clone(local_path)?;
+            let local_repo =
+                initialize_hosted_clone_repository(local_path, &remote_refs, &track_name)?;
             let result = client
                 .repair_clone_with_depth_and_materialization(
                     &local_repo,
@@ -1898,8 +1884,6 @@ async fn recover_interrupted_clone_connected(
     intent: &CloneIntent,
     client: &mut HostedClient,
 ) -> Result<()> {
-    let durability = CloneDurabilityBatch::begin(root);
-    let repo = Repository::init_clone(root)?;
     let remote_refs = client
         .list_refs_with_revision_addresses(&intent.repository)
         .await?;
@@ -1913,9 +1897,8 @@ async fn recover_interrupted_clone_connected(
     )?;
     let git_overlay_clone = hosted_clone_thread_revision_address(&remote_refs, &track_name)
         .is_some_and(|address| address.starts_with("git:"));
-    if git_overlay_clone && !root.join(".git").exists() {
-        SleyRepository::init(root).map_err(anyhow::Error::msg)?;
-    }
+    let durability = CloneDurabilityBatch::begin(root);
+    let repo = initialize_hosted_clone_repository(root, &remote_refs, &track_name)?;
     let materialization = if intent.lazy {
         PullMaterialization::Lazy
     } else {
@@ -2472,6 +2455,28 @@ fn hosted_clone_thread_revision_address<'a>(
 }
 
 #[cfg(feature = "client")]
+fn initialize_hosted_clone_repository(
+    root: &Path,
+    remote_refs: &[HostedRefEntry],
+    track_name: &str,
+) -> std::result::Result<Repository, wire::ProtocolError> {
+    let source_authority = if hosted_clone_thread_revision_address(remote_refs, track_name)
+        .is_some_and(|address| address.starts_with("git:"))
+    {
+        RepositorySourceAuthority::GitOverlay
+    } else {
+        RepositorySourceAuthority::Native
+    };
+    fs::create_dir_all(root)
+        .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
+    if source_authority == RepositorySourceAuthority::GitOverlay && !root.join(".git").exists() {
+        SleyRepository::init(root)
+            .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
+    }
+    Repository::init_clone(root, source_authority).map_err(wire::ProtocolError::from)
+}
+
+#[cfg(feature = "client")]
 fn finish_hosted_git_overlay_checkout(repo: &Repository, branch: &str) -> Result<()> {
     Repository::ensure_git_overlay_local_excludes(repo.root())?;
     let git_repo = SleyRepository::discover(repo.root()).map_err(anyhow::Error::msg)?;
@@ -2790,6 +2795,67 @@ mod tests {
                 .expect("thread selected");
 
         assert_eq!(selected, "feature");
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_initialization_adopts_advertised_git_lane() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("clone");
+        CloneIntent {
+            origin: "heddle://127.0.0.1:8421/owner/repo".to_string(),
+            endpoint: "127.0.0.1:8421".to_string(),
+            repository: "owner/repo".to_string(),
+            thread: Some("main".to_string()),
+            depth: None,
+            lazy: false,
+        }
+        .create(&root)
+        .expect("create clone intent");
+        let remote_refs = vec![HostedRefEntry {
+            name: "main".to_string(),
+            state_id: objects::object::StateId::from_bytes([1; 32]),
+            is_thread: true,
+            revision_address: "git:5b2471720c93ee30e5764a19f3d3b3ae9ec9712a".to_string(),
+        }];
+
+        let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
+            .expect("initialize Git-lane clone");
+
+        assert_eq!(
+            repo.source_authority(),
+            RepositorySourceAuthority::GitOverlay
+        );
+        assert!(root.join(".git").is_dir());
+    }
+
+    #[cfg(feature = "client")]
+    #[test]
+    fn hosted_clone_initialization_keeps_native_lane_native() {
+        let temp = tempfile::TempDir::new().expect("temp");
+        let root = temp.path().join("clone");
+        CloneIntent {
+            origin: "heddle://127.0.0.1:8421/owner/repo".to_string(),
+            endpoint: "127.0.0.1:8421".to_string(),
+            repository: "owner/repo".to_string(),
+            thread: Some("main".to_string()),
+            depth: None,
+            lazy: false,
+        }
+        .create(&root)
+        .expect("create clone intent");
+        let remote_refs = vec![HostedRefEntry {
+            name: "main".to_string(),
+            state_id: objects::object::StateId::from_bytes([2; 32]),
+            is_thread: true,
+            revision_address: "heddle:0123456789abcdef".to_string(),
+        }];
+
+        let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
+            .expect("initialize native clone");
+
+        assert_eq!(repo.source_authority(), RepositorySourceAuthority::Native);
+        assert!(!root.join(".git").exists());
     }
 
     // weft#633: the hosted ListRefs response for a git-overlay repo carries

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -4714,6 +4714,33 @@ mod git_lane_pull_staging_tests {
             .expect_err("duplicate ref update must be rejected");
         assert!(duplicate.to_string().contains("duplicate"));
     }
+
+    #[test]
+    fn hosted_pull_rejects_git_lane_transfer_for_native_repository() {
+        let temp = tempfile::TempDir::new().expect("temp native repo");
+        let repo = Repository::init_default(temp.path()).expect("init native repo");
+        let mut git_repo = None;
+        let mut pack_state = GitPackPullInstallState::default();
+        let mut staged = staging(true);
+
+        let error = accept_git_lane_pull_transfer(
+            &repo,
+            &mut git_repo,
+            &mut pack_state,
+            &mut staged,
+            GitLaneTransfer {
+                body: Some(git_lane_transfer::Body::Checkpoint(
+                    GitCheckpointTransfer::default(),
+                )),
+            },
+        )
+        .expect_err("native repositories must reject Git-lane transfers");
+
+        println!("{error}");
+        assert!(error.to_string().contains(
+            "received git-lane pull transfer for non-GitOverlay repository (capability NativeHeddle)"
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/crates/repo/src/clone_intent.rs
+++ b/crates/repo/src/clone_intent.rs
@@ -71,14 +71,15 @@ pub fn find_clone_intent_root(start: &Path) -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::Repository;
     use objects::{
         fs_atomic::CloneDurabilityBatch,
         object::{Attribution, Principal, State, ThreadName, Tree},
         store::ObjectStore,
     };
     use refs::Head;
+
+    use super::*;
+    use crate::{Repository, RepositorySourceAuthority};
 
     fn intent() -> CloneIntent {
         CloneIntent {
@@ -98,7 +99,7 @@ mod tests {
         intent().create(&root).unwrap();
 
         let durability = CloneDurabilityBatch::begin(&root);
-        let repo = Repository::init_clone(&root).unwrap();
+        let repo = Repository::init_clone(&root, RepositorySourceAuthority::Native).unwrap();
         assert!(!repo.heddle_dir().join("HEAD").exists());
         assert!(matches!(
             Repository::open(&root),

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -885,10 +885,14 @@ impl Repository {
     /// Build or resume the unpublished local skeleton for a hosted clone.
     ///
     /// A durable [`crate::clone_intent::CloneIntent`] must already exist. This
-    /// initializer deliberately creates no HEAD or thread ref: those are the
-    /// publication gate and are written only after the fetched closure passes
-    /// hash verification and its clone durability batch commits.
-    pub fn init_clone(path: impl AsRef<Path>) -> Result<Self> {
+    /// initializer persists the source authority selected from the server's
+    /// bootstrap refs, but deliberately creates no HEAD or thread ref: those
+    /// are the publication gate and are written only after the fetched closure
+    /// passes hash verification and its clone durability batch commits.
+    pub fn init_clone(
+        path: impl AsRef<Path>,
+        source_authority: RepositorySourceAuthority,
+    ) -> Result<Self> {
         let root = path.as_ref().to_path_buf();
         let heddle_dir = root.join(".heddle");
         if crate::clone_intent::CloneIntent::load(&root)?.is_none() {
@@ -907,15 +911,16 @@ impl Repository {
         oplog.init()?;
 
         let config_path = heddle_dir.join("config.toml");
-        let config = match RepoConfig::load_for_repository(&config_path) {
+        let mut config = match RepoConfig::load_for_repository(&config_path) {
             Ok(config) => config,
             Err(HeddleError::Io(error)) if error.kind() == std::io::ErrorKind::NotFound => {
-                let config = RepoConfig::default();
-                config.save(&config_path)?;
-                config
+                RepoConfig::default()
             }
             Err(error) => return Err(error),
         };
+        config.repository.source_authority = source_authority;
+        config.save(&config_path)?;
+        let store = Self::build_store(&config, &root, &heddle_dir, None)?;
 
         let reconciler = std::sync::Arc::new(crate::atomic::OplogRefReconciler::new(
             &heddle_dir,
@@ -931,7 +936,7 @@ impl Repository {
             root,
             heddle_dir: heddle_dir.clone(),
             capability: repository_capability_for_authority(config.repository.source_authority),
-            store: AnyStore::Fs(store),
+            store,
             refs,
             oplog,
             config,


### PR DESCRIPTION
## Summary

- derive hosted clone source authority from the selected bootstrap ref revision address before Repository::init_clone
- initialize Git-lane destinations as GitOverlay with the external Git object store, including interrupted-clone recovery
- preserve native clone initialization and the fail-closed Git-lane capability guard

## Verification

- parked git.git Git-lane clone completed in 256.81s as git-overlay
- HEAD: 5b2471720c93ee30e5764a19f3d3b3ae9ec9712a
- pack parity: 417860 objects, 316178524 bytes, SHA-256 6490ad8bf940ae5e1b8f2707952a2cede7ca77575953d49e3bc3417ab4f334ac
- invalid NativeHeddle/Git-lane transfer still rejects with the original invalid-state error
- native fixture clone remains native-heddle, verified clean, and creates no .git directory
- exact affected-package build, Clippy, and tests passed
- CI feature-contract and telemetry build, Clippy, and tests passed
- default CLI executable contracts passed

Closes #1241

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1242"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788476927&installation_model_id=21489&pr_number=1242&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1242&signature=2f925a03f0fd5ec574c1b3017c19eadb6cf37753276fab07ca57dcd740e29adc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->