### PR TITLE
feat(wire): carry key binding registries

### DIFF
--- a/crates/cli/src/hosted_runtime/hosted/helpers.rs
+++ b/crates/cli/src/hosted_runtime/hosted/helpers.rs
@@ -167,15 +167,24 @@ pub(super) fn parse_object_id(
                 kind,
             })
         }
-        ObjectType::Blob | ObjectType::Tree | ObjectType::Action | ObjectType::Redaction => {
-            Ok(ObjectId::Hash(ContentHash::from_hex(value).map_err(
-                |err| ProtocolError::InvalidState(err.to_string()),
-            )?))
-        }
+        ObjectType::Blob
+        | ObjectType::Tree
+        | ObjectType::Action
+        | ObjectType::Redaction
+        | ObjectType::KeyBinding => Ok(ObjectId::Hash(
+            ContentHash::from_hex(value)
+                .map_err(|err| ProtocolError::InvalidState(err.to_string()))?,
+        )),
     }
 }
 
 pub(super) fn parse_object_type(value: i32) -> Result<ObjectType, ProtocolError> {
+    // heddle-api 0.3 predates the key-binding closure object. Prost preserves
+    // unknown enum discriminants in the i32 field, so recognize the reserved
+    // next value before asking the generated enum to decode it.
+    if value == HOSTED_OBJECT_TYPE_KEY_BINDING {
+        return Ok(ObjectType::KeyBinding);
+    }
     match HostedObjectType::try_from(value).unwrap_or_default() {
         HostedObjectType::Blob => Ok(ObjectType::Blob),
         HostedObjectType::Tree => Ok(ObjectType::Tree),
@@ -190,15 +199,18 @@ pub(super) fn parse_object_type(value: i32) -> Result<ObjectType, ProtocolError>
     }
 }
 
-fn object_type_to_proto(obj_type: ObjectType) -> HostedObjectType {
+const HOSTED_OBJECT_TYPE_KEY_BINDING: i32 = 8;
+
+fn object_type_to_proto(obj_type: ObjectType) -> i32 {
     match obj_type {
-        ObjectType::Blob => HostedObjectType::Blob,
-        ObjectType::Tree => HostedObjectType::Tree,
-        ObjectType::State => HostedObjectType::State,
-        ObjectType::Action => HostedObjectType::Action,
-        ObjectType::Redaction => HostedObjectType::Redaction,
-        ObjectType::StateVisibility => HostedObjectType::StateVisibility,
-        ObjectType::StateAttachment => HostedObjectType::StateAttachment,
+        ObjectType::Blob => HostedObjectType::Blob as i32,
+        ObjectType::Tree => HostedObjectType::Tree as i32,
+        ObjectType::State => HostedObjectType::State as i32,
+        ObjectType::Action => HostedObjectType::Action as i32,
+        ObjectType::Redaction => HostedObjectType::Redaction as i32,
+        ObjectType::StateVisibility => HostedObjectType::StateVisibility as i32,
+        ObjectType::StateAttachment => HostedObjectType::StateAttachment as i32,
+        ObjectType::KeyBinding => HOSTED_OBJECT_TYPE_KEY_BINDING,
     }
 }
 
@@ -226,7 +238,7 @@ pub(super) fn object_descriptor_with_status(
                 format!("{}:{}", state.to_string_full(), id.as_hash().to_hex())
             }
         },
-        object_type: object_type_to_proto(info.obj_type) as i32,
+        object_type: object_type_to_proto(info.obj_type),
         availability_status: availability_status as i32,
         availability_note: availability_note.into(),
         attachment_kind: attachment_kind as i32,
@@ -255,7 +267,7 @@ pub(super) fn descriptor_id_from_info(info: &ObjectInfo) -> (String, i32) {
             format!("{}:{}", state.to_string_full(), id.as_hash().to_hex())
         }
     };
-    (id, object_type_to_proto(info.obj_type) as i32)
+    (id, object_type_to_proto(info.obj_type))
 }
 
 pub(super) fn hosted_to_protocol_error(error: HostedError) -> ProtocolError {
@@ -516,6 +528,24 @@ mod tests {
             error: None,
         });
         assert!(matches!(error, ProtocolError::AuthorizationFailed(_)));
