### PR TITLE
Handle try globals and abandoned thread cleanup

### DIFF
--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -29667,6 +29667,12 @@
       },
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "abandoned": {
+          "items": {
+            "$ref": "#/$defs/ThreadDroppedSchema"
+          },
+          "type": "array"
+        },
         "action": {
           "type": "string"
         },
@@ -29815,6 +29821,7 @@
         "dry_run",
         "merged",
         "auto",
+        "abandoned",
         "reclaimed_bytes",
         "would_reclaim_bytes",
         "output_kind"

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -2415,6 +2415,7 @@ export interface ThreadCaptureSummarySchema {
 }
 
 export interface ThreadCleanupSchema {
+  abandoned: ThreadDroppedSchema[];
   action: string;
   auto: ThreadDroppedSchema[];
   blockers: string[];

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -845,6 +845,11 @@ pub struct TryArgs {
     #[arg(long = "keep-on-success")]
     pub keep_on_success: bool,
 
+    /// Allow Heddle global-option spellings after `--` and pass them
+    /// unchanged to the inner command.
+    #[arg(long)]
+    pub allow_heddle_global_args: bool,
+
     /// The command to run. Everything after `--` lands here. The
     /// first token is the program; the rest are its arguments.
     #[arg(required = true, trailing_var_arg = true, allow_hyphen_values = true)]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -197,6 +197,9 @@ Examples:
     /// when you already have a thread and just want to exec a command
     /// inside its checkout (no thread creation, no capture, no
     /// rollback).
+    #[command(after_help = "\
+Heddle options must appear before `--`. Everything after `--` is passed unchanged to the inner command. If the inner command uses a Heddle global-option spelling, pass `--allow-heddle-global-args` before `--`.
+")]
     Try(TryArgs),
 
     /// Automation/workflow command: run a command inside an existing

--- a/crates/cli-args/src/cli/cli_args/commands_thread.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_thread.rs
@@ -117,7 +117,7 @@ Advanced split form:
     /// the repo's branch-protection policies. Read-only.
     CheckMerge(ThreadCheckMergeArgs),
 
-    /// Sweep merged or stale auto-created threads.
+    /// Sweep merged, stale auto-created, or abandoned threads.
     #[command(
         long_about = "\
 Sweep threads that have outlived their usefulness. Cleanup removes recorded checkouts, marks matching thread records abandoned, and prunes live thread refs so everyday thread lists stay focused.
@@ -125,13 +125,15 @@ Sweep threads that have outlived their usefulness. Cleanup removes recorded chec
 Modes:
   - --merged: clean up threads recorded as merged.
   - --auto --older-than <duration>: clean up harness-created threads that have not been touched in the given duration.
+  - --abandoned: remove live refs and checkout residue left by abandoned threads; retain their records, states, and audit history.
 
-The two modes can be combined. Pair with --dry-run to preview the work without changing anything on disk.",
+The three modes can be combined. Pair with --dry-run to preview the work without changing anything on disk.",
         after_help = "\
 Examples:
   heddle thread cleanup --merged --dry-run
   heddle thread cleanup --merged
   heddle thread cleanup --auto --older-than 7d --dry-run
+  heddle thread cleanup --abandoned --dry-run
 "
     )]
     Cleanup(ThreadCleanupArgs),
