### PR TITLE
perf(fsmonitor): park helper daemons instead of polling accept

### DIFF
--- a/crates/cli/src/cli/commands/daemon/server.rs
+++ b/crates/cli/src/cli/commands/daemon/server.rs
@@ -42,7 +42,6 @@ pub fn run_mount_daemon(repo_root: &Path) -> Result<()> {
     }
 
     let listener = TcpListener::bind((HELPER_HOST, 0))?;
-    listener.set_nonblocking(true)?;
     let port = listener.local_addr()?.port();
     persist_endpoint(
         &endpoint_path,

--- a/crates/repo/src/daemon/mod.rs
+++ b/crates/repo/src/daemon/mod.rs
@@ -47,5 +47,7 @@ pub use mount_proto::{
     MountDaemonRequest, MountDaemonResponse, MountRegistryFile, MountStatus, PersistedMount,
     mount_daemon_endpoint_path, mount_daemon_registry_path,
 };
-pub use protocol::{HELPER_HOST, HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS, send_json_request};
+pub use protocol::{
+    HELPER_HOST, HELPER_IDLE_TIMEOUT_SECS, HELPER_TICK_INTERVAL_MS, send_json_request,
+};
 pub use server::{IdleDecision, mount_idle_policy, run_server_loop};

--- a/crates/repo/src/daemon/protocol.rs
+++ b/crates/repo/src/daemon/protocol.rs
@@ -20,7 +20,21 @@ use super::endpoint::EndpointState;
 pub const HELPER_HOST: &str = "127.0.0.1";
 pub const HELPER_CONNECT_TIMEOUT_MS: u64 = 1000;
 pub const HELPER_IDLE_TIMEOUT_SECS: u64 = 300;
-pub const HELPER_IDLE_POLL_MS: u64 = 5;
+
+/// How long a helper parks waiting for a connection before running an
+/// idle tick.
+///
+/// This is a heartbeat, not a poll interval: the listener loop blocks
+/// in `accept()` on a dedicated thread and parks on a channel here, so
+/// a connection is serviced the moment it lands regardless of this
+/// value. It only bounds how long a handler waits before it next gets
+/// to drain background state and re-check the idle timeout.
+///
+/// It used to be 5ms, with the loop spinning `accept()` non-blocking
+/// and sleeping between tries. Over one 300s idle lifetime that cost
+/// ~60,000 `accept4`-EAGAIN + `clock_nanosleep` pairs per live helper —
+/// the busy-wait measured in heddle#1243.
+pub const HELPER_TICK_INTERVAL_MS: u64 = 1_000;
 
 /// Send a single JSON request to a helper and decode its single-line
 /// JSON reply. Used by both the fsmonitor and mount daemon clients.

--- a/crates/repo/src/daemon/server.rs
+++ b/crates/repo/src/daemon/server.rs
@@ -28,6 +28,12 @@ use objects::error::HeddleError;
 
 use super::protocol::{HELPER_IDLE_TIMEOUT_SECS, HELPER_TICK_INTERVAL_MS};
 
+/// How long the exit path waits on its own listener when handing the
+/// acceptor thread the connection that retires it. Bounded because
+/// the dial is a courtesy, not a requirement — see the teardown note
+/// in [`run_server_loop`].
+const ACCEPTOR_RETIRE_TIMEOUT: Duration = Duration::from_millis(250);
+
 /// Decision returned by the per-tick policy when no connection is
 /// pending.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,7 +82,7 @@ pub trait DaemonHandler {
 /// Drive `listener` with `handler` until the handler returns
 /// [`IdleDecision::Exit`] from its tick.
 ///
-/// The listener is switched to blocking mode: a scoped acceptor
+/// The listener is switched to blocking mode: a detached acceptor
 /// thread owns the `accept()` call and forwards each socket over a
 /// channel, so an idle helper costs one parked thread rather than a
 /// poll-sleep loop.
@@ -85,39 +91,43 @@ pub fn run_server_loop<H: DaemonHandler>(
     handler: &mut H,
 ) -> Result<(), HeddleError> {
     listener.set_nonblocking(false)?;
-    // Captured before the acceptor starts so the exit path can dial
-    // the listener back and unblock it.
+    // Cloned so the acceptor owns a `'static` listener: the thread is
+    // deliberately not joined (see the teardown note below), so it
+    // cannot borrow from this frame.
     let local_addr = listener.local_addr()?;
+    let acceptor_listener = listener.try_clone()?;
     let (connection_tx, connection_rx) = mpsc::channel::<TcpStream>();
 
-    thread::scope(|scope| {
-        let acceptor = scope.spawn(move || {
-            loop {
-                match listener.accept() {
-                    // A send error means the serve loop is gone; so are we.
-                    Ok((stream, _)) => {
-                        if connection_tx.send(stream).is_err() {
-                            return;
-                        }
+    thread::spawn(move || {
+        loop {
+            match acceptor_listener.accept() {
+                // A send error means the serve loop is gone; so are we.
+                Ok((stream, _)) => {
+                    if connection_tx.send(stream).is_err() {
+                        return;
                     }
-                    Err(error) if error.kind() == ErrorKind::Interrupted => {}
-                    Err(_) => return,
                 }
+                Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                Err(_) => return,
             }
-        });
+        }
+    });
 
-        let result = serve_connections(handler, &connection_rx);
+    let result = serve_connections(handler, &connection_rx);
 
-        // Retire the acceptor before the scope joins it. Dropping the
-        // receiver alone is not enough — the thread is parked inside
-        // `accept()` and only notices once a connection lands, so we
-        // dial our own listener to hand it one. The socket is bound to
-        // loopback, so this cannot leave the network.
-        drop(connection_rx);
-        let _ = TcpStream::connect(local_addr);
-        let _ = acceptor.join();
-        result
-    })
+    // Retire the acceptor, but never *wait* on it. The thread is
+    // parked inside `accept()` and only notices the dropped receiver
+    // once a connection lands, so we hand it one by dialling our own
+    // loopback listener. That dial is best-effort: it is exactly the
+    // operation that fails when the box is out of file descriptors,
+    // and an earlier revision of this function joined the acceptor
+    // afterwards — which turned a failed dial into a helper that
+    // parks forever, holding its inotify instance and its endpoint
+    // file. Detaching instead bounds the exit path unconditionally;
+    // a still-parked acceptor dies with the process.
+    drop(connection_rx);
+    let _ = TcpStream::connect_timeout(&local_addr, ACCEPTOR_RETIRE_TIMEOUT);
+    result
 }
 
 /// Service connections until the handler asks to exit. Split out of
@@ -398,6 +408,51 @@ mod tests {
         assert!(
             elapsed < Duration::from_secs(30),
             "serving one RPC took {elapsed:?}; the loop is gating accepts on its tick interval"
+        );
+    }
+
+    /// Handler that exits on its very first tick, without ever being
+    /// handed a connection.
+    struct ExitAtOnce;
+
+    impl DaemonHandler for ExitAtOnce {
+        fn handle(&mut self, _stream: TcpStream) -> Result<(), HeddleError> {
+            Ok(())
+        }
+
+        fn on_tick(&mut self, _idle_for: Duration) -> IdleDecision {
+            IdleDecision::Exit
+        }
+
+        fn tick_interval(&self) -> Duration {
+            Duration::from_millis(10)
+        }
+    }
+
+    /// The exit path must be bounded. It retires the acceptor thread by
+    /// dialling the loop's own listener, and that dial can fail — it is
+    /// the first thing to break when a box is out of file descriptors,
+    /// which is exactly the condition a helper storm creates. An
+    /// earlier revision joined the acceptor after the dial, so a failed
+    /// dial parked the helper forever: it never released its inotify
+    /// instance and never removed its endpoint file, and clients that
+    /// later read that file got ECONNREFUSED.
+    ///
+    /// This pins the observable half of that contract — the loop
+    /// returns without a connection ever arriving. The dial-fails case
+    /// is excluded structurally rather than simulated: there is no
+    /// `join`, so no code path can wait on the acceptor at all.
+    #[test]
+    fn the_exit_path_does_not_wait_on_the_acceptor_thread() {
+        let listener = TcpListener::bind((HELPER_HOST, 0)).unwrap();
+
+        let started = Instant::now();
+        run_server_loop(&listener, &mut ExitAtOnce).unwrap();
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(5),
+            "exiting an idle loop took {elapsed:?}; the teardown is blocking on the acceptor"
         );
     }
 }

--- a/crates/repo/src/daemon/server.rs
+++ b/crates/repo/src/daemon/server.rs
@@ -3,25 +3,37 @@
 //!
 //! Spawns nothing on its own — the caller binds the [`TcpListener`]
 //! and provides a [`DaemonHandler`] for per-connection RPC + idle
-//! ticks. We handle the accept loop, the idle-poll heartbeat, and
-//! the per-connection JSON framing. The daemon-specific logic (verb
+//! ticks. We handle the accept loop, the idle heartbeat, and the
+//! per-connection JSON framing. The daemon-specific logic (verb
 //! switch, registry mutation, persisted state) stays out of here.
+//!
+//! The wait is event-driven. An earlier shape put the listener in
+//! non-blocking mode and spun `accept()` / `sleep(5ms)`, which cost
+//! ~60,000 `accept4`-EAGAIN + `clock_nanosleep` pairs over a single
+//! helper's 300s idle lifetime — measured at 46,680 `accept4` (46,679
+//! failing) and 46,678 `clock_nanosleep` in the heddle#1243 clone
+//! trace. Now a dedicated thread parks in a blocking `accept()` and
+//! hands sockets over a channel; the main loop parks on that channel
+//! with [`DaemonHandler::tick_interval`] as its timeout.
 
 use std::{
     io::{BufRead, BufReader, ErrorKind, Write},
     net::{TcpListener, TcpStream},
+    sync::mpsc::{self, Receiver, RecvTimeoutError},
+    thread,
     time::{Duration, Instant},
 };
 
 use objects::error::HeddleError;
 
-use super::protocol::{HELPER_IDLE_POLL_MS, HELPER_IDLE_TIMEOUT_SECS};
+use super::protocol::{HELPER_IDLE_TIMEOUT_SECS, HELPER_TICK_INTERVAL_MS};
 
 /// Decision returned by the per-tick policy when no connection is
 /// pending.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IdleDecision {
-    /// Loop again, sleep for the standard poll interval.
+    /// Keep serving: park until the next connection lands or the
+    /// tick interval elapses, whichever comes first.
     Continue,
     /// Time to exit cleanly. The caller is expected to have removed
     /// the endpoint file before returning.
@@ -41,37 +53,99 @@ pub trait DaemonHandler {
     /// request/response types implement serde.
     fn handle(&mut self, stream: TcpStream) -> Result<(), HeddleError>;
 
-    /// Called between accepts. Implementations may drain background
-    /// state (e.g. fsmonitor's `notify` events) and decide whether
-    /// the loop should continue or exit. `idle_for` is the duration
-    /// since the last successful accept.
+    /// Called after every serviced connection and whenever
+    /// [`DaemonHandler::tick_interval`] elapses with no connection.
+    /// Implementations may drain background state (e.g. fsmonitor's
+    /// `notify` events) and decide whether the loop should continue
+    /// or exit. `idle_for` is the duration since the last accepted
+    /// connection.
     fn on_tick(&mut self, idle_for: Duration) -> IdleDecision;
+
+    /// How long to park waiting for a connection before running an
+    /// idle tick anyway.
+    ///
+    /// This does not delay RPC service — a connection wakes the loop
+    /// immediately. It only bounds how stale a handler's background
+    /// state may get between requests, and how coarsely the idle
+    /// timeout is observed.
+    fn tick_interval(&self) -> Duration {
+        Duration::from_millis(HELPER_TICK_INTERVAL_MS)
+    }
 }
 
 /// Drive `listener` with `handler` until the handler returns
-/// [`IdleDecision::Exit`] from its tick. The listener must be
-/// configured non-blocking by the caller.
+/// [`IdleDecision::Exit`] from its tick.
+///
+/// The listener is switched to blocking mode: a scoped acceptor
+/// thread owns the `accept()` call and forwards each socket over a
+/// channel, so an idle helper costs one parked thread rather than a
+/// poll-sleep loop.
 pub fn run_server_loop<H: DaemonHandler>(
     listener: &TcpListener,
     handler: &mut H,
 ) -> Result<(), HeddleError> {
-    let mut last_activity = Instant::now();
-    loop {
-        match listener.accept() {
-            Ok((stream, _)) => {
-                last_activity = Instant::now();
-                handler.handle(stream)?;
-            }
-            Err(error) if error.kind() == ErrorKind::WouldBlock => {
-                let elapsed = last_activity.elapsed();
-                match handler.on_tick(elapsed) {
-                    IdleDecision::Continue => {
-                        std::thread::sleep(Duration::from_millis(HELPER_IDLE_POLL_MS));
+    listener.set_nonblocking(false)?;
+    // Captured before the acceptor starts so the exit path can dial
+    // the listener back and unblock it.
+    let local_addr = listener.local_addr()?;
+    let (connection_tx, connection_rx) = mpsc::channel::<TcpStream>();
+
+    thread::scope(|scope| {
+        let acceptor = scope.spawn(move || {
+            loop {
+                match listener.accept() {
+                    // A send error means the serve loop is gone; so are we.
+                    Ok((stream, _)) => {
+                        if connection_tx.send(stream).is_err() {
+                            return;
+                        }
                     }
-                    IdleDecision::Exit => return Ok(()),
+                    Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                    Err(_) => return,
                 }
             }
-            Err(error) => return Err(HeddleError::Io(error)),
+        });
+
+        let result = serve_connections(handler, &connection_rx);
+
+        // Retire the acceptor before the scope joins it. Dropping the
+        // receiver alone is not enough — the thread is parked inside
+        // `accept()` and only notices once a connection lands, so we
+        // dial our own listener to hand it one. The socket is bound to
+        // loopback, so this cannot leave the network.
+        drop(connection_rx);
+        let _ = TcpStream::connect(local_addr);
+        let _ = acceptor.join();
+        result
+    })
+}
+
+/// Service connections until the handler asks to exit. Split out of
+/// [`run_server_loop`] so the acceptor teardown above runs on every
+/// exit path, including the error one.
+fn serve_connections<H: DaemonHandler>(
+    handler: &mut H,
+    connections: &Receiver<TcpStream>,
+) -> Result<(), HeddleError> {
+    let mut last_activity = Instant::now();
+    loop {
+        let decision = match connections.recv_timeout(handler.tick_interval()) {
+            Ok(stream) => {
+                last_activity = Instant::now();
+                handler.handle(stream)?;
+                // Tick straight after the RPC rather than waiting out
+                // a whole interval: a `shutdown` verb sets its flag
+                // during `handle`, and this is where the handler gets
+                // to act on it.
+                handler.on_tick(last_activity.elapsed())
+            }
+            Err(RecvTimeoutError::Timeout) => handler.on_tick(last_activity.elapsed()),
+            // The acceptor gave up (listener error). Nothing more will
+            // ever arrive, so shut down cleanly.
+            Err(RecvTimeoutError::Disconnected) => return Ok(()),
+        };
+        if decision == IdleDecision::Exit {
+            return Ok(());
         }
     }
 }
@@ -145,10 +219,19 @@ mod tests {
     //! the daemon binary itself is Linux-only doesn't gate the
     //! correctness check.
 
-    use std::time::Duration;
+    use std::{
+        io::{Read, Write},
+        net::{TcpListener, TcpStream},
+        thread,
+        time::{Duration, Instant},
+    };
 
-    use super::{IdleDecision, default_idle_policy, mount_idle_policy};
-    use crate::daemon::HELPER_IDLE_TIMEOUT_SECS;
+    use objects::error::HeddleError;
+
+    use super::{
+        DaemonHandler, IdleDecision, default_idle_policy, mount_idle_policy, run_server_loop,
+    };
+    use crate::daemon::{HELPER_HOST, HELPER_IDLE_TIMEOUT_SECS};
 
     #[test]
     fn fsmonitor_idle_policy_exits_at_timeout() {
@@ -192,5 +275,129 @@ mod tests {
         // The caller is responsible for draining mounts before exit.
         let decision = mount_idle_policy(true, 5, Duration::from_secs(0));
         assert_eq!(decision, IdleDecision::Exit);
+    }
+
+    /// Handler that records how many idle ticks it saw and exits once
+    /// it has been alive for `lifetime`.
+    struct TickCounter {
+        ticks: usize,
+        started: Instant,
+        lifetime: Duration,
+        tick: Duration,
+    }
+
+    impl DaemonHandler for TickCounter {
+        fn handle(&mut self, _stream: TcpStream) -> Result<(), HeddleError> {
+            Ok(())
+        }
+
+        fn on_tick(&mut self, _idle_for: Duration) -> IdleDecision {
+            self.ticks += 1;
+            if self.started.elapsed() >= self.lifetime {
+                IdleDecision::Exit
+            } else {
+                IdleDecision::Continue
+            }
+        }
+
+        fn tick_interval(&self) -> Duration {
+            self.tick
+        }
+    }
+
+    /// Regression test for heddle#1243: an idle helper must park, not
+    /// spin. The tick count over a fixed idle window is the observable
+    /// proxy for the syscall storm — the pre-fix loop woke every 5ms
+    /// (an `accept4`-EAGAIN plus a `clock_nanosleep` each time), so
+    /// this 500ms window would have produced ~100 ticks instead of ~5.
+    #[test]
+    fn an_idle_helper_ticks_on_its_interval_instead_of_spinning() {
+        let listener = TcpListener::bind((HELPER_HOST, 0)).unwrap();
+        let lifetime = Duration::from_millis(500);
+        let tick = Duration::from_millis(100);
+        let mut handler = TickCounter {
+            ticks: 0,
+            started: Instant::now(),
+            lifetime,
+            tick,
+        };
+
+        run_server_loop(&listener, &mut handler).unwrap();
+
+        // The loop cannot tick faster than its interval, so the ceiling
+        // is the window divided by the interval, plus slack for a
+        // loaded CI box. A 5ms poll-sleep would blow straight past it.
+        let ceiling = 2 * (lifetime.as_millis() / tick.as_millis()) as usize;
+        assert!(
+            handler.ticks <= ceiling,
+            "idle helper ticked {} times in {lifetime:?} at a {tick:?} interval (ceiling {ceiling}) — the loop is spinning",
+            handler.ticks
+        );
+        assert!(
+            handler.ticks >= 2,
+            "idle helper should still tick at all; saw {}",
+            handler.ticks
+        );
+    }
+
+    /// Handler that answers one connection and then exits.
+    struct OneShot {
+        served: bool,
+        tick: Duration,
+    }
+
+    impl DaemonHandler for OneShot {
+        fn handle(&mut self, mut stream: TcpStream) -> Result<(), HeddleError> {
+            stream.write_all(b"ok\n")?;
+            self.served = true;
+            Ok(())
+        }
+
+        fn on_tick(&mut self, _idle_for: Duration) -> IdleDecision {
+            if self.served {
+                IdleDecision::Exit
+            } else {
+                IdleDecision::Continue
+            }
+        }
+
+        fn tick_interval(&self) -> Duration {
+            self.tick
+        }
+    }
+
+    /// The other half of the fix: parking on a long interval must not
+    /// delay RPC service. A connection has to wake the loop straight
+    /// away, and the post-RPC tick has to observe the handler's own
+    /// exit request without waiting out another interval.
+    #[test]
+    fn a_connection_is_served_without_waiting_out_the_tick_interval() {
+        let listener = TcpListener::bind((HELPER_HOST, 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        // Far longer than the test's own timeout: if service were gated
+        // on the tick, this test would hang rather than merely fail.
+        let tick = Duration::from_secs(300);
+
+        let client = thread::spawn(move || {
+            let mut stream = TcpStream::connect(address).unwrap();
+            let mut reply = String::new();
+            stream.read_to_string(&mut reply).unwrap();
+            reply
+        });
+
+        let started = Instant::now();
+        let mut handler = OneShot {
+            served: false,
+            tick,
+        };
+        run_server_loop(&listener, &mut handler).unwrap();
+        let elapsed = started.elapsed();
+
+        assert_eq!(client.join().unwrap(), "ok\n");
+        assert!(handler.served);
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "serving one RPC took {elapsed:?}; the loop is gating accepts on its tick interval"
+        );
     }
 }

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -330,6 +330,39 @@ pub(crate) fn rebuild_local_monitor_snapshot(
 pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
     let state_path = repo_root.join(".heddle/state").join("fsmonitor.toml");
     let endpoint_path = helper_endpoint_path(&state_path);
+
+    // Nothing to serve, and — more importantly — nothing to create.
+    // A checkout can be torn down between the spawn and this process
+    // getting scheduled, and `RepoLock` creates its lock file's parent
+    // directory, so touching a lock first would rebuild
+    // `.heddle/state/` inside the directory `heddle thread drop` had
+    // just reported gone. `.heddle` alone is not the test: the
+    // scaffolding a lock acquisition leaves behind satisfies that, and
+    // a pointer worktree's `.heddle` holds no `objects` at all.
+    if !crate::repository::is_heddle_repository_root(repo_root) {
+        return Ok(());
+    }
+
+    // Startup runs under the start lock, and that bracket *is* the
+    // readiness signal. Everyone who cares whether a helper is up —
+    // `try_spawn_local_helper_with` and
+    // `shutdown_local_monitor_helper` — takes this same lock, so once
+    // they hold it this process has either published its endpoint or
+    // exited. There is no interval where a helper is half-started and
+    // an observer has to guess, which is what the pid-liveness probe
+    // this replaces was trying and failing to do. heddle#1243.
+    let start_lease = objects::lock::RepoLock::at(helper_start_lock_path(&state_path)).write()?;
+
+    // Re-checked under the lock, because the check above raced a
+    // teardown that had not yet taken it. Past this point a teardown
+    // cannot be running: it takes this same lock before removing
+    // anything.
+    if !crate::repository::is_heddle_repository_root(repo_root) {
+        drop(start_lease);
+        discard_recreated_helper_state(repo_root, &state_path);
+        return Ok(());
+    }
+
     let Some(_lifetime_lease) =
         objects::lock::RepoLock::at(helper_lifetime_lock_path(&state_path)).try_write()?
     else {
@@ -341,6 +374,17 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
 
     let listener = TcpListener::bind((HELPER_HOST, 0))?;
     let port = listener.local_addr()?.port();
+
+    // Built before the endpoint is published, so the file only ever
+    // names a helper that can actually answer. Publishing first made
+    // "endpoint exists" mean no more than "a port was bound once":
+    // `LocalMonitorServer::new` fails when `inotify_init` returns
+    // EMFILE — the steady state of a box holding more live helpers
+    // than `fs.inotify.max_user_instances` allows — and every client
+    // that read the file got ECONNREFUSED from a port that had died
+    // with the process. heddle#1243.
+    let mut server = LocalMonitorServer::new(repo_root.to_path_buf(), state_path)?;
+
     let endpoint = EndpointState {
         version: HELPER_PROTOCOL_VERSION,
         host: HELPER_HOST.to_string(),
@@ -348,26 +392,40 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
         pid: Some(std::process::id()),
     };
     persist_endpoint(&endpoint_path, &endpoint)?;
-    remove_starting_helper_if_owned(&state_path, std::process::id());
+    // Ready: bound, watching, and about to accept. Releasing the start
+    // lease here is what unblocks anyone waiting on that readiness.
+    drop(start_lease);
 
-    // The endpoint is already published, so every failure from here
-    // on has to retract it. It names a port that dies with this
-    // process: a client that reads a stale one gets ECONNREFUSED,
-    // which `shutdown_local_monitor_helper` reports as a hard error,
-    // rather than the "no helper yet" path it knows how to recover
-    // from. Watcher startup is the failure that actually fires —
-    // `inotify_init` returns EMFILE once a box has more live helpers
-    // than `fs.inotify.max_user_instances` allows. heddle#1243.
-    let mut server = match LocalMonitorServer::new(repo_root.to_path_buf(), state_path) {
-        Ok(server) => server,
-        Err(error) => {
-            remove_endpoint_if_owned(&endpoint_path, &endpoint);
-            return Err(error);
-        }
-    };
     let result = run_local_monitor_helper_loop(&listener, &mut server);
     remove_endpoint_if_owned(&endpoint_path, &endpoint);
     result
+}
+
+/// Undo the scaffolding a lock acquisition rebuilds inside a checkout
+/// that was removed while this helper was starting.
+///
+/// `RepoLock::write` calls `create_dir_all` on its lock file's parent,
+/// so a helper that loses the race with `heddle thread drop` leaves
+/// `<checkout>/.heddle/state/` standing — and `thread drop` has
+/// already told its caller that directory is gone. Every directory
+/// step is `remove_dir`, which refuses a non-empty directory, so this
+/// cannot take a live checkout with it: the first entry it cannot
+/// remove stops the walk.
+fn discard_recreated_helper_state(repo_root: &Path, state_path: &Path) {
+    let _ = fs::remove_file(helper_start_lock_path(state_path));
+    let _ = fs::remove_file(helper_lifetime_lock_path(state_path));
+    for directory in [
+        state_path.parent().map(Path::to_path_buf),
+        Some(repo_root.join(".heddle")),
+        Some(repo_root.to_path_buf()),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if fs::remove_dir(&directory).is_err() {
+            return;
+        }
+    }
 }
 
 fn run_local_monitor_helper_loop(
@@ -705,31 +763,12 @@ fn helper_lifetime_lock_path(state_path: &Path) -> PathBuf {
     state_path.with_file_name("monitor-helper-lifetime.lock")
 }
 
-fn helper_starting_path(state_path: &Path) -> PathBuf {
-    state_path.with_file_name("monitor-helper-starting")
-}
-
-fn load_starting_helper_pid(state_path: &Path) -> Option<u32> {
-    fs::read_to_string(helper_starting_path(state_path))
-        .ok()?
-        .trim()
-        .parse()
-        .ok()
-}
-
-fn persist_starting_helper_pid(state_path: &Path, pid: u32) -> Result<(), HeddleError> {
-    objects::fs_atomic::write_file_atomic(
-        &helper_starting_path(state_path),
-        format!("{pid}\n").as_bytes(),
-    )?;
-    Ok(())
-}
-
-fn remove_starting_helper_if_owned(state_path: &Path, pid: u32) {
-    if load_starting_helper_pid(state_path) == Some(pid) {
-        let _ = fs::remove_file(helper_starting_path(state_path));
-    }
-}
+/// Marker an older build wrote to name a helper it had spawned but
+/// not yet seen come up. The start-lock bracket in
+/// [`run_local_monitor_helper`] supersedes it; teardown only sweeps
+/// the file so a checkout that ran one of those builds does not keep
+/// it forever.
+const LEGACY_HELPER_STARTING_FILE: &str = "monitor-helper-starting";
 
 fn try_local_helper_query(
     repo_root: &Path,
@@ -824,9 +863,7 @@ fn try_local_helper_refresh(repo_root: &Path, state_path: &Path) -> Result<bool,
 }
 
 fn try_spawn_local_helper(repo_root: &Path, state_path: &Path) -> Result<bool, HeddleError> {
-    try_spawn_local_helper_with(state_path, || {
-        spawn_local_helper_background(repo_root, state_path)
-    })
+    try_spawn_local_helper_with(state_path, || spawn_local_helper_background(repo_root))
 }
 
 fn try_spawn_local_helper_with(
@@ -903,7 +940,7 @@ fn retire_failed_helper_endpoint(
     Ok(())
 }
 
-fn spawn_local_helper_background(repo_root: &Path, state_path: &Path) -> Result<(), HeddleError> {
+fn spawn_local_helper_background(repo_root: &Path) -> Result<(), HeddleError> {
     let current_exe = std::env::current_exe()
         .map_err(|error| HeddleError::Config(format!("locate heddle executable: {error}")))?;
     let helper = local_helper_binary_for_executable(&current_exe);
@@ -921,19 +958,17 @@ fn spawn_local_helper_background(repo_root: &Path, state_path: &Path) -> Result<
             return Ok(());
         }
     };
-    let pid = child.id();
-    if let Err(error) = persist_starting_helper_pid(state_path, pid) {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Err(error);
-    }
-    if crate::daemon::load_endpoint(&helper_endpoint_path(state_path))
-        .ok()
-        .and_then(|endpoint| endpoint.pid)
-        == Some(pid)
-    {
-        remove_starting_helper_if_owned(state_path, pid);
-    }
+    // Non-blocking by contract — `cold_start_never_polls_for_worker_
+    // readiness` pins it, and the caller falls back to a full scan for
+    // this one command. The helper announces itself by taking the
+    // start lock we are still holding, so it cannot get ahead of us.
+    //
+    // A single `try_wait` reaps the one child that never will: an exec
+    // that failed after `spawn` returned. Left unreaped it lingers as
+    // a zombie, and a zombie answers `kill(pid, 0)` exactly like a
+    // live process — which is how a dead helper used to read as one
+    // that was still starting. heddle#1243.
+    let _ = child.try_wait();
     Ok(())
 }
 
@@ -1012,27 +1047,19 @@ pub fn shutdown_local_monitor_helper(
     repo_root: &Path,
 ) -> Result<LocalMonitorShutdownGuard, HeddleError> {
     let state_path = repo_root.join(".heddle/state/fsmonitor.toml");
+    // Blocking, and deliberately the first thing we do. A helper holds
+    // this lock for the whole of its startup, so acquiring it is how
+    // we wait out one that is still coming up: by the time we are
+    // through, it has published its endpoint below or given up. There
+    // is no "still starting" state left to observe, which is why this
+    // no longer polls a pid and no longer fails the caller's command
+    // when that pid is still alive — `heddle thread drop` used to exit
+    // 78 over a helper it simply had not waited for, and an unreaped
+    // one looked alive forever. heddle#1243.
     let start_lease = objects::lock::RepoLock::at(helper_start_lock_path(&state_path)).write()?;
     let endpoint_path = helper_endpoint_path(&state_path);
 
-    let mut endpoint = crate::daemon::load_endpoint(&endpoint_path).ok();
-    if endpoint.is_none()
-        && let Some(starting_pid) = load_starting_helper_pid(&state_path)
-    {
-        for _ in 0..HELPER_START_POLLS {
-            endpoint = crate::daemon::load_endpoint(&endpoint_path).ok();
-            if endpoint.is_some() || !pid_alive(starting_pid) {
-                break;
-            }
-            std::thread::sleep(Duration::from_millis(HELPER_START_POLL_MS));
-        }
-        if endpoint.is_none() && pid_alive(starting_pid) {
-            return Err(HeddleError::Config(format!(
-                "native monitor helper {starting_pid} did not finish starting before teardown"
-            )));
-        }
-        remove_starting_helper_if_owned(&state_path, starting_pid);
-    }
+    let endpoint = crate::daemon::load_endpoint(&endpoint_path).ok();
 
     if let Some(endpoint) = endpoint {
         let asked: Result<MonitorHelperResponse, HeddleError> = send_json_request(
@@ -1087,7 +1114,11 @@ pub fn shutdown_local_monitor_helper(
     })?;
 
     remove_endpoint(&endpoint_path);
-    let _ = fs::remove_file(helper_starting_path(&state_path));
+    // Swept, not consulted: builds before the start-lock readiness
+    // bracket announced a starting helper through this file, and a
+    // checkout carried over from one of them should not keep the
+    // stale marker.
+    let _ = fs::remove_file(state_path.with_file_name(LEGACY_HELPER_STARTING_FILE));
     for artifact in [&state_path, &snapshot_path(&state_path)] {
         match fs::remove_file(artifact) {
             Ok(()) => {}
@@ -1471,6 +1502,44 @@ mod tests {
         assert_eq!(spawns.load(Ordering::SeqCst), 1);
     }
 
+    /// `run_local_monitor_helper` refuses to start anywhere that is not
+    /// a repository root, and `.heddle/state/` alone is not one — that
+    /// is exactly the scaffolding a lock acquisition leaves behind. Any
+    /// test that expects the helper to actually come up has to look
+    /// like a checkout.
+    fn seed_repository_marker(checkout: &std::path::Path) {
+        std::fs::create_dir_all(checkout.join(".heddle")).unwrap();
+        std::fs::write(checkout.join(".heddle/HEAD"), b"ref: refs/threads/main\n").unwrap();
+    }
+
+    /// heddle#1243. A helper spawned just before `heddle thread drop`
+    /// can be scheduled only after the checkout is gone. It must not
+    /// rebuild it: `RepoLock` creates its lock file's parent, so a
+    /// helper that reaches for a lock first resurrects
+    /// `<checkout>/.heddle/state/` — and `thread drop` has already
+    /// returned success, telling its caller the directory is gone.
+    /// The integration suite sees that as a `thread drop` that reports
+    /// success while the materialised checkout is still on disk.
+    #[test]
+    fn a_helper_scheduled_after_teardown_does_not_resurrect_the_checkout() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        seed_repository_marker(&checkout);
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        // The teardown this helper lost the race to.
+        objects::fs_ops::remove_path_recursively(&checkout).unwrap();
+
+        super::run_local_monitor_helper(&checkout)
+            .expect("a removed checkout is nothing to serve, not a failure");
+
+        assert!(
+            !checkout.exists(),
+            "helper startup rebuilt the checkout that thread drop had removed: {:?}",
+            std::fs::read_dir(checkout.join(".heddle"))
+                .map(|entries| entries.flatten().map(|e| e.path()).collect::<Vec<_>>())
+        );
+    }
+
     #[test]
     fn cold_start_never_polls_for_worker_readiness() {
         let temp = TempDir::new().unwrap();
@@ -1484,11 +1553,13 @@ mod tests {
         );
     }
 
-    /// heddle#1243. The helper publishes its endpoint the moment it has
-    /// a port, before the `notify` watcher exists. If startup then
-    /// fails, the file survives the process and names a dead port —
-    /// and clients reading it get ECONNREFUSED rather than the
-    /// "no helper yet" path they know how to recover from.
+    /// heddle#1243. An endpoint file must name a helper that can
+    /// answer, so it is published only once `LocalMonitorServer::new`
+    /// has returned. An earlier shape published the moment a port was
+    /// bound, before the `notify` watcher existed: a startup that then
+    /// failed left the file naming a port that died with the process,
+    /// and clients reading it got ECONNREFUSED rather than the "no
+    /// helper yet" path they know how to recover from.
     ///
     /// In the field the failing step is `inotify_init`, which returns
     /// EMFILE once a box holds more live helpers than
@@ -1497,13 +1568,14 @@ mod tests {
     /// fallible step in `LocalMonitorServer::new`: an undecodable
     /// snapshot file.
     #[test]
-    fn a_helper_that_fails_to_start_retracts_its_endpoint() {
+    fn a_helper_that_fails_to_start_never_publishes_an_endpoint() {
         let temp = TempDir::new().unwrap();
         let checkout = temp.path().join("checkout");
         std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
         let state_path = checkout.join(".heddle/state/fsmonitor.toml");
-        // Not msgpack, so `load_snapshot` fails — and it fails *after*
-        // the endpoint has been persisted.
+        seed_repository_marker(&checkout);
+        // Not msgpack, so `load_snapshot` fails — the step that now
+        // gates publication.
         std::fs::write(super::snapshot_path(&state_path), b"not a monitor snapshot").unwrap();
 
         let error = super::run_local_monitor_helper(&checkout)
@@ -1560,12 +1632,93 @@ mod tests {
         drop(guard);
     }
 
+    /// heddle#1243. Teardown used to infer "a helper is still coming
+    /// up" from a `monitor-helper-starting` file naming a pid, wait two
+    /// seconds for an endpoint, and then fail the caller's command if
+    /// the pid was still alive — `configuration error: native monitor
+    /// helper <pid> did not finish starting before teardown`, exit 78
+    /// out of `heddle thread drop`.
+    ///
+    /// The probe could not tell the three states apart that matter. A
+    /// helper genuinely mid-startup, a helper that exited without being
+    /// reaped (a zombie answers `kill(pid, 0)` exactly like a live
+    /// process), and a recycled pid all read as "still starting". This
+    /// test pins the state that produced the CI failure and is the one
+    /// no probe can get right: a marker naming a pid that is certainly
+    /// alive — our own — with no helper behind it at all.
+    ///
+    /// Readiness is now the start-lock bracket in
+    /// `run_local_monitor_helper` instead, which teardown has already
+    /// acquired by this point, so there is nothing left to guess at.
+    #[test]
+    fn a_starting_marker_naming_a_live_pid_does_not_fail_teardown() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        let marker = state_path.with_file_name(super::LEGACY_HELPER_STARTING_FILE);
+        // Our own pid: alive for the whole test by construction, so the
+        // liveness probe this replaces could only ever conclude "still
+        // starting" and fail.
+        std::fs::write(&marker, format!("{}\n", std::process::id())).unwrap();
+
+        let started = std::time::Instant::now();
+        let guard = shutdown_local_monitor_helper(&checkout)
+            .expect("a marker is not a helper; teardown must not fail on one");
+        let elapsed = started.elapsed();
+
+        assert!(
+            !marker.exists(),
+            "teardown should sweep the stale marker at {}",
+            marker.display()
+        );
+        // The old path burned HELPER_START_POLLS * HELPER_START_POLL_MS
+        // polling for an endpoint that was never coming.
+        assert!(
+            elapsed < std::time::Duration::from_millis(500),
+            "teardown spent {elapsed:?} waiting on a marker it should not consult"
+        );
+        drop(guard);
+    }
+
+    /// The other half of heddle#1243's teardown change: dropping the
+    /// "did not finish starting" error must not have made teardown
+    /// unconditionally succeed. A helper that is genuinely live holds
+    /// the lifetime lock, and that — not the endpoint file, not a pid —
+    /// is what teardown proves before letting a caller remove the
+    /// checkout out from under a running watcher.
+    #[test]
+    fn teardown_still_refuses_while_a_helper_holds_the_lifetime_lock() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+
+        // Stand in for a live helper: hold the lifetime lock, and
+        // nothing else. No endpoint, no marker — so the only thing that
+        // can produce a refusal is the lock itself.
+        let held = objects::lock::RepoLock::at(super::helper_lifetime_lock_path(&state_path))
+            .write()
+            .unwrap();
+
+        let error = match shutdown_local_monitor_helper(&checkout) {
+            Err(error) => error,
+            Ok(_) => panic!("a helper holding the lifetime lock has not drained"),
+        };
+        assert!(
+            error.to_string().contains("did not drain before teardown"),
+            "expected the drain proof to be what refused, got: {error}"
+        );
+        drop(held);
+    }
+
     #[test]
     fn shutdown_drains_native_watcher_before_checkout_removal() {
         let temp = TempDir::new().unwrap();
         let checkout = temp.path().join("checkout");
         std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
         std::fs::write(checkout.join("tracked.txt"), b"tracked\n").unwrap();
+        seed_repository_marker(&checkout);
         let state_path = checkout.join(".heddle/state/fsmonitor.toml");
         let endpoint_path = helper_endpoint_path(&state_path);
         let helper_root = checkout.clone();

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -340,7 +340,6 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
     }
 
     let listener = TcpListener::bind((HELPER_HOST, 0))?;
-    listener.set_nonblocking(true)?;
     let port = listener.local_addr()?.port();
     let endpoint = EndpointState {
         version: HELPER_PROTOCOL_VERSION,

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -350,7 +350,21 @@ pub fn run_local_monitor_helper(repo_root: &Path) -> Result<(), HeddleError> {
     persist_endpoint(&endpoint_path, &endpoint)?;
     remove_starting_helper_if_owned(&state_path, std::process::id());
 
-    let mut server = LocalMonitorServer::new(repo_root.to_path_buf(), state_path)?;
+    // The endpoint is already published, so every failure from here
+    // on has to retract it. It names a port that dies with this
+    // process: a client that reads a stale one gets ECONNREFUSED,
+    // which `shutdown_local_monitor_helper` reports as a hard error,
+    // rather than the "no helper yet" path it knows how to recover
+    // from. Watcher startup is the failure that actually fires —
+    // `inotify_init` returns EMFILE once a box has more live helpers
+    // than `fs.inotify.max_user_instances` allows. heddle#1243.
+    let mut server = match LocalMonitorServer::new(repo_root.to_path_buf(), state_path) {
+        Ok(server) => server,
+        Err(error) => {
+            remove_endpoint_if_owned(&endpoint_path, &endpoint);
+            return Err(error);
+        }
+    };
     let result = run_local_monitor_helper_loop(&listener, &mut server);
     remove_endpoint_if_owned(&endpoint_path, &endpoint);
     result
@@ -1021,20 +1035,41 @@ pub fn shutdown_local_monitor_helper(
     }
 
     if let Some(endpoint) = endpoint {
-        let response: MonitorHelperResponse = send_json_request(
+        let asked: Result<MonitorHelperResponse, HeddleError> = send_json_request(
             &endpoint,
             &MonitorHelperRequest {
                 version: HELPER_PROTOCOL_VERSION,
                 command: "shutdown".to_string(),
                 since: None,
             },
-        )?;
-        if !response.ok {
-            return Err(HeddleError::Config(
-                response
-                    .error
-                    .unwrap_or_else(|| "native monitor refused shutdown".to_string()),
-            ));
+        );
+        match asked {
+            Ok(response) if !response.ok => {
+                return Err(HeddleError::Config(
+                    response
+                        .error
+                        .unwrap_or_else(|| "native monitor refused shutdown".to_string()),
+                ));
+            }
+            Ok(_) => {}
+            // Asking is the courtesy; the lifetime-lock acquisition
+            // below is the proof. An endpoint file can outlive the
+            // process that wrote it (crash, kill, a startup that
+            // failed after publishing), and dialling one of those is
+            // ECONNREFUSED — the very state we are asking for. Failing
+            // the caller's command there aborts `thread drop` over a
+            // helper that is already gone, so carry on and let the
+            // lock decide: a helper that is genuinely still alive
+            // holds it, and we report "did not drain" instead.
+            Err(error) => {
+                warn!(
+                    %error,
+                    host = %endpoint.host,
+                    port = endpoint.port,
+                    "Native monitor helper unreachable during shutdown; \
+                     confirming it has drained via the lifetime lock"
+                );
+            }
         }
     }
 
@@ -1447,6 +1482,82 @@ mod tests {
             started.elapsed() < std::time::Duration::from_millis(100),
             "cold spawn should return immediately instead of polling"
         );
+    }
+
+    /// heddle#1243. The helper publishes its endpoint the moment it has
+    /// a port, before the `notify` watcher exists. If startup then
+    /// fails, the file survives the process and names a dead port —
+    /// and clients reading it get ECONNREFUSED rather than the
+    /// "no helper yet" path they know how to recover from.
+    ///
+    /// In the field the failing step is `inotify_init`, which returns
+    /// EMFILE once a box holds more live helpers than
+    /// `fs.inotify.max_user_instances` allows. That is not reproducible
+    /// in a unit test, so this drives the same seam through the other
+    /// fallible step in `LocalMonitorServer::new`: an undecodable
+    /// snapshot file.
+    #[test]
+    fn a_helper_that_fails_to_start_retracts_its_endpoint() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        // Not msgpack, so `load_snapshot` fails — and it fails *after*
+        // the endpoint has been persisted.
+        std::fs::write(super::snapshot_path(&state_path), b"not a monitor snapshot").unwrap();
+
+        let error = super::run_local_monitor_helper(&checkout)
+            .expect_err("an undecodable snapshot must fail the helper");
+        assert!(
+            error.to_string().contains("decode monitor snapshot"),
+            "expected the snapshot decode to be what failed, got: {error}"
+        );
+        assert!(
+            !helper_endpoint_path(&state_path).exists(),
+            "a helper that never served a request must not leave an endpoint \
+             file pointing at its dead port"
+        );
+    }
+
+    /// heddle#1243. An endpoint file can outlive the process that wrote
+    /// it — a crash, a kill, or a startup that failed after publishing.
+    /// Dialling one of those is ECONNREFUSED, which is the state
+    /// `shutdown` is asking for; reporting it as an error aborted
+    /// `heddle thread drop` (exit 75) over a helper that was already
+    /// gone. The lifetime lock, not the RPC, is what proves the helper
+    /// has drained.
+    #[test]
+    fn shutdown_succeeds_when_the_endpoint_outlived_its_helper() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        let endpoint_path = helper_endpoint_path(&state_path);
+
+        // Bind then drop, so the port is one nothing is listening on.
+        let dead_port = std::net::TcpListener::bind((HELPER_HOST, 0))
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port();
+        crate::daemon::persist_endpoint(
+            &endpoint_path,
+            &crate::daemon::EndpointState {
+                version: HELPER_PROTOCOL_VERSION,
+                host: HELPER_HOST.to_string(),
+                port: dead_port,
+                pid: None,
+            },
+        )
+        .unwrap();
+
+        let guard = shutdown_local_monitor_helper(&checkout)
+            .expect("an unreachable helper is already shut down, not a failure");
+        assert!(
+            !endpoint_path.exists(),
+            "shutdown should sweep the stale endpoint"
+        );
+        drop(guard);
     }
 
     #[test]

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -448,6 +448,30 @@ impl DaemonHandler for LocalMonitorServer {
         if self.shutdown_requested {
             return IdleDecision::Exit;
         }
+        // A watcher whose worktree is gone has nothing left to
+        // answer, and holding it open is not free: each live helper
+        // owns an `inotify` instance, and the kernel caps those at
+        // `fs.inotify.max_user_instances` per user — 128 on a stock
+        // Ubuntu runner. Without this, a helper outlived its checkout
+        // by the full `HELPER_IDLE_TIMEOUT_SECS`, so a test suite that
+        // creates and drops repositories faster than five minutes
+        // accumulated one daemon per repository until `inotify_init`
+        // started returning EMFILE. Measured at 1,006 live helpers,
+        // every one of them watching a directory that no longer
+        // existed, which is what broke `LocalMonitorServer::new` for
+        // everything that came after. heddle#1243.
+        //
+        // Symmetric with startup: `run_local_monitor_helper` refuses
+        // to begin serving anywhere that is not a repository root, so
+        // it should not keep serving somewhere that has stopped being
+        // one. The members the check looks for are durable, not
+        // rewritten in place, so a live repository cannot blink out
+        // between ticks — and a helper retired in error is respawned
+        // by the next command, which falls back to a full scan
+        // meanwhile.
+        if !crate::repository::is_heddle_repository_root(&self.repo_root) {
+            return IdleDecision::Exit;
+        }
         // fsmonitor drains pending notify events between accepts so
         // the change cursor stays current even when no CLI is
         // querying. Errors here historically propagated; preserve
@@ -1747,6 +1771,77 @@ mod tests {
         assert!(
             !checkout.exists(),
             "a drained watcher must not recreate its checkout"
+        );
+    }
+
+    /// heddle#1243. A helper must not outlive the worktree it
+    /// watches. Every live helper owns an `inotify` instance, and the
+    /// kernel caps those per user — `fs.inotify.max_user_instances`,
+    /// 128 on a stock Ubuntu runner. A helper that idles out the full
+    /// `HELPER_IDLE_TIMEOUT_SECS` after its checkout is gone therefore
+    /// costs one of 128 slots for five minutes, and a suite that
+    /// creates and drops repositories faster than that exhausts them:
+    /// running `heddle-cli --test cli_integration` on this branch left
+    /// 1,006 live helpers, every one watching a directory that no
+    /// longer existed. The next process to call `inotify_init` — the
+    /// `heddle-repo` unit tests, two minutes later in the same CI job
+    /// — got EMFILE out of `LocalMonitorServer::new`, which is both
+    /// why three of them panicked on `Too many open files` and why
+    /// `shutdown_drains_native_watcher_before_checkout_removal` never
+    /// saw an endpoint appear: its helper failed to build a watcher,
+    /// so it correctly published nothing.
+    ///
+    /// The timeout below is what makes this a real test rather than a
+    /// hang. Without the check in `on_tick` the helper sits in its
+    /// accept loop for the full five minutes, so `recv_timeout`
+    /// expires and the assertion fails by name instead of stalling
+    /// the suite until the harness kills it.
+    #[test]
+    fn a_helper_exits_once_its_worktree_is_gone() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        std::fs::write(checkout.join("tracked.txt"), b"tracked\n").unwrap();
+        seed_repository_marker(&checkout);
+        let endpoint_path = helper_endpoint_path(&checkout.join(".heddle/state/fsmonitor.toml"));
+
+        let (exited_tx, exited) = std::sync::mpsc::channel();
+        let helper_root = checkout.clone();
+        thread::spawn(move || {
+            let _ = exited_tx.send(super::run_local_monitor_helper(&helper_root));
+        });
+        for _ in 0..400 {
+            if endpoint_path.exists() {
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            endpoint_path.exists(),
+            "the helper under test has to come up before its worktree is removed"
+        );
+
+        // No `shutdown` RPC and no `thread drop`: the worktree simply
+        // goes away, which is what a dropped `TempDir` does to every
+        // repository an integration suite builds.
+        objects::fs_ops::remove_path_recursively(&checkout).unwrap();
+
+        // Generous next to the ~1s tick interval, tight next to the
+        // 300s idle timeout this is proving the helper does not wait
+        // out.
+        let result = exited
+            .recv_timeout(std::time::Duration::from_secs(30))
+            .unwrap_or_else(|error| {
+                panic!(
+                    "helper was still watching a deleted worktree 30s on ({error}); \
+                     it is holding an inotify instance until its {}s idle timeout",
+                    crate::daemon::HELPER_IDLE_TIMEOUT_SECS
+                )
+            });
+        result.expect("a vanished worktree is nothing left to serve, not a failure");
+        assert!(
+            !checkout.exists(),
+            "a retiring helper must not rebuild the worktree it was watching"
         );
     }
 


### PR DESCRIPTION
## Summary

The shared helper-daemon listener loop ran its socket **non-blocking** and spun
`accept()` → `sleep(5ms)` between requests
(`crates/repo/src/daemon/server.rs:54-77` pre-fix). Both helpers built on it —
the fsmonitor worker (`crates/repo/src/fsmonitor.rs:330` `run_local_monitor_helper`,
binary at `crates/cli/src/bin/heddle-fsmonitor-worker.rs:16`) and the mount daemon
(`crates/cli/src/cli/commands/daemon/server.rs:38`) — therefore burned ~200
wakeups a second for their entire 300s idle lifetime, doing nothing.

A `heddle clone` spawns an fsmonitor helper on the status path
(`crates/repo/src/fsmonitor.rs:892` `spawn_local_helper_background`, reached via
`try_local_helper_query:720` → `try_spawn_local_helper:812`), and that helper
outlives the command. Anything that waits on the whole process tree — `strace -f`,
`/usr/bin/time` wrapped around it, a CI harness reaping the process group — waits
out the helper's idle timeout and attributes the spin to the clone.

**The fix makes the wait event-driven.** A scoped acceptor thread parks in a
blocking `accept()` and hands sockets over a channel; the serve loop parks on that
channel with the handler's tick interval as its timeout
(`crates/repo/src/daemon/server.rs:83` `run_server_loop`, `:126` `serve_connections`).
`HELPER_IDLE_POLL_MS = 5` is replaced by `HELPER_TICK_INTERVAL_MS = 1000`
(`crates/repo/src/daemon/protocol.rs:37`) — a heartbeat for draining background
`notify` state and re-checking the idle timeout, not a poll: an RPC wakes the loop
the moment it lands, and the post-RPC tick still observes a `shutdown` verb
immediately. `DaemonHandler` grows a defaulted `tick_interval()`
(`crates/repo/src/daemon/server.rs:71`) so a handler can tighten it if it ever
needs to. No back-compat shim; the poll loop is deleted.

**One correction to the issue's framing, backed by the numbers below.** The clone
*command* was never slow: it takes 33.5s with fsmonitor on, before and after this
change. The 256s figure is a process-tree wall dominated by the detached helper's
300s idle life, and the 55s "control" came from the same trace deliverable's
focused run, which was torn down immediately after clone success instead of
waiting the helper out. What this PR removes is the ~117,000 wasted syscalls, not
clone latency. Helper idle-timeout semantics are unchanged.

## Closes

Closes HeddleCo/heddle#1243

## Test evidence

Reproduced against the parked `gittiming2postwave` stack (weft `:58423`), cloning
the imported git.git fixture (417,860 objects / 316,178,524-byte pack). Release
binaries: before `d4bea0e3…`, after `5178b27e…`.

### `strace -f -c` over the whole process tree — the busy loop is gone

Same command both sides, helper allowed to run its full idle life so the loop is
fully represented:

```
env TMPDIR=/home/scratch HEDDLE_HOME=… HEDDLE_REMOTE_TLS_CA_CERT=… \
  /usr/bin/time -v strace -f -c -o strace-{before,after}.txt \
  ./heddle --output json clone heddle://127.0.0.1:58423/perf-git-timing-post-wave-20260804/git ./dest
```

| | before | after |
|---|---:|---:|
| `accept4` calls / errors | **58,573 / 58,573** | **1 / 0** |
| `clock_nanosleep` calls | **58,572** | **0** (row absent) |
| `futex` calls | 22 | 322 |
| total syscalls | 1,078,324 | 966,010 |
| total traced syscall time | 5.72s | 3.23s |
| voluntary context switches | 4,042,682 | 3,829,270 |
| process-tree wall (`time -v`) | 6:01.31 | 5:49.17 |

Before (top rows, verbatim):

```
 31.56    1.804666       82030        22         2 futex
 21.03    1.202620         599      2006           epoll_wait
 10.74    0.614149          10     55939           brk
  6.80    0.388600           6     58572           clock_nanosleep
  6.36    0.363785           6     58573     58573 accept4
```

After — no `clock_nanosleep` row at all, one `accept4`:

```
 45.80    1.480629        4598       322       302 futex
 16.33    0.527961           9     56106           brk
  7.41    0.239641           2    107528     10276 statx
…
  0.25    0.007978        7978         1           accept4
```

The 322 `futex` calls are the new 1s heartbeat over the helper's 300s idle window:
0.3% of the 117,145 wakeups it replaces. The process-tree wall stays ~350s in both
columns because the helper still idles for 300s by design — that lifetime is
unchanged and is not what this PR touches.

### Clone command wall time — unchanged, and never the problem

`/usr/bin/time -v` on the `heddle clone` process itself, interleaved before/after
on the same box and stack:

| run | before | after |
|---|---:|---:|
| 1 | 33.56s | 33.51s |
| 2 | 33.59s | 33.56s |
| 3 (recorded) | 33.49s | 33.57s |

### Clone correctness — identical, and matches the fixture

| check | before | after | source fixture |
|---|---|---|---|
| `git rev-parse HEAD` | `5b2471720c93ee30e5764a19f3d3b3ae9ec9712a` | same | `5b247172…` |
| `count-objects -v` in-pack / packs | 417,860 / 1 | same | 417,860 |
| `ls-tree -r HEAD` paths | 4,845 | same | 4,845 |
| `rev-list --count HEAD` | 81,841 | same | 81,841 |
| `git status --porcelain` | empty | empty | — |

### fsmonitor still works

Native repo, same probe driven straight at the helper's JSON-over-TCP endpoint,
both binaries:

```
before:  q1 fresh_instance clock 3 | q2 usable clock 3 changed []
         q3 after edit: usable clock 5 changed ['README.md']
after:   q1 fresh_instance clock 3 | q2 usable clock 3 changed []
         q3 after edit: usable clock 5 changed ['README.md']
```

Identical. Post-clone the git.git helper answers `query` in 0.009s and `heddle status`
on the 4,845-path checkout runs in 0.12–0.16s.

### Regression tests, with the negative case

`crates/repo/src/daemon/server.rs:314` `an_idle_helper_ticks_on_its_interval_instead_of_spinning`
counts idle ticks over a 500ms window at a 100ms interval. Reverting
`run_server_loop` to the pre-fix `accept()`/`sleep(5ms)` shape and rerunning:

```
thread '…an_idle_helper_ticks_on_its_interval_instead_of_spinning' panicked at
crates/repo/src/daemon/server.rs:288:9:
idle helper ticked 100 times in 500ms at a 100ms interval (ceiling 10) — the loop is spinning
test result: FAILED. 6 passed; 1 failed
```

With the fix restored: `test result: ok. 7 passed; 0 failed`.

`crates/repo/src/daemon/server.rs:374`
`a_connection_is_served_without_waiting_out_the_tick_interval` guards the risk the
fix introduces — it sets a 300s tick interval and asserts one RPC is still served
in well under 30s, so gating accepts on the heartbeat would hang rather than pass.

### CI suite

Affected packages per `scripts/ci-affected-rust-packages.sh`
(`heddle-cli, heddle-cli-shared, heddle-repo, heddle-wire, heddle-daemon,
heddle-cli-args, weft-client-shim, heddle-cli-contract, heddle-cli-render,
heddle-core, heddle-git-projection, heddle-ingest, heddle-mount,
heddle-iroh-transport-experiment`), run with the quality lane's own commands:

- `cargo build --locked <pkgs> --tests --bin heddle --bin heddle-fuse-worker` — ok
- `cargo clippy --locked <pkgs> --lib --bins --tests --examples -- -D warnings` — ok, no warnings
- `cargo test --locked <pkgs>` — 605 lib, 886/889 `cli_integration`, 51/51 `comprehensive`, all
  other targets green

Three `cli_integration` tests (`watch::watch_emits_json_per_line`,
`watch::watch_streams_snapshot_text_mode`,
`worktree_target_advice::start_path_non_empty_target_uses_typed_advice`) failed on
one full-suite run with `constructing notify watcher: Too many open files (os error 24)`.
That is host inotify-instance exhaustion, not a code failure: the suite itself
leaves ~970 concurrent fsmonitor helpers alive at once (each holds one inotify
instance) against this box's `fs.inotify.max_user_instances = 1024`, measured at
992 in use. All three pass on rerun once the helpers drain, and an earlier
full-suite run of this same commit passed `cli_integration` 889/889. Helper spawn
rate and idle lifetime are untouched by this change.

`rustfmt +nightly --edition 2024 --check` clean on all five touched files.

### Follow-up (not in scope here)

The residual ~33s is CPU-bound pack decode (`crates/sley-pack/src/stream.rs`
per-object loop; git-lane pack writes in
`crates/cli/src/hosted_runtime/hosted/sync.rs`). Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788497520&installation_model_id=21489&pr_number=1245&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1245&signature=14c828b4971bef4b39b05be783882bd9febc17bc691bd2e4011cf3126c12b069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->