### PR TITLE
feat(object-model): canonical manifest/object encodings + fsck rules (reshape P1)

### DIFF
--- a/crates/object-model/src/object/manifest/binding.rs
+++ b/crates/object-model/src/object/manifest/binding.rs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical manifest bindings — what ties a content root to an identity.
+//!
+//! A binding names `(spool, facet, owner, content_root)`. The owner descriptor
+//! is deliberately **outside** the content root: every state and attachment has
+//! a distinct owner hash, while a context-only state must reuse its parent's
+//! content root byte-for-byte. Keeping owner identity in the binding is what
+//! makes that reuse possible.
+//!
+//! Facet identity follows the ratified weft #358 decision: every spool carries
+//! all four facets (content, governance, membership, children) uniformly, with
+//! no content-bearing discriminant, so a binding always names its facet
+//! explicitly rather than defaulting. The tokens match
+//! `heddle_refs::SpoolFacet::token()` exactly — this type exists only because
+//! the object model sits below the refs crate, not to introduce a second
+//! spelling.
+//!
+//! Mutable facts stay out. Audience and visibility, the current head, and pack
+//! locations are control-plane data resolved after authorization; changing who
+//! may see a state must not rewrite a single content byte.
+//!
+//! ```text
+//! binding: "WPMB" | u8(version=1) | u16(spool_len) | spool
+//!                 | u16(facet_len) | facet | u8(owner_kind)
+//!                 | [u8;32](owner_hash) | u64(owner_decoded_size)
+//!                 | [u8;32](content_root)
+//! ```
+
+use std::fmt;
+
+use crate::object::{ContentHash, SpoolId};
+
+/// Magic prefix on every canonical binding.
+pub const MANIFEST_BINDING_MAGIC: [u8; 4] = *b"WPMB";
+/// The only binding format version this binary reads or writes.
+pub const MANIFEST_BINDING_VERSION: u8 = 1;
+
+/// The four uniform spool facets from weft #358, plus an open named tail.
+///
+/// `Named` keeps the set genuinely open — the substrate treats a facet as a
+/// token. A `Named` token that spells a well-known facet normalizes to it, so
+/// the two spellings can never diverge in a content hash.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ManifestFacet {
+    Content,
+    Governance,
+    Membership,
+    Children,
+    Named(String),
+}
+
+impl ManifestFacet {
+    /// The facet token as it appears in canonical bytes, scope tokens, and ref
+    /// names.
+    pub fn token(&self) -> &str {
+        match self {
+            Self::Content => "content",
+            Self::Governance => "governance",
+            Self::Membership => "membership",
+            Self::Children => "children",
+            Self::Named(token) => token.as_str(),
+        }
+    }
+
+    /// Parse a token, normalizing the four well-known spellings.
+    pub fn parse(token: impl AsRef<str>) -> Result<Self, ManifestFacetParseError> {
+        let token = token.as_ref();
+        match token {
+            "content" => return Ok(Self::Content),
+            "governance" => return Ok(Self::Governance),
+            "membership" => return Ok(Self::Membership),
+            "children" => return Ok(Self::Children),
+            _ => {}
+        }
+        if !valid_facet_token(token) {
+            return Err(ManifestFacetParseError(token.to_string()));
+        }
+        Ok(Self::Named(token.to_string()))
+    }
+
+    /// The four facets every spool carries, per weft #358.
+    pub fn well_known() -> [Self; 4] {
+        [
+            Self::Content,
+            Self::Governance,
+            Self::Membership,
+            Self::Children,
+        ]
+    }
+}
+
+fn valid_facet_token(token: &str) -> bool {
+    !token.is_empty()
+        && token.len() <= 64
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || matches!(b, b'-' | b'_'))
+        && token.as_bytes()[0].is_ascii_alphanumeric()
+        && token.as_bytes()[token.len() - 1].is_ascii_alphanumeric()
+}
+
+impl fmt::Display for ManifestFacet {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.token())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+#[error("invalid facet token '{0}'")]
+pub struct ManifestFacetParseError(String);
+
+/// What a content root is bound to.
+///
+/// Distinct from [`super::node::ManifestObjectKind`] on purpose: leaves name
+/// content (blobs and trees), while owners name the publication unit.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ManifestOwnerKind {
+    State = 0,
+    StateAttachment = 1,
+}
+
+impl ManifestOwnerKind {
+    pub fn to_byte(self) -> u8 {
+        self as u8
+    }
+
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::State),
+            1 => Some(Self::StateAttachment),
+            _ => None,
+        }
+    }
+}
+
+/// An immutable `(spool, facet, owner) -> content_root` binding.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifestBinding {
+    pub spool: SpoolId,
+    pub facet: ManifestFacet,
+    pub owner_kind: ManifestOwnerKind,
+    pub owner_hash: ContentHash,
+    pub owner_decoded_size: u64,
+    pub content_root: ContentHash,
+}
+
+impl ManifestBinding {
+    /// Encode to the single canonical byte string for this binding.
+    pub fn encode(&self) -> Vec<u8> {
+        let spool = self.spool.as_str();
+        let facet = self.facet.token();
+        let mut out =
+            Vec::with_capacity(4 + 1 + 2 + spool.len() + 2 + facet.len() + 1 + 32 + 8 + 32);
+        out.extend_from_slice(&MANIFEST_BINDING_MAGIC);
+        out.push(MANIFEST_BINDING_VERSION);
+        out.extend_from_slice(&(spool.len() as u16).to_be_bytes());
+        out.extend_from_slice(spool.as_bytes());
+        out.extend_from_slice(&(facet.len() as u16).to_be_bytes());
+        out.extend_from_slice(facet.as_bytes());
+        out.push(self.owner_kind.to_byte());
+        out.extend_from_slice(self.owner_hash.as_bytes());
+        out.extend_from_slice(&self.owner_decoded_size.to_be_bytes());
+        out.extend_from_slice(self.content_root.as_bytes());
+        out
+    }
+
+    /// The binding's content address — `BLAKE3` of its canonical bytes.
+    pub fn address(&self) -> ContentHash {
+        ContentHash::compute(&self.encode())
+    }
+
+    /// Decode strictly, rejecting truncation, trailing bytes, unknown kinds,
+    /// invalid spool/facet tokens, and any non-canonical spelling.
+    pub fn decode(bytes: &[u8]) -> Result<Self, ManifestBindingDecodeError> {
+        let binding = Self::decode_inner(bytes)?;
+        if binding.encode() != bytes {
+            return Err(ManifestBindingDecodeError::NonCanonicalEncoding);
+        }
+        Ok(binding)
+    }
+
+    fn decode_inner(bytes: &[u8]) -> Result<Self, ManifestBindingDecodeError> {
+        let mut reader = BindingReader { bytes, pos: 0 };
+
+        if reader.take(4)? != MANIFEST_BINDING_MAGIC {
+            return Err(ManifestBindingDecodeError::BadMagic);
+        }
+        let version = reader.u8()?;
+        if version != MANIFEST_BINDING_VERSION {
+            return Err(ManifestBindingDecodeError::UnsupportedVersion(version));
+        }
+
+        let spool_token = reader.short_string()?;
+        let spool = SpoolId::parse(spool_token.clone())
+            .map_err(|_| ManifestBindingDecodeError::InvalidSpoolId(spool_token))?;
+        let facet_token = reader.short_string()?;
+        let facet = ManifestFacet::parse(&facet_token)
+            .map_err(|_| ManifestBindingDecodeError::InvalidFacet(facet_token))?;
+
+        let owner_byte = reader.u8()?;
+        let owner_kind = ManifestOwnerKind::from_byte(owner_byte)
+            .ok_or(ManifestBindingDecodeError::UnknownOwnerKind(owner_byte))?;
+        let owner_hash = ContentHash::from_bytes(reader.hash()?);
+        let owner_decoded_size = reader.u64()?;
+        let content_root = ContentHash::from_bytes(reader.hash()?);
+
+        if reader.pos != bytes.len() {
+            return Err(ManifestBindingDecodeError::TrailingBytes);
+        }
+
+        Ok(Self {
+            spool,
+            facet,
+            owner_kind,
+            owner_hash,
+            owner_decoded_size,
+            content_root,
+        })
+    }
+}
+
+struct BindingReader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> BindingReader<'a> {
+    fn take(&mut self, len: usize) -> Result<&'a [u8], ManifestBindingDecodeError> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or(ManifestBindingDecodeError::Truncated)?;
+        let slice = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or(ManifestBindingDecodeError::Truncated)?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, ManifestBindingDecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, ManifestBindingDecodeError> {
+        let bytes = self.take(2)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn u64(&mut self) -> Result<u64, ManifestBindingDecodeError> {
+        let bytes = self.take(8)?;
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(bytes);
+        Ok(u64::from_be_bytes(arr))
+    }
+
+    fn hash(&mut self) -> Result<[u8; 32], ManifestBindingDecodeError> {
+        let bytes = self.take(32)?;
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes);
+        Ok(arr)
+    }
+
+    fn short_string(&mut self) -> Result<String, ManifestBindingDecodeError> {
+        let len = usize::from(self.u16()?);
+        std::str::from_utf8(self.take(len)?)
+            .map(str::to_string)
+            .map_err(|_| ManifestBindingDecodeError::InvalidUtf8)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestBindingDecodeError {
+    #[error("binding does not start with the WPMB magic")]
+    BadMagic,
+    #[error("unsupported binding version {0}")]
+    UnsupportedVersion(u8),
+    #[error("unknown manifest owner kind {0}")]
+    UnknownOwnerKind(u8),
+    #[error("binding bytes are truncated")]
+    Truncated,
+    #[error("binding has trailing bytes after its declared content")]
+    TrailingBytes,
+    #[error("spool id or facet token is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("invalid spool id: {0}")]
+    InvalidSpoolId(String),
+    #[error("invalid facet token: {0}")]
+    InvalidFacet(String),
+    #[error("binding bytes are a non-canonical spelling of their own content")]
+    NonCanonicalEncoding,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binding() -> ManifestBinding {
+        ManifestBinding {
+            spool: SpoolId::parse("acme/api-v2").unwrap(),
+            facet: ManifestFacet::Content,
+            owner_kind: ManifestOwnerKind::State,
+            owner_hash: ContentHash::from_bytes([7; 32]),
+            owner_decoded_size: 4096,
+            content_root: ContentHash::from_bytes([9; 32]),
+        }
+    }
+
+    #[test]
+    fn binding_round_trips_and_is_hash_stable() {
+        let binding = binding();
+        let encoded = binding.encode();
+        let decoded = ManifestBinding::decode(&encoded).unwrap();
+        assert_eq!(decoded, binding);
+        assert_eq!(decoded.encode(), encoded);
+        assert_eq!(decoded.address(), binding.address());
+    }
+
+    #[test]
+    fn every_spool_carries_all_four_facets_and_they_bind_distinctly() {
+        // weft #358: facets are uniform and independent, so the same owner and
+        // content root under two facets must never collide.
+        let addresses: Vec<ContentHash> = ManifestFacet::well_known()
+            .into_iter()
+            .map(|facet| ManifestBinding { facet, ..binding() }.address())
+            .collect();
+        let unique: std::collections::BTreeSet<_> = addresses.iter().collect();
+        assert_eq!(unique.len(), 4, "facets must not collide in binding space");
+    }
+
+    #[test]
+    fn a_named_token_normalizes_to_its_well_known_facet() {
+        assert_eq!(
+            ManifestFacet::parse("children").unwrap(),
+            ManifestFacet::Children
+        );
+        // Normalization matters for hashing: two spellings must not produce
+        // two addresses for one logical binding.
+        let named = ManifestBinding {
+            facet: ManifestFacet::parse("content").unwrap(),
+            ..binding()
+        };
+        assert_eq!(named.address(), binding().address());
+    }
+
+    #[test]
+    fn owner_identity_is_outside_the_content_root() {
+        // A context-only state reuses its parent content root byte-for-byte;
+        // only the owner half of the binding moves.
+        let parent = binding();
+        let child = ManifestBinding {
+            owner_hash: ContentHash::from_bytes([11; 32]),
+            ..parent.clone()
+        };
+        assert_eq!(child.content_root, parent.content_root);
+        assert_ne!(child.address(), parent.address());
+    }
+
+    #[test]
+    fn decode_rejects_each_corruption_class() {
+        let encoded = binding().encode();
+
+        let mut bad_magic = encoded.clone();
+        bad_magic[0] = b'Q';
+        assert_eq!(
+            ManifestBinding::decode(&bad_magic).unwrap_err(),
+            ManifestBindingDecodeError::BadMagic
+        );
+
+        let mut bad_version = encoded.clone();
+        bad_version[4] = 4;
+        assert_eq!(
+            ManifestBinding::decode(&bad_version).unwrap_err(),
+            ManifestBindingDecodeError::UnsupportedVersion(4)
+        );
+
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert_eq!(
+            ManifestBinding::decode(&trailing).unwrap_err(),
+            ManifestBindingDecodeError::TrailingBytes
+        );
+
+        assert_eq!(
+            ManifestBinding::decode(&encoded[..encoded.len() - 1]).unwrap_err(),
+            ManifestBindingDecodeError::Truncated
+        );
+
+        // The owner-kind byte sits right after the two length-prefixed tokens.
+        let owner_kind_at = 4 + 1 + 2 + "acme/api-v2".len() + 2 + "content".len();
+        let mut bad_owner = encoded;
+        bad_owner[owner_kind_at] = 5;
+        assert_eq!(
+            ManifestBinding::decode(&bad_owner).unwrap_err(),
+            ManifestBindingDecodeError::UnknownOwnerKind(5)
+        );
+    }
+
+    #[test]
+    fn invalid_facet_tokens_are_rejected() {
+        for token in ["", "Content", "-bad", "bad-", "with space"] {
+            assert!(
+                ManifestFacet::parse(token).is_err(),
+                "accepted facet token {token:?}"
+            );
+        }
+    }
+}

--- a/crates/object-model/src/object/manifest/build.rs
+++ b/crates/object-model/src/object/manifest/build.rs
@@ -1,0 +1,409 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic construction and expansion of a canonical manifest trie.
+//!
+//! Construction is a pure function of the logical object set: the same set
+//! always yields the same node bytes and therefore the same root hash. Two
+//! sets that differ in one object share every subtree the change does not
+//! touch, so replacing one object rewrites only the old and new routes —
+//! O(path depth), never O(objects).
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::node::{
+    MANIFEST_BRANCH_WIDTH, MANIFEST_LEAF_MAX_ENTRIES, MANIFEST_ROUTE_LEVELS, ManifestBranch,
+    ManifestChild, ManifestDecodeError, ManifestKey, ManifestLeaf, ManifestNode, ManifestNodeError,
+    ManifestObject,
+};
+use crate::object::ContentHash;
+
+/// Read access to canonical manifest node bytes, keyed by node address.
+///
+/// The store is content-addressed, so an implementation may be a map, a pack
+/// reader, or a network fetcher; nothing here assumes locality.
+pub trait ManifestNodeSource {
+    fn node_bytes(&self, hash: &ContentHash) -> Option<&[u8]>;
+}
+
+/// Optional whole-store enumeration, used only to report nodes that are
+/// present but unreachable from a root.
+pub trait ManifestNodeStore: ManifestNodeSource {
+    fn node_hashes(&self) -> Vec<ContentHash>;
+}
+
+impl ManifestNodeSource for BTreeMap<ContentHash, Vec<u8>> {
+    fn node_bytes(&self, hash: &ContentHash) -> Option<&[u8]> {
+        self.get(hash).map(Vec::as_slice)
+    }
+}
+
+impl ManifestNodeStore for BTreeMap<ContentHash, Vec<u8>> {
+    fn node_hashes(&self) -> Vec<ContentHash> {
+        self.keys().copied().collect()
+    }
+}
+
+impl ManifestNodeSource for std::collections::HashMap<ContentHash, Vec<u8>> {
+    fn node_bytes(&self, hash: &ContentHash) -> Option<&[u8]> {
+        self.get(hash).map(Vec::as_slice)
+    }
+}
+
+impl ManifestNodeStore for std::collections::HashMap<ContentHash, Vec<u8>> {
+    fn node_hashes(&self) -> Vec<ContentHash> {
+        self.keys().copied().collect()
+    }
+}
+
+/// The output of a build: a root address plus every node byte string it
+/// reaches, deduplicated by address.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BuiltManifest {
+    pub root: ContentHash,
+    pub nodes: BTreeMap<ContentHash, Vec<u8>>,
+    pub object_count: u64,
+    pub decoded_bytes: u64,
+}
+
+impl BuiltManifest {
+    /// Addresses of every node in this manifest, in address order.
+    pub fn node_hashes(&self) -> Vec<ContentHash> {
+        self.nodes.keys().copied().collect()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestBuildError {
+    #[error(
+        "object key {key:?} appears twice with different declared sizes ({first} and {second})"
+    )]
+    ConflictingDuplicate {
+        key: ManifestKey,
+        first: u64,
+        second: u64,
+    },
+    #[error("total decoded bytes overflow u64")]
+    DecodedBytesOverflow,
+    #[error(transparent)]
+    Node(#[from] ManifestNodeError),
+}
+
+/// Build the canonical manifest for `objects`.
+///
+/// Objects are deduplicated by `(kind, hash)`; an exact repeat is collapsed,
+/// while a repeat that disagrees about `decoded_size` is a caller bug and is
+/// rejected rather than silently resolved.
+pub fn build_manifest(
+    objects: impl IntoIterator<Item = ManifestObject>,
+) -> Result<BuiltManifest, ManifestBuildError> {
+    let mut unique: BTreeMap<ManifestKey, ManifestObject> = BTreeMap::new();
+    for object in objects {
+        let key = object.key();
+        if let Some(existing) = unique.get(&key)
+            && existing.decoded_size != object.decoded_size
+        {
+            return Err(ManifestBuildError::ConflictingDuplicate {
+                key,
+                first: existing.decoded_size,
+                second: object.decoded_size,
+            });
+        }
+        unique.insert(key, object);
+    }
+
+    let entries: Vec<ManifestObject> = unique.into_values().collect();
+    let mut nodes = BTreeMap::new();
+    let summary = build_level(&entries, 0, &mut nodes)?;
+    Ok(BuiltManifest {
+        root: summary.hash,
+        nodes,
+        object_count: summary.object_count,
+        decoded_bytes: summary.decoded_bytes,
+    })
+}
+
+struct Summary {
+    hash: ContentHash,
+    object_count: u64,
+    decoded_bytes: u64,
+}
+
+/// Emit the subtree for `entries` at `depth`.
+///
+/// A leaf is used when the entries fit, or when the fixed 256-bit route is
+/// exhausted and no bits remain to split on. Otherwise the entries are
+/// partitioned by their 5-bit route group at this depth.
+fn build_level(
+    entries: &[ManifestObject],
+    depth: u8,
+    nodes: &mut BTreeMap<ContentHash, Vec<u8>>,
+) -> Result<Summary, ManifestBuildError> {
+    if entries.len() <= MANIFEST_LEAF_MAX_ENTRIES || depth >= MANIFEST_ROUTE_LEVELS {
+        let leaf = ManifestLeaf::new(entries.to_vec())?;
+        let object_count = leaf.object_count();
+        let decoded_bytes = leaf
+            .decoded_bytes()
+            .ok_or(ManifestBuildError::DecodedBytesOverflow)?;
+        let node = ManifestNode::Leaf(leaf);
+        let hash = insert(nodes, &node);
+        return Ok(Summary {
+            hash,
+            object_count,
+            decoded_bytes,
+        });
+    }
+
+    let mut buckets: Vec<Vec<ManifestObject>> = vec![Vec::new(); MANIFEST_BRANCH_WIDTH];
+    for entry in entries {
+        let slot = entry.key().route().group(depth);
+        buckets[usize::from(slot)].push(*entry);
+    }
+
+    let mut children = Vec::new();
+    let mut object_count = 0u64;
+    let mut decoded_bytes = 0u64;
+    for (slot, bucket) in buckets.iter().enumerate() {
+        if bucket.is_empty() {
+            continue;
+        }
+        let child = build_level(bucket, depth + 1, nodes)?;
+        object_count += child.object_count;
+        decoded_bytes = decoded_bytes
+            .checked_add(child.decoded_bytes)
+            .ok_or(ManifestBuildError::DecodedBytesOverflow)?;
+        children.push(ManifestChild {
+            slot: slot as u8,
+            hash: child.hash,
+            object_count: child.object_count,
+            decoded_bytes: child.decoded_bytes,
+        });
+    }
+
+    let branch = ManifestNode::Branch(ManifestBranch::new(depth, children)?);
+    let hash = insert(nodes, &branch);
+    Ok(Summary {
+        hash,
+        object_count,
+        decoded_bytes,
+    })
+}
+
+fn insert(nodes: &mut BTreeMap<ContentHash, Vec<u8>>, node: &ManifestNode) -> ContentHash {
+    let bytes = node.encode();
+    let hash = ContentHash::compute(&bytes);
+    nodes.insert(hash, bytes);
+    hash
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestExpandError {
+    #[error("manifest node {0} is missing from the node source")]
+    MissingNode(ContentHash),
+    #[error("manifest node {hash}: {source}")]
+    Decode {
+        hash: ContentHash,
+        #[source]
+        source: ManifestDecodeError,
+    },
+    #[error("manifest traversal exceeded the fixed route depth at node {0}")]
+    DepthExceeded(ContentHash),
+}
+
+/// Expand a manifest root into its object set, in canonical plan-key order.
+///
+/// This is the differential-comparison surface: the downstream consumer
+/// compares this ordered expansion against its existing membership rows.
+pub fn expand_manifest<S: ManifestNodeSource + ?Sized>(
+    source: &S,
+    root: &ContentHash,
+) -> Result<Vec<ManifestObject>, ManifestExpandError> {
+    let mut objects = BTreeSet::new();
+    let mut visited = BTreeSet::new();
+    expand_node(source, root, 0, &mut visited, &mut objects)?;
+    Ok(objects.into_iter().collect())
+}
+
+fn expand_node<S: ManifestNodeSource + ?Sized>(
+    source: &S,
+    hash: &ContentHash,
+    depth: u8,
+    visited: &mut BTreeSet<ContentHash>,
+    objects: &mut BTreeSet<ManifestObject>,
+) -> Result<(), ManifestExpandError> {
+    if depth > MANIFEST_ROUTE_LEVELS {
+        return Err(ManifestExpandError::DepthExceeded(*hash));
+    }
+    if !visited.insert(*hash) {
+        return Ok(());
+    }
+    let bytes = source
+        .node_bytes(hash)
+        .ok_or(ManifestExpandError::MissingNode(*hash))?;
+    let node = ManifestNode::decode_addressed(bytes, hash).map_err(|source| {
+        ManifestExpandError::Decode {
+            hash: *hash,
+            source,
+        }
+    })?;
+    match node {
+        ManifestNode::Leaf(leaf) => {
+            objects.extend(leaf.entries().iter().copied());
+        }
+        ManifestNode::Branch(branch) => {
+            for child in branch.children() {
+                expand_node(source, &child.hash, depth + 1, visited, objects)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::object::manifest::node::ManifestObjectKind;
+
+    fn object(seed: u32) -> ManifestObject {
+        let mut bytes = [0u8; 32];
+        bytes[..4].copy_from_slice(&seed.to_be_bytes());
+        ManifestObject::new(
+            if seed.is_multiple_of(3) {
+                ManifestObjectKind::Tree
+            } else {
+                ManifestObjectKind::Blob
+            },
+            ContentHash::compute(&bytes),
+            u64::from(seed) * 7 + 1,
+        )
+    }
+
+    fn objects(count: u32) -> Vec<ManifestObject> {
+        (0..count).map(object).collect()
+    }
+
+    #[test]
+    fn empty_set_builds_the_canonical_empty_root() {
+        let built = build_manifest([]).unwrap();
+        assert_eq!(built.root, ManifestNode::empty().address());
+        assert_eq!(built.object_count, 0);
+        assert_eq!(built.decoded_bytes, 0);
+        assert!(
+            expand_manifest(&built.nodes, &built.root)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn small_sets_stay_a_single_leaf() {
+        let built = build_manifest(objects(MANIFEST_LEAF_MAX_ENTRIES as u32)).unwrap();
+        assert_eq!(built.nodes.len(), 1);
+        let node = ManifestNode::decode(&built.nodes[&built.root]).unwrap();
+        assert!(matches!(node, ManifestNode::Leaf(_)));
+    }
+
+    #[test]
+    fn exceeding_the_leaf_bound_splits_into_a_branch() {
+        let built = build_manifest(objects(MANIFEST_LEAF_MAX_ENTRIES as u32 + 1)).unwrap();
+        let node = ManifestNode::decode(&built.nodes[&built.root]).unwrap();
+        let ManifestNode::Branch(branch) = node else {
+            panic!("expected a branch root");
+        };
+        assert_eq!(branch.depth(), 0);
+        let total: u64 = branch.children().iter().map(|c| c.object_count).sum();
+        assert_eq!(total, MANIFEST_LEAF_MAX_ENTRIES as u64 + 1);
+    }
+
+    #[test]
+    fn build_is_order_independent_and_root_stable() {
+        let mut forward = objects(200);
+        let mut reversed = forward.clone();
+        reversed.reverse();
+        // A duplicate that agrees is collapsed rather than rejected.
+        forward.push(forward[7]);
+
+        let a = build_manifest(forward).unwrap();
+        let b = build_manifest(reversed).unwrap();
+        assert_eq!(a.root, b.root);
+        assert_eq!(a.nodes, b.nodes);
+        assert_eq!(a.object_count, 200);
+    }
+
+    #[test]
+    fn expansion_round_trips_the_object_set_in_key_order() {
+        let mut expected = objects(500);
+        let built = build_manifest(expected.clone()).unwrap();
+        let expanded = expand_manifest(&built.nodes, &built.root).unwrap();
+        expected.sort_by_key(ManifestObject::key);
+        assert_eq!(expanded, expected);
+        assert_eq!(built.object_count, expanded.len() as u64);
+        assert_eq!(
+            built.decoded_bytes,
+            expanded.iter().map(|o| o.decoded_size).sum::<u64>()
+        );
+    }
+
+    #[test]
+    fn replacing_one_object_rewrites_only_a_bounded_path() {
+        let base = objects(2_000);
+        let before = build_manifest(base.clone()).unwrap();
+
+        let mut after_objects = base.clone();
+        after_objects[1_234] = object(999_999);
+        let after = build_manifest(after_objects).unwrap();
+
+        assert_ne!(before.root, after.root);
+        let rewritten = after
+            .nodes
+            .keys()
+            .filter(|hash| !before.nodes.contains_key(*hash))
+            .count();
+        // O(path depth), not O(objects): a 2000-object trie is only a few
+        // levels deep, so a single replacement must not approach node count.
+        assert!(
+            rewritten <= usize::from(MANIFEST_ROUTE_LEVELS),
+            "rewrote {rewritten} nodes for a single object change"
+        );
+        assert!(
+            rewritten * 8 < before.nodes.len(),
+            "rewrote {rewritten} of {} nodes; structural sharing is not holding",
+            before.nodes.len()
+        );
+    }
+
+    #[test]
+    fn an_unchanged_object_set_reuses_the_root_byte_for_byte() {
+        // The context-only-state case: identical content membership must
+        // produce an identical root so nothing is re-published.
+        let set = objects(300);
+        let a = build_manifest(set.clone()).unwrap();
+        let b = build_manifest(set).unwrap();
+        assert_eq!(a.root, b.root);
+        assert_eq!(a.nodes[&a.root], b.nodes[&b.root]);
+    }
+
+    #[test]
+    fn conflicting_duplicate_sizes_are_rejected() {
+        let first = object(1);
+        let second = ManifestObject::new(first.kind, first.hash, first.decoded_size + 1);
+        let err = build_manifest([first, second]).unwrap_err();
+        assert!(matches!(
+            err,
+            ManifestBuildError::ConflictingDuplicate { .. }
+        ));
+    }
+
+    #[test]
+    fn expansion_reports_a_missing_node_rather_than_a_partial_answer() {
+        let built = build_manifest(objects(100)).unwrap();
+        let mut nodes = built.nodes.clone();
+        let victim = *nodes
+            .keys()
+            .find(|hash| **hash != built.root)
+            .expect("branch root has children");
+        nodes.remove(&victim);
+        assert_eq!(
+            expand_manifest(&nodes, &built.root).unwrap_err(),
+            ManifestExpandError::MissingNode(victim)
+        );
+    }
+}

--- a/crates/object-model/src/object/manifest/extent.rs
+++ b/crates/object-model/src/object/manifest/extent.rs
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical pack-extent claims — the physical half of the reshape's read path.
+//!
+//! A manifest node names only immutable logical facts. Where an object's bytes
+//! actually live is a *mutable* control-plane fact, so it never enters the
+//! content root; repacking must change a read envelope, not a manifest hash.
+//! This module gives that envelope a canonical encoding of its own so it can be
+//! signed, transported, and checked byte-for-byte.
+//!
+//! Two rules from the downstream consumer are load-bearing and reproduced here
+//! exactly:
+//!
+//! * **Offset-canonical ordering.** Records are ordered by pack offset, not by
+//!   object key. Packs are laid out for delta compression, so object order and
+//!   physical order routinely disagree; ordering by object first makes valid
+//!   coalesced ranges fail their contiguity check (weft #1070, the bug fixed
+//!   after weft #1069 merged).
+//! * **Gap-free coverage.** A coalesced range carries a sorted partition of its
+//!   authorized records that covers `[start, end)` exactly — no gap, no
+//!   overlap. A pack may hold objects of mixed audience, so one physical range
+//!   read must never authorize an unselected byte gap between two authorized
+//!   records. Coalescing joins *exactly adjacent* extents only.
+//!
+//! ```text
+//! claim: "WPMX" | u8(version=1) | u16(pack_id_len) | pack_id
+//!               | u16(etag_len) | etag | u64(start) | u64(end)
+//!               | u32(record_count)
+//!               | count * ( u8(kind) | [u8;32](object_hash)
+//!                         | u64(decoded_size) | u64(offset) | u64(length)
+//!                         | [u8;32](encoded_digest) )
+//! ```
+
+use crate::object::{
+    ContentHash,
+    manifest::node::{ManifestKey, ManifestObject, ManifestObjectKind},
+};
+
+/// Magic prefix on every canonical pack-range claim.
+pub const PACK_CLAIM_MAGIC: [u8; 4] = *b"WPMX";
+/// The only claim format version this binary reads or writes.
+pub const PACK_CLAIM_VERSION: u8 = 1;
+
+/// One object's physical slice of a pack.
+///
+/// `encoded_digest` is the BLAKE3 of the *encoded record bytes* — the bytes as
+/// they sit in the pack, before decompression or delta resolution. It lets a
+/// receiver validate every record independently instead of trusting the whole
+/// range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PackRecord {
+    pub object: ManifestObject,
+    /// Byte offset of the encoded record within its pack.
+    pub offset: u64,
+    /// Encoded length in bytes. Zero-length records are not representable in a
+    /// gap-free partition and are rejected by fsck.
+    pub length: u64,
+    /// `BLAKE3(encoded record bytes)`.
+    pub encoded_digest: ContentHash,
+}
+
+impl PackRecord {
+    pub fn new(
+        object: ManifestObject,
+        offset: u64,
+        length: u64,
+        encoded_digest: ContentHash,
+    ) -> Self {
+        Self {
+            object,
+            offset,
+            length,
+            encoded_digest,
+        }
+    }
+
+    /// Exclusive end offset, or `None` on `u64` overflow.
+    pub fn end(&self) -> Option<u64> {
+        self.offset.checked_add(self.length)
+    }
+
+    pub fn key(&self) -> ManifestKey {
+        self.object.key()
+    }
+}
+
+/// One coalesced physical range read, plus the partition of authorized records
+/// it covers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PackRangeClaim {
+    pub pack_id: String,
+    /// Provider entity tag pinning the pack revision this claim was resolved
+    /// against. A repack changes the ETag, invalidating the claim without
+    /// touching any manifest.
+    pub etag: String,
+    pub start: u64,
+    pub end: u64,
+    records: Vec<PackRecord>,
+}
+
+impl PackRangeClaim {
+    /// Build a claim over `records`, sorting them into offset-canonical order.
+    ///
+    /// Sorting here is deliberate and is the whole point of weft #1070: the
+    /// canonical order is physical, so a pack whose object order differs from
+    /// its offset order still produces a contiguous, checkable partition.
+    pub fn new(
+        pack_id: impl Into<String>,
+        etag: impl Into<String>,
+        start: u64,
+        end: u64,
+        mut records: Vec<PackRecord>,
+    ) -> Self {
+        records.sort_by_key(|record| (record.offset, record.length, record.key()));
+        Self {
+            pack_id: pack_id.into(),
+            etag: etag.into(),
+            start,
+            end,
+            records,
+        }
+    }
+
+    /// Records in offset-canonical order.
+    pub fn records(&self) -> &[PackRecord] {
+        &self.records
+    }
+
+    /// Total bytes this claim authorizes, or `None` if the range is inverted.
+    pub fn byte_len(&self) -> Option<u64> {
+        self.end.checked_sub(self.start)
+    }
+
+    /// Encode to the single canonical byte string for this claim.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(
+            4 + 1
+                + 2
+                + self.pack_id.len()
+                + 2
+                + self.etag.len()
+                + 8
+                + 8
+                + 4
+                + self.records.len() * 89,
+        );
+        out.extend_from_slice(&PACK_CLAIM_MAGIC);
+        out.push(PACK_CLAIM_VERSION);
+        push_short_string(&mut out, &self.pack_id);
+        push_short_string(&mut out, &self.etag);
+        out.extend_from_slice(&self.start.to_be_bytes());
+        out.extend_from_slice(&self.end.to_be_bytes());
+        out.extend_from_slice(&(self.records.len() as u32).to_be_bytes());
+        for record in &self.records {
+            out.push(record.object.kind.to_byte());
+            out.extend_from_slice(record.object.hash.as_bytes());
+            out.extend_from_slice(&record.object.decoded_size.to_be_bytes());
+            out.extend_from_slice(&record.offset.to_be_bytes());
+            out.extend_from_slice(&record.length.to_be_bytes());
+            out.extend_from_slice(record.encoded_digest.as_bytes());
+        }
+        out
+    }
+
+    /// The claim's content address — `BLAKE3` of its canonical bytes.
+    pub fn address(&self) -> ContentHash {
+        ContentHash::compute(&self.encode())
+    }
+
+    /// Decode strictly, rejecting truncation, trailing bytes, non-UTF-8 ids,
+    /// out-of-order records, and any non-canonical spelling.
+    pub fn decode(bytes: &[u8]) -> Result<Self, PackClaimDecodeError> {
+        let claim = Self::decode_inner(bytes)?;
+        if claim.encode() != bytes {
+            return Err(PackClaimDecodeError::NonCanonicalEncoding);
+        }
+        Ok(claim)
+    }
+
+    fn decode_inner(bytes: &[u8]) -> Result<Self, PackClaimDecodeError> {
+        let mut reader = ClaimReader { bytes, pos: 0 };
+
+        if reader.take(4)? != PACK_CLAIM_MAGIC {
+            return Err(PackClaimDecodeError::BadMagic);
+        }
+        let version = reader.u8()?;
+        if version != PACK_CLAIM_VERSION {
+            return Err(PackClaimDecodeError::UnsupportedVersion(version));
+        }
+
+        let pack_id = reader.short_string()?;
+        let etag = reader.short_string()?;
+        let start = reader.u64()?;
+        let end = reader.u64()?;
+        let count = reader.u32()?;
+
+        let mut records = Vec::with_capacity((count as usize).min(4096));
+        let mut previous: Option<(u64, u64, ManifestKey)> = None;
+        for _ in 0..count {
+            let kind_byte = reader.u8()?;
+            let kind = ManifestObjectKind::from_byte(kind_byte)
+                .ok_or(PackClaimDecodeError::UnknownObjectKind(kind_byte))?;
+            let hash = ContentHash::from_bytes(reader.hash()?);
+            let decoded_size = reader.u64()?;
+            let offset = reader.u64()?;
+            let length = reader.u64()?;
+            let encoded_digest = ContentHash::from_bytes(reader.hash()?);
+            let object = ManifestObject::new(kind, hash, decoded_size);
+            let order = (offset, length, object.key());
+            if let Some(prev) = previous
+                && prev >= order
+            {
+                return Err(PackClaimDecodeError::RecordsOutOfOffsetOrder);
+            }
+            previous = Some(order);
+            records.push(PackRecord::new(object, offset, length, encoded_digest));
+        }
+        if reader.pos != bytes.len() {
+            return Err(PackClaimDecodeError::TrailingBytes);
+        }
+
+        Ok(Self {
+            pack_id,
+            etag,
+            start,
+            end,
+            records,
+        })
+    }
+}
+
+struct ClaimReader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> ClaimReader<'a> {
+    fn take(&mut self, len: usize) -> Result<&'a [u8], PackClaimDecodeError> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or(PackClaimDecodeError::Truncated)?;
+        let slice = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or(PackClaimDecodeError::Truncated)?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, PackClaimDecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, PackClaimDecodeError> {
+        let bytes = self.take(2)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32, PackClaimDecodeError> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn u64(&mut self) -> Result<u64, PackClaimDecodeError> {
+        let bytes = self.take(8)?;
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(bytes);
+        Ok(u64::from_be_bytes(arr))
+    }
+
+    fn hash(&mut self) -> Result<[u8; 32], PackClaimDecodeError> {
+        let bytes = self.take(32)?;
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes);
+        Ok(arr)
+    }
+
+    fn short_string(&mut self) -> Result<String, PackClaimDecodeError> {
+        let len = usize::from(self.u16()?);
+        std::str::from_utf8(self.take(len)?)
+            .map(str::to_string)
+            .map_err(|_| PackClaimDecodeError::InvalidUtf8)
+    }
+}
+
+fn push_short_string(out: &mut Vec<u8>, value: &str) {
+    out.extend_from_slice(&(value.len() as u16).to_be_bytes());
+    out.extend_from_slice(value.as_bytes());
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PackClaimDecodeError {
+    #[error("claim does not start with the WPMX magic")]
+    BadMagic,
+    #[error("unsupported pack claim version {0}")]
+    UnsupportedVersion(u8),
+    #[error("unknown manifest object kind {0}")]
+    UnknownObjectKind(u8),
+    #[error("claim bytes are truncated")]
+    Truncated,
+    #[error("claim has trailing bytes after its declared content")]
+    TrailingBytes,
+    #[error("pack id or etag is not valid UTF-8")]
+    InvalidUtf8,
+    #[error("records are not strictly ascending by pack offset")]
+    RecordsOutOfOffsetOrder,
+    #[error("claim bytes are a non-canonical spelling of their own content")]
+    NonCanonicalEncoding,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(offset: u64, length: u64, seed: u8) -> PackRecord {
+        PackRecord::new(
+            ManifestObject::new(
+                ManifestObjectKind::Blob,
+                ContentHash::from_bytes([seed; 32]),
+                length * 2,
+            ),
+            offset,
+            length,
+            ContentHash::from_bytes([seed.wrapping_add(100); 32]),
+        )
+    }
+
+    #[test]
+    fn records_canonicalize_by_offset_not_by_object_key() {
+        // Object key order (0x01 < 0x02 < 0x03) is the exact reverse of the
+        // physical offset order here — the weft #1070 shape.
+        let claim = PackRangeClaim::new(
+            "pack-a",
+            "etag-1",
+            0,
+            30,
+            vec![record(20, 10, 1), record(0, 10, 3), record(10, 10, 2)],
+        );
+        let offsets: Vec<u64> = claim.records().iter().map(|r| r.offset).collect();
+        assert_eq!(offsets, vec![0, 10, 20]);
+        let seeds: Vec<u8> = claim
+            .records()
+            .iter()
+            .map(|r| r.object.hash.as_bytes()[0])
+            .collect();
+        assert_eq!(
+            seeds,
+            vec![3, 2, 1],
+            "object order must not drive the layout"
+        );
+    }
+
+    #[test]
+    fn claim_round_trips_and_is_hash_stable() {
+        let claim = PackRangeClaim::new(
+            "pack-a",
+            "\"etag-xyz\"",
+            100,
+            140,
+            vec![record(120, 20, 2), record(100, 20, 1)],
+        );
+        let encoded = claim.encode();
+        let decoded = PackRangeClaim::decode(&encoded).unwrap();
+        assert_eq!(decoded, claim);
+        assert_eq!(decoded.encode(), encoded);
+        assert_eq!(decoded.address(), claim.address());
+    }
+
+    #[test]
+    fn decode_rejects_trailing_and_truncated_bytes() {
+        let claim = PackRangeClaim::new("p", "e", 0, 10, vec![record(0, 10, 1)]);
+        let encoded = claim.encode();
+
+        let mut trailing = encoded.clone();
+        trailing.push(0);
+        assert_eq!(
+            PackRangeClaim::decode(&trailing).unwrap_err(),
+            PackClaimDecodeError::TrailingBytes
+        );
+        assert_eq!(
+            PackRangeClaim::decode(&encoded[..encoded.len() - 1]).unwrap_err(),
+            PackClaimDecodeError::Truncated
+        );
+    }
+
+    #[test]
+    fn decode_rejects_records_written_out_of_offset_order() {
+        let claim = PackRangeClaim::new("p", "e", 0, 20, vec![record(0, 10, 1), record(10, 10, 2)]);
+        let encoded = claim.encode();
+        // Swap the two fixed-width record bodies.
+        let header = encoded.len() - 2 * 89;
+        let mut swapped = encoded.clone();
+        swapped[header..header + 89].copy_from_slice(&encoded[header + 89..]);
+        swapped[header + 89..].copy_from_slice(&encoded[header..header + 89]);
+        assert_eq!(
+            PackRangeClaim::decode(&swapped).unwrap_err(),
+            PackClaimDecodeError::RecordsOutOfOffsetOrder
+        );
+    }
+
+    #[test]
+    fn decode_rejects_a_bad_magic_and_version() {
+        let encoded = PackRangeClaim::new("p", "e", 0, 10, vec![record(0, 10, 1)]).encode();
+
+        let mut bad_magic = encoded.clone();
+        bad_magic[0] = b'Z';
+        assert_eq!(
+            PackRangeClaim::decode(&bad_magic).unwrap_err(),
+            PackClaimDecodeError::BadMagic
+        );
+
+        let mut bad_version = encoded;
+        bad_version[4] = 9;
+        assert_eq!(
+            PackRangeClaim::decode(&bad_version).unwrap_err(),
+            PackClaimDecodeError::UnsupportedVersion(9)
+        );
+    }
+}

--- a/crates/object-model/src/object/manifest/fsck.rs
+++ b/crates/object-model/src/object/manifest/fsck.rs
@@ -1,0 +1,747 @@
+// SPDX-License-Identifier: Apache-2.0
+//! fsck rules for a manifest/object graph.
+//!
+//! Every rule has a name. A corrupt graph is not merely "invalid" — fsck says
+//! *which* invariant broke and at which node, because the operator response
+//! differs: a digest mismatch means the bytes are wrong, a dangling ref means
+//! publication tore, and an extent gap means a grant would authorize bytes
+//! nobody selected.
+//!
+//! The rules divide into four families:
+//!
+//! 1. **Well-formed** — every reachable node decodes canonically
+//!    ([`FsckRule::MalformedNode`], [`FsckRule::NonCanonicalNodeEncoding`],
+//!    [`FsckRule::LeafEntriesOutOfOrder`], …).
+//! 2. **Digests match** — node bytes hash to the address they were fetched by,
+//!    subtree summaries equal what the subtree actually holds, and every
+//!    encoded pack record hashes to its declared digest.
+//! 3. **No dangling refs** — every branch child resolves, every leaf object is
+//!    present in the object index, and no grant names an object the manifest
+//!    does not cover.
+//! 4. **Gap-free coverage** — a pack range's records partition `[start, end)`
+//!    exactly, in offset-canonical order, with no gap and no overlap.
+//!
+//! fsck is *checking*, not repair, and it is total: it collects every finding
+//! rather than bailing at the first, so one run tells an operator the whole
+//! story. Traversal is still bounded — visited nodes are not re-entered and
+//! depth cannot exceed the fixed route — so an adversarial node set cannot
+//! make it spin.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::{
+    build::{ManifestNodeSource, ManifestNodeStore, build_manifest},
+    extent::PackRangeClaim,
+    node::{
+        MANIFEST_LEAF_MAX_ENTRIES, MANIFEST_ROUTE_LEVELS, ManifestDecodeError, ManifestKey,
+        ManifestNode, ManifestObject,
+    },
+};
+use crate::object::ContentHash;
+
+// ── Rules ───────────────────────────────────────────────────────────
+
+/// The named integrity rules fsck enforces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FsckRule {
+    // Well-formed.
+    /// Node bytes failed to decode at all (bad magic, unknown version or tag,
+    /// unknown object kind, truncation).
+    MalformedNode,
+    /// Node bytes decoded but are not their own canonical spelling.
+    NonCanonicalNodeEncoding,
+    /// Node bytes carry data past the declared content.
+    TrailingBytes,
+    /// Leaf entries are not strictly ascending by `(kind, hash)`.
+    LeafEntriesOutOfOrder,
+    /// A leaf names one object key twice.
+    DuplicateObjectKey,
+    /// A branch declares an empty bitmap; the canonical empty set is a leaf.
+    EmptyBranchBitmap,
+
+    // Digests match.
+    /// Node bytes do not hash to the address they were fetched by.
+    NodeDigestMismatch,
+    /// A branch's `(object_count, decoded_bytes)` summary disagrees with its
+    /// actual subtree.
+    SubtreeSummaryMismatch,
+    /// A leaf's declared `decoded_size` disagrees with the object index.
+    ObjectSizeMismatch,
+    /// An encoded pack record does not hash to its declared digest.
+    ExtentDigestMismatch,
+
+    // No dangling refs.
+    /// A branch names a child that is absent from the node source.
+    DanglingNodeRef,
+    /// A leaf names an object that is absent from the object index.
+    DanglingObjectRef,
+    /// A pack claim authorizes bytes for an object the manifest does not cover.
+    ExtentObjectNotInManifest,
+    /// A node is present in the store but unreachable from the root.
+    UnreachableNode,
+
+    // Structural canonicity.
+    /// A leaf holds more than the bound while routing bits remain to split on.
+    LeafOverfull,
+    /// A branch's whole subtree would fit in one leaf; it must not exist.
+    UnderfullBranch,
+    /// A non-root leaf holds no entries.
+    EmptyNonRootLeaf,
+    /// A branch's declared depth disagrees with its position in the trie.
+    BranchDepthMismatch,
+    /// An entry sits at a position its route does not lead to.
+    MisroutedEntry,
+    /// Rebuilding the trie from the expanded object set yields a different
+    /// root. The backstop for any structural deviation the local rules miss.
+    NonCanonicalTrieShape,
+    /// Traversal exceeded the fixed route depth.
+    DepthExceeded,
+
+    // Gap-free coverage.
+    /// Pack records are not strictly ascending by offset.
+    ExtentsOutOfOffsetOrder,
+    /// Two pack records claim overlapping bytes.
+    ExtentOverlap,
+    /// Consecutive pack records leave an unclaimed byte gap.
+    ExtentGap,
+    /// The record partition does not cover `[start, end)` exactly.
+    RangeCoverageMismatch,
+    /// A pack record claims zero bytes.
+    ZeroLengthExtent,
+}
+
+impl FsckRule {
+    /// The stable rule name, for logs, metrics, and test assertions.
+    pub fn name(self) -> &'static str {
+        match self {
+            Self::MalformedNode => "malformed-node",
+            Self::NonCanonicalNodeEncoding => "non-canonical-node-encoding",
+            Self::TrailingBytes => "trailing-bytes",
+            Self::LeafEntriesOutOfOrder => "leaf-entries-out-of-order",
+            Self::DuplicateObjectKey => "duplicate-object-key",
+            Self::EmptyBranchBitmap => "empty-branch-bitmap",
+            Self::NodeDigestMismatch => "node-digest-mismatch",
+            Self::SubtreeSummaryMismatch => "subtree-summary-mismatch",
+            Self::ObjectSizeMismatch => "object-size-mismatch",
+            Self::ExtentDigestMismatch => "extent-digest-mismatch",
+            Self::DanglingNodeRef => "dangling-node-ref",
+            Self::DanglingObjectRef => "dangling-object-ref",
+            Self::ExtentObjectNotInManifest => "extent-object-not-in-manifest",
+            Self::UnreachableNode => "unreachable-node",
+            Self::LeafOverfull => "leaf-overfull",
+            Self::UnderfullBranch => "underfull-branch",
+            Self::EmptyNonRootLeaf => "empty-non-root-leaf",
+            Self::BranchDepthMismatch => "branch-depth-mismatch",
+            Self::MisroutedEntry => "misrouted-entry",
+            Self::NonCanonicalTrieShape => "non-canonical-trie-shape",
+            Self::DepthExceeded => "depth-exceeded",
+            Self::ExtentsOutOfOffsetOrder => "extents-out-of-offset-order",
+            Self::ExtentOverlap => "extent-overlap",
+            Self::ExtentGap => "extent-gap",
+            Self::RangeCoverageMismatch => "range-coverage-mismatch",
+            Self::ZeroLengthExtent => "zero-length-extent",
+        }
+    }
+}
+
+impl std::fmt::Display for FsckRule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+impl ManifestDecodeError {
+    /// Map a decode failure onto the fsck rule it violates, so a rejection is
+    /// reported by name rather than as an opaque parse error.
+    pub fn fsck_rule(&self) -> FsckRule {
+        match self {
+            Self::BadMagic
+            | Self::UnsupportedVersion(_)
+            | Self::UnknownNodeTag(_)
+            | Self::UnknownObjectKind(_)
+            | Self::Truncated => FsckRule::MalformedNode,
+            Self::TrailingBytes => FsckRule::TrailingBytes,
+            Self::EntriesOutOfOrder => FsckRule::LeafEntriesOutOfOrder,
+            Self::DuplicateObjectKey(_) => FsckRule::DuplicateObjectKey,
+            Self::EmptyBranchBitmap => FsckRule::EmptyBranchBitmap,
+            Self::NonCanonicalEncoding => FsckRule::NonCanonicalNodeEncoding,
+            Self::AddressMismatch { .. } => FsckRule::NodeDigestMismatch,
+        }
+    }
+}
+
+// ── Findings ────────────────────────────────────────────────────────
+
+/// One violation: the rule, where it was found, and a human-readable detail.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FsckFinding {
+    pub rule: FsckRule,
+    /// The manifest node the finding attaches to, when there is one.
+    pub node: Option<ContentHash>,
+    pub detail: String,
+}
+
+impl FsckFinding {
+    fn new(rule: FsckRule, node: Option<ContentHash>, detail: impl Into<String>) -> Self {
+        Self {
+            rule,
+            node,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for FsckFinding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.node {
+            Some(node) => write!(f, "{}: {} ({})", self.rule, self.detail, node.short()),
+            None => write!(f, "{}: {}", self.rule, self.detail),
+        }
+    }
+}
+
+/// Every finding from one fsck run.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FsckReport {
+    findings: Vec<FsckFinding>,
+}
+
+impl FsckReport {
+    pub fn findings(&self) -> &[FsckFinding] {
+        &self.findings
+    }
+
+    /// True when nothing was found. A clean report is the *only* basis for
+    /// treating a root as usable.
+    pub fn is_clean(&self) -> bool {
+        self.findings.is_empty()
+    }
+
+    /// The distinct rules violated, in rule order.
+    pub fn violated_rules(&self) -> BTreeSet<FsckRule> {
+        self.findings.iter().map(|finding| finding.rule).collect()
+    }
+
+    pub fn has_rule(&self, rule: FsckRule) -> bool {
+        self.findings.iter().any(|finding| finding.rule == rule)
+    }
+
+    fn push(&mut self, finding: FsckFinding) {
+        self.findings.push(finding);
+    }
+}
+
+// ── Object index ────────────────────────────────────────────────────
+
+/// The set of content objects a manifest may legally name, with their decoded
+/// sizes.
+///
+/// Supplying an index turns on the dangling-object and size rules. Omitting it
+/// checks manifest structure alone, which is what a receiver that has the
+/// manifest but not yet the bodies can do.
+pub trait ManifestObjectIndex {
+    /// Decoded size of `key`, or `None` if the object is absent.
+    fn decoded_size(&self, key: &ManifestKey) -> Option<u64>;
+}
+
+impl ManifestObjectIndex for BTreeMap<ManifestKey, u64> {
+    fn decoded_size(&self, key: &ManifestKey) -> Option<u64> {
+        self.get(key).copied()
+    }
+}
+
+impl ManifestObjectIndex for std::collections::HashMap<ManifestKey, u64> {
+    fn decoded_size(&self, key: &ManifestKey) -> Option<u64> {
+        self.get(key).copied()
+    }
+}
+
+/// What fsck should check beyond node structure.
+#[derive(Default)]
+pub struct FsckOptions<'a> {
+    /// Objects the manifest may name. Enables [`FsckRule::DanglingObjectRef`]
+    /// and [`FsckRule::ObjectSizeMismatch`].
+    pub objects: Option<&'a dyn ManifestObjectIndex>,
+    /// Report nodes present in the store but unreachable from the root.
+    /// Off by default: a shared node store legitimately holds other roots'
+    /// nodes, so only a whole-store sweep should turn this on.
+    pub report_unreachable: bool,
+}
+
+// ── Manifest fsck ───────────────────────────────────────────────────
+
+/// Check a manifest graph rooted at `root` for structure and digests only.
+pub fn fsck_manifest<S: ManifestNodeSource + ?Sized>(source: &S, root: &ContentHash) -> FsckReport {
+    fsck_manifest_with(source, root, &FsckOptions::default())
+}
+
+/// Check a manifest graph rooted at `root`, with optional object and
+/// reachability checks.
+pub fn fsck_manifest_with<S: ManifestNodeSource + ?Sized>(
+    source: &S,
+    root: &ContentHash,
+    options: &FsckOptions<'_>,
+) -> FsckReport {
+    let mut report = FsckReport::default();
+    let mut visited = BTreeSet::new();
+    let mut objects = Vec::new();
+    let mut expansion_complete = true;
+
+    visit(
+        source,
+        root,
+        0,
+        true,
+        options,
+        &mut visited,
+        &mut objects,
+        &mut report,
+        &mut expansion_complete,
+    );
+
+    // Backstop: rebuild the canonical trie from what we actually expanded and
+    // compare roots. Local rules catch the diagnosable cases; this catches
+    // anything they do not. Skipped when expansion was incomplete, since a
+    // partial object set would rebuild to a different root for a reason
+    // already reported.
+    if expansion_complete
+        && let Ok(rebuilt) = build_manifest(objects.iter().copied())
+        && rebuilt.root != *root
+    {
+        report.push(FsckFinding::new(
+            FsckRule::NonCanonicalTrieShape,
+            Some(*root),
+            format!(
+                "rebuilding from {} expanded objects yields root {}",
+                objects.len(),
+                rebuilt.root
+            ),
+        ));
+    }
+
+    report
+}
+
+/// Check every root in `roots` against a whole node store, additionally
+/// reporting nodes no root reaches.
+pub fn fsck_manifest_store<S: ManifestNodeStore + ?Sized>(
+    store: &S,
+    roots: &[ContentHash],
+    options: &FsckOptions<'_>,
+) -> FsckReport {
+    let mut report = FsckReport::default();
+    let mut reachable = BTreeSet::new();
+
+    for root in roots {
+        let mut visited = BTreeSet::new();
+        let mut objects = Vec::new();
+        let mut expansion_complete = true;
+        visit(
+            store,
+            root,
+            0,
+            true,
+            options,
+            &mut visited,
+            &mut objects,
+            &mut report,
+            &mut expansion_complete,
+        );
+        if expansion_complete
+            && let Ok(rebuilt) = build_manifest(objects.iter().copied())
+            && rebuilt.root != *root
+        {
+            report.push(FsckFinding::new(
+                FsckRule::NonCanonicalTrieShape,
+                Some(*root),
+                format!("rebuilt root {} differs", rebuilt.root),
+            ));
+        }
+        reachable.extend(visited);
+    }
+
+    if options.report_unreachable {
+        for hash in store.node_hashes() {
+            if !reachable.contains(&hash) {
+                report.push(FsckFinding::new(
+                    FsckRule::UnreachableNode,
+                    Some(hash),
+                    "node is present but no supplied root reaches it",
+                ));
+            }
+        }
+    }
+
+    report
+}
+
+/// Visit one node, returning its `(object_count, decoded_bytes)` subtree
+/// summary when the subtree was readable enough to compute one.
+///
+/// `expansion_complete` is cleared only when a node could not be *read* —
+/// missing, mis-addressed, malformed, or past the route depth. A node that
+/// reads fine but violates a shape rule still expands completely, so the
+/// rebuild backstop stays meaningful for it.
+#[allow(clippy::too_many_arguments)]
+fn visit<S: ManifestNodeSource + ?Sized>(
+    source: &S,
+    hash: &ContentHash,
+    depth: u8,
+    is_root: bool,
+    options: &FsckOptions<'_>,
+    visited: &mut BTreeSet<ContentHash>,
+    objects: &mut Vec<ManifestObject>,
+    report: &mut FsckReport,
+    expansion_complete: &mut bool,
+) -> Option<(u64, u64)> {
+    if depth > MANIFEST_ROUTE_LEVELS {
+        *expansion_complete = false;
+        report.push(FsckFinding::new(
+            FsckRule::DepthExceeded,
+            Some(*hash),
+            format!("traversal passed the fixed {MANIFEST_ROUTE_LEVELS}-level route"),
+        ));
+        return None;
+    }
+    if !visited.insert(*hash) {
+        // Shared subtree, already accounted for. Content addressing makes a
+        // true cycle infeasible; this keeps a corrupt store from spinning.
+        return None;
+    }
+
+    let Some(bytes) = source.node_bytes(hash) else {
+        *expansion_complete = false;
+        report.push(FsckFinding::new(
+            FsckRule::DanglingNodeRef,
+            Some(*hash),
+            "node is referenced but absent from the node source",
+        ));
+        return None;
+    };
+
+    let actual = ContentHash::compute(bytes);
+    if actual != *hash {
+        *expansion_complete = false;
+        report.push(FsckFinding::new(
+            FsckRule::NodeDigestMismatch,
+            Some(*hash),
+            format!("bytes hash to {actual}"),
+        ));
+        return None;
+    }
+
+    let node = match ManifestNode::decode(bytes) {
+        Ok(node) => node,
+        Err(error) => {
+            *expansion_complete = false;
+            report.push(FsckFinding::new(
+                error.fsck_rule(),
+                Some(*hash),
+                error.to_string(),
+            ));
+            return None;
+        }
+    };
+
+    match node {
+        ManifestNode::Leaf(leaf) => {
+            let entries = leaf.entries();
+            if entries.is_empty() && !is_root {
+                report.push(FsckFinding::new(
+                    FsckRule::EmptyNonRootLeaf,
+                    Some(*hash),
+                    "only the root may be the empty leaf",
+                ));
+            }
+            if entries.len() > MANIFEST_LEAF_MAX_ENTRIES && depth < MANIFEST_ROUTE_LEVELS {
+                report.push(FsckFinding::new(
+                    FsckRule::LeafOverfull,
+                    Some(*hash),
+                    format!(
+                        "leaf at depth {depth} holds {} entries; the bound is {MANIFEST_LEAF_MAX_ENTRIES} while routing bits remain",
+                        entries.len()
+                    ),
+                ));
+            }
+
+            let mut decoded_bytes = 0u64;
+            for entry in entries {
+                decoded_bytes = decoded_bytes.saturating_add(entry.decoded_size);
+                if let Some(index) = options.objects {
+                    match index.decoded_size(&entry.key()) {
+                        None => {
+                            report.push(FsckFinding::new(
+                                FsckRule::DanglingObjectRef,
+                                Some(*hash),
+                                format!("{} object {} is not present", entry.kind, entry.hash),
+                            ));
+                        }
+                        Some(size) if size != entry.decoded_size => {
+                            report.push(FsckFinding::new(
+                                FsckRule::ObjectSizeMismatch,
+                                Some(*hash),
+                                format!(
+                                    "{} object {} declares {} bytes but holds {size}",
+                                    entry.kind, entry.hash, entry.decoded_size
+                                ),
+                            ));
+                        }
+                        Some(_) => {}
+                    }
+                }
+                objects.push(*entry);
+            }
+            Some((entries.len() as u64, decoded_bytes))
+        }
+        ManifestNode::Branch(branch) => {
+            if branch.depth() != depth {
+                report.push(FsckFinding::new(
+                    FsckRule::BranchDepthMismatch,
+                    Some(*hash),
+                    format!("declares depth {} but sits at {depth}", branch.depth()),
+                ));
+            }
+
+            let mut total_count = 0u64;
+            let mut total_bytes = 0u64;
+            let mut all_children_summarized = true;
+            for child in branch.children() {
+                let before = objects.len();
+                let summary = visit(
+                    source,
+                    &child.hash,
+                    depth + 1,
+                    false,
+                    options,
+                    visited,
+                    objects,
+                    report,
+                    expansion_complete,
+                );
+
+                // Everything newly expanded under this child must route through
+                // this branch's slot at this depth. Applied at every level of
+                // the descent, this checks the whole route, not just one group.
+                for entry in &objects[before..] {
+                    if entry.key().route().group(depth) != child.slot {
+                        report.push(FsckFinding::new(
+                            FsckRule::MisroutedEntry,
+                            Some(child.hash),
+                            format!(
+                                "{} object {} routes to slot {} at depth {depth}, not {}",
+                                entry.kind,
+                                entry.hash,
+                                entry.key().route().group(depth),
+                                child.slot
+                            ),
+                        ));
+                    }
+                }
+
+                match summary {
+                    Some((count, bytes)) => {
+                        if count != child.object_count || bytes != child.decoded_bytes {
+                            report.push(FsckFinding::new(
+                                FsckRule::SubtreeSummaryMismatch,
+                                Some(*hash),
+                                format!(
+                                    "slot {} summarizes ({}, {}) but holds ({count}, {bytes})",
+                                    child.slot, child.object_count, child.decoded_bytes
+                                ),
+                            ));
+                        }
+                        total_count += count;
+                        total_bytes = total_bytes.saturating_add(bytes);
+                    }
+                    None => {
+                        // Either a shared subtree (already counted) or a broken
+                        // one (already reported). Either way this branch's own
+                        // total is no longer checkable.
+                        all_children_summarized = false;
+                    }
+                }
+            }
+
+            if all_children_summarized {
+                if total_count <= MANIFEST_LEAF_MAX_ENTRIES as u64 && depth < MANIFEST_ROUTE_LEVELS
+                {
+                    report.push(FsckFinding::new(
+                        FsckRule::UnderfullBranch,
+                        Some(*hash),
+                        format!(
+                            "branch subtree holds {total_count} objects; it must be a single leaf"
+                        ),
+                    ));
+                }
+                Some((total_count, total_bytes))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+// ── Pack-range fsck ─────────────────────────────────────────────────
+
+/// What to check a pack claim against, beyond its own structure.
+#[derive(Default)]
+pub struct PackRangeAudit<'a> {
+    /// The raw bytes of `[start, end)` as fetched, enabling
+    /// [`FsckRule::ExtentDigestMismatch`].
+    pub range_bytes: Option<&'a [u8]>,
+    /// Object keys the manifest authorizes, enabling
+    /// [`FsckRule::ExtentObjectNotInManifest`].
+    pub authorized: Option<&'a BTreeSet<ManifestKey>>,
+}
+
+/// Check that a coalesced pack range is offset-canonical, gap-free, and — when
+/// the caller supplies them — digest-correct and manifest-covered.
+///
+/// This is the rule that keeps one physical range read from authorizing an
+/// unselected byte gap in a mixed-audience pack.
+pub fn fsck_pack_range(claim: &PackRangeClaim, audit: &PackRangeAudit<'_>) -> FsckReport {
+    let mut report = FsckReport::default();
+
+    if claim.end < claim.start {
+        report.push(FsckFinding::new(
+            FsckRule::RangeCoverageMismatch,
+            None,
+            format!("range end {} precedes start {}", claim.end, claim.start),
+        ));
+        return report;
+    }
+
+    let records = claim.records();
+    if records.is_empty() {
+        if claim.end != claim.start {
+            report.push(FsckFinding::new(
+                FsckRule::RangeCoverageMismatch,
+                None,
+                format!(
+                    "range covers {} bytes but claims no records",
+                    claim.end - claim.start
+                ),
+            ));
+        }
+        return report;
+    }
+
+    let mut cursor = claim.start;
+    for (index, record) in records.iter().enumerate() {
+        if record.length == 0 {
+            report.push(FsckFinding::new(
+                FsckRule::ZeroLengthExtent,
+                None,
+                format!("record {index} ({}) claims zero bytes", record.object.hash),
+            ));
+        }
+
+        if index > 0 && record.offset < records[index - 1].offset {
+            report.push(FsckFinding::new(
+                FsckRule::ExtentsOutOfOffsetOrder,
+                None,
+                format!(
+                    "record {index} at offset {} follows offset {}",
+                    record.offset,
+                    records[index - 1].offset
+                ),
+            ));
+        }
+
+        if record.offset > cursor {
+            report.push(FsckFinding::new(
+                FsckRule::ExtentGap,
+                None,
+                format!(
+                    "unclaimed bytes [{cursor}, {}) before record {index}",
+                    record.offset
+                ),
+            ));
+        } else if record.offset < cursor {
+            report.push(FsckFinding::new(
+                FsckRule::ExtentOverlap,
+                None,
+                format!(
+                    "record {index} starts at {} inside claimed bytes ending at {cursor}",
+                    record.offset
+                ),
+            ));
+        }
+
+        let Some(end) = record.end() else {
+            report.push(FsckFinding::new(
+                FsckRule::RangeCoverageMismatch,
+                None,
+                format!("record {index} offset + length overflows u64"),
+            ));
+            return report;
+        };
+        cursor = cursor.max(end);
+
+        if let (Some(bytes), Some(record_end)) = (audit.range_bytes, record.end())
+            && record.offset >= claim.start
+        {
+            let from = (record.offset - claim.start) as usize;
+            let to = record_end.saturating_sub(claim.start) as usize;
+            match bytes.get(from..to) {
+                Some(slice) => {
+                    let digest = ContentHash::compute(slice);
+                    if digest != record.encoded_digest {
+                        report.push(FsckFinding::new(
+                            FsckRule::ExtentDigestMismatch,
+                            None,
+                            format!(
+                                "record {index} ({}) hashes to {digest}, not {}",
+                                record.object.hash, record.encoded_digest
+                            ),
+                        ));
+                    }
+                }
+                None => {
+                    report.push(FsckFinding::new(
+                        FsckRule::RangeCoverageMismatch,
+                        None,
+                        format!("record {index} extends past the supplied range bytes"),
+                    ));
+                }
+            }
+        }
+
+        if let Some(authorized) = audit.authorized
+            && !authorized.contains(&record.key())
+        {
+            report.push(FsckFinding::new(
+                FsckRule::ExtentObjectNotInManifest,
+                None,
+                format!(
+                    "record {index} authorizes {} object {}, which the manifest does not cover",
+                    record.object.kind, record.object.hash
+                ),
+            ));
+        }
+    }
+
+    if cursor != claim.end {
+        report.push(FsckFinding::new(
+            FsckRule::RangeCoverageMismatch,
+            None,
+            format!(
+                "records cover through {cursor} but the range ends at {}",
+                claim.end
+            ),
+        ));
+    }
+
+    if let Some(bytes) = audit.range_bytes
+        && let Some(expected) = claim.byte_len()
+        && bytes.len() as u64 != expected
+    {
+        report.push(FsckFinding::new(
+            FsckRule::RangeCoverageMismatch,
+            None,
+            format!("supplied {} bytes for a {expected}-byte range", bytes.len()),
+        ));
+    }
+
+    report
+}

--- a/crates/object-model/src/object/manifest/mod.rs
+++ b/crates/object-model/src/object/manifest/mod.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical manifest/object encodings and fsck rules for the immutable CAS.
+//!
+//! **Additive.** Nothing in the existing object or wire paths reads or writes
+//! any of this yet. It is the upstream format definition the data-model
+//! reshape will build on (weft epic #1052, Phase 1: *"Design canonical
+//! manifest/object encodings and fsck rules upstream in Heddle because object
+//! and wire formats belong there"*). Cutover is a later phase, deliberately.
+//!
+//! # What is here
+//!
+//! * [`node`] — the canonical manifest node: a 32-way HAMT keyed by
+//!   `(object kind, object hash)`, addressed by `BLAKE3` of its canonical
+//!   bytes. One logical node has exactly one byte string, so identical
+//!   membership always yields an identical root.
+//! * [`build`] — deterministic construction and expansion. Replacing one object
+//!   rewrites only the old and new routes; every other subtree keeps its hash.
+//! * [`binding`] — the `(spool, facet, owner) -> content root` binding, with
+//!   owner identity deliberately outside the shared root.
+//! * [`extent`] — the canonical pack-range claim: per-record `BLAKE3` digests
+//!   in offset-canonical order, covering a range gap-free.
+//! * [`fsck`] — the integrity rules, each with a name.
+//!
+//! # The immutable/mutable line
+//!
+//! A manifest node carries object kind, object hash, decoded size, trie
+//! structure, and subtree summaries — nothing else. Pack id, storage key,
+//! offset, encoded length, ETag, audience, and current head are **mutable**
+//! control-plane facts. They live in [`extent`], resolved after authorization,
+//! so a repack changes a read envelope and never a manifest hash.
+//!
+//! # Compatibility
+//!
+//! The node layout, the `WPMF` magic, the `weft-plan-manifest-key-v1` routing
+//! domain, and the offset-canonical extent ordering are byte-identical to the
+//! already-merged downstream consumer (weft PR #1069 and its follow-up fix
+//! #1070, `weft/docs/PLAN_MANIFEST_FORMAT.md`). This module is the normative
+//! upstream *definition* of bytes that already exist downstream, not a second
+//! competing format — see the crate-level note in [`node`] on why the magic
+//! was kept rather than renamed.
+//!
+//! Facet identity follows the ratified weft #358 decision: four uniform facets
+//! per spool, no content-bearing discriminant.
+
+pub mod binding;
+pub mod build;
+pub mod extent;
+pub mod fsck;
+pub mod node;
+
+pub use binding::{
+    MANIFEST_BINDING_MAGIC, MANIFEST_BINDING_VERSION, ManifestBinding, ManifestBindingDecodeError,
+    ManifestFacet, ManifestFacetParseError, ManifestOwnerKind,
+};
+pub use build::{
+    BuiltManifest, ManifestBuildError, ManifestExpandError, ManifestNodeSource, ManifestNodeStore,
+    build_manifest, expand_manifest,
+};
+pub use extent::{
+    PACK_CLAIM_MAGIC, PACK_CLAIM_VERSION, PackClaimDecodeError, PackRangeClaim, PackRecord,
+};
+pub use fsck::{
+    FsckFinding, FsckOptions, FsckReport, FsckRule, ManifestObjectIndex, PackRangeAudit,
+    fsck_manifest, fsck_manifest_store, fsck_manifest_with, fsck_pack_range,
+};
+pub use node::{
+    MANIFEST_BRANCH_WIDTH, MANIFEST_FORMAT_VERSION, MANIFEST_LEAF_MAX_ENTRIES, MANIFEST_NODE_MAGIC,
+    MANIFEST_ROUTE_BITS, MANIFEST_ROUTE_DOMAIN, MANIFEST_ROUTE_LEVELS, ManifestBranch,
+    ManifestChild, ManifestDecodeError, ManifestKey, ManifestLeaf, ManifestNode, ManifestNodeError,
+    ManifestObject, ManifestObjectKind, ManifestRoute,
+};

--- a/crates/object-model/src/object/manifest/node.rs
+++ b/crates/object-model/src/object/manifest/node.rs
@@ -1,0 +1,746 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical manifest-node encoding — WPMF v1.
+//!
+//! A manifest node is addressed by `BLAKE3(canonical_node_bytes)`. There is
+//! exactly one byte string per logical node, so the same logical membership
+//! always produces the same root hash. Every integer is unsigned big-endian,
+//! entries and children are strictly ordered, and decoding rejects duplicates,
+//! truncation, trailing bytes, and any non-canonical spelling.
+//!
+//! The layouts below are byte-identical to the already-merged downstream
+//! consumer (weft PR #1069, `docs/PLAN_MANIFEST_FORMAT.md`), including the
+//! `WPMF` magic and the `weft-plan-manifest-key-v1` routing domain. Byte
+//! compatibility with a shipped consumer outranks upstream nomenclature: this
+//! module is the normative *definition* of bytes that already exist, not a
+//! second, competing format.
+//!
+//! ```text
+//! leaf:   "WPMF" | u8(version=1) | u8(tag=0) | u16(count)
+//!                | count  * ( u8(kind) | [u8;32](hash) | u64(decoded_size) )
+//! branch: "WPMF" | u8(version=1) | u8(tag=1) | u8(depth) | u32(bitmap)
+//!                | popcnt * ( [u8;32](child_hash) | u64(object_count)
+//!                                                 | u64(decoded_bytes) )
+//! ```
+
+use std::fmt;
+
+use crate::object::ContentHash;
+
+/// Magic prefix on every canonical manifest node.
+pub const MANIFEST_NODE_MAGIC: [u8; 4] = *b"WPMF";
+/// The only manifest format version this binary reads or writes.
+pub const MANIFEST_FORMAT_VERSION: u8 = 1;
+/// Domain separator for the trie route. Hashed with the plan key to derive the
+/// 256 routing bits.
+pub const MANIFEST_ROUTE_DOMAIN: &[u8] = b"weft-plan-manifest-key-v1";
+/// Routing bits consumed per trie level (32-way branching).
+pub const MANIFEST_ROUTE_BITS: u8 = 5;
+/// Branch fan-out — one bitmap slot per possible 5-bit route group.
+pub const MANIFEST_BRANCH_WIDTH: usize = 32;
+/// Levels available before the fixed 256-bit route is exhausted
+/// (`ceil(256 / 5)`). A leaf at this depth may exceed
+/// [`MANIFEST_LEAF_MAX_ENTRIES`] because no routing bits remain to split it.
+pub const MANIFEST_ROUTE_LEVELS: u8 = 52;
+/// Entries a leaf may hold before it must split into a branch, unless the
+/// route is already exhausted.
+pub const MANIFEST_LEAF_MAX_ENTRIES: usize = 16;
+
+const TAG_LEAF: u8 = 0;
+const TAG_BRANCH: u8 = 1;
+
+const LEAF_HEADER_LEN: usize = 4 + 1 + 1 + 2;
+const LEAF_ENTRY_LEN: usize = 1 + 32 + 8;
+const BRANCH_HEADER_LEN: usize = 4 + 1 + 1 + 1 + 4;
+const BRANCH_CHILD_LEN: usize = 32 + 8 + 8;
+
+// ── ManifestObjectKind ──────────────────────────────────────────────
+
+/// The object types a manifest leaf may name.
+///
+/// Deliberately narrow: a manifest carries *content* membership. Owner
+/// identity (State / StateAttachment) lives in the binding, outside the shared
+/// content root, so a context-only state reuses its parent root byte-for-byte.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ManifestObjectKind {
+    Blob = 0,
+    Tree = 1,
+}
+
+impl ManifestObjectKind {
+    pub fn to_byte(self) -> u8 {
+        self as u8
+    }
+
+    pub fn from_byte(byte: u8) -> Option<Self> {
+        match byte {
+            0 => Some(Self::Blob),
+            1 => Some(Self::Tree),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for ManifestObjectKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Blob => "blob",
+            Self::Tree => "tree",
+        })
+    }
+}
+
+// ── ManifestKey / ManifestRoute ─────────────────────────────────────
+
+/// The trie key: `(kind, object_hash)`. Ordering is the canonical plan order —
+/// kind first, then the 32 hash bytes lexicographically.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ManifestKey {
+    pub kind: ManifestObjectKind,
+    pub hash: ContentHash,
+}
+
+impl ManifestKey {
+    pub fn new(kind: ManifestObjectKind, hash: ContentHash) -> Self {
+        Self { kind, hash }
+    }
+
+    /// The 256 routing bits for this key.
+    pub fn route(&self) -> ManifestRoute {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(MANIFEST_ROUTE_DOMAIN);
+        hasher.update(&[self.kind.to_byte()]);
+        hasher.update(self.hash.as_bytes());
+        ManifestRoute(hasher.finalize().into())
+    }
+}
+
+/// The fixed 256-bit route derived from a [`ManifestKey`], read as successive
+/// 5-bit groups, most-significant bit first.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct ManifestRoute([u8; 32]);
+
+impl ManifestRoute {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// The bitmap slot this key occupies at `level`.
+    ///
+    /// Levels past the 256th bit are zero-padded on the right, so the final
+    /// level (51) carries a single real bit. Levels at or beyond
+    /// [`MANIFEST_ROUTE_LEVELS`] are exhausted and always return 0; callers
+    /// must stop splitting there rather than loop forever.
+    pub fn group(&self, level: u8) -> u8 {
+        let start = usize::from(level) * usize::from(MANIFEST_ROUTE_BITS);
+        let mut value = 0u8;
+        for offset in 0..usize::from(MANIFEST_ROUTE_BITS) {
+            let bit_index = start + offset;
+            let bit = if bit_index >= 256 {
+                0
+            } else {
+                (self.0[bit_index / 8] >> (7 - (bit_index % 8))) & 1
+            };
+            value = (value << 1) | bit;
+        }
+        value
+    }
+}
+
+impl fmt::Debug for ManifestRoute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "ManifestRoute({})", hex::encode(&self.0[..8]))
+    }
+}
+
+// ── ManifestObject ──────────────────────────────────────────────────
+
+/// One immutable content object named by a manifest leaf.
+///
+/// Only logical facts appear here. Pack id, storage key, offset, encoded
+/// length, encoded digest, ETag, audience, and current head are mutable
+/// control-plane facts and are resolved *after* authorization — see
+/// [`super::extent`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ManifestObject {
+    pub kind: ManifestObjectKind,
+    pub hash: ContentHash,
+    pub decoded_size: u64,
+}
+
+impl ManifestObject {
+    pub fn new(kind: ManifestObjectKind, hash: ContentHash, decoded_size: u64) -> Self {
+        Self {
+            kind,
+            hash,
+            decoded_size,
+        }
+    }
+
+    pub fn key(&self) -> ManifestKey {
+        ManifestKey::new(self.kind, self.hash)
+    }
+}
+
+// ── ManifestChild ───────────────────────────────────────────────────
+
+/// A branch's reference to one child subtree, with the summary that lets a
+/// planner size a subtree without descending into it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ManifestChild {
+    /// Bitmap slot (`0..32`) — the child's 5-bit route group at the parent's
+    /// depth.
+    pub slot: u8,
+    pub hash: ContentHash,
+    pub object_count: u64,
+    pub decoded_bytes: u64,
+}
+
+// ── ManifestNode ────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ManifestNode {
+    Leaf(ManifestLeaf),
+    Branch(ManifestBranch),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifestLeaf {
+    entries: Vec<ManifestObject>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ManifestBranch {
+    depth: u8,
+    children: Vec<ManifestChild>,
+}
+
+impl ManifestLeaf {
+    /// Build a leaf, sorting entries into canonical key order.
+    ///
+    /// Returns [`ManifestNodeError::DuplicateObjectKey`] if two entries share a
+    /// `(kind, hash)` key, even when their declared sizes agree: the canonical
+    /// form names each object exactly once.
+    pub fn new(mut entries: Vec<ManifestObject>) -> Result<Self, ManifestNodeError> {
+        entries.sort_by_key(ManifestObject::key);
+        if let Some(window) = entries.windows(2).find(|w| w[0].key() == w[1].key()) {
+            return Err(ManifestNodeError::DuplicateObjectKey(window[0].key()));
+        }
+        if u16::try_from(entries.len()).is_err() {
+            return Err(ManifestNodeError::LeafCountOverflow(entries.len()));
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn entries(&self) -> &[ManifestObject] {
+        &self.entries
+    }
+
+    pub fn object_count(&self) -> u64 {
+        self.entries.len() as u64
+    }
+
+    /// Total decoded bytes named by this leaf, or `None` on `u64` overflow.
+    pub fn decoded_bytes(&self) -> Option<u64> {
+        self.entries
+            .iter()
+            .try_fold(0u64, |acc, entry| acc.checked_add(entry.decoded_size))
+    }
+}
+
+impl ManifestBranch {
+    /// Build a branch, sorting children into ascending bitmap-slot order.
+    pub fn new(depth: u8, mut children: Vec<ManifestChild>) -> Result<Self, ManifestNodeError> {
+        children.sort_by_key(|child| child.slot);
+        if children.is_empty() {
+            return Err(ManifestNodeError::EmptyBranchBitmap);
+        }
+        if let Some(child) = children
+            .iter()
+            .find(|child| usize::from(child.slot) >= MANIFEST_BRANCH_WIDTH)
+        {
+            return Err(ManifestNodeError::SlotOutOfRange(child.slot));
+        }
+        if let Some(window) = children.windows(2).find(|w| w[0].slot == w[1].slot) {
+            return Err(ManifestNodeError::DuplicateBranchSlot(window[0].slot));
+        }
+        Ok(Self { depth, children })
+    }
+
+    pub fn depth(&self) -> u8 {
+        self.depth
+    }
+
+    pub fn children(&self) -> &[ManifestChild] {
+        &self.children
+    }
+
+    pub fn bitmap(&self) -> u32 {
+        self.children
+            .iter()
+            .fold(0u32, |acc, child| acc | (1u32 << child.slot))
+    }
+
+    pub fn child_at(&self, slot: u8) -> Option<&ManifestChild> {
+        self.children.iter().find(|child| child.slot == slot)
+    }
+}
+
+impl ManifestNode {
+    /// The canonical empty-set root: a leaf with no entries.
+    pub fn empty() -> Self {
+        Self::Leaf(ManifestLeaf {
+            entries: Vec::new(),
+        })
+    }
+
+    /// Encode to the single canonical byte string for this logical node.
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            Self::Leaf(leaf) => {
+                let mut out =
+                    Vec::with_capacity(LEAF_HEADER_LEN + leaf.entries.len() * LEAF_ENTRY_LEN);
+                out.extend_from_slice(&MANIFEST_NODE_MAGIC);
+                out.push(MANIFEST_FORMAT_VERSION);
+                out.push(TAG_LEAF);
+                out.extend_from_slice(&(leaf.entries.len() as u16).to_be_bytes());
+                for entry in &leaf.entries {
+                    out.push(entry.kind.to_byte());
+                    out.extend_from_slice(entry.hash.as_bytes());
+                    out.extend_from_slice(&entry.decoded_size.to_be_bytes());
+                }
+                out
+            }
+            Self::Branch(branch) => {
+                let mut out = Vec::with_capacity(
+                    BRANCH_HEADER_LEN + branch.children.len() * BRANCH_CHILD_LEN,
+                );
+                out.extend_from_slice(&MANIFEST_NODE_MAGIC);
+                out.push(MANIFEST_FORMAT_VERSION);
+                out.push(TAG_BRANCH);
+                out.push(branch.depth);
+                out.extend_from_slice(&branch.bitmap().to_be_bytes());
+                for child in &branch.children {
+                    out.extend_from_slice(child.hash.as_bytes());
+                    out.extend_from_slice(&child.object_count.to_be_bytes());
+                    out.extend_from_slice(&child.decoded_bytes.to_be_bytes());
+                }
+                out
+            }
+        }
+    }
+
+    /// The node's content address — `BLAKE3` of its canonical bytes.
+    pub fn address(&self) -> ContentHash {
+        ContentHash::compute(&self.encode())
+    }
+
+    /// Decode strictly.
+    ///
+    /// Rejects a bad magic, an unknown version or tag, an unknown object kind,
+    /// truncation, trailing bytes, out-of-order or duplicated entries, an empty
+    /// branch bitmap, and — as a final backstop — any input whose re-encoding
+    /// differs from the input. A node that decodes here is canonical, so its
+    /// address is meaningful.
+    pub fn decode(bytes: &[u8]) -> Result<Self, ManifestDecodeError> {
+        let node = Self::decode_inner(bytes)?;
+        if node.encode() != bytes {
+            return Err(ManifestDecodeError::NonCanonicalEncoding);
+        }
+        Ok(node)
+    }
+
+    /// Decode and verify the node addresses to `expected`.
+    pub fn decode_addressed(
+        bytes: &[u8],
+        expected: &ContentHash,
+    ) -> Result<Self, ManifestDecodeError> {
+        let node = Self::decode(bytes)?;
+        let actual = ContentHash::compute(bytes);
+        if actual != *expected {
+            return Err(ManifestDecodeError::AddressMismatch {
+                expected: *expected,
+                actual,
+            });
+        }
+        Ok(node)
+    }
+
+    fn decode_inner(bytes: &[u8]) -> Result<Self, ManifestDecodeError> {
+        let mut reader = Reader::new(bytes);
+        if reader.take(4)? != MANIFEST_NODE_MAGIC {
+            return Err(ManifestDecodeError::BadMagic);
+        }
+        let version = reader.u8()?;
+        if version != MANIFEST_FORMAT_VERSION {
+            return Err(ManifestDecodeError::UnsupportedVersion(version));
+        }
+        let tag = reader.u8()?;
+        let node = match tag {
+            TAG_LEAF => {
+                let count = usize::from(reader.u16()?);
+                let mut entries = Vec::with_capacity(count.min(1024));
+                let mut previous: Option<ManifestKey> = None;
+                for _ in 0..count {
+                    let kind_byte = reader.u8()?;
+                    let kind = ManifestObjectKind::from_byte(kind_byte)
+                        .ok_or(ManifestDecodeError::UnknownObjectKind(kind_byte))?;
+                    let hash = ContentHash::from_bytes(reader.hash()?);
+                    let decoded_size = reader.u64()?;
+                    let key = ManifestKey::new(kind, hash);
+                    match previous {
+                        Some(prev) if prev == key => {
+                            return Err(ManifestDecodeError::DuplicateObjectKey(key));
+                        }
+                        Some(prev) if prev > key => {
+                            return Err(ManifestDecodeError::EntriesOutOfOrder);
+                        }
+                        _ => {}
+                    }
+                    previous = Some(key);
+                    entries.push(ManifestObject::new(kind, hash, decoded_size));
+                }
+                Self::Leaf(ManifestLeaf { entries })
+            }
+            TAG_BRANCH => {
+                let depth = reader.u8()?;
+                let bitmap = reader.u32()?;
+                if bitmap == 0 {
+                    return Err(ManifestDecodeError::EmptyBranchBitmap);
+                }
+                let mut children = Vec::with_capacity(bitmap.count_ones() as usize);
+                for slot in 0..MANIFEST_BRANCH_WIDTH as u8 {
+                    if bitmap & (1u32 << slot) == 0 {
+                        continue;
+                    }
+                    let hash = ContentHash::from_bytes(reader.hash()?);
+                    let object_count = reader.u64()?;
+                    let decoded_bytes = reader.u64()?;
+                    children.push(ManifestChild {
+                        slot,
+                        hash,
+                        object_count,
+                        decoded_bytes,
+                    });
+                }
+                Self::Branch(ManifestBranch { depth, children })
+            }
+            other => return Err(ManifestDecodeError::UnknownNodeTag(other)),
+        };
+        if !reader.is_exhausted() {
+            return Err(ManifestDecodeError::TrailingBytes);
+        }
+        Ok(node)
+    }
+
+    /// Objects named directly by this node (empty for a branch).
+    pub fn leaf_entries(&self) -> &[ManifestObject] {
+        match self {
+            Self::Leaf(leaf) => leaf.entries(),
+            Self::Branch(_) => &[],
+        }
+    }
+}
+
+// ── Reader ──────────────────────────────────────────────────────────
+
+struct Reader<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes, pos: 0 }
+    }
+
+    fn take(&mut self, len: usize) -> Result<&'a [u8], ManifestDecodeError> {
+        let end = self
+            .pos
+            .checked_add(len)
+            .ok_or(ManifestDecodeError::Truncated)?;
+        let slice = self
+            .bytes
+            .get(self.pos..end)
+            .ok_or(ManifestDecodeError::Truncated)?;
+        self.pos = end;
+        Ok(slice)
+    }
+
+    fn u8(&mut self) -> Result<u8, ManifestDecodeError> {
+        Ok(self.take(1)?[0])
+    }
+
+    fn u16(&mut self) -> Result<u16, ManifestDecodeError> {
+        let bytes = self.take(2)?;
+        Ok(u16::from_be_bytes([bytes[0], bytes[1]]))
+    }
+
+    fn u32(&mut self) -> Result<u32, ManifestDecodeError> {
+        let bytes = self.take(4)?;
+        Ok(u32::from_be_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]))
+    }
+
+    fn u64(&mut self) -> Result<u64, ManifestDecodeError> {
+        let bytes = self.take(8)?;
+        let mut arr = [0u8; 8];
+        arr.copy_from_slice(bytes);
+        Ok(u64::from_be_bytes(arr))
+    }
+
+    fn hash(&mut self) -> Result<[u8; 32], ManifestDecodeError> {
+        let bytes = self.take(32)?;
+        let mut arr = [0u8; 32];
+        arr.copy_from_slice(bytes);
+        Ok(arr)
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.pos == self.bytes.len()
+    }
+}
+
+// ── Errors ──────────────────────────────────────────────────────────
+
+/// Rejected while *constructing* a node in memory.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestNodeError {
+    #[error("duplicate manifest object key {0:?}")]
+    DuplicateObjectKey(ManifestKey),
+    #[error("leaf holds {0} entries; the canonical count field is a u16")]
+    LeafCountOverflow(usize),
+    #[error("branch bitmap is empty; the canonical empty set is the empty leaf")]
+    EmptyBranchBitmap,
+    #[error("branch slot {0} is outside 0..32")]
+    SlotOutOfRange(u8),
+    #[error("duplicate branch slot {0}")]
+    DuplicateBranchSlot(u8),
+}
+
+/// Rejected while *decoding* node bytes. Each variant is a distinct corruption
+/// class and maps to a named fsck rule via
+/// [`ManifestDecodeError::fsck_rule`](super::fsck::FsckRule).
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ManifestDecodeError {
+    #[error("node does not start with the WPMF magic")]
+    BadMagic,
+    #[error("unsupported manifest format version {0}")]
+    UnsupportedVersion(u8),
+    #[error("unknown manifest node tag {0}")]
+    UnknownNodeTag(u8),
+    #[error("unknown manifest object kind {0}")]
+    UnknownObjectKind(u8),
+    #[error("node bytes are truncated")]
+    Truncated,
+    #[error("node has trailing bytes after its declared content")]
+    TrailingBytes,
+    #[error("leaf entries are not strictly ascending by (kind, hash)")]
+    EntriesOutOfOrder,
+    #[error("leaf names object key {0:?} more than once")]
+    DuplicateObjectKey(ManifestKey),
+    #[error("branch bitmap is empty; the canonical empty set is the empty leaf")]
+    EmptyBranchBitmap,
+    #[error("node bytes are a non-canonical spelling of their own content")]
+    NonCanonicalEncoding,
+    #[error("node bytes hash to {actual} but were addressed as {expected}")]
+    AddressMismatch {
+        expected: ContentHash,
+        actual: ContentHash,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(seed: u8) -> ContentHash {
+        ContentHash::from_bytes([seed; 32])
+    }
+
+    fn object(seed: u8, size: u64) -> ManifestObject {
+        ManifestObject::new(ManifestObjectKind::Blob, hash(seed), size)
+    }
+
+    #[test]
+    fn empty_leaf_is_the_canonical_empty_root() {
+        let encoded = ManifestNode::empty().encode();
+        assert_eq!(encoded, b"WPMF\x01\x00\x00\x00");
+        assert_eq!(
+            ManifestNode::decode(&encoded).unwrap(),
+            ManifestNode::empty()
+        );
+    }
+
+    #[test]
+    fn leaf_layout_is_byte_exact() {
+        let leaf = ManifestNode::Leaf(ManifestLeaf::new(vec![object(1, 0x0102)]).unwrap());
+        let encoded = leaf.encode();
+        assert_eq!(&encoded[..4], b"WPMF");
+        assert_eq!(encoded[4], MANIFEST_FORMAT_VERSION);
+        assert_eq!(encoded[5], TAG_LEAF);
+        assert_eq!(&encoded[6..8], &1u16.to_be_bytes());
+        assert_eq!(encoded[8], 0); // Blob
+        assert_eq!(&encoded[9..41], &[1u8; 32]);
+        assert_eq!(&encoded[41..49], &0x0102u64.to_be_bytes());
+        assert_eq!(encoded.len(), LEAF_HEADER_LEN + LEAF_ENTRY_LEN);
+    }
+
+    #[test]
+    fn branch_layout_is_byte_exact() {
+        let branch = ManifestNode::Branch(
+            ManifestBranch::new(
+                3,
+                vec![
+                    ManifestChild {
+                        slot: 5,
+                        hash: hash(9),
+                        object_count: 17,
+                        decoded_bytes: 40,
+                    },
+                    ManifestChild {
+                        slot: 1,
+                        hash: hash(8),
+                        object_count: 2,
+                        decoded_bytes: 6,
+                    },
+                ],
+            )
+            .unwrap(),
+        );
+        let encoded = branch.encode();
+        assert_eq!(encoded[5], TAG_BRANCH);
+        assert_eq!(encoded[6], 3);
+        assert_eq!(&encoded[7..11], &0b100010u32.to_be_bytes());
+        // Children follow occupied bitmap slots in ascending order, so slot 1
+        // precedes slot 5 regardless of construction order.
+        assert_eq!(&encoded[11..43], &[8u8; 32]);
+        assert_eq!(encoded.len(), BRANCH_HEADER_LEN + 2 * BRANCH_CHILD_LEN);
+        assert_eq!(ManifestNode::decode(&encoded).unwrap(), branch);
+    }
+
+    #[test]
+    fn decode_rejects_each_corruption_class() {
+        let good = ManifestNode::Leaf(ManifestLeaf::new(vec![object(1, 1), object(2, 2)]).unwrap())
+            .encode();
+
+        let mut bad_magic = good.clone();
+        bad_magic[0] = b'X';
+        assert_eq!(
+            ManifestNode::decode(&bad_magic).unwrap_err(),
+            ManifestDecodeError::BadMagic
+        );
+
+        let mut bad_version = good.clone();
+        bad_version[4] = 2;
+        assert_eq!(
+            ManifestNode::decode(&bad_version).unwrap_err(),
+            ManifestDecodeError::UnsupportedVersion(2)
+        );
+
+        let mut bad_tag = good.clone();
+        bad_tag[5] = 7;
+        assert_eq!(
+            ManifestNode::decode(&bad_tag).unwrap_err(),
+            ManifestDecodeError::UnknownNodeTag(7)
+        );
+
+        let mut bad_kind = good.clone();
+        bad_kind[8] = 9;
+        assert_eq!(
+            ManifestNode::decode(&bad_kind).unwrap_err(),
+            ManifestDecodeError::UnknownObjectKind(9)
+        );
+
+        let mut trailing = good.clone();
+        trailing.push(0);
+        assert_eq!(
+            ManifestNode::decode(&trailing).unwrap_err(),
+            ManifestDecodeError::TrailingBytes
+        );
+
+        let truncated = &good[..good.len() - 1];
+        assert_eq!(
+            ManifestNode::decode(truncated).unwrap_err(),
+            ManifestDecodeError::Truncated
+        );
+
+        // Swap the two entries so they descend rather than ascend.
+        let mut swapped = good.clone();
+        let (a, b) = (8, 8 + LEAF_ENTRY_LEN);
+        let entry_a = good[a..a + LEAF_ENTRY_LEN].to_vec();
+        let entry_b = good[b..b + LEAF_ENTRY_LEN].to_vec();
+        swapped[a..a + LEAF_ENTRY_LEN].copy_from_slice(&entry_b);
+        swapped[b..b + LEAF_ENTRY_LEN].copy_from_slice(&entry_a);
+        assert_eq!(
+            ManifestNode::decode(&swapped).unwrap_err(),
+            ManifestDecodeError::EntriesOutOfOrder
+        );
+
+        // Duplicate the first entry over the second.
+        let mut duplicated = good.clone();
+        duplicated[b..b + LEAF_ENTRY_LEN].copy_from_slice(&entry_a);
+        assert_eq!(
+            ManifestNode::decode(&duplicated).unwrap_err(),
+            ManifestDecodeError::DuplicateObjectKey(ManifestKey::new(
+                ManifestObjectKind::Blob,
+                hash(1)
+            ))
+        );
+    }
+
+    #[test]
+    fn decode_rejects_empty_branch_bitmap() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MANIFEST_NODE_MAGIC);
+        bytes.push(MANIFEST_FORMAT_VERSION);
+        bytes.push(TAG_BRANCH);
+        bytes.push(0);
+        bytes.extend_from_slice(&0u32.to_be_bytes());
+        assert_eq!(
+            ManifestNode::decode(&bytes).unwrap_err(),
+            ManifestDecodeError::EmptyBranchBitmap
+        );
+    }
+
+    #[test]
+    fn decode_addressed_rejects_a_wrong_address() {
+        let node = ManifestNode::Leaf(ManifestLeaf::new(vec![object(1, 1)]).unwrap());
+        let bytes = node.encode();
+        let err = ManifestNode::decode_addressed(&bytes, &hash(0xff)).unwrap_err();
+        assert!(matches!(err, ManifestDecodeError::AddressMismatch { .. }));
+        assert!(ManifestNode::decode_addressed(&bytes, &node.address()).is_ok());
+    }
+
+    #[test]
+    fn route_groups_read_five_bits_msb_first() {
+        let route = ManifestRoute([0b1010_1010; 32]);
+        assert_eq!(route.group(0), 0b10101);
+        assert_eq!(route.group(1), 0b01010);
+        // The final level starts at bit 255 — the last bit of the last byte —
+        // and the remaining four are zero padding. Here that bit is 0.
+        assert_eq!(route.group(MANIFEST_ROUTE_LEVELS - 1), 0b00000);
+        // Same position, last bit set: the one real bit lands in the high
+        // position of the group and the padding stays zero.
+        assert_eq!(
+            ManifestRoute([0b1010_1011; 32]).group(MANIFEST_ROUTE_LEVELS - 1),
+            0b10000
+        );
+        // Past the route, every group is 0 — splitting must stop, not spin.
+        assert_eq!(route.group(MANIFEST_ROUTE_LEVELS), 0);
+    }
+
+    #[test]
+    fn route_is_domain_separated_from_the_raw_hash() {
+        let key = ManifestKey::new(ManifestObjectKind::Blob, hash(3));
+        assert_ne!(key.route().as_bytes(), hash(3).as_bytes());
+        // Kind participates: the same hash under a different kind routes apart.
+        let other = ManifestKey::new(ManifestObjectKind::Tree, hash(3));
+        assert_ne!(key.route().as_bytes(), other.route().as_bytes());
+    }
+
+    #[test]
+    fn constructing_a_leaf_rejects_duplicate_keys() {
+        let err = ManifestLeaf::new(vec![object(1, 1), object(1, 1)]).unwrap_err();
+        assert!(matches!(err, ManifestNodeError::DuplicateObjectKey(_)));
+    }
+}

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -13,6 +13,7 @@ mod diff;
 mod discussion;
 mod hash;
 mod identifiers;
