### PR TITLE
Persist per-file semantic imports and references

### DIFF
--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -72,9 +72,11 @@ pub use risk_signal::{
 };
 pub use semantic_change::{ChangeImportance, ModificationKind, SemanticChange};
 pub use semantic_index::{
-    SemanticEntryKind, SemanticFileNode, SemanticIndexError, SemanticIndexRoot, SemanticTreeEntry,
-    SemanticTreeNode, SymbolEntry, SymbolKindTag, compute_dir_semantic_digest,
-    compute_file_scaffold_hash, compute_file_semantic_digest, compute_symbol_semantic_hash,
+    ByteSpan, ImportBinding, ImportEntry, ImportKindTag, OccurrenceEntry, OccurrenceRole,
+    ScopeEntry, ScopeKind, SemanticEntryKind, SemanticFileFacts, SemanticFileNode,
+    SemanticIndexError, SemanticIndexRoot, SemanticTreeEntry, SemanticTreeNode, SymbolEntry,
+    SymbolKindTag, SymbolNamespace, compute_dir_semantic_digest, compute_file_scaffold_hash,
+    compute_file_semantic_digest, compute_symbol_semantic_hash,
 };
 pub use session::{Session, SessionSegment, generate_session_id};
 #[cfg(feature = "async-source")]

--- a/crates/object-model/src/object/semantic_index.rs
+++ b/crates/object-model/src/object/semantic_index.rs
@@ -2,7 +2,7 @@
 //! Content-addressed merkle semantic index (heddle#1067).
 //!
 //! A parallel merkle DAG over the source tree that stores *semantic* facts —
-//! the symbols a file defines and a normalization-stable fingerprint of each —
+//! definitions, scopes, imports, and symbol occurrences —
 //! rather than raw bytes. It mirrors the blob/tree/state DAG so semantic data
 //! over all of history costs about as much to maintain as the source history
 //! itself, and queries short-circuit on hash equality without re-parsing.
@@ -20,7 +20,7 @@
 //!   digest compare prunes reformatted-but-semantically-identical subtrees
 //!   with zero re-parse.
 //!
-//! The digest byte layouts (`hd-sem-sym-v1`, `hd-sem-file-v1`, `hd-sem-dir-v1`)
+//! The digest byte layouts (`hd-sem-sym-v1`, `hd-sem-file-v3`, `hd-sem-dir-v2`)
 //! are the canonical, cross-language-reproducible definitions. A verifier in
 //! any language that reproduces these byte streams computes byte-identical
 //! digests.
@@ -141,15 +141,159 @@ impl SymbolEntry {
         }
     }
 
-    /// Sort key: `(container_path, name, kind, span.0)`.
-    fn sort_key(&self) -> (&[String], &str, u8, u32) {
+    /// Span-free sort key: `(container_path, name, kind, semantic_hash)`.
+    fn sort_key(&self) -> (&[String], &str, u8, ContentHash) {
         (
             &self.container_path,
             self.name.as_str(),
             self.kind.tag_byte(),
-            self.span.0,
+            self.semantic_hash,
         )
     }
+}
+
+/// Half-open byte range in the source blob. Spans are provenance metadata:
+/// they are encoded for navigation, but excluded from semantic digests.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ByteSpan {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl ByteSpan {
+    pub fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+}
+
+/// Source-local lexical scope classification.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeKind {
+    Module,
+    Type,
+    Function,
+    Block,
+}
+
+impl ScopeKind {
+    fn tag_byte(self) -> u8 {
+        match self {
+            Self::Module => 1,
+            Self::Type => 2,
+            Self::Function => 3,
+            Self::Block => 4,
+        }
+    }
+}
+
+/// A deterministic source-local scope. `local_id` is assigned in preorder.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScopeEntry {
+    pub local_id: u32,
+    pub parent: Option<u32>,
+    pub kind: ScopeKind,
+    pub span: ByteSpan,
+}
+
+/// Source-level import form. Resolution to repository paths happens later.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ImportKindTag {
+    Use,
+    Import,
+    Reexport,
+    Dynamic,
+}
+
+impl ImportKindTag {
+    fn tag_byte(self) -> u8 {
+        match self {
+            Self::Use => 1,
+            Self::Import => 2,
+            Self::Reexport => 3,
+            Self::Dynamic => 4,
+        }
+    }
+}
+
+/// Namespace in which a binding or occurrence participates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SymbolNamespace {
+    Value,
+    Type,
+    Both,
+}
+
+impl SymbolNamespace {
+    fn tag_byte(self) -> u8 {
+        match self {
+            Self::Value => 1,
+            Self::Type => 2,
+            Self::Both => 3,
+        }
+    }
+}
+
+/// One name introduced by an import, in canonical source order.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ImportBinding {
+    pub imported: String,
+    pub local: String,
+    pub namespace: SymbolNamespace,
+}
+
+/// One unresolved, source-local import record.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ImportEntry {
+    pub kind: ImportKindTag,
+    pub module_specifier: String,
+    pub bindings: Vec<ImportBinding>,
+    pub scope: u32,
+    pub span: ByteSpan,
+}
+
+/// Role played by a source-level symbol occurrence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OccurrenceRole {
+    Definition,
+    Reference,
+    Call,
+    TypeReference,
+}
+
+impl OccurrenceRole {
+    fn tag_byte(self) -> u8 {
+        match self {
+            Self::Definition => 1,
+            Self::Reference => 2,
+            Self::Call => 3,
+            Self::TypeReference => 4,
+        }
+    }
+}
+
+/// One unresolved symbol occurrence, numbered in source order.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OccurrenceEntry {
+    pub local_id: u32,
+    pub role: OccurrenceRole,
+    pub name: String,
+    pub qualifier: Vec<String>,
+    pub namespace: SymbolNamespace,
+    pub scope: u32,
+    pub span: ByteSpan,
+}
+
+/// Canonical source-local facts assembled into a [`SemanticFileNode`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SemanticFileFacts {
+    pub symbols: Vec<SymbolEntry>,
+    pub scopes: Vec<ScopeEntry>,
+    pub imports: Vec<ImportEntry>,
+    pub occurrences: Vec<OccurrenceEntry>,
 }
 
 /// Compute a symbol's normalization-stable `semantic_hash`.
@@ -183,22 +327,25 @@ pub fn compute_file_scaffold_hash(token_stream: &[u8]) -> ContentHash {
     ContentHash::compute_typed("hd-sem-scaffold-v1", token_stream)
 }
 
-/// Compute a file node's `semantic_digest` over its scaffold and (already
-/// sorted) symbols — so the digest covers ALL of a file's semantic content,
-/// not just its extracted definitions.
+/// Compute a file node's `semantic_digest` over its scaffold and canonical
+/// source-local facts. Spans are deliberately excluded from this identity.
 ///
-/// Canonical layout `hd-sem-file-v2`: `scaffold_hash`, then per symbol
+/// Canonical layout `hd-sem-file-v3`: `scaffold_hash`, then per symbol
 /// `u32-LE(container element count) ‖ (u32-LE-len ‖ bytes)* ‖ u32-LE(name len) ‖
 /// name ‖ kind_tag ‖ semantic_hash`. Every variable-length field is
 /// length-framed (no record-boundary ambiguity; `["a::b"]` no longer aliases
