### PR TITLE
Complete lossy Git residual closure capture

### DIFF
--- a/crates/cli/tests/git_projection_engine_integration.rs
+++ b/crates/cli/tests/git_projection_engine_integration.rs
@@ -69,45 +69,14 @@ fn import_all_with_options(
     git_path: Option<&std::path::Path>,
     options: ingest::ImportOptions,
 ) -> TestImportResult<ImportStats> {
-    let target = git_projection_root_from_mirror(git_projection);
-    let source_owned;
-    let source = if let Some(path) = git_path {
-        path
-    } else {
-        source_owned = target.clone();
-        source_owned.as_path()
-    };
-    let (stats, _map) = ingest::import_git_into_with_options(source, &target, options)
-        .map_err(|error| error.to_string())?;
-    test_support::stage_ingest_source_in_mirror(git_projection, source, &[])
-        .map_err(|error| error.to_string())?;
-    test_support::build_existing_mapping(git_projection, Some(source))
-        .map_err(|error| error.to_string())?;
-    let mirror_repo =
-        test_support::open_git_repo(git_projection).map_err(|error| error.to_string())?;
-    test_support::seed_ingest_identity_mappings_from_repo(git_projection, &mirror_repo)
-        .map_err(|error| error.to_string())?;
-    Ok(import_stats_from_ingest(stats))
-}
-
-fn git_projection_root_from_mirror(git_projection: &GitProjection<'_>) -> std::path::PathBuf {
-    git_projection
-        .mirror_path()
-        .parent()
-        .and_then(std::path::Path::parent)
-        .expect("mirror path should be <root>/.heddle/git")
-        .to_path_buf()
-}
-
-fn import_stats_from_ingest(stats: ingest::ImportStats) -> ImportStats {
-    ImportStats {
-        commits_imported: stats.commits_imported,
-        states_created: stats.states_created,
-        branches_synced: stats.refs.threads_written,
-        tags_synced: stats.refs.markers_written,
-        skipped_non_commit_refs: stats.refs_seen.non_commit_skipped,
-        lossy_entries: stats.lossy_entries,
-    }
+    heddle_git_projection::git_ingest::import_git_history(
+        git_projection,
+        git_path,
+        &[],
+        options,
+        None,
+    )
+    .map_err(|error| error.to_string())
 }
 
 trait SleyTestRepoExt {
@@ -1226,6 +1195,91 @@ fn run_lossy_then_default_rerun(engine: ImportEngine) {
 fn both_engines_fail_hard_on_default_rerun_after_lossy() {
     for engine in [ImportEngine::Ingest, ImportEngine::Bridge] {
         run_lossy_then_default_rerun(engine);
+    }
+}
+
+/// #1279: a lossy import must be self-contained after the Bridge Mirror object
+/// warehouse is removed. The source has a non-UTF-8 tree name and an annotated
+/// tag, so the residual set must contain the mapped commit, its tree/blob
+/// closure, and the tag wrapper. A brand-new export then reproduces every OID
+/// and body byte using only native state plus those residuals.
+#[test]
+fn lossy_import_captures_full_residual_closure_for_fresh_export() {
+    let source_temp = init_invalid_utf8_name_repo();
+    let source_repo = open_git(source_temp.path()).expect("open source");
+    let commit_oid = find_reference(&source_repo, "refs/heads/main")
+        .expect("main ref")
+        .target()
+        .try_id()
+        .expect("main direct oid")
+        .to_owned();
+    let tag_oid = create_annotated_tag(&source_repo, "v1.0", commit_oid, "lossy release");
+    let commit = source_repo
+        .read_commit(&commit_oid)
+        .expect("read source commit");
+    let tree_oid = commit.tree;
+    let tree = source_repo.read_tree(&tree_oid).expect("read source tree");
+    let blob_oid = tree.entries[0].oid;
+
+    let heddle_temp = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_temp.path()).expect("init heddle");
+    let mut git_projection = GitProjection::new(&repo);
+    let stats = import_all_with_options(
+        &mut git_projection,
+        Some(source_temp.path()),
+        ingest::ImportOptions {
+            lossy: true,
+            ..ingest::ImportOptions::default()
+        },
+    )
+    .expect("lossy import");
+    assert_eq!(stats.lossy_entries.len(), 1);
+
+    let residuals = heddle_git_projection::ResidualStore::open(repo.heddle_dir());
+    for (label, oid) in [
+        ("commit", commit_oid),
+        ("tree", tree_oid),
+        ("blob", blob_oid),
+        ("annotated tag", tag_oid),
+    ] {
+        assert!(
+            residuals
+                .has_residual(source_repo.object_format(), &oid)
+                .expect("inspect residual"),
+            "lossy import must capture {label} residual {oid}",
+        );
+    }
+
+    drop(git_projection);
+    std::fs::remove_dir_all(repo.heddle_dir().join("git"))
+        .expect("remove test Bridge Mirror object warehouse");
+    let destination_temp = TempDir::new().expect("destination temp");
+    let destination = destination_temp.path().join("fresh.git");
+    let mut fresh_projection = GitProjection::new(&repo);
+    fresh_projection
+        .export_to_path(&destination)
+        .expect("fresh export from native state plus residuals");
+    let exported = open_git(&destination).expect("open fresh export");
+
+    let exported_commit = find_reference(&exported, "refs/heads/main")
+        .expect("exported main")
+        .target()
+        .try_id()
+        .expect("exported main direct oid")
+        .to_owned();
+    let exported_tag = find_reference(&exported, "refs/tags/v1.0")
+        .expect("exported tag")
+        .target()
+        .try_id()
+        .expect("exported tag direct oid")
+        .to_owned();
+    assert_eq!(exported_commit, commit_oid);
+    assert_eq!(exported_tag, tag_oid);
+    for oid in [commit_oid, tree_oid, blob_oid, tag_oid] {
+        let source = source_repo.read_object(&oid).expect("read source object");
+        let round_trip = exported.read_object(&oid).expect("read exported object");
+        assert_eq!(round_trip.object_type, source.object_type);
+        assert_eq!(round_trip.body, source.body, "object {oid} changed bytes");
     }
 }
 

--- a/crates/core/src/fsck/git_projection.rs
+++ b/crates/core/src/fsck/git_projection.rs
@@ -15,6 +15,8 @@ use repo::Repository;
 use serde::Deserialize;
 use sley::{ObjectFormat, ObjectId, Repository as SleyRepository};
 
+use heddle_git_projection::{ResidualStore, git_export::commit_requires_residual};
+
 use super::{FsckError, invalid_fsck_config, make_error};
 
 const NOTES_REF: &str = "refs/notes/heddle";
@@ -25,56 +27,75 @@ pub(crate) fn check_git_projection(
     warnings: &mut Vec<String>,
     objects_checked: &mut usize,
 ) -> Result<()> {
-    if !mirror_path(repo).exists() {
+    let mirror = if mirror_path(repo).exists() {
+        Some(open_git_repo(&mirror_path(repo)).map_err(|err| {
+            invalid_fsck_config(format!("legacy Bridge Mirror open failed: {err}"))
+        })?)
+    } else {
         warnings.push(
-            "legacy Bridge Mirror is absent; mirror-backed Git projection checks were skipped"
+            "legacy Bridge Mirror is absent; Git projection mapping and residual checks continued"
                 .to_string(),
         );
-        return Ok(());
-    }
-
-    let mirror = open_git_repo(&mirror_path(repo))
-        .map_err(|err| invalid_fsck_config(format!("legacy Bridge Mirror open failed: {err}")))?;
-    let mapping = build_existing_mapping(repo, &mirror).map_err(|err| {
+        None
+    };
+    let mapping = build_existing_mapping(repo, mirror.as_ref()).map_err(|err| {
         invalid_fsck_config(format!("Git Projection Mapping check failed: {err}"))
     })?;
+    let residuals = ResidualStore::open(repo.heddle_dir());
 
     for (state_id, git_oid) in mapping.iter() {
         *objects_checked += 1;
-        if mirror.read_object(git_oid).is_err() {
-            errors.push(make_error(
-                "git-projection-mapping",
-                &format!("mapped Git object {git_oid} is missing from the legacy Bridge Mirror"),
-                Some(state_id.to_string()),
-            ));
-        }
-        if repo.store().get_state(state_id)?.is_none() {
+        let Some(state) = repo.store().get_state(state_id)? else {
             errors.push(make_error(
                 "git-projection-mapping",
                 &format!("mapped Heddle state {state_id} is missing from the store"),
                 Some(git_oid.to_string()),
             ));
+            continue;
+        };
+        if commit_requires_residual(&state) {
+            match residuals.validate_commit_closure(git_oid.format(), git_oid) {
+                Ok(true) => {}
+                Ok(false) => errors.push(make_error(
+                    "git-projection-residual",
+                    &format!(
+                        "mapped non-reconstructable Git object {git_oid} is missing Raw Git Object Residual bytes"
+                    ),
+                    Some(state_id.to_string()),
+                )),
+                Err(error) => errors.push(make_error(
+                    "git-projection-residual",
+                    &format!(
+                        "mapped non-reconstructable Git object {git_oid} has an invalid Raw Git Object Residual: {error}"
+                    ),
+                    Some(state_id.to_string()),
+                )),
+            }
         }
     }
 
-    for (git_oid, note) in read_all_notes(&mirror)
-        .map_err(|err| invalid_fsck_config(format!("Git projection notes check failed: {err}")))?
-    {
-        *objects_checked += 1;
-        let Ok(state_id) = StateId::parse(&note.state_id) else {
-            errors.push(make_error(
-                "git-projection-notes",
-                &format!("note for {git_oid} contains an invalid Heddle change id"),
-                Some(note.state_id),
-            ));
-            continue;
-        };
-        if mapping.get_git(&state_id) != Some(git_oid) {
-            errors.push(make_error(
-                "git-projection-notes",
-                &format!("note for {git_oid} does not round-trip through Git Projection Mapping"),
-                Some(state_id.to_string()),
-            ));
+    if let Some(mirror) = &mirror {
+        for (git_oid, note) in read_all_notes(mirror).map_err(|err| {
+            invalid_fsck_config(format!("Git projection notes check failed: {err}"))
+        })? {
+            *objects_checked += 1;
+            let Ok(state_id) = StateId::parse(&note.state_id) else {
+                errors.push(make_error(
+                    "git-projection-notes",
+                    &format!("note for {git_oid} contains an invalid Heddle change id"),
+                    Some(note.state_id),
+                ));
+                continue;
+            };
+            if mapping.get_git(&state_id) != Some(git_oid) {
+                errors.push(make_error(
+                    "git-projection-notes",
+                    &format!(
+                        "note for {git_oid} does not round-trip through Git Projection Mapping"
+                    ),
+                    Some(state_id.to_string()),
+                ));
+            }
         }
     }
 
@@ -158,10 +179,13 @@ fn open_git_repo(path: &Path) -> std::result::Result<SleyRepository, String> {
 
 fn build_existing_mapping(
     repo: &Repository,
-    mirror: &SleyRepository,
+    mirror: Option<&SleyRepository>,
 ) -> std::result::Result<SyncMapping, String> {
     let cache = read_mapping_cache_from_disk(repo)?;
-    let mut index = GitIdentityIndex::from_notes(mirror)?;
+    let mut index = match mirror {
+        Some(mirror) => GitIdentityIndex::from_notes(mirror)?,
+        None => GitIdentityIndex::default(),
+    };
     index.fill_gaps_from_cache(&cache);
     Ok(index.into_mapping())
 }
@@ -463,6 +487,45 @@ mod tests {
         assert_eq!(
             objects_checked, expected_objects_checked,
             "expected mapping + valid note + one check per thread to be counted, got {objects_checked}",
+        );
+    }
+
+    /// Negative control for #1279: removing residual validation must make this
+    /// test fail, because the mapped lossy commit is intentionally left without
+    /// its HR01 bytes.
+    #[test]
+    fn mapped_non_reconstructable_commit_without_residual_fails_fsck() {
+        let temp = TempDir::new().expect("create temp dir");
+        let repo = Repository::init_default(temp.path()).expect("init repo");
+        let tree = repo.store().put_tree(&Tree::new()).expect("write tree");
+        let state = State::new(
+            tree,
+            Vec::new(),
+            Attribution::human(Principal::new("Test User", "test@example.com")),
+        )
+        .with_raw_message("lossy import\n")
+        .with_git_lossy(true);
+        let state_id = state.state_id.to_string_full();
+        repo.store().put_state(&state).expect("store state");
+        let git_oid: sley::ObjectId = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+            .parse()
+            .expect("parse mapped oid");
+        write_projection_mapping(&repo, &state_id, &git_oid);
+
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+        let mut objects_checked = 0;
+        check_git_projection(&repo, &mut errors, &mut warnings, &mut objects_checked)
+            .expect("run Git projection check");
+
+        assert!(
+            errors.iter().any(|error| {
+                error.kind == "git-projection-residual"
+                    && error
+                        .message
+                        .contains("missing Raw Git Object Residual bytes")
+            }),
+            "fsck must fail the mapped non-reconstructable oid when residual bytes are missing: {errors:?}",
         );
     }
 }

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -2442,20 +2442,12 @@ fn materialize_active_checkout_closure(
             continue;
         }
 
-        if !residuals.install_into(object_repo, &git_oid)? {
+        if !residuals.install_commit_closure_into(object_repo, &git_oid)? {
             return Err(GitProjectionError::CommitNotFound(format!(
                 "{git_oid} for state {state_id}; the authoritative checkout .git and Raw Git Object Residual store do not contain it"
             )));
         }
-        match verify_closure_present(object_repo, &[git_oid], excluded) {
-            Ok(()) => {}
-            Err(ClosureCheck::Incomplete { missing }) => {
-                return Err(GitProjectionError::CommitNotFound(format!(
-                    "{missing} in the closure of {git_oid}; restore the original object to the authoritative checkout .git"
-                )));
-            }
-            Err(ClosureCheck::Walk(error)) => return Err(error),
-        }
+        stack.extend(state.parents);
     }
     Ok(())
 }
@@ -4196,9 +4188,9 @@ fn clone_url_to_bare_via_sley(
 ///     [`reconstruct_commit_bytes`]'s [`export_tree`], its whole tree/blob closure)
 ///     directly into `object_repo`, then recurse into its parents;
 ///   * otherwise (lossy: `--lossy` import or non-UTF8 identity) ⇒ install that
-///     commit's object from residual storage when present; otherwise copy its
-///     reachable closure from the Bridge Mirror (lazily migrating the root into
-///     residuals) and DO NOT recurse when the mirror supplied the closure.
+///     commit's exact tree/blob closure from residual storage and continue through
+///     its state parents; legacy imports without residuals copy their reachable
+///     closure from the Bridge Mirror and lazily migrate the root.
 ///
 /// CRITICAL safety gate: every reconstructed commit's git OID MUST equal the
 /// mapped `git_oid`. A mismatch means reconstruction diverged from the imported
@@ -4225,9 +4217,9 @@ pub fn materialize_checkout_closure_from_state(
     tip_oid: ObjectId,
     excluded: &HashSet<ObjectId>,
 ) -> GitProjectionResult<()> {
-    // Lossy commits whose closure still needs Bridge Mirror copy after residual
-    // install attempts. Residual-only roots are installed per-oid below; mirror
-    // roots are batched into one excluding pack install for perf shape parity.
+    // Lossy commits whose closure must come from residuals or the legacy Bridge
+    // Mirror. Mirror-only roots are batched into one excluding pack install for
+    // performance parity.
     let mut lossy_roots: Vec<ObjectId> = Vec::new();
     let mut stack: Vec<StateId> = vec![*tip_state_id];
     let mut seen: HashSet<StateId> = HashSet::new();
@@ -4276,12 +4268,11 @@ pub fn materialize_checkout_closure_from_state(
             stack.extend(state.parents.iter().copied());
         } else {
             // Lossy residual path: prefer Raw Git Object Residual, else Bridge
-            // Mirror. Residual install covers only this commit object (not its
-            // full tree closure); when residual is present we still fall back to
-            // mirror for missing dependents if the residual is commit-only, so
-            // keep the oid in lossy_roots for mirror closure copy when residual
-            // install alone is insufficient for the checkout.
+            // Mirror. New residuals carry the exact commit/tree/blob closure;
+            // parent commits remain independently reconstructable or residual-
+            // backed, so keep walking the native state DAG.
             lossy_roots.push(git_oid);
+            stack.extend(state.parents.iter().copied());
         }
     }
 
@@ -4325,18 +4316,11 @@ fn materialize_lossy_roots_from_residual_or_mirror(
         if excluded.contains(oid) || object_repo.read_object(oid).is_ok() {
             continue;
         }
-        // Prefer residual. If residual is only the commit root, mirror copy may
-        // still be required for tree/blob dependents — those are pulled via the
-        // mirror batch below when the object still cannot be fully satisfied.
-        // For a residual that installs successfully, still attempt mirror
-        // closure copy for dependents that residual storage may not yet hold
-        // (foundation: residual capture is often commit-granular first).
-        match residual_store.install_into(object_repo, oid) {
-            Ok(true) => {
-                // Root installed from residual; still ask the mirror for any
-                // missing reachable dependents when the mirror is available.
-                mirror_needed.push(*oid);
-            }
+        // New imports capture the complete commit/tree/blob closure, so a
+        // successful residual install needs no mirror fill. Legacy stores that
+        // have no root residual still use the lazy mirror migration below.
+        match residual_store.install_commit_closure_into(object_repo, oid) {
+            Ok(true) => {}
             Ok(false) => {
                 // No residual: require mirror (and migrate the root into residual
                 // when the mirror has it).
@@ -4365,11 +4349,7 @@ fn materialize_lossy_roots_from_residual_or_mirror(
     }
 
     if !mirror_needed.is_empty() {
-        // Closure fill from the Bridge Mirror. If the mirror lacks an object
-        // that residual already supplied as a root, copy is a no-op for present
-        // oids; missing dependents (trees/blobs the residual root did not carry)
-        // must be pulled from the mirror here or the checkout `.git` is silently
-        // corrupt — commit present, closure absent.
+        // Closure fill for legacy root-only residuals / mirror-only imports.
         if let Err(error) = copy_reachable_objects_excluding(
             mirror_repo,
             object_repo,

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -89,6 +89,16 @@ pub fn commit_is_byte_faithful(state: &State) -> bool {
             .unwrap_or(true)
 }
 
+/// Whether an imported state's mapped Git commit must be backed by residual
+/// bytes instead of reconstruction from native state.
+///
+/// Native Heddle states have no captured original (`raw_message` is absent),
+/// so their mapped projection commit can be minted normally and must not be
+/// mistaken for a lossy import by fsck.
+pub fn commit_requires_residual(state: &State) -> bool {
+    has_git_fidelity(state) && !commit_is_byte_faithful(state)
+}
+
 pub struct ExportStateOptions<'a> {
     pub identity: Option<&'a LocalGitIdentity>,
     pub message_override: Option<&'a str>,
@@ -309,6 +319,30 @@ pub fn export_current_thread(
     bridge.with_mapping_rollback(|bridge| export_scoped(bridge, Some(thread)))
 }
 
+fn seed_exportable_ingest_identities(
+    bridge: &mut GitProjection<'_>,
+    residuals: &ResidualStore,
+) -> GitProjectionResult<()> {
+    for (git_sha, state_id) in bridge.heddle_repo.git_overlay_ingest_commit_mapping()? {
+        let state_id = StateId::parse(&state_id)?;
+        let Some(state) = bridge.heddle_repo.store().get_state(&state_id)? else {
+            continue;
+        };
+        if bridge.mapping.has_heddle(&state_id) {
+            continue;
+        }
+        let git_oid = git_sha
+            .parse::<ObjectId>()
+            .map_err(|error| GitProjectionError::InvalidMapping(error.to_string()))?;
+        let can_materialize = commit_is_byte_faithful(&state)
+            || residuals.has_residual(git_oid.format(), &git_oid)?;
+        if can_materialize && !bridge.mapping.has_git(git_oid) {
+            bridge.mapping.insert(state_id, git_oid);
+        }
+    }
+    Ok(())
+}
+
 fn export_scoped(
     bridge: &mut GitProjection,
     thread: Option<&str>,
@@ -333,6 +367,8 @@ fn export_scoped(
     let mut stats = ExportStats::default();
 
     bridge.build_existing_mapping(None)?;
+    let residual_store = ResidualStore::open(bridge.heddle_repo.heddle_dir());
+    seed_exportable_ingest_identities(bridge, &residual_store)?;
     let identity = git_config_identity_with_global_fallback(bridge.heddle_repo.root())?;
 
     // Git projection export publishes the public projection — the export audience is
@@ -347,6 +383,33 @@ fn export_scoped(
     // boundary (absent from both).
     let reachable: HashSet<StateId> = sorted_states.iter().copied().collect();
     let repo = bridge.open_git_repo()?;
+    residual_store.install_tag_residuals_into(&repo)?;
+    for state_id in &sorted_states {
+        let Some(mapped_oid) = bridge.mapping.get_git(state_id) else {
+            continue;
+        };
+        let Some(state) = bridge.heddle_repo.store().get_state(state_id)? else {
+            continue;
+        };
+        if commit_requires_residual(&state) {
+            let installed = residual_store.install_commit_closure_into(&repo, &mapped_oid)?;
+            if !installed && repo.read_object(&mapped_oid).is_err() {
+                return Err(GitProjectionError::Git(format!(
+                    "mapped non-reconstructable Git object {mapped_oid} for state {state_id} has no Raw Git Object Residual and is unavailable from the Bridge Mirror"
+                )));
+            }
+        } else if commit_is_byte_faithful(&state) && repo.read_object(&mapped_oid).is_err() {
+            let content =
+                reconstruct_commit_bytes(bridge.heddle_repo, &repo, &bridge.mapping, &state)?;
+            let reconstructed = commit_object_id(&content);
+            if reconstructed != mapped_oid {
+                return Err(GitProjectionError::Git(format!(
+                    "fresh export reconstruction OID mismatch for state {state_id}: reconstructed {reconstructed}, expected mapped {mapped_oid}"
+                )));
+            }
+            write_commit_object(&repo, &content)?;
+        }
+    }
     bridge.mapping.retain_git_objects(&repo);
     bridge.seed_git_checkpoint_mappings_from_checkout(&repo)?;
     bridge.seed_ingest_identity_mappings_from_repo(&repo)?;
@@ -489,10 +552,6 @@ fn export_scoped(
                 if mapped.is_some_and(|oid| repo.read_object(&oid).is_ok()) {
                     continue;
                 }
-                // mirror still required for non-byte-faithful commits (non-UTF8
-                // identities, --lossy); #568 mirror elimination must account for
-                // these, and full de-lossy needs byte-preserving identities (#564
-                // follow-up).
                 // Fidelity guard (#567): regenerate from state ONLY when the
                 // state is fully byte-faithful to the original import. A
                 // non-byte-faithful commit (non-UTF8 identity, or a `--lossy`
@@ -518,12 +577,17 @@ fn export_scoped(
                         write_commit_object(&repo, &content)?;
                     }
                 } else if let Some(mapped_oid) = mapped {
-                    // Lossy path: prefer residual, else leave mirror bytes as the
-                    // served object (pre-#567). Foundation: install residual when
-                    // present so export no longer *requires* the mirror for that
-                    // root when residual capture has already run.
-                    let residual_store = ResidualStore::open(bridge.heddle_repo.heddle_dir());
-                    let _ = residual_store.install_into(&repo, &mapped_oid)?;
+                    // Lossy path: install the commit plus its exact tree/blob
+                    // closure. Import capture guarantees this is complete, so a
+                    // fresh projection no longer needs the Bridge Mirror as an
+                    // object warehouse.
+                    let installed =
+                        residual_store.install_commit_closure_into(&repo, &mapped_oid)?;
+                    if !installed && repo.read_object(&mapped_oid).is_err() {
+                        return Err(GitProjectionError::Git(format!(
+                            "mapped non-reconstructable Git object {mapped_oid} for state {state_id} has no Raw Git Object Residual and is unavailable from the Bridge Mirror"
+                        )));
+                    }
                 }
             }
             continue;
@@ -664,6 +728,27 @@ fn export_scoped(
         .filter(|oid| !served_note_oids.contains(oid))
         .collect();
     git_notes::remove_notes(&repo, &notes_to_retract)?;
+
+    // A native marker remembers the peeled StateId, while this residual
+    // sidecar remembers the original annotated wrapper OID. Restore a wrapper
+    // only when it still peels to the marker's current mapped commit; a moved
+    // marker must become an ordinary projected tag instead of resurrecting an
+    // obsolete annotation.
+    for tag_ref in residual_store.list_tag_refs(repo.object_format())? {
+        let Some(state_id) = bridge
+            .heddle_repo
+            .refs()
+            .get_marker(&MarkerName::new(tag_ref.name.as_str()))?
+        else {
+            continue;
+        };
+        let Some(mapped_oid) = bridge.mapping.get_git(&state_id) else {
+            continue;
+        };
+        if peel_to_commit_oid(&repo, tag_ref.oid) == Some(mapped_oid) {
+            sync_marker_to_tag(&repo, &tag_ref.name, tag_ref.oid)?;
+        }
+    }
 
     // THE PROJECTION (heddle#316 r13): the desired heddle-owned ref-set for this
     // audience — heads lagged to the served frontier, tags at served markers — as

--- a/crates/git-projection/src/git_ingest.rs
+++ b/crates/git-projection/src/git_ingest.rs
@@ -8,10 +8,12 @@ use sley::{GitObjectType, ObjectId, Repository as SleyRepository};
 
 use super::{
     git_core::{
-        GitProjection, GitProjectionError, GitProjectionResult, collect_import_source_ref_updates,
-        open_repo,
+        GitProjection, GitProjectionError, GitProjectionResult, RefNamespace,
+        collect_import_source_ref_updates, open_repo,
     },
+    git_export::commit_requires_residual,
     git_notes,
+    git_residual::ResidualStore,
     git_util::ImportStats,
 };
 
@@ -45,8 +47,54 @@ pub fn import_git_history(
     }
     let mirror_repo = bridge.open_git_repo()?;
     bridge.seed_ingest_identity_mappings_from_repo(&mirror_repo)?;
+    capture_import_residuals(bridge, source, refs, &stats)?;
     backfill_ingest_identity_notes_in_mirror(bridge, &mirror_repo, refs)?;
     Ok(import_stats_from_ingest(stats))
+}
+
+fn capture_import_residuals(
+    bridge: &GitProjection<'_>,
+    source: &Path,
+    refs: &[String],
+    stats: &ingest::ImportStats,
+) -> GitProjectionResult<()> {
+    let source_repo = open_repo(source)?;
+    let updates = collect_import_source_ref_updates(&source_repo, refs)?;
+    let residuals = ResidualStore::open(bridge.heddle_repo.heddle_dir());
+
+    for git_sha in &stats.non_reconstructable_commits {
+        let git_oid = git_sha
+            .parse::<ObjectId>()
+            .map_err(|error| GitProjectionError::InvalidMapping(error.to_string()))?;
+        let Some(state_id) = bridge.mapping.get_heddle(git_oid) else {
+            return Err(GitProjectionError::InvalidMapping(format!(
+                "non-reconstructable imported commit {git_oid} has no Git Projection Mapping"
+            )));
+        };
+        let Some(state) = bridge.heddle_repo.store().get_state(&state_id)? else {
+            return Err(GitProjectionError::StateNotFound(state_id));
+        };
+        if !commit_requires_residual(&state) {
+            return Err(GitProjectionError::InvalidMapping(format!(
+                "ingest classified {git_oid} as non-reconstructable but its mapped state {state_id} is byte-faithful"
+            )));
+        }
+        residuals.capture_commit_closure_from_git_repo(&source_repo, &git_oid)?;
+    }
+
+    for update in updates
+        .into_iter()
+        .filter(|update| update.namespace == RefNamespace::Tag)
+    {
+        let object = source_repo
+            .read_object(&update.target)
+            .map_err(super::git_core::git_err)?;
+        if object.object_type == GitObjectType::Tag {
+            residuals.capture_tag_chain_from_git_repo(&source_repo, &update.target)?;
+            residuals.record_tag_ref(&update.name, update.target)?;
+        }
+    }
+    Ok(())
 }
 
 fn map_ingest_error(error: ingest::IngestError) -> GitProjectionError {

--- a/crates/git-projection/src/git_residual.rs
+++ b/crates/git-projection/src/git_residual.rs
@@ -39,11 +39,13 @@
 //! `docs/VERIFICATION_CLEANUP_PLAN.md`.
 
 use std::{
+    collections::{BTreeMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
 
 use objects::fs_atomic::write_file_atomic;
+use serde::{Deserialize, Serialize};
 use sley::{
     GitObjectType, ObjectFormat, ObjectId, Repository as SleyRepository,
     plumbing::sley_object::EncodedObject,
@@ -55,6 +57,18 @@ use crate::git_core::{GitProjectionError, GitProjectionResult, git_err};
 pub const RESIDUALS_DIR_NAME: &str = "git-residuals";
 
 const RESIDUAL_MAGIC: &[u8; 4] = b"HR01";
+const TAG_REFS_FILE_NAME: &str = "tag-refs.json";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResidualTagRef {
+    pub name: String,
+    pub oid: ObjectId,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct TagRefFile {
+    refs: BTreeMap<String, String>,
+}
 
 /// On-disk Raw Git Object Residual record.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -247,6 +261,139 @@ impl ResidualStore {
         Ok(true)
     }
 
+    /// Capture a non-reconstructable commit and its complete file closure.
+    ///
+    /// Parent commits are deliberately not traversed: each imported commit is
+    /// classified independently, so reconstructable parents remain backed by
+    /// native state while non-reconstructable parents are captured as their own
+    /// roots. Trees and blobs are captured recursively because the verbatim
+    /// commit points at the original tree, not the lossy native translation.
+    pub fn capture_commit_closure_from_git_repo(
+        &self,
+        source: &SleyRepository,
+        commit_oid: &ObjectId,
+    ) -> GitProjectionResult<()> {
+        let format = source.object_format();
+        let mut stack = vec![*commit_oid];
+        let mut seen = HashSet::new();
+        while let Some(oid) = stack.pop() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            let object = source.read_object(&oid).map_err(git_err)?;
+            self.put_residual_verified(oid, format, object.object_type, object.body.clone())?;
+            match object.object_type {
+                GitObjectType::Commit => {
+                    if oid != *commit_oid {
+                        return Err(GitProjectionError::Git(format!(
+                            "unexpected commit {oid} inside tree closure for {commit_oid}"
+                        )));
+                    }
+                    let commit =
+                        sley::CommitObject::parse_ref(format, &object.body).map_err(git_err)?;
+                    stack.push(commit.tree);
+                }
+                GitObjectType::Tree => {
+                    let tree = sley::TreeObject::parse(format, &object.body).map_err(git_err)?;
+                    stack.extend(
+                        tree.entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_gitlink())
+                            .map(|entry| entry.oid),
+                    );
+                }
+                GitObjectType::Blob => {}
+                GitObjectType::Tag => {
+                    return Err(GitProjectionError::Git(format!(
+                        "unexpected tag {oid} inside tree closure for {commit_oid}"
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Capture an annotated tag wrapper and any tag-of-tag wrappers beneath it.
+    ///
+    /// The eventual commit/tree/blob target is captured by its own import
+    /// classification. This method preserves only the tag objects that native
+    /// markers cannot reconstruct.
+    pub fn capture_tag_chain_from_git_repo(
+        &self,
+        source: &SleyRepository,
+        tag_oid: &ObjectId,
+    ) -> GitProjectionResult<()> {
+        let format = source.object_format();
+        let mut oid = *tag_oid;
+        let mut seen = HashSet::new();
+        loop {
+            if !seen.insert(oid) {
+                return Err(GitProjectionError::Git(format!(
+                    "annotated tag cycle while capturing {tag_oid}"
+                )));
+            }
+            let object = source.read_object(&oid).map_err(git_err)?;
+            if object.object_type != GitObjectType::Tag {
+                return Ok(());
+            }
+            self.put_residual_verified(oid, format, GitObjectType::Tag, object.body.clone())?;
+            oid = sley::TagObject::parse(format, &object.body)
+                .map_err(git_err)?
+                .object;
+        }
+    }
+
+    /// Persist the raw annotated-tag object targeted by an imported tag ref.
+    /// Native markers retain the peeled state identity; this sidecar retains the
+    /// wrapper identity needed to recreate an annotated ref in a fresh projection.
+    pub fn record_tag_ref(&self, name: &str, oid: ObjectId) -> GitProjectionResult<()> {
+        let path = self.residuals_dir().join(TAG_REFS_FILE_NAME);
+        let mut file = match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice::<TagRefFile>(&bytes).map_err(|error| {
+                GitProjectionError::Git(format!(
+                    "invalid Raw Git Object Residual tag-ref mapping: {error}"
+                ))
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => TagRefFile::default(),
+            Err(error) => return Err(error.into()),
+        };
+        file.refs.insert(name.to_string(), oid.to_string());
+        let bytes = serde_json::to_vec_pretty(&file).map_err(|error| {
+            GitProjectionError::Git(format!(
+                "serialize Raw Git Object Residual tag-ref mapping: {error}"
+            ))
+        })?;
+        write_file_atomic(&path, &bytes)?;
+        Ok(())
+    }
+
+    /// Read the durable imported annotated-tag ref identities.
+    pub fn list_tag_refs(&self, format: ObjectFormat) -> GitProjectionResult<Vec<ResidualTagRef>> {
+        let path = self.residuals_dir().join(TAG_REFS_FILE_NAME);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        let file = serde_json::from_slice::<TagRefFile>(&bytes).map_err(|error| {
+            GitProjectionError::Git(format!(
+                "invalid Raw Git Object Residual tag-ref mapping: {error}"
+            ))
+        })?;
+        file.refs
+            .into_iter()
+            .map(|(name, oid)| {
+                ObjectId::from_hex(format, &oid)
+                    .map(|oid| ResidualTagRef { name, oid })
+                    .map_err(|error| {
+                        GitProjectionError::Git(format!(
+                            "invalid annotated-tag residual oid {oid}: {error}"
+                        ))
+                    })
+            })
+            .collect()
+    }
+
     /// Install a residual into a target Git object database.
     ///
     /// Prefer this over reading residual bytes and re-framing in call sites.
@@ -268,6 +415,153 @@ impl ResidualStore {
             )));
         }
         Ok(true)
+    }
+
+    /// Install a captured non-reconstructable commit and its tree/blob closure.
+    /// Returns `false` only when the root residual is absent; a missing dependent
+    /// is a hard fidelity error.
+    pub fn install_commit_closure_into(
+        &self,
+        target: &SleyRepository,
+        commit_oid: &ObjectId,
+    ) -> GitProjectionResult<bool> {
+        let format = target.object_format();
+        if self.get_residual(format, commit_oid)?.is_none() {
+            return Ok(false);
+        }
+        let mut stack = vec![*commit_oid];
+        let mut seen = HashSet::new();
+        while let Some(oid) = stack.pop() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            let residual = self.get_residual(format, &oid)?.ok_or_else(|| {
+                GitProjectionError::Git(format!(
+                    "Raw Git Object Residual closure for {commit_oid} is missing reachable object {oid}"
+                ))
+            })?;
+            let written = target
+                .write_object(EncodedObject::new(
+                    residual.object_type,
+                    residual.body.clone(),
+                ))
+                .map_err(git_err)?;
+            if written != oid {
+                return Err(GitProjectionError::Git(format!(
+                    "installing Raw Git Object Residual wrote {written}, expected {oid}"
+                )));
+            }
+            match residual.object_type {
+                GitObjectType::Commit => {
+                    if oid != *commit_oid {
+                        return Err(GitProjectionError::Git(format!(
+                            "unexpected commit {oid} inside residual closure for {commit_oid}"
+                        )));
+                    }
+                    let commit =
+                        sley::CommitObject::parse_ref(format, &residual.body).map_err(git_err)?;
+                    stack.push(commit.tree);
+                }
+                GitObjectType::Tree => {
+                    let tree = sley::TreeObject::parse(format, &residual.body).map_err(git_err)?;
+                    stack.extend(
+                        tree.entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_gitlink())
+                            .map(|entry| entry.oid),
+                    );
+                }
+                GitObjectType::Blob => {}
+                GitObjectType::Tag => {
+                    return Err(GitProjectionError::Git(format!(
+                        "unexpected tag {oid} inside residual closure for {commit_oid}"
+                    )));
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    /// Validate a captured commit/tree/blob closure without materializing it.
+    /// Returns `false` only when the mapped root residual is absent. Missing or
+    /// corrupt dependents are reported as integrity errors.
+    pub fn validate_commit_closure(
+        &self,
+        format: ObjectFormat,
+        commit_oid: &ObjectId,
+    ) -> GitProjectionResult<bool> {
+        if self.get_residual(format, commit_oid)?.is_none() {
+            return Ok(false);
+        }
+        let mut stack = vec![*commit_oid];
+        let mut seen = HashSet::new();
+        while let Some(oid) = stack.pop() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            let residual = self.get_residual(format, &oid)?.ok_or_else(|| {
+                GitProjectionError::Git(format!(
+                    "Raw Git Object Residual closure for {commit_oid} is missing reachable object {oid}"
+                ))
+            })?;
+            match residual.object_type {
+                GitObjectType::Commit => {
+                    if oid != *commit_oid {
+                        return Err(GitProjectionError::Git(format!(
+                            "unexpected commit {oid} inside residual closure for {commit_oid}"
+                        )));
+                    }
+                    let commit =
+                        sley::CommitObject::parse_ref(format, &residual.body).map_err(git_err)?;
+                    stack.push(commit.tree);
+                }
+                GitObjectType::Tree => {
+                    let tree = sley::TreeObject::parse(format, &residual.body).map_err(git_err)?;
+                    stack.extend(
+                        tree.entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_gitlink())
+                            .map(|entry| entry.oid),
+                    );
+                }
+                GitObjectType::Blob => {}
+                GitObjectType::Tag => {
+                    return Err(GitProjectionError::Git(format!(
+                        "unexpected tag {oid} inside residual closure for {commit_oid}"
+                    )));
+                }
+            }
+        }
+        Ok(true)
+    }
+
+    /// Install every captured annotated-tag object into a Git object database.
+    /// Ref reconciliation remains name/ownership based; this only replaces the
+    /// Bridge Mirror's former role as the tag byte warehouse.
+    pub fn install_tag_residuals_into(
+        &self,
+        target: &SleyRepository,
+    ) -> GitProjectionResult<usize> {
+        let format = target.object_format();
+        let mut installed = 0;
+        for oid in self.list_residual_oids(format)? {
+            let Some(residual) = self.get_residual(format, &oid)? else {
+                continue;
+            };
+            if residual.object_type != GitObjectType::Tag {
+                continue;
+            }
+            let written = target
+                .write_object(EncodedObject::new(residual.object_type, residual.body))
+                .map_err(git_err)?;
+            if written != oid {
+                return Err(GitProjectionError::Git(format!(
+                    "installing annotated-tag residual wrote {written}, expected {oid}"
+                )));
+            }
+            installed += 1;
+        }
+        Ok(installed)
     }
 
     fn residual_path(&self, object_format: ObjectFormat, oid: &ObjectId) -> PathBuf {

--- a/crates/git-projection/src/lib.rs
+++ b/crates/git-projection/src/lib.rs
@@ -25,5 +25,5 @@ pub use git_core::{
 };
 pub use git_residual::{
     BridgeMirrorRetirementStatus, RESIDUALS_DIR_NAME, ResidualObject, ResidualStore,
-    bridge_mirror_retirement_status, resolve_lossy_object,
+    ResidualTagRef, bridge_mirror_retirement_status, resolve_lossy_object,
 };

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -84,6 +84,14 @@ pub struct ImportStats {
     /// Git tree entries that were dropped or converted because the caller
     /// explicitly opted into lossy import.
     pub lossy_entries: Vec<LossyImportEntry>,
+    /// Original Git commits whose native States cannot reconstruct their
+    /// mapped bytes (lossy trees or non-UTF-8 identities). Git projection uses
+    /// these exact roots to capture Raw Git Object Residual closures.
+    pub non_reconstructable_commits: Vec<String>,
+    /// Original Git trees at which a lossy path conversion occurred. This is
+    /// retained as import evidence even though residual capture walks the full
+    /// tree closure from each commit root.
+    pub lossy_trees: Vec<String>,
 }
 
 /// Which Git refs a mechanical import should ingest.
@@ -419,6 +427,12 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
                     git_lossy,
                     ParentMapPolicy::RequireMapped,
                 )?;
+                if git_lossy || commit_has_lossy_identity(commit) {
+                    packed
+                        .stats
+                        .non_reconstructable_commits
+                        .insert(commit.sha.clone());
+                }
                 if let Some(progress) = self.progress.as_deref_mut() {
                     progress(ImportProgressEvent {
                         commits_imported: idx + 1,
@@ -517,6 +531,19 @@ impl<'a, R: RefBackend, S: ObjectStore, O: OpLogBackend> Importer<'a, R, S, O> {
             oplog: oplog_stats,
             reflog_only_commits,
             lossy_entries: packed_stats.lossy_entries,
+            non_reconstructable_commits: {
+                let mut commits = packed_stats
+                    .non_reconstructable_commits
+                    .into_iter()
+                    .collect::<Vec<_>>();
+                commits.sort();
+                commits
+            },
+            lossy_trees: {
+                let mut trees = packed_stats.lossy_trees.into_iter().collect::<Vec<_>>();
+                trees.sort();
+                trees
+            },
         })
     }
 }
@@ -529,6 +556,14 @@ struct PackedImportStats {
     trees: usize,
     blobs: usize,
     lossy_entries: Vec<LossyImportEntry>,
+    non_reconstructable_commits: HashSet<String>,
+    lossy_trees: HashSet<String>,
+}
+
+fn commit_has_lossy_identity(commit: &CommitEntry) -> bool {
+    [&commit.author, &commit.committer].iter().any(|signature| {
+        signature.name.contains('\u{FFFD}') || signature.email.contains('\u{FFFD}')
+    })
 }
 
 trait ImportPackSink {
@@ -748,6 +783,7 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
                         .iter()
                         .map(|entry| rebase_lossy_entry(path_prefix, entry)),
                 );
+                self.stats.lossy_trees.insert(git_tree_sha.to_string());
             }
             return Ok(hash);
         }
@@ -765,6 +801,9 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
             .iter()
             .map(|entry| entry_relative_to_prefix(path_prefix, entry))
             .collect::<Vec<_>>();
+        if !tree_lossy_entries.is_empty() {
+            self.stats.lossy_trees.insert(git_tree_sha.to_string());
+        }
 
         let tree = Tree::from_entries(entries);
         let hash = tree.hash();
@@ -1805,6 +1844,8 @@ mod tests {
 
         assert_eq!(stats.commits_imported, 1);
         assert_eq!(stats.lossy_entries.len(), 1);
+        assert_eq!(stats.non_reconstructable_commits.len(), 1);
+        assert_eq!(stats.lossy_trees.len(), 1);
         assert_eq!(stats.lossy_entries[0].path, converted_name);
         assert!(stats.lossy_entries[0].summary_line().contains("converted"));
     }

--- a/docs/VERIFICATION_CLEANUP_PLAN.md
+++ b/docs/VERIFICATION_CLEANUP_PLAN.md
@@ -173,10 +173,11 @@ Use the glossary terms in `CONTEXT.md` exactly.
      export lossy paths prefer reconstruct → residual → Bridge Mirror, with a
      hard fail when neither residual nor mirror can supply the object.
    - Fsck verifies mapped non-reconstructable objects have residuals.
-     (**Not yet** — residual validation remains follow-on.)
+     (**Shipped** — missing or invalid residual bytes are a hard fsck failure.)
    - Export/write-through can use residuals instead of the mirror for lossy objects.
-     (**Partial** — residual install is hooked; full closure capture on lossy
-     import and mirror-free export are not complete.)
+     (**Shipped** — imports capture non-reconstructable commits with their full
+     tree/blob closure plus annotated-tag wrappers; fresh export and
+     write-through install that closure without the mirror object warehouse.)
    - Old `.heddle/git` mirrors can lazily migrate needed residuals.
      (**Partial** — migrate helper exists; automatic full-mirror migration and
      explicit mirror deletion maintenance are not complete. Mirror is **not**


### PR DESCRIPTION
## Summary

- Capture HR01 residuals for every non-reconstructable imported commit and its recursive tree/blob closure.
- Preserve annotated-tag object chains and ref wrapper identities so fresh exports reproduce tags without the Bridge Mirror warehouse.
- Install full residual closures in export and checkout write-through paths, while keeping ingest identities out of the served mapping cache until export validates them.
- Make fsck report mapped non-reconstructable commits with missing or corrupt residual closures as hard errors.
- Mark the two Track B step 4 residual bullets shipped.

## Closes

Closes #1279

## Test evidence

- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1279-target cargo test -p heddle-ingest -p heddle-git-projection -p heddle-core`
- `lossy_import_captures_full_residual_closure_for_fresh_export`: imports a lossy non-UTF-8 tree name plus annotated tag, removes `.heddle/git`, and proves commit/tree/blob/tag types, bodies, refs, and OIDs are byte-identical after fresh export.
- Negative control `mapped_non_reconstructable_commit_without_residual_fails_fsck`: intentionally maps a lossy state without HR01 bytes and asserts the fsck residual error. Removing validation makes this test fail.
- Projection integration target: 96/96 current cases passed; the separately exercised 10k-commit deep-history case also passed.
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1279-target cargo test -p heddle-devtools` (71 passed)
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/h1279-target cargo clippy --workspace -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788874733&installation_model_id=21489&pr_number=1284&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1284&signature=c60a91867a35aafe99fff3d4bca4fae8b7df9e1d1b7ce8bc967d0e44e8a94207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->