+pub mod manifest;
 mod operation_id;
 mod redaction;
 mod risk_signal;
@@ -50,6 +51,13 @@ pub use discussion::{
 };
 pub use hash::{ChangeId, ChangeIdParseError, ContentHash, StateId, StateIdParseError};
 pub use identifiers::{MarkerName, Scope, ThreadName};
+pub use manifest::{
+    BuiltManifest, FsckFinding, FsckOptions, FsckReport, FsckRule, ManifestBinding,
+    ManifestBuildError, ManifestFacet, ManifestKey, ManifestNode, ManifestNodeSource,
+    ManifestObject, ManifestObjectKind, ManifestOwnerKind, PackRangeAudit, PackRangeClaim,
+    PackRecord, build_manifest, expand_manifest, fsck_manifest, fsck_manifest_with,
+    fsck_pack_range,
+};
 pub use operation_id::{OperationId, OperationIdParseError};
 pub use redaction::{
     REDACTION_SIGNING_PAYLOAD_VERSION_TAG, Redaction, RedactionError, RedactionsBlob,

--- a/crates/object-model/tests/manifest_canonical_fsck.rs
+++ b/crates/object-model/tests/manifest_canonical_fsck.rs
@@ -1,0 +1,839 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical manifest encoding + fsck: round-trip, hash stability, and one
+//! named rejection per corruption class.
+//!
+//! The negative cases are the point. A checker that only ever sees valid input
+//! proves nothing, so every rule below is exercised by a graph that violates it
+//! and is asserted *by rule name*.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use heddle_object_model::object::{
+    ContentHash,
+    manifest::{
+        FsckOptions, FsckRule, MANIFEST_LEAF_MAX_ENTRIES, MANIFEST_ROUTE_LEVELS, ManifestBranch,
+        ManifestChild, ManifestLeaf, ManifestNode, ManifestObject, ManifestObjectKind,
+        PackRangeAudit, PackRangeClaim, PackRecord, build_manifest, expand_manifest, fsck_manifest,
+        fsck_manifest_store, fsck_manifest_with, fsck_pack_range,
+    },
+};
+use proptest::prelude::*;
+
+// ── Fixtures ────────────────────────────────────────────────────────
+
+type Nodes = BTreeMap<ContentHash, Vec<u8>>;
+
+fn object(seed: u32) -> ManifestObject {
+    let mut bytes = [0u8; 32];
+    bytes[..4].copy_from_slice(&seed.to_be_bytes());
+    ManifestObject::new(
+        if seed.is_multiple_of(4) {
+            ManifestObjectKind::Tree
+        } else {
+            ManifestObjectKind::Blob
+        },
+        ContentHash::compute(&bytes),
+        u64::from(seed) * 13 + 1,
+    )
+}
+
+fn objects(count: u32) -> Vec<ManifestObject> {
+    (0..count).map(object).collect()
+}
+
+/// A two-level fixture: 100 objects spread over 32 slots leaves every child a
+/// leaf, so a test can rewrite one leaf and repair its parent by hand.
+fn fixture() -> (ContentHash, Nodes, Vec<ManifestObject>) {
+    let set = objects(100);
+    let built = build_manifest(set.clone()).expect("fixture builds");
+    (built.root, built.nodes, set)
+}
+
+fn branch_at(nodes: &Nodes, hash: &ContentHash) -> ManifestBranch {
+    match ManifestNode::decode(&nodes[hash]).expect("node decodes") {
+        ManifestNode::Branch(branch) => branch,
+        ManifestNode::Leaf(_) => panic!("expected a branch at {hash}"),
+    }
+}
+
+fn leaf_at(nodes: &Nodes, hash: &ContentHash) -> ManifestLeaf {
+    match ManifestNode::decode(&nodes[hash]).expect("node decodes") {
+        ManifestNode::Leaf(leaf) => leaf,
+        ManifestNode::Branch(_) => panic!("expected a leaf at {hash}"),
+    }
+}
+
+fn insert(nodes: &mut Nodes, node: &ManifestNode) -> ContentHash {
+    let bytes = node.encode();
+    let hash = ContentHash::compute(&bytes);
+    nodes.insert(hash, bytes);
+    hash
+}
+
+/// Replace the leaf under `slot` of the root branch with `entries`, rebuilding
+/// the root so every digest still checks out. When `repair_summary` is set the
+/// new child summary matches the new leaf, so a test can isolate the rule it
+/// actually cares about.
+fn replace_root_leaf(
+    root: &ContentHash,
+    nodes: &mut Nodes,
+    slot: u8,
+    entries: Vec<ManifestObject>,
+    repair_summary: bool,
+) -> ContentHash {
+    let branch = branch_at(nodes, root);
+    let old = *branch.child_at(slot).expect("slot is occupied");
+
+    let leaf = ManifestLeaf::new(entries).expect("leaf builds");
+    let count = leaf.object_count();
+    let bytes = leaf.decoded_bytes().expect("no overflow");
+    let child_hash = insert(nodes, &ManifestNode::Leaf(leaf));
+
+    let children: Vec<ManifestChild> = branch
+        .children()
+        .iter()
+        .map(|child| {
+            if child.slot == slot {
+                ManifestChild {
+                    slot,
+                    hash: child_hash,
+                    object_count: if repair_summary {
+                        count
+                    } else {
+                        old.object_count
+                    },
+                    decoded_bytes: if repair_summary {
+                        bytes
+                    } else {
+                        old.decoded_bytes
+                    },
+                }
+            } else {
+                *child
+            }
+        })
+        .collect();
+
+    let new_root =
+        ManifestNode::Branch(ManifestBranch::new(branch.depth(), children).expect("branch builds"));
+    insert(nodes, &new_root)
+}
+
+fn object_index(set: &[ManifestObject]) -> BTreeMap<heddle_object_model::object::ManifestKey, u64> {
+    set.iter()
+        .map(|object| (object.key(), object.decoded_size))
+        .collect()
+}
+
+// ── Encoding: round-trip and hash stability ─────────────────────────
+
+#[test]
+fn every_node_of_a_built_manifest_round_trips_byte_for_byte() {
+    let (root, nodes, _) = fixture();
+    assert!(nodes.len() > 1, "fixture should be more than one node");
+    for (hash, bytes) in &nodes {
+        let node = ManifestNode::decode(bytes).expect("node decodes");
+        assert_eq!(&node.encode(), bytes, "re-encode differs at {hash}");
+        assert_eq!(node.address(), *hash, "address is not BLAKE3 of the bytes");
+    }
+    assert!(nodes.contains_key(&root));
+}
+
+#[test]
+fn the_same_logical_membership_always_hashes_the_same() {
+    let set = objects(400);
+    let mut shuffled = set.clone();
+    shuffled.rotate_left(137);
+    shuffled.reverse();
+
+    let a = build_manifest(set.clone()).unwrap();
+    let b = build_manifest(shuffled).unwrap();
+    assert_eq!(a.root, b.root);
+    assert_eq!(a.nodes, b.nodes);
+
+    // And it is stable across runs of this binary, not merely self-consistent.
+    let c = build_manifest(set).unwrap();
+    assert_eq!(a.root, c.root);
+}
+
+#[test]
+fn expansion_is_the_original_set_in_canonical_key_order() {
+    let (root, nodes, mut set) = fixture();
+    let expanded = expand_manifest(&nodes, &root).unwrap();
+    set.sort_by_key(ManifestObject::key);
+    assert_eq!(expanded, set);
+    assert!(
+        expanded.windows(2).all(|w| w[0].key() < w[1].key()),
+        "expansion must be strictly ascending by plan key"
+    );
+}
+
+#[test]
+fn a_context_only_republish_reuses_the_root_and_a_content_change_does_not() {
+    // The structural-sharing contract: identical membership → identical root
+    // (nothing republished); one object replaced → bounded rewrite.
+    let set = objects(2_000);
+    let before = build_manifest(set.clone()).unwrap();
+    assert_eq!(before.root, build_manifest(set.clone()).unwrap().root);
+
+    let mut changed = set;
+    changed[900] = object(10_000_000);
+    let after = build_manifest(changed).unwrap();
+    assert_ne!(before.root, after.root);
+
+    let rewritten = after
+        .nodes
+        .keys()
+        .filter(|hash| !before.nodes.contains_key(*hash))
+        .count();
+    assert!(
+        rewritten <= usize::from(MANIFEST_ROUTE_LEVELS),
+        "one object change rewrote {rewritten} nodes"
+    );
+}
+
+// ── fsck: the happy path ────────────────────────────────────────────
+
+#[test]
+fn fsck_accepts_a_well_formed_graph() {
+    let (root, nodes, set) = fixture();
+    assert!(fsck_manifest(&nodes, &root).is_clean());
+
+    let index = object_index(&set);
+    let report = fsck_manifest_with(
+        &nodes,
+        &root,
+        &FsckOptions {
+            objects: Some(&index),
+            report_unreachable: false,
+        },
+    );
+    assert!(report.is_clean(), "unexpected findings: {report:?}");
+}
+
+#[test]
+fn fsck_accepts_the_canonical_empty_root() {
+    let built = build_manifest([]).unwrap();
+    assert!(fsck_manifest(&built.nodes, &built.root).is_clean());
+}
+
+#[test]
+fn fsck_accepts_a_deep_multi_level_graph() {
+    // 20k objects forces at least two branch levels, exercising depth and
+    // summary rules on real interior nodes.
+    let built = build_manifest(objects(20_000)).unwrap();
+    let has_depth_1_branch = built.nodes.values().any(|bytes| {
+        matches!(ManifestNode::decode(bytes), Ok(ManifestNode::Branch(b)) if b.depth() == 1)
+    });
+    assert!(
+        has_depth_1_branch,
+        "fixture is not deep enough to be useful"
+    );
+    assert!(fsck_manifest(&built.nodes, &built.root).is_clean());
+}
+
+// ── fsck: one named rejection per corruption class ──────────────────
+
+#[test]
+fn rejects_bad_digest() {
+    let (root, mut nodes, _) = fixture();
+    let victim = *nodes.keys().find(|hash| **hash != root).unwrap();
+    let bytes = nodes.get_mut(&victim).unwrap();
+    let last = bytes.len() - 1;
+    bytes[last] ^= 0xff;
+
+    let report = fsck_manifest(&nodes, &root);
+    assert!(report.has_rule(FsckRule::NodeDigestMismatch), "{report:?}");
+}
+
+#[test]
+fn rejects_dangling_node_ref() {
+    let (root, mut nodes, _) = fixture();
+    let victim = *nodes.keys().find(|hash| **hash != root).unwrap();
+    nodes.remove(&victim);
+
+    let report = fsck_manifest(&nodes, &root);
+    assert!(report.has_rule(FsckRule::DanglingNodeRef), "{report:?}");
+    assert!(
+        report
+            .findings()
+            .iter()
+            .any(|f| f.node == Some(victim) && f.rule == FsckRule::DanglingNodeRef)
+    );
+}
+
+#[test]
+fn rejects_dangling_object_ref_and_size_mismatch() {
+    let (root, nodes, set) = fixture();
+
+    let mut index = object_index(&set);
+    let missing = set[3].key();
+    index.remove(&missing);
+    let wrong_size = set[7].key();
+    *index.get_mut(&wrong_size).unwrap() += 1;
+
+    let report = fsck_manifest_with(
+        &nodes,
+        &root,
+        &FsckOptions {
+            objects: Some(&index),
+            report_unreachable: false,
+        },
+    );
+    assert!(report.has_rule(FsckRule::DanglingObjectRef), "{report:?}");
+    assert!(report.has_rule(FsckRule::ObjectSizeMismatch), "{report:?}");
+}
+
+#[test]
+fn rejects_wrong_order_within_a_leaf() {
+    let (root, mut nodes, _) = fixture();
+    let branch = branch_at(&nodes, &root);
+    let slot = branch
+        .children()
+        .iter()
+        .find(|child| child.object_count >= 2)
+        .expect("a leaf with two entries")
+        .slot;
+    let leaf = leaf_at(&nodes, &branch.child_at(slot).unwrap().hash);
+
+    // Hand-write the leaf with its first two entries swapped. `ManifestLeaf`
+    // would re-sort them, so the bytes are assembled directly.
+    let entries = leaf.entries();
+    let mut bytes = vec![b'W', b'P', b'M', b'F', 1, 0];
+    bytes.extend_from_slice(&(entries.len() as u16).to_be_bytes());
+    let mut order: Vec<&ManifestObject> = entries.iter().collect();
+    order.swap(0, 1);
+    for entry in order {
+        bytes.push(entry.kind.to_byte());
+        bytes.extend_from_slice(entry.hash.as_bytes());
+        bytes.extend_from_slice(&entry.decoded_size.to_be_bytes());
+    }
+    let corrupt = ContentHash::compute(&bytes);
+    nodes.insert(corrupt, bytes);
+
+    let children: Vec<ManifestChild> = branch
+        .children()
+        .iter()
+        .map(|child| {
+            if child.slot == slot {
+                ManifestChild {
+                    hash: corrupt,
+                    ..*child
+                }
+            } else {
+                *child
+            }
+        })
+        .collect();
+    let new_root = insert(
+        &mut nodes,
+        &ManifestNode::Branch(ManifestBranch::new(branch.depth(), children).unwrap()),
+    );
+
+    let report = fsck_manifest(&nodes, &new_root);
+    assert!(
+        report.has_rule(FsckRule::LeafEntriesOutOfOrder),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn rejects_duplicate_object_key_and_trailing_bytes_and_bad_magic() {
+    let (root, nodes, _) = fixture();
+    let leaf_hash = branch_at(&nodes, &root).children()[0].hash;
+    let leaf = leaf_at(&nodes, &leaf_hash);
+    let entry = leaf.entries()[0];
+
+    // Duplicate: two identical entries, written directly.
+    let mut duplicated = vec![b'W', b'P', b'M', b'F', 1, 0];
+    duplicated.extend_from_slice(&2u16.to_be_bytes());
+    for _ in 0..2 {
+        duplicated.push(entry.kind.to_byte());
+        duplicated.extend_from_slice(entry.hash.as_bytes());
+        duplicated.extend_from_slice(&entry.decoded_size.to_be_bytes());
+    }
+    assert_eq!(
+        check_single_node(duplicated),
+        Some(FsckRule::DuplicateObjectKey)
+    );
+
+    let mut trailing = nodes[&leaf_hash].clone();
+    trailing.push(0);
+    assert_eq!(check_single_node(trailing), Some(FsckRule::TrailingBytes));
+
+    let mut bad_magic = nodes[&leaf_hash].clone();
+    bad_magic[0] = b'Q';
+    assert_eq!(check_single_node(bad_magic), Some(FsckRule::MalformedNode));
+}
+
+/// Store `bytes` under their own (correct) digest and fsck them as a root, so
+/// the only thing that can fail is the node's own well-formedness.
+fn check_single_node(bytes: Vec<u8>) -> Option<FsckRule> {
+    let hash = ContentHash::compute(&bytes);
+    let nodes: Nodes = [(hash, bytes)].into_iter().collect();
+    fsck_manifest(&nodes, &hash)
+        .findings()
+        .first()
+        .map(|f| f.rule)
+}
+
+#[test]
+fn rejects_subtree_summary_mismatch() {
+    let (root, mut nodes, _) = fixture();
+    let leaf_hash = branch_at(&nodes, &root).children()[0].hash;
+    let mut entries = leaf_at(&nodes, &leaf_hash).entries().to_vec();
+    entries.pop();
+
+    // Drop an entry but leave the parent's summary claiming the old totals.
+    let slot = branch_at(&nodes, &root).children()[0].slot;
+    let new_root = replace_root_leaf(&root, &mut nodes, slot, entries, false);
+
+    let report = fsck_manifest(&nodes, &new_root);
+    assert!(
+        report.has_rule(FsckRule::SubtreeSummaryMismatch),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn rejects_misrouted_entry() {
+    let (root, mut nodes, _) = fixture();
+    let branch = branch_at(&nodes, &root);
+    let host = branch.children()[1];
+    let donor_entry = leaf_at(&nodes, &branch.children()[0].hash).entries()[0];
+    assert_ne!(
+        donor_entry.key().route().group(branch.depth()),
+        host.slot,
+        "the donor entry must not legitimately belong in the host slot"
+    );
+
+    let mut entries = leaf_at(&nodes, &host.hash).entries().to_vec();
+    entries.push(donor_entry);
+    let new_root = replace_root_leaf(&root, &mut nodes, host.slot, entries, true);
+
+    let report = fsck_manifest(&nodes, &new_root);
+    assert!(report.has_rule(FsckRule::MisroutedEntry), "{report:?}");
+}
+
+#[test]
+fn rejects_underfull_branch_and_empty_non_root_leaf() {
+    // A branch whose whole subtree fits in one leaf must not exist, and only
+    // the root may be the empty leaf. Both are built here by hand.
+    let small = objects(4);
+    let leaf = ManifestLeaf::new(small.clone()).unwrap();
+    let mut nodes: Nodes = BTreeMap::new();
+    let leaf_hash = insert(&mut nodes, &ManifestNode::Leaf(leaf));
+    let slot = small[0].key().route().group(0);
+    let branch = ManifestBranch::new(
+        0,
+        vec![ManifestChild {
+            slot,
+            hash: leaf_hash,
+            object_count: 4,
+            decoded_bytes: small.iter().map(|o| o.decoded_size).sum(),
+        }],
+    )
+    .unwrap();
+    let root = insert(&mut nodes, &ManifestNode::Branch(branch));
+    let report = fsck_manifest(&nodes, &root);
+    assert!(report.has_rule(FsckRule::UnderfullBranch), "{report:?}");
+
+    let mut nodes: Nodes = BTreeMap::new();
+    let empty_hash = insert(&mut nodes, &ManifestNode::empty());
+    let branch = ManifestBranch::new(
+        0,
+        vec![ManifestChild {
+            slot: 0,
+            hash: empty_hash,
+            object_count: 0,
+            decoded_bytes: 0,
+        }],
+    )
+    .unwrap();
+    let root = insert(&mut nodes, &ManifestNode::Branch(branch));
+    let report = fsck_manifest(&nodes, &root);
+    assert!(report.has_rule(FsckRule::EmptyNonRootLeaf), "{report:?}");
+}
+
+#[test]
+fn rejects_branch_depth_mismatch() {
+    let (root, mut nodes, _) = fixture();
+    let branch = branch_at(&nodes, &root);
+    let lying = ManifestBranch::new(branch.depth() + 3, branch.children().to_vec()).unwrap();
+    let new_root = insert(&mut nodes, &ManifestNode::Branch(lying));
+
+    let report = fsck_manifest(&nodes, &new_root);
+    assert!(report.has_rule(FsckRule::BranchDepthMismatch), "{report:?}");
+}
+
+#[test]
+fn rejects_leaf_overfull() {
+    // A leaf holding more than the bound while routing bits remain must have
+    // split into a branch.
+    let entries = objects(MANIFEST_LEAF_MAX_ENTRIES as u32 + 1);
+    let leaf = ManifestLeaf::new(entries).unwrap();
+    let mut nodes: Nodes = BTreeMap::new();
+    let root = insert(&mut nodes, &ManifestNode::Leaf(leaf));
+
+    let report = fsck_manifest(&nodes, &root);
+    assert!(report.has_rule(FsckRule::LeafOverfull), "{report:?}");
+    // The shape backstop must fire too: the canonical trie for that set is a
+    // branch, not one leaf.
+    assert!(
+        report.has_rule(FsckRule::NonCanonicalTrieShape),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn rejects_empty_branch_bitmap_bytes() {
+    let mut bytes = vec![b'W', b'P', b'M', b'F', 1, 1, 0];
+    bytes.extend_from_slice(&0u32.to_be_bytes());
+    assert_eq!(
+        check_single_node(bytes),
+        Some(FsckRule::EmptyBranchBitmap),
+        "an empty bitmap must be rejected; the empty set is the empty leaf"
+    );
+}
+
+#[test]
+fn reports_unreachable_nodes_only_on_a_store_sweep() {
+    let (root, mut nodes, _) = fixture();
+    let orphan = build_manifest(objects(3)).unwrap();
+    nodes.extend(orphan.nodes.clone());
+
+    // A per-root check must stay quiet: a shared store legitimately holds
+    // other roots' nodes.
+    assert!(fsck_manifest(&nodes, &root).is_clean());
+
+    let report = fsck_manifest_store(
+        &nodes,
+        &[root],
+        &FsckOptions {
+            objects: None,
+            report_unreachable: true,
+        },
+    );
+    assert!(report.has_rule(FsckRule::UnreachableNode), "{report:?}");
+
+    // Naming both roots makes the sweep clean again.
+    let report = fsck_manifest_store(
+        &nodes,
+        &[root, orphan.root],
+        &FsckOptions {
+            objects: None,
+            report_unreachable: true,
+        },
+    );
+    assert!(report.is_clean(), "{report:?}");
+}
+
+// ── fsck: pack-extent rules ─────────────────────────────────────────
+
+fn pack_bytes(len: usize) -> Vec<u8> {
+    (0..len).map(|i| (i % 251) as u8).collect()
+}
+
+fn record_over(bytes: &[u8], range_start: u64, offset: u64, length: u64, seed: u32) -> PackRecord {
+    let from = (offset - range_start) as usize;
+    let slice = &bytes[from..from + length as usize];
+    PackRecord::new(object(seed), offset, length, ContentHash::compute(slice))
+}
+
+/// A valid claim: three records, offset-canonical, exactly covering [0, 30).
+fn valid_claim() -> (PackRangeClaim, Vec<u8>) {
+    let bytes = pack_bytes(30);
+    let claim = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        30,
+        vec![
+            record_over(&bytes, 0, 20, 10, 3),
+            record_over(&bytes, 0, 0, 10, 1),
+            record_over(&bytes, 0, 10, 10, 2),
+        ],
+    );
+    (claim, bytes)
+}
+
+#[test]
+fn fsck_accepts_a_gap_free_offset_canonical_claim() {
+    let (claim, bytes) = valid_claim();
+    let authorized: BTreeSet<_> = claim.records().iter().map(PackRecord::key).collect();
+    let report = fsck_pack_range(
+        &claim,
+        &PackRangeAudit {
+            range_bytes: Some(&bytes),
+            authorized: Some(&authorized),
+        },
+    );
+    assert!(report.is_clean(), "{report:?}");
+}
+
+#[test]
+fn claims_canonicalize_by_pack_offset_not_object_order() {
+    // weft #1070: a pack laid out for delta compression has object order and
+    // offset order disagree. Canonicalizing by object first breaks contiguity.
+    let bytes = pack_bytes(30);
+    let claim = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        30,
+        vec![
+            record_over(&bytes, 0, 0, 10, 900),
+            record_over(&bytes, 0, 10, 10, 5),
+            record_over(&bytes, 0, 20, 10, 40),
+        ],
+    );
+    let offsets: Vec<u64> = claim.records().iter().map(|r| r.offset).collect();
+    assert_eq!(offsets, vec![0, 10, 20]);
+
+    let by_object: Vec<_> = {
+        let mut keys: Vec<_> = claim.records().iter().map(PackRecord::key).collect();
+        keys.sort();
+        keys
+    };
+    let in_offset_order: Vec<_> = claim.records().iter().map(PackRecord::key).collect();
+    assert_ne!(
+        by_object, in_offset_order,
+        "fixture must have object order differ from offset order to be meaningful"
+    );
+    assert!(
+        fsck_pack_range(&claim, &PackRangeAudit::default()).is_clean(),
+        "a contiguous claim must validate regardless of object order"
+    );
+}
+
+#[test]
+fn rejects_extent_gap() {
+    let bytes = pack_bytes(30);
+    // Drop the middle record: bytes [10, 20) are covered by the range but
+    // claimed by nobody — exactly the mixed-audience leak this rule blocks.
+    let claim = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        30,
+        vec![
+            record_over(&bytes, 0, 0, 10, 1),
+            record_over(&bytes, 0, 20, 10, 3),
+        ],
+    );
+    let report = fsck_pack_range(&claim, &PackRangeAudit::default());
+    assert!(report.has_rule(FsckRule::ExtentGap), "{report:?}");
+}
+
+#[test]
+fn rejects_extent_overlap() {
+    let bytes = pack_bytes(30);
+    let claim = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        30,
+        vec![
+            record_over(&bytes, 0, 0, 15, 1),
+            record_over(&bytes, 0, 10, 20, 2),
+        ],
+    );
+    let report = fsck_pack_range(&claim, &PackRangeAudit::default());
+    assert!(report.has_rule(FsckRule::ExtentOverlap), "{report:?}");
+}
+
+#[test]
+fn rejects_range_coverage_mismatch_and_zero_length_extents() {
+    let bytes = pack_bytes(30);
+    // Records stop at 20 while the range claims 30 bytes.
+    let short = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        30,
+        vec![
+            record_over(&bytes, 0, 0, 10, 1),
+            record_over(&bytes, 0, 10, 10, 2),
+        ],
+    );
+    let report = fsck_pack_range(&short, &PackRangeAudit::default());
+    assert!(
+        report.has_rule(FsckRule::RangeCoverageMismatch),
+        "{report:?}"
+    );
+
+    let zero = PackRangeClaim::new(
+        "pack-1",
+        "etag-1",
+        0,
+        10,
+        vec![
+            PackRecord::new(object(1), 0, 0, ContentHash::compute(b"")),
+            record_over(&bytes, 0, 0, 10, 2),
+        ],
+    );
+    let report = fsck_pack_range(&zero, &PackRangeAudit::default());
+    assert!(report.has_rule(FsckRule::ZeroLengthExtent), "{report:?}");
+}
+
+#[test]
+fn rejects_extent_digest_mismatch() {
+    let (claim, mut bytes) = valid_claim();
+    bytes[15] ^= 0xff;
+    let report = fsck_pack_range(
+        &claim,
+        &PackRangeAudit {
+            range_bytes: Some(&bytes),
+            authorized: None,
+        },
+    );
+    assert!(
+        report.has_rule(FsckRule::ExtentDigestMismatch),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn rejects_a_grant_for_an_object_the_manifest_does_not_cover() {
+    let (claim, bytes) = valid_claim();
+    let mut authorized: BTreeSet<_> = claim.records().iter().map(PackRecord::key).collect();
+    authorized.remove(&claim.records()[1].key());
+
+    let report = fsck_pack_range(
+        &claim,
+        &PackRangeAudit {
+            range_bytes: Some(&bytes),
+            authorized: Some(&authorized),
+        },
+    );
+    assert!(
+        report.has_rule(FsckRule::ExtentObjectNotInManifest),
+        "{report:?}"
+    );
+}
+
+#[test]
+fn rejects_records_written_out_of_offset_order_on_the_wire() {
+    let (claim, _) = valid_claim();
+    let encoded = claim.encode();
+    const RECORD_LEN: usize = 1 + 32 + 8 + 8 + 8 + 32;
+    let head = encoded.len() - 3 * RECORD_LEN;
+    let mut swapped = encoded.clone();
+    swapped[head..head + RECORD_LEN]
+        .copy_from_slice(&encoded[head + RECORD_LEN..head + 2 * RECORD_LEN]);
+    swapped[head + RECORD_LEN..head + 2 * RECORD_LEN]
+        .copy_from_slice(&encoded[head..head + RECORD_LEN]);
+    assert!(
+        PackRangeClaim::decode(&swapped).is_err(),
+        "a decoder must reject non-offset-canonical records"
+    );
+}
+
+// ── Property tests ──────────────────────────────────────────────────
+
+prop_compose! {
+    fn arb_object()(
+        is_tree in any::<bool>(),
+        seed in any::<[u8; 8]>(),
+        size in 0u64..1_000_000,
+    ) -> ManifestObject {
+        ManifestObject::new(
+            if is_tree { ManifestObjectKind::Tree } else { ManifestObjectKind::Blob },
+            ContentHash::compute(&seed),
+            size,
+        )
+    }
+}
+
+fn arb_objects() -> impl Strategy<Value = Vec<ManifestObject>> {
+    prop::collection::vec(arb_object(), 0..250)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// encode → decode → encode is a fixed point, and the address is BLAKE3 of
+    /// exactly those bytes.
+    #[test]
+    fn prop_encoding_round_trip_is_stable(set in arb_objects()) {
+        let built = build_manifest(dedupe(set))?;
+        for (hash, bytes) in &built.nodes {
+            let node = ManifestNode::decode(bytes)
+                .map_err(|e| TestCaseError::fail(format!("{e}")))?;
+            prop_assert_eq!(&node.encode(), bytes);
+            prop_assert_eq!(node.address(), *hash);
+            // Decoding the re-encoding yields the same node.
+            let again = ManifestNode::decode(&node.encode())
+                .map_err(|e| TestCaseError::fail(format!("{e}")))?;
+            prop_assert_eq!(again, node);
+        }
+    }
+
+    /// The root is a pure function of the logical set, not of insertion order.
+    #[test]
+    fn prop_root_is_permutation_invariant(set in arb_objects(), rotate in 0usize..250) {
+        let set = dedupe(set);
+        let mut permuted = set.clone();
+        if !permuted.is_empty() {
+            let len = permuted.len();
+            permuted.rotate_left(rotate % len);
+            permuted.reverse();
+        }
+        prop_assert_eq!(build_manifest(set)?.root, build_manifest(permuted)?.root);
+    }
+
+    /// Any manifest this builder produces passes every fsck rule.
+    #[test]
+    fn prop_built_graphs_pass_fsck(set in arb_objects()) {
+        let set = dedupe(set);
+        let built = build_manifest(set.clone())?;
+        let index = object_index(&set);
+        let report = fsck_manifest_with(
+            &built.nodes,
+            &built.root,
+            &FsckOptions { objects: Some(&index), report_unreachable: false },
+        );
+        prop_assert!(report.is_clean(), "{:?}", report);
+    }
+
+    /// Expansion recovers exactly the input set, in canonical key order.
+    #[test]
+    fn prop_expansion_recovers_the_set(set in arb_objects()) {
+        let mut set = dedupe(set);
+        let built = build_manifest(set.clone())?;
+        set.sort_by_key(ManifestObject::key);
+        prop_assert_eq!(expand_manifest(&built.nodes, &built.root)?, set);
+    }
+
+    /// Flipping any single byte of any node is always caught — either the
+    /// digest no longer matches, or the bytes no longer decode canonically.
+    #[test]
+    fn prop_single_byte_corruption_is_always_caught(
+        set in prop::collection::vec(arb_object(), 20..80),
+        node_pick in any::<prop::sample::Index>(),
+        byte_pick in any::<prop::sample::Index>(),
+        mask in 1u8..=255,
+    ) {
+        let built = build_manifest(dedupe(set))?;
+        let hashes: Vec<ContentHash> = built.nodes.keys().copied().collect();
+        let victim = *node_pick.get(&hashes);
+
+        let mut nodes = built.nodes.clone();
+        let bytes = nodes.get_mut(&victim).expect("victim present");
+        let at = byte_pick.index(bytes.len());
+        bytes[at] ^= mask;
+
+        let report = fsck_manifest(&nodes, &built.root);
+        prop_assert!(!report.is_clean(), "corruption at byte {} of {} went unreported", at, victim);
+    }
+}
+
+/// Property inputs may repeat a key; the builder rejects a *conflicting*
+/// repeat, so collapse them to the first size seen before building.
+fn dedupe(set: Vec<ManifestObject>) -> Vec<ManifestObject> {
+    let mut seen = BTreeMap::new();
+    for object in set {
+        seen.entry(object.key()).or_insert(object);
+    }
+    seen.into_values().collect()
+}


### PR DESCRIPTION
## Summary

Phase 1 of the data-model reshape (weft#1052), upstream half: the **canonical manifest/object encoding + fsck rules** the immutable CAS will use. Object and wire formats belong in heddle, so they are defined here.

**Purely additive, nothing cut over.** No existing wire or object path reads or writes any of this. The only change to a tracked file is 8 added lines in `crates/object-model/src/object/mod.rs` (a `pub mod` + a re-export block) — `git diff` on the pre-existing tree has **zero deleted lines**. Cutover is a later phase, deliberately, so this change cannot regress live behaviour.

### What lands

| Module | What |
|---|---|
| `manifest/node.rs` | The canonical manifest node — a 32-way HAMT keyed by `(object kind, object hash)`, addressed by `BLAKE3` of its canonical bytes |
| `manifest/build.rs` | Deterministic construction + expansion; the root is a pure function of the logical object set |
| `manifest/binding.rs` | The `(spool, facet, owner) -> content root` binding |
| `manifest/extent.rs` | The canonical pack-range claim: per-record `BLAKE3` digests, offset-canonical order, gap-free coverage |
| `manifest/fsck.rs` | 26 named integrity rules across four families |

### Format choices and tradeoffs

**1. Byte-compatibility with the shipped downstream consumer outranks upstream nomenclature.**
weft#1069 already merged WPMF v1, and weft#1070 fixed its record ordering. The obvious "upstream owns the name" move would rename the `WPMF` magic and the `weft-plan-manifest-key-v1` routing domain to something heddle-flavoured. I did **not** do that: renaming either changes every node hash and would force a change to a manifest contract that is already merged and tested downstream. So this module is the normative *definition* of bytes that already exist, not a competing second format. Cost: the magic reads as weft-branded inside heddle. Benefit: weft can depend on this crate with a zero-diff cutover.

**2. Manifests carry logical facts only; physical location is a separate, non-content-addressed claim.**
A node holds object kind, object hash, decoded size, trie structure, and subtree summaries. Pack id, storage key, offset, encoded length, encoded digest, ETag, audience, and current head live in `extent.rs`, resolved *after* authorization. So a repack changes a read envelope and never a manifest hash. Alternative considered: fold locations into the manifest for one-hop reads. Rejected — it makes every repack rewrite content roots, which defeats the structural sharing this whole phase exists to buy.

**3. Records are canonicalized by pack offset, not object key.**
This is weft#1070's fix, reproduced upstream rather than re-derived. Packs are laid out for delta compression, so object order and physical order routinely disagree; ordering by object first makes valid coalesced ranges fail their contiguity check. Test `claims_canonicalize_by_pack_offset_not_object_order` asserts the fixture actually has the two orders disagree, so it cannot silently stop testing the thing it names.

**4. Owner identity sits outside the shared content root.**
Every state and attachment has a distinct owner hash, but a context-only state must reuse its parent's content root byte-for-byte. Putting the owner in the binding is what makes that reuse possible. Facets follow weft#358's **ratified** decision (four uniform facets per spool, no content-bearing discriminant), not the older open questions.

**5. Strict decode + re-encode backstop.**
Decoding rejects a bad magic, unknown version/tag/kind, truncation, trailing bytes, out-of-order or duplicated entries, and an empty branch bitmap — then re-encodes and compares. A node that decodes is therefore canonical, so its address is meaningful. Cost: one extra encode per decode. Tradeoff taken deliberately: a manifest whose address does not pin its bytes is not worth having.

**6. fsck is total, not fail-fast**, and every rule has a stable kebab-case name (`FsckRule::name()`). A digest mismatch, a dangling ref, and an extent gap need different operator responses, so one run reports all of them rather than the first. A whole-graph rebuild-and-compare (`non-canonical-trie-shape`) backs up the local rules, gated on expansion having actually completed.

**No cross-repo format decision was needed** — nothing here contradicts weft#1069/#1070's manifest contract or weft#358, so I did not need to stop and post a proposal.

## Closes

Closes HeddleCo/heddle#1247
Refs HeddleCo/weft#1052

## Test evidence

`cargo test -p heddle-object-model`: **181 lib passed**, **32 integration passed**, 0 failed.

### Encoding round-trip + hash stability

```
test every_node_of_a_built_manifest_round_trips_byte_for_byte ... ok
test the_same_logical_membership_always_hashes_the_same ... ok
test expansion_is_the_original_set_in_canonical_key_order ... ok
test a_context_only_republish_reuses_the_root_and_a_content_change_does_not ... ok
test prop_encoding_round_trip_is_stable ... ok      # encode→decode→encode is a fixed point
test prop_root_is_permutation_invariant ... ok      # root is a pure function of the set
test prop_expansion_recovers_the_set ... ok
```

`a_context_only_republish_...` pins the structural-sharing contract on 2 000 objects: identical membership reproduces the identical root, and replacing one object rewrites at most `MANIFEST_ROUTE_LEVELS` (52) nodes — O(path depth), not O(objects).

### fsck accepts valid graphs

```
test fsck_accepts_a_well_formed_graph ... ok
test fsck_accepts_the_canonical_empty_root ... ok
test fsck_accepts_a_deep_multi_level_graph ... ok    # 20k objects, asserts a depth-1 branch exists
test fsck_accepts_a_gap_free_offset_canonical_claim ... ok
test prop_built_graphs_pass_fsck ... ok
```

### fsck rejects each corruption class, by name

```
test rejects_bad_digest ... ok                                      # node-digest-mismatch
test rejects_dangling_node_ref ... ok                               # dangling-node-ref
test rejects_dangling_object_ref_and_size_mismatch ... ok           # dangling-object-ref, object-size-mismatch
test rejects_wrong_order_within_a_leaf ... ok                       # leaf-entries-out-of-order
test rejects_duplicate_object_key_and_trailing_bytes_and_bad_magic  # duplicate-object-key, trailing-bytes, malformed-node
test rejects_empty_branch_bitmap_bytes ... ok                       # empty-branch-bitmap
test rejects_subtree_summary_mismatch ... ok                        # subtree-summary-mismatch
test rejects_misrouted_entry ... ok                                 # misrouted-entry
test rejects_underfull_branch_and_empty_non_root_leaf ... ok        # underfull-branch, empty-non-root-leaf
test rejects_branch_depth_mismatch ... ok                           # branch-depth-mismatch
test rejects_leaf_overfull ... ok                                   # leaf-overfull + non-canonical-trie-shape
test reports_unreachable_nodes_only_on_a_store_sweep ... ok         # unreachable-node
test rejects_extent_gap ... ok                                      # extent-gap
test rejects_extent_overlap ... ok                                  # extent-overlap
test rejects_range_coverage_mismatch_and_zero_length_extents ... ok # range-coverage-mismatch, zero-length-extent
test rejects_extent_digest_mismatch ... ok                          # extent-digest-mismatch
test rejects_a_grant_for_an_object_the_manifest_does_not_cover ... ok  # extent-object-not-in-manifest
test rejects_records_written_out_of_offset_order_on_the_wire ... ok    # extents-out-of-offset-order
test prop_single_byte_corruption_is_always_caught ... ok
```

`prop_single_byte_corruption_is_always_caught` XORs an arbitrary bit into an arbitrary byte of an arbitrary node and asserts fsck is never clean afterwards.

### Negative control — proof the checks can fail

Green tests are worthless if the rule underneath is inert, so I deleted two rules and re-ran:

```
$ # ExtentGap push replaced with `if false`, NodeDigestMismatch guard replaced with `if false &&`
$ cargo test -p heddle-object-model --test manifest_canonical_fsck
test rejects_extent_gap ... FAILED
test rejects_bad_digest ... FAILED
...
failures:
    rejects_bad_digest
    rejects_extent_gap

test result: FAILED. 30 passed; 2 failed
```

Restored, and back to `test result: ok. 32 passed; 0 failed`.

One thing this surfaced worth recording: with the digest check disabled, `prop_single_byte_corruption_is_always_caught` **still passed** — the canonical re-encode check catches single-byte corruption independently. That is defence in depth working, but it means the property test is not a substitute for the targeted `rejects_bad_digest` case.

### Check matrix

All run on this branch with `TMPDIR=/home/scratch`, matching `.github/workflows/rust-tests.yml` (build → clippy → test over the changed crate and its reverse dependents, which for `heddle-object-model` is the workspace):

- `cargo build --locked --workspace --tests` — passed
- `cargo clippy --locked --workspace --lib --bins --tests --examples -- -D warnings` — passed, clean
- `cargo test --locked --workspace` — one flake, see below; everything else passed
- `cargo test --locked -p heddle-object-model` — 181 + 32 passed
- `rustfmt +nightly --edition 2024` on touched files only; `git status` clean afterwards

**One flake, disclosed rather than hidden.** The workspace run had `heddle-cli`'s `cli::commands::undo_apply::atomic_tests::undo_redo_lock_is_exclusive` fail (`604 passed; 1 failed`). It is a lock-contention test and the box was at load 13.5 from concurrent builds at the time. Re-run in isolation: passes. Re-run as the full `-p heddle-cli --lib` suite twice: `605 passed; 0 failed` both times. Nothing in `heddle-cli` or `heddle-oplog` references this PR's module (the only `manifest` hits there are the unrelated pre-existing `repo::thread_manifest`), and this PR deletes no line of existing code — so the failure is not attributable to this change. Flagging it because a timing-sensitive lock test that fails under load is worth someone's attention on its own.

Note: nightly rustfmt follows `mod` declarations, so running it on `object/mod.rs` reformatted two untouched neighbours (`source.rs`, `tree_walk.rs`) with pre-existing import drift. Those were reverted — this PR's diff stays additive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788534150&installation_model_id=21489&pr_number=1248&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1248&signature=e76e623a2a0fac31b79dacc226979ce9d54ee8f7dadd58dc39bf74cb02ca2f41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->