-/// `["a","b"]`). Spans are EXCLUDED — that is what makes the digest
-/// reformat-stable.
+/// `["a","b"]`). Scope, import, and occurrence records use count-framed
+/// fields and stable one-byte enum tags. All spans are EXCLUDED.
 pub fn compute_file_semantic_digest(
     scaffold_hash: ContentHash,
     symbols: &[SymbolEntry],
+    scopes: &[ScopeEntry],
+    imports: &[ImportEntry],
+    occurrences: &[OccurrenceEntry],
 ) -> ContentHash {
     let mut buf = Vec::new();
     buf.extend_from_slice(scaffold_hash.as_bytes());
+    buf.extend_from_slice(&(symbols.len() as u32).to_le_bytes());
     for symbol in symbols {
         buf.extend_from_slice(&(symbol.container_path.len() as u32).to_le_bytes());
         for segment in &symbol.container_path {
@@ -210,7 +357,48 @@ pub fn compute_file_semantic_digest(
         buf.push(symbol.kind.tag_byte());
         buf.extend_from_slice(symbol.semantic_hash.as_bytes());
     }
-    ContentHash::compute_typed("hd-sem-file-v2", &buf)
+    buf.extend_from_slice(&(scopes.len() as u32).to_le_bytes());
+    for scope in scopes {
+        buf.extend_from_slice(&scope.local_id.to_le_bytes());
+        match scope.parent {
+            Some(parent) => {
+                buf.push(1);
+                buf.extend_from_slice(&parent.to_le_bytes());
+            }
+            None => buf.push(0),
+        }
+        buf.push(scope.kind.tag_byte());
+    }
+    buf.extend_from_slice(&(imports.len() as u32).to_le_bytes());
+    for import in imports {
+        buf.push(import.kind.tag_byte());
+        push_str(&mut buf, &import.module_specifier);
+        buf.extend_from_slice(&(import.bindings.len() as u32).to_le_bytes());
+        for binding in &import.bindings {
+            push_str(&mut buf, &binding.imported);
+            push_str(&mut buf, &binding.local);
+            buf.push(binding.namespace.tag_byte());
+        }
+        buf.extend_from_slice(&import.scope.to_le_bytes());
+    }
+    buf.extend_from_slice(&(occurrences.len() as u32).to_le_bytes());
+    for occurrence in occurrences {
+        buf.extend_from_slice(&occurrence.local_id.to_le_bytes());
+        buf.push(occurrence.role.tag_byte());
+        push_str(&mut buf, &occurrence.name);
+        buf.extend_from_slice(&(occurrence.qualifier.len() as u32).to_le_bytes());
+        for segment in &occurrence.qualifier {
+            push_str(&mut buf, segment);
+        }
+        buf.push(occurrence.namespace.tag_byte());
+        buf.extend_from_slice(&occurrence.scope.to_le_bytes());
+    }
+    ContentHash::compute_typed("hd-sem-file-v3", &buf)
+}
+
+fn push_str(buf: &mut Vec<u8>, value: &str) {
+    buf.extend_from_slice(&(value.len() as u32).to_le_bytes());
+    buf.extend_from_slice(value.as_bytes());
 }
 
 /// Compute a directory node's `semantic_digest` over its entries.
@@ -229,8 +417,8 @@ pub fn compute_dir_semantic_digest(entries: &[SemanticTreeEntry]) -> ContentHash
     ContentHash::compute_typed("hd-sem-dir-v2", &buf)
 }
 
-/// The per-file semantic node: the symbols a source blob defines plus the
-/// reformat-stable digest over them.
+/// The per-file semantic node: deterministic source-local facts extracted from
+/// one source blob plus their reformat-stable digest.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SemanticFileNode {
     pub format_version: u8,
@@ -243,14 +431,20 @@ pub struct SemanticFileNode {
     /// [`compute_file_scaffold_hash`]. Binds semantic content that lives outside
     /// any extracted symbol into the file digest.
     pub scaffold_hash: ContentHash,
-    /// Symbols sorted by `(container_path, name, kind, span.0)`.
+    /// Symbols sorted by the span-free semantic key.
     pub symbols: Vec<SymbolEntry>,
+    /// Scopes sorted by deterministic preorder `local_id`.
+    pub scopes: Vec<ScopeEntry>,
+    /// Imports sorted by their span-free semantic key; bindings retain source order.
+    pub imports: Vec<ImportEntry>,
+    /// Occurrences sorted by deterministic source-order `local_id`.
+    pub occurrences: Vec<OccurrenceEntry>,
     /// Reformat-stable digest — see [`compute_file_semantic_digest`].
     pub semantic_digest: ContentHash,
 }
 
 impl SemanticFileNode {
-    pub const FORMAT_VERSION: u8 = 1;
+    pub const FORMAT_VERSION: u8 = 2;
 
     /// Build a node, sorting the symbols canonically and computing the digest
     /// over the scaffold plus the symbols.
@@ -260,10 +454,27 @@ impl SemanticFileNode {
         extractor_version: u32,
         source_blob: ContentHash,
         scaffold_hash: ContentHash,
-        mut symbols: Vec<SymbolEntry>,
+        facts: SemanticFileFacts,
     ) -> Self {
+        let SemanticFileFacts {
+            mut symbols,
+            mut scopes,
+            mut imports,
+            mut occurrences,
+        } = facts;
         symbols.sort_by(|a, b| a.sort_key().cmp(&b.sort_key()));
-        let semantic_digest = compute_file_semantic_digest(scaffold_hash, &symbols);
+        scopes.sort_by_key(|scope| scope.local_id);
+        imports.sort_by(|a, b| {
+            (a.kind, &a.module_specifier, a.scope, &a.bindings).cmp(&(
+                b.kind,
+                &b.module_specifier,
+                b.scope,
+                &b.bindings,
+            ))
+        });
+        occurrences.sort_by_key(|occurrence| occurrence.local_id);
+        let semantic_digest =
+            compute_file_semantic_digest(scaffold_hash, &symbols, &scopes, &imports, &occurrences);
         Self {
             format_version: Self::FORMAT_VERSION,
             language: language.into(),
@@ -272,6 +483,9 @@ impl SemanticFileNode {
             source_blob,
             scaffold_hash,
             symbols,
+            scopes,
+            imports,
+            occurrences,
             semantic_digest,
         }
     }
@@ -439,7 +653,10 @@ mod tests {
             1,
             h(1),
             h(0),
-            vec![sym("foo", &[], SymbolKindTag::Function, (10, 20))],
+            SemanticFileFacts {
+                symbols: vec![sym("foo", &[], SymbolKindTag::Function, (10, 20))],
+                ..SemanticFileFacts::default()
+            },
         );
         // Same symbol, moved by a reformat (span shifted).
         let b = SemanticFileNode::new(
@@ -448,7 +665,10 @@ mod tests {
             1,
             h(1),
             h(0),
-            vec![sym("foo", &[], SymbolKindTag::Function, (99, 120))],
+            SemanticFileFacts {
+                symbols: vec![sym("foo", &[], SymbolKindTag::Function, (99, 120))],
+                ..SemanticFileFacts::default()
+            },
         );
         assert_eq!(
             a.semantic_digest, b.semantic_digest,
@@ -457,19 +677,145 @@ mod tests {
     }
 
     #[test]
+    fn semantic_content_hash_excludes_all_provenance_spans() {
+        let source_blob = ContentHash::compute(b"use crate::api::greet; greet();");
+        let scope = |span| ScopeEntry {
+            local_id: 0,
+            parent: None,
+            kind: ScopeKind::Module,
+            span,
+        };
+        let import = |module_specifier: &str, span| ImportEntry {
+            kind: ImportKindTag::Use,
+            module_specifier: module_specifier.to_string(),
+            bindings: vec![ImportBinding {
+                imported: "greet".to_string(),
+                local: "greet".to_string(),
+                namespace: SymbolNamespace::Both,
+            }],
+            scope: 0,
+            span,
+        };
+        let occurrence = |span| OccurrenceEntry {
+            local_id: 0,
+            role: OccurrenceRole::Call,
+            name: "greet".to_string(),
+            qualifier: Vec::new(),
+            namespace: SymbolNamespace::Value,
+            scope: 0,
+            span,
+        };
+        let node = |scope_span, import_spans: [ByteSpan; 2], occurrence_span| {
+            SemanticFileNode::new(
+                "rust",
+                "0.24",
+                4,
+                source_blob,
+                h(0),
+                SemanticFileFacts {
+                    symbols: vec![],
+                    scopes: vec![scope(scope_span)],
+                    imports: vec![
+                        import("crate::api", import_spans[0]),
+                        import("crate::util", import_spans[1]),
+                    ],
+                    occurrences: vec![occurrence(occurrence_span)],
+                },
+            )
+        };
+        let a = node(
+            ByteSpan::new(0, 38),
+            [ByteSpan::new(0, 22), ByteSpan::new(23, 32)],
+            ByteSpan::new(23, 30),
+        );
+        let b = node(
+            ByteSpan::new(10, 48),
+            [ByteSpan::new(33, 42), ByteSpan::new(10, 32)],
+            ByteSpan::new(33, 40),
+        );
+
+        assert_eq!(
+            a.semantic_digest, b.semantic_digest,
+            "span-only differences must not affect semantic content identity"
+        );
+        assert_ne!(
+            a.encode().unwrap(),
+            b.encode().unwrap(),
+            "encoded provenance still records the distinct spans"
+        );
+    }
+
+    #[test]
+    fn file_node_roundtrip_preserves_source_local_facts() {
+        let node = SemanticFileNode::new(
+            "typescript",
+            "0.23",
+            4,
+            h(1),
+            h(0),
+            SemanticFileFacts {
+                symbols: vec![sym("run", &[], SymbolKindTag::Function, (2, 4))],
+                scopes: vec![ScopeEntry {
+                    local_id: 0,
+                    parent: None,
+                    kind: ScopeKind::Module,
+                    span: ByteSpan::new(0, 64),
+                }],
+                imports: vec![ImportEntry {
+                    kind: ImportKindTag::Import,
+                    module_specifier: "./api".to_string(),
+                    bindings: vec![ImportBinding {
+                        imported: "greet".to_string(),
+                        local: "hello".to_string(),
+                        namespace: SymbolNamespace::Value,
+                    }],
+                    scope: 0,
+                    span: ByteSpan::new(0, 39),
+                }],
+                occurrences: vec![OccurrenceEntry {
+                    local_id: 0,
+                    role: OccurrenceRole::Call,
+                    name: "hello".to_string(),
+                    qualifier: Vec::new(),
+                    namespace: SymbolNamespace::Value,
+                    scope: 0,
+                    span: ByteSpan::new(50, 55),
+                }],
+            },
+        );
+
+        assert_eq!(
+            SemanticFileNode::decode(&node.encode().unwrap()).unwrap(),
+            node
+        );
+    }
+
+    #[test]
     fn file_digest_changes_on_symbol_hash_change() {
         let mut s = sym("foo", &[], SymbolKindTag::Function, (1, 2));
-        let d1 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s));
+        let d1 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s), &[], &[], &[]);
         s.semantic_hash = ContentHash::compute(b"different-body");
-        let d2 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s));
+        let d2 = compute_file_semantic_digest(h(0), std::slice::from_ref(&s), &[], &[], &[]);
         assert_ne!(d1, d2);
     }
 
     #[test]
     fn file_digest_changes_on_scaffold_change() {
         let syms = [sym("foo", &[], SymbolKindTag::Function, (1, 2))];
-        let d1 = compute_file_semantic_digest(compute_file_scaffold_hash(b"use a;"), &syms);
-        let d2 = compute_file_semantic_digest(compute_file_scaffold_hash(b"use b;"), &syms);
+        let d1 = compute_file_semantic_digest(
+            compute_file_scaffold_hash(b"use a;"),
+            &syms,
+            &[],
+            &[],
+            &[],
+        );
+        let d2 = compute_file_semantic_digest(
+            compute_file_scaffold_hash(b"use b;"),
+            &syms,
+            &[],
+            &[],
+            &[],
+        );
         assert_ne!(
             d1, d2,
             "scaffold (non-definition top-level tokens) must affect the file digest"
@@ -483,8 +829,8 @@ mod tests {
         let one = sym("f", &["a::b"], SymbolKindTag::Function, (0, 0));
         let two = sym("f", &["a", "b"], SymbolKindTag::Function, (0, 0));
         assert_ne!(
-            compute_file_semantic_digest(h(0), &[one]),
-            compute_file_semantic_digest(h(0), &[two]),
+            compute_file_semantic_digest(h(0), &[one], &[], &[], &[]),
+            compute_file_semantic_digest(h(0), &[two], &[], &[], &[]),
         );
     }
 
@@ -506,11 +852,14 @@ mod tests {
             1,
             h(1),
             h(0),
-            vec![
-                sym("zed", &[], SymbolKindTag::Function, (1, 1)),
-                sym("abe", &["Impl"], SymbolKindTag::Function, (2, 2)),
-                sym("abe", &[], SymbolKindTag::Function, (3, 3)),
-            ],
+            SemanticFileFacts {
+                symbols: vec![
+                    sym("zed", &[], SymbolKindTag::Function, (1, 1)),
+                    sym("abe", &["Impl"], SymbolKindTag::Function, (2, 2)),
+                    sym("abe", &[], SymbolKindTag::Function, (3, 3)),
+                ],
+                ..SemanticFileFacts::default()
+            },
         );
         let names: Vec<_> = node.symbols.iter().map(|s| s.address()).collect();
         assert_eq!(names, vec!["abe", "zed", "Impl::abe"]);

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -33,8 +33,9 @@ use std::collections::{BTreeMap, HashMap};
 
 use objects::{
     object::{
-        ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot, SemanticTreeEntry,
-        SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry, Tree, TreeEntryTarget,
+        ContentHash, SemanticEntryKind, SemanticFileFacts, SemanticFileNode, SemanticIndexRoot,
+        SemanticTreeEntry, SemanticTreeNode, State, StateId, SymbolAnchor, SymbolEntry, Tree,
+        TreeEntryTarget,
     },
     store::ObjectStore,
 };
@@ -351,7 +352,12 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             self.extractor_version,
             source_hash,
             extracted.scaffold_hash,
-            extracted.symbols,
+            SemanticFileFacts {
+                symbols: extracted.symbols,
+                scopes: extracted.scopes,
+                imports: extracted.imports,
+                occurrences: extracted.occurrences,
+            },
         );
         let digest = node.semantic_digest;
         let node_hash = self.put_node(node.encode()?);
@@ -944,14 +950,37 @@ mod tests {
     #[test]
     fn shared_blob_parsed_once() {
         let (_temp, repo) = repo();
-        let blob = put_blob(&repo, b"fn shared() -> i32 { 7 }\n");
+        let blob = put_blob(&repo, b"use crate::api::greet;\nfn shared() { greet(); }\n");
         let tree = Tree::from_entries(vec![
             TreeEntry::file("x.rs", blob, false).unwrap(),
             TreeEntry::file("y.rs", blob, false).unwrap(),
         ]);
         let mut builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
-        builder.build_root(&tree, None).unwrap();
+        let (root, _) = builder.build_root(&tree, None).unwrap();
         assert_eq!(builder.parse_count, 1, "shared blob parsed once");
+        let x = repo.resolve_file_node(&root, "x.rs").unwrap().unwrap();
+        let y = repo.resolve_file_node(&root, "y.rs").unwrap().unwrap();
+        assert_eq!(x, y, "identical source blobs must share one file node");
+    }
+
+    #[test]
+    fn extracted_facts_roundtrip_through_persisted_file_node() {
+        let (_temp, repo) = repo();
+        let source = b"use crate::api::greet;\nfn run() { greet(); }\n";
+        let blob = put_blob(&repo, source);
+        let tree = Tree::from_entries(vec![TreeEntry::file("main.rs", blob, false).unwrap()]);
+        let expected = extract_semantic_file(source, Language::Rust).unwrap();
+
+        let mut builder = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
+        let (root, _) = builder.build_root(&tree, None).unwrap();
+        let node_hash = repo.resolve_file_node(&root, "main.rs").unwrap().unwrap();
+        let loaded = repo.load_semantic_file(&node_hash).unwrap();
+
+        assert_eq!(loaded.symbols, expected.symbols);
+        assert_eq!(loaded.scopes, expected.scopes);
+        assert_eq!(loaded.imports, expected.imports);
+        assert_eq!(loaded.occurrences, expected.occurrences);
+        assert_eq!(loaded.source_blob, blob);
     }
 
     /// The lazy backfill indexes every state once and is a no-op the second
@@ -984,25 +1013,27 @@ mod tests {
         let blob = put_blob(&repo, b"fn a() -> i32 { 1 }\n");
         let tree = Tree::from_entries(vec![TreeEntry::file("a.rs", blob, false).unwrap()]);
 
-        let mut b1 = SemanticIndexBuilder::new(repo.store(), 1);
+        assert_eq!(EXTRACTOR_VERSION, 4, "schema addition must bump extraction");
+        let old_version = EXTRACTOR_VERSION - 1;
+        let mut b1 = SemanticIndexBuilder::new(repo.store(), old_version);
         let (root1, _) = b1.build_root(&tree, None).unwrap();
-        assert_eq!(root1.extractor_version, 1);
+        assert_eq!(root1.extractor_version, old_version);
 
-        // Same source, extractor bumped to 2, parent (v1) offered for reuse.
+        // Same source, current extractor offered a stale-version parent.
         let parent = parent_index(&repo, tree.clone(), root1);
-        let mut b2 = SemanticIndexBuilder::new(repo.store(), 2);
+        let mut b2 = SemanticIndexBuilder::new(repo.store(), EXTRACTOR_VERSION);
         let (root2, _) = b2.build_root(&tree, Some(&parent)).unwrap();
         assert_eq!(
             b2.parse_count, 1,
             "extractor bump must reparse, not reuse the v1 node"
         );
-        assert_eq!(root2.extractor_version, 2);
+        assert_eq!(root2.extractor_version, EXTRACTOR_VERSION);
         let node_hash = repo.resolve_file_node(&root2, "a.rs").unwrap().unwrap();
         assert_eq!(
             repo.load_semantic_file(&node_hash)
                 .unwrap()
                 .extractor_version,
-            2,
+            EXTRACTOR_VERSION,
             "no mixed-version index"
         );
     }

--- a/crates/repo/src/repository_semantic_query.rs
+++ b/crates/repo/src/repository_semantic_query.rs
@@ -484,7 +484,8 @@ mod tests {
 
     use chrono::Utc;
     use objects::object::{
-        Attribution, Blob, Principal, State, StateAttachment, StateAttachmentBody, Tree, TreeEntry,
+        Attribution, Blob, Principal, SemanticFileFacts, State, StateAttachment,
+        StateAttachmentBody, Tree, TreeEntry,
     };
     use tempfile::TempDir;
 
@@ -521,7 +522,10 @@ mod tests {
             1,
             ContentHash::compute(b"src-blob"),
             ContentHash::compute(b"scaffold"),
-            vec![sym],
+            SemanticFileFacts {
+                symbols: vec![sym],
+                ..SemanticFileFacts::default()
+            },
         );
         let file_hash = put_encoded(repo, file_node.encode().unwrap());
         let (tree_node, tree_digest) = SemanticTreeNode::new(vec![SemanticTreeEntry {

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -3,6 +3,10 @@
 
 use std::ops::Range;
 
+use objects::object::{
+    ByteSpan, ImportBinding, ImportEntry, ImportKindTag, OccurrenceEntry, OccurrenceRole,
+    ScopeEntry, ScopeKind, SymbolNamespace,
+};
 use tree_sitter::Node;
 
 use super::{
@@ -15,6 +19,9 @@ use super::{
 pub struct SyntaxIndex {
     functions: Vec<IndexedFunction>,
     imports: Vec<IndexedImport>,
+    semantic_scopes: Vec<ScopeEntry>,
+    semantic_imports: Vec<ImportEntry>,
+    occurrences: Vec<OccurrenceEntry>,
     line_offsets: Vec<usize>,
 }
 
@@ -52,6 +59,9 @@ impl SyntaxIndex {
         let mut index = Self {
             functions: Vec::new(),
             imports: Vec::new(),
+            semantic_scopes: Vec::new(),
+            semantic_imports: Vec::new(),
+            occurrences: Vec::new(),
             line_offsets: line_offsets(source),
         };
 
@@ -117,6 +127,12 @@ impl SyntaxIndex {
             }
         }
 
+        let (semantic_scopes, semantic_imports, occurrences) =
+            build_source_facts(language, source, root);
+        index.semantic_scopes = semantic_scopes;
+        index.semantic_imports = semantic_imports;
+        index.occurrences = occurrences;
+
         index
     }
 
@@ -135,6 +151,18 @@ impl SyntaxIndex {
     /// Byte offsets where each line starts. The first entry is always `0`.
     pub fn line_offsets(&self) -> &[usize] {
         &self.line_offsets
+    }
+
+    pub(crate) fn semantic_scopes(&self) -> &[ScopeEntry] {
+        &self.semantic_scopes
+    }
+
+    pub(crate) fn semantic_imports(&self) -> &[ImportEntry] {
+        &self.semantic_imports
+    }
+
+    pub(crate) fn occurrences(&self) -> &[OccurrenceEntry] {
+        &self.occurrences
     }
 }
 
@@ -183,6 +211,732 @@ impl ImportRef<'_> {
         Import {
             raw: self.raw().to_string(),
             kind: self.kind(),
+        }
+    }
+}
+
+fn build_source_facts(
+    language: Language,
+    source: &str,
+    root: Node<'_>,
+) -> (Vec<ScopeEntry>, Vec<ImportEntry>, Vec<OccurrenceEntry>) {
+    let mut scopes = vec![ScopeEntry {
+        local_id: 0,
+        parent: None,
+        kind: ScopeKind::Module,
+        span: byte_span(root),
+    }];
+    let mut imports = Vec::new();
+    let mut occurrences = Vec::new();
+    let mut stack = Vec::new();
+    push_children_with_scope_reverse(root, 0, &mut stack);
+
+    while let Some((node, parent_scope)) = stack.pop() {
+        let scope = if let Some(kind) = scope_kind(node.kind()) {
+            let local_id = scopes.len() as u32;
+            scopes.push(ScopeEntry {
+                local_id,
+                parent: Some(parent_scope),
+                kind,
+                span: byte_span(node),
+            });
+            local_id
+        } else {
+            parent_scope
+        };
+
+        if is_import_node(node, language) {
+            imports.extend(extract_import_entries(node, language, source, scope));
+            continue;
+        }
+        if let Some(import) = extract_dynamic_import(node, language, source, scope) {
+            imports.push(import);
+            continue;
+        }
+
+        if is_path_node(node.kind()) {
+            if let Some(occurrence) = path_occurrence(node, source, scope) {
+                occurrences.push(occurrence);
+            }
+            continue;
+        }
+        if is_identifier_node(node.kind()) {
+            occurrences.push(identifier_occurrence(node, source, scope, &scopes));
+            continue;
+        }
+
+        push_children_with_scope_reverse(node, scope, &mut stack);
+    }
+
+    imports.sort_by_key(|import| import.span.start);
+    occurrences.sort_by_key(|occurrence| occurrence.span.start);
+    for (local_id, occurrence) in occurrences.iter_mut().enumerate() {
+        occurrence.local_id = local_id as u32;
+    }
+    (scopes, imports, occurrences)
+}
+
+fn scope_kind(kind: &str) -> Option<ScopeKind> {
+    if is_function_node_kind(kind) {
+        return Some(ScopeKind::Function);
+    }
+    if matches!(
+        kind,
+        "struct_item"
+            | "enum_item"
+            | "trait_item"
+            | "impl_item"
+            | "class_definition"
+            | "class_declaration"
+            | "interface_declaration"
+            | "type_declaration"
+            | "struct_declaration"
+            | "enum_declaration"
+    ) {
+        return Some(ScopeKind::Type);
+    }
+    if matches!(kind, "mod_item" | "namespace_definition" | "module") {
+        return Some(ScopeKind::Module);
+    }
+    if matches!(
+        kind,
+        "block" | "compound_statement" | "statement_block" | "suite"
+    ) {
+        return Some(ScopeKind::Block);
+    }
+    None
+}
+
+fn is_function_node_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "function_item"
+            | "function_definition"
+            | "function_declaration"
+            | "method_definition"
+            | "method_declaration"
+            | "constructor_declaration"
+            | "generator_function_declaration"
+            | "closure_expression"
+            | "arrow_function"
+            | "function_expression"
+            | "generator_function"
+    )
+}
+
+fn is_import_node(node: Node<'_>, language: Language) -> bool {
+    match language {
+        Language::Rust => matches!(node.kind(), "use_declaration" | "extern_crate_declaration"),
+        Language::Python => matches!(node.kind(), "import_statement" | "import_from_statement"),
+        Language::JavaScript | Language::TypeScript => {
+            node.kind() == "import_statement"
+                || (node.kind() == "export_statement"
+                    && node.child_by_field_name("source").is_some())
+        }
+        Language::Go => node.kind() == "import_spec",
+        Language::Java => node.kind() == "import_declaration",
+        Language::C | Language::Cpp => node.kind() == "preproc_include",
+        Language::Zig | Language::Unknown => false,
+    }
+}
+
+fn extract_import_entries(
+    node: Node<'_>,
+    language: Language,
+    source: &str,
+    scope: u32,
+) -> Vec<ImportEntry> {
+    match language {
+        Language::Rust => vec![rust_import(node, source, scope)],
+        Language::Python => python_imports(node, source, scope),
+        Language::JavaScript | Language::TypeScript => {
+            vec![javascript_import(node, language, source, scope)]
+        }
+        Language::Go => vec![go_import(node, source, scope)],
+        Language::Java => vec![java_import(node, source, scope)],
+        Language::C | Language::Cpp => vec![c_import(node, source, scope)],
+        Language::Zig | Language::Unknown => Vec::new(),
+    }
+}
+
+fn rust_import(node: Node<'_>, source: &str, scope: u32) -> ImportEntry {
+    if node.kind() == "extern_crate_declaration" {
+        let imported = node
+            .child_by_field_name("name")
+            .map(|name| node_text(name, source).to_string())
+            .unwrap_or_default();
+        let local = node
+            .child_by_field_name("alias")
+            .map(|alias| node_text(alias, source).to_string())
+            .unwrap_or_else(|| imported.clone());
+        return ImportEntry {
+            kind: ImportKindTag::Use,
+            module_specifier: imported.clone(),
+            bindings: vec![ImportBinding {
+                imported,
+                local,
+                namespace: SymbolNamespace::Both,
+            }],
+            scope,
+            span: byte_span(node),
+        };
+    }
+
+    let body = node
+        .child_by_field_name("argument")
+        .map(|argument| node_text(argument, source))
+        .unwrap_or_default();
+    let (module_specifier, binding_texts) = if let Some(open) = body.find('{') {
+        let prefix = body[..open].trim().trim_end_matches("::").to_string();
+        let close = body.rfind('}').unwrap_or(body.len());
+        (prefix, split_top_level(&body[open + 1..close]))
+    } else {
+        let path = body.split(" as ").next().unwrap_or(body).trim();
+        let module = path
+            .rsplit_once("::")
+            .map(|(module, _)| module)
+            .unwrap_or(path)
+            .to_string();
+        (module, vec![body])
+    };
+    let bindings = binding_texts
+        .into_iter()
+        .filter_map(|binding| rust_binding(binding.trim()))
+        .collect();
+    ImportEntry {
+        kind: if named_child_of_kind(node, "visibility_modifier").is_some() {
+            ImportKindTag::Reexport
+        } else {
+            ImportKindTag::Use
+        },
+        module_specifier,
+        bindings,
+        scope,
+        span: byte_span(node),
+    }
+}
+
+fn rust_binding(value: &str) -> Option<ImportBinding> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if value == "*" || value.ends_with("::*") {
+        return Some(ImportBinding {
+            imported: "*".to_string(),
+            local: "*".to_string(),
+            namespace: SymbolNamespace::Both,
+        });
+    }
+    let (path, alias) = value
+        .split_once(" as ")
+        .map_or((value, None), |(path, alias)| (path, Some(alias.trim())));
+    let imported = path.rsplit("::").next().unwrap_or(path).trim();
+    let local = alias.unwrap_or(imported);
+    Some(ImportBinding {
+        imported: imported.to_string(),
+        local: local.to_string(),
+        namespace: SymbolNamespace::Both,
+    })
+}
+
+fn javascript_import(node: Node<'_>, language: Language, source: &str, scope: u32) -> ImportEntry {
+    let raw = node_text(node, source);
+    let namespace = if language == Language::TypeScript
+        && (raw.trim_start().starts_with("import type")
+            || raw.trim_start().starts_with("export type"))
+    {
+        SymbolNamespace::Type
+    } else {
+        SymbolNamespace::Value
+    };
+    let module_specifier = node
+        .child_by_field_name("source")
+        .map(|source_node| unquote(node_text(source_node, source)))
+        .unwrap_or_default();
+    let mut bindings = Vec::new();
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        match current.kind() {
+            "import_clause" => {
+                let mut cursor = current.walk();
+                for child in current.named_children(&mut cursor) {
+                    if child.kind() == "identifier" {
+                        bindings.push(ImportBinding {
+                            imported: "default".to_string(),
+                            local: node_text(child, source).to_string(),
+                            namespace,
+                        });
+                    }
+                }
+            }
+            "namespace_import" | "namespace_export" => {
+                if let Some(local) = first_identifier(current, source) {
+                    bindings.push(ImportBinding {
+                        imported: "*".to_string(),
+                        local,
+                        namespace,
+                    });
+                }
+            }
+            "import_specifier" | "export_specifier" => {
+                let imported = current
+                    .child_by_field_name("name")
+                    .map(|name| unquote(node_text(name, source)))
+                    .or_else(|| first_identifier(current, source))
+                    .unwrap_or_default();
+                let local = current
+                    .child_by_field_name("alias")
+                    .map(|alias| unquote(node_text(alias, source)))
+                    .unwrap_or_else(|| imported.clone());
+                bindings.push(ImportBinding {
+                    imported,
+                    local,
+                    namespace,
+                });
+            }
+            _ => {}
+        }
+        push_children_reverse(current, &mut stack);
+    }
+    ImportEntry {
+        kind: if node.kind() == "export_statement" {
+            ImportKindTag::Reexport
+        } else {
+            ImportKindTag::Import
+        },
+        module_specifier,
+        bindings,
+        scope,
+        span: byte_span(node),
+    }
+}
+
+fn python_imports(node: Node<'_>, source: &str, scope: u32) -> Vec<ImportEntry> {
+    if node.kind() == "import_from_statement" {
+        let module_specifier = node
+            .child_by_field_name("module_name")
+            .map(|module| node_text(module, source).to_string())
+            .unwrap_or_default();
+        let mut bindings = Vec::new();
+        let module_id = node
+            .child_by_field_name("module_name")
+            .map(|module| module.id());
+        let mut cursor = node.walk();
+        for child in node.named_children(&mut cursor) {
+            if Some(child.id()) == module_id {
+                continue;
+            }
+            if child.kind() == "aliased_import" || child.kind() == "dotted_name" {
+                bindings.push(python_binding(child, source));
+            } else if child.kind() == "wildcard_import" {
+                bindings.push(ImportBinding {
+                    imported: "*".to_string(),
+                    local: "*".to_string(),
+                    namespace: SymbolNamespace::Both,
+                });
+            }
+        }
+        return vec![ImportEntry {
+            kind: ImportKindTag::Import,
+            module_specifier,
+            bindings,
+            scope,
+            span: byte_span(node),
+        }];
+    }
+
+    let mut entries = Vec::new();
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if matches!(child.kind(), "aliased_import" | "dotted_name") {
+            let binding = python_binding(child, source);
+            let module_specifier = child
+                .child_by_field_name("name")
+                .map(|name| node_text(name, source).to_string())
+                .unwrap_or_else(|| {
+                    node_text(child, source)
+                        .split(" as ")
+                        .next()
+                        .unwrap()
+                        .into()
+                });
+            entries.push(ImportEntry {
+                kind: ImportKindTag::Import,
+                module_specifier,
+                bindings: vec![binding],
+                scope,
+                span: byte_span(child),
+            });
+        }
+    }
+    entries
+}
+
+fn python_binding(node: Node<'_>, source: &str) -> ImportBinding {
+    let imported = node
+        .child_by_field_name("name")
+        .map(|name| node_text(name, source).to_string())
+        .unwrap_or_else(|| node_text(node, source).split(" as ").next().unwrap().into());
+    let local = node
+        .child_by_field_name("alias")
+        .map(|alias| node_text(alias, source).to_string())
+        .unwrap_or_else(|| imported.rsplit('.').next().unwrap_or(&imported).to_string());
+    ImportBinding {
+        imported,
+        local,
+        namespace: SymbolNamespace::Both,
+    }
+}
+
+fn go_import(node: Node<'_>, source: &str, scope: u32) -> ImportEntry {
+    let module_specifier = node
+        .child_by_field_name("path")
+        .map(|path| unquote(node_text(path, source)))
+        .unwrap_or_default();
+    let imported = module_specifier
+        .rsplit('/')
+        .next()
+        .unwrap_or(&module_specifier)
+        .to_string();
+    let local = node
+        .child_by_field_name("name")
+        .map(|name| node_text(name, source).to_string())
+        .unwrap_or_else(|| imported.clone());
+    ImportEntry {
+        kind: ImportKindTag::Import,
+        module_specifier,
+        bindings: vec![ImportBinding {
+            imported,
+            local,
+            namespace: SymbolNamespace::Both,
+        }],
+        scope,
+        span: byte_span(node),
+    }
+}
+
+fn java_import(node: Node<'_>, source: &str, scope: u32) -> ImportEntry {
+    let raw = node_text(node, source);
+    let module_specifier = raw
+        .trim()
+        .trim_start_matches("import ")
+        .trim_start_matches("static ")
+        .trim_end_matches(';')
+        .trim()
+        .to_string();
+    let imported = module_specifier
+        .rsplit('.')
+        .next()
+        .unwrap_or(&module_specifier)
+        .to_string();
+    ImportEntry {
+        kind: ImportKindTag::Import,
+        module_specifier,
+        bindings: vec![ImportBinding {
+            local: imported.clone(),
+            imported,
+            namespace: SymbolNamespace::Both,
+        }],
+        scope,
+        span: byte_span(node),
+    }
+}
+
+fn c_import(node: Node<'_>, source: &str, scope: u32) -> ImportEntry {
+    let raw = node_text(node, source);
+    let module_specifier = raw
+        .trim()
+        .trim_start_matches("#include")
+        .trim()
+        .trim_matches(['<', '>', '"'])
+        .to_string();
+    ImportEntry {
+        kind: ImportKindTag::Import,
+        module_specifier,
+        bindings: Vec::new(),
+        scope,
+        span: byte_span(node),
+    }
+}
+
+fn extract_dynamic_import(
+    node: Node<'_>,
+    language: Language,
+    source: &str,
+    scope: u32,
+) -> Option<ImportEntry> {
+    let is_dynamic_import = match language {
+        Language::JavaScript | Language::TypeScript if node.kind() == "call_expression" => node
+            .child_by_field_name("function")
+            .is_some_and(|function| node_text(function, source) == "import"),
+        Language::Zig if node.kind() == "builtin_function" => {
+            named_child_of_kind(node, "builtin_identifier")
+                .is_some_and(|function| node_text(function, source) == "@import")
+        }
+        _ => false,
+    };
+    if !is_dynamic_import {
+        return None;
+    }
+    let string = first_node_of_kind(node, &["string", "string_literal"])?;
+    Some(ImportEntry {
+        kind: ImportKindTag::Dynamic,
+        module_specifier: unquote(node_text(string, source)),
+        bindings: Vec::new(),
+        scope,
+        span: byte_span(node),
+    })
+}
+
+fn path_occurrence(node: Node<'_>, source: &str, scope: u32) -> Option<OccurrenceEntry> {
+    let mut segments = Vec::new();
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if is_identifier_node(current.kind())
+            || matches!(current.kind(), "self" | "super" | "crate")
+        {
+            segments.push((current.start_byte(), node_text(current, source).to_string()));
+            continue;
+        }
+        push_children_reverse(current, &mut stack);
+    }
+    segments.sort_by_key(|(start, _)| *start);
+    segments.dedup_by_key(|(start, _)| *start);
+    let (_, name) = segments.pop()?;
+    let qualifier = segments.into_iter().map(|(_, name)| name).collect();
+    let namespace = if node.kind().contains("type") {
+        SymbolNamespace::Type
+    } else {
+        SymbolNamespace::Value
+    };
+    Some(OccurrenceEntry {
+        local_id: 0,
+        role: occurrence_role(node, namespace),
+        name,
+        qualifier,
+        namespace,
+        scope,
+        span: byte_span(node),
+    })
+}
+
+fn identifier_occurrence(
+    node: Node<'_>,
+    source: &str,
+    scope: u32,
+    scopes: &[ScopeEntry],
+) -> OccurrenceEntry {
+    let namespace = identifier_namespace(node);
+    let role = occurrence_role(node, namespace);
+    let definition_in_own_scope = role == OccurrenceRole::Definition
+        && node
+            .parent()
+            .is_some_and(|parent| scope_kind(parent.kind()).is_some());
+    OccurrenceEntry {
+        local_id: 0,
+        role,
+        name: node_text(node, source).to_string(),
+        qualifier: Vec::new(),
+        namespace,
+        scope: if definition_in_own_scope {
+            scopes[scope as usize].parent.unwrap_or(scope)
+        } else {
+            scope
+        },
+        span: byte_span(node),
+    }
+}
+
+fn occurrence_role(node: Node<'_>, namespace: SymbolNamespace) -> OccurrenceRole {
+    if is_definition_name(node) {
+        OccurrenceRole::Definition
+    } else if is_call_target(node) {
+        OccurrenceRole::Call
+    } else if namespace == SymbolNamespace::Type {
+        OccurrenceRole::TypeReference
+    } else {
+        OccurrenceRole::Reference
+    }
+}
+
+fn is_definition_name(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let is_name_field = parent
+        .child_by_field_name("name")
+        .is_some_and(|name| name.id() == node.id());
+    is_name_field
+        && matches!(
+            parent.kind(),
+            "function_item"
+                | "function_definition"
+                | "function_declaration"
+                | "method_definition"
+                | "method_declaration"
+                | "constructor_declaration"
+                | "class_definition"
+                | "class_declaration"
+                | "interface_declaration"
+                | "struct_item"
+                | "struct_declaration"
+                | "enum_item"
+                | "enum_declaration"
+                | "trait_item"
+                | "type_item"
+                | "type_alias_declaration"
+                | "mod_item"
+                | "const_item"
+                | "static_item"
+                | "variable_declarator"
+                | "parameter"
+                | "required_parameter"
+                | "optional_parameter"
+                | "formal_parameter"
+                | "field_declaration"
+        )
+}
+
+fn is_call_target(mut node: Node<'_>) -> bool {
+    while let Some(parent) = node.parent() {
+        if is_path_node(parent.kind()) {
+            node = parent;
+            continue;
+        }
+        if parent.kind() == "call_expression" {
+            return parent
+                .child_by_field_name("function")
+                .is_some_and(|function| function.id() == node.id());
+        }
+        return false;
+    }
+    false
+}
+
+fn identifier_namespace(node: Node<'_>) -> SymbolNamespace {
+    if node.kind().contains("type") {
+        return SymbolNamespace::Type;
+    }
+    let mut current = node;
+    for _ in 0..4 {
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        if matches!(
+            parent.kind(),
+            "type_annotation"
+                | "generic_type"
+                | "type_arguments"
+                | "type_parameters"
+                | "return_type"
+                | "trait_bounds"
+        ) {
+            return SymbolNamespace::Type;
+        }
+        current = parent;
+    }
+    SymbolNamespace::Value
+}
+
+fn is_identifier_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "identifier"
+            | "type_identifier"
+            | "field_identifier"
+            | "property_identifier"
+            | "package_identifier"
+            | "namespace_identifier"
+    )
+}
+
+fn is_path_node(kind: &str) -> bool {
+    matches!(
+        kind,
+        "scoped_identifier"
+            | "scoped_type_identifier"
+            | "qualified_identifier"
+            | "field_expression"
+            | "member_expression"
+            | "attribute"
+            | "selector_expression"
+            | "field_access"
+    )
+}
+
+fn split_top_level(value: &str) -> Vec<&str> {
+    let mut depth = 0u32;
+    let mut start = 0usize;
+    let mut parts = Vec::new();
+    for (index, byte) in value.bytes().enumerate() {
+        match byte {
+            b'{' | b'(' | b'[' => depth += 1,
+            b'}' | b')' | b']' => depth = depth.saturating_sub(1),
+            b',' if depth == 0 => {
+                parts.push(&value[start..index]);
+                start = index + 1;
+            }
+            _ => {}
+        }
+    }
+    parts.push(&value[start..]);
+    parts
+}
+
+fn first_identifier(node: Node<'_>, source: &str) -> Option<String> {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if is_identifier_node(current.kind()) {
+            return Some(node_text(current, source).to_string());
+        }
+        push_children_reverse(current, &mut stack);
+    }
+    None
+}
+
+fn first_node_of_kind<'tree>(node: Node<'tree>, kinds: &[&str]) -> Option<Node<'tree>> {
+    let mut stack = vec![node];
+    while let Some(current) = stack.pop() {
+        if kinds.contains(&current.kind()) {
+            return Some(current);
+        }
+        push_children_reverse(current, &mut stack);
+    }
+    None
+}
+
+fn named_child_of_kind<'tree>(node: Node<'tree>, kind: &str) -> Option<Node<'tree>> {
+    let mut cursor = node.walk();
+    node.named_children(&mut cursor)
+        .find(|child| child.kind() == kind)
+}
+
+fn node_text<'a>(node: Node<'_>, source: &'a str) -> &'a str {
+    &source[node.byte_range()]
+}
+
+fn unquote(value: &str) -> String {
+    value
+        .strip_prefix(['\'', '"', '`'])
+        .and_then(|value| value.strip_suffix(['\'', '"', '`']))
+        .unwrap_or(value)
+        .to_string()
+}
+
+fn byte_span(node: Node<'_>) -> ByteSpan {
+    ByteSpan::new(node.start_byte() as u32, node.end_byte() as u32)
+}
+
+fn push_children_with_scope_reverse<'tree>(
+    node: Node<'tree>,
+    scope: u32,
+    stack: &mut Vec<(Node<'tree>, u32)>,
+) {
+    let child_count = node.child_count();
+    for index in (0..child_count).rev() {
+        if let Some(child) = node.child(index as u32) {
+            stack.push((child, scope));
         }
     }
 }

