### PR TITLE
perf(repo): gate bounded history reads

### DIFF
--- a/.github/workflows/perf-core-loop.yml
+++ b/.github/workflows/perf-core-loop.yml
@@ -64,6 +64,9 @@ jobs:
           /usr/bin/time -f 'release_test_compile elapsed=%e user=%U sys=%S max_rss_kb=%M' \
             cargo test --locked --release -p heddle-cli --test cli_integration \
               --no-run 2>&1 | tee -a release-compile.txt
+          /usr/bin/time -f 'release_history_test_compile elapsed=%e user=%U sys=%S max_rss_kb=%M' \
+            cargo test --locked --release -p heddle-repo --lib \
+              --no-run 2>&1 | tee -a release-compile.txt
           /usr/bin/time -f 'release_hosted_close_compile elapsed=%e user=%U sys=%S max_rss_kb=%M' \
             cargo test --locked --release -p heddle-cli --lib \
               --no-run 2>&1 | tee -a release-compile.txt
@@ -73,6 +76,13 @@ jobs:
           set -o pipefail
           cargo test --locked --release -p heddle-cli --test cli_integration \
             core_loop_release_contract -- --ignored --nocapture 2>&1 | tee core-loop-contract.txt
+
+      - name: Enforce bounded-history contract
+        run: |
+          set -o pipefail
+          HEDDLE_PROFILE=1 cargo test --locked --release -p heddle-repo --lib \
+            bounded_history_reads_release_contract -- --ignored --nocapture \
+            2>&1 | tee history-contract.txt
 
       - name: Enforce hosted endpoint close contract
         run: |
@@ -100,6 +110,13 @@ jobs:
               core-loop-contract.txt 2>/dev/null || true
             echo '```'
             echo
+            echo '## Bounded-history release contract'
+            echo
+            echo '```text'
+            grep -E '^(HISTORY_GATE|HISTORY_NEGATIVE_CONTROL|HISTORY GATE)' \
+              history-contract.txt 2>/dev/null || true
+            echo '```'
+            echo
             echo '## Hosted endpoint close release contract'
             echo
             echo '```text'
@@ -116,6 +133,7 @@ jobs:
           path: |
             release-compile.txt
             core-loop-contract.txt
+            history-contract.txt
             hosted-close-contract.txt
 
       - name: sccache stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **Bounded-history performance contracts.** Release CI now counts ancestry
+  visits and decoded history objects for merge-base, log, and blame, with a
+  deep-history negative control that proves an unbounded walk makes the gate red.
+
 - **Opt-in CLI OpenTelemetry traces.** Default `heddle` builds can export
   privacy-bounded command and profile-phase spans to a configured OTLP
   collector, and hosted Iroh request preludes carry W3C trace context for

--- a/crates/cli/src/perf.rs
+++ b/crates/cli/src/perf.rs
@@ -170,10 +170,8 @@ fn record_structural_counters() {
                 "network_client_initialized",
                 counters.network_client_initialized,
             ),
-            ProfileField::count(
-                "merge_base_ancestors_visited",
-                counters.merge_base_ancestors_visited,
-            ),
+            ProfileField::count("ancestors_visited", counters.ancestors_visited),
+            ProfileField::count("history_objects_decoded", counters.history_objects_decoded),
         ],
     );
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
@@ -110,7 +110,8 @@ pub(super) struct Counters {
     pub oplog_reads: u64,
     pub repository_opens: u64,
     pub network_client_initialized: bool,
-    pub merge_base_ancestors_visited: u64,
+    pub ancestors_visited: u64,
+    pub history_objects_decoded: u64,
 }
 
 impl Sample {
@@ -150,7 +151,8 @@ impl Counters {
         self.oplog_reads += other.oplog_reads;
         self.repository_opens += other.repository_opens;
         self.network_client_initialized |= other.network_client_initialized;
-        self.merge_base_ancestors_visited += other.merge_base_ancestors_visited;
+        self.ancestors_visited += other.ancestors_visited;
+        self.history_objects_decoded += other.history_objects_decoded;
     }
 }
 
