### PR TITLE
fix(crypto): domain-tag State signatures

### DIFF
--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -32,6 +32,15 @@ pub trait Signer: Send + Sync {
     fn verify(&self, data: &[u8], signature: &[u8]) -> Result<(), SignerError>;
 }
 
+const STATE_SIGNATURE_DOMAIN: &[u8; 16] = b"hd-state-sig-v1\x00";
+
+fn state_signature_payload(content_hash: &ContentHash) -> [u8; 48] {
+    let mut payload = [0; 48];
+    payload[..STATE_SIGNATURE_DOMAIN.len()].copy_from_slice(STATE_SIGNATURE_DOMAIN);
+    payload[STATE_SIGNATURE_DOMAIN.len()..].copy_from_slice(content_hash.as_bytes());
+    payload
+}
+
 /// Load a signer from a key file. When `algorithm` is `None`, the PEM
 /// header (or raw-seed shape) selects the backend via
 /// [`pem_loader::load_signer_from_pem`].
@@ -89,7 +98,12 @@ pub fn verify_state_signature(
     public_key: &[u8],
     signature: &[u8],
 ) -> Result<(), SignerError> {
-    verify_payload_signature(content_hash.as_bytes(), algorithm, public_key, signature)
+    verify_payload_signature(
+        &state_signature_payload(content_hash),
+        algorithm,
+        public_key,
+        signature,
+    )
 }
 
 /// Verify a detached signature over an arbitrary payload. Used by

--- a/crates/crypto/src/state_signature.rs
+++ b/crates/crypto/src/state_signature.rs
@@ -3,7 +3,7 @@
 
 use objects::object::{ContentHash, StateSignature};
 
-use crate::{Signer, SignerError, verify_state_signature};
+use crate::{Signer, SignerError, state_signature_payload, verify_state_signature};
 
 /// Error type for state signature operations.
 #[derive(Debug, thiserror::Error)]