--- a/crates/semantic/src/semantic_index.rs
+++ b/crates/semantic/src/semantic_index.rs
@@ -16,8 +16,8 @@
 //! one-token change perturbs exactly the symbols that contain it.
 
 use objects::object::{
-    ContentHash, SymbolEntry, SymbolKindTag, compute_file_scaffold_hash,
-    compute_symbol_semantic_hash,
+    ContentHash, ImportEntry, OccurrenceEntry, ScopeEntry, SymbolEntry, SymbolKindTag,
+    compute_file_scaffold_hash, compute_symbol_semantic_hash,
 };
 
 use crate::{
@@ -25,9 +25,9 @@ use crate::{
     symbol_resolver::{DefinitionKind, visit_definitions},
 };
 
-/// Version of the extraction logic itself. Bump when the taxonomy, container
-/// resolution, or token-stream framing changes in a way that would alter a
-/// `semantic_hash` for unchanged source — it participates in the file node's
+/// Version of the extraction logic itself. Bump when the taxonomy, source-fact
+/// extraction, container resolution, or token-stream framing changes the
+/// durable file artifact for unchanged source. It participates in file-node
 /// identity so a bump forces a clean recompute via the supersedes chain.
 ///
 /// v2: `hd-sem-file-v2`/`hd-sem-dir-v2` framed layouts, the `scaffold_hash`
@@ -39,7 +39,10 @@ use crate::{
 /// *present* in the parent's map, so a pre-Zig index (no `"zig"` entry) would
 /// otherwise carry `.zig` files forward as `Opaque` indefinitely. The bump
 /// forces those to recompute so imported Zig repos gain granularity.
-pub const EXTRACTOR_VERSION: u32 = 3;
+///
+/// v4: Persist deterministic source-local scopes, imports, and symbol
+/// occurrences alongside definitions in each semantic file node.
+pub const EXTRACTOR_VERSION: u32 = 4;
 
 /// Stable lowercase language name recorded in file nodes and the root's
 /// grammar map.
@@ -119,6 +122,9 @@ pub struct ExtractedFile {
     /// the file digest. See [`compute_file_scaffold_hash`].
     pub scaffold_hash: ContentHash,
     pub symbols: Vec<SymbolEntry>,
+    pub scopes: Vec<ScopeEntry>,
+    pub imports: Vec<ImportEntry>,
+    pub occurrences: Vec<OccurrenceEntry>,
 }
 
 /// Parse `source` (as `language`) and extract its symbols with per-symbol
@@ -153,11 +159,15 @@ pub fn extract_semantic_file(source: &[u8], language: Language) -> Option<Extrac
     });
 
     let scaffold_hash = compute_scaffold(parsed.root_node(), source, covered);