@@ -186,8 +188,8 @@ pub enum ThreadMarkerCommands {
 
 /// Arguments for `heddle thread list`.
 ///
-/// The default view hides harness-auto-created threads (those marked
-/// with `auto: true` on disk). Pass `--include-auto` to surface them.
+/// The default view hides harness-auto-created and abandoned threads.
+/// Pass the corresponding include flags to surface them.
 #[derive(Args, Clone, Debug, Default)]
 pub struct ThreadListArgs {
     /// Include threads created automatically by harness integrations
@@ -195,13 +197,17 @@ pub struct ThreadListArgs {
     /// the view focused on threads the user explicitly created.
     #[arg(long)]
     pub include_auto: bool,
+
+    /// Include threads whose lifecycle state is abandoned. Hidden by
+    /// default because they are no longer actionable.
+    #[arg(long)]
+    pub include_abandoned: bool,
 }
 
 /// Arguments for `heddle thread cleanup`.
 ///
-/// At least one of `--merged` or `--auto` must be set; otherwise the
-/// command refuses with a clear message. `--older-than` is required
-/// when `--auto` is set.
+/// At least one cleanup mode must be set; otherwise the command refuses
+/// with a clear message. `--older-than` is required when `--auto` is set.
 #[derive(Args, Clone, Debug)]
 pub struct ThreadCleanupArgs {
     /// Clean up threads whose recorded state is `merged`.
@@ -212,6 +218,11 @@ pub struct ThreadCleanupArgs {
     /// Combine with `--older-than` to gate the sweep on staleness.
     #[arg(long)]
     pub auto: bool,
+
+    /// Clean abandoned threads that still have a live ref or checkout
+    /// residue. States and audit history are retained.
+    #[arg(long)]
+    pub abandoned: bool,
 
     /// Maximum age (since `updated_at`) for an auto-thread to be
     /// considered live. Threads older than this are eligible for

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -1626,6 +1626,7 @@ pub struct ThreadCleanupSchema {
     pub dry_run: bool,
     pub merged: Vec<ThreadDroppedSchema>,
     pub auto: Vec<ThreadDroppedSchema>,
+    pub abandoned: Vec<ThreadDroppedSchema>,
     pub reclaimed_bytes: u64,
     pub would_reclaim_bytes: u64,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -467,7 +467,9 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
     let collect_start = Instant::now();
     let report = list_threads(
         repo,
-        ThreadListOptions::new().include_auto(args.include_auto),
+        ThreadListOptions::new()
+            .include_auto(args.include_auto)
+            .include_abandoned(args.include_abandoned),
     )?;
     let collect_summaries_ms = collect_start.elapsed().as_millis();
     let verification_start = Instant::now();

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -18,7 +18,7 @@ use heddle_core::{
 use objects::{
     fs_ops::remove_path_recursively,
     object::{StateId, ThreadName},
-    store::{ActorPresenceStore, ObjectStore, WriterLeaseStore},
+    store::{ActorPresenceStore, ObjectStore, WriterLeaseStatus, WriterLeaseStore},
 };
 use oplog::{OpLogRecorder, OpRecord, ThreadUpdateSnapshots};
 use refs::{Head, RefExpectation, RefUpdate};
@@ -987,13 +987,14 @@ fn current_thread_drop_advice(repo: &Repository, thread_id: &str) -> RecoveryAdv
 fn thread_cleanup_mode_required_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "thread_cleanup_mode_required",
-        "heddle thread cleanup requires at least one mode flag: pass --merged to sweep merged threads, --auto --older-than <duration> to sweep stale auto-threads, or both.",
-        "Choose `heddle thread cleanup --merged --dry-run` or `heddle thread cleanup --auto --older-than 7d --dry-run` first.",
+        "heddle thread cleanup requires at least one mode flag: --merged, --auto --older-than <duration>, or --abandoned.",
+        "Add --dry-run to the cleanup mode you intend; for abandoned threads, run `heddle thread cleanup --abandoned --dry-run`.",
         "thread cleanup was invoked without a mode flag",
         "cleanup without an explicit mode could remove threads the user did not mean to sweep",
         "no thread metadata, checkout directories, mounts, or reservations were changed",
-        "heddle thread cleanup --merged --dry-run",
+        "heddle thread cleanup --abandoned --dry-run",
         vec![
+            "heddle thread cleanup --abandoned --dry-run".to_string(),
             "heddle thread cleanup --merged --dry-run".to_string(),
             "heddle thread cleanup --auto --older-than 7d --dry-run".to_string(),
         ],
@@ -1586,6 +1587,9 @@ struct ThreadCleanupOutput {
     /// Threads dropped (or that would be dropped, in dry-run) because
     /// they are auto-created and stale per `--older-than`.
     auto: Vec<DroppedThread>,
+    /// Abandoned threads cleaned (or that would be cleaned, in dry-run)
+    /// because operational residue remains.
+    abandoned: Vec<DroppedThread>,
     /// Total bytes reclaimed from removing thread checkouts. Always
     /// `0` in dry-run mode — see `would_reclaim_bytes` for the
     /// estimate. This split prevents automation that reads
@@ -1751,7 +1755,7 @@ fn format_bytes(bytes: u64) -> String {
 }
 
 fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> Result<()> {
-    if !args.merged && !args.auto {
+    if !args.merged && !args.auto && !args.abandoned {
         return Err(anyhow!(thread_cleanup_mode_required_advice()));
     }
     if args.older_than.is_some() && !args.auto {
@@ -1770,6 +1774,16 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
     let manager = thread_manager(repo);
     let threads = manager.list()?;
     let now = Utc::now();
+    let actor_presence = if args.abandoned {
+        ActorPresenceStore::new(repo.heddle_dir()).list_without_pruning()?
+    } else {
+        Vec::new()
+    };
+    let writer_leases = if args.abandoned {
+        WriterLeaseStore::new(repo.heddle_dir()).list_without_reaping()?
+    } else {
+        Vec::new()
+    };
 
     // Cleanup running from inside a qualifying thread used to drop
     // its own checkout mid-command, leaving the user in a deleted
@@ -1783,13 +1797,68 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
 
     let mut merged_drops: Vec<(Thread, DroppedThread)> = Vec::new();
     let mut auto_drops: Vec<(Thread, DroppedThread)> = Vec::new();
+    let mut abandoned_drops: Vec<(Thread, DroppedThread)> = Vec::new();
     let mut skipped: Vec<SkippedThread> = Vec::new();
 
     for thread in threads {
-        // Skip already-abandoned threads — `cmd_thread_drop` marks
-        // dropped threads abandoned, so re-running cleanup should be
-        // a no-op for them.
         if matches!(thread.state, ThreadState::Abandoned) {
+            if !args.abandoned {
+                continue;
+            }
+            let thread_name = ThreadName::new(&thread.thread);
+            let has_live_ref = repo.refs().get_thread(&thread_name)?.is_some();
+            let has_execution_path = thread.execution_path.exists();
+            let has_manifest =
+                repo::thread_manifest::manifest_path(repo.heddle_dir(), &thread.thread).exists();
+            let has_actor_presence = actor_presence.iter().any(|entry| {
+                entry.thread == thread.thread
+                    || entry.thread_id.as_deref() == Some(thread.id.as_str())
+            });
+            let has_active_writer_lease = writer_leases.iter().any(|lease| {
+                lease.thread == thread.thread && lease.status == WriterLeaseStatus::Active
+            });
+            if !(has_live_ref
+                || has_execution_path
+                || has_manifest
+                || has_actor_presence
+                || has_active_writer_lease)
+            {
+                continue;
+            }
+
+            let is_active = active_thread_id
+                .as_deref()
+                .is_some_and(|id| id == thread.id);
+            if is_active {
+                skipped.push(SkippedThread {
+                    thread: thread.thread.clone(),
+                    id: thread.id.clone(),
+                    reason: "active",
+                    note:
+                        "currently the active thread; would leave the user in a deleted directory"
+                            .to_string(),
+                });
+                continue;
+            }
+
+            let age_seconds = (now - thread.updated_at).num_seconds().max(0);
+            let bytes = directory_size(&thread.execution_path);
+            let execution_path = thread
+                .execution_path
+                .to_str()
+                .map(ToString::to_string)
+                .filter(|path| !path.is_empty());
+            abandoned_drops.push((
+                thread.clone(),
+                DroppedThread {
+                    thread: thread.thread,
+                    id: thread.id,
+                    reason: "abandoned",
+                    age_seconds,
+                    bytes,
+                    execution_path,
+                },
+            ));
             continue;
         }
         let age_seconds = (now - thread.updated_at).num_seconds().max(0);
@@ -1867,7 +1936,11 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
 
     let mut reclaimed_bytes: u64 = 0;
     if !args.dry_run {
-        for (thread, dropped) in merged_drops.iter().chain(auto_drops.iter()) {
+        for (thread, dropped) in merged_drops
+            .iter()
+            .chain(auto_drops.iter())
+            .chain(abandoned_drops.iter())
+        {
             apply_thread_drop(repo, &manager, thread)?;
             reclaimed_bytes = reclaimed_bytes.saturating_add(dropped.bytes);
         }
@@ -1875,10 +1948,13 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
 
     let merged_summary: Vec<DroppedThread> = merged_drops.iter().map(|(_, d)| d.clone()).collect();
     let auto_summary: Vec<DroppedThread> = auto_drops.iter().map(|(_, d)| d.clone()).collect();
-    let total_dropped = merged_summary.len() + auto_summary.len();
+    let abandoned_summary: Vec<DroppedThread> =
+        abandoned_drops.iter().map(|(_, d)| d.clone()).collect();
+    let total_dropped = merged_summary.len() + auto_summary.len() + abandoned_summary.len();
     let would_reclaim: u64 = merged_summary
         .iter()
         .chain(auto_summary.iter())
+        .chain(abandoned_summary.iter())
         .map(|d| d.bytes)
         .sum();
 
@@ -1900,6 +1976,18 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
             "{} {} stale auto-thread(s)",
             action_word,
             auto_summary.len()
+        ));
+    }
+    if args.abandoned {
+        let abandoned_action = if args.dry_run {
+            "would clean"
+        } else {
+            "cleaned"
+        };
+        parts.push(format!(
+            "{} {} abandoned thread(s)",
+            abandoned_action,
+            abandoned_summary.len()
         ));
     }
     let bytes_for_message = if args.dry_run {
@@ -1936,6 +2024,7 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
         dry_run: args.dry_run,
         merged: merged_summary.clone(),
         auto: auto_summary.clone(),
+        abandoned: abandoned_summary.clone(),
         reclaimed_bytes: if args.dry_run { 0 } else { reclaimed_bytes },
         would_reclaim_bytes: would_reclaim,
         skipped: skipped.clone(),
@@ -1948,7 +2037,11 @@ fn cmd_thread_cleanup(cli: &Cli, repo: &Repository, args: ThreadCleanupArgs) -> 
         if total_dropped == 0 {
             println!("No threads matched the cleanup criteria.");
         } else {
-            for entry in merged_summary.iter().chain(auto_summary.iter()) {
+            for entry in merged_summary
+                .iter()
+                .chain(auto_summary.iter())
+                .chain(abandoned_summary.iter())
+            {
                 println!(
                     "  - {} ({}) [{}]  {}  age {}s",
                     entry.thread,

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -610,6 +610,7 @@ mod tests {
             workspace: WorkspaceModeArg::Materialized,
             auto_merge: false,
             keep_on_success: false,
+            allow_heddle_global_args: false,
             command: vec!["true".into()],
         };
         let cli = Cli {

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -101,6 +101,9 @@ impl HeddleExitCode {
             "remote_not_configured" | "remote_not_found" | "repository_not_found" => {
                 Some(Self::Config)
             }
+            // A Heddle global option after `try --` is a malformed
+            // invocation, not a child-command argument.
+            "try_global_option_after_separator" => Some(Self::Usage),
             // Well-formed input the command semantically rejects:
             // - nothing staged / no changes to capture
             // - a reconcile that needs a `--prefer` side
@@ -110,8 +113,7 @@ impl HeddleExitCode {
             //   that output contract (the invocation parses fine; the
             //   command rejects the requested projection)
             "nothing_to_capture"
-            | "try_global_option_after_separator" => Some(Self::Usage),
-            "commit_requires_git_overlay"
+            | "commit_requires_git_overlay"
             | "commit_capture_required"
             | "git_repair_requires_adoption"
             | "git_repair_requires_import"

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -110,7 +110,8 @@ impl HeddleExitCode {
             //   that output contract (the invocation parses fine; the
             //   command rejects the requested projection)
             "nothing_to_capture"
-            | "commit_requires_git_overlay"
+            | "try_global_option_after_separator" => Some(Self::Usage),
+            "commit_requires_git_overlay"
             | "commit_capture_required"
             | "git_repair_requires_adoption"
             | "git_repair_requires_import"
@@ -489,6 +490,7 @@ mod tests {
             ("remote_not_configured", HeddleExitCode::Config),
             ("remote_not_found", HeddleExitCode::Config),
             ("repository_not_found", HeddleExitCode::Config),
+            ("try_global_option_after_separator", HeddleExitCode::Usage),
             ("nothing_to_capture", HeddleExitCode::DataErr),
             ("dirty_worktree", HeddleExitCode::DataErr),
             ("state_corrupted", HeddleExitCode::DataErr),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,13 +26,13 @@ use cli::{
         MaintenanceCommands, ResolveArgs, RetroArgs, RevertArgs, RunArgs, ThreadCommands, UndoArgs,
         cli_args::LandArgs,
         commands::{
-            LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
-            cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_clone, cmd_collapse,
-            cmd_commit, cmd_complete, cmd_context_audit, cmd_context_check, cmd_context_edit,
-            cmd_context_get, cmd_context_history, cmd_context_list, cmd_context_rm,
-            cmd_context_set, cmd_context_suggest, cmd_context_supersede, cmd_continue,
-            cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff, cmd_discuss,
-            cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_fsck,
+            LogCommandOptions, RecoveryAdvice, RetroCommandOptions, SnapshotAgentOverrides,
+            build_command_catalog, cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_clone,
+            cmd_collapse, cmd_commit, cmd_complete, cmd_context_audit, cmd_context_check,
+            cmd_context_edit, cmd_context_get, cmd_context_history, cmd_context_list,
+            cmd_context_rm, cmd_context_set, cmd_context_suggest, cmd_context_supersede,
+            cmd_continue, cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff,
+            cmd_discuss, cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_fsck,
             cmd_fsck_repair_git, cmd_hook, cmd_init, cmd_integration, cmd_land, cmd_log,
             cmd_maintenance, cmd_oplog, cmd_pull, cmd_push, cmd_query, cmd_ready, cmd_redo,
             cmd_remote, cmd_resolve, cmd_retro, cmd_revert, cmd_review, cmd_run, cmd_schemas,
@@ -175,7 +175,7 @@ async fn async_main() -> Result<()> {
         // arg form `heddle help <topic>` also goes through clap.
     }
     let raw_argv: Vec<String> = std::env::args().collect();
-    let cli = match Cli::try_parse_from(raw_argv) {
+    let cli = match Cli::try_parse_from(raw_argv.clone()) {
         Ok(cli) => cli,
         Err(err) => {
             let raw: Vec<String> = std::env::args().skip(1).collect();
@@ -216,6 +216,12 @@ async fn async_main() -> Result<()> {
     // doing this inside each render path would re-query the env on
     // every line and fight the brand goal of restraint.
     cli::cli::style::init_from_cli(&cli);
+    if let Some(advice) = try_global_options_after_separator_advice(&cli, &raw_argv) {
+        let err = anyhow::anyhow!(advice);
+        let code = HeddleExitCode::from_error(&err);
+        print_error_with_hint(&cli, &err);
+        std::process::exit(code.into());
+    }
     let command_contract = command_runtime_contract_for_command(&cli.command);
     let command_name = command_contract.display.clone();
     let command_supports_op_id = command_contract.supports_op_id;
@@ -1020,6 +1026,109 @@ fn raw_global_flag_at<'a>(
     Some((global_arg_by_short(command, first_short)?, None, 1))
 }
 
+/// Refuse canonical Heddle global options after `try`'s separator before any
+/// repository or child-process side effect can occur.
+fn try_global_options_after_separator_advice(
+    cli: &Cli,
+    raw_argv: &[String],
+) -> Option<RecoveryAdvice> {
+    let Commands::Try(args) = &cli.command else {
+        return None;
+    };
+    if args.allow_heddle_global_args {
+        return None;
+    }
+
+    let separator = raw_argv.iter().position(|token| token == "--")?;
+    let command = Cli::command();
+    let mut matches = Vec::new();
+    let mut index = separator + 1;
+    while index < raw_argv.len() {
+        let token = &raw_argv[index];
+        let Some(long_token) = token.strip_prefix("--") else {
+            index += 1;
+            continue;
+        };
+        let canonical_long = long_token
+            .split_once('=')
+            .map_or(long_token, |(long, _)| long);
+        let Some((arg, value, consumed)) = raw_global_flag_at(&command, raw_argv, index) else {
+            index += 1;
+            continue;
+        };
+        if arg.get_long() != Some(canonical_long) {
+            index += 1;
+            continue;
+        }
+
+        let recognized = match canonical_long {
+            "output" => matches!(value, Some("text" | "json" | "json-compact")),
+            "no-color" | "verbose" | "quiet" => value.is_none(),
+            "repo" | "op-id" => value.is_some(),
+            _ => false,
+        };
+        if recognized {
+            matches.push((index, consumed));
+            index += consumed;
+        } else {
+            index += 1;
+        }
+    }
+    if matches.is_empty() {
+        return None;
+    }
+
+    let detected_tokens = matches
+        .iter()
+        .flat_map(|(start, consumed)| raw_argv[*start..*start + *consumed].iter())
+        .map(|token| repo::shell_quote(token))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let matched_indexes = matches
+        .iter()
+        .flat_map(|(start, consumed)| *start..*start + *consumed)
+        .collect::<std::collections::HashSet<_>>();
+
+    let mut corrected = raw_argv[1..separator].to_vec();
+    for (start, consumed) in &matches {
+        corrected.extend_from_slice(&raw_argv[*start..*start + *consumed]);
+    }
+    corrected.push("--".to_string());
+    corrected.extend(
+        raw_argv[separator + 1..]
+            .iter()
+            .enumerate()
+            .filter(|(offset, _)| !matched_indexes.contains(&(separator + 1 + offset)))
+            .map(|(_, token)| token.clone()),
+    );
+
+    let mut pass_through = raw_argv[1..separator].to_vec();
+    pass_through.push("--allow-heddle-global-args".to_string());
+    pass_through.extend_from_slice(&raw_argv[separator..]);
+
+    let primary_command = render_heddle_invocation(&corrected);
+    let pass_through_command = render_heddle_invocation(&pass_through);
+    Some(RecoveryAdvice::safety_refusal(
+        "try_global_option_after_separator",
+        format!(
+            "Heddle global options appear after `--` and would be passed to the inner command: `{detected_tokens}`."
+        ),
+        "Move Heddle options before `--`. If the listed options belong to the inner command, add `--allow-heddle-global-args` before `--`.",
+        "canonical Heddle global options were placed after `try`'s command separator",
+        "running the command would pass those options to the inner command instead of applying them to Heddle",
+        "no repository was opened, no thread was created, and no child process was started",
+        primary_command.clone(),
+        vec![primary_command, pass_through_command],
+    ))
+}
+
+fn render_heddle_invocation(args: &[String]) -> String {
+    std::iter::once("heddle".to_string())
+        .chain(args.iter().map(|arg| repo::shell_quote(arg)))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn global_arg_by_long<'a>(command: &'a clap::Command, long: &str) -> Option<&'a Arg> {
     command
         .get_arguments()
@@ -1218,6 +1327,151 @@ mod tests {
         assert!(!raw_wants_json(&args(&["--output", "text"])));
         assert!(!raw_wants_json(&args(&["--output=text"])));
         assert!(!raw_wants_json(&args(&["--output", "--no-color"])));
+    }
+
+    fn parsed_try(raw: &[&str]) -> (Cli, Vec<String>) {
+        let argv = args(raw);
+        let cli = Cli::try_parse_from(&argv)
+            .unwrap_or_else(|error| panic!("parse {raw:?} as try invocation: {error}"));
+        (cli, argv)
+    }
+
+    #[test]
+    fn try_separator_detector_matches_every_canonical_long_global_form() {
+        let cases: &[&[&str]] = &[
+            &["--output", "text"],
+            &["--output", "json"],
+            &["--output", "json-compact"],
+            &["--output=text"],
+            &["--output=json"],
+            &["--output=json-compact"],
+            &["--no-color"],
+            &["--repo", "/tmp/repo"],
+            &["--repo=/tmp/repo"],
+            &["--verbose"],
+            &["--quiet"],
+            &["--op-id", "operation-id"],
+            &["--op-id=operation-id"],
+        ];
+        for post_separator in cases {
+            let mut raw = vec!["heddle", "try", "--", "true"];
+            raw.extend_from_slice(post_separator);
+            let (cli, argv) = parsed_try(&raw);
+            assert!(
+                try_global_options_after_separator_advice(&cli, &argv).is_some(),
+                "canonical global form must be detected: {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_separator_detector_ignores_short_unknown_and_shell_string_collisions() {
+        let cases: &[&[&str]] = &[
+            &["-C", "/tmp/repo"],
+            &["-v"],
+            &["-q"],
+            &["--help"],
+            &["--version"],
+            &["--output", "artifact.json"],
+            &["--output-file=json"],
+            &["tool --output json"],
+            &["--repo"],
+            &["--op-id"],
+        ];
+        for post_separator in cases {
+            let mut raw = vec!["heddle", "try", "--", "true"];
+            raw.extend_from_slice(post_separator);
+            let (cli, argv) = parsed_try(&raw);
+            assert!(
+                try_global_options_after_separator_advice(&cli, &argv).is_none(),
+                "non-canonical child argv must pass through: {raw:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn try_separator_advice_uses_exact_copy_and_recovery_commands() {
+        let raw = [
+            "heddle",
+            "try",
+            "--",
+            "bash",
+            "-lc",
+            "printf ok",
+            "--output",
+            "json",
+        ];
+        let (cli, argv) = parsed_try(&raw);
+        let advice = try_global_options_after_separator_advice(&cli, &argv)
+            .expect("post-separator --output json must be refused");
+        assert_eq!(advice.kind, "try_global_option_after_separator");
+        assert_eq!(
+            advice.error,
+            "Heddle global options appear after `--` and would be passed to the inner command: `--output json`."
+        );
+        assert_eq!(
+            advice.hint,
+            "Move Heddle options before `--`. If the listed options belong to the inner command, add `--allow-heddle-global-args` before `--`."
+        );
+        assert_eq!(
+            advice.primary_command,
+            "heddle try --output json -- bash -lc 'printf ok'"
+        );
+        assert_eq!(
+            advice.recovery_commands,
+            [
+                "heddle try --output json -- bash -lc 'printf ok'",
+                "heddle try --allow-heddle-global-args -- bash -lc 'printf ok' --output json",
+            ]
+        );
+    }
+
+    #[test]
+    fn try_separator_advice_moves_all_matches_in_original_order() {
+        let raw = [
+            "heddle",
+            "try",
+            "--",
+            "tool",
+            "first",
+            "--quiet",
+            "middle",
+            "--output=json",
+            "--repo",
+            "path with space",
+            "last",
+        ];
+        let (cli, argv) = parsed_try(&raw);
+        let advice = try_global_options_after_separator_advice(&cli, &argv)
+            .expect("all canonical globals must be collected");
+        assert_eq!(
+            advice.primary_command,
+            "heddle try --quiet --output=json --repo 'path with space' -- tool first middle last"
+        );
+        assert_eq!(
+            advice.recovery_commands[1],
+            "heddle try --allow-heddle-global-args -- tool first --quiet middle --output=json --repo 'path with space' last"
+        );
+    }
+
+    #[test]
+    fn try_separator_escape_disables_only_the_detector() {
+        let raw = [
+            "heddle",
+            "try",
+            "--allow-heddle-global-args",
+            "--",
+            "tool",
+            "--output",
+            "json",
+        ];
+        let (cli, argv) = parsed_try(&raw);
+        let Commands::Try(args) = &cli.command else {
+            panic!("expected try command");
+        };
+        assert!(args.allow_heddle_global_args);
+        assert_eq!(args.command, ["tool", "--output", "json"]);
+        assert!(try_global_options_after_separator_advice(&cli, &argv).is_none());
     }
 
     #[test]

--- a/crates/cli/tests/cli_integration/thread_cleanup.rs
+++ b/crates/cli/tests/cli_integration/thread_cleanup.rs
@@ -21,7 +21,14 @@
 use std::fs;
 
 use chrono::{Duration, Utc};
-use objects::{object::ThreadName, store::ObjectStore};
+use objects::{
+    object::ThreadName,
+    store::{
+        ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary, ObjectStore,
+        WriterLeaseDraft, WriterLeaseReserveOutcome, WriterLeaseStatus, WriterLeaseStore,
+    },
+};
+use oplog::{OpLogBackend, OpRecord};
 use repo::{
     Repository, Thread, ThreadConfidenceSummary, ThreadFreshness, ThreadIntegrationPolicy,
     ThreadManager, ThreadMode, ThreadState, ThreadVerificationSummary,
@@ -164,6 +171,394 @@ fn thread_list_hides_auto_threads_by_default() {
     );
 }
 
+#[test]
+fn thread_list_hides_abandoned_in_text_and_json_and_composes_include_flags() {
+    let temp = setup_repo();
+    seed_thread(
+        temp.path(),
+        "abandoned/explicit",
+        false,
+        ThreadState::Abandoned,
+        Utc::now(),
+    );
+    seed_thread(
+        temp.path(),
+        "abandoned/auto",
+        true,
+        ThreadState::Abandoned,
+        Utc::now(),
+    );
+
+    let default_json = list_thread_names(temp.path(), &[]);
+    assert!(!default_json.iter().any(|name| name == "abandoned/explicit"));
+    assert!(!default_json.iter().any(|name| name == "abandoned/auto"));
+    let default_text = heddle(&["thread", "list"], Some(temp.path())).unwrap();
+    assert!(!default_text.contains("abandoned/explicit"));
+    assert!(!default_text.contains("abandoned/auto"));
+
+    let abandoned_only = list_thread_names(temp.path(), &["--include-abandoned"]);
+    assert!(
+        abandoned_only
+            .iter()
+            .any(|name| name == "abandoned/explicit")
+    );
+    assert!(!abandoned_only.iter().any(|name| name == "abandoned/auto"));
+
+    let auto_only = list_thread_names(temp.path(), &["--include-auto"]);
+    assert!(!auto_only.iter().any(|name| name == "abandoned/explicit"));
+    assert!(!auto_only.iter().any(|name| name == "abandoned/auto"));
+
+    let audit = list_thread_names(temp.path(), &["--include-auto", "--include-abandoned"]);
+    assert!(audit.iter().any(|name| name == "abandoned/explicit"));
+    assert!(audit.iter().any(|name| name == "abandoned/auto"));
+}
+
+#[test]
+fn thread_cleanup_abandoned_dry_run_then_cleans_ref_but_retains_audit_history() {
+    let temp = setup_repo();
+    seed_thread(
+        temp.path(),
+        "abandoned/audit",
+        false,
+        ThreadState::Abandoned,
+        Utc::now(),
+    );
+    let repo = Repository::open(temp.path()).unwrap();
+    let retained_state = repo.head().unwrap().expect("seeded repository has HEAD");
+    let oplog_len_before = repo.oplog().recent(256).unwrap().len();
+
+    let dry_run = heddle(
+        &[
+            "--output",
+            "json",
+            "thread",
+            "cleanup",
+            "--abandoned",
+            "--dry-run",
+        ],
+        Some(temp.path()),
+    )
+    .expect("abandoned cleanup dry run");
+    let dry_run: Value = serde_json::from_str(&dry_run).unwrap();
+    assert_eq!(
+        dry_run["message"],
+        "would clean 1 abandoned thread(s) (would reclaim 0 B)"
+    );
+    assert_eq!(dry_run["abandoned"].as_array().unwrap().len(), 1);
+    assert_eq!(dry_run["abandoned"][0]["reason"], "abandoned");
+    assert_eq!(dry_run["reclaimed_bytes"], 0);
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("abandoned/audit"))
+            .unwrap()
+            .is_some(),
+        "dry-run must retain the live ref"
+    );
+    assert_eq!(repo.oplog().recent(256).unwrap().len(), oplog_len_before);
+
+    let cleaned = heddle(
+        &["--output", "json", "thread", "cleanup", "--abandoned"],
+        Some(temp.path()),
+    )
+    .expect("clean abandoned residue");
+    let cleaned: Value = serde_json::from_str(&cleaned).unwrap();
+    assert_eq!(
+        cleaned["message"],
+        "cleaned 1 abandoned thread(s) (reclaimed 0 B)"
+    );
+    assert_eq!(cleaned["abandoned"].as_array().unwrap().len(), 1);
+
+    let reopened = Repository::open(temp.path()).unwrap();
+    assert!(
+        reopened
+            .refs()
+            .get_thread(&ThreadName::new("abandoned/audit"))
+            .unwrap()
+            .is_none(),
+        "cleanup must prune the abandoned live ref"
+    );
+    let manager = ThreadManager::new(reopened.heddle_dir());
+    let record = manager
+        .load("abandoned/audit")
+        .unwrap()
+        .expect("abandoned manager record is retained");
+    assert!(matches!(record.state, ThreadState::Abandoned));
+    assert!(
+        reopened
+            .store()
+            .get_state(&retained_state)
+            .unwrap()
+            .is_some(),
+        "captured state objects must be retained"
+    );
+    assert!(
+        reopened.oplog().recent(256).unwrap().iter().any(|entry| {
+            matches!(
+                &entry.operation,
+                OpRecord::ThreadDelete { name, .. } if name == "abandoned/audit"
+            )
+        }),
+        "recorded ref deletion must remain in the oplog"
+    );
+    assert!(
+        list_thread_names(temp.path(), &["--include-abandoned"])
+            .iter()
+            .any(|name| name == "abandoned/audit"),
+        "audit view must include the retained no-ref abandoned record"
+    );
+
+    let second = heddle(
+        &["--output", "json", "thread", "cleanup", "--abandoned"],
+        Some(temp.path()),
+    )
+    .expect("idempotent abandoned cleanup rerun");
+    let second: Value = serde_json::from_str(&second).unwrap();
+    assert!(second["abandoned"].as_array().unwrap().is_empty());
+    assert_eq!(
+        second["message"],
+        "cleaned 0 abandoned thread(s) (reclaimed 0 B)"
+    );
+    let text = heddle(&["thread", "cleanup", "--abandoned"], Some(temp.path())).unwrap();
+    assert!(text.contains("No threads matched the cleanup criteria."));
+}
+
+#[test]
+fn thread_cleanup_abandoned_selects_each_residue_kind_and_dry_run_is_immutable() {
+    let temp = setup_repo();
+    for name in [
+        "abandoned/path",
+        "abandoned/manifest",
+        "abandoned/presence",
+        "abandoned/lease",
+        "abandoned/clean",
+    ] {
+        seed_thread(temp.path(), name, false, ThreadState::Abandoned, Utc::now());
+    }
+    let repo = Repository::open(temp.path()).unwrap();
+    for name in [
+        "abandoned/path",
+        "abandoned/manifest",
+        "abandoned/presence",
+        "abandoned/lease",
+        "abandoned/clean",
+    ] {
+        repo.refs().delete_thread(&ThreadName::new(name)).unwrap();
+    }
+    let manager = ThreadManager::new(repo.heddle_dir());
+
+    let execution_path = temp.path().join("abandoned-path-residue");
+    fs::create_dir_all(&execution_path).unwrap();
+    fs::write(execution_path.join("residue.txt"), "residue").unwrap();
+    let mut path_record = manager.load("abandoned/path").unwrap().unwrap();
+    path_record.execution_path = execution_path.clone();
+    manager.save(&path_record).unwrap();
+
+    let manifest_path =
+        repo::thread_manifest::manifest_path(repo.heddle_dir(), "abandoned/manifest");
+    fs::create_dir_all(manifest_path.parent().unwrap()).unwrap();
+    fs::write(&manifest_path, "residue").unwrap();
+
+    let presence_store = ActorPresenceStore::new(repo.heddle_dir());
+    presence_store
+        .save(&ActorPresence {
+            session_id: "agent-abandoned-presence".to_string(),
+            client_instance_id: None,
+            native_actor_key: None,
+            native_parent_actor_key: None,
+            native_instance_key: None,
+            heddle_session_id: None,
+            thread_id: Some("abandoned/presence".to_string()),
+            thread: "abandoned/presence".to_string(),
+            anchor_state: None,
+            anchor_root: None,
+            path: None,
+            base_state: String::new(),
+            started_at: Utc::now(),
+            provider: None,
+            model: None,
+            harness: None,
+            thinking_level: None,
+            usage_summary: AgentUsageSummary::default(),
+            last_progress_at: None,
+            report_flush_state: None,
+            attach_reason: None,
+            task_assignment_id: None,
+            attach_precedence: Vec::new(),
+            winning_attach_rule: None,
+            probe_source: None,
+            probe_confidence: None,
+            status: ActorPresenceStatus::Active,
+            completed_at: None,
+            context_queries: Vec::new(),
+        })
+        .unwrap();
+
+    let lease_store = WriterLeaseStore::new(repo.heddle_dir());
+    let WriterLeaseReserveOutcome::Reserved(lease_grant) = lease_store
+        .reserve(
+            WriterLeaseDraft {
+                thread: "abandoned/lease".to_string(),
+                actor_session_id: None,
+                task_assignment_id: None,
+                anchor_state: None,
+                anchor_root: None,
+                path: None,
+                pid: None,
+                boot_id: None,
+            },
+            Utc::now(),
+        )
+        .unwrap()
+    else {
+        panic!("fresh writer lease should reserve");
+    };
+
+    let dry_run = heddle(
+        &[
+            "--output",
+            "json",
+            "thread",
+            "cleanup",
+            "--abandoned",
+            "--dry-run",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let dry_run: Value = serde_json::from_str(&dry_run).unwrap();
+    let selected = dry_run["abandoned"].as_array().unwrap();
+    assert_eq!(
+        selected.len(),
+        4,
+        "clean audit record must not rematch: {dry_run}"
+    );
+    assert!(execution_path.exists());
+    assert!(manifest_path.exists());
+    assert!(
+        presence_store
+            .load("agent-abandoned-presence")
+            .unwrap()
+            .is_some()
+    );
+    assert_eq!(
+        lease_store
+            .load(&lease_grant.lease.lease_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        WriterLeaseStatus::Active
+    );
+
+    heddle(&["thread", "cleanup", "--abandoned"], Some(temp.path())).unwrap();
+    assert!(!execution_path.exists());
+    assert!(!manifest_path.exists());
+    assert!(
+        presence_store
+            .load("agent-abandoned-presence")
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        lease_store
+            .load(&lease_grant.lease.lease_id)
+            .unwrap()
+            .unwrap()
+            .status,
+        WriterLeaseStatus::Abandoned
+    );
+}
+
+#[test]
+fn thread_cleanup_abandoned_skips_the_current_checkout() {
+    let temp = setup_repo();
+    seed_thread(
+        temp.path(),
+        "main",
+        false,
+        ThreadState::Abandoned,
+        Utc::now(),
+    );
+    assert!(
+        list_thread_names(temp.path(), &[])
+            .iter()
+            .any(|name| name == "main"),
+        "the current checkout is never hidden even with inconsistent abandoned metadata"
+    );
+
+    let output = heddle(
+        &["--output", "json", "thread", "cleanup", "--abandoned"],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let output: Value = serde_json::from_str(&output).unwrap();
+    assert!(output["abandoned"].as_array().unwrap().is_empty());
+    assert_eq!(output["skipped"][0]["thread"], "main");
+    assert_eq!(output["skipped"][0]["reason"], "active");
+    let repo = Repository::open(temp.path()).unwrap();
+    assert!(
+        repo.refs()
+            .get_thread(&ThreadName::new("main"))
+            .unwrap()
+            .is_some(),
+        "current thread ref must remain untouched"
+    );
+}
+
+#[test]
+fn thread_cleanup_modes_combine_without_double_counting_abandoned_auto_threads() {
+    let temp = setup_repo();
+    seed_thread(
+        temp.path(),
+        "merged/one",
+        false,
+        ThreadState::Merged,
+        Utc::now(),
+    );
+    seed_thread(
+        temp.path(),
+        "auto/stale",
+        true,
+        ThreadState::Active,
+        Utc::now() - Duration::days(14),
+    );
+    seed_thread(
+        temp.path(),
+        "abandoned/auto",
+        true,
+        ThreadState::Abandoned,
+        Utc::now() - Duration::days(14),
+    );
+
+    let output = heddle(
+        &[
+            "--output",
+            "json",
+            "thread",
+            "cleanup",
+            "--merged",
+            "--auto",
+            "--older-than",
+            "7d",
+            "--abandoned",
+            "--dry-run",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap();
+    let output: Value = serde_json::from_str(&output).unwrap();
+    assert_eq!(output["merged"].as_array().unwrap().len(), 1);
+    assert_eq!(output["auto"].as_array().unwrap().len(), 1);
+    assert_eq!(output["abandoned"].as_array().unwrap().len(), 1);
+    assert_eq!(output["abandoned"][0]["thread"], "abandoned/auto");
+    assert!(
+        output["auto"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|entry| entry["thread"] != "abandoned/auto")
+    );
+}
+
 /// `heddle thread cleanup` with no mode flag must refuse — we don't
 /// want the user to type `heddle thread cleanup` and have it silently
 /// no-op (or worse, sweep something they didn't ask to).
@@ -183,6 +578,10 @@ fn thread_cleanup_without_mode_flag_refuses() {
     assert!(
         err.contains("--auto"),
         "refusal should name --auto; got: {err}"
+    );
+    assert!(
+        err.contains("--abandoned"),
+        "refusal should name --abandoned; got: {err}"
     );
 }
 
@@ -204,17 +603,13 @@ fn thread_cleanup_without_mode_flag_uses_typed_advice_json() {
     let envelope: Value =
         serde_json::from_str(stderr).expect("cleanup mode refusal should emit JSON envelope");
     assert_eq!(envelope["kind"], "thread_cleanup_mode_required");
-    assert!(
-        envelope["error"]
-            .as_str()
-            .is_some_and(|error| error.contains("requires at least one mode flag")),
-        "cleanup mode refusal should include typed recovery detail: {stderr}"
+    assert_eq!(
+        envelope["error"],
+        "heddle thread cleanup requires at least one mode flag: --merged, --auto --older-than <duration>, or --abandoned."
     );
-    assert!(
-        envelope["hint"]
-            .as_str()
-            .is_some_and(|hint| hint.contains("--dry-run")),
-        "cleanup mode hint should recommend a dry run: {stderr}"
+    assert_eq!(
+        envelope["hint"],
+        "Add --dry-run to the cleanup mode you intend; for abandoned threads, run `heddle thread cleanup --abandoned --dry-run`."
     );
 }
 

--- a/crates/cli/tests/cli_integration/try_cmd.rs
+++ b/crates/cli/tests/cli_integration/try_cmd.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 use super::{
-    assert_json_recovery_advice_fields, heddle, heddle_argv_json, heddle_output,
+    assert_json_recovery_advice_fields, heddle, heddle_argv_json, heddle_help, heddle_output,
     heddle_output_with_env,
 };
 
@@ -68,6 +68,142 @@ fn worktree_snapshot(repo: &std::path::Path) -> Vec<(String, Vec<u8>)> {
     }
     out.sort();
     out
+}
+
+#[test]
+fn try_help_explains_the_separator_boundary_and_escape() {
+    let help = heddle_help(&["try", "--help"]);
+    let paragraph = "Heddle options must appear before `--`. Everything after `--` is passed unchanged to the inner command. If the inner command uses a Heddle global-option spelling, pass `--allow-heddle-global-args` before `--`.";
+    assert!(
+        help.contains(paragraph),
+        "try help must carry exact separator guidance: {help}"
+    );
+    assert!(
+        help.contains("--allow-heddle-global-args"),
+        "try help must expose the explicit child-CLI escape: {help}"
+    );
+}
+
+#[test]
+fn try_output_after_separator_refuses_with_exact_text_and_usage_exit() {
+    let temp = TempDir::new().unwrap();
+    let output = heddle_output(
+        &["try", "--", "bash", "-lc", "printf ok", "--output", "json"],
+        Some(temp.path()),
+    )
+    .expect("invoke try separator refusal");
+    assert_eq!(output.status.code(), Some(64));
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        str::from_utf8(&output.stderr).unwrap(),
+        "Error: Heddle global options appear after `--` and would be passed to the inner command: `--output json`.\n\
+Next: heddle try --output json -- bash -lc 'printf ok'\n\
+Also: heddle try --allow-heddle-global-args -- bash -lc 'printf ok' --output json\n"
+    );
+    assert!(
+        !temp.path().join(".heddle").exists(),
+        "preflight refusal must not bootstrap repository metadata"
+    );
+}
+
+#[test]
+fn try_separator_refusal_has_no_child_side_effect() {
+    let temp = TempDir::new().unwrap();
+    let marker = temp.path().join("child-ran");
+    let script = format!("touch {}", marker.display());
+    let output = heddle_output(
+        &["try", "--", "sh", "-c", &script, "--quiet"],
+        Some(temp.path()),
+    )
+    .expect("invoke try separator refusal");
+    assert_eq!(output.status.code(), Some(64));
+    assert!(
+        !marker.exists(),
+        "refused invocation must not start the child"
+    );
+    assert!(!temp.path().join(".heddle").exists());
+}
+
+#[test]
+fn try_separator_refusal_uses_real_preseparator_json_mode() {
+    let temp = TempDir::new().unwrap();
+    let output = heddle_output(
+        &["--output", "json", "try", "--", "true", "--quiet"],
+        Some(temp.path()),
+    )
+    .expect("invoke JSON try separator refusal");
+    assert_eq!(output.status.code(), Some(64));
+    assert!(output.stdout.is_empty());
+    let stderr = str::from_utf8(&output.stderr).unwrap();
+    let envelope: Value = serde_json::from_str(stderr).expect("typed JSON refusal");
+    assert_eq!(envelope["kind"], "try_global_option_after_separator");
+    assert_eq!(
+        envelope["error"],
+        "Heddle global options appear after `--` and would be passed to the inner command: `--quiet`."
+    );
+    assert_eq!(
+        envelope["hint"],
+        "Move Heddle options before `--`. If the listed options belong to the inner command, add `--allow-heddle-global-args` before `--`."
+    );
+    assert_eq!(
+        envelope["primary_command"],
+        "heddle --output json try --quiet -- true"
+    );
+    assert_eq!(
+        envelope["recovery_commands"],
+        serde_json::json!([
+            "heddle --output json try --quiet -- true",
+            "heddle --output json try --allow-heddle-global-args -- true --quiet"
+        ])
+    );
+}
+
+#[test]
+fn try_allows_legitimate_inner_output_with_explicit_escape() {
+    let temp = setup_repo();
+    let probe = TempDir::new().unwrap();
+    let marker = probe.path().join("inner-output-received");
+    let script = probe.path().join("accept-output.sh");
+    fs::write(
+        &script,
+        format!(
+            "#!/bin/sh\n[ \"$1\" = \"--output\" ]\n[ \"$2\" = \"json\" ]\ntouch '{}'\n",
+            marker.display()
+        ),
+    )
+    .unwrap();
+
+    heddle(
+        &[
+            "try",
+            "--allow-heddle-global-args",
+            "--",
+            "sh",
+            script.to_str().unwrap(),
+            "--output",
+            "json",
+        ],
+        Some(temp.path()),
+    )
+    .expect("the explicit escape must pass inner argv unchanged");
+    assert!(
+        marker.exists(),
+        "inner command did not receive --output json"
+    );
+}
+
+#[test]
+fn try_does_not_flag_output_text_inside_one_shell_program_token() {
+    let temp = setup_repo();
+    let probe = TempDir::new().unwrap();
+    let marker = probe.path().join("shell-string-ran");
+    let script = format!("touch '{}'; : tool --output json", marker.display());
+    heddle(&["try", "--", "sh", "-c", &script], Some(temp.path()))
+        .expect("a shell program string is one child token, not a global option");
+    assert!(
+        marker.exists(),
+        "legitimate shell-string command did not run"
+    );
 }
 
 #[test]

--- a/crates/core/src/thread.rs
+++ b/crates/core/src/thread.rs
@@ -52,6 +52,9 @@ pub struct ThreadListOptions {
     /// When `false` (default for CLI), harness-created (`auto`) threads are
     /// omitted unless they are the current checkout lane.
     pub include_auto: bool,
+    /// When `false` (default for CLI), abandoned threads are omitted unless
+    /// they are the current checkout lane.
+    pub include_abandoned: bool,
 }
 
 impl ThreadListOptions {
@@ -61,6 +64,11 @@ impl ThreadListOptions {
 
     pub fn include_auto(mut self, include_auto: bool) -> Self {
         self.include_auto = include_auto;
+        self
+    }
+
+    pub fn include_abandoned(mut self, include_abandoned: bool) -> Self {
+        self.include_abandoned = include_abandoned;
         self
     }
 }
@@ -297,6 +305,11 @@ pub fn list_threads(repo: &Repository, options: ThreadListOptions) -> Result<Thr
         // worse than the noise it adds.
         summaries.retain(|summary| summary.is_current || !summary.auto);
     }
+    if !options.include_abandoned {
+        summaries.retain(|summary| {
+            summary.is_current || !matches!(summary.thread_state, Some(ThreadState::Abandoned))
+        });
+    }
     let available_git_refs = split_available_git_refs(&mut summaries);
     let current = summaries
         .iter()
@@ -336,14 +349,6 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
             .push(entry);
     }
     for mut thread in thread_manager.list()? {
-        if thread.state == ThreadState::Abandoned
-            && repo
-                .refs()
-                .get_thread(&ThreadName::new(&thread.thread))?
-                .is_none()
-        {
-            continue;
-        }
         refresh_thread_freshness(repo, &mut thread)?;
         threads_by_name.insert(thread.thread.clone(), thread);
     }

--- a/crates/objects/src/store/actor_presence.rs
+++ b/crates/objects/src/store/actor_presence.rs
@@ -378,6 +378,35 @@ impl ActorPresenceStore {
         Ok(entries)
     }
 
+    /// List every persisted entry without pruning stale terminal records.
+    ///
+    /// Cleanup previews use this read-only view so residue detection cannot
+    /// mutate actor-presence storage as a side effect.
+    pub fn list_without_pruning(&self) -> Result<Vec<ActorPresence>> {
+        if !self.presence_dir.exists() {
+            return Ok(Vec::new());
+        }
+
+        let mut entries = Vec::new();
+        for dir_entry in std::fs::read_dir(&self.presence_dir)? {
+            let path = dir_entry?.path();
+            if path
+                .extension()
+                .is_some_and(|extension| extension == "toml")
+            {
+                let content = std::fs::read_to_string(&path)?;
+                entries.push(toml::from_str::<ActorPresence>(&content).map_err(|err| {
+                    HeddleError::Config(format!(
+                        "failed to parse agent registry entry '{}': {err}",
+                        path.display()
+                    ))
+                })?);
+            }
+        }
+        entries.sort_by_key(|entry| std::cmp::Reverse(entry.started_at));
+        Ok(entries)
+    }
+
     /// Update the status of an agent entry in place.
     pub fn update_status(&self, session_id: &str, status: ActorPresenceStatus) -> Result<()> {
         let _lock = self.write_lock()?;

--- a/crates/objects/src/store/writer_lease.rs
+++ b/crates/objects/src/store/writer_lease.rs
@@ -280,6 +280,14 @@ impl WriterLeaseStore {
         self.list_locked()
     }
 
+    /// List persisted leases without reaping expired active records.
+    ///
+    /// Cleanup previews use this read-only view so residue detection cannot
+    /// mutate lease storage as a side effect.
+    pub fn list_without_reaping(&self) -> Result<Vec<WriterLease>> {
+        self.list_locked()
+    }
+
     pub fn abandon_thread(&self, thread: &str, now: DateTime<Utc>) -> Result<()> {
         let _lock = self.write_lock()?;
         for mut lease in self.list_locked()? {

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -951,6 +951,7 @@ emits an array of the same object.
     }
   ],
   "auto": [],
+  "abandoned": [],
   "reclaimed_bytes": 0,
   "would_reclaim_bytes": 12288,
   "skipped": []


### PR DESCRIPTION
## Summary

- reject canonical Heddle global options placed after `try --` with the spike's typed usage refusal, exact corrected/pass-through commands, and explicit `--allow-heddle-global-args` escape
- hide abandoned threads from default text and JSON lists while adding the composable `--include-abandoned` audit view
- add combinable `thread cleanup --abandoned` pruning for live refs and operational residue while retaining manager records, states, objects, writer-lease records, and oplog history
- extend the `thread_cleanup` JSON contract with the `abandoned` result array

## Decided design implemented

Implemented `docs/spikes/heddle-335-try-output-and-abandoned-thread-cleanup.md` as written: token-based canonical long-form detection after the first `try` separator; no lifting or short-form detection; preflight exit 64; exact error/hint/recovery copy; abandoned-by-default list filtering with independent include flags; and explicit, dry-run-capable abandoned cleanup with no interactive prompt or history erasure.

Confirmed the current `Commands` enum and `main.rs` dispatch contain `try` and no `attempt` subcommand.

## Evidence

- `cargo test -p heddle-cli --bin heddle try_separator` — 5 passed
- `cargo test -p heddle-cli --test cli_integration try_cmd::` — 13 passed
- `cargo test -p heddle-cli --test cli_integration thread_cleanup::` — 16 passed
- `cargo test -p heddle-core list_threads` — 3 passed
- `cargo test -p heddle-cli-contract` — 125 passed
- targeted cleanup help, output-kind, and repository schema-doc coverage tests passed
- `cargo clippy -p heddle-cli --tests -- -D warnings` passed
- `cargo clippy -p heddle-objects -p heddle-core -p heddle-cli-contract -- -D warnings` passed
- `rustfmt +nightly --edition 2024 --check` passed for every touched Rust file

Commit: `f3f0f8083f5cc69d5cebd55232146631b381a69b`

Closes #309

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788907926&installation_model_id=21489&pr_number=1297&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1297&signature=ee9af71a8a7b3846d5c9a3bbfbeb2934f131116ce6a1719b0c4169d38df51a16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->