### PR TITLE
fix(ci): raise CLI test open-file limit

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -298,6 +298,11 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::cargo test"
+          current_fd_limit=$(ulimit -n)
+          if [ "$current_fd_limit" != "unlimited" ] && [ "$current_fd_limit" -lt 65536 ]; then
+            ulimit -n 65536
+          fi
+          echo "Open-file limit: $(ulimit -n)"
           cargo test --locked "${package_args[@]}"
           echo "::endgroup::"
 
@@ -362,6 +367,11 @@ jobs:
           cargo build --locked -p heddle-cli --features telemetry --tests --bin heddle
           cargo clippy --locked -p heddle-cli -p heddle-cli-shared \
             --features heddle-cli/telemetry --lib --bins --tests --examples -- -D warnings
+          current_fd_limit=$(ulimit -n)
+          if [ "$current_fd_limit" != "unlimited" ] && [ "$current_fd_limit" -lt 65536 ]; then
+            ulimit -n 65536
+          fi
+          echo "Open-file limit: $(ulimit -n)"
           cargo test --locked -p heddle-cli -p heddle-cli-shared \
             --features heddle-cli/telemetry
 


### PR DESCRIPTION
## Summary

- restore the CLI test harness, cwd/env behavior, and fixtures to their pre-PR implementation
- raise the open-file soft limit to at least 65,536 immediately before both CI invocations that run the CLI tests
- leave the fsmonitor helper cleanup as a follow-up rather than changing test behavior in this fix

## Verification

Run with `TMPDIR=/home/scratch`, `CARGO_TARGET_DIR=/home/scratch/h1290b-target`, four Cargo jobs, four libtest threads, and `ulimit -n 65536`:

- **Quality:** full workspace build, `clippy -D warnings`, full workspace tests, Python tests, and default CLI contracts passed
  - default-feature `cli_integration`: 904 passed, 0 failed, 19 ignored
  - benchmark comparison: 12 passed
- **Feature contracts:** all four no-default-feature checks, telemetry build, telemetry `clippy -D warnings`, and full telemetry tests passed
  - telemetry `cli_integration`: 905 passed, 0 failed, 19 ignored
  - all remaining CLI/CLI-shared test binaries and doctests passed
- **Check & test:** the workflow aggregation logic passed with all required jobs successful

Closes #1290