+    let syntax_index = parsed.syntax_index();
 
     Some(ExtractedFile {
         language,
         scaffold_hash,
         symbols,
+        scopes: syntax_index.semantic_scopes().to_vec(),
+        imports: syntax_index.semantic_imports().to_vec(),
+        occurrences: syntax_index.occurrences().to_vec(),
     })
 }
 
@@ -349,6 +359,93 @@ mod tests {
         assert!(extract_semantic_file(b"whatever", Language::Unknown).is_none());
     }
 
+    #[test]
+    fn extracts_structured_imports_and_symbol_occurrences() {
+        use objects::object::{ImportKindTag, OccurrenceRole, SymbolNamespace};
+
+        let source = "pub use crate::api::{greet as hello, User};\nfn run(user: User) { crate::api::greet(); hello(); }\n";
+        let extracted = extract_semantic_file(source.as_bytes(), Language::Rust).unwrap();
+
+        assert_eq!(extracted.imports.len(), 1);
+        let import = &extracted.imports[0];
+        assert_eq!(import.kind, ImportKindTag::Reexport);
+        assert_eq!(import.module_specifier, "crate::api");
+        assert_eq!(
+            import
+                .bindings
+                .iter()
+                .map(|binding| (&*binding.imported, &*binding.local))
+                .collect::<Vec<_>>(),
+            vec![("greet", "hello"), ("User", "User")]
+        );
+
+        assert!(extracted.occurrences.iter().any(|occurrence| {
+            occurrence.role == OccurrenceRole::Call
+                && occurrence.name == "greet"
+                && occurrence.qualifier == ["crate", "api"]
+        }));
+        assert!(extracted.occurrences.iter().any(|occurrence| {
+            occurrence.role == OccurrenceRole::Call && occurrence.name == "hello"
+        }));
+        assert!(extracted.occurrences.iter().any(|occurrence| {
+            occurrence.role == OccurrenceRole::TypeReference
+                && occurrence.name == "User"
+                && occurrence.namespace == SymbolNamespace::Type
+        }));
+        assert!(extracted.occurrences.iter().any(|occurrence| {
+            occurrence.role == OccurrenceRole::Definition
+                && occurrence.name == "run"
+                && occurrence.scope == 0
+        }));
+        assert_eq!(extracted.scopes[0].local_id, 0);
+    }
+
+    #[cfg(feature = "lang-typescript")]
+    #[test]
+    fn typescript_import_bindings_reexports_and_calls_are_source_local() {
+        use objects::object::{ImportKindTag, OccurrenceRole, SymbolNamespace};
+
+        let source = "import type { Request as Req } from './types';\nimport client, { run as execute } from './client';\nexport { User } from './models';\nexport function handle(req: Req) { client.run(); execute(); }\n";
+        let extracted = extract_semantic_file(source.as_bytes(), Language::TypeScript).unwrap();
+
+        let types = extracted
+            .imports
+            .iter()
+            .find(|import| import.module_specifier == "./types")
+            .unwrap();
+        assert_eq!(types.bindings[0].imported, "Request");
+        assert_eq!(types.bindings[0].local, "Req");
+        assert_eq!(types.bindings[0].namespace, SymbolNamespace::Type);
+
+        let client = extracted
+            .imports
+            .iter()
+            .find(|import| import.module_specifier == "./client")
+            .unwrap();
+        assert_eq!(
+            client
+                .bindings
+                .iter()
+                .map(|binding| (&*binding.imported, &*binding.local))
+                .collect::<Vec<_>>(),
+            vec![("default", "client"), ("run", "execute")]
+        );
+        assert_eq!(
+            extracted
+                .imports
+                .iter()
+                .find(|import| import.module_specifier == "./models")
+                .unwrap()
+                .kind,
+            ImportKindTag::Reexport
+        );
+        assert!(extracted.occurrences.iter().any(|occurrence| {
+            occurrence.role == OccurrenceRole::Call
+                && occurrence.name == "run"
+                && occurrence.qualifier == ["client"]
+        }));
+    }
+
     // ── Zig (heddle#1068) ────────────────────────────────────────────────
 
     /// A `.zig` blob must extract a real file node — symbols with per-symbol
