### PR TITLE
perf(cli): gate 100k warm status

### DIFF
--- a/.github/workflows/perf-core-loop.yml
+++ b/.github/workflows/perf-core-loop.yml
@@ -106,7 +106,7 @@ jobs:
             echo 'Compilation and fixture construction are reported separately from command samples.'
             echo
             echo '```text'
-            grep -E '^(RUNNER|SETUP|RESULT|COUNTERS|BASELINE|BAND|SCALE|GATES|PERF GATE)' \
+            grep -E '^(RUNNER|SETUP|RESULT|COUNTERS|BASELINE|BAND|TARGET|SCALE|GATES|PERF GATE)' \
               core-loop-contract.txt 2>/dev/null || true
             echo '```'
             echo

--- a/crates/cli/benches/local_ops.rs
+++ b/crates/cli/benches/local_ops.rs
@@ -2,7 +2,7 @@
 use std::{env, hint::black_box, path::Path};
 
 use cli::bench::{detect_renames_for_bench, find_merge_base_for_bench, three_way_merge_for_bench};
-use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group};
 use objects::{
     object::{Blob, MarkerName, StateId, ThreadName, Tree, TreeEntry},
     store::{InMemoryStore, ObjectStore},
@@ -138,6 +138,41 @@ fn setup_repo_with_files(count: usize) -> (TempDir, Repository) {
     (temp, repo)
 }
 
+fn setup_warm_native_repo(count: usize) -> (TempDir, Repository, Tree) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path())
+        .unwrap()
+        .without_fsmonitor();
+    write_files(temp.path(), count, "tracked");
+    let state = repo.snapshot(Some("base".to_string()), None).unwrap();
+    let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
+    let mut config = repo.config().clone();
+    config.worktree.fsmonitor.mode = FsMonitorMode::Native;
+    config.save(&repo.heddle_dir().join("config.toml")).unwrap();
+    drop(repo);
+
+    let monitor_root = temp.path().to_path_buf();
+    std::thread::spawn(move || {
+        let _ = run_local_monitor_helper(&monitor_root);
+    });
+    let repo = Repository::open(temp.path()).unwrap();
+    let options = WorktreeStatusOptions {
+        fsmonitor: FsMonitorSettings {
+            mode: FsMonitorMode::Native,
+        },
+    };
+    for _ in 0..100 {
+        let (_, profile) = repo
+            .compare_worktree_cached_profiled_with_options(&tree, &options)
+            .unwrap();
+        if profile.scan_mode == "changed_paths" {
+            return (temp, repo, tree);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+    panic!("native monitor did not become usable for benchmark fixture");
+}
+
 fn setup_flat_repo_with_files(count: usize) -> (TempDir, Repository) {
     let temp = TempDir::new().unwrap();
     let repo = Repository::init_default(temp.path()).unwrap();
@@ -175,6 +210,10 @@ fn setup_repo_with_many_untracked_dirs(
 
 fn ref_scale_counts() -> [usize; 4] {
     [1_000, 10_000, 50_000, 100_000]
+}
+
+fn tracked_path_scale_counts() -> [usize; 3] {
+    [100, 1_000, 100_000]
 }
 
 fn setup_ref_manager() -> (TempDir, RefManager) {
@@ -285,20 +324,19 @@ fn bench_build_tree_cold_shapes(c: &mut Criterion) {
 
 fn bench_compare_worktree(c: &mut Criterion) {
     let mut group = c.benchmark_group("compare_worktree");
-    for &file_count in &[100usize, 1_000] {
-        let (_temp, repo) = setup_repo_with_files(file_count);
-        let state = repo.snapshot(Some("base".to_string()), None).unwrap();
-        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
-        std::fs::write(
-            repo.root().join("tracked/dir-00/file-00000.txt"),
-            "modified\n",
-        )
-        .unwrap();
-
+    for file_count in tracked_path_scale_counts() {
         group.bench_with_input(
             BenchmarkId::from_parameter(file_count),
             &file_count,
             |b, _| {
+                let (_temp, repo, tree) = setup_warm_native_repo(file_count);
+                std::fs::write(
+                    repo.root().join("tracked/dir-00/file-00000.txt"),
+                    "modified\n",
+                )
+                .unwrap();
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                black_box(repo.compare_worktree_cached(&tree).unwrap());
                 b.iter(|| {
                     let status = repo.compare_worktree_cached(&tree).unwrap();
                     black_box(status.change_count());
@@ -306,6 +344,41 @@ fn bench_compare_worktree(c: &mut Criterion) {
             },
         );
     }
+    group.finish();
+}
+
+fn bench_capture_one_path(c: &mut Criterion) {
+    let mut group = c.benchmark_group("capture_one_path");
+    group.sample_size(10);
+    let file_count = 100_000usize;
+    group.bench_with_input(
+        BenchmarkId::from_parameter(file_count),
+        &file_count,
+        |b, _| {
+            let (_temp, repo, _tree) = setup_warm_native_repo(file_count);
+            let attribution = repo.get_attribution().unwrap();
+            let dirty_path = repo.root().join("tracked/dir-00/file-00000.txt");
+            let mut generation = 0usize;
+            b.iter_batched(
+                || {
+                    generation += 1;
+                    std::fs::write(&dirty_path, format!("capture generation {generation}\n"))
+                        .unwrap();
+                },
+                |()| {
+                    let execution = repo
+                        .snapshot_with_attribution_profiled(
+                            Some("bench".to_string()),
+                            None,
+                            attribution.clone(),
+                        )
+                        .unwrap();
+                    black_box(execution.state.state_id);
+                },
+                BatchSize::SmallInput,
+            );
+        },
+    );
     group.finish();
 }
 
@@ -609,15 +682,12 @@ fn bench_compare_worktree_symlink_heavy(c: &mut Criterion) {
 
 fn bench_worktree_clean(c: &mut Criterion) {
     let mut group = c.benchmark_group("worktree_is_clean");
-    for &file_count in &[100usize, 1_000] {
-        let (_temp, repo) = setup_repo_with_files(file_count);
-        let state = repo.snapshot(Some("base".to_string()), None).unwrap();
-        let tree = repo.store().get_tree(&state.tree).unwrap().unwrap();
-
+    for file_count in tracked_path_scale_counts() {
         group.bench_with_input(
             BenchmarkId::from_parameter(file_count),
             &file_count,
             |b, _| {
+                let (_temp, repo, tree) = setup_warm_native_repo(file_count);
                 b.iter(|| {
                     let clean = repo.worktree_is_clean_cached(&tree).unwrap();
                     black_box(clean);
@@ -1153,7 +1223,6 @@ criterion_group!(
     bench_build_tree,
     bench_build_tree_cold_shapes,
     bench_snapshot_profile_flat_repo,
-    bench_compare_worktree,
     bench_compare_worktree_many_added_files,
     bench_compare_worktree_untracked_dirs_with_tracked_changes,
     bench_compare_worktree_untracked_dirs_second_run,
@@ -1164,7 +1233,6 @@ criterion_group!(
     bench_refs_update_marker_rebuild_summary,
     bench_refs_update_remote_thread_rebuild_summary,
     bench_worktree_is_clean_untracked_dirs_second_run,
-    bench_worktree_clean,
     bench_worktree_clean_modes,
     bench_worktree_clean_native_profile,
     bench_goto_same_tree,
@@ -1183,11 +1251,22 @@ criterion_group!(
     bench_semantic_parse_cache_cold
 );
 
+criterion_group!(
+    tracked_path_ops,
+    bench_compare_worktree,
+    bench_capture_one_path,
+    bench_worktree_clean
+);
+
 #[cfg(unix)]
 criterion_group!(unix_status_ops, bench_compare_worktree_symlink_heavy);
 
-#[cfg(unix)]
-criterion_main!(local_ops, unix_status_ops);
-
-#[cfg(not(unix))]
-criterion_main!(local_ops);
+fn main() {
+    tracked_path_ops();
+    if env::var_os("HEDDLE_BENCH_TRACKED_PATHS_ONLY").is_none() {
+        local_ops();
+        #[cfg(unix)]
+        unix_status_ops();
+    }
+    Criterion::default().configure_from_args().final_summary();
+}

--- a/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
@@ -7,7 +7,7 @@ use std::{
     time::Instant,
 };
 
-use repo::{FsMonitorMode, Repository};
+use repo::{FsMonitorMode, FsMonitorSettings, Repository, WorktreeStatusOptions};
 use tempfile::TempDir;
 
 pub(super) struct PerfFixture {
@@ -44,8 +44,7 @@ impl PerfFixture {
         drop(repo);
 
         let warm_start = Instant::now();
-        run_setup(binary, &["--output", "json", "status"], &root);
-        run_setup(binary, &["--output", "json", "status"], &root);
+        warm_native_monitor(binary, &root);
         let warm_ms = warm_start.elapsed().as_millis();
         println!(
             "SETUP paths={path_count} total_ms={} init_ms={init_ms} files_ms={files_ms} seed_ms={seed_ms} monitor_warm_ms={warm_ms}",
@@ -95,6 +94,27 @@ impl PerfFixture {
     fn dirty_path(&self) -> PathBuf {
         self.root.join("tracked/dir-00000/file-000000.txt")
     }
+}
+
+fn warm_native_monitor(binary: &Path, root: &Path) {
+    let options = WorktreeStatusOptions {
+        fsmonitor: FsMonitorSettings {
+            mode: FsMonitorMode::Native,
+        },
+    };
+    for _ in 0..20 {
+        run_setup(binary, &["--output", "json", "status"], root);
+        let repo = Repository::open(root).expect("open perf fixture for monitor warmup");
+        let report = repo
+            .inspect_change_monitor_with_options(&options)
+            .expect("inspect native monitor during warmup");
+        if report.status == "usable" {
+            run_setup(binary, &["--output", "json", "status"], root);
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(25));
+    }
+    panic!("native monitor did not become usable during fixture warmup");
 }
 
 fn write_files(root: &Path, count: usize) {

--- a/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
@@ -6,6 +6,8 @@ use serde::Deserialize;
 
 use super::measurement::{CaseKind, CaseResult, NegativeControl};
 
+const WARM_CLEAN_STATUS_100K_P95_MS: f64 = 50.0;
+
 #[derive(Deserialize)]
 struct BaselineFile {
     profiles: Vec<BaselineProfile>,
@@ -134,6 +136,17 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
         enforce_scale(results, kind, &baseline, &mut failures);
     }
     if let Some(clean_100k) = find(results, CaseKind::StatusClean, 100_000) {
+        let wall = clean_100k.metric(|sample| sample.wall_ms);
+        println!(
+            "TARGET case=status_clean paths=100000 budget_p95_ms={WARM_CLEAN_STATUS_100K_P95_MS:.3} observed_p95_ms={:.3}",
+            wall.p95
+        );
+        if wall.p95 > WARM_CLEAN_STATUS_100K_P95_MS {
+            failures.push(format!(
+                "instant target gate: clean status @ 100k paths p95 {:.3} ms > {WARM_CLEAN_STATUS_100K_P95_MS:.3} ms",
+                wall.p95
+            ));
+        }
         let dirs = clean_100k.counter(|counters| counters.directories_scanned);
         let hashes = clean_100k.counter(|counters| counters.files_hashed);
         if dirs.p95 > 10.0 || hashes.max > 0.0 {
@@ -142,6 +155,8 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
                 dirs.p95, hashes.max
             ));
         }
+    } else {
+        failures.push("instant target gate: missing clean status @ 100k paths".to_string());
     }
     if let Some(dirty_100k) = find(results, CaseKind::StatusDirty, 100_000) {
         let dirs = dirty_100k.counter(|counters| counters.directories_scanned);

--- a/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
@@ -96,7 +96,9 @@ fn core_loop_release_contract() {
         println!("GATES skipped: HEDDLE_PERF_RECORD_ONLY=1");
     } else {
         enforce_contract(&results);
-        println!("GATES green: latency, scale invariance, repository opens, zero network");
+        println!(
+            "GATES green: 100k clean status target, latency, scale invariance, repository opens, zero network"
+        );
     }
 }
 

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -166,11 +166,11 @@ pub(crate) fn load_hot_profiled_for_directories(
     stats.snapshot_load_ms = load_start.elapsed().as_millis();
 
     let journal_path = journal_path(path);
-    if journal_path.exists() {
-        stats.journal_bytes = journal_path
-            .metadata()
-            .map(|metadata| metadata.len())
-            .unwrap_or(0);
+    stats.journal_bytes = journal_path
+        .metadata()
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
+    if directory_keys.iter().any(|key| !key.is_empty()) && journal_path.exists() {
         let replay_start = Instant::now();
         stats.journal_ops = apply_journal(&mut index, &journal_path)?;
         stats.journal_replay_ms = replay_start.elapsed().as_millis();
@@ -2041,7 +2041,7 @@ mod tests {
         );
         save_snapshot_profiled(&index, &path).unwrap();
 
-        let (hot, _) =
+        let (mut hot, _) =
             load_hot_profiled_for_directories(&path, &BTreeSet::from([String::new()])).unwrap();
         assert_eq!(hot.len(), 0);
         assert_eq!(hot.directory_len(), 1);
@@ -2055,6 +2055,29 @@ mod tests {
         assert_eq!(full.len(), 2);
         assert_eq!(full.directory_len(), 2);
         assert!(!full.is_hot_loaded());
+
+        hot.insert(
+            "journal-only.txt".to_string(),
+            sample_file_entry("journal-only.txt"),
+        );
+        save_profiled(&hot, &path).unwrap();
+        let (hot_after_journal, hot_stats) =
+            load_hot_profiled_for_directories(&path, &BTreeSet::from([String::new()])).unwrap();
+        assert!(hot_stats.journal_bytes > 0);
+        assert_eq!(hot_stats.journal_ops, 0);
+        assert_eq!(hot_stats.journal_replay_ms, 0);
+        assert!(hot_after_journal.get("journal-only.txt").is_none());
+        assert!(hot_after_journal.get_directory("").is_some());
+        let (targeted_after_journal, targeted_stats) = load_hot_profiled_for_directories(
+            &path,
+            &BTreeSet::from([String::new(), "journal-only.txt".to_string()]),
+        )
+        .unwrap();
+        assert!(targeted_stats.journal_ops > 0);
+        assert!(targeted_after_journal.get("journal-only.txt").is_some());
+        let (full_after_journal, full_stats) = load_profiled(&path).unwrap();
+        assert!(full_stats.journal_ops > 0);
+        assert!(full_after_journal.get("journal-only.txt").is_some());
 
         fs::write(hot_directory_record_path(&path, ""), b"corrupt").unwrap();
         let (self_healed, _) =

--- a/docs/perf/cli-core-loop-baseline.json
+++ b/docs/perf/cli-core-loop-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "heddle-cli-core-loop-baseline/v2",
-  "recorded_at": "2026-08-04",
+  "recorded_at": "2026-08-09",
   "sample_count": 20,
   "profiles": [
     {
@@ -28,8 +28,8 @@
           "paths": 100000,
           "target_p95_ms": 50.0,
           "measured_p95_ms": 337.419,
-          "gate_p95_ms": 372.0,
-          "disposition": "controlled-runner baseline + 10% noise; 287.419 ms above target"
+          "gate_p95_ms": 50.0,
+          "disposition": "target; clean hot status does not replay the full worktree journal"
         },
         {
           "case": "status_one_dirty",
@@ -69,7 +69,7 @@
     },
     {
       "name": "local-calibration",
-      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 58037072 bytes",
+      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 57338320 bytes",
       "cases": [
         {
           "case": "version",
@@ -91,9 +91,9 @@
           "case": "status_clean",
           "paths": 100000,
           "target_p95_ms": 50.0,
-          "measured_p95_ms": 73.271,
-          "gate_p95_ms": 81.0,
-          "disposition": "local lazy-pack baseline + 10% noise; 23.271 ms above target"
+          "measured_p95_ms": 11.703,
+          "gate_p95_ms": 50.0,
+          "disposition": "target; clean hot status does not replay the full worktree journal"
         },
         {
           "case": "status_one_dirty",

--- a/docs/perf/cli-core-loop.md
+++ b/docs/perf/cli-core-loop.md
@@ -69,9 +69,10 @@ Blacksmith profile with `HEDDLE_PERF_BASELINE`; local runs use the recorded
 local calibration profile.
 
 The ignored marker keeps the harness out of debug and ordinary unit-test runs;
-the dedicated release workflow runs it on a controlled runner. Absolute bands
-already met use the product target. Missed bands use a baseline ratchet and keep
-the target gap explicit.
+the dedicated release workflow runs it on a controlled runner. Warm clean
+status at 100k paths has an explicit 50 ms p95 assertion independent of the
+runner baseline. Other absolute bands already met use the product target;
+missed bands use a baseline ratchet and keep the target gap explicit.
 
 The repeatable negative controls are:
 
@@ -91,16 +92,16 @@ repository open inside each sample. Each invocation must fail with `PERF GATE
 RED`. The eager-index control is pinned by the warm repository-open p95 gate
 (2 ms), not only by the aggregate wall-time band.
 
-## 2026-08-04 local calibration
+## 2026-08-09 local calibration
 
-The 20-sample local release run after lazy pack lookup measured the following
-100k-path p95 values. The previous column is the prior recorded local
-calibration; the gate column is the new baseline plus roughly 10% noise and is
-strictly tighter than the previous gate.
+The 100k clean-status path now consumes its root hot sidecar without replaying
+the full file journal. Changed-path operations still replay the file entries
+they need. The release contract pins clean status p95 directly to the product
+target; one-path status and capture retain their existing ratchets.
 
-| Case | Previous p95 | Lazy-pack p95 | New gate | Product target |
+| Case | Previous p95 | Recorded p95 | Gate | Product target |
 |---|---:|---:|---:|---:|
-| Clean status | 218.697 ms | 73.271 ms | 81 ms | 50 ms |
+| Clean status | 73.271 ms | 11.703 ms | 50 ms | 50 ms |
 | One-path status | 415.569 ms | 78.619 ms | 87 ms | 75 ms |
 | One-path capture | 2436.937 ms | 971.053 ms | 1069 ms | 100 ms |
 


### PR DESCRIPTION
## Summary

- Add focused Criterion fixtures for warm clean status, one-path compare, and one-path capture at 100k tracked paths.
- Keep clean hot-index loads on directory sidecars while preserving journal replay for changed-path and full loads.
- Enforce the Instant 100k warm clean status target as an explicit p95 <= 50 ms release-CI assertion and surface it in the workflow summary.

## Closes

Closes #1266

## Evidence

- Exact release-CI contract profile, 20 samples: clean status at 100k paths p95 **11.703 ms** against the **50.000 ms** target; structural counters were 2 directories scanned and 0 files hashed.
- Negative control (`HEDDLE_PERF_NEGATIVE_CONTROL=full-scan`, 5 samples): exited 101 with `PERF GATE RED`; clean status p95 **1296.809 ms**, 2,004 directories scanned, and 100,000 files hashed.
- Focused Criterion executions: `worktree_is_clean/100000` and `capture_one_path/100000` both reported `Success`.
- `cargo test --locked -p heddle-repo v6_hot_load_reads_directory_proofs_without_file_table` passed.
- `cargo test --locked -p heddle-devtools` passed all 71 tests.
- `cargo clippy --locked --workspace -- -D warnings` passed.
- `cargo clippy --locked -p heddle-cli --bench local_ops -- -D warnings` passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788840445&installation_model_id=21489&pr_number=1267&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1267&signature=f8470353441b5ea7bc5774d3530e8de1ea530d39d081d27c91848b9034057e42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->