### PR TITLE
perf(clone): stop starting the fsmonitor helper during clone

### DIFF
--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -560,7 +560,7 @@ fn finish_git_overlay_clone(
     remote_display: String,
 ) -> Result<FinishedGitOverlayClone> {
     configure_git_overlay_origin(local_path, &remote_label)?;
-    let repo = Repository::init_git_overlay_sidecar(local_path)?;
+    let repo = Repository::init_git_overlay_sidecar(local_path)?.without_fsmonitor();
     let refs = options
         .thread
         .as_ref()
@@ -1201,7 +1201,7 @@ async fn clone_local(
     // Create and initialize the local repository only after all
     // preflight target selection has succeeded.
     fs::create_dir_all(local_path)?;
-    let local_repo = Repository::init(local_path)?;
+    let local_repo = Repository::init(local_path)?.without_fsmonitor();
 
     // Fetch the state and dependencies
     let mut objects_copied = if let Some(d) = depth {
@@ -2337,7 +2337,8 @@ async fn execute_monorepo_node_steps(
             MonorepoNodeExecutionStep::InitRepo => {
                 repo = Some(
                     Repository::init(dest)
-                        .with_context(|| format!("failed at {}", progress.label()))?,
+                        .with_context(|| format!("failed at {}", progress.label()))?
+                        .without_fsmonitor(),
                 );
             }
             MonorepoNodeExecutionStep::FetchContent { state } => {
@@ -2473,7 +2474,9 @@ fn initialize_hosted_clone_repository(
         SleyRepository::init(root)
             .map_err(|error| wire::ProtocolError::InvalidState(error.to_string()))?;
     }
-    Repository::init_clone(root, source_authority).map_err(wire::ProtocolError::from)
+    Repository::init_clone(root, source_authority)
+        .map(Repository::without_fsmonitor)
+        .map_err(wire::ProtocolError::from)
 }
 
 #[cfg(feature = "client")]

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -266,6 +266,8 @@ mod basics;
 mod cli_help_consistency;
 #[path = "cli_integration/cli_premium_output.rs"]
 mod cli_premium_output;
+#[path = "cli_integration/clone_fsmonitor_decoupling.rs"]
+mod clone_fsmonitor_decoupling;
 #[path = "cli_integration/clone_output_contract.rs"]
 mod clone_output_contract;
 #[path = "cli_integration/compact_output.rs"]

--- a/crates/cli/tests/cli_integration/clone_fsmonitor_decoupling.rs
+++ b/crates/cli/tests/cli_integration/clone_fsmonitor_decoupling.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `heddle clone` must never start the filesystem-monitor helper daemon.
+//!
+//! A clone materializes a worktree and exits. It has no ongoing worktree to
+//! watch, but a monitor-backed status walk during clone verification used to
+//! spawn `heddle-fsmonitor-worker` as a **child of the clone process** — so
+//! anything waiting on the clone's process tree (CI harnesses, `strace -f`,
+//! `/usr/bin/time`) blocked on the helper's idle lifetime long after the clone
+//! itself had finished. A hosted git.git clone took 351 s of process-tree wall
+//! against 35 s of actual clone work, with ~59k `accept4`-EAGAIN /
+//! `clock_nanosleep` pairs from the helper's accept loop in between
+//! (HeddleCo/heddle#1243).
+//!
+//! These tests are Linux-only because that is where the native backend is
+//! supported (`fsmonitor::native_backend_supported`); elsewhere `auto` resolves
+//! to "off" and the assertions would pass without proving anything.
+#![cfg(target_os = "linux")]
+
+use std::path::Path;
+
+use tempfile::TempDir;
+
+use super::*;
+
+/// Files the monitor's start seam writes into a repository's state directory.
+///
+/// The two lock files are created **synchronously by the calling process** in
+/// `fsmonitor::try_spawn_local_helper_with`, before the daemon is spawned, so
+/// their absence right after a command returns is a deterministic "this command
+/// never tried to start the helper" — there is no race against daemon startup.
+const MONITOR_START_MARKERS: [&str; 3] = [
+    ".heddle/state/monitor-helper-start.lock",
+    ".heddle/state/monitor-helper-lifetime.lock",
+    ".heddle/state/monitor-helper.json",
+];
+
+fn monitor_start_markers(root: &Path) -> Vec<&'static str> {
+    MONITOR_START_MARKERS
+        .into_iter()
+        .filter(|relative| root.join(relative).exists())
+        .collect()
+}
+
+/// Stop any helper a test started so the daemon does not outlive the `TempDir`
+/// it is watching.
+fn stop_monitor_helper(root: &Path) {
+    let _ = repo::shutdown_local_monitor_helper(root);
+}
+
+#[test]
+fn clone_does_not_start_the_fsmonitor_helper() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source");
+    let destination = temp.path().join("destination");
+    std::fs::create_dir_all(&source).unwrap();
+    heddle(&["init"], Some(&source)).expect("init source repo");
+    std::fs::write(source.join("tracked.txt"), "tracked\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(&source)).expect("capture source repo");
+
+    // `--output json` matters: on the native lane the clone only builds its
+    // Repository Verification State — the walk that used to reach the monitor —
+    // when it has a JSON envelope to put it in. A text-mode clone would pass
+    // this assertion even with the coupling still in place.
+    heddle(
+        &[
+            "--output",
+            "json",
+            "clone",
+            source.to_str().expect("source path is utf8"),
+            destination.to_str().expect("destination path is utf8"),
+        ],
+        Some(temp.path()),
+    )
+    .expect("clone source repo");
+
+    assert_eq!(
+        monitor_start_markers(&destination),
+        Vec::<&str>::new(),
+        "clone must not start the fsmonitor helper for the repository it just materialized",
+    );
+
+    // The negative case: the same predicate has to be able to observe a start,
+    // otherwise the assertion above would hold for a clone that never ran. The
+    // monitor is deferred to the cloned repo's first status, not removed.
+    heddle(&["status"], Some(&destination)).expect("status in cloned repo");
+    assert!(
+        !monitor_start_markers(&destination).is_empty(),
+        "post-clone status should still start the fsmonitor helper on demand",
+    );
+
+    stop_monitor_helper(&destination);
+    stop_monitor_helper(&source);
+}
+
+#[test]
+fn git_overlay_clone_does_not_start_the_fsmonitor_helper() {
+    let temp = TempDir::new().unwrap();
+    let origin = temp.path().join("origin.git");
+    let destination = temp.path().join("work");
+    let git_repo = SleyRepository::init_bare(&origin).expect("init bare git origin");
+    let commit = git_commit_with_tree(
+        &git_repo,
+        Some("refs/heads/main"),
+        git_empty_tree_oid(&git_repo),
+        "seed",
+        &[],
+    );
+    git_set_reference(&git_repo, "HEAD", commit);
+
+    // No `--output json` here: the Git-import lane builds its verification
+    // state unconditionally, so text mode already exercises the seam.
+    heddle(
+        &[
+            "clone",
+            origin.to_str().expect("origin path is utf8"),
+            destination.to_str().expect("destination path is utf8"),
+        ],
+        Some(temp.path()),
+    )
+    .expect("clone bare git origin");
+
+    assert_eq!(
+        monitor_start_markers(&destination),
+        Vec::<&str>::new(),
+        "git-overlay clone must not start the fsmonitor helper either",
+    );
+
+    heddle(&["status"], Some(&destination)).expect("status in cloned repo");
+    assert!(
+        !monitor_start_markers(&destination).is_empty(),
+        "post-clone status should still start the fsmonitor helper on demand",
+    );
+
+    stop_monitor_helper(&destination);
+}

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -2841,6 +2841,34 @@ impl Repository {
         &self.config
     }
 
+    /// Turn the filesystem monitor off for this handle only.
+    ///
+    /// Every worktree-status walk resolves its fsmonitor mode from
+    /// `config.worktree.fsmonitor` — `default_worktree_status_options`,
+    /// maintenance, snapshot fingerprints, and core's verification-health walk
+    /// all read it — so clearing it here disables the monitor for *all* status
+    /// this handle performs, including the walks that resolve their own
+    /// options deep inside core rather than accepting them from the caller.
+    ///
+    /// This is in-memory only. Nothing persists `self.config`: every
+    /// `config.toml` write reloads the file first (see
+    /// [`Repository::transition_source_authority`]), so the next process to
+    /// open the repository sees its configured mode again.
+    ///
+    /// `heddle clone` uses this. A clone materializes a worktree and exits; it
+    /// has no ongoing worktree to watch, but a monitor-backed status walk would
+    /// spawn the long-lived `heddle-fsmonitor-worker` daemon as a child of the
+    /// clone process, leaving anything that waits on the clone's process tree
+    /// blocked on the helper's idle lifetime long after the clone finished
+    /// (heddle#1243). The monitor is deferred, not removed: the first
+    /// `heddle status` in the cloned repository starts the helper on demand
+    /// exactly as it always has.
+    #[must_use]
+    pub fn without_fsmonitor(mut self) -> Self {
+        self.config.worktree.fsmonitor.mode = crate::FsMonitorMode::Off;
+        self
+    }
+
     pub fn config(&self) -> &RepoConfig {
         self.repo_config()
     }


### PR DESCRIPTION
## Summary

`heddle clone` no longer spawns or blocks on the `heddle-fsmonitor-worker` daemon. A clone materializes a worktree and exits — it has no ongoing worktree to watch — but the clone's Repository Verification State walk went through `ChangeMonitorSession::prepare`, which starts the long-lived helper **as a child of the clone process**. Anything waiting on the clone's process tree (CI harnesses, `strace -f`, `/usr/bin/time`, a process-group wait) then blocked on the helper's idle lifetime long after the clone had printed its result.

The cut is at the clone's repository handles: every `Repository` the clone creates is now built `.without_fsmonitor()` (`crates/cli/src/cli/commands/clone.rs:563, 1204, 2340, 2477`), backed by a new in-memory-only `Repository::without_fsmonitor()` (`crates/repo/src/repository.rs:2844`).

Passing a precomputed worktree status into the verification builder is *not* enough: the git-overlay branch of `build_repository_verification_health_with_worktree_status` (`crates/core/src/status.rs:713-718`) resolves its own options from `repo.config().worktree.fsmonitor` and re-walks regardless of what the caller supplied. Verified with a backtrace from the spawn seam — that path still started the helper under a caller-supplied-status fix. The override therefore has to live on the handle that every downstream walk reads.

**The helper daemon is untouched.** No change to `crates/repo/src/fsmonitor.rs` — accept loop, lifetime, readiness, advertising all as-is (`git show --stat` below). The monitor is deferred, not removed: the first `heddle status` in the cloned repository starts it on demand exactly as before.

`without_fsmonitor()` mutates only the in-memory handle. Nothing persists `self.config` — every `config.toml` write reloads the file first — so the cloned repo's configured mode is unchanged on disk and applies to the next process that opens it.

## Closes

Closes HeddleCo/heddle#1243

## Test evidence

### git.git via the parked `gittiming2postwave` stack

`heddle --output json clone heddle://127.0.0.1:58423/perf-git-timing-post-wave-20260804/git`, release binaries built from this branch with and without the two source hunks (`heddle-before` `da83bf6a…`, `heddle-after` `9c0abafa…`), 417,860 objects / 316 MB pack:

| measurement | before | after |
|---|---:|---:|
| process-tree wall (`strace -f -c`) | **351.62 s** | **49.53 s** |
| `accept4` (all EAGAIN) | 58,710 | **0** |
| `clock_nanosleep` | 58,709 | **0** |
| `execve` | 2 (`heddle` + `heddle-fsmonitor-worker`) | **1** (`heddle` only) |
| heddle-process wall, untraced | 37.60 s | 34.92 s |
| live helper daemon after clone | `heddle-fsmonitor-worker --repo-root ./dest-before` | none |

```
### BEFORE under strace -f -c (process-tree lifetime) ###
tree_wall=351.62
% time     seconds  usecs/call     calls    errors syscall
 50.36    0.380478           6     58709           clock_nanosleep
 49.64    0.375033           6     58710     58710 accept4
  0.00    0.000000           0         2           execve

### AFTER under strace -f -c (process-tree lifetime) ###
tree_wall=49.53
% time     seconds  usecs/call     calls    errors syscall
  0.00    0.000000           0         1           execve
```

The accept4-EAGAIN + `clock_nanosleep` loop is gone because the helper is never executed — `execve` drops from 2 to 1. The clone's own work is unchanged (37.6 s → 34.9 s, run-to-run noise); what collapses is the tree lifetime the issue measured.

The clone's JSON envelope is **byte-identical** before/after apart from the destination path, including the full `verification` block (`verified`, `worktree_state`, `import_state`, `machine_contract_coverage`, …). Same for a local native clone and a local git-overlay clone.

### Regression tests, both directions

New `crates/cli/tests/cli_integration/clone_fsmonitor_decoupling.rs` asserts the destination has none of `monitor-helper-start.lock` / `monitor-helper-lifetime.lock` / `monitor-helper.json` after a clone. The two lock files are written **synchronously by the calling process** in `try_spawn_local_helper_with` before the daemon is spawned, so their absence is deterministic — no race with daemon startup.

```
### WITH fix ###
test clone_fsmonitor_decoupling::git_overlay_clone_does_not_start_the_fsmonitor_helper ... ok
test clone_fsmonitor_decoupling::clone_does_not_start_the_fsmonitor_helper ... ok
test result: ok. 2 passed; 0 failed

### WITHOUT fix (source hunks stashed) ###
test clone_fsmonitor_decoupling::git_overlay_clone_does_not_start_the_fsmonitor_helper ... FAILED
test clone_fsmonitor_decoupling::clone_does_not_start_the_fsmonitor_helper ... FAILED
  left: [".heddle/state/monitor-helper-start.lock", ".heddle/state/monitor-helper-lifetime.lock", ".heddle/state/monitor-helper.json"]
 right: []
test result: FAILED. 0 passed; 2 failed
```

Each test also asserts the *positive* case in the same run: a `heddle status` in the cloned repo does bring the markers back, so the predicate can observe a start and the monitor is provably deferred rather than disabled. The native test uses `--output json` deliberately — a text-mode clone builds no verification state and would pass even with the coupling in place.

### fsmonitor and worktree suites, unchanged

```
cargo test -p heddle-repo                      626 passed; 0 failed; 2 ignored
cargo test -p heddle-repo --lib fsmonitor::     10 passed; 0 failed
cargo test -p heddle-repo --lib status_monitor    4 passed; 0 failed
cargo test -p heddle-cli --test cli_integration git_replacement_matrix::
                                                20 passed; 0 failed
cargo test -p heddle-cli --test core_functionality maintenance::   (HEDDLE_FSMONITOR=native)
                                                 5 passed; 0 failed
cargo test -p heddle-cli --test multi_agent_worktrees
                                                63 passed; 2 failed; 13 ignored
```

`multi_agent_worktrees`' two failures are this dev box's known environment issue (`actor_presence::start_path_inherits_codex_probe_identity_into_actor_metadata`, `e2e::agent_capture_and_ready_require_authenticated_writer_authority` want the box's real credentials); they are the documented local baseline and pass on CI. `maintenance::` needs `HEDDLE_CONFIG` pointed away from the box's stale `~/.config/heddle/config.toml`, which references a swept `/home/scratch/demo` CA path and fails every test in 0.03 s with `fatal TLS/auth configuration error` — environment, not this diff.

Full `cargo test -p heddle-cli`: 900 passed / 3 failed on the loaded box; all three (`watch::watch_emits_json_per_line`, `watch::watch_streams_snapshot_text_mode`, `worktree_target_advice::start_path_non_empty_target_uses_typed_advice`) fail with `constructing notify watcher: Too many open files (os error 24)` under full-suite parallelism and pass when re-run in isolation.

### Lint and format

```
cargo clippy --locked -p heddle-repo -p heddle-cli --lib --bins --tests --examples -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.81s
```
`rustfmt +nightly --edition 2024` on the four touched files.

### Helper internals untouched

```
 crates/cli/src/cli/commands/clone.rs               |  11 +-
 crates/cli/tests/cli_integration.rs                |   2 +
 .../cli_integration/clone_fsmonitor_decoupling.rs  | 135 +++++++++++++++++++++
 crates/repo/src/repository.rs                      |  28 +++++
```

`crates/repo/src/fsmonitor.rs` is not in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788556052&installation_model_id=21489&pr_number=1249&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1249&signature=5dbbbfd7840c33e470059cd6a05defebec9aef91fc9a2f9d548ba9ca65060850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->