### PR TITLE
feat(provenance): verify offline state chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2230,6 +2230,7 @@ dependencies = [
  "heddle-refs",
  "heddle-repo",
  "heddle-semantic",
+ "hex",
  "ignore",
  "rmp-serde",
  "schemars",

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -17261,6 +17261,78 @@
             "count"
           ],
           "type": "object"
+        },
+        "ProvenanceReport": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "registry_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "registry_status": {
+              "type": "string"
+            },
+            "states": {
+              "items": {
+                "$ref": "#/$defs/StateProvenanceVerification"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "clean",
+            "registry_status",
+            "states"
+          ],
+          "type": "object"
+        },
+        "StateProvenanceVerification": {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "failed_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewer_identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reviews_verified": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "state_id",
+            "status",
+            "detail",
+            "reviews_verified",
+            "reviewer_identities"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17278,6 +17350,16 @@
           "format": "uint",
           "minimum": 0,
           "type": "integer"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "repair_target": {
           "type": [
@@ -17363,6 +17445,78 @@
             "count"
           ],
           "type": "object"
+        },
+        "ProvenanceReport": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "registry_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "registry_status": {
+              "type": "string"
+            },
+            "states": {
+              "items": {
+                "$ref": "#/$defs/StateProvenanceVerification"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "clean",
+            "registry_status",
+            "states"
+          ],
+          "type": "object"
+        },
+        "StateProvenanceVerification": {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "failed_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewer_identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reviews_verified": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "state_id",
+            "status",
+            "detail",
+            "reviews_verified",
+            "reviewer_identities"
+          ],
+          "type": "object"
         }
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -17417,6 +17571,16 @@
                 "replayed"
               ],
               "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceReport"
             },
             {
               "type": "null"
@@ -37938,6 +38102,34 @@
           ],
           "type": "object"
         },
