### PR TITLE
feat(provenance): add fail-closed KeyBinding registry

### DIFF
--- a/crates/object-model/src/object/key_binding.rs
+++ b/crates/object-model/src/object/key_binding.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Offline-verifiable bindings from signing keys to durable identities.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{ContentHash, StateSignature};
+
+/// Domain separator for signatures that authorize a [`KeyBinding`].
+pub const KEY_BINDING_SIGNING_PAYLOAD_VERSION_TAG: &[u8] = b"hd-key-binding-v1\x00";
+
+/// A signing key's role within an identity's provenance chain.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyBinding {
+    /// Signature algorithm used by the bound key.
+    pub algorithm: String,
+    /// Hex-encoded raw public key bytes.
+    pub public_key: String,
+    /// Durable identity subject resolved by this key.
+    pub identity_ref: String,
+    /// Repository role granted to this key, such as `author` or `ci-runner`.
+    pub role: String,
+    /// Identity-key signature authorizing this binding.
+    pub added_by_sig: StateSignature,
+    /// First instant at which this binding may authenticate authored objects.
+    pub valid_from: DateTime<Utc>,
+    /// First instant at which this binding no longer authenticates new objects.
+    #[serde(default)]
+    pub revoked_at: Option<DateTime<Utc>>,
+    /// Content hash of the identity-owned root binding that authorized this
+    /// key. Only one delegation hop is permitted by repository verification.
+    #[serde(default)]
+    pub delegated_from: Option<ContentHash>,
+}
+
+impl KeyBinding {
+    /// Deterministic bytes covered by [`Self::added_by_sig`].
+    pub fn canonical_signing_payload(&self) -> Vec<u8> {
+        let mut payload = Vec::with_capacity(256);
+        payload.extend_from_slice(KEY_BINDING_SIGNING_PAYLOAD_VERSION_TAG);
+        push_field(&mut payload, self.algorithm.as_bytes());
+        push_field(&mut payload, self.public_key.as_bytes());
+        push_field(&mut payload, self.identity_ref.as_bytes());
+        push_field(&mut payload, self.role.as_bytes());
+        push_time(&mut payload, self.valid_from);
+        push_optional_time(&mut payload, self.revoked_at);
+        push_optional_hash(&mut payload, self.delegated_from);
+        payload
+    }
+
+    /// Stable address of this signed binding.
+    pub fn content_hash(&self) -> Result<ContentHash, KeyBindingError> {
+        self.validate()?;
+        let encoded =
+            rmp_serde::to_vec(self).map_err(|error| KeyBindingError::Codec(error.to_string()))?;
+        Ok(ContentHash::compute_typed("key-binding", &encoded))
+    }
+
+    /// Validate the durable shape. Cryptographic authorization is checked by
+    /// the repository resolver, which has access to the signing backends.
+    pub fn validate(&self) -> Result<(), KeyBindingError> {
+        require_non_empty(&self.algorithm, KeyBindingError::EmptyAlgorithm)?;
+        require_hex(&self.public_key, KeyBindingError::InvalidPublicKey)?;
+        require_non_empty(&self.identity_ref, KeyBindingError::EmptyIdentityRef)?;
+        require_non_empty(&self.role, KeyBindingError::EmptyRole)?;
+        require_non_empty(
+            &self.added_by_sig.algorithm,
+            KeyBindingError::EmptyAddedByAlgorithm,
+        )?;
+        require_hex(
+            &self.added_by_sig.public_key,
+            KeyBindingError::InvalidAddedByPublicKey,
+        )?;
+        require_hex(
+            &self.added_by_sig.signature,
+            KeyBindingError::InvalidAddedBySignature,
+        )?;
+        if self
+            .revoked_at
+            .is_some_and(|revoked| revoked < self.valid_from)
+        {
+            return Err(KeyBindingError::RevokedBeforeValid);
+        }
+        Ok(())
+    }
+}
+
+/// Versioned, content-addressed flat set of key bindings.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct KeyBindingRegistry {
+    pub format_version: u8,
+    pub bindings: Vec<KeyBinding>,
+}
+
+impl KeyBindingRegistry {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    pub fn new(bindings: Vec<KeyBinding>) -> Self {
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            bindings,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Vec::new())
+    }
+
+    pub fn encode(&self) -> Result<Vec<u8>, KeyBindingError> {
+        self.validate()?;
+        rmp_serde::to_vec(self).map_err(|error| KeyBindingError::Codec(error.to_string()))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, KeyBindingError> {
+        let registry: Self = rmp_serde::from_slice(bytes)
+            .map_err(|error| KeyBindingError::Codec(error.to_string()))?;
+        registry.validate()?;
+        Ok(registry)
+    }
+
+    /// Stable address of the registry's validated canonical encoding.
+    pub fn content_hash(&self) -> Result<ContentHash, KeyBindingError> {
+        Ok(ContentHash::compute_typed(
+            "key-binding-registry",
+            &self.encode()?,
+        ))
+    }
+
+    pub fn validate(&self) -> Result<(), KeyBindingError> {
+        if self.format_version != Self::FORMAT_VERSION {
+            return Err(KeyBindingError::UnsupportedVersion(self.format_version));
+        }
+        for (index, binding) in self.bindings.iter().enumerate() {
+            binding.validate()?;
+            if self.bindings[..index].iter().any(|prior| {
+                prior.algorithm.eq_ignore_ascii_case(&binding.algorithm)
+                    && prior.public_key.eq_ignore_ascii_case(&binding.public_key)
+            }) {
+                return Err(KeyBindingError::DuplicateKey);
+            }
+        }
+        Ok(())
+    }
+}
+
+fn require_non_empty(value: &str, error: KeyBindingError) -> Result<(), KeyBindingError> {
+    if value.trim().is_empty() {
+        Err(error)
+    } else {
+        Ok(())
+    }
+}
+
+fn require_hex(value: &str, error: KeyBindingError) -> Result<(), KeyBindingError> {
+    if value.is_empty() || hex::decode(value).is_err() {
+        Err(error)
+    } else {
+        Ok(())
+    }
+}
+
+fn push_field(payload: &mut Vec<u8>, value: &[u8]) {
+    payload.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    payload.extend_from_slice(value);
+}
+
+fn push_optional_hash(payload: &mut Vec<u8>, value: Option<ContentHash>) {
+    match value {
+        Some(value) => {
+            payload.push(1);
+            payload.extend_from_slice(value.as_bytes());
+        }
+        None => payload.push(0),
+    }
+}
+
+fn push_time(payload: &mut Vec<u8>, value: DateTime<Utc>) {
+    payload.extend_from_slice(&value.timestamp().to_le_bytes());
+    payload.extend_from_slice(&value.timestamp_subsec_nanos().to_le_bytes());
+}
+
+fn push_optional_time(payload: &mut Vec<u8>, value: Option<DateTime<Utc>>) {
+    match value {
+        Some(value) => {
+            payload.push(1);
+            push_time(payload, value);
+        }
+        None => payload.push(0),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum KeyBindingError {
+    #[error("unsupported key-binding registry version {0}")]
+    UnsupportedVersion(u8),
+    #[error("key-binding registry codec error: {0}")]
+    Codec(String),
+    #[error("key binding algorithm must not be empty")]
+    EmptyAlgorithm,
+    #[error("key binding public key must be non-empty hexadecimal bytes")]
+    InvalidPublicKey,
+    #[error("key binding identity_ref must not be empty")]
+    EmptyIdentityRef,
+    #[error("key binding role must not be empty")]
+    EmptyRole,
+    #[error("key binding authorizing signature algorithm must not be empty")]
+    EmptyAddedByAlgorithm,
+    #[error("key binding authorizing public key must be non-empty hexadecimal bytes")]
+    InvalidAddedByPublicKey,
+    #[error("key binding authorizing signature must be non-empty hexadecimal bytes")]
+    InvalidAddedBySignature,
+    #[error("key binding revoked_at must not precede valid_from")]
+    RevokedBeforeValid,
+    #[error("key-binding registry contains a duplicate algorithm/public-key pair")]
+    DuplicateKey,
+}

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -13,6 +13,7 @@ mod diff;
 mod discussion;
 mod hash;
 mod identifiers;
+mod key_binding;
 pub mod manifest;
 mod operation_id;
 mod redaction;
@@ -51,6 +52,9 @@ pub use discussion::{
 };
 pub use hash::{ChangeId, ChangeIdParseError, ContentHash, StateId, StateIdParseError};
 pub use identifiers::{MarkerName, Scope, ThreadName};
+pub use key_binding::{
+    KEY_BINDING_SIGNING_PAYLOAD_VERSION_TAG, KeyBinding, KeyBindingError, KeyBindingRegistry,
+};
 pub use manifest::{
     BuiltManifest, FsckFinding, FsckOptions, FsckReport, FsckRule, ManifestBinding,
     ManifestBuildError, ManifestFacet, ManifestKey, ManifestNode, ManifestNodeSource,

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -38,6 +38,7 @@ pub mod migration;
 pub mod namespace_policy;
 pub mod operation_dedup;
 mod repository;
+mod repository_key_binding;
 mod repository_redaction;
 #[path = "repository_resolve_for_command.rs"]
 mod repository_resolve_for_command;
@@ -154,6 +155,7 @@ pub use repository::{
 pub use repository::{GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitOverlayShortStatus};
 #[cfg(feature = "async-source")]
 pub use repository::{find_merge_base_async, is_ancestor_async};
+pub use repository_key_binding::AuthorshipVerification;
 pub use repository_redaction::{PurgeOutcome, RemoveRedactionOutcome};
 pub use repository_resolve_for_command::{
     EmptyHeadBootstrap, ResolvePolicy, ResolvedState, StateResolveError, StateResolveFailure,

--- a/crates/repo/src/repository_key_binding.rs
+++ b/crates/repo/src/repository_key_binding.rs
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fail-closed resolution of state signatures through a key-binding registry.
+
+use crypto::{verify_payload_signature, verify_state_signature_bytes};
+use objects::object::{KeyBinding, KeyBindingRegistry, State, StateAttachmentBody, StateSignature};
+
+use crate::{Repository, Result};
+
+/// Identity resolution result for a state's detached authorship signature.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AuthorshipVerification {
+    /// At least one active, authorized binding authenticated the state.
+    Verified(String),
+    /// The state was signed, but none of its signing keys occur in the registry.
+    UnknownKey,
+    /// A valid state signature resolved to a binding revoked at signing time.
+    Revoked,
+    /// The state, registry, binding authorization, or signature was invalid.
+    Invalid,
+}
+
+impl Repository {
+    /// Verify integrity and resolve a state author through an offline registry.
+    ///
+    /// Unknown keys fail closed even when their state signature is
+    /// cryptographically valid. Binding windows are evaluated at the state's
+    /// signed whole-second `created_at`, the only trusted signing-time value
+    /// in the current state-signature envelope. A subsecond boundary that
+    /// shares the signed second is treated conservatively.
+    pub fn verify_authored_by_known_actor(
+        &self,
+        state: &State,
+        registry: &KeyBindingRegistry,
+    ) -> Result<AuthorshipVerification> {
+        if !registry_is_authorized(registry) {
+            return Ok(AuthorshipVerification::Invalid);
+        }
+
+        let signatures: Vec<_> = self
+            .list_state_attachments(&state.id())?
+            .into_iter()
+            .filter_map(|attachment| match attachment.body {
+                StateAttachmentBody::Signature(signature) => Some(signature),
+                _ => None,
+            })
+            .collect();
+        if signatures.is_empty() {
+            return Ok(AuthorshipVerification::Invalid);
+        }
+
+        let mut verified_identity: Option<&str> = None;
+        let mut saw_unknown = false;
+        let mut saw_revoked = false;
+        let mut saw_invalid = false;
+        for signature in &signatures {
+            let Some(binding) = find_binding(registry, signature) else {
+                saw_unknown = true;
+                continue;
+            };
+            if verify_state_signature_bytes(signature, &state.compute_hash()).is_err() {
+                saw_invalid = true;
+                continue;
+            }
+            let signed_at = state.created_at.timestamp();
+            if signed_second_precedes(signed_at, binding.valid_from) {
+                saw_invalid = true;
+                continue;
+            }
+            if binding
+                .revoked_at
+                .is_some_and(|revoked_at| signed_second_may_be_revoked(signed_at, revoked_at))
+            {
+                saw_revoked = true;
+                continue;
+            }
+            match verified_identity {
+                Some(identity) if identity != binding.identity_ref => saw_invalid = true,
+                Some(_) => {}
+                None => verified_identity = Some(&binding.identity_ref),
+            }
+        }
+
+        Ok(match verified_identity {
+            Some(identity) if !saw_invalid => {
+                AuthorshipVerification::Verified(identity.to_string())
+            }
+            Some(_) => AuthorshipVerification::Invalid,
+            None if saw_revoked => AuthorshipVerification::Revoked,
+            None if saw_invalid => AuthorshipVerification::Invalid,
+            None if saw_unknown => AuthorshipVerification::UnknownKey,
+            None => AuthorshipVerification::Invalid,
+        })
+    }
+}
+
+fn registry_is_authorized(registry: &KeyBindingRegistry) -> bool {
+    registry.validate().is_ok()
+        && registry
+            .bindings
+            .iter()
+            .all(|binding| binding_is_authorized(binding, registry))
+}
+
+fn binding_is_authorized(binding: &KeyBinding, registry: &KeyBindingRegistry) -> bool {
+    let added_by = &binding.added_by_sig;
+    let is_self_signed = key_matches(
+        &binding.algorithm,
+        &binding.public_key,
+        &added_by.algorithm,
+        &added_by.public_key,
+    );
+    if is_self_signed {
+        if binding.delegated_from.is_some() {
+            return false;
+        }
+    } else {
+        let Some(delegated_from) = binding.delegated_from else {
+            return false;
+        };
+        let Some(root) = registry.bindings.iter().find(|candidate| {
+            candidate.content_hash().ok() == Some(delegated_from)
+                && key_matches(
+                    &candidate.algorithm,
+                    &candidate.public_key,
+                    &added_by.algorithm,
+                    &added_by.public_key,
+                )
+        }) else {
+            return false;
+        };
+        if root.delegated_from.is_some()
+            || root.identity_ref != binding.identity_ref
+            || !binding_active_at(root, binding.valid_from)
+            || !binding_self_signature_verifies(root)
+        {
+            return false;
+        }
+    }
+    signature_verifies(&binding.canonical_signing_payload(), added_by)
+}
+
+fn binding_self_signature_verifies(binding: &KeyBinding) -> bool {
+    key_matches(
+        &binding.algorithm,
+        &binding.public_key,
+        &binding.added_by_sig.algorithm,
+        &binding.added_by_sig.public_key,
+    ) && signature_verifies(&binding.canonical_signing_payload(), &binding.added_by_sig)
+}
+
+fn binding_active_at(binding: &KeyBinding, at: chrono::DateTime<chrono::Utc>) -> bool {
+    binding.valid_from <= at && binding.revoked_at.is_none_or(|revoked| at < revoked)
+}
+
+fn signed_second_precedes(signed_at: i64, valid_from: chrono::DateTime<chrono::Utc>) -> bool {
+    signed_at < valid_from.timestamp()
+        || (signed_at == valid_from.timestamp() && valid_from.timestamp_subsec_nanos() != 0)
+}
+
+fn signed_second_may_be_revoked(signed_at: i64, revoked_at: chrono::DateTime<chrono::Utc>) -> bool {
+    signed_at >= revoked_at.timestamp()
+}
+
+fn signature_verifies(payload: &[u8], signature: &StateSignature) -> bool {
+    let Ok(public_key) = hex::decode(&signature.public_key) else {
+        return false;
+    };
+    let Ok(signature_bytes) = hex::decode(&signature.signature) else {
+        return false;
+    };
+    verify_payload_signature(payload, &signature.algorithm, &public_key, &signature_bytes).is_ok()
+}
+
+fn find_binding<'a>(
+    registry: &'a KeyBindingRegistry,
+    signature: &StateSignature,
+) -> Option<&'a KeyBinding> {
+    registry.bindings.iter().find(|binding| {
+        key_matches(
+            &binding.algorithm,
+            &binding.public_key,
+            &signature.algorithm,
+            &signature.public_key,
+        )
+    })
+}
+
+fn key_matches(
+    left_algorithm: &str,
+    left_public_key: &str,
+    right_algorithm: &str,
+    right_public_key: &str,
+) -> bool {
+    left_algorithm.eq_ignore_ascii_case(right_algorithm)
+        && left_public_key.eq_ignore_ascii_case(right_public_key)
+}
+
+#[cfg(test)]
+#[path = "repository_key_binding_tests.rs"]
+mod tests;

--- a/crates/repo/src/repository_key_binding_tests.rs
+++ b/crates/repo/src/repository_key_binding_tests.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::{TimeZone, Utc};
+use crypto::{Ed25519Signer, Signer, state_signature_from_signer};
+use objects::{
+    object::{
+        Attribution, ContentHash, KeyBinding, KeyBindingRegistry, Principal, State,
+        StateAttachment, StateAttachmentBody, StateSignature, Tree,
+    },
+    store::ObjectStore,
+};
+use tempfile::TempDir;
+
+use super::{AuthorshipVerification, Repository};
+
+fn setup() -> (TempDir, Repository, State) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    let tree = Tree::new();
+    let tree_hash = repo.store().put_tree(&tree).expect("put tree");
+    let mut state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    );
+    state.created_at = Utc.timestamp_opt(2_000, 0).unwrap();
+    repo.store().put_state(&state).expect("put state");
+    (temp, repo, state)
+}
+
+fn attach_signature(repo: &Repository, state: &State, signature: StateSignature) {
+    repo.put_state_attachment(&StateAttachment {
+        state_id: state.id(),
+        body: StateAttachmentBody::Signature(signature),
+        attribution: state.attribution.clone(),
+        created_at: state.created_at,
+        supersedes: None,
+    })
+    .expect("attach signature");
+}
+
+fn binding(signer: &Ed25519Signer, valid_from: i64, revoked_at: Option<i64>) -> KeyBinding {
+    let public_key = hex::encode(signer.public_key());
+    let mut binding = KeyBinding {
+        algorithm: signer.algorithm().to_string(),
+        public_key: public_key.clone(),
+        identity_ref: "identity:alice".to_string(),
+        role: "author".to_string(),
+        added_by_sig: StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key,
+            signature: String::new(),
+        },
+        valid_from: Utc.timestamp_opt(valid_from, 0).unwrap(),
+        revoked_at: revoked_at.map(|timestamp| Utc.timestamp_opt(timestamp, 0).unwrap()),
+        delegated_from: None,
+    };
+    binding.added_by_sig.signature = hex::encode(
+        signer
+            .sign(&binding.canonical_signing_payload())
+            .expect("sign binding"),
+    );
+    binding
+}
+
+fn delegated_binding(
+    signer: &Ed25519Signer,
+    root_signer: &Ed25519Signer,
+    root: &KeyBinding,
+) -> KeyBinding {
+    let mut binding = KeyBinding {
+        algorithm: signer.algorithm().to_string(),
+        public_key: hex::encode(signer.public_key()),
+        identity_ref: root.identity_ref.clone(),
+        role: "author".to_string(),
+        added_by_sig: StateSignature {
+            algorithm: root_signer.algorithm().to_string(),
+            public_key: hex::encode(root_signer.public_key()),
+            signature: String::new(),
+        },
+        valid_from: Utc.timestamp_opt(1_500, 0).unwrap(),
+        revoked_at: None,
+        delegated_from: Some(root.content_hash().expect("root hash")),
+    };
+    binding.added_by_sig.signature = hex::encode(
+        root_signer
+            .sign(&binding.canonical_signing_payload())
+            .expect("sign delegated binding"),
+    );
+    binding
+}
+
+fn signed_state(state: &State, signer: &Ed25519Signer) -> StateSignature {
+    state_signature_from_signer(&state.compute_hash(), signer).expect("sign state")
+}
+
+#[test]
+fn resolves_registered_active_key_as_verified_identity() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    attach_signature(&repo, &state, signed_state(&state, &signer));
+    let registry = KeyBindingRegistry::new(vec![binding(&signer, 1_000, None)]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Verified("identity:alice".to_string())
+    );
+}
+
+#[test]
+fn resolves_one_hop_identity_delegation() {
+    let (_temp, repo, state) = setup();
+    let root_signer = Ed25519Signer::generate().expect("root signer");
+    let state_signer = Ed25519Signer::generate().expect("state signer");
+    let root = binding(&root_signer, 1_000, None);
+    let delegated = delegated_binding(&state_signer, &root_signer, &root);
+    attach_signature(&repo, &state, signed_state(&state, &state_signer));
+    let registry = KeyBindingRegistry::new(vec![root, delegated]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Verified("identity:alice".to_string())
+    );
+}
+
+#[test]
+fn valid_signature_from_unregistered_key_is_unknown_not_verified() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    let other_signer = Ed25519Signer::generate().expect("registered signer");
+    attach_signature(&repo, &state, signed_state(&state, &signer));
+    let non_matching_registry = KeyBindingRegistry::new(vec![binding(&other_signer, 1_000, None)]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &non_matching_registry)
+            .unwrap(),
+        AuthorshipVerification::UnknownKey
+    );
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &KeyBindingRegistry::empty())
+            .unwrap(),
+        AuthorshipVerification::UnknownKey,
+        "an empty registry must also fail closed"
+    );
+}
+
+#[test]
+fn registered_key_past_revoked_at_is_revoked() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    attach_signature(&repo, &state, signed_state(&state, &signer));
+    let registry = KeyBindingRegistry::new(vec![binding(&signer, 1_000, Some(1_999))]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Revoked
+    );
+}
+
+#[test]
+fn registered_key_with_bad_state_signature_is_invalid() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    let mut signature = signed_state(&state, &signer);
+    let mut bytes = hex::decode(&signature.signature).expect("decode signature");
+    bytes[0] ^= 0xff;
+    signature.signature = hex::encode(bytes);
+    attach_signature(&repo, &state, signature);
+    let registry = KeyBindingRegistry::new(vec![binding(&signer, 1_000, None)]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Invalid
+    );
+}
+
+#[test]
+fn registered_key_before_valid_from_is_invalid() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    attach_signature(&repo, &state, signed_state(&state, &signer));
+    let registry = KeyBindingRegistry::new(vec![binding(&signer, 2_001, None)]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Invalid
+    );
+}
+
+#[test]
+fn invalid_binding_signature_makes_registry_invalid() {
+    let (_temp, repo, state) = setup();
+    let signer = Ed25519Signer::generate().expect("signer");
+    attach_signature(&repo, &state, signed_state(&state, &signer));
+    let mut invalid_binding = binding(&signer, 1_000, None);
+    invalid_binding.added_by_sig.signature = hex::encode([0; 64]);
+    let registry = KeyBindingRegistry::new(vec![invalid_binding]);
+
+    assert_eq!(
+        repo.verify_authored_by_known_actor(&state, &registry)
+            .unwrap(),
+        AuthorshipVerification::Invalid
+    );
+}
+
+#[test]
+fn registry_encoding_is_content_addressed() {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let registry = KeyBindingRegistry::new(vec![binding(&signer, 1_000, None)]);
+    let encoded = registry.encode().expect("encode registry");
+    let decoded = KeyBindingRegistry::decode(&encoded).expect("decode registry");
+
+    assert_eq!(decoded, registry);
+    assert_eq!(
+        decoded.content_hash().unwrap(),
+        registry.content_hash().unwrap()
+    );
+    assert_ne!(
+        registry.content_hash().unwrap(),
+        ContentHash::compute_typed("some-other-object", &encoded)
+    );
+}


