### PR TITLE
Bound merge-base walks by generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2540,6 +2540,7 @@ dependencies = [
  "ignore",
  "libc",
  "notify",
+ "proptest",
  "rmp-serde",
  "rusqlite",
  "serde",

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1820,7 +1820,7 @@ async fn clone_network_connected(
         // subsequent `heddle <verb>` would surface MissingObject on
         // any blob read.
         if lazy {
-            local_repo.refs().write_head(&Head::Attached {
+            local_repo.write_head_recorded(&Head::Attached {
                 thread: ThreadName::new(&track_name),
             })?;
         } else if git_overlay_clone {
@@ -1831,7 +1831,7 @@ async fn clone_network_connected(
             local_repo
                 .goto_from_materialized_state(&final_state, None)
                 .context("failed to materialize hosted clone worktree")?;
-            local_repo.refs().write_head(&Head::Attached {
+            local_repo.write_head_recorded(&Head::Attached {
                 thread: ThreadName::new(&track_name),
             })?;
         }
@@ -2026,7 +2026,7 @@ async fn recover_interrupted_clone_connected(
         .await?;
     repo.set_thread_recorded(&ThreadName::new(&track_name), &final_state)?;
     if intent.lazy {
-        repo.refs().write_head(&Head::Attached {
+        repo.write_head_recorded(&Head::Attached {
             thread: ThreadName::new(&track_name),
         })?;
     } else if git_overlay_clone {
@@ -2035,7 +2035,7 @@ async fn recover_interrupted_clone_connected(
         configure_git_overlay_origin_tracking(root, &track_name)?;
     } else {
         repo.goto_from_materialized_state(&final_state, None)?;
-        repo.refs().write_head(&Head::Attached {
+        repo.write_head_recorded(&Head::Attached {
             thread: ThreadName::new(&track_name),
         })?;
     }

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -170,6 +170,10 @@ fn record_structural_counters() {
                 "network_client_initialized",
                 counters.network_client_initialized,
             ),
+            ProfileField::count(
+                "merge_base_ancestors_visited",
+                counters.merge_base_ancestors_visited,
+            ),
         ],
     );
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
@@ -110,6 +110,7 @@ pub(super) struct Counters {
     pub oplog_reads: u64,
     pub repository_opens: u64,
     pub network_client_initialized: bool,
+    pub merge_base_ancestors_visited: u64,
 }
 
 impl Sample {
@@ -149,6 +150,7 @@ impl Counters {
         self.oplog_reads += other.oplog_reads;
         self.repository_opens += other.repository_opens;
         self.network_client_initialized |= other.network_client_initialized;
+        self.merge_base_ancestors_visited += other.merge_base_ancestors_visited;
     }
 }
 
@@ -205,7 +207,7 @@ impl CaseResult {
             self.metric(|sample| sample.network_ms),
         );
         println!(
-            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={}",
+            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={} merge_base_ancestors_visited={}",
             self.kind.name(),
             self.path_count,
             self.counter(|value| value.directories_scanned),
@@ -219,6 +221,7 @@ impl CaseResult {
             self.samples
                 .iter()
                 .any(|sample| sample.counters.network_client_initialized),
+            self.counter(|value| value.merge_base_ancestors_visited),
         );
     }
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
@@ -80,5 +80,6 @@ fn structural_counters(trace: &Value) -> Counters {
         network_client_initialized: metrics["network_client_initialized"]["value"]
             .as_bool()
             .unwrap_or(true),
+        merge_base_ancestors_visited: count("merge_base_ancestors_visited"),
     }
 }

--- a/crates/cli/tests/cli_integration/perf_trace.rs
+++ b/crates/cli/tests/cli_integration/perf_trace.rs
@@ -130,6 +130,7 @@ fn perf_trace_jsonl_status_reports_structural_counters() {
         "ref_reads",
         "oplog_reads",
         "repository_opens",
+        "merge_base_ancestors_visited",
     ] {
         assert!(metrics.contains_key(name), "missing `{name}` in {trace}");
     }

--- a/crates/perf-contract/src/lib.rs
+++ b/crates/perf-contract/src/lib.rs
@@ -17,6 +17,7 @@ static REF_READS: AtomicU64 = AtomicU64::new(0);
 static OPLOG_READS: AtomicU64 = AtomicU64::new(0);
 static REPOSITORY_OPENS: AtomicU64 = AtomicU64::new(0);
 static NETWORK_CLIENT_INITIALIZATIONS: AtomicU64 = AtomicU64::new(0);
+static MERGE_BASE_ANCESTORS_VISITED: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct StructuralCounters {
@@ -30,6 +31,7 @@ pub struct StructuralCounters {
     pub oplog_reads: u64,
     pub repository_opens: u64,
     pub network_client_initialized: bool,
+    pub merge_base_ancestors_visited: u64,
 }
 
 fn enabled() -> bool {
@@ -83,6 +85,10 @@ pub fn record_network_client_initialization() {
     add(&NETWORK_CLIENT_INITIALIZATIONS, 1);
 }
 
+pub fn record_merge_base_ancestors_visited(ancestors_visited: u64) {
+    add(&MERGE_BASE_ANCESTORS_VISITED, ancestors_visited);
+}
+
 pub fn snapshot() -> StructuralCounters {
     StructuralCounters {
         directories_scanned: DIRECTORIES_SCANNED.load(Ordering::Relaxed),
@@ -95,5 +101,6 @@ pub fn snapshot() -> StructuralCounters {
         oplog_reads: OPLOG_READS.load(Ordering::Relaxed),
         repository_opens: REPOSITORY_OPENS.load(Ordering::Relaxed),
         network_client_initialized: NETWORK_CLIENT_INITIALIZATIONS.load(Ordering::Relaxed) > 0,
+        merge_base_ancestors_visited: MERGE_BASE_ANCESTORS_VISITED.load(Ordering::Relaxed),
     }
 }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -84,6 +84,7 @@ async-source = ["objects/async-source"]
 [dev-dependencies]
 hex.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["async-source", "memory-backend"] }
+proptest.workspace = true
 tempfile.workspace = true
 
 [lib]

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! In-memory commit graph index with persistence and Bloom filter support.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet};
 
 use anyhow::Result;
 #[cfg(feature = "async-source")]
@@ -32,6 +32,31 @@ struct CommitGraphNode {
     bloom: Option<[u8; 256]>,
 }
 
+const PAINT_A: u8 = 1;
+const PAINT_B: u8 = 2;
+const PAINT_BOTH: u8 = PAINT_A | PAINT_B;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct MergeBaseSearch {
+    merge_base: Option<StateId>,
+    ancestors_visited: u64,
+}
+
+trait MergeBaseGraph {
+    fn generation(&self, state_id: StateId) -> Option<usize>;
+    fn parents(&self, state_id: StateId) -> Option<&[StateId]>;
+}
+
+impl MergeBaseGraph for HashMap<StateId, CommitGraphNode> {
+    fn generation(&self, state_id: StateId) -> Option<usize> {
+        self.get(&state_id).map(|node| node.generation)
+    }
+
+    fn parents(&self, state_id: StateId) -> Option<&[StateId]> {
+        self.get(&state_id).map(|node| node.parents.as_slice())
+    }
+}
+
 type CommitGraphStateData = (Vec<StateId>, ContentHash, i64, Option<String>);
 
 impl CommitGraphNode {
@@ -48,6 +73,17 @@ impl CommitGraphNode {
 struct AsyncCommitGraphNode {
     parents: Vec<StateId>,
     generation: usize,
+}
+
+#[cfg(feature = "async-source")]
+impl MergeBaseGraph for HashMap<StateId, AsyncCommitGraphNode> {
+    fn generation(&self, state_id: StateId) -> Option<usize> {
+        self.get(&state_id).map(|node| node.generation)
+    }
+
+    fn parents(&self, state_id: StateId) -> Option<&[StateId]> {
+        self.get(&state_id).map(|node| node.parents.as_slice())
+    }
 }
 
 /// Cached metadata for a node — cheap to return by value.
@@ -172,35 +208,9 @@ where
         self.ensure_loaded(*state_a)?;
         self.ensure_loaded(*state_b)?;
 
-        let ancestors_a = self.collect_ancestors(*state_a)?;
-        let ancestors_b = self.collect_ancestors(*state_b)?;
-        let best = ancestors_a
-            .intersection(&ancestors_b)
-            .copied()
-            .max_by(|left, right| {
-                self.generation(*left)
-                    .cmp(&self.generation(*right))
-                    .then_with(|| right.as_bytes().cmp(left.as_bytes()))
-            });
-
-        Ok(best)
-    }
-
-    fn collect_ancestors(&mut self, start: StateId) -> Result<HashSet<StateId>> {
-        self.ensure_loaded(start)?;
-
-        let mut ancestors = HashSet::new();
-        let mut stack = vec![start];
-        while let Some(state_id) = stack.pop() {
-            if !ancestors.insert(state_id) {
-                continue;
-            }
-            if let Some(node) = self.nodes.get(&state_id) {
-                stack.extend(node.parents.iter().copied());
-            }
-        }
-
-        Ok(ancestors)
+        let search = find_merge_base_in_graph(&self.nodes, *state_a, *state_b);
+        heddle_perf_contract::record_merge_base_ancestors_visited(search.ancestors_visited);
+        Ok(search.merge_base)
     }
 
     pub fn ensure_loaded(&mut self, state_id: StateId) -> Result<()> {
@@ -399,6 +409,77 @@ impl LoadedCommitGraphExt for LoadedCommitGraph {
     }
 }
 
+/// Paint both ancestries in generation order. Once a common ancestor is
+/// found, only the rest of that generation is drained so the historical
+/// state-id tie-break remains unchanged.
+fn find_merge_base_in_graph<G>(graph: &G, state_a: StateId, state_b: StateId) -> MergeBaseSearch
+where
+    G: MergeBaseGraph,
+{
+    let mut queue = BinaryHeap::new();
+    let mut paint = HashMap::new();
+    let mut propagated = HashMap::new();
+    paint_state(graph, &mut queue, &mut paint, state_a, PAINT_A);
+    paint_state(graph, &mut queue, &mut paint, state_b, PAINT_B);
+
+    let mut best: Option<(Option<usize>, StateId)> = None;
+    let mut ancestors_visited = 0;
+    while let Some((generation, state_id)) = queue.pop() {
+        if best.is_some_and(|(best_generation, _)| generation < best_generation) {
+            break;
+        }
+
+        let colors = paint[&state_id];
+        let already_propagated = propagated.entry(state_id).or_insert(0);
+        if colors & !*already_propagated == 0 {
+            continue;
+        }
+        *already_propagated = colors;
+        ancestors_visited += 1;
+
+        if colors == PAINT_BOTH {
+            match best {
+                Some((best_generation, best_id))
+                    if (generation, std::cmp::Reverse(state_id))
+                        <= (best_generation, std::cmp::Reverse(best_id)) => {}
+                _ => best = Some((generation, state_id)),
+            }
+            continue;
+        }
+
+        if best.is_some() {
+            continue;
+        }
+        if let Some(parents) = graph.parents(state_id) {
+            for parent in parents {
+                paint_state(graph, &mut queue, &mut paint, *parent, colors);
+            }
+        }
+    }
+
+    MergeBaseSearch {
+        merge_base: best.map(|(_, state_id)| state_id),
+        ancestors_visited,
+    }
+}
+
+fn paint_state<G>(
+    graph: &G,
+    queue: &mut BinaryHeap<(Option<usize>, StateId)>,
+    paint: &mut HashMap<StateId, u8>,
+    state_id: StateId,
+    colors: u8,
+) where
+    G: MergeBaseGraph,
+{
+    let entry = paint.entry(state_id).or_insert(0);
+    let combined = *entry | colors;
+    if combined != *entry {
+        *entry = combined;
+        queue.push((graph.generation(state_id), state_id));
+    }
+}
+
 /// Return whether `ancestor_id` is reachable from `descendant_id` using an async object source.
 #[cfg(feature = "async-source")]
 pub async fn is_ancestor_async<S>(
@@ -458,43 +539,9 @@ where
     ensure_loaded_async(source, &mut nodes, *state_a).await?;
     ensure_loaded_async(source, &mut nodes, *state_b).await?;
 
-    let ancestors_a = collect_ancestors_async(source, &mut nodes, *state_a).await?;
-    let ancestors_b = collect_ancestors_async(source, &mut nodes, *state_b).await?;
-    let best = ancestors_a
-        .intersection(&ancestors_b)
-        .copied()
-        .max_by(|left, right| {
-            generation_async(&nodes, *left)
-                .cmp(&generation_async(&nodes, *right))
-                .then_with(|| right.as_bytes().cmp(left.as_bytes()))
-        });
-
-    Ok(best)
-}
-
-#[cfg(feature = "async-source")]
-async fn collect_ancestors_async<S>(
-    source: &S,
-    nodes: &mut HashMap<StateId, AsyncCommitGraphNode>,
-    start: StateId,
-) -> Result<HashSet<StateId>>
-where
-    S: AsyncObjectSource + ?Sized,
-{
-    ensure_loaded_async(source, nodes, start).await?;
-
-    let mut ancestors = HashSet::new();
-    let mut stack = vec![start];
-    while let Some(state_id) = stack.pop() {
-        if !ancestors.insert(state_id) {
-            continue;
-        }
-        if let Some(node) = nodes.get(&state_id) {
-            stack.extend(node.parents.iter().copied());
-        }
-    }
-
-    Ok(ancestors)
+    let search = find_merge_base_in_graph(&nodes, *state_a, *state_b);
+    heddle_perf_contract::record_merge_base_ancestors_visited(search.ancestors_visited);
+    Ok(search.merge_base)
 }
 
 #[cfg(feature = "async-source")]
@@ -581,21 +628,19 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{collections::HashSet, fs};
 
     use anyhow::Result;
-    use objects::{
-        object::{Attribution, ContentHash, Principal, State, Tree},
-        store::ObjectStore,
-    };
     #[cfg(feature = "async-source")]
+    use objects::{object::Blob, store::AsyncObjectSource};
     use objects::{
-        object::{Blob, StateId},
-        store::{AsyncObjectSource, InMemoryStore},
+        object::{Attribution, ContentHash, Principal, State, StateId, Tree},
+        store::{InMemoryStore, ObjectStore},
     };
+    use proptest::prelude::*;
     use tempfile::TempDir;
 
-    use super::{super::Repository, CommitGraphIndex};
+    use super::{super::Repository, CommitGraphIndex, find_merge_base_in_graph};
 
     fn commit_graph_path(repo: &Repository) -> std::path::PathBuf {
         repo.root().join(".heddle/state").join("commit-graph.bin")
@@ -824,6 +869,152 @@ mod tests {
         assert!(bloom_maybe_contains(bloom, "alpha.txt"));
 
         Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(128))]
+
+        #[test]
+        fn bounded_merge_base_matches_full_dfs_across_random_dags(
+            parent_selectors in prop::collection::vec(
+                prop::collection::vec(any::<u16>(), 0..=3),
+                0..64,
+            ),
+            query_a in any::<u16>(),
+            query_b in any::<u16>(),
+        ) {
+            let store = InMemoryStore::new();
+
+            // Every generated graph includes a criss-cross pair with two
+            // merge bases and a separate root for the unrelated-history case.
+            let root = put_graph_state(&store, vec![]);
+            let left_base = put_graph_state(&store, vec![root.id()]);
+            let right_base = put_graph_state(&store, vec![root.id()]);
+            let merge_a = put_graph_state(&store, vec![left_base.id(), right_base.id()]);
+            let merge_b = put_graph_state(&store, vec![right_base.id(), left_base.id()]);
+            let unrelated = put_graph_state(&store, vec![]);
+            let mut states = vec![root, left_base, right_base, merge_a, merge_b, unrelated];
+
+            for selectors in parent_selectors {
+                let mut parents = selectors
+                    .into_iter()
+                    .map(|selector| states[usize::from(selector) % states.len()].id())
+                    .collect::<Vec<_>>();
+                parents.sort_unstable();
+                parents.dedup();
+                states.push(put_graph_state(&store, parents));
+            }
+
+            let random_pair = (
+                states[usize::from(query_a) % states.len()].id(),
+                states[usize::from(query_b) % states.len()].id(),
+            );
+            let cases = [
+                (states[3].id(), states[4].id()),
+                (states[3].id(), states[5].id()),
+                random_pair,
+            ];
+            let mut graph = CommitGraphIndex::with_cache(
+                &store,
+                super::super::commit_graph_persistence::NullCommitGraphCache,
+            );
+
+            for (left, right) in cases {
+                let actual = graph.find_merge_base(&left, &right).unwrap();
+                let (expected, _) = full_dfs_merge_base(&graph, left, right);
+                prop_assert_eq!(
+                    actual,
+                    expected,
+                    "merge base mismatch for {} and {}",
+                    left,
+                    right,
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn merge_base_walk_prunes_deep_history_after_near_base() {
+        const HISTORY_LEN: usize = 2_048;
+
+        let store = InMemoryStore::new();
+        let mut tip = put_graph_state(&store, vec![]);
+        for _ in 1..HISTORY_LEN {
+            tip = put_graph_state(&store, vec![tip.id()]);
+        }
+        let left = put_graph_state(&store, vec![tip.id()]);
+        let right = put_graph_state(&store, vec![tip.id()]);
+        let mut graph = CommitGraphIndex::with_cache(
+            &store,
+            super::super::commit_graph_persistence::NullCommitGraphCache,
+        );
+        graph.ensure_loaded(left.id()).unwrap();
+        graph.ensure_loaded(right.id()).unwrap();
+
+        let bounded = find_merge_base_in_graph(&graph.nodes, left.id(), right.id());
+        let (old_result, old_visited) = full_dfs_merge_base(&graph, left.id(), right.id());
+
+        assert_eq!(bounded.merge_base, Some(tip.id()));
+        assert_eq!(bounded.merge_base, old_result);
+        assert!(
+            bounded.ancestors_visited < (HISTORY_LEN / 10) as u64,
+            "bounded walk visited {} ancestors in a {HISTORY_LEN}-node history",
+            bounded.ancestors_visited,
+        );
+        assert!(
+            old_visited >= HISTORY_LEN * 2,
+            "legacy full DFS visited only {old_visited} ancestors"
+        );
+        eprintln!(
+            "merge-base pruning: bounded_visited={} old_full_dfs_visited={old_visited} history_len={HISTORY_LEN}",
+            bounded.ancestors_visited,
+        );
+    }
+
+    fn full_dfs_merge_base(
+        graph: &CommitGraphIndex<'_, InMemoryStore>,
+        state_a: StateId,
+        state_b: StateId,
+    ) -> (Option<StateId>, usize) {
+        let ancestors_a = collect_ancestors_full_dfs(graph, state_a);
+        let ancestors_b = collect_ancestors_full_dfs(graph, state_b);
+        let best = ancestors_a
+            .intersection(&ancestors_b)
+            .copied()
+            .max_by(|left, right| {
+                graph
+                    .generation(*left)
+                    .cmp(&graph.generation(*right))
+                    .then_with(|| right.as_bytes().cmp(left.as_bytes()))
+            });
+        (best, ancestors_a.len() + ancestors_b.len())
+    }
+
+    fn collect_ancestors_full_dfs(
+        graph: &CommitGraphIndex<'_, InMemoryStore>,
+        start: StateId,
+    ) -> HashSet<StateId> {
+        let mut ancestors = HashSet::new();
+        let mut stack = vec![start];
+        while let Some(state_id) = stack.pop() {
+            if !ancestors.insert(state_id) {
+                continue;
+            }
+            if let Some(node) = graph.nodes.get(&state_id) {
+                stack.extend(node.parents.iter().copied());
+            }
+        }
+        ancestors
+    }
+
+    fn put_graph_state(store: &InMemoryStore, parents: Vec<StateId>) -> State {
+        let state = State::new(
+            Tree::new().hash(),
+            parents,
+            Attribution::human(Principal::new("Test User", "test@example.com")),
+        );
+        store.put_state(&state).unwrap();
+        state
     }
 
     #[cfg(feature = "async-source")]


### PR DESCRIPTION
## Summary

- replace full ancestor-set DFS merge-base discovery with a highest-generation-first bidirectional paint walk
- stop below the first common generation while draining that generation to preserve the existing state-ID tie-break exactly
- expose `merge_base_ancestors_visited` through the structural performance counters for the follow-up perf-contract gate
- apply the same bounded selection helper to sync and async commit-graph callers

## Closes

Closes #1258

## Test evidence

- `cargo test -p heddle-repo bounded_merge_base_matches_full_dfs_across_random_dags -- --nocapture`: 1 passed; 128 generated DAG cases, each covering criss-cross/multiple merge bases and unrelated histories plus a random query
- `cargo test -p heddle-repo merge_base_walk_prunes_deep_history_after_near_base -- --nocapture`: 1 passed; `bounded_visited=3 old_full_dfs_visited=4098 history_len=2048`
- `cargo test -p heddle-repo commit_graph --features async-source -- --nocapture`: 16 passed
- `cargo test -p heddle-cli perf_trace_jsonl_status_reports_structural_counters -- --nocapture`: 1 passed
- `cargo build`: passed
- `cargo clippy -- -D warnings`: passed
- `cargo clippy -p heddle-repo --tests --features async-source -- -D warnings`: passed

All cargo commands used `CARGO_TARGET_DIR=/home/scratch/h1258-target` and `TMPDIR=/home/scratch`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1259"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788819531&installation_model_id=21489&pr_number=1259&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1259&signature=c74f61f39a29101db9797e83ba2b39a1b0c8ba3ce8ec19d4e2ba4b0b7d23fca0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->