@@ -395,6 +492,10 @@ mod tests {
         let ea = extract_semantic_file(tight.as_bytes(), Language::Zig).expect("tight parses");
         let eb = extract_semantic_file(loose.as_bytes(), Language::Zig).expect("loose parses");
 
+        assert_eq!(ea.imports.len(), 1);
+        assert_eq!(ea.imports[0].module_specifier, "std");
+        assert_eq!(ea.imports[0].kind, objects::object::ImportKindTag::Dynamic);
+
         assert_eq!(
             ea.scaffold_hash, eb.scaffold_hash,
             "scaffold must be reformat/comment stable"
@@ -407,7 +508,12 @@ mod tests {
                 EXTRACTOR_VERSION,
                 ContentHash::compute(src.as_bytes()),
                 e.scaffold_hash,
-                e.symbols.clone(),
+                objects::object::SemanticFileFacts {
+                    symbols: e.symbols.clone(),
+                    scopes: e.scopes.clone(),
+                    imports: e.imports.clone(),
+                    occurrences: e.occurrences.clone(),
+                },
             )
         };
         // The source blobs differ, but the reformat-stable digest must not.


### PR DESCRIPTION
## Summary

- extend `SemanticFileNode` v2 with deterministic source-local scopes, structured imports/bindings, and symbol occurrences
- extract Rust, TypeScript/JavaScript, Python, Go, Java, C/C++, and Zig import facts plus definition/reference/call/type-reference occurrences
- preserve source-blob Merkle sharing and keep repository paths/resolved targets out of the per-file artifact
- bump `EXTRACTOR_VERSION` from 3 to 4 so stale attached indexes regenerate

## Evidence

- Round-trip: `extracted_facts_roundtrip_through_persisted_file_node` proves extract → persist → load returns identical definitions, scopes, imports, and occurrences.
- Content addressing: `shared_blob_parsed_once` proves identical source blobs at two paths resolve to the same semantic file node.
- Two-hash rule: `semantic_content_hash_excludes_all_provenance_spans` proves span-only changes, including reversed import-span ordering, do not change `semantic_digest`; encoded storage still retains spans as provenance, matching the #1272 artifact decision.
- Regeneration: `extractor_bump_refuses_stale_reuse` exercises a v3 → v4 rebuild and verifies the loaded node is v4.
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1273-target cargo test --locked -p heddle-object-model -p heddle-semantic --all-features` — 184 object-model unit tests + 32 integration tests + 307 semantic tests passed (3 ignored).
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1273-target cargo test --locked -p heddle-repo --features tree-sitter-symbols repository_semantic_index::tests::` — 14 passed.
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/issue-1273-target cargo clippy --locked -p heddle-object-model -p heddle-semantic -p heddle-repo --all-features --lib --tests -- -D warnings` — passed.
- Formatted touched Rust files with `rustfmt +nightly --edition 2024`.
- Commit: `6be07e35bb108008cd018d3e9d8c9e7e794b7eda`

This establishes the source-local artifact required by and unblocks #1274.

Closes #1273

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788908085&installation_model_id=21489&pr_number=1298&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1298&signature=8c45a8c41fd3354f207fcc847b1937a93e941c27ce498a9169cf4bbccbd6bfd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->