### PR DESCRIPTION
## Summary

- add versioned, content-addressed `KeyBinding` and `KeyBindingRegistry` objects with domain-separated identity signatures, validity windows, roles, and one-hop content-hash delegation
- add offline registry authorization and `Repository::verify_authored_by_known_actor`, resolving only registered active signing keys
- fail closed for empty/non-matching registries and reject invalid registry signatures, bad state signatures, pre-valid states, and post-revocation states

## Closes

Closes #1256

## Test evidence

- `CARGO_TARGET_DIR=/home/scratch/h1256-target cargo build -p heddle-object-model -p heddle-repo` — passed
- `CARGO_TARGET_DIR=/home/scratch/h1256-target cargo build --workspace` — passed
- `CARGO_TARGET_DIR=/home/scratch/h1256-target cargo clippy -- -D warnings` — passed
- `CARGO_TARGET_DIR=/home/scratch/h1256-target cargo test -p heddle-repo repository_key_binding::tests -- --nocapture` — 8 passed, 0 failed
  - fail-closed negative control: `valid_signature_from_unregistered_key_is_unknown_not_verified ... ok`; it asserts `UnknownKey` for both a non-matching non-empty registry and an empty registry
- `CARGO_TARGET_DIR=/home/scratch/h1256-target cargo test -p heddle-object-model --quiet` — 213 passed, 0 failed
- full serial `heddle-repo` run — 634 passed, 0 failed, 2 ignored; repeated suite stress later exhausted inotify/file descriptors in four unrelated fsmonitor tests (`EMFILE`), whose focused serial rerun passed 10/10

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788820496&installation_model_id=21489&pr_number=1260&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1260&signature=5895f1d228eb84e2fde4c05511357dfc68ca7c2ab38b6ee91a2a8c701e3033bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->