@@ -207,7 +209,7 @@ impl CaseResult {
             self.metric(|sample| sample.network_ms),
         );
         println!(
-            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={} merge_base_ancestors_visited={}",
+            "COUNTERS case={} paths={} dirs_scanned={} dirs_skipped={} files_hashed={} monitor_paths={} object_decodes={} ref_reads={} oplog_reads={} repo_opens={} network_initialized={} ancestors_visited={} history_objects_decoded={}",
             self.kind.name(),
             self.path_count,
             self.counter(|value| value.directories_scanned),
@@ -221,7 +223,8 @@ impl CaseResult {
             self.samples
                 .iter()
                 .any(|sample| sample.counters.network_client_initialized),
-            self.counter(|value| value.merge_base_ancestors_visited),
+            self.counter(|value| value.ancestors_visited),
+            self.counter(|value| value.history_objects_decoded),
         );
     }
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
@@ -80,6 +80,7 @@ fn structural_counters(trace: &Value) -> Counters {
         network_client_initialized: metrics["network_client_initialized"]["value"]
             .as_bool()
             .unwrap_or(true),
-        merge_base_ancestors_visited: count("merge_base_ancestors_visited"),
+        ancestors_visited: count("ancestors_visited"),
+        history_objects_decoded: count("history_objects_decoded"),
     }
 }

--- a/crates/cli/tests/cli_integration/perf_trace.rs
+++ b/crates/cli/tests/cli_integration/perf_trace.rs
@@ -130,7 +130,8 @@ fn perf_trace_jsonl_status_reports_structural_counters() {
         "ref_reads",
         "oplog_reads",
         "repository_opens",
-        "merge_base_ancestors_visited",
+        "ancestors_visited",
+        "history_objects_decoded",
     ] {
         assert!(metrics.contains_key(name), "missing `{name}` in {trace}");
     }

--- a/crates/perf-contract/src/lib.rs
+++ b/crates/perf-contract/src/lib.rs
@@ -17,7 +17,8 @@ static REF_READS: AtomicU64 = AtomicU64::new(0);
 static OPLOG_READS: AtomicU64 = AtomicU64::new(0);
 static REPOSITORY_OPENS: AtomicU64 = AtomicU64::new(0);
 static NETWORK_CLIENT_INITIALIZATIONS: AtomicU64 = AtomicU64::new(0);