+        "ProvenanceReport": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "registry_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "registry_status": {
+              "type": "string"
+            },
+            "states": {
+              "items": {
+                "$ref": "#/$defs/StateProvenanceVerification"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "clean",
+            "registry_status",
+            "states"
+          ],
+          "type": "object"
+        },
         "RepositoryContextInfo": {
           "properties": {
             "kind": {
@@ -38095,6 +38287,50 @@
           ],
           "type": "object"
         },
+        "StateProvenanceVerification": {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "failed_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewer_identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reviews_verified": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "state_id",
+            "status",
+            "detail",
+            "reviews_verified",
+            "reviewer_identities"
+          ],
+          "type": "object"
+        },
         "VerificationCheck": {
           "properties": {
             "clean": {
@@ -38166,6 +38402,16 @@
             "verify"
           ],
           "type": "string"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "repository_context": {
           "anyOf": [

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1074,6 +1074,7 @@ export interface FsckRepairGitSchema {
   objects_checked: number;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  provenance?: ProvenanceReport | null;
   repair_target?: string | null;
   repaired: boolean;
   repairs: FsckRepair[];
@@ -1086,6 +1087,7 @@ export interface FsckSchema {
   errors: FsckError[];
   git_projection_checked: boolean;
   objects_checked: number;
+  provenance?: ProvenanceReport | null;
   repair_target?: string | null;
   repaired: boolean;
   repairs: FsckRepair[];
@@ -1555,6 +1557,13 @@ export interface ParallelThreadInfo {
 export interface PartialFetchInspectionSchema {
   count: number;
   missing_blob_count: number;
+}
+
+export interface ProvenanceReport {
+  clean: boolean;
+  registry_hash?: string | null;
+  registry_status: string;
+  states: StateProvenanceVerification[];
 }
 
 export interface PullGitSchema {
@@ -2230,6 +2239,16 @@ export interface StateInfo {
   content_hash: string;
   intent?: string | null;
   state_id: string;
+}
+
+export interface StateProvenanceVerification {
+  detail: string;
+  failed_link?: string | null;
+  identity?: string | null;
+  reviewer_identities: string[];
+  reviews_verified: number;
+  state_id: string;
+  status: string;
 }
 
 export interface StatusSchema {
@@ -3174,6 +3193,7 @@ export interface VerificationCheckSchema {
 export interface VerifyReport {
   clean: boolean;
   output_kind: "verify";
+  provenance?: ProvenanceReport | null;
   repository_context?: RepositoryContextInfo | null;
   repository_label: string;
   verification: RepositoryVerificationState;

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -31,6 +31,10 @@ pub struct FsckArgs {
     #[arg(long)]
     pub thorough: bool,
 
+    /// Verify offline authorship identity and review-signature chains.
+    #[arg(long, requires = "thorough")]
+    pub provenance: bool,
+
     /// Include Git projection, mapping, notes, and checkout checks.
     #[arg(long)]
     pub git: bool,
@@ -137,7 +141,11 @@ Examples:
   heddle verify --verbose      # full proof rows and machine-contract details
   heddle verify --output json  # proof JSON when clean; error envelope when blocked
 ")]
-    Verify,
+    Verify {
+        /// Verify each state's offline authorship and review-signature chain.
+        #[arg(long)]
+        provenance: bool,
+    },
 
     /// Explain repository health, or run targeted doctor checks.
     ///

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -4459,7 +4459,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         Commands::Help { .. } => vec!["help"],
         Commands::Status { .. } => vec!["status"],
         Commands::Watch(_) => vec!["watch"],
-        Commands::Verify => vec!["verify"],
+        Commands::Verify { .. } => vec!["verify"],
         Commands::Doctor(args) => match &args.command {
             None => vec!["doctor"],
             Some(DoctorCommands::Docs(_)) => vec!["doctor", "docs"],

--- a/crates/cli-render/src/cli/render/fsck.rs
+++ b/crates/cli-render/src/cli/render/fsck.rs
@@ -66,6 +66,24 @@ pub fn fsck_text(report: &FsckReport) -> Result<()> {
             }
         }
     }
+    if let Some(provenance) = &report.provenance {
+        text.push_str(&format!(
+            "  {}\n",
+            style::field("Provenance registry", &provenance.registry_status)
+        ));
+        for state in &provenance.states {
+            let short = state
+                .state_id
+                .strip_prefix("hs-")
+                .unwrap_or(&state.state_id);
+            let short = &short[..short.len().min(12)];
+            text.push_str(&format!(
+                "    {short} {:<24} {}\n",
+                state.display_status(),
+                state.detail
+            ));
+        }
+    }
     for warning in &report.warnings {
         text.push_str(&format!("{} {}\n", style::warn_marker(), warning));
     }

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -8,9 +8,15 @@ use repo::RepositorySourceAuthority;
 use super::advice::RecoveryAdvice;
 use crate::cli::{Cli, execution_context_from_cli, render, should_output_json};
 
-pub fn cmd_fsck(cli: &Cli, full: bool, thorough: bool, git_projection: bool) -> Result<()> {
+pub fn cmd_fsck(
+    cli: &Cli,
+    full: bool,
+    thorough: bool,
+    provenance: bool,
+    git_projection: bool,
+) -> Result<()> {
     let ctx = execution_context_from_cli(cli)?;
-    run_fsck(cli, &ctx, full, thorough, git_projection, None)
+    run_fsck(cli, &ctx, full, thorough, provenance, git_projection, None)
 }
 
 pub fn cmd_fsck_repair_git(
@@ -21,7 +27,7 @@ pub fn cmd_fsck_repair_git(
 ) -> Result<()> {
     let ctx = execution_context_from_cli(cli)?;
     let repairs = repair_git(ctx.require_repo()?, ref_name, prefer, preview)?;
-    run_fsck(cli, &ctx, false, false, true, Some(repairs))
+    run_fsck(cli, &ctx, false, false, false, true, Some(repairs))
 }
 
 fn run_fsck(
@@ -29,6 +35,7 @@ fn run_fsck(
     ctx: &heddle_core::ExecutionContext,
     full: bool,
     thorough: bool,
+    provenance: bool,
     git_projection: bool,
     repairs: Option<Vec<FsckRepair>>,
 ) -> Result<()> {
@@ -37,6 +44,7 @@ fn run_fsck(
         FsckOptions {
             full,
             thorough,
+            provenance,
             git_projection,
         },
     )?;

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -5,8 +5,8 @@ use std::{path::Path, time::Instant};
 
 use anyhow::{Result, anyhow};
 use heddle_core::{
-    MachineContractInput, RepositorySetupGuidance, RepositoryVerificationState, VerificationCheck,
-    VerifyOptions, VerifyReport, repository_setup_guidance, verify as core_verify,
+    MachineContractInput, RepositorySetupGuidance, VerificationCheck, VerifyOptions, VerifyReport,
+    repository_setup_guidance, verify as core_verify,
 };
 use repo::{Repository, discover_heddle_root};
 
@@ -17,7 +17,7 @@ use crate::{
     perf::{ProfileField, ProfileMode, emit_profile, instrumentation_enabled, profile_mode},
 };
 
-pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
+pub fn cmd_verify(cli: &Cli, verbose: bool, provenance: bool) -> Result<()> {
     let body_start = Instant::now();
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd).to_path_buf();
@@ -28,7 +28,8 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
             .with_start_path(start)
             .with_machine_contract_input(MachineContractInput::from_coverage(
                 super::verification_health::machine_contract_coverage(),
-            )),
+            ))
+            .with_provenance(provenance),
     )?;
     // Open cost is paid either in the CLI shell (injected) or inside core
     // (facade open). Exactly one side owns it; sum keeps profile truthful.
@@ -74,11 +75,11 @@ pub fn cmd_verify(cli: &Cli, verbose: bool) -> Result<()> {
     // Config comes from the single open above — never re-open for JSON mode.
     let as_json = should_output_json(cli, prepared.repo_config.as_ref());
     if !output.clean && as_json {
-        return Err(anyhow!(verify_failed_advice(&output.trust)));
+        return Err(anyhow!(verify_failed_advice(&output)));
     }
     render_verify(&output, verbose, as_json)?;
     if !output.clean {
-        return Err(anyhow!(verify_failed_advice(&output.trust)));
+        return Err(anyhow!(verify_failed_advice(&output)));
     }
     Ok(())
 }
@@ -164,7 +165,7 @@ fn render_verify(output: &VerifyReport, verbose: bool, as_json: bool) -> Result<
     let status = human_verify_status(output);
     println!(
         "{trust_label}: {}",
-        if output.trust.verified {
+        if output.clean {
             style::accent(&status)
         } else {
             style::warn(&status)
@@ -219,6 +220,7 @@ fn render_verify(output: &VerifyReport, verbose: bool, as_json: bool) -> Result<
             println!("{:<18} {}", "", style::dim(&details));
         }
     }
+    render_provenance(output);
     if verbose {
         println!();
         println!("Repository mode: {}", output.trust.repository_mode);
@@ -250,13 +252,14 @@ fn render_compact_verify(output: &VerifyReport) -> Result<()> {
     let status = compact_verify_status(output);
     println!(
         "{trust_label}: {}",
-        if output.trust.verified {
+        if output.clean {
             style::accent(&status)
         } else {
             style::warn(&status)
         }
     );
     let summary = human_output_summary(output);
+    render_provenance(output);
     let blocker = output.trust.checks.iter().find(|check| !check.clean);
     let blocker_summary = blocker.map(|check| human_summary(check, None, false));
     if !summary.is_empty() && blocker_summary.as_deref() != Some(summary.as_str()) {
@@ -300,6 +303,27 @@ fn render_compact_verify(output: &VerifyReport) -> Result<()> {
     Ok(())
 }
 
+fn render_provenance(output: &VerifyReport) {
+    let Some(report) = &output.provenance else {
+        return;
+    };
+    println!();
+    println!("{}", style::bold("Provenance"));
+    println!("Registry: {}", report.registry_status);
+    for state in &report.states {
+        let short = state
+            .state_id
+            .strip_prefix("hs-")
+            .unwrap_or(&state.state_id);
+        let short = &short[..short.len().min(12)];
+        println!(
+            "  {short} {:<24} {}",
+            state.display_status(),
+            style::dim(&state.detail)
+        );
+    }
+}
+
 fn render_verify_observe_only_note() {
     println!(
         "Mode: {}",
@@ -323,6 +347,13 @@ fn render_verify_repository_context(output: &VerifyReport) {
 }
 
 fn human_verify_status(output: &VerifyReport) -> String {
+    if output
+        .provenance
+        .as_ref()
+        .is_some_and(|report| !report.clean)
+    {
+        return "provenance failed".to_string();
+    }
     if let Some(check) = output.trust.checks.iter().find(|check| !check.clean) {
         if is_worktree_save_blocker(check) {
             return "changes to save".to_string();
@@ -338,7 +369,7 @@ fn human_verify_status(output: &VerifyReport) -> String {
 }
 
 fn compact_verify_status(output: &VerifyReport) -> String {
-    if output.trust.verified {
+    if output.clean {
         "verified".to_string()
     } else {
         human_verify_status(output)
@@ -358,6 +389,13 @@ fn human_check_status(check: &VerificationCheck) -> String {
 }
 
 fn human_output_summary(output: &VerifyReport) -> String {
+    if let Some(state) = output
+        .provenance
+        .as_ref()
+        .and_then(|report| report.states.iter().find(|state| !state.is_clean()))
+    {
+        return format!("{}: {}", state.display_status(), state.detail);
+    }
     if let Some(check) = output.trust.checks.iter().find(|check| !check.clean) {
         if setup_needed_guidance(output).is_some() {
             return String::new();
@@ -394,7 +432,37 @@ fn verify_status_label(output: &VerifyReport) -> &'static str {
     }
 }
 
-fn verify_failed_advice(verification: &RepositoryVerificationState) -> RecoveryAdvice {
+fn verify_failed_advice(output: &VerifyReport) -> RecoveryAdvice {
+    let verification = &output.trust;
+    if verification.verified
+        && let Some(provenance) = output.provenance.as_ref().filter(|report| !report.clean)
+    {
+        let blocker = provenance
+            .states
+            .iter()
+            .find(|state| !state.is_clean())
+            .expect("an unclean provenance report has a blocker");
+        let primary_command = "heddle verify --provenance".to_string();
+        let mut advice = RecoveryAdvice::safety_refusal(
+            "provenance_verify_failed",
+            format!(
+                "Provenance verification failed: {}",
+                blocker.display_status()
+            ),
+            format!("Inspect the broken chain with `{primary_command} --verbose`."),
+            blocker.detail.clone(),
+            "accepting this state would render an unverified provenance claim as verified",
+            "verify is observe-only; repository objects, refs, index, and worktree files were left unchanged",
+            primary_command.clone(),
+            vec![primary_command],
+        );
+        if let Ok(value) = serde_json::to_value(provenance) {
+            advice
+                .extra_json_fields
+                .insert("provenance".to_string(), value);
+        }
+        return advice;
+    }
     let primary_command = if verification.recommended_action.trim().is_empty() {
         "heddle status".to_string()
     } else {
@@ -418,6 +486,13 @@ fn verify_failed_advice(verification: &RepositoryVerificationState) -> RecoveryA
         advice
             .extra_json_fields
             .insert("verification".to_string(), value);
+    }
+    if let Some(provenance) = &output.provenance
+        && let Ok(value) = serde_json::to_value(provenance)
+    {
+        advice
+            .extra_json_fields
+            .insert("provenance".to_string(), value);
     }
     advice
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -370,7 +370,7 @@ async fn async_main() -> Result<()> {
 
         Commands::Watch(args) => cmd_watch(&cli, args.clone()).await,
 
-        Commands::Verify => cmd_verify(&cli, cli.verbose > 0),
+        Commands::Verify { provenance } => cmd_verify(&cli, cli.verbose > 0, *provenance),
 
         Commands::Doctor(args) => match &args.command {
             None => cmd_doctor(&cli, args.profile),
@@ -595,7 +595,7 @@ async fn async_main() -> Result<()> {
         },
 
         Commands::Fsck(args) => match &args.command {
-            None => cmd_fsck(&cli, args.full, args.thorough, args.git),
+            None => cmd_fsck(&cli, args.full, args.thorough, args.provenance, args.git),
             Some(cli::cli::FsckCommands::Repair { target }) => match target {
                 cli::cli::FsckRepairCommands::Git(args) => cmd_fsck_repair_git(
                     &cli,

--- a/crates/cli/tests/provenance_verify.rs
+++ b/crates/cli/tests/provenance_verify.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+use chrono::Duration;
+use crypto::{Ed25519Signer, Signer, state_signature_from_signer};
+use objects::{
+    object::{
+        Blob, KeyBinding, KeyBindingRegistry, StateAttachment, StateAttachmentBody, StateSignature,
+    },
+    store::ObjectStore,
+};
+use repo::Repository;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn signed_repository() -> (TempDir, Repository) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    let state = repo
+        .current_state()
+        .expect("read current state")
+        .expect("seeded state");
+    let signer = Ed25519Signer::generate().expect("signer");
+    repo.store()
+        .put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::Signature(
+                state_signature_from_signer(&state.compute_hash(), &signer).expect("sign state"),
+            ),
+            attribution: state.attribution.clone(),
+            created_at: state.created_at,
+            supersedes: None,
+        })
+        .expect("attach state signature");
+
+    let public_key = hex::encode(signer.public_key());
+    let mut binding = KeyBinding {
+        algorithm: signer.algorithm().to_string(),
+        public_key: public_key.clone(),
+        identity_ref: "identity:alice".to_string(),
+        role: "author".to_string(),
+        added_by_sig: StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key,
+            signature: String::new(),
+        },
+        valid_from: state.created_at - Duration::seconds(1),
+        revoked_at: None,
+        delegated_from: None,
+    };
+    binding.added_by_sig.signature = hex::encode(
+        signer
+            .sign(&binding.canonical_signing_payload())
+            .expect("sign binding"),
+    );
+    let registry = KeyBindingRegistry::new(vec![binding]);
+    repo.store()
+        .put_blob(&Blob::new(registry.encode().expect("encode registry")))
+        .expect("store registry");
+    (temp, repo)
+}
+
+fn run_json(repo: &Repository, args: &[&str]) -> Value {
+    let output = Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .current_dir(repo.root())
+        .env_remove("CODEX_THREAD_ID")
+        .output()
+        .expect("run heddle");
+    assert!(
+        output.status.success(),
+        "command failed: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("JSON output")
+}
+
+#[test]
+fn verify_and_fsck_render_verified_registry_identity_end_to_end() {
+    let (_temp, repo) = signed_repository();
+
+    let verify = run_json(&repo, &["--output", "json", "verify", "--provenance"]);
+    assert_eq!(verify["clean"], true, "{verify}");
+    assert_eq!(
+        verify["provenance"]["states"][0]["status"], "Verified(identity:alice)",
+        "{verify}"
+    );
+    assert_eq!(
+        verify["provenance"]["states"][0]["identity"], "identity:alice",
+        "{verify}"
+    );
+
+    let fsck = run_json(
+        &repo,
+        &["--output", "json", "fsck", "--thorough", "--provenance"],
+    );
+    assert_eq!(fsck["valid"], true, "{fsck}");
+    assert_eq!(
+        fsck["provenance"]["states"][0]["status"], "Verified(identity:alice)",
+        "{fsck}"
+    );
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,6 +16,7 @@ cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = 
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
 merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
 ignore.workspace = true
+hex.workspace = true
 objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
 heddle-git-projection = { path = "../git-projection", version = "0.11", default-features = false }
 oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11", default-features = false }

--- a/crates/core/src/fsck/mod.rs
+++ b/crates/core/src/fsck/mod.rs
@@ -18,6 +18,7 @@ use crate::{ExecutionContext, HeddleReport, MachineOutputKind, ReportContract, s
 pub struct FsckOptions {
     pub full: bool,
     pub thorough: bool,
+    pub provenance: bool,
     pub git_projection: bool,
 }
 
@@ -28,6 +29,8 @@ pub struct FsckReport {
     pub warnings: Vec<String>,
     pub objects_checked: usize,
     pub git_projection_checked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<crate::ProvenanceReport>,
     pub repair_target: Option<String>,
     pub repaired: bool,
     pub repairs: Vec<FsckRepair>,
@@ -78,6 +81,35 @@ pub fn fsck(ctx: &ExecutionContext, opts: FsckOptions) -> Result<FsckReport> {
 
     state::check_states(repo, &mut errors, &mut objects_checked, opts.thorough)?;
 
+    let provenance = (opts.thorough && opts.provenance)
+        .then(|| crate::verify_repository_provenance(repo))
+        .transpose()?;
+    if let Some(provenance) = &provenance {
+        for state in &provenance.states {
+            match (state.status.as_str(), state.failed_link.as_deref()) {
+                ("Legacy", _) => errors.push(make_error(
+                    "legacy_provenance",
+                    &format!(
+                        "State {} Legacy at content link: {}",
+                        state.state_id, state.detail
+                    ),
+                    Some(state.state_id.clone()),
+                )),
+                (_, Some(_)) => errors.push(make_error(
+                    "invalid_provenance_chain",
+                    &format!(
+                        "State {} {}: {}",
+                        state.state_id,
+                        state.display_status(),
+                        state.detail
+                    ),
+                    Some(state.state_id.clone()),
+                )),
+                _ => {}
+            }
+        }
+    }
+
     if opts.full {
         objects::check_tree_objects(repo, &mut errors, &mut warnings, &mut objects_checked)?;
     }
@@ -101,6 +133,7 @@ pub fn fsck(ctx: &ExecutionContext, opts: FsckOptions) -> Result<FsckReport> {
         warnings,
         objects_checked,
         git_projection_checked: opts.git_projection,
+        provenance,
         repair_target: None,
         repaired: false,
         repairs: Vec::new(),

--- a/crates/core/src/fsck/tests.rs
+++ b/crates/core/src/fsck/tests.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
-use crypto::Ed25519Signer;
+use crypto::{Ed25519Signer, Signer};
 use objects::{
     object::{
         Attribution, Blob, FileProvenance, LineSpan, Origin, OriginSet, Principal, State,
-        StateAttachment, StateAttachmentBody, Tree, TreeEntry,
+        StateAttachment, StateAttachmentBody, StateSignature, Tree, TreeEntry,
     },
     store::ObjectStore,
 };
@@ -69,6 +69,48 @@ fn test_check_states_thorough_rejects_invalid_signature() {
         "expected invalid signature error, got {:?}",
         errors.iter().map(|error| &error.kind).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn fsck_thorough_provenance_fails_legacy_with_named_link() {
+    let (_temp, repo) = setup_repo();
+    let tree_hash = put_empty_tree(&repo).expect("put tree");
+    let state = State::new(tree_hash, vec![], sample_attribution());
+    let signer = Ed25519Signer::from_seed(&[8u8; 32]).expect("create signer");
+    repo.store().put_state(&state).expect("put state");
+    repo.store()
+        .put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::Signature(StateSignature {
+                algorithm: signer.algorithm().to_string(),
+                public_key: hex::encode(signer.public_key()),
+                signature: hex::encode(
+                    signer
+                        .sign(state.compute_hash().as_bytes())
+                        .expect("sign legacy state hash"),
+                ),
+            }),
+            attribution: state.attribution.clone(),
+            created_at: state.created_at,
+            supersedes: None,
+        })
+        .expect("put legacy signature");
+    let ctx = crate::ExecutionContext::builder().repo(repo).build();
+
+    let report = super::fsck(
+        &ctx,
+        super::FsckOptions {
+            thorough: true,
+            provenance: true,
+            ..super::FsckOptions::default()
+        },
+    )
+    .expect("run fsck");
+
+    assert!(!report.valid);
+    assert!(report.errors.iter().any(|error| {
+        error.kind == "legacy_provenance" && error.message.contains("Legacy at content link")
+    }));
 }
 
 #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod onboarding;
 pub mod oplog_plan;
 pub mod oss_plan;
 pub mod prove_plan;
+pub mod provenance_verify;
 pub mod purge_plan;
 pub mod query;
 pub mod rebase_plan;
@@ -199,6 +200,9 @@ pub use oplog_plan::{
 pub use prove_plan::{
     HostRepoPlanError, ProofStatusKind, proof_status_label, proof_submit_followup,
     require_host_repo,
+};
+pub use provenance_verify::{
+    ProvenanceReport, StateProvenanceVerification, verify_repository_provenance,
 };
 pub use purge_plan::{PurgeApplyPlan, plan_purge_apply, purge_apply_message, purge_force_command};
 pub use query::{QueryHit, QueryReport, QueryRequest, query};

--- a/crates/core/src/provenance_verify/content.rs
+++ b/crates/core/src/provenance_verify/content.rs
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use objects::{error::Result, object::ContentHash, store::ObjectStore};
+use repo::Repository;
+
+pub(super) fn verify_tree_content(repo: &Repository, root: ContentHash) -> Result<Option<String>> {
+    let mut pending = vec![root];
+    let mut seen = HashSet::new();
+    while let Some(hash) = pending.pop() {
+        if !seen.insert(hash) {
+            continue;
+        }
+        let tree = match repo.store().get_tree(&hash) {
+            Ok(Some(tree)) => tree,
+            Ok(None) => return Ok(Some(format!("tree {} is missing", hash.short()))),
+            Err(error) => {
+                return Ok(Some(format!(
+                    "tree {} failed content binding: {error}",
+                    hash.short()
+                )));
+            }
+        };
+        if tree.hash() != hash {
+            return Ok(Some(format!(
+                "tree {} failed content binding",
+                hash.short()
+            )));
+        }
+        for entry in tree.entries() {
+            if let Some(child) = entry.tree_hash() {
+                pending.push(child);
+            } else if let Some(blob_hash) = entry.blob_hash() {
+                let blob = match repo.store().get_blob(&blob_hash) {
+                    Ok(Some(blob)) => blob,
+                    Ok(None) => {
+                        return Ok(Some(format!(
+                            "tree path '{}' references missing blob {}",
+                            entry.name(),
+                            blob_hash.short()
+                        )));
+                    }
+                    Err(error) => {
+                        return Ok(Some(format!(
+                            "tree path '{}' blob {} failed content binding: {error}",
+                            entry.name(),
+                            blob_hash.short()
+                        )));
+                    }
+                };
+                if blob.hash() != blob_hash {
+                    return Ok(Some(format!(
+                        "tree path '{}' blob {} failed content binding",
+                        entry.name(),
+                        blob_hash.short()
+                    )));
+                }
+            }
+        }
+    }
+    Ok(None)
+}

--- a/crates/core/src/provenance_verify/mod.rs
+++ b/crates/core/src/provenance_verify/mod.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Offline verification of the state authorship and review-signature chain.
+
+mod content;
+mod result;
+#[cfg(test)]
+mod tests;
+
+use chrono::{DateTime, Utc};
+use crypto::verify_payload_signature;
+use objects::{
+    error::Result,
+    object::{
+        ContentHash, KeyBindingRegistry, ReviewSignature, ReviewSignaturesBlob, SignatureStatus,
+        State, StateAttachmentBody, StateAttachmentKind, StateId, signing_payload,
+    },
+    store::ObjectStore,
+};
+use repo::{AuthorshipVerification, Repository};
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use self::{
+    content::verify_tree_content,
+    result::{discover_registry, failed, identity_error, integrity_only, legacy},
+};
+
+const MAX_REGISTRY_BLOB_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct ProvenanceReport {
+    pub clean: bool,
+    pub registry_status: String,
+    pub registry_hash: Option<String>,
+    pub states: Vec<StateProvenanceVerification>,
+}
+
+#[derive(Debug, Clone, Serialize, JsonSchema, PartialEq, Eq)]
+pub struct StateProvenanceVerification {
+    pub state_id: String,
+    pub status: String,
+    pub identity: Option<String>,
+    pub failed_link: Option<String>,
+    pub detail: String,
+    pub reviews_verified: usize,
+    pub reviewer_identities: Vec<String>,
+}
+
+impl StateProvenanceVerification {
+    pub fn display_status(&self) -> String {
+        self.status.clone()
+    }
+
+    pub fn is_clean(&self) -> bool {
+        self.status == "IntegrityOnly" || self.status.starts_with("Verified(")
+    }
+}
+
+enum RegistryDiscovery {
+    Absent,
+    Available {
+        registry: KeyBindingRegistry,
+        hash: ContentHash,
+    },
+    Invalid(String),
+}
+
+pub fn verify_repository_provenance(repo: &Repository) -> Result<ProvenanceReport> {
+    let registry = discover_registry(repo)?;
+    let (registry_status, registry_hash) = match &registry {
+        RegistryDiscovery::Absent => ("absent", None),
+        RegistryDiscovery::Available { hash, .. } => ("available", Some(hash.to_string())),
+        RegistryDiscovery::Invalid(_) => ("invalid", None),
+    };
+    let mut state_ids = repo.store().list_states()?;
+    state_ids.sort();
+    let mut states = Vec::with_capacity(state_ids.len());
+    for state_id in state_ids {
+        match repo.store().get_state(&state_id) {
+            Ok(Some(state)) => states.push(verify_state(repo, &state, &registry)?),
+            Ok(None) => states.push(failed(state_id, "content", "state object is missing")),
+            Err(error) => states.push(failed(
+                state_id,
+                "content",
+                &format!("state object failed content binding: {error}"),
+            )),
+        }
+    }
+    Ok(ProvenanceReport {
+        clean: states.iter().all(StateProvenanceVerification::is_clean),
+        registry_status: registry_status.to_string(),
+        registry_hash,
+        states,
+    })
+}
+
+fn verify_state(
+    repo: &Repository,
+    state: &State,
+    registry: &RegistryDiscovery,
+) -> Result<StateProvenanceVerification> {
+    let attachments = repo.list_state_attachments(&state.state_id)?;
+    let signature_attributions: Vec<_> = attachments
+        .iter()
+        .filter_map(|attachment| match &attachment.body {
+            StateAttachmentBody::Signature(_) => Some(&attachment.attribution),
+            _ => None,
+        })
+        .collect();
+    let signature_attribution_matches = signature_attributions
+        .iter()
+        .all(|attribution| **attribution == state.attribution);
+    if state.id() != state.state_id {
+        return Ok(failed(
+            state.state_id,
+            "content",
+            "state content hash does not match its stored state id",
+        ));
+    }
+    if let Some(detail) = verify_tree_content(repo, state.tree)? {
+        return Ok(failed(state.state_id, "content", &detail));
+    }
+
+    let verification = match repo.verify_state_signature(&state.state_id)? {
+        SignatureStatus::Unsigned => match registry {
+            RegistryDiscovery::Available { registry, .. } => {
+                verify_reviews(repo, state, Some(registry), None)
+            }
+            RegistryDiscovery::Absent => verify_reviews(repo, state, None, None),
+            RegistryDiscovery::Invalid(detail) => {
+                if repo
+                    .latest_state_attachment(
+                        &state.state_id,
+                        StateAttachmentKind::ReviewSignatures,
+                    )?
+                    .is_some()
+                {
+                    failed(state.state_id, "review", detail)
+                } else {
+                    integrity_only(state.state_id, "state has no authorship signature")
+                }
+            }
+        },
+        SignatureStatus::Legacy => legacy(state.state_id),
+        SignatureStatus::Invalid => failed(
+            state.state_id,
+            "content",
+            "domain-tagged authorship signature did not verify",
+        ),
+        SignatureStatus::Valid => {
+            if !signature_attribution_matches {
+                failed(
+                    state.state_id,
+                    "identity",
+                    "signed state attribution does not match its signature evidence",
+                )
+            } else {
+                match registry {
+                    RegistryDiscovery::Absent => verify_reviews(repo, state, None, None),
+                    RegistryDiscovery::Invalid(detail) => {
+                        failed(state.state_id, "identity", detail)
+                    }
+                    RegistryDiscovery::Available { registry, .. } => {
+                        match repo.verify_authored_by_known_actor(state, registry)? {
+                            AuthorshipVerification::Verified(identity) => {
+                                verify_reviews(repo, state, Some(registry), Some(identity))
+                            }
+                            other => failed(
+                                state.state_id,
+                                "identity",
+                                &format!(
+                                    "authorship key resolution returned {}",
+                                    identity_error(&other)
+                                ),
+                            ),
+                        }
+                    }
+                }
+            }
+        }
+    };
+    Ok(verification)
+}
+
+fn verify_reviews(
+    repo: &Repository,
+    state: &State,
+    registry: Option<&KeyBindingRegistry>,
+    author_identity: Option<String>,
+) -> StateProvenanceVerification {
+    match verify_review_chain(repo, state, registry) {
+        Ok((count, reviewer_identities)) => match author_identity {
+            Some(identity) => StateProvenanceVerification {
+                state_id: state.state_id.to_string_full(),
+                status: format!("Verified({identity})"),
+                identity: Some(identity),
+                failed_link: None,
+                detail: format!("authorship and {count} review signature(s) verified offline"),
+                reviews_verified: count,
+                reviewer_identities,
+            },
+            None => {
+                let mut result = integrity_only(
+                    state.state_id,
+                    if registry.is_some() && count > 0 {
+                        "state is unsigned; review-signature identities verified offline"
+                    } else if registry.is_some() {
+                        "state has no authorship signature"
+                    } else {
+                        "content and signatures verify, but no key-binding registry is present"
+                    },
+                );
+                result.reviews_verified = count;
+                result.reviewer_identities = reviewer_identities;
+                result
+            }
+        },
+        Err(detail) => failed(state.state_id, "review", &detail),
+    }
+}
+
+fn verify_review_chain(
+    repo: &Repository,
+    state: &State,
+    registry: Option<&KeyBindingRegistry>,
+) -> std::result::Result<(usize, Vec<String>), String> {
+    let attachment = repo
+        .latest_state_attachment(&state.state_id, StateAttachmentKind::ReviewSignatures)
+        .map_err(|error| error.to_string())?;
+    let Some(attachment) = attachment else {
+        return Ok((0, Vec::new()));
+    };
+    let StateAttachmentBody::ReviewSignatures(hash) = attachment.body else {
+        return Err("review attachment has the wrong body kind".to_string());
+    };
+    let blob = repo
+        .store()
+        .get_blob(&hash)
+        .map_err(|error| error.to_string())?
+        .ok_or_else(|| format!("review-signatures blob {} is missing", hash.short()))?;
+    if blob.hash() != hash {
+        return Err(format!(
+            "review-signatures blob {} failed content binding",
+            hash.short()
+        ));
+    }
+    let reviews =
+        ReviewSignaturesBlob::decode(blob.content()).map_err(|error| error.to_string())?;
+    let mut identities = Vec::with_capacity(reviews.signatures.len());
+    for review in &reviews.signatures {
+        verify_review_signature(state.state_id, review)?;
+        if let Some(registry) = registry {
+            let signed_at = DateTime::<Utc>::from_timestamp(review.signed_at, 0)
+                .ok_or_else(|| "review signature has an invalid signed_at".to_string())?;
+            match repo.verify_known_actor_key(
+                &review.algorithm,
+                &review.public_key,
+                signed_at,
+                registry,
+            ) {
+                AuthorshipVerification::Verified(identity) => identities.push(identity),
+                other => {
+                    return Err(format!(
+                        "reviewer key resolution returned {}",
+                        identity_error(&other)
+                    ));
+                }
+            }
+        }
+    }
+    Ok((reviews.signatures.len(), identities))
+}
+
+fn verify_review_signature(
+    state_id: StateId,
+    review: &ReviewSignature,
+) -> std::result::Result<(), String> {
+    review.validate().map_err(|error| error.to_string())?;
+    let public_key = hex::decode(&review.public_key)
+        .map_err(|error| format!("review public key is not hexadecimal: {error}"))?;
+    let signature = hex::decode(&review.signature)
+        .map_err(|error| format!("review signature is not hexadecimal: {error}"))?;
+    let payload = signing_payload(
+        state_id,
+        review.kind,
+        &review.scope,
+        review.signed_at,
+        review.justification.as_deref(),
+    );
+    verify_payload_signature(&payload, &review.algorithm, &public_key, &signature)
+        .map_err(|error| format!("review signature did not verify: {error}"))
+}

--- a/crates/core/src/provenance_verify/result.rs
+++ b/crates/core/src/provenance_verify/result.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashSet;
+
+use objects::{
+    error::Result,
+    object::{ContentHash, KeyBindingRegistry, StateAttachmentBody, StateId},
+    store::ObjectStore,
+};
+use repo::{AuthorshipVerification, Repository};
+
+use super::{MAX_REGISTRY_BLOB_BYTES, RegistryDiscovery, StateProvenanceVerification};
+
+pub(super) fn discover_registry(repo: &Repository) -> Result<RegistryDiscovery> {
+    let source_and_metadata_blobs = referenced_content_hashes(repo)?;
+    let mut candidates = Vec::new();
+    for hash in repo.store().list_blobs()? {
+        if source_and_metadata_blobs.contains(&hash) {
+            continue;
+        }
+        let Ok(Some(blob)) = repo.store().get_blob(&hash) else {
+            continue;
+        };
+        if blob.size() > MAX_REGISTRY_BLOB_BYTES {
+            continue;
+        }
+        let Ok(registry) = KeyBindingRegistry::decode(blob.content()) else {
+            continue;
+        };
+        if blob.hash() != hash {
+            return Ok(RegistryDiscovery::Invalid(format!(
+                "key-binding registry blob {} failed content binding",
+                hash.short()
+            )));
+        }
+        if !candidates
+            .iter()
+            .any(|(candidate_hash, _)| *candidate_hash == hash)
+        {
+            candidates.push((hash, registry));
+        }
+    }
+    match candidates.len() {
+        0 => Ok(RegistryDiscovery::Absent),
+        1 => {
+            let (hash, registry) = candidates.pop().expect("one candidate exists");
+            Ok(RegistryDiscovery::Available { registry, hash })
+        }
+        count => Ok(RegistryDiscovery::Invalid(format!(
+            "found {count} distinct key-binding registries; offline trust root is ambiguous"
+        ))),
+    }
+}
+
+fn referenced_content_hashes(repo: &Repository) -> Result<HashSet<ContentHash>> {
+    let mut referenced = HashSet::new();
+    let mut trees = Vec::new();
+    for state_id in repo.store().list_states()? {
+        let Ok(Some(state)) = repo.store().get_state(&state_id) else {
+            continue;
+        };
+        trees.push(state.tree);
+        if let Some(provenance) = state.provenance {
+            trees.push(provenance);
+        }
+        for attachment in repo.list_state_attachments(&state_id)? {
+            match attachment.body {
+                StateAttachmentBody::Context(root) | StateAttachmentBody::SemanticIndex(root) => {
+                    trees.push(root)
+                }
+                StateAttachmentBody::RiskSignals(hash)
+                | StateAttachmentBody::ReviewSignatures(hash)
+                | StateAttachmentBody::Discussions(hash)
+                | StateAttachmentBody::StructuredConflicts(hash) => {
+                    referenced.insert(hash);
+                }
+                StateAttachmentBody::Signature(_) => {}
+            }
+        }
+    }
+    while let Some(hash) = trees.pop() {
+        if !referenced.insert(hash) {
+            continue;
+        }
+        let Ok(Some(tree)) = repo.store().get_tree(&hash) else {
+            continue;
+        };
+        for entry in tree.entries() {
+            if let Some(child) = entry.tree_hash() {
+                trees.push(child);
+            } else if let Some(blob) = entry.blob_hash() {
+                referenced.insert(blob);
+            }
+        }
+    }
+    Ok(referenced)
+}
+
+pub(super) fn identity_error(result: &AuthorshipVerification) -> &'static str {
+    match result {
+        AuthorshipVerification::Verified(_) => "Verified",
+        AuthorshipVerification::UnknownKey => "UnknownKey",
+        AuthorshipVerification::Revoked => "Revoked",
+        AuthorshipVerification::Invalid => "Invalid",
+    }
+}
+
+pub(super) fn integrity_only(state_id: StateId, detail: &str) -> StateProvenanceVerification {
+    StateProvenanceVerification {
+        state_id: state_id.to_string_full(),
+        status: "IntegrityOnly".to_string(),
+        identity: None,
+        failed_link: None,
+        detail: detail.to_string(),
+        reviews_verified: 0,
+        reviewer_identities: Vec::new(),
+    }
+}
+
+pub(super) fn legacy(state_id: StateId) -> StateProvenanceVerification {
+    StateProvenanceVerification {
+        state_id: state_id.to_string_full(),
+        status: "Legacy".to_string(),
+        identity: None,
+        failed_link: Some("content".to_string()),
+        detail: "only an untagged legacy authorship signature verifies".to_string(),
+        reviews_verified: 0,
+        reviewer_identities: Vec::new(),
+    }
+}
+
+pub(super) fn failed(state_id: StateId, link: &str, detail: &str) -> StateProvenanceVerification {
+    StateProvenanceVerification {
+        state_id: state_id.to_string_full(),
+        status: format!("FAILED({link})"),
+        identity: None,
+        failed_link: Some(link.to_string()),
+        detail: detail.to_string(),
+        reviews_verified: 0,
+        reviewer_identities: Vec::new(),
+    }
+}

--- a/crates/core/src/provenance_verify/tests.rs
+++ b/crates/core/src/provenance_verify/tests.rs
@@ -1,0 +1,311 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs;
+
+use chrono::{TimeZone, Utc};
+use crypto::{Ed25519Signer, Signer, state_signature_from_signer};
+use objects::{
+    object::{
+        Attribution, Blob, KeyBinding, KeyBindingRegistry, Principal, ReviewKind, ReviewScope,
+        ReviewSignature, ReviewSignaturesBlob, State, StateAttachment, StateAttachmentBody,
+        StateSignature, Tree, TreeEntry, signing_payload,
+    },
+    store::ObjectStore,
+};
+use repo::Repository;
+use tempfile::TempDir;
+
+use super::{StateProvenanceVerification, verify_repository_provenance};
+
+fn setup() -> (TempDir, Repository) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    (temp, repo)
+}
+
+fn alice() -> Attribution {
+    Attribution::human(Principal::new("Alice", "alice@example.com"))
+}
+
+fn state_with_blob(repo: &Repository, blob_hash: objects::object::ContentHash) -> State {
+    let tree = Tree::from_entries(vec![
+        TreeEntry::file("proof.txt", blob_hash, false).expect("tree entry"),
+    ]);
+    let tree_hash = repo.store().put_tree(&tree).expect("put tree");
+    State::new(tree_hash, Vec::new(), alice()).with_timestamp(Utc.timestamp_opt(2_000, 0).unwrap())
+}
+
+fn attach_signature(
+    repo: &Repository,
+    state: &State,
+    signature: StateSignature,
+    attribution: Attribution,
+) {
+    repo.store()
+        .put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::Signature(signature),
+            attribution,
+            created_at: state.created_at,
+            supersedes: None,
+        })
+        .expect("put signature attachment");
+}
+
+fn binding(signer: &Ed25519Signer, identity: &str, revoked_at: Option<i64>) -> KeyBinding {
+    let public_key = hex::encode(signer.public_key());
+    let mut binding = KeyBinding {
+        algorithm: signer.algorithm().to_string(),
+        public_key: public_key.clone(),
+        identity_ref: identity.to_string(),
+        role: "author".to_string(),
+        added_by_sig: StateSignature {
+            algorithm: signer.algorithm().to_string(),
+            public_key,
+            signature: String::new(),
+        },
+        valid_from: Utc.timestamp_opt(1_000, 0).unwrap(),
+        revoked_at: revoked_at.map(|value| Utc.timestamp_opt(value, 0).unwrap()),
+        delegated_from: None,
+    };
+    binding.added_by_sig.signature = hex::encode(
+        signer
+            .sign(&binding.canonical_signing_payload())
+            .expect("sign binding"),
+    );
+    binding
+}
+
+fn put_registry(repo: &Repository, bindings: Vec<KeyBinding>) {
+    let bytes = KeyBindingRegistry::new(bindings)
+        .encode()
+        .expect("encode registry");
+    repo.store()
+        .put_blob(&Blob::new(bytes))
+        .expect("put registry blob");
+}
+
+fn result_for(repo: &Repository, state: &State) -> StateProvenanceVerification {
+    verify_repository_provenance(repo)
+        .expect("verify provenance")
+        .states
+        .into_iter()
+        .find(|result| result.state_id == state.state_id.to_string_full())
+        .expect("state result")
+}
+
+#[test]
+fn flipped_tree_byte_fails_content_link() {
+    let (_temp, repo) = setup();
+    let expected_blob = Blob::from("hello");
+    let expected_hash = expected_blob.hash();
+    let state = state_with_blob(&repo, expected_hash);
+    let signer = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    attach_signature(
+        &repo,
+        &state,
+        state_signature_from_signer(&state.compute_hash(), &signer).unwrap(),
+        state.attribution.clone(),
+    );
+    put_registry(&repo, vec![binding(&signer, "identity:alice", None)]);
+    repo.store().put_blob(&expected_blob).unwrap();
+    let tree_hex = state.tree.to_hex();
+    let path = repo
+        .heddle_dir()
+        .join("objects/trees")
+        .join(&tree_hex[..2])
+        .join(&tree_hex[2..]);
+    let mut bytes = fs::read(&path).unwrap();
+    let last = bytes.last_mut().expect("non-empty tree file");
+    *last ^= 1;
+    fs::write(path, bytes).unwrap();
+    repo.store().clear_recent_caches();
+
+    let result = result_for(&repo, &state);
+    assert_eq!(result.display_status(), "FAILED(content)");
+    assert!(result.detail.contains("content binding"));
+}
+
+#[test]
+fn swapped_attribution_fails_identity_link() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let original = state_with_blob(&repo, blob_hash);
+    let signer = Ed25519Signer::generate().unwrap();
+    let signature = state_signature_from_signer(&original.compute_hash(), &signer).unwrap();
+    repo.store().put_state(&original).unwrap();
+    attach_signature(
+        &repo,
+        &original,
+        signature,
+        Attribution::human(Principal::new("Mallory", "mallory@example.com")),
+    );
+    put_registry(&repo, vec![binding(&signer, "identity:alice", None)]);
+
+    let result = result_for(&repo, &original);
+    assert_eq!(result.display_status(), "FAILED(identity)");
+    assert!(result.detail.contains("attribution"));
+}
+
+#[test]
+fn unregistered_key_fails_identity_as_unknown_key() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let state = state_with_blob(&repo, blob_hash);
+    let signer = Ed25519Signer::generate().unwrap();
+    let other = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    attach_signature(
+        &repo,
+        &state,
+        state_signature_from_signer(&state.compute_hash(), &signer).unwrap(),
+        state.attribution.clone(),
+    );
+    put_registry(&repo, vec![binding(&other, "identity:other", None)]);
+
+    let result = result_for(&repo, &state);
+    assert_eq!(result.display_status(), "FAILED(identity)");
+    assert!(result.detail.contains("UnknownKey"));
+}
+
+#[test]
+fn revoked_key_fails_identity_as_revoked() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let state = state_with_blob(&repo, blob_hash);
+    let signer = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    attach_signature(
+        &repo,
+        &state,
+        state_signature_from_signer(&state.compute_hash(), &signer).unwrap(),
+        state.attribution.clone(),
+    );
+    put_registry(&repo, vec![binding(&signer, "identity:alice", Some(1_999))]);
+
+    let result = result_for(&repo, &state);
+    assert_eq!(result.display_status(), "FAILED(identity)");
+    assert!(result.detail.contains("Revoked"));
+}
+
+#[test]
+fn untagged_signature_is_legacy_and_not_clean() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let state = state_with_blob(&repo, blob_hash);
+    let signer = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    let legacy = StateSignature {
+        algorithm: signer.algorithm().to_string(),
+        public_key: hex::encode(signer.public_key()),
+        signature: hex::encode(signer.sign(state.compute_hash().as_bytes()).unwrap()),
+    };
+    attach_signature(&repo, &state, legacy, state.attribution.clone());
+
+    let report = verify_repository_provenance(&repo).unwrap();
+    let result = report
+        .states
+        .iter()
+        .find(|result| result.state_id == state.state_id.to_string_full())
+        .unwrap();
+    assert_eq!(result.display_status(), "Legacy");
+    assert!(!report.clean);
+}
+
+#[test]
+fn verifies_authorship_and_review_chain_by_registry_identity() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let state = state_with_blob(&repo, blob_hash);
+    let author = Ed25519Signer::generate().unwrap();
+    let reviewer = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    attach_signature(
+        &repo,
+        &state,
+        state_signature_from_signer(&state.compute_hash(), &author).unwrap(),
+        state.attribution.clone(),
+    );
+    attach_review(&repo, &state, &reviewer, false);
+    put_registry(
+        &repo,
+        vec![
+            binding(&author, "identity:alice", None),
+            binding(&reviewer, "identity:bob", None),
+        ],
+    );
+
+    let result = result_for(&repo, &state);
+    assert_eq!(result.display_status(), "Verified(identity:alice)");
+    assert_eq!(result.reviewer_identities, vec!["identity:bob"]);
+}
+
+#[test]
+fn tampered_review_signature_fails_review_link() {
+    let (_temp, repo) = setup();
+    let blob_hash = repo.store().put_blob(&Blob::from("hello")).unwrap();
+    let state = state_with_blob(&repo, blob_hash);
+    let author = Ed25519Signer::generate().unwrap();
+    let reviewer = Ed25519Signer::generate().unwrap();
+    repo.store().put_state(&state).unwrap();
+    attach_signature(
+        &repo,
+        &state,
+        state_signature_from_signer(&state.compute_hash(), &author).unwrap(),
+        state.attribution.clone(),
+    );
+    attach_review(&repo, &state, &reviewer, true);
+    put_registry(
+        &repo,
+        vec![
+            binding(&author, "identity:alice", None),
+            binding(&reviewer, "identity:bob", None),
+        ],
+    );
+
+    let result = result_for(&repo, &state);
+    assert_eq!(result.display_status(), "FAILED(review)");
+    assert!(result.detail.contains("did not verify"));
+}
+
+fn attach_review(repo: &Repository, state: &State, signer: &Ed25519Signer, tamper: bool) {
+    let signed_at = 2_001;
+    let payload = signing_payload(
+        state.state_id,
+        ReviewKind::Read,
+        &ReviewScope::WholeChange,
+        signed_at,
+        None,
+    );
+    let mut review = ReviewSignature {
+        actor: Principal::new("Unverified label", "claim@example.com"),
+        kind: ReviewKind::Read,
+        scope: ReviewScope::WholeChange,
+        justification: None,
+        signed_at,
+        algorithm: signer.algorithm().to_string(),
+        public_key: hex::encode(signer.public_key()),
+        signature: hex::encode(signer.sign(&payload).unwrap()),
+    };
+    if tamper {
+        let mut signature = hex::decode(&review.signature).unwrap();
+        signature[0] ^= 1;
+        review.signature = hex::encode(signature);
+    }
+    let hash = repo
+        .store()
+        .put_blob(&Blob::new(
+            ReviewSignaturesBlob::new(vec![review]).encode().unwrap(),
+        ))
+        .unwrap();
+    repo.store()
+        .put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::ReviewSignatures(hash),
+            attribution: state.attribution.clone(),
+            created_at: state.created_at,
+            supersedes: None,
+        })
+        .unwrap();
+}

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -32,6 +32,7 @@ pub struct VerifyOptions {
     pub start_path: Option<PathBuf>,
     pub machine_contract_input: MachineContractInput,
     pub action_audience: ActionAudience,
+    pub provenance: bool,
 }
 
 impl VerifyOptions {
@@ -40,6 +41,7 @@ impl VerifyOptions {
             start_path: None,
             machine_contract_input: MachineContractInput::default(),
             action_audience: ActionAudience::Human,
+            provenance: false,
         }
     }
 
@@ -55,6 +57,11 @@ impl VerifyOptions {
 
     pub fn with_action_audience(mut self, audience: ActionAudience) -> Self {
         self.action_audience = audience;
+        self
+    }
+
+    pub fn with_provenance(mut self, provenance: bool) -> Self {
+        self.provenance = provenance;
         self
     }
 }
@@ -101,6 +108,8 @@ pub struct VerifyReport {
     pub repository_context: Option<RepositoryContextInfo>,
     #[serde(rename = "verification")]
     pub trust: RepositoryVerificationState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provenance: Option<crate::ProvenanceReport>,
     #[serde(skip)]
     #[schemars(skip)]
     pub profile: VerifyProfile,
@@ -1471,6 +1480,7 @@ pub fn verify(ctx: &ExecutionContext, opts: VerifyOptions) -> Result<VerifyRepor
                 repository_label: repository_mode_label("plain-git", "git-only"),
                 repository_context: None,
                 trust: probe.trust,
+                provenance: None,
                 profile,
             });
         }
@@ -1485,14 +1495,19 @@ pub fn verify(ctx: &ExecutionContext, opts: VerifyOptions) -> Result<VerifyRepor
         repo,
         &opts.machine_contract_input,
     )?;
+    let provenance = opts
+        .provenance
+        .then(|| crate::verify_repository_provenance(repo))
+        .transpose()?;
     profile.verification_ms = verification_start.elapsed().as_millis();
     let presentation = repository_presentation(repo, None, None);
     Ok(VerifyReport {
         output_kind: "verify",
-        clean: trust.verified,
+        clean: trust.verified && provenance.as_ref().is_none_or(|report| report.clean),
         repository_label: presentation.label,
         repository_context: presentation.context,
         trust,
+        provenance,
         profile,
     })
 }

--- a/crates/repo/src/repository_key_binding.rs
+++ b/crates/repo/src/repository_key_binding.rs
@@ -20,6 +20,35 @@ pub enum AuthorshipVerification {
 }
 
 impl Repository {
+    /// Resolve a signing key through an offline registry at a claimed signing time.
+    ///
+    /// This verifies the registry's signed binding chain and validity window. It
+    /// deliberately does not verify a payload signature; callers must do that
+    /// first with the domain-specific signing payload.
+    pub fn verify_known_actor_key(
+        &self,
+        algorithm: &str,
+        public_key: &str,
+        signed_at: chrono::DateTime<chrono::Utc>,
+        registry: &KeyBindingRegistry,
+    ) -> AuthorshipVerification {
+        if !registry_is_authorized(registry) {
+            return AuthorshipVerification::Invalid;
+        }
+        let Some(binding) = find_binding_by_key(registry, algorithm, public_key) else {
+            return AuthorshipVerification::UnknownKey;
+        };
+        if signed_second_precedes(signed_at.timestamp(), binding.valid_from) {
+            return AuthorshipVerification::Invalid;
+        }
+        if binding.revoked_at.is_some_and(|revoked_at| {
+            signed_second_may_be_revoked(signed_at.timestamp(), revoked_at)
+        }) {
+            return AuthorshipVerification::Revoked;
+        }
+        AuthorshipVerification::Verified(binding.identity_ref.clone())
+    }
+
     /// Verify integrity and resolve a state author through an offline registry.
     ///
     /// Unknown keys fail closed even when their state signature is
@@ -32,10 +61,6 @@ impl Repository {
         state: &State,
         registry: &KeyBindingRegistry,
     ) -> Result<AuthorshipVerification> {
-        if !registry_is_authorized(registry) {
-            return Ok(AuthorshipVerification::Invalid);
-        }
-
         let signatures: Vec<_> = self
             .list_state_attachments(&state.id())?
             .into_iter()
@@ -48,42 +73,34 @@ impl Repository {
             return Ok(AuthorshipVerification::Invalid);
         }
 
-        let mut verified_identity: Option<&str> = None;
+        let mut verified_identity: Option<String> = None;
         let mut saw_unknown = false;
         let mut saw_revoked = false;
         let mut saw_invalid = false;
         for signature in &signatures {
-            let Some(binding) = find_binding(registry, signature) else {
-                saw_unknown = true;
-                continue;
-            };
             if verify_state_signature_bytes(signature, &state.compute_hash()).is_err() {
                 saw_invalid = true;
                 continue;
             }
-            let signed_at = state.created_at.timestamp();
-            if signed_second_precedes(signed_at, binding.valid_from) {
-                saw_invalid = true;
-                continue;
-            }
-            if binding
-                .revoked_at
-                .is_some_and(|revoked_at| signed_second_may_be_revoked(signed_at, revoked_at))
-            {
-                saw_revoked = true;
-                continue;
-            }
-            match verified_identity {
-                Some(identity) if identity != binding.identity_ref => saw_invalid = true,
-                Some(_) => {}
-                None => verified_identity = Some(&binding.identity_ref),
+            match self.verify_known_actor_key(
+                &signature.algorithm,
+                &signature.public_key,
+                state.created_at,
+                registry,
+            ) {
+                AuthorshipVerification::Verified(identity) => match &verified_identity {
+                    Some(prior) if *prior != identity => saw_invalid = true,
+                    Some(_) => {}
+                    None => verified_identity = Some(identity),
+                },
+                AuthorshipVerification::UnknownKey => saw_unknown = true,
+                AuthorshipVerification::Revoked => saw_revoked = true,
+                AuthorshipVerification::Invalid => saw_invalid = true,
             }
         }
 
         Ok(match verified_identity {
-            Some(identity) if !saw_invalid => {
-                AuthorshipVerification::Verified(identity.to_string())
-            }
+            Some(identity) if !saw_invalid => AuthorshipVerification::Verified(identity),
             Some(_) => AuthorshipVerification::Invalid,
             None if saw_revoked => AuthorshipVerification::Revoked,
             None if saw_invalid => AuthorshipVerification::Invalid,
@@ -171,16 +188,17 @@ fn signature_verifies(payload: &[u8], signature: &StateSignature) -> bool {
     verify_payload_signature(payload, &signature.algorithm, &public_key, &signature_bytes).is_ok()
 }
 
-fn find_binding<'a>(
+fn find_binding_by_key<'a>(
     registry: &'a KeyBindingRegistry,
-    signature: &StateSignature,
+    algorithm: &str,
+    public_key: &str,
 ) -> Option<&'a KeyBinding> {
     registry.bindings.iter().find(|binding| {
         key_matches(
             &binding.algorithm,
             &binding.public_key,
-            &signature.algorithm,
-            &signature.public_key,
+            algorithm,
+            public_key,
         )
     })
 }


### PR DESCRIPTION
## Summary

- add offline, per-state provenance verification across content-addressed tree/blob integrity, domain-tagged `hd-state-sig-v1` authorship signatures, active `KeyBindingRegistry` identity resolution, and review signatures
- emit only exact fail-closed statuses: `Verified(identity)`, `IntegrityOnly`, `Legacy`, or `FAILED(link)`; registry identities are the only identities rendered as verified
- add `heddle verify --provenance` and `heddle fsck --thorough --provenance`, including JSON schemas, generated TypeScript contracts, text rendering, and typed failure advice

## Closes

Closes #1257

## Test evidence

- `cargo test -p heddle-core provenance_verify -- --nocapture` — 7 passed, including:
  - flipped stored tree byte → `FAILED(content)`
  - swapped signature attribution → `FAILED(identity)`
  - unregistered signing key → `FAILED(identity)` with `UnknownKey`
  - key revoked at signing time → `FAILED(identity)` with `Revoked`
  - untagged legacy signature → `Legacy` and an unclean report
  - tampered review signature → `FAILED(review)`
  - valid authorship + review chain → `Verified(identity:alice)` with registry-resolved reviewer identity
- `cargo test -p heddle-cli --test provenance_verify -- --nocapture` — real CLI `verify` and `fsck` JSON paths passed with `Verified(identity:alice)`
- full affected-package targets (`heddle-repo`, `heddle-core`, `heddle-cli-args`, `heddle-cli-contract`, `heddle-cli-render`, `heddle-cli`) — passed; the 923-case CLI integration binary was fully covered with process isolation for its existing process-global harness-environment leakage (normal disposition: 904 passed, 19 ignored)
- `cargo test -p heddle-cli --test ts_types_in_sync` — 2 passed after regenerating JSON/TypeScript contracts
- `cargo test -p heddle-devtools` — 71 passed
- `cargo clippy --workspace -- -D warnings` — passed

All commands used `CARGO_TARGET_DIR=/home/scratch/h1257-target`, `TMPDIR=/home/scratch`, and ran in the foreground.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788848150&installation_model_id=21489&pr_number=1269&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1269&signature=072c76fef25ff0f0b5d0ce7d7b00f2376af4865c6af1d85e3ed3fd342f54b5ca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->