### PR TITLE
feat(hosted): adopt heddle-api 0.3 streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2044,6 +2044,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "heddle-api"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722263983a39fca723f5263d5ec64604d8db468f4aa379d8c037c530ddcd7e4f"
+dependencies = [
+ "bytes",
+ "hex",
+ "prost 0.14.1",
+ "prost-build",
+ "prost-reflect",
+ "prost-types 0.14.1",
+ "protoc-bin-vendored",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "heddle-cli"
 version = "0.11.0"
 dependencies = [
@@ -2058,7 +2075,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "heddle-api",
+ "heddle-api 0.3.0",
  "heddle-cli-args",
  "heddle-cli-contract",
  "heddle-cli-render",
@@ -2128,7 +2145,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api",
+ "heddle-api 0.3.0",
  "heddle-cli-shared",
  "heddle-objects",
  "heddle-repo",
@@ -2246,7 +2263,7 @@ version = "0.11.0"
 dependencies = [
  "chrono",
  "futures",
- "heddle-api",
+ "heddle-api 0.3.0",
  "heddle-crypto",
  "heddle-objects",
  "heddle-oplog",
@@ -2348,7 +2365,7 @@ name = "heddle-iroh-transport-experiment"
 version = "0.11.0"
 dependencies = [
  "bytes",
- "heddle-api",
+ "heddle-api 0.2.1",
  "heddle-objects",
  "heddle-wire",
  "heddleco-iroh",

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.2.1" }
+api = { package = "heddle-api", version = "0.3.0" }
 clap.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.11" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,7 +42,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.11" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
-api = { package = "heddle-api", version = "0.2.1" }
+api = { package = "heddle-api", version = "0.3.0" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
 heddle-cli-args = { path = "../cli-args", version = "0.11", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.11", default-features = false }

--- a/crates/cli/examples/repo_events.rs
+++ b/crates/cli/examples/repo_events.rs
@@ -20,6 +20,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             thread: String::new(),
             after_event_id,
             event_types: Vec::new(),
+            thread_id: String::new(),
         })
         .await?;
     let event = events.next().await?;

--- a/crates/cli/src/cli/commands/clone.rs
+++ b/crates/cli/src/cli/commands/clone.rs
@@ -1618,7 +1618,7 @@ async fn clone_network_connected(
         PullMaterialization::Full
     };
     let mut folded_refs = None;
-    let folded = client
+    let (mut result, local_repo) = client
         .clone_pull_with_depth_and_materialization(
             repo_path,
             thread.as_deref(),
@@ -1650,46 +1650,8 @@ async fn clone_network_connected(
                 Ok(repo)
             },
         )
-        .await;
-    let (mut result, local_repo, remote_refs) = match folded {
-        Ok((result, local_repo)) => (
-            result,
-            local_repo,
-            folded_refs.context("folded clone response is missing its refs")?,
-        ),
-        Err(error) if folded_refs.is_none() && !local_path.join(".git").exists() => {
-            let remote_refs = client
-                .list_refs_with_revision_addresses(repo_path)
-                .await?
-                .into_iter()
-                .filter(|entry| entry.is_thread)
-                .collect::<Vec<_>>();
-            let track_name = select_hosted_clone_thread(
-                thread.as_deref(),
-                remote_refs.iter().map(|entry| entry.name.as_str()),
-                repo_path,
-            )?;
-            let local_repo =
-                initialize_hosted_clone_repository(local_path, &remote_refs, &track_name)?;
-            let result = client
-                .repair_clone_with_depth_and_materialization(
-                    &local_repo,
-                    repo_path,
-                    &track_name,
-                    depth,
-                    materialization,
-                )
-                .await
-                .map_err(|fallback| {
-                    let error = format!(
-                        "folded clone bootstrap failed ({error}); ListRefs fallback failed ({fallback})"
-                    );
-                    anyhow!(RecoveryAdvice::network_clone_failed(&error, local_path))
-                })?;
-            (result, local_repo, remote_refs)
-        }
-        Err(error) => return Err(error.into()),
-    };
+        .await?;
+    let remote_refs = folded_refs.context("folded clone response is missing its refs")?;
     let track_name = select_hosted_clone_thread(
         thread.as_deref(),
         remote_refs
@@ -1740,9 +1702,13 @@ async fn clone_network_connected(
 
         let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)
             .context("decode hosted clone bootstrap")?
-            .as_ref()
-            .map(|metadata| metadata.resolve(&local_repo, Some(final_state)))
-            .transpose()
+            .ok_or_else(|| {
+                anyhow!(RecoveryAdvice::network_clone_failed(
+                    "hosted response is missing required folded metadata",
+                    local_path,
+                ))
+            })?
+            .resolve(&local_repo, Some(final_state))
             .context("resolve hosted clone bootstrap")?;
 
         if lazy {
@@ -1766,9 +1732,7 @@ async fn clone_network_connected(
             &local_repo,
             client,
             repo_path,
-            bootstrap
-                .as_ref()
-                .map(|metadata| metadata.discussions.as_slice()),
+            Some(bootstrap.discussions.as_slice()),
         )
         .await
         {
@@ -1787,9 +1751,7 @@ async fn clone_network_connected(
             &local_repo,
             client,
             repo_path,
-            bootstrap
-                .as_ref()
-                .map(|metadata| metadata.context.as_slice()),
+            Some(bootstrap.context.as_slice()),
         )
         .await
         {
@@ -1981,16 +1943,18 @@ async fn recover_interrupted_clone_connected(
     }
     configure_hosted_clone_origin(&repo, &intent.endpoint, &intent.repository)?;
     let bootstrap = crate::hosted_runtime::hosted::decode_pull_bootstrap(&result.checkpoint)?
-        .as_ref()
-        .map(|metadata| metadata.resolve(&repo, Some(final_state)))
-        .transpose()?;
+        .ok_or_else(|| {
+            anyhow!(RecoveryAdvice::network_clone_failed(
+                "hosted response is missing required folded metadata",
+                root,
+            ))
+        })?
+        .resolve(&repo, Some(final_state))?;
     if let Err(error) = crate::client::discussion_sync::pull_discussions(
         &repo,
         client,
         &intent.repository,
-        bootstrap
-            .as_ref()
-            .map(|metadata| metadata.discussions.as_slice()),
+        Some(bootstrap.discussions.as_slice()),
     )
     .await
     {
@@ -2003,9 +1967,7 @@ async fn recover_interrupted_clone_connected(
         &repo,
         client,
         &intent.repository,
-        bootstrap
-            .as_ref()
-            .map(|metadata| metadata.context.as_slice()),
+        Some(bootstrap.context.as_slice()),
     )
     .await
     {
@@ -2844,6 +2806,7 @@ mod tests {
             state_id: objects::object::StateId::from_bytes([1; 32]),
             is_thread: true,
             revision_address: "git:5b2471720c93ee30e5764a19f3d3b3ae9ec9712a".to_string(),
+            thread_id: Some("thread-main".to_string()),
         }];
 
         let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")
@@ -2876,6 +2839,7 @@ mod tests {
             state_id: objects::object::StateId::from_bytes([2; 32]),
             is_thread: true,
             revision_address: "heddle:0123456789abcdef".to_string(),
+            thread_id: Some("thread-main".to_string()),
         }];
 
         let repo = initialize_hosted_clone_repository(&root, &remote_refs, "main")

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1054,9 +1054,15 @@ async fn pull_network_connected(
         .context("decode hosted pull bootstrap")?;
     let bootstrap = if result.success {
         bootstrap
-            .as_ref()
-            .map(|metadata| metadata.resolve(repo, result.final_state))
-            .transpose()
+            .ok_or_else(|| {
+                anyhow::anyhow!(RecoveryAdvice::remote_pull_failed(
+                    options.remote_thread,
+                    options.local_thread,
+                    "hosted response is missing required folded metadata",
+                ))
+            })?
+            .resolve(repo, result.final_state)
+            .map(Some)
             .context("resolve hosted pull bootstrap")?
     } else {
         None

--- a/crates/cli/src/client/context_sync.rs
+++ b/crates/cli/src/client/context_sync.rs
@@ -1071,12 +1071,12 @@ async fn list_server_targets(
     client: &mut HostedClient,
     repo_path: &str,
 ) -> Result<Vec<(ContextTarget, ContextAnnotation)>> {
-    let response = client
+    let (files, states) = client
         .list_context(repo_path, None, None, None)
         .await
         .context("list hosted context")?;
     let mut out = Vec::new();
-    for file in response.files {
+    for file in files {
         let Ok(target) = ContextTarget::file(&file.path) else {
             continue;
         };
@@ -1084,7 +1084,7 @@ async fn list_server_targets(
             out.push((target.clone(), annotation));
         }
     }
-    for state in response.states {
+    for state in states {
         let Some(state_id) = state_id_from_proto(state.state_id.as_ref()) else {
             continue;
         };
@@ -1108,7 +1108,6 @@ async fn fetch_history(
         .await
         .with_context(|| format!("fetch hosted annotation history {annotation_id}"))?;
     let mut revisions: Vec<AnnotationRevision> = history
-        .revisions
         .into_iter()
         .map(|revision| AnnotationRevision {
             revision_id: revision.revision_id,

--- a/crates/cli/src/client/repo_events_tests.rs
+++ b/crates/cli/src/client/repo_events_tests.rs
@@ -19,6 +19,7 @@ fn request() -> SubscribeRepoEventsRequest {
         thread: "main".to_string(),
         after_event_id: 40,
         event_types: vec!["ref.updated".to_string()],
+        thread_id: "thread-main".to_string(),
     }
 }
 

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -98,6 +98,18 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
         AgentAuthOperationDisposition::ReviewedSafe,
     ),
     (
+        "BindSignupInviteEmail",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "IssueSignupEmailChallenge",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    (
+        "ResolveSignupInvite",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
         "GetInvitationSummary",
         AgentAuthOperationDisposition::ReviewedSafe,
     ),

--- a/crates/cli/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/cli/src/hosted_runtime/hosted/collaboration.rs
@@ -19,6 +19,7 @@
 use api::heddle::api::v1alpha1::{
     AppendTurnRequest, Discussion as ProtoDiscussion, DiscussionStatusFilter,
     ListDiscussionsByStateRequest, OpenDiscussionRequest, PathSymbolRef, StateId as ProtoStateId,
+    list_discussions_response,
 };
 use objects::object::{ChangeId, StateId};
 use wire::ProtocolError;
@@ -118,6 +119,7 @@ impl HostedClient {
             visibility: visibility.to_string(),
             thread_ref: String::new(),
             client_operation_id,
+            thread_id: String::new(),
         };
         let response = self
             .routes()
@@ -158,21 +160,53 @@ impl HostedClient {
         change_id: ChangeId,
         status: &str,
     ) -> Result<Vec<HostedDiscussion>, ProtocolError> {
-        let request = ListDiscussionsByStateRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-            state_id: change_id_state_field(change_id),
-            status: discussion_status_filter(status)? as i32,
-        };
-        let response = self
-            .routes()
-            .list_discussions_by_state(&request)
-            .await
-            .map_err(hosted_to_protocol_error)?;
-        Ok(response
-            .discussions
-            .into_iter()
-            .map(decode_discussion)
-            .collect())
+        let status = discussion_status_filter(status)? as i32;
+        let mut discussions = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let request = ListDiscussionsByStateRequest {
+                repo_path: super::helpers::repository_ref(repo_path),
+                state_id: change_id_state_field(change_id),
+                status,
+                page_size: api::MAX_PAGE_SIZE,
+                page_token: page_token.clone(),
+            };
+            let mut stream = self
+                .routes()
+                .list_discussions_by_state(&request)
+                .await
+                .map_err(hosted_to_protocol_error)?;
+            let mut next_page_token = None;
+            while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
+                match response.frame {
+                    Some(list_discussions_response::Frame::Item(discussion)) => {
+                        discussions.push(decode_discussion(*discussion));
+                    }
+                    Some(list_discussions_response::Frame::PageEnd(page_end)) => {
+                        next_page_token = Some(page_end.next_page_token);
+                    }
+                    None => {
+                        return Err(ProtocolError::InvalidState(
+                            "ListByState emitted an empty frame".to_string(),
+                        ));
+                    }
+                }
+            }
+            let next_page_token = next_page_token.ok_or_else(|| {
+                ProtocolError::InvalidState(
+                    "ListByState ended without a terminal page frame".to_string(),
+                )
+            })?;
+            if next_page_token.is_empty() {
+                return Ok(discussions);
+            }
+            if next_page_token == page_token {
+                return Err(ProtocolError::InvalidState(
+                    "ListByState returned a repeated page token".to_string(),
+                ));
+            }
+            page_token = next_page_token;
+        }
     }
 }
 

--- a/crates/cli/src/hosted_runtime/hosted/content.rs
+++ b/crates/cli/src/hosted_runtime/hosted/content.rs
@@ -1,9 +1,10 @@
 use api::heddle::api::v1alpha1::{
-    AnnotationScope, CompareResponse, ContextAnnotationKind, GetBlameRequest, GetBlameResponse,
-    GetCompareRequest, GetContextHistoryRequest, GetContextHistoryResponse, ListContextRequest,
-    ListContextResponse, ListContextSuggestionsRequest, ListContextSuggestionsResponse,
+    AnnotatedFile, AnnotationScope, CompareResponse, ContextAnnotationKind, ContextRevision,
+    GetBlameRequest, GetBlameResponse, GetCompareRequest, GetContextHistoryRequest,
+    ListContextRequest, ListContextSuggestionsRequest, ListContextSuggestionsResponse,
     ReviseContextRequest, ReviseContextResponse, SetContextRequest, SetContextResponse,
-    SupersedeContextRequest, SupersedeContextResponse,
+    StateContextEntry, SupersedeContextRequest, SupersedeContextResponse,
+    get_context_history_response, list_context_response,
 };
 use wire::ProtocolError;
 
@@ -56,17 +57,48 @@ impl HostedClient {
         r#ref: Option<&str>,
         prefix: Option<&str>,
         tag_filter: Option<&str>,
-    ) -> Result<ListContextResponse, ProtocolError> {
-        let request = ListContextRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-            r#ref: r#ref.unwrap_or_default().to_string(),
-            prefix: prefix.map(str::to_string),
-            tag_filter: tag_filter.map(str::to_string),
-        };
-        self.routes()
-            .list_context(&request)
-            .await
-            .map_err(hosted_to_protocol_error)
+    ) -> Result<(Vec<AnnotatedFile>, Vec<StateContextEntry>), ProtocolError> {
+        let mut files = Vec::new();
+        let mut states = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let request = ListContextRequest {
+                repo_path: super::helpers::repository_ref(repo_path),
+                r#ref: r#ref.unwrap_or_default().to_string(),
+                prefix: prefix.map(str::to_string),
+                tag_filter: tag_filter.map(str::to_string),
+                page_size: api::MAX_PAGE_SIZE,
+                page_token: page_token.clone(),
+            };
+            let mut stream = self
+                .routes()
+                .list_context(&request)
+                .await
+                .map_err(hosted_to_protocol_error)?;
+            let mut next_page_token = None;
+            while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
+                if !response.states.is_empty() {
+                    states = response.states;
+                }
+                match response.frame {
+                    Some(list_context_response::Frame::Item(file)) => files.push(file),
+                    Some(list_context_response::Frame::PageEnd(page_end)) => {
+                        next_page_token = Some(page_end.next_page_token);
+                    }
+                    None => {
+                        return Err(ProtocolError::InvalidState(
+                            "ListContext emitted an empty frame".to_string(),
+                        ));
+                    }
+                }
+            }
+            let next_page_token = terminal_page_token("ListContext", next_page_token)?;
+            if next_page_token.is_empty() {
+                return Ok((files, states));
+            }
+            reject_repeated_page_token("ListContext", &page_token, &next_page_token)?;
+            page_token = next_page_token;
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -110,16 +142,45 @@ impl HostedClient {
         repo_path: &str,
         r#ref: Option<&str>,
         annotation_id: &str,
-    ) -> Result<GetContextHistoryResponse, ProtocolError> {
-        let request = GetContextHistoryRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-            r#ref: r#ref.unwrap_or_default().to_string(),
-            annotation_id: annotation_id.to_string(),
-        };
-        self.routes()
-            .get_context_history(&request)
-            .await
-            .map_err(hosted_to_protocol_error)
+    ) -> Result<Vec<ContextRevision>, ProtocolError> {
+        let mut revisions = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let request = GetContextHistoryRequest {
+                repo_path: super::helpers::repository_ref(repo_path),
+                r#ref: r#ref.unwrap_or_default().to_string(),
+                annotation_id: annotation_id.to_string(),
+                page_size: api::MAX_PAGE_SIZE,
+                page_token: page_token.clone(),
+            };
+            let mut stream = self
+                .routes()
+                .get_context_history(&request)
+                .await
+                .map_err(hosted_to_protocol_error)?;
+            let mut next_page_token = None;
+            while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
+                match response.frame {
+                    Some(get_context_history_response::Frame::Item(revision)) => {
+                        revisions.push(revision);
+                    }
+                    Some(get_context_history_response::Frame::PageEnd(page_end)) => {
+                        next_page_token = Some(page_end.next_page_token);
+                    }
+                    None => {
+                        return Err(ProtocolError::InvalidState(
+                            "GetContextHistory emitted an empty frame".to_string(),
+                        ));
+                    }
+                }
+            }
+            let next_page_token = terminal_page_token("GetContextHistory", next_page_token)?;
+            if next_page_token.is_empty() {
+                return Ok(revisions);
+            }
+            reject_repeated_page_token("GetContextHistory", &page_token, &next_page_token)?;
+            page_token = next_page_token;
+        }
     }
 
     pub async fn list_context_suggestions(
@@ -204,6 +265,25 @@ impl HostedClient {
             .await
             .map_err(hosted_to_protocol_error)
     }
+}
+
+fn terminal_page_token(method: &str, page_token: Option<String>) -> Result<String, ProtocolError> {
+    page_token.ok_or_else(|| {
+        ProtocolError::InvalidState(format!("{method} ended without a terminal page frame"))
+    })
+}
+
+fn reject_repeated_page_token(
+    method: &str,
+    current: &str,
+    next: &str,
+) -> Result<(), ProtocolError> {
+    if current == next {
+        return Err(ProtocolError::InvalidState(format!(
+            "{method} returned a repeated page token"
+        )));
+    }
+    Ok(())
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli/src/hosted_runtime/hosted/helpers.rs
+++ b/crates/cli/src/hosted_runtime/hosted/helpers.rs
@@ -372,7 +372,10 @@ fn remote_failure_detail(
             rule: value.rule,
             human_verification_can_override: value.human_verification_can_override,
         },
-        Some(Context::HumanVerification(_)) | None => wire::RemoteFailureDetail::Unknown {
+        Some(Context::HumanVerification(_))
+        | Some(Context::AmbiguousChangeId(_))
+        | Some(Context::Signup(_))
+        | None => wire::RemoteFailureDetail::Unknown {
             type_url: "type.googleapis.com/heddle.api.v1alpha1.ErrorDetail".to_string(),
             value: encoded,
         },

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -27,6 +27,20 @@ macro_rules! unary_method {
     };
 }
 
+macro_rules! server_stream_method {
+    ($name:ident, $service:literal, $rpc:literal, $request:ty, $response:ty) => {
+        pub async fn $name(&self, request: &$request) -> Result<ServerStream<$response>> {
+            self.client
+                .call_server_stream(
+                    concat!("/heddle.api.v1alpha1.", $service, "/", $rpc),
+                    request,
+                    "",
+                )
+                .await
+        }
+    };
+}
+
 impl HostedRoutes<'_> {
     unary_method!(
         begin_web_authn_authentication,
@@ -198,7 +212,7 @@ impl HostedRoutes<'_> {
         HostedRepository
     );
 
-    unary_method!(
+    server_stream_method!(
         list_refs,
         "RepoSyncService",
         "ListRefs",
@@ -234,14 +248,14 @@ impl HostedRoutes<'_> {
         GetCompareRequest,
         CompareResponse
     );
-    unary_method!(
+    server_stream_method!(
         get_context_history,
         "RepositoryService",
         "GetContextHistory",
         GetContextHistoryRequest,
         GetContextHistoryResponse
     );
-    unary_method!(
+    server_stream_method!(
         list_context,
         "RepositoryService",
         "ListContext",
@@ -298,6 +312,13 @@ impl HostedRoutes<'_> {
         GetThreadRequest,
         ThreadSummary
     );
+    server_stream_method!(
+        list_threads,
+        "WorkflowService",
+        "ListThreads",
+        ListThreadsRequest,
+        ListThreadsResponse
+    );
     unary_method!(
         list_thread_approvals,
         "WorkflowService",
@@ -327,7 +348,7 @@ impl HostedRoutes<'_> {
         AppendTurnRequest,
         Discussion
     );
-    unary_method!(
+    server_stream_method!(
         list_discussions_by_state,
         "CollaborationService",
         "ListByState",
@@ -412,7 +433,7 @@ mod tests {
     };
 
     #[test]
-    fn shipped_native_inventory_is_43_unary_two_server_streams_and_two_bidi() {
+    fn shipped_native_inventory_is_40_unary_seven_server_streams_and_two_bidi() {
         const ROUTES: &[MethodRoute] = &[
             MethodRoute::CollaborationServiceAppendTurn,
             MethodRoute::CollaborationServiceListByState,
@@ -459,7 +480,9 @@ mod tests {
             MethodRoute::StateReviewServiceSignState,
             MethodRoute::WorkflowServiceApproveThread,
             MethodRoute::WorkflowServiceCheckMergeEligibility,
+            MethodRoute::WorkflowServiceGetThread,
             MethodRoute::WorkflowServiceListThreadApprovals,
+            MethodRoute::WorkflowServiceListThreads,
             MethodRoute::WorkflowServiceRevokeApproval,
         ];
         let shipped = ALL_METHODS
@@ -471,20 +494,20 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(shipped.len(), 47);
+        assert_eq!(shipped.len(), 49);
         assert_eq!(
             shipped
                 .iter()
                 .filter(|method| method.streaming == StreamingShape::Unary)
                 .count(),
-            43
+            40
         );
         assert_eq!(
             shipped
                 .iter()
                 .filter(|method| method.streaming == StreamingShape::ServerStreaming)
                 .count(),
-            2
+            7
         );
         assert_eq!(
             shipped

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -27,6 +27,7 @@ mod state_review;
 mod sync;
 #[cfg(test)]
 mod test_https;
+mod thread_identity;
 mod thread_metadata;
 mod user;
 

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -19,8 +19,8 @@ use api::heddle::api::v1alpha1::{
     StateVisibilityTransfer, StreamOpeningProof, ThreadConfidenceSummary,
     ThreadFreshness as ProtoThreadFreshness, ThreadIntegrationPolicy, ThreadMetadata,
     ThreadMode as ProtoThreadMode, ThreadVerificationSummary, TransportMode, UpdateRefRequest,
-    WantObjects, git_lane_transfer, pull_client_frame, pull_server_frame, push_client_frame,
-    push_server_frame, thread_state::Kind as ProtoThreadState,
+    WantObjects, git_lane_transfer, list_refs_response, pull_client_frame, pull_server_frame,
+    push_client_frame, push_server_frame, thread_state::Kind as ProtoThreadState,
 };
 use objects::{
     Progress,
@@ -189,6 +189,7 @@ pub(crate) fn decode_pull_refs(
                 state_id,
                 is_thread,
                 revision_address,
+                thread_id: None,
             })
         })
         .collect::<Result<Vec<_>, ProtocolError>>()?;
@@ -364,6 +365,7 @@ pub struct HostedRefEntry {
     pub state_id: StateId,
     pub is_thread: bool,
     pub revision_address: String,
+    pub thread_id: Option<String>,
 }
 
 impl PullObjectMix {
@@ -476,28 +478,83 @@ impl HostedClient {
         &mut self,
         repo_path: &str,
     ) -> Result<Vec<HostedRefEntry>, ProtocolError> {
-        let request = ListRefsRequest {
-            repo_path: super::helpers::repository_ref(repo_path),
-        };
-        let response = self
-            .routes()
-            .list_refs(&request)
-            .await
-            .map_err(hosted_to_protocol_error)?;
-        response
-            .refs
-            .into_iter()
-            .map(|entry| {
-                Ok(HostedRefEntry {
-                    name: entry.name,
-                    state_id: super::helpers::parse_proto_state_id(entry.state_id)?.ok_or_else(
-                        || ProtocolError::InvalidState("ref is missing its state ID".to_string()),
-                    )?,
-                    is_thread: entry.is_thread,
-                    revision_address: entry.revision_address,
-                })
-            })
-            .collect()
+        let mut refs = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let request = ListRefsRequest {
+                repo_path: super::helpers::repository_ref(repo_path),
+                page_size: api::MAX_PAGE_SIZE,
+                page_token: page_token.clone(),
+            };
+            let mut stream = self
+                .routes()
+                .list_refs(&request)
+                .await
+                .map_err(hosted_to_protocol_error)?;
+            let mut next_page_token = None;
+            while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
+                match response.frame {
+                    Some(list_refs_response::Frame::Item(entry)) => {
+                        let thread_id = if entry.is_thread {
+                            if entry.thread_id.is_empty() {
+                                return Err(ProtocolError::InvalidState(format!(
+                                    "hosted thread ref '{}' is missing its stable identity",
+                                    entry.name
+                                )));
+                            }
+                            Some(entry.thread_id)
+                        } else {
+                            None
+                        };
+                        refs.push(HostedRefEntry {
+                            name: entry.name,
+                            state_id: super::helpers::parse_proto_state_id(entry.state_id)?
+                                .ok_or_else(|| {
+                                    ProtocolError::InvalidState(
+                                        "ref is missing its state ID".to_string(),
+                                    )
+                                })?,
+                            is_thread: entry.is_thread,
+                            revision_address: entry.revision_address,
+                            thread_id,
+                        });
+                    }
+                    Some(list_refs_response::Frame::PageEnd(page_end)) => {
+                        next_page_token = Some(page_end.next_page_token);
+                    }
+                    None => {
+                        return Err(ProtocolError::InvalidState(
+                            "ListRefs emitted an empty frame".to_string(),
+                        ));
+                    }
+                }
+            }
+            let next_page_token = next_page_token.ok_or_else(|| {
+                ProtocolError::InvalidState(
+                    "ListRefs ended without a terminal page frame".to_string(),
+                )
+            })?;
+            if next_page_token.is_empty() {
+                return Ok(refs);
+            }
+            if next_page_token == page_token {
+                return Err(ProtocolError::InvalidState(
+                    "ListRefs returned a repeated page token".to_string(),
+                ));
+            }
+            page_token = next_page_token;
+        }
+    }
+
+    async fn pull_thread_id(
+        &self,
+        repo_path: &str,
+        remote_thread: &str,
+    ) -> Result<String, ProtocolError> {
+        if remote_thread.starts_with(PULL_CLONE_BOOTSTRAP_THREAD_PREFIX) {
+            return Ok(String::new());
+        }
+        self.require_thread_id(repo_path, remote_thread).await
     }
 
     /// Fetch and validate the managed record for a pulled hosted thread.
@@ -511,6 +568,7 @@ impl HostedClient {
         let request = GetThreadRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             name: remote_thread.to_string(),
+            thread_id: self.require_thread_id(repo_path, remote_thread).await?,
         };
         let summary = match self.routes().get_thread(&request).await {
             Ok(summary) => summary,
@@ -550,6 +608,31 @@ impl HostedClient {
             "heddle.api.v1alpha1.RepoSyncService/UpdateRef",
             client_operation_id,
         )?;
+        let remote_refs = if is_thread || thread_metadata.is_some() {
+            Some(self.list_refs_with_revision_addresses(repo_path).await?)
+        } else {
+            None
+        };
+        let thread_id = if is_thread {
+            remote_refs
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .find(|entry| entry.is_thread && entry.name == name)
+                .and_then(|entry| entry.thread_id.clone())
+                .unwrap_or_default()
+        } else {
+            String::new()
+        };
+        let thread_metadata = thread_metadata
+            .map(|metadata| {
+                to_proto_thread_metadata(
+                    metadata,
+                    (!thread_id.is_empty()).then_some(thread_id.as_str()),
+                    remote_refs.as_deref().unwrap_or_default(),
+                )
+            })
+            .transpose()?;
         let request = UpdateRefRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             name: name.to_string(),
@@ -559,12 +642,13 @@ impl HostedClient {
                 .map(|value| value.to_string_full())
                 .unwrap_or_default(),
             new_value: new_value.to_string_full(),
-            thread_metadata: thread_metadata.map(to_proto_thread_metadata),
+            thread_metadata,
             old_revision_address: old_value
                 .map(|value| RevisionAddress::heddle(value).to_string())
                 .unwrap_or_default(),
             new_revision_address: RevisionAddress::heddle(new_value).to_string(),
             client_operation_id: operation_id.to_wire(),
+            thread_id,
         };
         let response = self
             .routes()
@@ -814,14 +898,19 @@ impl HostedClient {
             GitLaneTransferIntent::HeddleObjectsOnly
         };
         let remote_ref_discovery_started = std::time::Instant::now();
+        let remote_refs = self.list_refs_with_revision_addresses(repo_path).await?;
+        let remote_target = remote_refs
+            .iter()
+            .find(|entry| entry.is_thread && entry.name == target_thread);
+        let target_thread_id = remote_target
+            .and_then(|entry| entry.thread_id.clone())
+            .unwrap_or_default();
         let native_expected_remote_head = if git_lane.is_none() {
-            match expected_remote_head {
-                Some(expected) => Some(expected),
-                None => {
-                    let remote_refs = self.list_refs(repo_path).await?;
-                    Some(expected_remote_head_from_refs(&remote_refs, target_thread))
-                }
-            }
+            Some(expected_remote_head.unwrap_or_else(|| {
+                remote_target.map_or(ExpectedRemoteHead::Missing, |entry| {
+                    ExpectedRemoteHead::State(entry.state_id)
+                })
+            }))
         } else {
             None
         };
@@ -863,12 +952,21 @@ impl HostedClient {
             operation_id.as_str(),
         );
         let transport_mode = preferred_transport_mode(&self.transport, object_count);
-        let thread_metadata = load_thread_metadata(repo, target_thread, local_state)?;
+        let thread_metadata = load_thread_metadata(repo, target_thread, local_state)?
+            .as_ref()
+            .map(|metadata| {
+                to_proto_thread_metadata(
+                    metadata,
+                    (!target_thread_id.is_empty()).then_some(target_thread_id.as_str()),
+                    &remote_refs,
+                )
+            })
+            .transpose()?;
         let mut push_request = PushRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             local_state: super::helpers::proto_state_id(local_state),
             target_thread: target_thread.to_string(),
-            create_thread: true,
+            create_thread: target_thread_id.is_empty(),
             force,
             objects: full_objects.as_ref().map_or_else(
                 || {
@@ -889,10 +987,11 @@ impl HostedClient {
             )),
             partial_fetch_status: partial_fetch_status_for_repo(repo),
             allow_partial_fetch: true,
-            thread_metadata: thread_metadata.map(|metadata| to_proto_thread_metadata(&metadata)),
+            thread_metadata,
             local_revision_address,
             expected_remote_head: None,
             expected_remote_head_missing: false,
+            target_thread_id,
         };
         if let Some(expected) = native_expected_remote_head {
             apply_expected_remote_head(&mut push_request, expected);
@@ -1349,6 +1448,8 @@ impl HostedClient {
             repo_path: super::helpers::repository_ref(repo_path),
             r#ref: reference.to_string(),
             path: path.to_string(),
+            start_line: 0,
+            line_count: 0,
         };
         let response = self
             .routes()
@@ -1458,6 +1559,7 @@ impl HostedClient {
             options.target_state,
             uuid::Uuid::new_v4(),
         );
+        let remote_thread_id = self.pull_thread_id(repo_path, remote_thread).await?;
         let (provider_session, provider_capability_context) =
             self.begin_provider_pull(&transfer_id, repo_path)?;
         let request_message = PullClientFrame {
@@ -1490,6 +1592,7 @@ impl HostedClient {
                     .target_state
                     .map(|state| RevisionAddress::heddle(state).to_string())
                     .unwrap_or_default(),
+                remote_thread_id,
             })),
         };
 
@@ -2144,6 +2247,7 @@ fn native_push_boundaries(
     )
 }
 
+#[cfg(test)]
 fn expected_remote_head_from_refs(
     remote_refs: &[RefEntry],
     target_thread: &str,
@@ -2708,7 +2812,7 @@ mod pull_bootstrap_tests {
     use super::*;
 
     #[test]
-    fn bootstrap_decoder_accepts_structured_empty_metadata_and_old_server_falls_back() {
+    fn bootstrap_decoder_accepts_structured_empty_metadata() {
         let temp = TempDir::new().expect("temp repo");
         let repo = Repository::init_default(temp.path()).expect("init repo");
         std::fs::write(temp.path().join("README.md"), "bootstrap\n").expect("write fixture");
@@ -2744,12 +2848,6 @@ mod pull_bootstrap_tests {
                 .expect("read marker"),
             Some(snapshot.state_id)
         );
-        assert!(
-            decode_pull_bootstrap(b"heddle-markers-v1\n")
-                .expect("legacy checkpoint is valid")
-                .is_none(),
-            "an old server must retain the unary metadata fallback"
-        );
     }
 
     #[test]
@@ -2766,7 +2864,7 @@ mod pull_bootstrap_tests {
     }
 
     #[test]
-    fn folded_refs_decode_identically_and_old_server_selects_fallback() {
+    fn folded_refs_decode_identically() {
         let main = StateId::from_bytes([7; 32]);
         let release = StateId::from_bytes([8; 32]);
         let payload: PullRefsPayload = (
@@ -2804,12 +2902,6 @@ mod pull_bootstrap_tests {
         assert_eq!(decoded.refs[1].name, "release");
         assert_eq!(decoded.refs[1].state_id, release);
         assert!(!decoded.refs[1].is_thread);
-        assert!(
-            decode_pull_refs(b"heddle-markers-v1\n")
-                .expect("old-server checkpoint remains valid")
-                .is_none(),
-            "absence of folded refs must select the standalone ListRefs fallback"
-        );
     }
 
     #[test]
@@ -2901,8 +2993,32 @@ fn state_id_string_to_bytes(s: &str) -> Vec<u8> {
         .unwrap_or_default()
 }
 
-fn to_proto_thread_metadata(metadata: &SyncedThreadMetadata) -> ThreadMetadata {
-    ThreadMetadata {
+fn hosted_thread_id(
+    remote_refs: &[HostedRefEntry],
+    thread_name: &str,
+) -> Result<String, ProtocolError> {
+    remote_refs
+        .iter()
+        .find(|entry| entry.is_thread && entry.name == thread_name)
+        .and_then(|entry| entry.thread_id.clone())
+        .ok_or_else(|| ProtocolError::ObjectNotFound(format!("hosted thread '{thread_name}'")))
+}
+
+fn related_thread_id(
+    remote_refs: &[HostedRefEntry],
+    thread_name: Option<&String>,
+) -> Result<Option<String>, ProtocolError> {
+    thread_name
+        .map(|name| hosted_thread_id(remote_refs, name))
+        .transpose()
+}
+
+fn to_proto_thread_metadata(
+    metadata: &SyncedThreadMetadata,
+    thread_id: Option<&str>,
+    remote_refs: &[HostedRefEntry],
+) -> Result<ThreadMetadata, ProtocolError> {
+    Ok(ThreadMetadata {
         name: metadata.thread.clone(),
         target_thread: metadata.target_thread.clone(),
         parent_thread: metadata.parent_thread.clone(),
@@ -2989,7 +3105,10 @@ fn to_proto_thread_metadata(metadata: &SyncedThreadMetadata) -> ThreadMetadata {
             seconds: metadata.updated_at.timestamp(),
             nanos: metadata.updated_at.timestamp_subsec_nanos() as i32,
         }),
-    }
+        thread_id: thread_id.unwrap_or_default().to_string(),
+        target_thread_id: related_thread_id(remote_refs, metadata.target_thread.as_ref())?,
+        parent_thread_id: related_thread_id(remote_refs, metadata.parent_thread.as_ref())?,
+    })
 }
 
 struct PullExchange {

--- a/crates/cli/src/hosted_runtime/hosted/thread_identity.rs
+++ b/crates/cli/src/hosted_runtime/hosted/thread_identity.rs
@@ -1,0 +1,79 @@
+use api::heddle::api::v1alpha1::{ListThreadsRequest, ThreadOrder, list_threads_response::Frame};
+use wire::ProtocolError;
+
+use super::{HostedClient, helpers::hosted_to_protocol_error};
+
+impl HostedClient {
+    pub(super) async fn require_thread_id(
+        &self,
+        repo_path: &str,
+        thread_name: &str,
+    ) -> Result<String, ProtocolError> {
+        let mut page_token = String::new();
+        loop {
+            let request = ListThreadsRequest {
+                repo_path: super::helpers::repository_ref(repo_path),
+                page_size: api::MAX_PAGE_SIZE,
+                page_token: page_token.clone(),
+                states: Vec::new(),
+                query: thread_name.to_string(),
+                order: ThreadOrder::NameAsc as i32,
+            };
+            let mut stream = self
+                .routes()
+                .list_threads(&request)
+                .await
+                .map_err(hosted_to_protocol_error)?;
+            let mut found = None;
+            let mut next_page_token = None;
+            while let Some(response) = stream.next().await.map_err(hosted_to_protocol_error)? {
+                match response.frame {
+                    Some(Frame::Item(item)) if item.name == thread_name => {
+                        if item.thread_id.is_empty() {
+                            return Err(ProtocolError::InvalidState(format!(
+                                "hosted thread '{thread_name}' is missing its stable identity"
+                            )));
+                        }
+                        match found.as_deref() {
+                            Some(existing) if existing != item.thread_id => {
+                                return Err(ProtocolError::InvalidState(format!(
+                                    "hosted thread name '{thread_name}' resolves to multiple identities"
+                                )));
+                            }
+                            None => found = Some(item.thread_id),
+                            _ => {}
+                        }
+                    }
+                    Some(Frame::Item(_)) => {}
+                    Some(Frame::PageEnd(page_end)) => {
+                        next_page_token = Some(page_end.next_page_token);
+                    }
+                    None => {
+                        return Err(ProtocolError::InvalidState(
+                            "ListThreads emitted an empty frame".to_string(),
+                        ));
+                    }
+                }
+            }
+            let next_page_token = next_page_token.ok_or_else(|| {
+                ProtocolError::InvalidState(
+                    "ListThreads ended without a terminal page frame".to_string(),
+                )
+            })?;
+            if let Some(thread_id) = found {
+                return Ok(thread_id);
+            }
+            if next_page_token.is_empty() {
+                return Err(ProtocolError::ObjectNotFound(format!(
+                    "hosted thread '{thread_name}'"
+                )));
+            }
+            if next_page_token == page_token {
+                return Err(ProtocolError::InvalidState(
+                    "ListThreads returned a repeated page token".to_string(),
+                ));
+            }
+            page_token = next_page_token;
+        }
+    }
+}

--- a/crates/cli/src/hosted_runtime/hosted/user.rs
+++ b/crates/cli/src/hosted_runtime/hosted/user.rs
@@ -413,6 +413,8 @@ impl HostedClient {
             "heddle.api.v1alpha1.WorkflowService/ApproveThread",
             client_operation_id,
         );
+        let source_thread_id = self.require_thread_id(repo_path, source_thread).await?;
+        let target_thread_id = self.require_thread_id(repo_path, target_thread).await?;
         Ok(workflow_call!(
             self,
             approve_thread,
@@ -426,6 +428,8 @@ impl HostedClient {
                     .and_then(super::helpers::proto_state_id),
                 note: note.unwrap_or_default().to_string(),
                 client_operation_id: operation_id.to_wire(),
+                source_thread_id,
+                target_thread_id,
             }
         ))
     }
@@ -457,6 +461,8 @@ impl HostedClient {
         source_thread: &str,
         target_thread: &str,
     ) -> Result<Vec<ThreadApproval>, ProtocolError> {
+        let source_thread_id = self.require_thread_id(repo_path, source_thread).await?;
+        let target_thread_id = self.require_thread_id(repo_path, target_thread).await?;
         Ok(workflow_call!(
             self,
             list_thread_approvals,
@@ -465,6 +471,8 @@ impl HostedClient {
                 repo_path: super::helpers::repository_ref(repo_path),
                 source_thread: source_thread.to_string(),
                 target_thread: target_thread.to_string(),
+                source_thread_id,
+                target_thread_id,
             }
         )
         .approvals)
@@ -485,6 +493,8 @@ impl HostedClient {
         changed_paths: Vec<String>,
         author_user_id: Option<&str>,
     ) -> Result<CheckMergeEligibilityResponse, ProtocolError> {
+        let source_thread_id = self.require_thread_id(repo_path, source_thread).await?;
+        let target_thread_id = self.require_thread_id(repo_path, target_thread).await?;
         Ok(workflow_call!(
             self,
             check_merge_eligibility,
@@ -499,6 +509,8 @@ impl HostedClient {
                 gated_action: gated_action.to_string(),
                 changed_paths,
                 author_user_id: author_user_id.unwrap_or_default().to_string(),
+                source_thread_id,
+                target_thread_id,
             }
         ))
     }

--- a/crates/cli/tests/cli_integration/clone_output_contract.rs
+++ b/crates/cli/tests/cli_integration/clone_output_contract.rs
@@ -17,7 +17,7 @@ mod fixture {
 
     use api::{
         HOSTED_ALPN_V1,
-        framing::{decode_request_prelude, encode_failure_response},
+        framing::{decode_request_prelude, encode_stream_failure},
         heddle::api::v1alpha1::{
             CallFailure, CallFailureCode, EndpointDescriptor, SignedEndpointDescriptor,
         },
@@ -51,6 +51,8 @@ mod fixture {
         )]));
         let certificate = temp.path().join("descriptor-ca.pem");
         std::fs::write(&certificate, &https.certificate_pem).expect("write descriptor test CA");
+        let credential = temp.path().join("clone-test.hcred");
+        write_test_credential(&credential, &https.authority);
         let destination = temp.path().join("clone");
         let remote = format!("heddle://{}/owner/repo", https.authority);
         let descriptor_public_key = hex::encode(signer.public_key());
@@ -76,6 +78,10 @@ mod fixture {
                     &descriptor_public_key,
                 ),
                 ("HEDDLE_HOME", heddle_home.to_str().expect("UTF-8 home")),
+                (
+                    "HEDDLE_CREDENTIAL",
+                    credential.to_str().expect("UTF-8 credential path"),
+                ),
             ],
         )
         .expect("invoke clone against disconnecting fixture");
@@ -87,7 +93,13 @@ mod fixture {
             String::from_utf8_lossy(&output.stdout),
             String::from_utf8_lossy(&output.stderr)
         );
-        assert_eq!(output.status.code(), Some(75));
+        assert_eq!(
+            output.status.code(),
+            Some(75),
+            "stdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         let records = String::from_utf8(output.stdout).expect("clone stdout is UTF-8");
         let records = records
             .lines()
@@ -264,7 +276,7 @@ mod fixture {
                         "an authenticated clone must start with folded Pull, not ListRefs"
                     );
                 }
-                let failure = encode_failure_response(&CallFailure {
+                let failure = encode_stream_failure(&CallFailure {
                     code: CallFailureCode::Unavailable as i32,
                     message: "Broken pipe".to_string(),
                     error: None,

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -13,7 +13,7 @@ categories.workspace = true
 chrono.workspace = true
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
 futures.workspace = true
-api = { package = "heddle-api", version = "0.2.1" }
+api = { package = "heddle-api", version = "0.3.0" }
 hex.workspace = true
 libc.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.11" }

--- a/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
+++ b/crates/devtools/src/check_ref_write_chokepoint/exemptions.rs
@@ -10,6 +10,7 @@ pub(super) fn path_key(path: &Path) -> &str {
         "repo/src/repository_thread_materialize.rs",
         "cli/src/cli/commands/undo_apply/mod.rs",
         "cli/src/cli/commands/start_atomic.rs",
+        "cli/src/cli/commands/clone.rs",
         "cli/src/cli/commands/git_projection_io.rs",
         "git-projection/src/git_core.rs",
     ];
@@ -51,6 +52,8 @@ pub(super) fn budget(path: &Path, function: &str, method: &str) -> usize {
         ("cli/src/cli/commands/undo_apply/mod.rs", "apply", "set_undo_recovery") => 2,
         ("cli/src/cli/commands/undo_apply/mod.rs", "apply", "clear_undo_recovery") => 1,
         ("cli/src/cli/commands/start_atomic.rs", "stage_ref", "set_thread_cas") => 2,
+        ("cli/src/cli/commands/clone.rs", "clone_network_connected", "write_head") => 2,
+        ("cli/src/cli/commands/clone.rs", "recover_interrupted_clone_connected", "write_head") => 2,
         (
             "cli/src/cli/commands/git_projection_io.rs",
             "materialize_imported_attached_thread",


### PR DESCRIPTION
## Summary
- clean 0.3.0 cutover for the CLI and daemon dependency set
- replace ListRefs, ListContext, GetContextHistory, ListByState, and ListThreads unary routes with cursor-aware server streams
- resolve slim ThreadListItem records to stable thread IDs and use GetThread for detail
- require 0.3 folded clone and pull metadata and remove the old ListRefs and metadata fallback paths
- populate new stable identity, range, error-detail, and device-flow policy fields introduced across the nine-version jump

## Closes
Closes #1253

## Evidence
- no unary or streamed compatibility paths remain for the five migrated RPCs
- clone and pull require the 0.3 folded response contract; no old-server fallback remains
- `TMPDIR=/home/scratch cargo build --workspace` passed
- `TMPDIR=/home/scratch cargo clippy --workspace --all-targets -- -D warnings` passed
- clean-harness `RUST_TEST_THREADS=1 TMPDIR=/home/scratch cargo test --workspace` passed, including workspace doc tests
- `TMPDIR=/home/scratch bash scripts/check-default-cli-contracts.sh` passed
- all four CI reduced-feature cargo check lanes passed
- telemetry build, clippy with `-D warnings`, and tests passed
- live hosted fixture tests remain ignored because this environment has no live hosted service; no database-only lane was required by the touched scope

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788829595&installation_model_id=21489&pr_number=1261&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1261&signature=f334d87582e78c821c2868cbd34df8aa5ec88fd133f3b169b76c96b957271dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->