@@ -24,7 +24,7 @@ pub fn state_signature_from_signer(
     hash: &ContentHash,
     signer: &dyn Signer,
 ) -> Result<StateSignature, StateSignatureError> {
-    let signature = signer.sign(hash.as_bytes())?;
+    let signature = signer.sign(&state_signature_payload(hash))?;
 
     Ok(StateSignature {
         algorithm: signer.algorithm().to_string(),
@@ -70,5 +70,25 @@ mod tests {
         assert_eq!(sig.algorithm(), "ed25519");
 
         verify_state_signature_bytes(&sig, &hash).expect("verify should not error");
+
+        let signature = signature_bytes(&sig).expect("decode tagged signature");
+        signer
+            .verify(&state_signature_payload(&hash), &signature)
+            .expect("signature covers the canonical domain-tagged payload");
+    }
+
+    #[test]
+    fn untagged_signature_is_rejected() {
+        let signer = Ed25519Signer::generate().expect("generate key");
+        let hash = make_test_hash();
+        let signature = signer.sign(hash.as_bytes()).expect("sign bare hash");
+        let untagged = StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(signature),
+        };
+
+        verify_state_signature_bytes(&untagged, &hash)
+            .expect_err("an untagged signature must fail verification");
     }
 }

--- a/crates/object-model/src/object/state_core.rs
+++ b/crates/object-model/src/object/state_core.rs
@@ -82,6 +82,7 @@ impl StateSignature {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SignatureStatus {
     Valid,
+    Legacy,
     Invalid,
     Unsigned,
 }
@@ -93,6 +94,10 @@ impl SignatureStatus {
 
     pub fn is_unsigned(self) -> bool {
         self == SignatureStatus::Unsigned
+    }
+
+    pub fn is_legacy(self) -> bool {
+        self == SignatureStatus::Legacy
     }
 }
 
@@ -567,6 +572,11 @@ impl State {
             }
 
             len += 1;
+            if let Some(segment_id) = &agent.segment_id {
+                len += segment_id.len() as u64 + 1;
+            }
+
+            len += 1;
             if let Some(policy_id) = &agent.policy_id {
                 len += policy_id.len() as u64 + 1;
             }
@@ -960,6 +970,30 @@ mod tests {
             .with_timestamp(timestamp);
 
         assert_ne!(state_a.compute_hash(), state_b.compute_hash());
+    }
+
+    #[test]
+    fn agent_segment_is_included_in_state_hash_length_prefix() {
+        let state = State::new_snapshot(
+            ContentHash::compute(b"tree"),
+            vec![],
+            Attribution::with_agent(
+                Principal::new("Alice", "alice@example.com"),
+                crate::object::Agent::new("openai", "gpt-5").with_session("sess-1", "segment-1"),
+            ),
+        );
+        let segment_len = "segment-1".len() as u64 + 2;
+        let missing_segment_len_hash = ContentHash::compute_typed_with_len(
+            "state",
+            state.hash_len() - segment_len,
+            |hasher| state.update_hash(hasher),
+        );
+
+        assert_ne!(
+            state.compute_hash(),
+            missing_segment_len_hash,
+            "segment_id's option tag, bytes, and terminator must affect the typed length prefix",
+        );
     }
 
     fn sample_state() -> State {

--- a/crates/repo/src/identity.rs
+++ b/crates/repo/src/identity.rs
@@ -249,6 +249,13 @@ pub fn load_local_signer(local_path: &Path) -> Option<Box<dyn Signer>> {
     signer_from_pem(&local.private_key_pem).ok()
 }
 
+/// Load the global device signing key at `path` without falling back to or
+/// minting a local identity.
+pub fn load_device_signer(device_path: &Path) -> Option<Box<dyn Signer>> {
+    let device = load_device(device_path).ok().flatten()?;
+    signer_from_pem(&device.private_key_pem).ok()
+}
+
 /// Load the per-repo local identity at `path`, minting and persisting a fresh
 /// ed25519 key if the file is absent.
 pub fn load_or_mint_local(path: &Path) -> std::io::Result<LocalIdentity> {

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -516,6 +516,10 @@ impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> RepositoryLockExt for Repos
 }
 
 impl<R: RefBackend, O: OpLogBackend, S: ObjectStore> Repository<R, O, S> {
+    pub fn heddle_dir(&self) -> &Path {
+        &self.heddle_dir
+    }
+
     /// Expert-only constructor for callers that already own the repository's
     /// component backends and invariant state.
     ///
@@ -1302,10 +1306,6 @@ impl Repository {
 
     pub fn root(&self) -> &Path {
         &self.root
-    }
-
-    pub fn heddle_dir(&self) -> &Path {
-        &self.heddle_dir
     }
 
     /// Root whose directory name should be used for managed thread checkout

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -4,8 +4,8 @@
 use std::sync::Arc;
 
 use crypto::{
-    Signer, load_signer, state_signature_from_signer, verify_payload_signature,
-    verify_state_signature_bytes,
+    Signer, load_signer, public_key_bytes, signature_bytes, state_signature_from_signer,
+    verify_payload_signature, verify_state_signature_bytes,
 };
 use objects::{
     object::{
@@ -13,9 +13,74 @@ use objects::{
     },
     store::ObjectStore,
 };
+use oplog::OpLogBackend;
+use refs::RefBackend;
 use tracing::{debug, instrument};
 
 use super::{HeddleError, Repository, Result};
+
+impl<R, O, S> Repository<R, O, S>
+where
+    R: RefBackend,
+    O: OpLogBackend,
+    S: ObjectStore,
+{
+    /// Re-sign a legacy state signature when its private key is still owned by
+    /// this device or repository. The legacy attachment remains as immutable
+    /// evidence; migration appends a domain-tagged signature.
+    pub(crate) fn resign_if_owned(&self, state: &State) -> Result<bool> {
+        let hash = state.compute_hash();
+        let signatures: Vec<_> = self
+            .list_state_attachments(&state.id())?
+            .into_iter()
+            .filter_map(|attachment| match attachment.body {
+                StateAttachmentBody::Signature(signature) => Some(signature),
+                _ => None,
+            })
+            .collect();
+        if signatures
+            .iter()
+            .any(|signature| verify_state_signature_bytes(signature, &hash).is_ok())
+        {
+            return Ok(false);
+        }
+
+        for signature in signatures {
+            if !legacy_signature_verifies(&signature, &hash) {
+                continue;
+            }
+            let Some(signer) = self.owning_signer_for(&signature) else {
+                continue;
+            };
+            let replacement =
+                state_signature_from_signer(&hash, signer.as_ref()).map_err(|error| {
+                    HeddleError::Conflict(format!("failed to re-sign state: {error}"))
+                })?;
+            self.put_state_attachment(&StateAttachment {
+                state_id: state.id(),
+                body: StateAttachmentBody::Signature(replacement),
+                attribution: state.attribution.clone(),
+                created_at: chrono::Utc::now(),
+                supersedes: None,
+            })?;
+            debug!(state_id = %state.id().short(), "Re-signed owned legacy state signature");
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    fn owning_signer_for(&self, signature: &StateSignature) -> Option<Box<dyn Signer>> {
+        let device_path = crate::identity::device_identity_path();
+        if let Some(signer) = crate::identity::load_device_signer(&device_path)
+            && signer_matches_signature(signer.as_ref(), signature)
+        {
+            return Some(signer);
+        }
+        let local_path = self.heddle_dir().join(crate::identity::LOCAL_IDENTITY_FILE);
+        let signer = crate::identity::load_local_signer(&local_path)?;
+        signer_matches_signature(signer.as_ref(), signature).then_some(signer)
+    }
+}
 
 impl Repository {
     /// Path to this repo's per-repo local signing identity (heddle#482).
@@ -205,6 +270,7 @@ impl Repository {
     ///
     /// Returns the signature status:
     /// - `SignatureStatus::Valid` if the signature is valid
+    /// - `SignatureStatus::Legacy` if only pre-domain-tag signatures verify
     /// - `SignatureStatus::Invalid` if the signature is invalid
     /// - `SignatureStatus::Unsigned` if the state has no signature
     ///
@@ -232,17 +298,9 @@ impl Repository {
             debug!("State has no signature");
             return Ok(SignatureStatus::Unsigned);
         }
-        let hash = state.compute_hash();
-        if signatures
-            .iter()
-            .any(|signature| verify_state_signature_bytes(signature, &hash).is_ok())
-        {
-            debug!("At least one state signature is valid");
-            Ok(SignatureStatus::Valid)
-        } else {
-            debug!("No state signature verifies");
-            Ok(SignatureStatus::Invalid)
-        }
+        let status = classify_state_signatures(&signatures, &state.compute_hash());
+        debug!(?status, "Classified state signatures");
+        Ok(status)
     }
 
     /// Get the signature of a state.
@@ -265,6 +323,51 @@ impl Repository {
                 _ => None,
             })
             .find(|signature| verify_state_signature_bytes(signature, &hash).is_ok()))
+    }
+}
+
+fn signer_matches_signature(signer: &dyn Signer, signature: &StateSignature) -> bool {
+    signer
+        .algorithm()
+        .eq_ignore_ascii_case(&signature.algorithm)
+        && hex::encode(signer.public_key()).eq_ignore_ascii_case(&signature.public_key)
+}
+
+fn legacy_signature_verifies(
+    signature: &StateSignature,
+    hash: &objects::object::ContentHash,
+) -> bool {
+    let Ok(public_key) = public_key_bytes(signature) else {
+        return false;
+    };
+    let Ok(signature_bytes) = signature_bytes(signature) else {
+        return false;
+    };
+    verify_payload_signature(
+        hash.as_bytes(),
+        &signature.algorithm,
+        &public_key,
+        &signature_bytes,
+    )
+    .is_ok()
+}
+
+fn classify_state_signatures(
+    signatures: &[StateSignature],
+    hash: &objects::object::ContentHash,
+) -> SignatureStatus {
+    if signatures
+        .iter()
+        .any(|signature| verify_state_signature_bytes(signature, hash).is_ok())
+    {
+        SignatureStatus::Valid
+    } else if signatures
+        .iter()
+        .any(|signature| legacy_signature_verifies(signature, hash))
+    {
+        SignatureStatus::Legacy
+    } else {
+        SignatureStatus::Invalid
     }
 }
 
@@ -420,6 +523,150 @@ mod tests {
             .expect("read signature")
             .expect("state is signed")
             .public_key
+    }
+
+    fn untagged_signature(state: &State, signer: &dyn Signer) -> StateSignature {
+        StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            signature: hex::encode(
+                signer
+                    .sign(state.compute_hash().as_bytes())
+                    .expect("sign legacy bare hash"),
+            ),
+        }
+    }
+
+    fn attach_signature(repo: &Repository, state: &State, signature: StateSignature) {
+        repo.put_state_attachment(&StateAttachment {
+            state_id: state.id(),
+            body: StateAttachmentBody::Signature(signature),
+            attribution: state.attribution.clone(),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach signature");
+    }
+
+    fn write_context_attachment(repo: &Repository, state: &State) {
+        repo.put_state_attachment(&StateAttachment {
+            state_id: state.id(),
+            body: StateAttachmentBody::Context(objects::object::ContentHash::compute(b"context")),
+            attribution: state.attribution.clone(),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .expect("write context attachment");
+    }
+
+    #[test]
+    fn foreign_untagged_signature_is_classified_legacy() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (_temp, repo) = setup_repo();
+            let state_id = create_test_state(&repo);
+            let state = repo
+                .store()
+                .get_state(&state_id)
+                .expect("get state")
+                .expect("state exists");
+            let foreign = Ed25519Signer::generate().expect("foreign signer");
+            attach_signature(&repo, &state, untagged_signature(&state, &foreign));
+
+            assert_eq!(
+                repo.verify_state_signature(&state_id).expect("verify"),
+                SignatureStatus::Legacy,
+            );
+
+            write_context_attachment(&repo, &state);
+            assert_eq!(
+                repo.verify_state_signature(&state_id).expect("verify"),
+                SignatureStatus::Legacy,
+                "a foreign legacy signature must not be laundered with a local key",
+            );
+        });
+    }
+
+    #[test]
+    fn next_write_resigns_legacy_local_signature_after_device_link() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (_temp, repo) = setup_repo();
+            let state_id = create_test_state(&repo);
+            let state = repo
+                .store()
+                .get_state(&state_id)
+                .expect("get state")
+                .expect("state exists");
+            let local = repo.signing_signer().expect("local signer");
+            let local_public_key = hex::encode(local.public_key());
+            attach_signature(&repo, &state, untagged_signature(&state, local.as_ref()));
+            assert_eq!(
+                repo.verify_state_signature(&state_id).expect("verify"),
+                SignatureStatus::Legacy,
+            );
+
+            let device = Ed25519Signer::generate().expect("device signer");
+            crate::identity::link_device_key(
+                device.public_key(),
+                &device.to_pem().expect("device pem"),
+                "api.example",
+            )
+            .expect("link device key");
+            assert_ne!(hex::encode(device.public_key()), local_public_key);
+
+            write_context_attachment(&repo, &state);
+
+            assert_eq!(
+                repo.verify_state_signature(&state_id).expect("verify"),
+                SignatureStatus::Valid,
+            );
+            let tagged = repo
+                .get_state_signature(&state_id)
+                .expect("get signature")
+                .expect("tagged signature");
+            assert_eq!(
+                tagged.public_key, local_public_key,
+                "migration must use the original owning local key",
+            );
+        });
+    }
+
+    #[test]
+    fn next_write_resigns_legacy_device_signature() {
+        let home = TempDir::new().expect("home temp");
+        with_signing_home(home.path(), || {
+            let (_temp, repo) = setup_repo();
+            let state_id = create_test_state(&repo);
+            let state = repo
+                .store()
+                .get_state(&state_id)
+                .expect("get state")
+                .expect("state exists");
+            let device = Ed25519Signer::generate().expect("device signer");
+            let device_public_key = hex::encode(device.public_key());
+            crate::identity::link_device_key(
+                device.public_key(),
+                &device.to_pem().expect("device pem"),
+                "api.example",
+            )
+            .expect("link device key");
+            attach_signature(&repo, &state, untagged_signature(&state, &device));
+
+            write_context_attachment(&repo, &state);
+
+            assert_eq!(
+                repo.verify_state_signature(&state_id).expect("verify"),
+                SignatureStatus::Valid,
+            );
+            assert_eq!(
+                repo.get_state_signature(&state_id)
+                    .expect("get signature")
+                    .expect("tagged signature")
+                    .public_key,
+                device_public_key,
+            );
+        });
     }
 
     #[test]

--- a/crates/repo/src/state_attachments.rs
+++ b/crates/repo/src/state_attachments.rs
@@ -53,6 +53,13 @@ where
                 )),
             };
         }