+    }
+
+    #[test]
+    fn key_binding_descriptor_roundtrips_through_the_forward_proto_discriminant() {
+        let hash = ContentHash::from_bytes([0x61; 32]);
+        let info = ObjectInfo {
+            id: ObjectId::Hash(hash),
+            obj_type: ObjectType::KeyBinding,
+            size: 0,
+            delta_base: None,
+        };
+
+        let descriptor = to_proto_object_info(&info);
+        assert_eq!(descriptor.object_type, HOSTED_OBJECT_TYPE_KEY_BINDING);
+        let parsed = parse_descriptor_to_info(descriptor).expect("parse key-binding descriptor");
+
+        assert_eq!(parsed.id, ObjectId::Hash(hash));
+        assert_eq!(parsed.obj_type, ObjectType::KeyBinding);
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -357,6 +357,7 @@ pub struct PullObjectMix {
     pub redactions: usize,
     pub state_visibilities: usize,
     pub state_attachments: usize,
+    pub key_bindings: usize,
 }
 
 #[derive(Debug, Clone)]
@@ -378,6 +379,7 @@ impl PullObjectMix {
             ObjectTypeBucket::Redaction => self.redactions += 1,
             ObjectTypeBucket::StateVisibility => self.state_visibilities += 1,
             ObjectTypeBucket::StateAttachment => self.state_attachments += 1,
+            ObjectTypeBucket::KeyBinding => self.key_bindings += 1,
         }
     }
 
@@ -389,6 +391,7 @@ impl PullObjectMix {
             + self.redactions
             + self.state_visibilities
             + self.state_attachments
+            + self.key_bindings
     }
 }
 

--- a/crates/cli/tests/performance.rs
+++ b/crates/cli/tests/performance.rs
@@ -635,6 +635,11 @@ fn encode_native_pack(objects: &[ObjectData]) -> (Vec<u8>, Vec<u8>) {
                 // pack; the test fixture doesn't construct them.
                 unreachable!("performance harness does not synthesize StateVisibility objects");
             }
+            ObjectType::KeyBinding => {
+                // Key-binding registry objects use the out-of-pack closure
+                // lane; the test fixture only synthesizes native-pack data.
+                unreachable!("performance harness does not synthesize KeyBinding objects");
+            }
         };
         builder.add_id(id, obj_type, object.data.clone());
     }

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 blake3.workspace = true
+chrono.workspace = true
 # `objects/zstd` is forwarded via this crate's own `zstd` feature
 # instead of being hardcoded on. Hardcoding here meant every consumer
 # (repo → ingest → cli) got zstd unconditionally even
@@ -36,5 +37,4 @@ name = "wire"
 # the published manifest (dev-deps without version are not packaged).
 repo = { path = "../repo", package = "heddle-repo" }
 tempfile.workspace = true
-chrono.workspace = true
 sley.workspace = true