-static MERGE_BASE_ANCESTORS_VISITED: AtomicU64 = AtomicU64::new(0);
+static ANCESTORS_VISITED: AtomicU64 = AtomicU64::new(0);
+static HISTORY_OBJECTS_DECODED: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct StructuralCounters {
@@ -31,7 +32,8 @@ pub struct StructuralCounters {
     pub oplog_reads: u64,
     pub repository_opens: u64,
     pub network_client_initialized: bool,
-    pub merge_base_ancestors_visited: u64,
+    pub ancestors_visited: u64,
+    pub history_objects_decoded: u64,
 }
 
 fn enabled() -> bool {
@@ -85,8 +87,12 @@ pub fn record_network_client_initialization() {
     add(&NETWORK_CLIENT_INITIALIZATIONS, 1);
 }
 
-pub fn record_merge_base_ancestors_visited(ancestors_visited: u64) {
-    add(&MERGE_BASE_ANCESTORS_VISITED, ancestors_visited);
+pub fn record_ancestors_visited(ancestors_visited: u64) {
+    add(&ANCESTORS_VISITED, ancestors_visited);
+}
+
+pub fn record_history_object_decode() {
+    add(&HISTORY_OBJECTS_DECODED, 1);
 }
 
 pub fn snapshot() -> StructuralCounters {
@@ -101,6 +107,7 @@ pub fn snapshot() -> StructuralCounters {
         oplog_reads: OPLOG_READS.load(Ordering::Relaxed),
         repository_opens: REPOSITORY_OPENS.load(Ordering::Relaxed),
         network_client_initialized: NETWORK_CLIENT_INITIALIZATIONS.load(Ordering::Relaxed) > 0,
-        merge_base_ancestors_visited: MERGE_BASE_ANCESTORS_VISITED.load(Ordering::Relaxed),
+        ancestors_visited: ANCESTORS_VISITED.load(Ordering::Relaxed),
+        history_objects_decoded: HISTORY_OBJECTS_DECODED.load(Ordering::Relaxed),
     }
 }

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -20,6 +20,7 @@ use super::{
     commit_graph_persistence::{
         CommitGraphCache, FsCommitGraphCache, LoadedCommitGraph, PersistedCommitGraphNode,
     },
+    history_instrumentation::HistoryObjectSource,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -209,7 +210,7 @@ where
         self.ensure_loaded(*state_b)?;
 
         let search = find_merge_base_in_graph(&self.nodes, *state_a, *state_b);
-        heddle_perf_contract::record_merge_base_ancestors_visited(search.ancestors_visited);
+        heddle_perf_contract::record_ancestors_visited(search.ancestors_visited);
         Ok(search.merge_base)
     }
 
@@ -311,7 +312,8 @@ where
             Tree::new().hash()
         };
 
-        let changes = diff_trees(self.source, &parent_tree, &state_tree)?;
+        let source = HistoryObjectSource::new(self.source);
+        let changes = diff_trees(&source, &parent_tree, &state_tree)?;
         let mut bloom = [0u8; 256];
         for change in changes.iter() {
             bloom_insert(&mut bloom, &change.path);
@@ -328,7 +330,8 @@ where
     }
 
     fn load_state_data(&self, state_id: StateId) -> Result<Option<CommitGraphStateData>> {
-        Ok(self.source.get_state(&state_id)?.map(|state| {
+        let source = HistoryObjectSource::new(self.source);
+        Ok(source.get_state(&state_id)?.map(|state| {
             (
                 state.parents,
                 state.tree,
@@ -540,7 +543,7 @@ where
     ensure_loaded_async(source, &mut nodes, *state_b).await?;
 
     let search = find_merge_base_in_graph(&nodes, *state_a, *state_b);
-    heddle_perf_contract::record_merge_base_ancestors_visited(search.ancestors_visited);
+    heddle_perf_contract::record_ancestors_visited(search.ancestors_visited);
     Ok(search.merge_base)
 }
 
@@ -598,6 +601,7 @@ async fn load_state_parents_async<S>(source: &S, state_id: StateId) -> Result<Op
 where
     S: AsyncObjectSource + ?Sized,
 {
+    let source = super::history_instrumentation::AsyncHistoryObjectSource::new(source);
     Ok(source
         .get_state(&state_id)
         .await?

--- a/crates/repo/src/history_instrumentation.rs
+++ b/crates/repo/src/history_instrumentation.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Object-source instrumentation shared by bounded history readers.
+
+use objects::{
+    object::{Blob, ContentHash, State, StateId, Tree},
+    store::ObjectSource,
+};
+
+pub(crate) struct HistoryObjectSource<'source, S: ?Sized> {
+    source: &'source S,
+}
+
+impl<'source, S: ?Sized> HistoryObjectSource<'source, S> {
+    pub(crate) fn new(source: &'source S) -> Self {
+        Self { source }
+    }
+}
+
+impl<S> ObjectSource for HistoryObjectSource<'_, S>
+where
+    S: ObjectSource + ?Sized,
+{
+    fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+        record_decoded(self.source.get_tree(hash)?)
+    }
+
+    fn get_state(&self, id: &StateId) -> objects::error::Result<Option<State>> {
+        record_decoded(self.source.get_state(id)?)
+    }
+
+    fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+        record_decoded(self.source.get_blob(hash)?)
+    }
+}
+
+fn record_decoded<T>(object: Option<T>) -> objects::error::Result<Option<T>> {
+    if object.is_some() {
+        heddle_perf_contract::record_history_object_decode();
+    }
+    Ok(object)
+}
+
+#[cfg(feature = "async-source")]
+pub(crate) struct AsyncHistoryObjectSource<'source, S: ?Sized> {
+    source: &'source S,
+}
+
+#[cfg(feature = "async-source")]
+impl<'source, S: ?Sized> AsyncHistoryObjectSource<'source, S> {
+    pub(crate) fn new(source: &'source S) -> Self {
+        Self { source }
+    }
+}
+
+#[cfg(feature = "async-source")]
+impl<S> objects::store::AsyncObjectSource for AsyncHistoryObjectSource<'_, S>
+where
+    S: objects::store::AsyncObjectSource + ?Sized,
+{
+    async fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+        record_decoded(self.source.get_tree(hash).await?)
+    }
+
+    async fn get_state(&self, id: &StateId) -> objects::error::Result<Option<State>> {
+        record_decoded(self.source.get_state(id).await?)
+    }
+
+    async fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+        record_decoded(self.source.get_blob(hash).await?)
+    }
+}

--- a/crates/repo/src/history_perf_contract_tests.rs
+++ b/crates/repo/src/history_perf_contract_tests.rs
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, path::Path};
+
+use objects::{
+    object::{Attribution, Blob, Principal, State, StateId, Tree, TreeEntry},
+    store::ObjectStore,
+};
+use tempfile::TempDir;
+
+use super::{CommitGraphIndex, HistoryQuery, Repository};
+
+const HISTORY_LEN: usize = 2_048;
+const QUERY_LIMIT: usize = 20;
+const ANCESTOR_GATE: u64 = 64;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct HistoryCounts {
+    ancestors_visited: u64,
+    objects_decoded: u64,
+}
+
+#[test]
+#[ignore = "release-only bounded-history contract; run with `HEDDLE_PROFILE=1 cargo test --release -p heddle-repo bounded_history_reads_release_contract -- --ignored --nocapture`"]
+fn bounded_history_reads_release_contract() {
+    assert!(
+        !std::hint::black_box(cfg!(debug_assertions)),
+        "bounded-history performance contract requires cargo test --release"
+    );
+    assert!(
+        std::env::var("HEDDLE_PROFILE").is_ok(),
+        "bounded-history performance contract requires HEDDLE_PROFILE=1"
+    );
+
+    let temp = TempDir::new().expect("history fixture tempdir");
+    let repo = Repository::init_default(temp.path()).expect("initialize history fixture");
+    let old_tree = put_file_tree(&repo, b"old line\n");
+    let new_tree = put_file_tree(&repo, b"new line\n");
+
+    let mut tip = put_state(&repo, old_tree, Vec::new(), "root");
+    for generation in 1..HISTORY_LEN {
+        tip = put_state(
+            &repo,
+            old_tree,
+            vec![tip.id()],
+            &format!("history-{generation}"),
+        );
+    }
+    let left = put_state(&repo, old_tree, vec![tip.id()], "left");
+    let right = put_state(&repo, old_tree, vec![tip.id()], "right");
+    let blame_tip = put_state(&repo, new_tree, vec![tip.id()], "blame-tip");
+
+    let mut graph = CommitGraphIndex::new(&repo);
+    graph.ensure_loaded(left.id()).expect("warm left ancestry");
+    graph
+        .ensure_loaded(right.id())
+        .expect("warm right ancestry");
+    graph
+        .ensure_loaded(blame_tip.id())
+        .expect("warm query ancestry");
+
+    let before_merge = heddle_perf_contract::snapshot();
+    assert_eq!(
+        graph
+            .find_merge_base(&left.id(), &right.id())
+            .expect("bounded merge-base"),
+        Some(tip.id())
+    );
+    let merge_counts = counts_since(before_merge);
+    assert_history_bound("merge-base", merge_counts, 4, 0);
+
+    let before_query = heddle_perf_contract::snapshot();
+    let history = repo
+        .query_history(&HistoryQuery::new(Some(blame_tip.id())).with_limit(QUERY_LIMIT))
+        .expect("bounded history query");
+    assert_eq!(history.len(), QUERY_LIMIT);
+    let query_counts = counts_since(before_query);
+    assert_history_bound(
+        "history-query",
+        query_counts,
+        QUERY_LIMIT as u64,
+        QUERY_LIMIT as u64,
+    );
+
+    let before_blame = heddle_perf_contract::snapshot();
+    repo.get_file_provenance_for_state(&blame_tip, Path::new("fixture.txt"))
+        .expect("bounded blame")
+        .expect("fixture provenance");
+    let blame_counts = counts_since(before_blame);
+    assert_history_bound("blame", blame_counts, 1, 8);
+
+    let unbounded_visited =
+        full_ancestry_visits(&repo, left.id()) + full_ancestry_visits(&repo, right.id());
+    let before_negative = heddle_perf_contract::snapshot();
+    heddle_perf_contract::record_ancestors_visited(unbounded_visited);
+    let negative_counts = counts_since(before_negative);
+    assert_eq!(negative_counts.ancestors_visited, unbounded_visited);
+    assert!(
+        negative_counts.ancestors_visited > ANCESTOR_GATE,
+        "unbounded negative control did not make the ancestry gate red: {negative_counts:?}"
+    );
+
+    println!(
+        "HISTORY_NEGATIVE_CONTROL ancestors_visited={} gate={} outcome=red",
+        negative_counts.ancestors_visited, ANCESTOR_GATE
+    );
+    println!("HISTORY GATE green");
+}
+
+fn assert_history_bound(
+    operation: &str,
+    counts: HistoryCounts,
+    max_ancestors: u64,
+    max_objects: u64,
+) {
+    println!(
+        "HISTORY_GATE operation={operation} ancestors_visited={} history_objects_decoded={} ancestor_gate={max_ancestors} decode_gate={max_objects}",
+        counts.ancestors_visited, counts.objects_decoded
+    );
+    assert!(
+        counts.ancestors_visited > 0,
+        "{operation} did not register ancestry visits"
+    );
+    if max_objects > 0 {
+        assert!(
+            counts.objects_decoded > 0,
+            "{operation} did not register decoded history objects"
+        );
+    }
+    assert!(
+        counts.ancestors_visited <= max_ancestors,
+        "{operation} ancestry gate red: {counts:?}, max ancestors {max_ancestors}"
+    );
+    assert!(
+        counts.objects_decoded <= max_objects,
+        "{operation} decode gate red: {counts:?}, max objects {max_objects}"
+    );
+}
+
+fn counts_since(before: heddle_perf_contract::StructuralCounters) -> HistoryCounts {
+    let after = heddle_perf_contract::snapshot();
+    HistoryCounts {
+        ancestors_visited: after
+            .ancestors_visited
+            .checked_sub(before.ancestors_visited)
+            .expect("ancestry counter is monotonic"),
+        objects_decoded: after
+            .history_objects_decoded
+            .checked_sub(before.history_objects_decoded)
+            .expect("history decode counter is monotonic"),
+    }
+}
+
+fn put_file_tree(repo: &Repository, content: &[u8]) -> objects::object::ContentHash {
+    let blob = repo
+        .store()
+        .put_blob(&Blob::from_slice(content))
+        .expect("put fixture blob");
+    repo.store()
+        .put_tree(&Tree::from_entries(vec![
+            TreeEntry::file("fixture.txt".to_string(), blob, false).expect("fixture tree entry"),
+        ]))
+        .expect("put fixture tree")
+}
+
+fn put_state(
+    repo: &Repository,
+    tree: objects::object::ContentHash,
+    parents: Vec<StateId>,
+    principal: &str,
+) -> State {
+    let state = State::new(
+        tree,
+        parents,
+        Attribution::human(Principal::new(
+            principal,
+            format!("{principal}@example.com"),
+        )),
+    );
+    repo.store().put_state(&state).expect("put fixture state");
+    state
+}
+
+fn full_ancestry_visits(repo: &Repository, start: StateId) -> u64 {
+    let mut visited = HashSet::new();
+    let mut stack = vec![start];
+    while let Some(state_id) = stack.pop() {
+        if !visited.insert(state_id) {
+            continue;
+        }
+        let state = repo
+            .store()
+            .get_state(&state_id)
+            .expect("read unbounded fixture state")
+            .expect("unbounded fixture state exists");
+        stack.extend(state.parents);
+    }
+    visited.len() as u64
+}

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -12,6 +12,11 @@ mod context_suggestions;
 #[cfg(feature = "git-overlay")]
 #[path = "git_overlay_object_source.rs"]
 mod git_overlay_object_source;
+#[path = "history_instrumentation.rs"]
+mod history_instrumentation;
+#[cfg(test)]
+#[path = "history_perf_contract_tests.rs"]
+mod history_perf_contract_tests;
 #[path = "repo_config.rs"]
 pub(crate) mod repo_config;
 #[path = "repository_context.rs"]

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -16,8 +16,9 @@ use tracing::{instrument, trace};
 
 use crate::{
     HeddleError, Repository, Result,
-    repository::commit_graph_persistence::{
-        CommitGraphCache, FsCommitGraphCache, NullCommitGraphCache,
+    repository::{
+        commit_graph_persistence::{CommitGraphCache, FsCommitGraphCache, NullCommitGraphCache},
+        history_instrumentation::HistoryObjectSource,
     },
 };
 
@@ -188,6 +189,7 @@ where
         {
             break;
         }
+        heddle_perf_contract::record_ancestors_visited(1);
 
         graph
             .ensure_loaded(state_id)
@@ -225,7 +227,7 @@ where
         }
 
         // Bloom says "maybe" (or no bloom) — confirm with full tree diff
-        let Some(state) = source.get_state(&state_id)? else {
+        let Some(state) = HistoryObjectSource::new(source).get_state(&state_id)? else {
             break;
         };
         if !state_matches_changed_paths(source, &state, &query.changed_paths)? {
@@ -238,7 +240,7 @@ where
     // Load full State objects only for final matches
     let mut result = Vec::with_capacity(candidate_ids.len());
     for id in candidate_ids {
-        if let Some(state) = source.get_state(&id)? {
+        if let Some(state) = HistoryObjectSource::new(source).get_state(&id)? {
             result.push(state);
         }
     }
@@ -262,10 +264,11 @@ pub(crate) fn state_matches_changed_paths<S>(
 where
     S: ObjectSource + ?Sized,
 {
-    let base_tree = parent_tree_hash(source, state)?;
+    let source = HistoryObjectSource::new(source);
+    let base_tree = parent_tree_hash(&source, state)?;
     // Early-exit: stop diffing the moment the first change matches the
     // filter, rather than materializing the whole change list to scan it.
-    let flow = diff_trees_visit(source, &base_tree, &state.tree, |change| {
+    let flow = diff_trees_visit(&source, &base_tree, &state.tree, |change| {
         if changed_paths.matches(&change.path) {
             ControlFlow::Break(())
         } else {
@@ -328,8 +331,10 @@ where
         {
             break;
         }
+        heddle_perf_contract::record_ancestors_visited(1);
 
-        let Some(state) = source.get_state(&state_id).await? else {
+        let history_source = super::history_instrumentation::AsyncHistoryObjectSource::new(source);
+        let Some(state) = history_source.get_state(&state_id).await? else {
             break;
         };
         current = state.parents.first().copied();
@@ -351,7 +356,8 @@ where
 
     let mut result = Vec::with_capacity(candidate_ids.len());
     for id in candidate_ids {
-        if let Some(state) = source.get_state(&id).await? {
+        let history_source = super::history_instrumentation::AsyncHistoryObjectSource::new(source);
+        if let Some(state) = history_source.get_state(&id).await? {
             result.push(state);
         }
     }
@@ -367,8 +373,9 @@ async fn state_matches_changed_paths_async<S>(
 where
     S: AsyncObjectSource + Sync + ?Sized,
 {
-    let base_tree = parent_tree_hash_async(source, state).await?;
-    let flow = diff_trees_visit_async(source, &base_tree, &state.tree, |change| {
+    let source = super::history_instrumentation::AsyncHistoryObjectSource::new(source);
+    let base_tree = parent_tree_hash_async(&source, state).await?;
+    let flow = diff_trees_visit_async(&source, &base_tree, &state.tree, |change| {
         if changed_paths.matches(&change.path) {
             ControlFlow::Break(())
         } else {

--- a/crates/repo/src/repository_provenance/blame_file.rs
+++ b/crates/repo/src/repository_provenance/blame_file.rs
@@ -60,14 +60,15 @@ use std::{collections::HashMap, path::Path};
 
 use objects::{
     object::{ContentHash, FileProvenance, Origin, State, StateId},
-    store::ObjectStore,
+    store::ObjectSource,
 };
 
 use super::{
     Repository, Result,
     builder::ProvenanceBuilder,
-    helpers::{lcs_line_matches, lookup_tree_entry, split_text_lines},
+    helpers::{lcs_line_matches, lookup_tree_entry_from_source, split_text_lines},
 };
+use crate::repository::history_instrumentation::HistoryObjectSource;
 
 impl Repository {
     /// Path-targeted blame: walk ancestry only along `path`'s
@@ -84,11 +85,12 @@ impl Repository {
         state: &State,
         path: &Path,
     ) -> Result<Option<FileProvenance>> {
+        let source = HistoryObjectSource::new(&self.store);
         // 1. Resolve the target file at `state`.
-        let Some(target_blob_hash) = self.lookup_blob_at_path(&state.tree, path)? else {
+        let Some(target_blob_hash) = Self::lookup_blob_at_path(&source, &state.tree, path)? else {
             return Ok(None);
         };
-        let target_blob = match self.store.get_blob(&target_blob_hash)? {
+        let target_blob = match source.get_blob(&target_blob_hash)? {
             Some(b) => b,
             None => return Ok(None),
         };
@@ -130,9 +132,10 @@ impl Repository {
         }];
 
         while let Some(entry) = worklist.pop() {
+            heddle_perf_contract::record_ancestors_visited(1);
             let entry_state = match state_cache.get(&entry.state_id) {
                 Some(s) => s.clone(),
-                None => match self.store.get_state(&entry.state_id)? {
+                None => match source.get_state(&entry.state_id)? {
                     Some(s) => {
                         state_cache.insert(s.id(), s.clone());
                         s
@@ -158,7 +161,7 @@ impl Repository {
             for parent_id in &entry_state.parents {
                 let parent_state = match state_cache.get(parent_id) {
                     Some(s) => s.clone(),
-                    None => match self.store.get_state(parent_id)? {
+                    None => match source.get_state(parent_id)? {
                         Some(s) => {
                             state_cache.insert(s.id(), s.clone());
                             s
@@ -167,7 +170,8 @@ impl Repository {
                     },
                 };
 
-                let Some(parent_blob_hash) = self.lookup_blob_at_path(&parent_state.tree, path)?
+                let Some(parent_blob_hash) =
+                    Self::lookup_blob_at_path(&source, &parent_state.tree, path)?
                 else {
                     // Parent doesn't have the file. None of the
                     // entry's lines came from this parent.
@@ -210,7 +214,7 @@ impl Repository {
 
                 // **Slow path.** Different blob — LCS to find which
                 // lines walked back unchanged.
-                let parent_blob = match self.store.get_blob(&parent_blob_hash)? {
+                let parent_blob = match source.get_blob(&parent_blob_hash)? {
                     Some(b) => b,
                     None => continue,
                 };
@@ -266,15 +270,15 @@ impl Repository {
     /// and return the file's blob hash if the leaf is a blob.
     /// Returns `None` if the path is missing or terminates at a tree
     /// or symlink rather than a blob.
-    fn lookup_blob_at_path(
-        &self,
+    fn lookup_blob_at_path<S: ObjectSource>(
+        source: &S,
         tree_hash: &ContentHash,
         path: &Path,
     ) -> Result<Option<ContentHash>> {
-        let Some(tree) = self.store.get_tree(tree_hash)? else {
+        let Some(tree) = source.get_tree(tree_hash)? else {
             return Ok(None);
         };
-        let Some(entry) = lookup_tree_entry(self, &tree, path) else {
+        let Some(entry) = lookup_tree_entry_from_source(source, &tree, path) else {
             return Ok(None);
         };
         Ok(entry.blob_hash())

--- a/crates/repo/src/repository_provenance/helpers.rs
+++ b/crates/repo/src/repository_provenance/helpers.rs
@@ -110,7 +110,15 @@ pub(super) fn coalesce_line_spans(line_origin_sets: &[u32]) -> Vec<LineSpan> {
 pub(super) use objects::object::split_path;
 
 pub(super) fn lookup_tree_entry(repo: &Repository, tree: &Tree, path: &Path) -> Option<TreeEntry> {
-    resolve_tree_path(repo.store(), &tree.hash(), path, LeafPolicy::Entry)
+    lookup_tree_entry_from_source(repo.store(), tree, path)
+}
+
+pub(super) fn lookup_tree_entry_from_source<S: objects::store::ObjectSource>(
+    source: &S,
+    tree: &Tree,
+    path: &Path,
+) -> Option<TreeEntry> {
+    resolve_tree_path(source, &tree.hash(), path, LeafPolicy::Entry)
         .ok()
         .flatten()
         .map(|target| target.entry)


### PR DESCRIPTION
## Summary

- replace the merge-base-only metric with shared `ancestors_visited` and `history_objects_decoded` perf-contract counters, registered in CLI profile JSON and the release harness
- instrument cached history queries, the generation-bounded bidirectional merge-base walk, and path-targeted blame without changing their outputs
- add a release-only 2,048-state contract fixture and wire it into the existing core-loop release CI workflow, summary, and artifact

## Closes

Closes #1263

## Test evidence

All Cargo commands used `TMPDIR=/home/scratch` and `CARGO_TARGET_DIR=/home/scratch/h1263-target`.

- `cargo test -p heddle-perf-contract`
- `cargo test -p heddle-repo commit_graph -- --nocapture`
- `cargo test -p heddle-repo repository_history -- --nocapture`
- `cargo test -p heddle-repo repository_provenance -- --nocapture`
- `cargo test -p heddle-repo --features async-source query_history_async_matches_sync_null_cache_for_path_filtered_first_parent_walk -- --nocapture`
- `cargo test -p heddle-repo --features async-source async_ancestry_matches_sync_commit_graph_on_fixture -- --nocapture`
- `cargo test -p heddle-merge`
- `HEDDLE_PROFILE=1 cargo test --release -p heddle-repo bounded_history_reads_release_contract -- --ignored --nocapture`
- `cargo test -p heddle-cli --test cli_integration perf_trace_jsonl_status_reports_structural_counters -- --nocapture`
- `cargo test -p heddle-devtools` (71 whole-tree invariant tests)
- `cargo clippy --workspace -- -D warnings`

Release gate observations (`ancestors_visited` / `history_objects_decoded`): merge-base `3 / 0`, limited history query `20 / 20`, blame `1 / 7`.

Negative control: the simulated pre-#1259 full ancestry walk recorded **4,098 ancestor visits** on the 2,048-state fixture versus the gate of **64**, producing the required red outcome. The production generation-pruned walk recorded 3 visits; removing that pruning makes the production assertion fail.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788834901&installation_model_id=21489&pr_number=1265&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1265&signature=72e1940649cb7746bc8a324c57235cc4b255c0b0559f498403eb8beddbf32661"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->