+        if attachment.body.kind() != StateAttachmentKind::Signature {
+            let state = self
+                .store()
+                .get_state(&attachment.state_id)?
+                .ok_or(HeddleError::StateNotFound(attachment.state_id))?;
+            self.resign_if_owned(&state)?;
+        }
         self.store().put_state_attachment(attachment)
     }
 


### PR DESCRIPTION
## Summary
- sign and verify State hashes as `b"hd-state-sig-v1\x00" || compute_hash()` and reject bare-hash signatures
- include `segment_id` option framing and bytes in the State typed-hash length prefix
- classify valid pre-tag evidence as `Legacy`; on the next state-attachment write, append a tagged signature only when the matching protected device or repo-local key is still available
- preserve legacy signature attachments as append-only evidence and do not add a dual-acceptance verification shim

## Closes
Closes #1255

## Test evidence
- `cargo test -p heddle-crypto state_signature -- --nocapture` — 2 passed, including the negative control proving an untagged/bare signature fails verification
- `cargo test -p heddle-object-model agent_segment -- --nocapture` — 2 passed, including the omitted-length-prefix comparison
- `cargo test -p heddle-repo repository_signing::tests -- --nocapture` — 13 passed, including `Legacy` classification and local/device re-sign-on-write migration
- `cargo test -p heddle-devtools` — 71 passed, including ref-write chokepoint, snapshot atomicity, atomic-ledger encapsulation, and production-tree invariant scanners
- `cargo test -p heddle-crypto -p heddle-object-model -p heddle-objects -p heddle-repo` — full affected-package suites passed
- `cargo test -p heddle-cli --test production_features state_signing` — 7 passed (Ed25519, P-256, cross-algorithm, tamper, and auto-signing coverage)
- `cargo clippy --workspace -- -D warnings` — passed

All Cargo commands used `CARGO_TARGET_DIR=/home/scratch/h1255-target` and `TMPDIR=/home/scratch`.