--- a/crates/wire/src/key_binding.rs
+++ b/crates/wire/src/key_binding.rs
@@ -1,0 +1,198 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wire representation of the offline key-binding registry.
+
+use chrono::{DateTime, Utc};
+use objects::object::{ContentHash, KeyBinding, KeyBindingRegistry, StateSignature};
+use serde::{Deserialize, Serialize};
+
+use crate::{ObjectData, ObjectId, ObjectType, ProtocolError, Result};
+
+/// Liveness portion of a signed key binding, explicit at the wire boundary.
+///
+/// The conversion back to the object model restores `revoked_at` before any
+/// signature verification, so the fields covered by `added_by_sig` remain
+/// byte-for-byte equivalent to the source binding.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireKeyBindingLiveness {
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+/// Transport form of a [`KeyBinding`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireKeyBinding {
+    pub algorithm: String,
+    pub public_key: String,
+    pub identity_ref: String,
+    pub role: String,
+    pub added_by_sig: StateSignature,
+    pub valid_from: DateTime<Utc>,
+    pub delegated_from: Option<ContentHash>,
+    pub liveness: WireKeyBindingLiveness,
+}
+
+/// Versioned set of key bindings carried as one closure object.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WireKeyBindingRegistry {
+    pub format_version: u8,
+    pub bindings: Vec<WireKeyBinding>,
+}
+
+impl From<&KeyBinding> for WireKeyBinding {
+    fn from(binding: &KeyBinding) -> Self {
+        Self {
+            algorithm: binding.algorithm.clone(),
+            public_key: binding.public_key.clone(),
+            identity_ref: binding.identity_ref.clone(),
+            role: binding.role.clone(),
+            added_by_sig: binding.added_by_sig.clone(),
+            valid_from: binding.valid_from,
+            delegated_from: binding.delegated_from,
+            liveness: WireKeyBindingLiveness {
+                revoked_at: binding.revoked_at,
+            },
+        }
+    }
+}
+
+impl From<WireKeyBinding> for KeyBinding {
+    fn from(binding: WireKeyBinding) -> Self {
+        Self {
+            algorithm: binding.algorithm,
+            public_key: binding.public_key,
+            identity_ref: binding.identity_ref,
+            role: binding.role,
+            added_by_sig: binding.added_by_sig,
+            valid_from: binding.valid_from,
+            revoked_at: binding.liveness.revoked_at,
+            delegated_from: binding.delegated_from,
+        }
+    }
+}
+
+impl From<&KeyBindingRegistry> for WireKeyBindingRegistry {
+    fn from(registry: &KeyBindingRegistry) -> Self {
+        Self {
+            format_version: registry.format_version,
+            bindings: registry.bindings.iter().map(WireKeyBinding::from).collect(),
+        }
+    }
+}
+
+impl From<WireKeyBindingRegistry> for KeyBindingRegistry {
+    fn from(registry: WireKeyBindingRegistry) -> Self {
+        Self {
+            format_version: registry.format_version,
+            bindings: registry
+                .bindings
+                .into_iter()
+                .map(KeyBinding::from)
+                .collect(),
+        }
+    }
+}
+
+/// Encode a validated registry as a typed, content-addressed wire object.
+pub fn encode_key_binding_registry(registry: &KeyBindingRegistry) -> Result<ObjectData> {
+    registry
+        .validate()
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    let id = registry
+        .content_hash()
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    let wire = WireKeyBindingRegistry::from(registry);
+    Ok(ObjectData {
+        id: ObjectId::Hash(id),
+        obj_type: ObjectType::KeyBinding,
+        data: rmp_serde::to_vec_named(&wire)?,
+        is_delta: false,
+    })
+}
+
+/// Decode a key-binding wire object and verify its advertised content address.
+pub fn decode_key_binding_registry(data: &ObjectData) -> Result<KeyBindingRegistry> {
+    let (ObjectId::Hash(expected), ObjectType::KeyBinding) = (&data.id, data.obj_type) else {
+        return Err(ProtocolError::InvalidState(
+            "object id/type mismatch for key-binding registry".to_string(),
+        ));
+    };
+    if data.is_delta {
+        return Err(ProtocolError::InvalidState(
+            "key-binding registry objects cannot be delta encoded".to_string(),
+        ));
+    }
+    let wire: WireKeyBindingRegistry = rmp_serde::from_slice(&data.data)?;
+    let registry = KeyBindingRegistry::from(wire);
+    registry
+        .validate()
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    let actual = registry
+        .content_hash()
+        .map_err(|error| ProtocolError::InvalidState(error.to_string()))?;
+    if actual != *expected {
+        return Err(ProtocolError::InvalidState(format!(
+            "key-binding registry hash mismatch: expected {}, computed {}",
+            expected.to_hex(),
+            actual.to_hex()
+        )));
+    }
+    Ok(registry)
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{TimeZone, Utc};
+    use objects::object::{ContentHash, KeyBinding, KeyBindingRegistry, StateSignature};
+
+    use super::{WireKeyBinding, decode_key_binding_registry, encode_key_binding_registry};
+    use crate::{ObjectData, ObjectType};
+
+    #[test]
+    fn key_binding_registry_roundtrips_with_liveness_overlay_losslessly() {
+        let binding = KeyBinding {
+            algorithm: "ed25519".to_string(),
+            public_key: "11".repeat(32),
+            identity_ref: "user:01HZZZZZZZZZZZZZZZZZZZZZZZ".to_string(),
+            role: "author".to_string(),
+            added_by_sig: StateSignature {
+                algorithm: "ed25519".to_string(),
+                public_key: "22".repeat(32),
+                signature: "33".repeat(64),
+            },
+            valid_from: Utc.timestamp_opt(1_725_000_000, 123_456_789).unwrap(),
+            revoked_at: Some(Utc.timestamp_opt(1_735_000_000, 987_654_321).unwrap()),
+            delegated_from: Some(ContentHash::from_bytes([0x44; 32])),
+        };
+        let wire_binding = WireKeyBinding::from(&binding);
+        assert_eq!(wire_binding.liveness.revoked_at, binding.revoked_at);
+        assert_eq!(KeyBinding::from(wire_binding), binding);
+        let registry = KeyBindingRegistry::new(vec![binding]);
+
+        let wire = encode_key_binding_registry(&registry).expect("encode wire registry");
+        assert_eq!(wire.obj_type, ObjectType::KeyBinding);
+        assert_eq!(ObjectType::KeyBinding.wire_name(), "key_binding");
+        assert_eq!(
+            ObjectType::from_wire("key_binding").expect("parse key-binding type"),
+            ObjectType::KeyBinding
+        );
+        let encoded_frame = rmp_serde::to_vec_named(&wire).expect("encode object frame");
+        let transferred: ObjectData =
+            rmp_serde::from_slice(&encoded_frame).expect("decode object frame");
+        let decoded = decode_key_binding_registry(&transferred).expect("decode wire registry");
+
+        assert_eq!(decoded, registry);
+        assert_eq!(
+            decoded.content_hash().unwrap(),
+            registry.content_hash().unwrap()
+        );
+    }
+
+    #[test]
+    fn key_binding_registry_rejects_a_mismatched_content_address() {
+        let registry = KeyBindingRegistry::empty();
+        let mut wire = encode_key_binding_registry(&registry).expect("encode wire registry");
+        wire.id = crate::ObjectId::Hash(ContentHash::from_bytes([0x55; 32]));
+
+        let error = decode_key_binding_registry(&wire).expect_err("hash mismatch must fail closed");
+        assert!(error.to_string().contains("hash mismatch"));
+    }
+}

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -6,6 +6,7 @@
 mod auth_tests;
 mod auth_token;
 mod capabilities;
