### PR TITLE
Expose symbol-level semantic diff through the CLI

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -26966,6 +26966,23 @@
       "title": "SchemasListSchema",
       "type": "object"
     },
+    "semantic diff": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "semantic_diff"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
     "semantic hot": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -2147,6 +2147,11 @@ export interface SemanticChangeEntry {
   to_path?: string | null;
 }
 
+export interface SemanticDiffSchema {
+  output_kind: "semantic_diff";
+  [key: string]: unknown;
+}
+
 export type SemanticHotSchema = Record<string, unknown>;
 
 export interface SessionEntrySchema {
@@ -3407,6 +3412,7 @@ export interface HeddleVerbOutputs {
   "review show": ReviewShowSchema;
   "review sign": ReviewSignSchema;
   schemas: SchemasListSchema;
+  "semantic diff": SemanticDiffSchema;
   "semantic hot": SemanticHotSchema;
   show: ShowSchema;
   start: StartSchema;
@@ -3569,6 +3575,7 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "review show",
   "review sign",
   "schemas",
+  "semantic diff",
   "semantic hot",
   "show",
   "start",

--- a/crates/cli-args/src/cli/cli_args/commands_semantic.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_semantic.rs
@@ -5,6 +5,13 @@ use clap::{Subcommand, ValueEnum};
 
 #[derive(Subcommand, Clone)]
 pub enum SemanticCommands {
+    /// Compare the symbols stored in two states' attached semantic indexes.
+    Diff {
+        /// Earlier state or revision.
+        a: String,
+        /// Later state or revision.
+        b: String,
+    },
     /// Aggregate semantic-change events across recent history and
     /// surface the files or functions with the most activity.
     ///

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -2493,6 +2493,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
     ),
     entry(&["semantic"], category(GROUP, "states")),
     entry(
+        &["semantic", "diff"],
+        json_discriminators(
+            opaque_schemas(READ_JSON, &["semantic diff"]),
+            &[json_discriminator(
+                Some("semantic diff"),
+                "output_kind",
+                "semantic_diff",
+            )],
+        ),
+    ),
+    entry(
         &["semantic", "hot"],
         opaque_schemas(READ_JSON, &["semantic hot"]),
     ),
@@ -4643,6 +4654,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         },
         #[cfg(feature = "semantic")]
         Commands::Semantic { command } => match command {
+            SemanticCommands::Diff { .. } => vec!["semantic", "diff"],
             SemanticCommands::Hot { .. } => vec!["semantic", "hot"],
             SemanticCommands::Index { .. } => vec!["semantic", "index"],
         },

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -358,6 +358,8 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["run"], &["run", "true"]),
     sample(&["schemas"], &["schemas"]),
     #[cfg(feature = "semantic")]
