### PR TITLE
perf(adopt): batch packed state mirror writes

### DIFF
--- a/crates/cli/src/cli/commands/adopt.rs
+++ b/crates/cli/src/cli/commands/adopt.rs
@@ -50,6 +50,7 @@ struct AdoptOutput {
 struct AdoptImportStats {
     commits_imported: usize,
     states_created: usize,
+    state_store_write_ms: u128,
     branches_synced: usize,
     tags_synced: usize,
     skipped_non_commit_refs: usize,
@@ -126,6 +127,7 @@ pub fn cmd_adopt(cli: &Cli, args: AdoptArgs) -> Result<()> {
             "adopt",
             &[
                 ProfileField::millis("import_ms", import_ms),
+                ProfileField::millis("state_store_write_ms", stats.state_store_write_ms),
                 ProfileField::millis("verification_ms", verification_ms),
                 ProfileField::millis(
                     "verification_worktree_status_ms",
@@ -223,6 +225,7 @@ fn import_ingest_for_adopt(
     Ok(AdoptImportStats {
         commits_imported: stats.commits_imported,
         states_created: stats.states_created,
+        state_store_write_ms: stats.state_store_write_ms,
         branches_synced: stats.refs.threads_written,
         tags_synced: stats.refs.markers_written,
         skipped_non_commit_refs: stats.refs_seen.non_commit_skipped,

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -72,6 +72,7 @@ use crate::{
         should_output_json, style,
     },
     client::LocalSync,
+    perf::{ProfileField, emit_profile},
     remote::{Remote, RemoteConfig, RemoteTarget},
 };
 
@@ -429,6 +430,8 @@ struct FinishedGitOverlayClone {
     branch: String,
     commits_imported: usize,
     states_created: usize,
+    ingest_ms: u128,
+    state_store_write_ms: u128,
     trust: RepositoryVerificationState,
 }
 
@@ -445,6 +448,7 @@ fn clone_git_overlay_url(
         .filter
         .as_deref()
         .or_else(|| options.lazy.then_some("blob:none"));
+    let mirror_copy_start = std::time::Instant::now();
     clone_url_to_bare(
         url,
         &staging.path().join(".git"),
@@ -453,6 +457,7 @@ fn clone_git_overlay_url(
         &mut progress,
     )
     .map_err(anyhow::Error::msg)?;
+    let mirror_copy_ms = mirror_copy_start.elapsed().as_millis();
     finish_line(
         &progress.progress,
         &format!(
@@ -469,6 +474,7 @@ fn clone_git_overlay_url(
         redact_url_for_display(url),
     )?;
     staging.publish()?;
+    emit_git_overlay_clone_profile(mirror_copy_ms, &finished);
     render_finished_git_overlay_clone(local_path, finished)?;
     Ok(())
 }
@@ -482,8 +488,10 @@ fn clone_git_overlay_path(
     reject_unsupported_for_git_overlay(options)?;
     let staging = AtomicCloneDestination::new(local_path)?;
     SleyRepository::init(staging.path()).map_err(anyhow::Error::msg)?;
+    let mirror_copy_start = std::time::Instant::now();
     copy_local_repo_to_bare(remote_path, &staging.path().join(".git"))
         .map_err(anyhow::Error::msg)?;
+    let mirror_copy_ms = mirror_copy_start.elapsed().as_millis();
     let remote_label = fs::canonicalize(remote_path)
         .unwrap_or_else(|_| remote_path.to_path_buf())
         .display()
@@ -496,6 +504,7 @@ fn clone_git_overlay_path(
         remote_label,
     )?;
     staging.publish()?;
+    emit_git_overlay_clone_profile(mirror_copy_ms, &finished);
     render_finished_git_overlay_clone(local_path, finished)?;
     Ok(())
 }
@@ -582,6 +591,7 @@ fn finish_git_overlay_clone(
     );
     progress.begin_commit_import();
     let mut on_commit = |event| progress.commit_tick(event);
+    let ingest_start = std::time::Instant::now();
     let (stats, _map) = ingest::import_git_into_scoped_with_options_and_progress(
         local_path,
         local_path,
@@ -599,6 +609,7 @@ fn finish_git_overlay_clone(
             err.to_string()
         ))
     })?;
+    let ingest_ms = ingest_start.elapsed().as_millis();
     progress.begin_ref_write();
     progress.finish();
 
@@ -634,8 +645,21 @@ fn finish_git_overlay_clone(
         branch: track_name,
         commits_imported: stats.commits_imported,
         states_created: stats.states_created,
+        ingest_ms,
+        state_store_write_ms: stats.state_store_write_ms,
         trust,
     })
+}
+
+fn emit_git_overlay_clone_profile(mirror_copy_ms: u128, finished: &FinishedGitOverlayClone) {
+    emit_profile(
+        "git overlay clone phases",
+        &[
+            ProfileField::millis("sley_mirror_copy_ms", mirror_copy_ms),
+            ProfileField::millis("heddle_ingest_ms", finished.ingest_ms),
+            ProfileField::millis("state_store_write_ms", finished.state_store_write_ms),
+        ],
+    );
 }
 
 fn render_finished_git_overlay_clone(

--- a/crates/cli/tests/cli_integration/perf_trace.rs
+++ b/crates/cli/tests/cli_integration/perf_trace.rs
@@ -254,6 +254,44 @@ fn perf_trace_jsonl_verify_uses_named_phase_records() {
 }
 
 #[test]
+fn perf_trace_jsonl_git_overlay_clone_separates_copy_and_state_store_write() {
+    let temp = TempDir::new().unwrap();
+    let source = temp.path().join("source");
+    let destination = temp.path().join("clone");
+    let git = SleyRepository::init(&source).unwrap();
+    let tree = git_empty_tree_oid(&git);
+    git_commit_with_tree(&git, Some("refs/heads/main"), tree, "seed", &[]);
+    let source_arg = source.to_str().unwrap();
+    let destination_arg = destination.to_str().unwrap();
+
+    let output = heddle_output_with_env(
+        &["--output", "json", "clone", source_arg, destination_arg],
+        Some(temp.path()),
+        &[("HEDDLE_PROFILE", "jsonl")],
+    )
+    .expect("profiled Git-overlay clone should run");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap();
+    assert!(output.status.success(), "clone should succeed: {stderr}");
+
+    let trace = profile_trace_from_stderr(stderr);
+    let phase = trace["phases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|phase| phase["name"] == "git overlay clone phases")
+        .unwrap_or_else(|| panic!("trace should separate Git copy from Heddle ingest: {trace}"));
+    let metrics = phase["metrics"].as_object().unwrap();
+    for name in [
+        "sley_mirror_copy_ms",
+        "heddle_ingest_ms",
+        "state_store_write_ms",
+    ] {
+        assert!(metrics.contains_key(name), "missing `{name}` in {trace}");
+        assert_eq!(metrics[name]["unit"], "milliseconds");
+    }
+}
+
+#[test]
 fn perf_trace_human_mode_still_writes_profile_text() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -65,6 +65,9 @@ pub struct ImportStats {
     /// New Heddle states written during this import. Re-runs can inspect the
     /// same commits while creating zero new states.
     pub states_created: usize,
+    /// Time spent installing the native pack and publishing its authoritative
+    /// loose state bodies.
+    pub state_store_write_ms: u128,
     /// Distinct trees materialized (after memoization).
     pub trees_imported: usize,
     /// Distinct blobs materialized (after memoization).
@@ -431,9 +434,11 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
                     last_log = idx;
                 }
             }
-            let stats = packed.stats;
+            let mut stats = packed.stats;
             if stats.object_count > 0 {
+                let state_store_write_start = std::time::Instant::now();
                 packed.builder.finish(self.store, &pack_path, &index_path)?;
+                stats.state_store_write_ms = state_store_write_start.elapsed().as_millis();
             } else {
                 // No objects to install — drop the empty staging file.
                 let _ = std::fs::remove_file(&pack_path);
@@ -505,6 +510,7 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             refs_seen,
             commits_imported: commits.len(),
             states_created: packed_stats.states,
+            state_store_write_ms: packed_stats.state_store_write_ms,
             trees_imported: packed_stats.trees,
             blobs_imported: packed_stats.blobs,
             refs: ref_stats,
@@ -519,6 +525,7 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
 struct PackedImportStats {
     object_count: usize,
     states: usize,
+    state_store_write_ms: u128,
     trees: usize,
     blobs: usize,
     lossy_entries: Vec<LossyImportEntry>,

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -152,6 +152,29 @@ fn append_packed_hashes(
 }
 
 impl FsStore {
+    /// Publish the authoritative loose copies of packed states behind one
+    /// parent-directory durability barrier. A later pack may refresh mutable
+    /// tail fields under the same StateId, so the loose bodies cannot be
+    /// dropped even though the pack already contains each state.
+    fn write_packed_state_mirrors_batch(&self, states: Vec<(StateId, Vec<u8>)>) -> Result<()> {
+        if states.is_empty() {
+            return Ok(());
+        }
+
+        self.begin_snapshot_write_batch_impl()?;
+        for (id, data) in states {
+            if let Err(error) = ObjectStore::put_state_serialized(self, &data, id) {
+                self.abort_snapshot_write_batch_impl();
+                return Err(error);
+            }
+        }
+        if let Err(error) = self.flush_snapshot_write_batch_impl() {
+            self.abort_snapshot_write_batch_impl();
+            return Err(error);
+        }
+        Ok(())
+    }
+
     fn with_state_attachment_index_lock<T>(
         &self,
         state: &StateId,
@@ -1308,9 +1331,7 @@ impl ObjectStore for FsStore {
         let ids = validate_and_list_pack(&reader)?;
         let state_entries = state_entries_from_pack(&reader, &ids)?;
         self.install_pack_files(pack_data, index_data)?;
-        for (id, data) in state_entries {
-            self.put_state_serialized(&data, id)?;
-        }
+        self.write_packed_state_mirrors_batch(state_entries)?;
         for id in &ids {
             let Some((ObjectType::StateAttachment, data)) = reader.get_object(id)? else {
                 continue;
@@ -1373,9 +1394,7 @@ impl ObjectStore for FsStore {
             attachment_entries_from_pack(&reader, &ids)?
         };
         self.install_pack_files_streaming(pack_path, index_path)?;
-        for (id, data) in state_entries {
-            self.put_state_serialized(&data, id)?;
-        }
+        self.write_packed_state_mirrors_batch(state_entries)?;
         for attachment in attachment_entries {
             self.put_state_attachment(&attachment)?;
         }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Core FsStore structure.
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     hash::Hash,
@@ -244,6 +246,8 @@ pub struct FsStore {
     pub(super) external_source: Option<Arc<dyn super::super::ExternalObjectSource>>,
     loose_object_write_mode: LooseObjectWriteMode,
     pending_directory_syncs: Mutex<BTreeSet<PathBuf>>,
+    #[cfg(test)]
+    snapshot_batch_flushes: AtomicUsize,
     /// In-process trust cache for loose-blob cache mirrors. A hash
     /// enters this LRU when this process either (a) wrote the blob
     /// itself via `promote_to_loose_uncompressed` or (b) successfully
@@ -301,6 +305,8 @@ impl FsStore {
             external_source: None,
             loose_object_write_mode: LooseObjectWriteMode::Durable,
             pending_directory_syncs: Mutex::new(BTreeSet::new()),
+            #[cfg(test)]
+            snapshot_batch_flushes: AtomicUsize::new(0),
             verified_loose_blobs: RwLock::new(RecentObjectCache::with_capacity(
                 VERIFIED_LOOSE_BLOB_CACHE_CAPACITY,
             )),
@@ -328,6 +334,8 @@ impl FsStore {
             external_source: None,
             loose_object_write_mode: LooseObjectWriteMode::Durable,
             pending_directory_syncs: Mutex::new(BTreeSet::new()),
+            #[cfg(test)]
+            snapshot_batch_flushes: AtomicUsize::new(0),
             verified_loose_blobs: RwLock::new(RecentObjectCache::with_capacity(
                 VERIFIED_LOOSE_BLOB_CACHE_CAPACITY,
             )),
@@ -579,6 +587,9 @@ impl FsStore {
             return Ok(());
         }
 
+        #[cfg(test)]
+        self.snapshot_batch_flushes.fetch_add(1, Ordering::Relaxed);
+
         // Batches may overlap across snapshot preparers. Each successful
         // preparer must establish durability for its own writes before it can
         // publish an oplog edge, even while another batch remains active.
@@ -621,5 +632,10 @@ impl FsStore {
             .lock()
             .map(|pending| pending.len())
             .unwrap_or(0)
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot_batch_flush_count(&self) -> usize {
+        self.snapshot_batch_flushes.load(Ordering::Relaxed)
     }
 }

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -6,7 +6,7 @@ use tempfile::TempDir;
 
 use super::{
     FsStore, LooseObjectWriteMode,
-    fs_paths::{blobs_dir, hash_path, packs_dir, trees_dir},
+    fs_paths::{blobs_dir, hash_path, packs_dir, state_path, trees_dir},
 };
 use crate::{
     fs_atomic::temp_path,
@@ -333,6 +333,48 @@ fn install_pack_streaming_publishes_via_durable_rename_and_loads_objects() {
 
     let loaded = store.get_blob(&blob_hash).unwrap().expect("packed blob");
     assert_eq!(loaded.content(), blob.content());
+}
+
+#[test]
+fn install_pack_batches_authoritative_loose_state_writes() {
+    let (_temp, store) = create_test_store();
+    let attribution = Attribution::human(Principal::new("Batch", "batch@example.com"));
+    let first = State::new(
+        ContentHash::compute(b"first tree"),
+        vec![],
+        attribution.clone(),
+    );
+    let second = State::new(
+        ContentHash::compute(b"second tree"),
+        vec![first.id()],
+        attribution,
+    );
+    let states = [&first, &second];
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    for state in states {
+        builder.add_id(
+            PackObjectId::StateId(state.id()),
+            PackObjectType::State,
+            rmp_serde::to_vec_named(state).unwrap(),
+        );
+    }
+    let (pack_data, index_data, _) = builder.build().unwrap();
+
+    store.install_pack(&pack_data, &index_data).unwrap();
+
+    assert_eq!(
+        store.snapshot_batch_flush_count(),
+        1,
+        "one pack must publish every loose state behind one directory-sync flush"
+    );
+    assert_eq!(store.pending_directory_sync_count(), 0);
+    for state in states {
+        assert!(
+            state_path(store.root(), &state.id()).is_file(),
+            "packed state must retain its authoritative loose copy"
+        );
+        assert_eq!(store.get_state(&state.id()).unwrap().as_ref(), Some(state));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- batch authoritative loose state publication during pack installation behind one parent-directory durability barrier
- preserve loose-state refresh semantics while removing the per-state directory fsync round trip
- expose sley mirror-copy, Heddle ingest, and state-store write timings in profiling output
- add focused batch-flush and clone-profile coverage

## Closes

Closes HeddleCo/heddle#730

## Test evidence

- Real ripgrep mirror clone (2,327 imported states): 5,098 -> 2,774 fsync/fdatasync calls, 2,324 fewer overall (45.6%); the state batch itself reduces 2,327 directory barriers to 1.
- Before/after state-store composite SHA-256: `0e85e7ac8804e41fe73c3d0c1f0ddd3f81c9cc210e2ae7560ff17410fd670bd3`; pack composite SHA-256: `2f17b21b9863c9e5d7381f813cad74e195c8e1adf995b36e57eb6dac27877c4d`. Final clone verification was clean.
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked` plus clean serialized CLI integration rerun: 904 passed, 19 ignored
- telemetry build/clippy/tests, all four repository/CLI feature combinations, CLI/repo fault-injection tests, default CLI contracts, facade boundary check, and script unit tests
- postgres-feature clippy with `-D warnings`; live Postgres tests could not authenticate against the pre-existing local server using the CI fixture credentials
- all seven touched Rust files pass nightly rustfmt with repository keys; the repo-wide fmt script also reports unrelated pre-existing drift in untouched origin/main files

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788776958&installation_model_id=21489&pr_number=1252&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1252&signature=54a840b310d89a3fdc658c9464ec78ccb6f439770f733632e0d0dd3448070033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->