+mod key_binding;
 mod message_delta;
 mod message_hosted;
 mod message_objects;
@@ -23,6 +24,10 @@ pub use auth_token::AuthToken;
 pub use capabilities::{
     CAPABILITY_CHUNKED_TRANSFER, CAPABILITY_PACK_TRANSFER, CAPABILITY_PARTIAL_FETCH,
     CAPABILITY_RESUMABLE_TRANSFER, Capabilities, CapabilitySet,
+};
+pub use key_binding::{
+    WireKeyBinding, WireKeyBindingLiveness, WireKeyBindingRegistry, decode_key_binding_registry,
+    encode_key_binding_registry,
 };
 pub use message_delta::{DeltaData, RequestDelta};
 pub use message_hosted::{

--- a/crates/wire/src/native_pack.rs
+++ b/crates/wire/src/native_pack.rs
@@ -599,7 +599,11 @@ impl PackStreamSpool {
 }
 
 pub fn native_pack_excluded_object_types() -> &'static [ObjectType] {
-    &[ObjectType::Redaction, ObjectType::StateVisibility]
+    &[
+        ObjectType::Redaction,
+        ObjectType::StateVisibility,
+        ObjectType::KeyBinding,
+    ]
 }
 
 pub fn is_native_packable_object_type(obj_type: ObjectType) -> bool {

--- a/crates/wire/src/object_availability.rs
+++ b/crates/wire/src/object_availability.rs
@@ -33,6 +33,9 @@ pub fn has_object(store: &impl ObjectStore, info: &ObjectInfo) -> Result<bool> {
         // semantics. Like Redaction, conservatively refetch and let the
         // repository boundary validate + dedupe.
         (ObjectId::StateId(_), ObjectType::StateVisibility) => Ok(false),
+        // Hosted registries are materialized snapshots with a liveness overlay;
+        // let the receiver validate and deduplicate the complete payload.
+        (ObjectId::Hash(_), ObjectType::KeyBinding) => Ok(false),
         _ => Ok(false),
     }
 }

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -69,6 +69,11 @@ pub enum ObjectType {
     /// and ships via the per-object transfer path, not the pack.
     StateVisibility,
     StateAttachment,
+    /// A content-addressed `KeyBindingRegistry` together with each binding's
+    /// revocation/liveness overlay. Hosted materializers append this object to
+    /// a closure and carry it out of pack because the native pack format has no
+    /// key-binding record kind.
+    KeyBinding,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -80,6 +85,7 @@ pub enum ObjectTypeBucket {
     Redaction,
     StateVisibility,
     StateAttachment,
+    KeyBinding,
 }
 
 impl ObjectType {
@@ -92,6 +98,7 @@ impl ObjectType {
             ObjectType::Redaction => "redaction",
             ObjectType::StateVisibility => "state_visibility",
             ObjectType::StateAttachment => "state_attachment",
+            ObjectType::KeyBinding => "key_binding",
         }
     }
 
@@ -104,6 +111,7 @@ impl ObjectType {
             "redaction" => Ok(ObjectType::Redaction),
             "state_visibility" => Ok(ObjectType::StateVisibility),
             "state_attachment" => Ok(ObjectType::StateAttachment),
+            "key_binding" => Ok(ObjectType::KeyBinding),
             _ => Err(ProtocolError::InvalidState(format!(
                 "unknown object type: {value}"
             ))),
@@ -121,7 +129,10 @@ impl ObjectType {
     /// method retains the pull/general semantics so pack construction,
     /// have-set, and local-copy planners are unchanged.
     pub fn packable(self) -> bool {
-        !matches!(self, ObjectType::Redaction | ObjectType::StateVisibility)
+        !matches!(
+            self,
+            ObjectType::Redaction | ObjectType::StateVisibility | ObjectType::KeyBinding
+        )
     }
 
     /// Whether this object type may ride the client→server **push** pack.
@@ -162,6 +173,10 @@ impl ObjectType {
                 "StateVisibility sidecar records cannot be packed into the content-addressed object pack"
                     .to_string(),
             )),
+            ObjectType::KeyBinding => Err(ProtocolError::InvalidState(
+                "KeyBinding registry objects cannot be packed into the content-addressed object pack"
+                    .to_string(),
+            )),
         }
     }
 
