### PR TITLE
fix(ignore): honour .gitignore under status monitor + document ignore surface

### DIFF
--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -157,7 +157,7 @@ pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
                  or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
                  `git-overlay`, \
                  `threads`, `daemon`, `signals`, `git-projection`, `operation-ids`, \
-                 `remotes`, `output-formats`, `heddleignore`, `git-dependencies`)."
+                 `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`)."
             );
         }
         [name] if name == "advanced" => {

--- a/crates/cli/src/cli/commands/init.rs
+++ b/crates/cli/src/cli/commands/init.rs
@@ -291,6 +291,14 @@ fn render_init(output: &InitOutput, json: bool) -> Result<()> {
                 println!("  - {effect}");
             }
         }
+        // heddle#1155: init never installs ignore policy, but must not leave
+        // that fact silent — operators need a pointer before the first
+        // capture sweeps build junk into permanent history.
+        if !output.installed_heddleignore {
+            println!(
+                "Ignore: not installed. Root `.gitignore` is honoured; add Heddle-only rules in `.heddleignore` (see `heddle help ignore`)."
+            );
+        }
         if let Some(next) = output.recommended_action.as_deref() {
             print_next(next);
         }

--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -163,4 +163,178 @@ fn heddleignore_help_topic_prints_the_documented_contract() {
     assert!(help.contains("# `.heddleignore`"));
     assert!(help.contains("one ordered rule stream"));
     assert!(help.contains("500 or more paths"));
+    assert!(help.contains("[worktree] ignore"));
+    assert!(help.contains("no `--path` filter") || help.contains("no `--path`"));
+}
+
+#[test]
+fn ignore_help_alias_renders_the_same_topic() {
+    let help = heddle_help(&["help", "ignore"]);
+    assert!(!help.contains("no topic or command"));
+    assert!(help.contains("# `.heddleignore`"));
+    assert!(help.contains(".gitignore"));
+    assert!(help.contains("[worktree] ignore"));
+}
+
+#[test]
+fn status_and_capture_omit_python_build_junk_listed_in_gitignore() {
+    // Evaluator repro for heddle#1155: pytest leaves `__pycache__` / `.pyc`
+    // next to source; with those patterns in root `.gitignore`, status must
+    // not list them and capture must not record them.
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join(".gitignore"),
+        "__pycache__/\n*.pyc\n.pytest_cache/\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("app.py"), "print('hi')\n").unwrap();
+    std::fs::write(temp.path().join("kept.txt"), "real\n").unwrap();
+    std::fs::create_dir_all(temp.path().join("__pycache__")).unwrap();
+    std::fs::create_dir_all(temp.path().join("src/__pycache__")).unwrap();
+    std::fs::create_dir_all(temp.path().join(".pytest_cache/v")).unwrap();
+    std::fs::write(
+        temp.path().join("__pycache__/app.cpython-312.pyc"),
+        "binary",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join("src/__pycache__/mod.cpython-312.pyc"),
+        "binary",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("src/app.pyc"), "binary").unwrap();
+    std::fs::write(temp.path().join(".pytest_cache/v/cache"), "cache").unwrap();
+
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let status = heddle(&["status"], Some(temp.path())).unwrap();
+    assert!(
+        !status.contains("__pycache__")
+            && !status.contains(".pyc")
+            && !status.contains(".pytest_cache"),
+        "status must not list gitignored build junk: {status}"
+    );
+    assert!(
+        status.contains("kept.txt") && status.contains("app.py"),
+        "status must still list real worktree files: {status}"
+    );
+
+    heddle(
+        &["capture", "-m", "seed without build junk"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    assert!(!captured_path_exists(
+        temp.path(),
+        "__pycache__/app.cpython-312.pyc"
+    ));
+    assert!(!captured_path_exists(
+        temp.path(),
+        "src/__pycache__/mod.cpython-312.pyc"
+    ));
+    assert!(!captured_path_exists(temp.path(), "src/app.pyc"));
+    assert!(!captured_path_exists(temp.path(), ".pytest_cache/v/cache"));
+    assert!(captured_path_exists(temp.path(), "kept.txt"));
+    assert!(captured_path_exists(temp.path(), "app.py"));
+}
+
+#[test]
+fn thread_checkout_status_and_capture_honour_root_gitignore() {
+    // heddle#1155: isolated thread checkouts must use the same ignore
+    // stream as the origin root, including root `.gitignore`.
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin");
+    let thread = temp.path().join("thread");
+    std::fs::create_dir(&origin).unwrap();
+    std::fs::write(
+        origin.join(".gitignore"),
+        "__pycache__/\n*.pyc\n.pytest_cache/\n",
+    )
+    .unwrap();
+    std::fs::write(origin.join("app.py"), "print('hi')\n").unwrap();
+    heddle(&["init"], Some(&origin)).unwrap();
+    heddle(&["capture", "-m", "seed"], Some(&origin)).unwrap();
+    heddle(
+        &[
+            "start",
+            "feature/pytest",
+            "--path",
+            thread.to_str().expect("utf-8 thread path"),
+        ],
+        Some(&origin),
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(thread.join("__pycache__")).unwrap();
+    std::fs::create_dir_all(thread.join("src/__pycache__")).unwrap();
+    std::fs::create_dir_all(thread.join(".pytest_cache/v")).unwrap();
+    std::fs::write(thread.join("__pycache__/app.cpython-312.pyc"), "binary").unwrap();
+    std::fs::write(thread.join("src/__pycache__/mod.cpython-312.pyc"), "binary").unwrap();
+    std::fs::write(thread.join(".pytest_cache/v/cache"), "cache").unwrap();
+    std::fs::write(thread.join("feature.txt"), "new feature\n").unwrap();
+
+    let status = heddle(&["status"], Some(&thread)).unwrap();
+    assert!(
+        !status.contains("__pycache__")
+            && !status.contains(".pyc")
+            && !status.contains(".pytest_cache"),
+        "thread status must not list gitignored build junk: {status}"
+    );
+    assert!(
+        status.contains("feature.txt"),
+        "thread status must list the real unignored change: {status}"
+    );
+
+    heddle(&["capture", "-m", "after pytest junk"], Some(&thread)).unwrap();
+    assert!(!captured_path_exists(
+        &thread,
+        "__pycache__/app.cpython-312.pyc"
+    ));
+    assert!(!captured_path_exists(
+        &thread,
+        "src/__pycache__/mod.cpython-312.pyc"
+    ));
+    assert!(!captured_path_exists(&thread, ".pytest_cache/v/cache"));
+    assert!(captured_path_exists(&thread, "feature.txt"));
+    assert!(captured_path_exists(&thread, "app.py"));
+}
+
+#[test]
+fn removing_gitignore_rule_makes_junk_reappear_in_status_and_capture() {
+    // Guard is load-bearing: without the ignore rule the same paths return.
+    let temp = TempDir::new().unwrap();
+    std::fs::write(temp.path().join(".gitignore"), "__pycache__/\n").unwrap();
+    std::fs::write(temp.path().join("kept.txt"), "real\n").unwrap();
+    std::fs::create_dir(temp.path().join("__pycache__")).unwrap();
+    std::fs::write(temp.path().join("__pycache__/app.pyc"), "binary").unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    heddle(&["capture", "-m", "ignored junk"], Some(temp.path())).unwrap();
+    assert!(!captured_path_exists(temp.path(), "__pycache__/app.pyc"));
+
+    std::fs::write(temp.path().join(".gitignore"), "").unwrap();
+    let status = heddle(&["status"], Some(temp.path())).unwrap();
+    assert!(
+        status.contains("__pycache__") || status.contains("app.pyc"),
+        "clearing the ignore rule must surface the junk again: {status}"
+    );
+    heddle(
+        &["capture", "-m", "junk no longer ignored"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    assert!(captured_path_exists(temp.path(), "__pycache__/app.pyc"));
+    assert!(captured_path_exists(temp.path(), "kept.txt"));
+}
+
+#[test]
+fn init_text_points_at_ignore_help_when_heddleignore_not_installed() {
+    let temp = TempDir::new().unwrap();
+    let out = heddle(&["init"], Some(temp.path())).unwrap();
+    assert!(
+        out.contains("heddle help ignore") || out.contains("`heddle help ignore`"),
+        "init must point at ignore docs when it does not install .heddleignore: {out}"
+    );
+    assert!(
+        out.contains(".heddleignore") || out.contains("Ignore:"),
+        "init must name the ignore surface: {out}"
+    );
 }

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -166,7 +166,11 @@ impl ChangeMonitorSession {
         let Some(changed_paths) = &self.changed_paths else {
             return true;
         };
-        if changed_paths.contains(".heddleignore") {
+        // Ignore-policy files rewrite which paths are visible. Any change to
+        // them invalidates per-path monitor skips so previously-ignored junk
+        // reappears (and newly-ignored paths disappear) without requiring a
+        // touch inside those trees (heddle#1155).
+        if ignore_policy_paths_changed(changed_paths) {
             return true;
         }
         let key = cache_key(rel_path);
@@ -208,7 +212,7 @@ impl ChangeMonitorSession {
             Some(paths) => paths,
             None => return false,
         };
-        if changed_paths.contains(".heddleignore") {
+        if ignore_policy_paths_changed(changed_paths) {
             return false;
         }
         let tree = match tree {
@@ -283,6 +287,15 @@ impl ChangeMonitorSession {
 fn subtree_skip_disabled() -> bool {
     std::env::var("HEDDLE_PERF_DISABLE_SUBTREE_SKIP")
         .is_ok_and(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+}
+
+/// Root ignore-policy files whose content rewrite which paths status/capture
+/// may observe. A change to any of these forces a full ignore re-evaluation
+/// under the change monitor (same as editing a tracked source file would).
+fn ignore_policy_paths_changed(changed_paths: &BTreeSet<String>) -> bool {
+    changed_paths.iter().any(|path| {
+        path == ".heddleignore" || path == ".gitignore" || path == ".heddle/info/exclude"
+    })
 }
 
 const fn native_backend_supported() -> bool {

--- a/crates/repo/src/status_monitor_tests.rs
+++ b/crates/repo/src/status_monitor_tests.rs
@@ -178,6 +178,39 @@ fn ignore_rule_transitions_force_the_same_safe_result_as_a_full_scan() {
 }
 
 #[test]
+fn gitignore_rule_transitions_force_the_same_safe_result_as_a_full_scan() {
+    // heddle#1155: clearing root `.gitignore` must re-surface previously
+    // ignored untracked paths under the change monitor, not leave them
+    // hidden until something inside the junk tree is touched.
+    let (temp, repo, tree, index) = seed_repo();
+    fs::create_dir_all(temp.path().join("__pycache__")).unwrap();
+    fs::write(temp.path().join("__pycache__/app.pyc"), "binary").unwrap();
+    fs::write(temp.path().join(".gitignore"), "__pycache__/\n").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".gitignore".to_string()]),
+    );
+
+    fs::write(temp.path().join(".gitignore"), "").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".gitignore".to_string()]),
+    );
+
+    fs::write(temp.path().join(".gitignore"), "__pycache__/\n").unwrap();
+    assert_monitor_matches_full(
+        &repo,
+        &tree,
+        &index,
+        &BTreeSet::from([".gitignore".to_string()]),
+    );
+}
+
+#[test]
 fn missing_or_cursor_lagging_index_never_reports_false_clean() {
     let (temp, repo, tree, mut index) = seed_repo();
     fs::write(temp.path().join("src/a.txt"), "changed after cursor").unwrap();

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -49,8 +49,35 @@ Native mode reads `.gitignore` directly from the worktree even when no `.git`
 directory exists. Reading it does not discover, initialize, or otherwise
 require a Git repository.
 
+`heddle status` and `heddle capture` share this matcher in the root checkout
+and in isolated thread checkouts (`heddle start --path …`). Build junk that
+matches a root ignore rule is never listed as unsaved work and never enters
+permanent history.
+
 Heddle always protects its own `.heddle/` metadata. Other paths must
-be explicit in `.gitignore` or `.heddleignore`.
+be explicit in `.gitignore`, `.heddleignore`, or the config key below.
+
+## Config key: `[worktree] ignore`
+
+Repository config (`.heddle/config.toml`) can also contribute patterns:
+
+```toml
+[worktree]
+ignore = [".heddle", "scratch/"]
+```
+
+Config patterns are loaded first, then root `.gitignore`, then
+`.heddle/info/exclude`, then root `.heddleignore`. Prefer the ignore files
+for project policy; use `[worktree] ignore` for operator-local or
+repo-engine defaults that should not appear as a tracked ignore file.
+Default config always includes `.heddle`.
+
+## Capture path scoping
+
+`heddle capture` has no `--path` filter and no staging area: it saves the
+full unignored worktree. Exclude build junk with ignore rules before
+capture; do not expect path selection on the capture command. Path-scoped
+capture is a possible follow-up feature, not current behaviour.
 
 Ignore changes affect future captures only. Existing states are immutable, so
 previously captured artifacts remain in history. To clean the current line of


### PR DESCRIPTION
## Summary

`status`/`capture` already honour root `.gitignore` (and thread checkouts) via the ordered ignore stream at `Repository::ignore_patterns` (`crates/repo/src/repository.rs`); this PR closes heddle#1155 by (1) making the change-monitor invalidation load-bearing for `.gitignore` / `.heddle/info/exclude` so narrowing ignore rules re-surfaces build junk without touching those trees (`crates/repo/src/fsmonitor.rs`), (2) documenting `.heddleignore`, `[worktree] ignore`, gitignore honouring, and that capture has no `--path` filter (`docs/heddleignore.md` / `heddle help ignore`), and (3) locking the evaluator pycache scenario with root + thread regression tests. Capture path scoping remains a deliberate follow-up, not part of this PR.

## Closes
Closes HeddleCo/heddle#1155

## Test evidence

**Before (monitor gap on this branch pre-fix):** with `__pycache__/` in `.gitignore`, generate junk, capture (clean), then clear `.gitignore`. Status only showed `modified: .gitignore` and hid `__pycache__/app.pyc` until something inside the junk tree was touched — ignore narrowing was not load-bearing under the change monitor.

**After (actual outputs):**

Thread checkout with pytest junk on disk; status lists only the real file:
```
Changes not yet saved
  added:    feature.txt
```
Capture records only that file:
```
--- a/feature.txt
+++ b/feature.txt
@@ -0,0 +1,1 @@
        1 | +new feature
```
Clearing `.gitignore` re-surfaces junk without touching it:
```
Changes not yet saved
  modified: .gitignore
  added:    .pytest_cache/v/cache
  added:    __pycache__/app.cpython-312.pyc
  added:    src/__pycache__/mod.cpython-312.pyc
  added:    src/app.pyc
```
`heddle init` no longer leaves ignore policy silent:
```
Ignore: not installed. Root `.gitignore` is honoured; add Heddle-only rules in `.heddleignore` (see `heddle help ignore`).
```
`heddle help ignore` renders and names `.heddleignore`, `.gitignore`, and `[worktree] ignore`.

**Automated:**
- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli --test cli_integration ignore_mechanics` — 11 passed
- `TMPDIR=/home/scratch cargo test --locked -p heddle-repo --lib` — 626 passed, 2 ignored
- `TMPDIR=/home/scratch cargo test --locked -p heddle-cli-contract --lib` — 125 passed
- `cargo clippy --locked -p heddle-repo -p heddle-cli -p heddle-cli-contract --all-targets -- -D warnings` — clean
- `rustfmt +nightly --edition 2024 --check` on touched Rust files — clean

**Follow-up (out of scope):** `capture --path` path scoping.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1244"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788494607&installation_model_id=21489&pr_number=1244&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1244&signature=3cd604ff5b16c09ba6ec8b11630d8d9a6db94494b5ae2bc2da87524aa9167991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->