+    sample(&["semantic", "diff"], &["semantic", "diff", "HEAD", "HEAD"]),
+    #[cfg(feature = "semantic")]
     sample(&["semantic", "hot"], &["semantic", "hot"]),
     sample(&["semantic", "index"], &["semantic", "index"]),
     sample(
@@ -1714,6 +1716,9 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "review next",
             "review health",
             "schemas",
+            // heddle#1271 exposes the stored symbol-index comparison through
+            // a stable `semantic_diff` machine envelope.
+            "semantic diff",
             // `land` advertises the single-peer and `--threads` batch
             // envelope discriminators.
             "land",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -294,6 +294,11 @@ name = "semantic_diff_integration"
 path = "tests/semantic_diff_integration.rs"
 required-features = ["semantic"]
 
+[[test]]
+name = "semantic_symbol_diff_cli"
+path = "tests/semantic_symbol_diff_cli.rs"
+required-features = ["semantic"]
+
 [[bench]]
 name = "local_ops"
 harness = false

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -59,6 +59,8 @@ mod review;
 mod run_cmd;
 #[cfg(feature = "semantic")]
 mod semantic_cmd;
+#[cfg(feature = "semantic")]
+mod semantic_diff_cmd;
 mod shell;
 mod show;
 pub(crate) mod snapshot;

--- a/crates/cli/src/cli/commands/semantic_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_cmd.rs
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Semantic-analysis CLI commands (`heddle semantic ...`).
 //!
-//! Thin shim over [`semantic`] — the analysis lives in the core
-//! semantic crate so the same primitives are available to hosted calls and the
-//! web UI without a CLI round-trip.
+//! Thin dispatch over the parser-backed analysis and parse-free stored-index
+//! query surfaces.
 
 use std::collections::BTreeMap;
 
@@ -23,6 +22,7 @@ use crate::{
 /// Top-level dispatch for `heddle semantic <subcommand>`.
 pub fn cmd_semantic(cli: &Cli, command: SemanticCommands) -> Result<()> {
     match command {
+        SemanticCommands::Diff { a, b } => super::semantic_diff_cmd::cmd_semantic_diff(cli, a, b),
         SemanticCommands::Hot {
             from,
             limit,

--- a/crates/cli/src/cli/commands/semantic_diff_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_diff_cmd.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Parse-free symbol diff rendering for `heddle semantic diff`.
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Context, Result};
 use objects::object::{SymbolAnchor, SymbolKindTag};
 use repo::SymbolDelta;
 use serde::Serialize;
 
+use super::history_target::resolve_state_id;
 use crate::cli::{Cli, should_output_json};
 
 #[derive(Debug, Serialize)]
@@ -45,12 +46,8 @@ impl From<SymbolDelta> for SymbolDeltaOutput {
 
 pub(super) fn cmd_semantic_diff(cli: &Cli, a: String, b: String) -> Result<()> {
     let repo = cli.open_repo()?;
-    let a = repo
-        .resolve_state(&a)?
-        .ok_or_else(|| anyhow!("could not resolve state {a:?}"))?;
-    let b = repo
-        .resolve_state(&b)?
-        .ok_or_else(|| anyhow!("could not resolve state {b:?}"))?;
+    let a = resolve_state_id(&repo, &a)?;
+    let b = resolve_state_id(&repo, &b)?;
     let deltas = repo
         .semantic_diff_symbols(&a, &b)
         .context("querying attached semantic indexes")?
@@ -65,17 +62,22 @@ pub(super) fn cmd_semantic_diff(cli: &Cli, a: String, b: String) -> Result<()> {
     };
 
     if should_output_json(cli, Some(repo.config())) {
-        println!(
-            "{}",
-            serde_json::to_string(&output).context("serializing semantic diff output")?
-        );
+        write_json(&output)?;
     } else {
-        print_human(&output);
+        render_human(&output);
     }
     Ok(())
 }
 
-fn print_human(output: &SemanticDiffOutput) {
+fn write_json(output: &SemanticDiffOutput) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string(output).context("serializing semantic diff output")?
+    );
+    Ok(())
+}
+
+fn render_human(output: &SemanticDiffOutput) {
     if output.deltas.is_empty() {
         println!(
             "No symbol changes between {} and {}.",

--- a/crates/cli/src/cli/commands/semantic_diff_cmd.rs
+++ b/crates/cli/src/cli/commands/semantic_diff_cmd.rs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Parse-free symbol diff rendering for `heddle semantic diff`.
+
+use anyhow::{Context, Result, anyhow};
+use objects::object::{SymbolAnchor, SymbolKindTag};
+use repo::SymbolDelta;
+use serde::Serialize;
+
+use crate::cli::{Cli, should_output_json};
+
+#[derive(Debug, Serialize)]
+struct SemanticDiffOutput {
+    output_kind: &'static str,
+    from_state: String,
+    to_state: String,
+    deltas: Vec<SymbolDeltaOutput>,
+}
+
+#[derive(Debug, Serialize)]
+struct SymbolDeltaOutput {
+    change: &'static str,
+    anchor: SymbolAnchor,
+    kind: SymbolKindTag,
+    old_hash: Option<String>,
+    new_hash: Option<String>,
+}
+
+impl From<SymbolDelta> for SymbolDeltaOutput {
+    fn from(delta: SymbolDelta) -> Self {
+        let change = match (delta.old_hash, delta.new_hash) {
+            (None, Some(_)) => "added",
+            (Some(_), None) => "removed",
+            (Some(_), Some(_)) => "modified",
+            (None, None) => "modified",
+        };
+        Self {
+            change,
+            anchor: delta.anchor,
+            kind: delta.kind,
+            old_hash: delta.old_hash.map(|hash| hash.to_hex()),
+            new_hash: delta.new_hash.map(|hash| hash.to_hex()),
+        }
+    }
+}
+
+pub(super) fn cmd_semantic_diff(cli: &Cli, a: String, b: String) -> Result<()> {
+    let repo = cli.open_repo()?;
+    let a = repo
+        .resolve_state(&a)?
+        .ok_or_else(|| anyhow!("could not resolve state {a:?}"))?;
+    let b = repo
+        .resolve_state(&b)?
+        .ok_or_else(|| anyhow!("could not resolve state {b:?}"))?;
+    let deltas = repo
+        .semantic_diff_symbols(&a, &b)
+        .context("querying attached semantic indexes")?
+        .into_iter()
+        .map(SymbolDeltaOutput::from)
+        .collect();
+    let output = SemanticDiffOutput {
+        output_kind: "semantic_diff",
+        from_state: a.to_string_full(),
+        to_state: b.to_string_full(),
+        deltas,
+    };
+
+    if should_output_json(cli, Some(repo.config())) {
+        println!(
+            "{}",
+            serde_json::to_string(&output).context("serializing semantic diff output")?
+        );
+    } else {
+        print_human(&output);
+    }
+    Ok(())
+}
+
+fn print_human(output: &SemanticDiffOutput) {
+    if output.deltas.is_empty() {
+        println!(
+            "No symbol changes between {} and {}.",
+            output.from_state, output.to_state
+        );
+        return;
+    }
+
+    println!(
+        "Symbol changes between {} and {} ({}):",
+        output.from_state,
+        output.to_state,
+        output.deltas.len()
+    );
+    for delta in &output.deltas {
+        let marker = match delta.change {
+            "added" => '+',
+            "removed" => '-',
+            _ => '~',
+        };
+        println!(
+            "  {marker} {:<10} {}::{} ({})",
+            delta.change,
+            delta.anchor.file,
+            delta.anchor.symbol,
+            symbol_kind_label(delta.kind)
+        );
+    }
+}
+
+fn symbol_kind_label(kind: SymbolKindTag) -> &'static str {
+    match kind {
+        SymbolKindTag::Function => "function",
+        SymbolKindTag::Type => "type",
+        SymbolKindTag::Enum => "enum",
+        SymbolKindTag::Trait => "trait",
+        SymbolKindTag::Class => "class",
+        SymbolKindTag::Interface => "interface",
+        SymbolKindTag::TypeAlias => "type_alias",
+        SymbolKindTag::Const => "const",
+        SymbolKindTag::Module => "module",
+        SymbolKindTag::Other => "other",
+    }
+}

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -109,6 +109,7 @@ const SWEPT: &[&str] = &[
     "review next",
     "review health",
     "resolve",
+    "semantic diff",
     // heddle#662 — additive discriminator paths for state inspection,
     // rebase progress JSONL, and conflict-resolution success.
     "show",
@@ -1107,6 +1108,19 @@ fn runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
             (
                 t,
                 sv(&["query", "--attribution", "src/lib.rs", "--context"]),
+            )
+        }
+        "semantic_diff" => {
+            let t = init_fixture();
+            std::fs::write(t.path().join("lib.rs"), "fn value() -> i32 { 1 }\n").unwrap();
+            heddle(&["capture", "-m", "base"], Some(t.path())).expect("capture base");
+            let first = head_state_id(t.path());
+            std::fs::write(t.path().join("lib.rs"), "fn value() -> i32 { 2 }\n").unwrap();
+            heddle(&["capture", "-m", "change"], Some(t.path())).expect("capture change");
+            let second = head_state_id(t.path());
+            (
+                t,
+                vec!["semantic".to_string(), "diff".to_string(), first, second],
             )
         }
         "redact_trust_add" => (

--- a/crates/cli/tests/semantic_symbol_diff_cli.rs
+++ b/crates/cli/tests/semantic_symbol_diff_cli.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end coverage for the stored-index symbol diff CLI.
+
+use std::process::Command;
+
+use repo::Repository;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_heddle(repo: &TempDir, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_heddle"))
+        .args(args)
+        .current_dir(repo.path())
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("run heddle")
+}
+
+#[test]
+fn semantic_diff_reports_added_removed_modified_and_moved_symbols() {
+    let temp = TempDir::new().expect("temp repo");
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    std::fs::write(
+        temp.path().join("lib.rs"),
+        "fn changed() -> i32 { 1 }\nfn removed() {}\nfn moved() -> i32 { 7 }\n",
+    )
+    .expect("write first state");
+    let first = repo
+        .snapshot(Some("first".into()), None)
+        .expect("first state");
+
+    std::fs::write(
+        temp.path().join("lib.rs"),
+        "fn changed() -> i32 { 2 }\nfn added() {}\n",
+    )
+    .expect("write second state");
+    std::fs::write(temp.path().join("moved.rs"), "fn moved() -> i32 { 7 }\n")
+        .expect("move symbol to second file");
+    let second = repo
+        .snapshot(Some("second".into()), None)
+        .expect("second state");
+    let first_id = first.state_id.to_string_full();
+    let second_id = second.state_id.to_string_full();
+
+    let json = run_heddle(
+        &temp,
+        &[
+            "--output", "json", "semantic", "diff", &first_id, &second_id,
+        ],
+    );
+    assert!(
+        json.status.success(),
+        "semantic diff JSON failed: {}",
+        String::from_utf8_lossy(&json.stderr)
+    );
+    let value: Value = serde_json::from_slice(&json.stdout).expect("valid JSON output");
+    assert_eq!(value["output_kind"], "semantic_diff");
+    assert_eq!(value["from_state"], first_id);
+    assert_eq!(value["to_state"], second_id);
+    let deltas = value["deltas"].as_array().expect("deltas array");
+    assert_eq!(deltas.len(), 5, "unexpected deltas: {value}");
+    for (symbol, change, old_present, new_present) in [
+        ("changed", "modified", true, true),
+        ("removed", "removed", true, false),
+        ("added", "added", false, true),
+    ] {
+        let delta = deltas
+            .iter()
+            .find(|delta| delta["anchor"]["symbol"] == symbol)
+            .unwrap_or_else(|| panic!("missing {symbol} delta: {value}"));
+        assert_eq!(delta["change"], change);
+        assert_eq!(delta["anchor"]["file"], "lib.rs");
+        assert_eq!(delta["kind"], "function");
+        assert_eq!(delta["old_hash"].is_string(), old_present);
+        assert_eq!(delta["new_hash"].is_string(), new_present);
+    }
+    let moved_from = deltas
+        .iter()
+        .find(|delta| delta["anchor"]["file"] == "lib.rs" && delta["anchor"]["symbol"] == "moved")
+        .unwrap_or_else(|| panic!("missing moved-symbol removal: {value}"));
+    let moved_to = deltas
+        .iter()
+        .find(|delta| delta["anchor"]["file"] == "moved.rs" && delta["anchor"]["symbol"] == "moved")
+        .unwrap_or_else(|| panic!("missing moved-symbol addition: {value}"));
+    assert_eq!(moved_from["change"], "removed");
+    assert_eq!(moved_to["change"], "added");
+    assert_eq!(moved_from["old_hash"], moved_to["new_hash"]);
+
+    let human = run_heddle(&temp, &["semantic", "diff", &first_id, &second_id]);
+    assert!(
+        human.status.success(),
+        "semantic diff text failed: {}",
+        String::from_utf8_lossy(&human.stderr)
+    );
+    let stdout = String::from_utf8(human.stdout).expect("UTF-8 text output");
+    assert!(
+        stdout.contains("~ modified   lib.rs::changed (function)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("- removed    lib.rs::removed (function)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("+ added      lib.rs::added (function)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("- removed    lib.rs::moved (function)"),
+        "{stdout}"
+    );
+    assert!(
+        stdout.contains("+ added      moved.rs::moved (function)"),
+        "{stdout}"
+    );
+}

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -48,7 +48,7 @@ use semantic::{
 use tracing::warn;
 
 use crate::{
-    HeddleError, Repository, Result, StateAttachmentKind, SymbolDelta,
+    HeddleError, Repository, Result, StateAttachmentKind,
     repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH,
 };
 
@@ -642,28 +642,6 @@ impl Repository {
         let da = self.digest_at_path(&root_a, path_prefix)?;
         let db = self.digest_at_path(&root_b, path_prefix)?;
         Ok(da != db)
-    }
-
-    /// Symbol-level delta between two states, via a merkle walk that descends
-    /// only into differing digests (identical subtrees are pruned without
-    /// loading their file nodes).
-    pub fn semantic_diff_symbols(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
-        self.recover_on_broken(&[a, b], |me| me.semantic_diff_symbols_inner(a, b))
-    }
-
-    fn semantic_diff_symbols_inner(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
-        let (root_a, root_b) = match (self.semantic_index(a)?, self.semantic_index(b)?) {
-            (Some(ra), Some(rb)) => (ra, rb),
-            _ => return Ok(Vec::new()),
-        };
-        if root_a.semantic_digest == root_b.semantic_digest {
-            return Ok(Vec::new());
-        }
-        let node_a = self.load_semantic_tree(&root_a.tree)?;
-        let node_b = self.load_semantic_tree(&root_b.tree)?;
-        let mut out = Vec::new();
-        self.diff_tree_nodes(&node_a, &node_b, "", 0, &mut out)?;
-        Ok(out)
     }
 
     /// Lazy backfill: compute-and-attach a semantic index for every state that

--- a/crates/repo/src/repository_semantic_query.rs
+++ b/crates/repo/src/repository_semantic_query.rs
@@ -150,7 +150,6 @@ impl Repository {
 
     /// Never-compute `semantic_diff_symbols`: merkle-walk the two states'
     /// ATTACHED indexes, descending only into differing digests.
-    #[cfg(not(feature = "tree-sitter-symbols"))]
     pub(crate) fn semantic_diff_symbols_readonly(
         &self,
         a: &StateId,
@@ -350,10 +349,9 @@ impl Repository {
     }
 }
 
-/// Never-compute public read methods, compiled when the parser is absent — the
-/// parse-free consumer's (weft's) surface. When `tree-sitter-symbols` is on,
-/// `repository_semantic_index` supplies get-or-compute + self-heal variants of
-/// these same names instead.
+/// Never-compute public reads whose parser-enabled builds retain legacy
+/// get-or-compute behaviour. The always-never-compute symbol diff is exposed
+/// separately below so every feature combination uses this module's query.
 #[cfg(not(feature = "tree-sitter-symbols"))]
 impl Repository {
     /// Resolve a symbol anchor to its entry in a state's ATTACHED index.
@@ -370,8 +368,13 @@ impl Repository {
     pub fn semantic_changed(&self, a: &StateId, b: &StateId, path_prefix: &str) -> Result<bool> {
         self.semantic_changed_readonly(a, b, path_prefix)
     }
+}
 
+impl Repository {
     /// Symbol-level delta between two states' ATTACHED indexes.
+    ///
+    /// This is always a never-compute query, including in builds that also
+    /// contain the tree-sitter-backed index builder.
     pub fn semantic_diff_symbols(&self, a: &StateId, b: &StateId) -> Result<Vec<SymbolDelta>> {
         self.semantic_diff_symbols_readonly(a, b)
     }
@@ -481,7 +484,7 @@ mod tests {
 
     use chrono::Utc;
     use objects::object::{
-        Attribution, Blob, Principal, State, StateAttachment, StateAttachmentBody,
+        Attribution, Blob, Principal, State, StateAttachment, StateAttachmentBody, Tree, TreeEntry,
     };
     use tempfile::TempDir;
 
@@ -590,5 +593,26 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
+    }
+
+    #[test]
+    fn semantic_diff_symbols_never_computes_missing_indexes() {
+        let (_temp, repo) = repo();
+        let put_state = |source: &str| {
+            let blob = Blob::new(source.as_bytes().to_vec());
+            let blob_hash = repo.store().put_blob(&blob).unwrap();
+            let tree =
+                Tree::from_entries(vec![TreeEntry::file("lib.rs", blob_hash, false).unwrap()]);
+            let tree_hash = repo.store().put_tree(&tree).unwrap();
+            let state = State::new(tree_hash, vec![], author());
+            repo.store().put_state(&state).unwrap();
+            state.id()
+        };
+        let a = put_state("fn answer() -> i32 { 1 }\n");
+        let b = put_state("fn answer() -> i32 { 2 }\n");
+
+        assert!(repo.semantic_diff_symbols(&a, &b).unwrap().is_empty());
+        assert!(repo.attached_semantic_index(&a).unwrap().is_none());
+        assert!(repo.attached_semantic_index(&b).unwrap().is_none());
     }
 }

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3075,7 +3075,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust remove",
       "redact purge apply"
     ],
-    "accepted_opaque_schema_verbs_total": 39,
+    "accepted_opaque_schema_verbs_total": 40,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
@@ -3087,14 +3087,14 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust remove",
       "redact purge apply"
     ],
-    "advanced_scope_json_commands_total": 108,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 39,
+    "advanced_scope_json_commands_total": 109,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 40,
     "advanced_scope_mutating_commands_total": 62,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 22,
-    "catalog_commands_total": 186,
+    "catalog_commands_total": 187,
     "catalog_mutating_commands_total": 90,
-    "json_commands_total": 148,
-    "json_commands_with_accepted_opaque_schema": 39,
+    "json_commands_total": 149,
+    "json_commands_with_accepted_opaque_schema": 40,
     "json_commands_with_schema": 109,
     "json_commands_without_schema": 0,
     "json_mutating_commands_total": 86,
@@ -3104,9 +3104,9 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "mutating_commands_with_accepted_opaque_schema": 22,
     "mutating_commands_with_schema": 64,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 39,
+    "opaque_schema_verbs_total": 40,
     "status": "available",
-    "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+    "summary": "187 command(s), 149 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 40 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3144,7 +3144,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "186 command(s), 148 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 39 accepted opaque schema(s) outside clean verification",
+  "summary": "187 command(s), 149 JSON command(s), 90 mutating command(s), 86 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 40 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -3516,6 +3516,13 @@ no record exists — public-by-absence):
 
 ```json
 {"hotspots": [{"path": "src/lib.rs", "score": 0.87, "reasons": ["changed often"]}]}
+```
+
+`heddle semantic diff --output json` emits the attached-index symbol deltas
+for its two state arguments without parsing source:
+
+```json
+{"output_kind": "semantic_diff", "from_state": "hs-0000000000000000000000000000000000000000000000000000", "to_state": "hs-1111111111111111111111111111111111111111111111111111", "deltas": [{"change": "modified", "anchor": {"file": "src/lib.rs", "symbol": "calculate"}, "kind": "function", "old_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "new_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}
 ```
 
 ## Other verbs


### PR DESCRIPTION
## Summary

- add `heddle semantic diff <a> <b>` with human-readable and JSON symbol-delta output
- route the public query through attached semantic indexes only, preserving the parse-free never-compute contract in every feature combination
- register the machine contract and documentation, with end-to-end coverage for added, removed, modified, and moved symbols

## Closes

Closes #1271

## Test evidence

- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1271-target cargo test -p heddle-devtools` — 71 passed
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1271-target cargo test -p heddle-repo -p heddle-cli-args -p heddle-cli-contract` — passed
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1271-target cargo test -p heddle-repo --no-default-features --features native repository_semantic_query` — 3 passed, verifies the parser-free query path
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1271-target cargo test -p heddle-cli --lib --bins --test semantic_symbol_diff_cli` — 612 passed, 1 ignored
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1271-target cargo clippy --workspace -- -D warnings` — passed
- Full `heddle-cli` integration matrix with `--test-threads=4`: 901 passed, 19 ignored; 3 pre-existing stderr-sensitive tests saw transient dead-fsmonitor socket warnings. All three, and all 16 resource-affected failures from the uncapped run, passed when rerun individually with `--test-threads=1`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788874634&installation_model_id=21489&pr_number=1283&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1283&signature=5de0e819883c246cae8fed6fcef5554cc4920518ac1809cac4744479c9d35be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->