@@ -174,6 +189,7 @@ impl ObjectType {
             ObjectType::Redaction => ObjectTypeBucket::Redaction,
             ObjectType::StateVisibility => ObjectTypeBucket::StateVisibility,
             ObjectType::StateAttachment => ObjectTypeBucket::StateAttachment,
+            ObjectType::KeyBinding => ObjectTypeBucket::KeyBinding,
         }
     }
 }
@@ -1858,7 +1874,11 @@ mod tests {
     #[test]
     fn packable_predicates_split_state_attachment_by_direction() {
         // Sidecar records are never packable in either direction.
-        for sidecar in [ObjectType::Redaction, ObjectType::StateVisibility] {
+        for sidecar in [
+            ObjectType::Redaction,
+            ObjectType::StateVisibility,
+            ObjectType::KeyBinding,
+        ] {
             assert!(!sidecar.packable_for_push(), "{sidecar:?} push");
             assert!(!sidecar.packable_for_pull(), "{sidecar:?} pull");
         }

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -191,6 +191,12 @@ pub fn load_object_data(
                 .ok_or_else(|| ProtocolError::ObjectNotFound(id.to_string()))?;
             rmp_serde::to_vec_named(&attachment)?
         }
+        (ObjectId::Hash(_), ObjectType::KeyBinding) => {
+            return Err(ProtocolError::InvalidState(
+                "KeyBinding registry objects must be constructed with encode_key_binding_registry"
+                    .to_string(),
+            ));
+        }
         _ => {
             return Err(ProtocolError::InvalidState(
                 "object id/type mismatch".to_string(),
@@ -270,6 +276,12 @@ pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Res
             return Err(ProtocolError::InvalidState(
                 "StateVisibility objects must be persisted via Repository::accept_wire_state_visibility, \
                  not store_received_object — sidecar validation is required"
+                    .to_string(),
+            ));
+        }
+        (_, ObjectType::KeyBinding) => {
+            return Err(ProtocolError::InvalidState(
+                "KeyBinding registry objects must be decoded and verified with decode_key_binding_registry"
                     .to_string(),
             ));
         }

--- a/crates/wire/src/transfer_plan.rs
+++ b/crates/wire/src/transfer_plan.rs
@@ -54,6 +54,7 @@ pub struct TransferPlanStats {
     pub redactions: usize,
     pub state_visibilities: usize,
     pub state_attachments: usize,
+    pub key_bindings: usize,
 }
 
 impl RepositoryTransferPlan<PlannedObject> {
@@ -139,6 +140,7 @@ impl TransferPlanStats {
             ObjectTypeBucket::Redaction => self.redactions += 1,
             ObjectTypeBucket::StateVisibility => self.state_visibilities += 1,
             ObjectTypeBucket::StateAttachment => self.state_attachments += 1,
+            ObjectTypeBucket::KeyBinding => self.key_bindings += 1,
         }
     }
 }
@@ -208,19 +210,24 @@ mod tests {
                     id: ObjectId::StateId(state),
                     obj_type: ObjectType::StateVisibility,
                 },
+                PlannedObject {
+                    id: ObjectId::Hash(hash(3)),
+                    obj_type: ObjectType::KeyBinding,
+                },
             ],
             GitLaneTransferIntent::HeddleObjectsOnly,
         );
 
         assert_eq!(plan.partitions.packable_objects.len(), 2);
-        assert_eq!(plan.partitions.sidecar_objects.len(), 2);
-        assert_eq!(plan.stats.total_objects, 4);
+        assert_eq!(plan.partitions.sidecar_objects.len(), 3);
+        assert_eq!(plan.stats.total_objects, 5);
         assert_eq!(plan.stats.packable_objects, 2);
-        assert_eq!(plan.stats.sidecar_objects, 2);
+        assert_eq!(plan.stats.sidecar_objects, 3);
         assert_eq!(plan.stats.blobs, 1);
         assert_eq!(plan.stats.trees, 1);
         assert_eq!(plan.stats.redactions, 1);
         assert_eq!(plan.stats.state_visibilities, 1);
+        assert_eq!(plan.stats.key_bindings, 1);
         assert!(plan.requires_native_pack(false));
     }
 


### PR DESCRIPTION
## Summary
- add a typed `WireKeyBindingRegistry` / `WireKeyBinding` representation with an explicit revocation/liveness overlay
- carry registries as content-addressed, out-of-pack `ObjectType::KeyBinding` closure objects and fail closed on mismatched hashes
- preserve KeyBinding descriptors across the hosted protobuf boundary with the forward object-type discriminant

Unblocks HeddleCo/weft#1143.

## Closes
Closes #1268

## Test evidence
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1268-target cargo test -p heddle-devtools` — 71 passed
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1268-target cargo test -p heddle-wire` — 66 passed, including lossless KeyBinding/ObjectData round-trip and content-address mismatch rejection
- `env -u CODEX_THREAD_ID TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1268-target cargo test -p heddle-cli -- --test-threads=4` — full affected package passed; the 923-test CLI integration binary reported 904 passed and 19 expected ignored
- `env -u CODEX_THREAD_ID TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1268-target cargo clippy --workspace -- -D warnings` — passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788848375&installation_model_id=21489&pr_number=1270&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1270&signature=9234b613b9c09c45e115f71151b4aa636852a0f0bee2cf511c99ea72b2279cbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->