### PR TITLE
refactor(objects/repo): fs-store cache + git-overlay source refresh (part of #1262)

### DIFF
--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -151,6 +151,18 @@ fn append_packed_hashes(
     append_packed_hashes_with_counter(hashes, manager, expected_type, &mut NoopEnumerationCounter)
 }
 
+fn append_unique_states(
+    states: &mut Vec<StateId>,
+    known: &mut HashSet<StateId>,
+    incoming: impl IntoIterator<Item = StateId>,
+) {
+    for id in incoming {
+        if known.insert(id) {
+            states.push(id);
+        }
+    }
+}
+
 impl FsStore {
     /// Publish the authoritative loose copies of packed states behind one
     /// parent-directory durability barrier. A later pack may refresh mutable
@@ -384,12 +396,45 @@ impl FsStore {
         }
     }
 
+    fn cache_recent_tree(&self, hash: ContentHash, tree: &Tree) {
+        if let Ok(mut cache) = self.recent_trees.write() {
+            cache.insert(hash, tree.clone());
+        }
+    }
+
+    fn cache_recent_state(&self, id: StateId, state: &State) {
+        if let Ok(mut cache) = self.recent_states.write() {
+            cache.insert(id, state.clone());
+        }
+    }
+
+    fn recent_blob(&self, hash: &ContentHash) -> Option<Blob> {
+        self.recent_blobs
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(hash).cloned())
+    }
+
+    fn recent_tree(&self, hash: &ContentHash) -> Option<Tree> {
+        self.recent_trees
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(hash).cloned())
+    }
+
+    fn recent_state(&self, id: &StateId) -> Option<State> {
+        self.recent_states
+            .read()
+            .ok()
+            .and_then(|cache| cache.get(id).cloned())
+    }
+
     /// Single-pass blob lookup. The wrapper in `ObjectStore::get_blob`
     /// retries this once after a stale-reload on miss.
     fn try_get_blob_once(&self, hash: &ContentHash) -> Result<Option<Blob>> {
         // Cache first — avoid `path.exists()` / pack probes on warm hits.
-        // Write lock: LRU promotion mutates the order list.
-        if let Ok(mut cache) = self.recent_blobs.write()
+        // Access bits are atomic, so hits remain concurrent under a read lock.
+        if let Ok(cache) = self.recent_blobs.read()
             && let Some(blob) = cache.get(hash)
         {
             trace!("Found blob in recent object cache");
@@ -453,15 +498,9 @@ impl FsStore {
     }
 
     fn try_has_blob_once(&self, hash: &ContentHash) -> Result<bool> {
-        // Keep `has_blob` coherent with cache-first `get_blob`. A pure
-        // existence check needs no LRU promotion, so take the *read*
-        // lock and use `contains` — concurrent `has_blob` calls in
-        // heddled/mount don't serialize on the exclusive write lock.
-        if let Ok(cache) = self.recent_blobs.read()
-            && cache.contains(hash)
-        {
-            return Ok(true);
-        }
+        // This is the native-ownership probe used by `has_blob_locally`.
+        // Recent-object entries may be read-through values from an external
+        // Git overlay, so cache presence cannot establish local durability.
         let path = hash_path(&blobs_dir(&self.root), hash);
         self.loose_or_packed(&path, |m| m.has_object(hash))
     }
@@ -481,7 +520,7 @@ impl FsStore {
     /// pure in-memory varint decode for packed blobs. *No*
     /// decompression.
     fn try_get_blob_size_once(&self, hash: &ContentHash) -> Result<Option<u64>> {
-        if let Ok(mut cache) = self.recent_blobs.write()
+        if let Ok(cache) = self.recent_blobs.read()
             && let Some(blob) = cache.get(hash)
         {
             return Ok(Some(blob.content().len() as u64));
@@ -508,8 +547,8 @@ impl FsStore {
     fn try_get_tree_once(&self, hash: &ContentHash) -> Result<Option<Tree>> {
         // Cache first. The recent-object cache only ever holds trees we
         // wrote or read this process, so a hit is authoritative for a
-        // read. Write lock: LRU promotion mutates the order list.
-        if let Ok(mut cache) = self.recent_trees.write()
+        // read. Atomic second-chance marking keeps the map under a shared lock.
+        if let Ok(cache) = self.recent_trees.read()
             && let Some(tree) = cache.get(hash)
         {
             trace!("Found tree in recent object cache");
@@ -579,22 +618,19 @@ impl FsStore {
     }
 
     fn try_has_tree_once(&self, hash: &ContentHash) -> Result<bool> {
-        // Read-lock `contains`: an existence check needs no LRU
-        // promotion, so it must not serialize on the write lock.
-        if let Ok(cache) = self.recent_trees.read()
-            && cache.contains(hash)
-        {
-            return Ok(true);
-        }
+        // This is the native-ownership probe used by `has_tree_locally`.
+        // Recent-object entries may be read-through values from an external
+        // Git overlay, so cache presence cannot establish local durability.
         let path = hash_path(&trees_dir(&self.root), hash);
         self.loose_or_packed(&path, |m| m.has_object(hash))
     }
 
     fn try_get_state_once(&self, id: &StateId) -> Result<Option<State>> {
         // Cache first — avoid `path.exists()` / pack probes on warm hits.
-        // Write lock: LRU promotion mutates the order list. Put paths and
-        // successful reads below keep this coherent for the process.
-        if let Ok(mut cache) = self.recent_states.write()
+        // Atomic second-chance marking keeps hits under a shared lock. Put
+        // paths and successful reads below keep the cache coherent for the
+        // process.
+        if let Ok(cache) = self.recent_states.read()
             && let Some(state) = cache.get(id)
         {
             trace!("Found state in recent object cache");
@@ -629,7 +665,7 @@ impl FsStore {
     }
 
     fn try_has_state_once(&self, id: &StateId) -> Result<bool> {
-        // Read-lock `contains`: an existence check needs no LRU
+        // Read-lock `contains`: an existence check needs no clock
         // promotion, so it must not serialize on the write lock.
         if let Ok(cache) = self.recent_states.read()
             && cache.contains(id)
@@ -688,6 +724,9 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self), fields(hash = %hash.short()))]
     fn get_blob(&self, hash: &ContentHash) -> Result<Option<Blob>> {
+        if let Some(blob) = self.recent_blob(hash) {
+            return Ok(Some(blob));
+        }
         if let Some(blob) = self.try_get_blob_once(hash)? {
             return Ok(Some(blob));
         }
@@ -700,11 +739,14 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(blob));
         }
-        trace!("Blob not found");
-        match &self.external_source {
-            Some(source) => source.get_blob(hash),
-            None => Ok(None),
+        if let Some(source) = &self.external_source
+            && let Some(blob) = source.get_blob(hash)?
+        {
+            self.cache_recent_blob(*hash, &blob);
+            return Ok(Some(blob));
         }
+        trace!("Blob not found");
+        Ok(None)
     }
 
     #[instrument(skip(self, blob), fields(size = blob.content().len()))]
@@ -770,10 +812,16 @@ impl ObjectStore for FsStore {
         if ObjectStore::has_blob_locally(self, hash)? {
             return Ok(true);
         }
-        match &self.external_source {
-            Some(source) => Ok(source.get_blob(hash)?.is_some()),
-            None => Ok(false),
+        if let Some(source) = &self.external_source {
+            if self.recent_blob(hash).is_some() {
+                return Ok(true);
+            }
+            if let Some(blob) = source.get_blob(hash)? {
+                self.cache_recent_blob(*hash, &blob);
+                return Ok(true);
+            }
         }
+        Ok(false)
     }
 
     fn has_blob_locally(&self, hash: &ContentHash) -> Result<bool> {
@@ -858,13 +906,12 @@ impl ObjectStore for FsStore {
     fn promote_to_loose_uncompressed(&self, hash: &ContentHash) -> Result<bool> {
         let path = hash_path(&blobs_dir(&self.root), hash);
 
-        // An external Git-overlay blob must stay external: materialization can
-        // read its bytes through `get_blob_bytes`, but promotion would turn a
-        // read-through into an accidental native copy and violate the source-
-        // authority boundary.
-        if !self.try_has_blob_once(hash)?
+        // External-only overlay blobs stay external. If Heddle also owns a
+        // native copy, promotion is a native storage optimization and does not
+        // cross the source-authority boundary.
+        if !ObjectStore::has_blob_locally(self, hash)?
             && let Some(source) = &self.external_source
-            && source.get_blob(hash)?.is_some()
+            && (self.recent_blob(hash).is_some() || source.get_blob(hash)?.is_some())
         {
             return Ok(false);
         }
@@ -923,16 +970,24 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(size));
         }
-        match &self.external_source {
-            Some(source) => Ok(source
-                .get_blob(hash)?
-                .map(|blob| blob.content().len() as u64)),
-            None => Ok(None),
+        if let Some(source) = &self.external_source {
+            if let Some(blob) = self.recent_blob(hash) {
+                return Ok(Some(blob.content().len() as u64));
+            }
+            if let Some(blob) = source.get_blob(hash)? {
+                let size = blob.content().len() as u64;
+                self.cache_recent_blob(*hash, &blob);
+                return Ok(Some(size));
+            }
         }
+        Ok(None)
     }
 
     #[instrument(skip(self), fields(hash = %hash.short()))]
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
+        if let Some(tree) = self.recent_tree(hash) {
+            return Ok(Some(tree));
+        }
         if let Some(tree) = self.try_get_tree_once(hash)? {
             return Ok(Some(tree));
         }
@@ -941,11 +996,14 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(tree));
         }
-        trace!("Tree not found");
-        match &self.external_source {
-            Some(source) => source.get_tree(hash),
-            None => Ok(None),
+        if let Some(source) = &self.external_source
+            && let Some(tree) = source.get_tree(hash)?
+        {
+            self.cache_recent_tree(*hash, &tree);
+            return Ok(Some(tree));
         }
+        trace!("Tree not found");
+        Ok(None)
     }
 
     #[instrument(skip(self), fields(hash = %hash.short()))]
@@ -958,14 +1016,23 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(data));
         }
-        match &self.external_source {
-            Some(source) => source
-                .get_tree(hash)?
-                .map(|tree| rmp_serde::to_vec_named(&tree))
-                .transpose()
-                .map_err(|error| HeddleError::InvalidObject(error.to_string())),
-            None => Ok(None),
+        let external_tree = if let Some(tree) = self.recent_tree(hash) {
+            Some(tree)
+        } else if let Some(source) = &self.external_source {
+            let tree = source.get_tree(hash)?;
+            if let Some(tree) = &tree {
+                self.cache_recent_tree(*hash, tree);
+            }
+            tree
+        } else {
+            None
+        };
+        if let Some(tree) = external_tree {
+            return rmp_serde::to_vec_named(&tree)
+                .map(Some)
+                .map_err(|error| HeddleError::InvalidObject(error.to_string()));
         }
+        Ok(None)
     }
 
     #[instrument(skip(self, tree), fields(entry_count = tree.entries().len()))]
@@ -1016,10 +1083,16 @@ impl ObjectStore for FsStore {
         if ObjectStore::has_tree_locally(self, hash)? {
             return Ok(true);
         }
-        match &self.external_source {
-            Some(source) => Ok(source.get_tree(hash)?.is_some()),
-            None => Ok(false),
+        if let Some(source) = &self.external_source {
+            if self.recent_tree(hash).is_some() {
+                return Ok(true);
+            }
+            if let Some(tree) = source.get_tree(hash)? {
+                self.cache_recent_tree(*hash, &tree);
+                return Ok(true);
+            }
         }
+        Ok(false)
     }
 
     fn has_tree_locally(&self, hash: &ContentHash) -> Result<bool> {
@@ -1031,6 +1104,9 @@ impl ObjectStore for FsStore {
 
     #[instrument(skip(self), fields(id = %id.short()))]
     fn get_state(&self, id: &StateId) -> Result<Option<State>> {
+        if let Some(state) = self.recent_state(id) {
+            return Ok(Some(state));
+        }
         if let Some(state) = self.try_get_state_once(id)? {
             return Ok(Some(state));
         }
@@ -1039,11 +1115,14 @@ impl ObjectStore for FsStore {
         {
             return Ok(Some(state));
         }
-        trace!("State not found");
-        match &self.external_source {
-            Some(source) => source.get_state(id),
-            None => Ok(None),
+        if let Some(source) = &self.external_source
+            && let Some(state) = source.get_state(id)?
+        {
+            self.cache_recent_state(*id, &state);
+            return Ok(Some(state));
         }
+        trace!("State not found");
+        Ok(None)
     }
 
     #[instrument(skip(self, state), fields(id = %state.id().short()))]
@@ -1081,18 +1160,25 @@ impl ObjectStore for FsStore {
         if self.reload_packs_if_stale()? && self.try_has_state_once(id)? {
             return Ok(true);
         }
-        match &self.external_source {
-            Some(source) => Ok(source.get_state(id)?.is_some()),
-            None => Ok(false),
+        if let Some(source) = &self.external_source {
+            if self.recent_state(id).is_some() {
+                return Ok(true);
+            }
+            if let Some(state) = source.get_state(id)? {
+                self.cache_recent_state(*id, &state);
+                return Ok(true);
+            }
         }
+        Ok(false)
     }
 
     #[instrument(skip(self))]
     fn list_states(&self) -> Result<Vec<StateId>> {
         self.reload_packs_if_stale()?;
 
-        let dir = states_dir(&self.root);
         let mut states = Vec::new();
+        let mut known = HashSet::new();
+        let dir = states_dir(&self.root);
         if dir.exists() {
             for entry in fs::read_dir(&dir)? {
                 let entry = entry?;
@@ -1100,26 +1186,27 @@ impl ObjectStore for FsStore {
                 if let Some(name) = path.file_stem()
                     && let Some(name_str) = name.to_str()
                     && let Ok(id) = StateId::parse(name_str)
+                    && known.insert(id)
                 {
                     states.push(id);
                 }
             }
         }
         if let Ok(manager) = self.pack_manager().read() {
-            for id in manager.list_all_ids()? {
-                if let PackObjectId::StateId(change_id) = id
-                    && !states.contains(&change_id)
-                {
-                    states.push(change_id);
-                }
-            }
+            append_unique_states(
+                &mut states,
+                &mut known,
+                manager
+                    .list_all_ids()?
+                    .into_iter()
+                    .filter_map(|id| match id {
+                        PackObjectId::StateId(state) => Some(state),
+                        PackObjectId::Hash(_) => None,
+                    }),
+            );
         }
         if let Some(source) = &self.external_source {
-            for id in source.list_states()? {
-                if !states.contains(&id) {
-                    states.push(id);
-                }
-            }
+            append_unique_states(&mut states, &mut known, source.list_states()?);
         }
         debug!(count = states.len(), "Listed states");
         Ok(states)
@@ -1898,5 +1985,29 @@ mod enumeration_tests {
                 "negative control unexpectedly passed the structural contract: {legacy_metrics:?}"
             );
         }
+    }
+
+    #[test]
+    fn state_union_preserves_first_seen_order_at_scale() {
+        let first = (0..20_000u32)
+            .map(|value| {
+                StateId::from_bytes(*ContentHash::compute(&value.to_le_bytes()).as_bytes())
+            })
+            .collect::<Vec<_>>();
+        let second = first[10_000..]
+            .iter()
+            .copied()
+            .chain((20_000..30_000u32).map(|value| {
+                StateId::from_bytes(*ContentHash::compute(&value.to_le_bytes()).as_bytes())
+            }))
+            .collect::<Vec<_>>();
+        let mut states = Vec::new();
+        let mut known = HashSet::new();
+
+        append_unique_states(&mut states, &mut known, first.iter().copied());
+        append_unique_states(&mut states, &mut known, second);
+
+        assert_eq!(states.len(), 30_000);
+        assert_eq!(&states[..20_000], first.as_slice());
     }
 }

--- a/crates/objects/src/store/fs/fs_store.rs
+++ b/crates/objects/src/store/fs/fs_store.rs
@@ -2,12 +2,15 @@
 //! Core FsStore structure.
 
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 use std::{
     collections::{BTreeSet, HashMap, VecDeque},
     hash::Hash,
     path::{Path, PathBuf},
-    sync::{Arc, Mutex, RwLock},
+    sync::{
+        Arc, Mutex, RwLock,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use heddle_format::compression::CompressionConfig;
@@ -26,7 +29,7 @@ const RECENT_BLOB_CACHE_CAPACITY: usize = 2_048;
 const RECENT_TREE_CACHE_CAPACITY: usize = 1_024;
 /// Soft cap on the in-process loose-blob verification cache. Each
 /// entry is one `ContentHash` (~32 bytes) so this is ≈2 MB of memory
-/// for the upper bound, and the LRU eviction is bounded by hash
+/// for the upper bound, and clock eviction is bounded by hash
 /// hits rather than store size. 65k entries covers the typical hot
 /// working set for million-blob monorepos; a daemon that materialises
 /// dozens of unrelated trees won't drift toward unbounded growth.
@@ -54,7 +57,7 @@ pub enum LooseObjectWriteMode {
     BatchDirectorySync,
 }
 
-/// Bounded in-process object cache with true LRU eviction.
+/// Bounded in-process object cache with second-chance clock eviction.
 ///
 /// Two independent caps are enforced on every [`insert`](Self::insert):
 ///
@@ -68,15 +71,17 @@ pub enum LooseObjectWriteMode {
 /// workload (mount / `heddled`) that streams many multi-MB blobs
 /// through `get_blob` can otherwise retain `capacity × max-entry-bytes`
 /// of deep-cloned `Vec`s. With the budget, inserting a new large blob
-/// evicts LRU entries until the total fits.
+/// advances the second-chance clock until the total fits.
 ///
-/// [`get`](Self::get) promotes the key to MRU; [`insert`](Self::insert)
-/// treats re-insert as a touch. Evicts from the front of `order` when
-/// over either cap.
+/// [`get`](Self::get) marks the entry recently used through an atomic bit, so
+/// cache hits need only a shared map lock. Eviction advances a clock queue and
+/// gives marked entries one additional chance before removal. Both hits and
+/// amortized eviction stay O(1), including for the 65k-entry verification
+/// cache.
 #[derive(Debug)]
 pub(super) struct RecentObjectCache<K, V> {
-    entries: HashMap<K, V>,
-    order: VecDeque<K>,
+    entries: HashMap<K, RecentObjectCacheEntry<V>>,
+    eviction_clock: VecDeque<K>,
     capacity: usize,
     /// Soft cap on cumulative cached bytes; `None` = count-only.
     byte_budget: Option<usize>,
@@ -85,6 +90,12 @@ pub(super) struct RecentObjectCache<K, V> {
     sizer: fn(&V) -> usize,
     /// Running sum of `sizer(v)` over all `entries`.
     cached_bytes: usize,
+}
+
+#[derive(Debug)]
+struct RecentObjectCacheEntry<V> {
+    value: V,
+    recently_accessed: AtomicBool,
 }
 
 impl<K, V> RecentObjectCache<K, V>
@@ -97,7 +108,7 @@ where
     pub(super) fn with_capacity(capacity: usize) -> Self {
         Self {
             entries: HashMap::new(),
-            order: VecDeque::new(),
+            eviction_clock: VecDeque::new(),
             capacity,
             byte_budget: None,
             sizer: |_| 0,
@@ -107,7 +118,7 @@ where
 
     /// Cache capped by *both* entry count and cumulative bytes.
     /// `sizer` reports each value's heap-ish footprint; the cache
-    /// evicts LRU entries until both caps hold.
+    /// advances the second-chance clock until both caps hold.
     pub(super) fn with_byte_budget(
         capacity: usize,
         byte_budget: usize,
@@ -115,7 +126,7 @@ where
     ) -> Self {
         Self {
             entries: HashMap::new(),
-            order: VecDeque::new(),
+            eviction_clock: VecDeque::new(),
             capacity,
             byte_budget: Some(byte_budget),
             sizer,
@@ -123,15 +134,12 @@ where
         }
     }
 
-    /// Lookup with LRU promotion. Callers that hold only a read lock must
-    /// upgrade to a write lock before calling this (promotion mutates
-    /// `order`).
-    pub(super) fn get(&mut self, key: &K) -> Option<&V> {
-        if !self.entries.contains_key(key) {
-            return None;
-        }
-        self.promote(key);
-        self.entries.get(key)
+    /// Lookup with lock-free second-chance promotion inside an already-held
+    /// shared map lock. Only insertion and eviction require exclusive access.
+    pub(super) fn get(&self, key: &K) -> Option<&V> {
+        let entry = self.entries.get(key)?;
+        entry.recently_accessed.store(true, Ordering::Relaxed);
+        Some(&entry.value)
     }
 
     /// Presence check without promotion. Cheap enough to run under a
@@ -152,10 +160,7 @@ where
     /// store-level `evict_recent_blob` used in tests.
     #[cfg(test)]
     pub(super) fn remove(&mut self, key: &K) -> Option<V> {
-        let removed = self.entries.remove(key)?;
-        if let Some(position) = self.order.iter().position(|existing| existing == key) {
-            self.order.remove(position);
-        }
+        let removed = self.entries.remove(key)?.value;
         self.cached_bytes = self.cached_bytes.saturating_sub((self.sizer)(&removed));
         Some(removed)
     }
@@ -165,25 +170,31 @@ where
             return;
         }
         let new_bytes = self.byte_budget.map(|_| (self.sizer)(&value)).unwrap_or(0);
-        if let Some(old) = self.entries.insert(key, value) {
-            self.cached_bytes = self
-                .cached_bytes
-                .saturating_sub(self.byte_budget.map(|_| (self.sizer)(&old)).unwrap_or(0));
-            self.promote(&key);
+        let entry = RecentObjectCacheEntry {
+            value,
+            recently_accessed: AtomicBool::new(false),
+        };
+        if let Some(old) = self.entries.insert(key, entry) {
+            self.cached_bytes = self.cached_bytes.saturating_sub(
+                self.byte_budget
+                    .map(|_| (self.sizer)(&old.value))
+                    .unwrap_or(0),
+            );
         } else {
-            self.order.push_back(key);
+            self.eviction_clock.push_back(key);
         }
         self.cached_bytes += new_bytes;
-        self.evict_to_fit();
+        self.evict_to_fit(key);
     }
 
-    /// Evict from the LRU front until both the count cap and the byte
-    /// budget hold. The freshly-inserted entry is at the MRU back, so
-    /// it is never the eviction target (a single entry larger than the
-    /// whole budget is kept — the budget is a soft cap, not a hard
-    /// per-entry gate; the per-entry `RECENT_BLOB_CACHE_MAX_BYTES` gate
-    /// already bounds the largest thing that reaches here).
-    fn evict_to_fit(&mut self) {
+    /// Advance the second-chance clock until both the count cap and the byte
+    /// budget hold. A recently read entry is marked cold and moved to the back
+    /// once before it can be evicted. The freshly inserted entry starts at the
+    /// back, so it is not the first target (a single entry larger than the
+    /// whole budget is kept — the budget is a soft cap, not a hard per-entry
+    /// gate; the per-entry `RECENT_BLOB_CACHE_MAX_BYTES` gate already bounds
+    /// the largest thing that reaches here).
+    fn evict_to_fit(&mut self, admitted_key: K) {
         loop {
             let over_count = self.entries.len() > self.capacity;
             let over_bytes = self
@@ -192,25 +203,31 @@ where
             if !over_count && !over_bytes {
                 break;
             }
-            let Some(oldest) = self.order.pop_front() else {
+            let Some(candidate) = self.eviction_clock.pop_front() else {
                 break;
             };
-            // A key appears at most once in `order`; if it was already
-            // removed by a concurrent logical path we just skip.
-            if let Some(evicted) = self.entries.remove(&oldest) {
+            let Some(entry) = self.entries.get(&candidate) else {
+                continue;
+            };
+            // The value that triggered this pass has not had an opportunity to
+            // serve a read yet. Keep it for this pass when another victim
+            // exists; otherwise an all-hot full cache would cycle through the
+            // residents and evict the new external object immediately.
+            if candidate == admitted_key && self.entries.len() > 1 {
+                self.eviction_clock.push_back(candidate);
+                continue;
+            }
+            if entry.recently_accessed.swap(false, Ordering::Relaxed) {
+                self.eviction_clock.push_back(candidate);
+                continue;
+            }
+            if let Some(evicted) = self.entries.remove(&candidate) {
                 self.cached_bytes = self.cached_bytes.saturating_sub(
                     self.byte_budget
-                        .map(|_| (self.sizer)(&evicted))
+                        .map(|_| (self.sizer)(&evicted.value))
                         .unwrap_or(0),
                 );
             }
-        }
-    }
-
-    fn promote(&mut self, key: &K) {
-        if let Some(position) = self.order.iter().position(|existing| existing == key) {
-            let key = self.order.remove(position).expect("position in range");
-            self.order.push_back(key);
         }
     }
 }
@@ -249,7 +266,7 @@ pub struct FsStore {
     #[cfg(test)]
     snapshot_batch_flushes: AtomicUsize,
     /// In-process trust cache for loose-blob cache mirrors. A hash
-    /// enters this LRU when this process either (a) wrote the blob
+    /// enters this bounded clock cache when this process either (a) wrote the blob
     /// itself via `promote_to_loose_uncompressed` or (b) successfully
     /// hash-verified it on first read. Bytes-on-disk for any entry
     /// in this cache can be trusted without a re-hash by subsequent
@@ -257,10 +274,10 @@ pub struct FsStore {
     ///
     /// Capped at [`VERIFIED_LOOSE_BLOB_CACHE_CAPACITY`] entries so a
     /// long-lived process (`heddled`) materialising many unrelated
-    /// trees doesn't drift into unbounded memory growth. LRU
+    /// trees doesn't drift into unbounded memory growth. Second-chance
     /// eviction; an evicted hash pays one extra BLAKE3 on its next
     /// read (cost-of-evict ≈ working-set-size BLAKE3 ops). Stored as
-    /// `RecentObjectCache<…, ()>` to share the LRU-eviction
+    /// `RecentObjectCache<…, ()>` to share the clock-eviction
     /// machinery with the other on-store caches; the unit value is
     /// a marker that the corresponding loose mirror was verified.
     ///

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1,4 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
 use chrono::{TimeZone, Utc};
 use heddle_format::compression::CompressionConfig;
 use serde::Serialize;
@@ -15,7 +20,7 @@ use crate::{
         TreeEntry,
     },
     store::{
-        HeddleError, ObjectStore,
+        ExternalObjectSource, HeddleError, ObjectStore, Result as StoreResult,
         pack::{
             ObjectType as PackObjectType, PackBuilder, PackIndex, PackObjectId,
             decode_tagged_entry_header,
@@ -24,12 +29,114 @@ use crate::{
     sync::RwLockExt,
 };
 
+struct CountingBlobSource {
+    blob: Blob,
+    reads: AtomicUsize,
+}
+
+impl ExternalObjectSource for CountingBlobSource {
+    fn get_blob(&self, hash: &ContentHash) -> StoreResult<Option<Blob>> {
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        Ok((self.blob.hash() == *hash).then(|| self.blob.clone()))
+    }
+
+    fn get_tree(&self, _hash: &ContentHash) -> StoreResult<Option<Tree>> {
+        Ok(None)
+    }
+
+    fn get_state(&self, _id: &StateId) -> StoreResult<Option<State>> {
+        Ok(None)
+    }
+
+    fn list_states(&self) -> StoreResult<Vec<StateId>> {
+        Ok(Vec::new())
+    }
+}
+
 fn create_test_store() -> (TempDir, FsStore) {
     let temp_dir = TempDir::new().unwrap();
     let heddle_dir = temp_dir.path().join(".heddle");
     let store = FsStore::new(&heddle_dir);
     store.init().unwrap();
     (temp_dir, store)
+}
+
+#[test]
+fn external_blob_hits_are_memory_cached_without_native_materialization() {
+    let (_temp, mut store) = create_test_store();
+    let blob = Blob::from("authoritative Git bytes");
+    let hash = blob.hash();
+    let source = Arc::new(CountingBlobSource {
+        blob: blob.clone(),
+        reads: AtomicUsize::new(0),
+    });
+    store.set_external_source(source.clone());
+
+    assert_eq!(store.get_blob(&hash).unwrap(), Some(blob.clone()));
+    assert_eq!(store.get_blob(&hash).unwrap(), Some(blob.clone()));
+    assert!(store.has_blob(&hash).unwrap());
+    assert_eq!(
+        store.blob_size(&hash).unwrap(),
+        Some(blob.content().len() as u64)
+    );
+    assert_eq!(
+        store.get_blob_bytes(&hash).unwrap().unwrap().as_ref(),
+        blob.content()
+    );
+    assert_eq!(
+        source.reads.load(Ordering::Relaxed),
+        1,
+        "warm authoritative reads must stay in the in-process cache"
+    );
+    assert!(
+        !hash_path(&blobs_dir(store.root()), &hash).exists(),
+        "read-through cache hits must not create native loose objects"
+    );
+}
+
+#[test]
+fn native_blob_wins_over_external_source_without_external_io() {
+    let (_temp, mut store) = create_test_store();
+    let blob = Blob::from("Heddle-native bytes");
+    let hash = store.put_blob(&blob).unwrap();
+    let source = Arc::new(CountingBlobSource {
+        blob: blob.clone(),
+        reads: AtomicUsize::new(0),
+    });
+    store.set_external_source(source.clone());
+    store.clear_recent_caches();
+
+    assert_eq!(store.get_blob(&hash).unwrap(), Some(blob.clone()));
+    store.clear_recent_caches();
+    assert!(store.has_blob(&hash).unwrap());
+    assert_eq!(
+        store.blob_size(&hash).unwrap(),
+        Some(blob.content().len() as u64)
+    );
+    assert_eq!(source.reads.load(Ordering::Relaxed), 0);
+}
+
+#[test]
+fn native_pack_blob_can_be_promoted_when_external_source_also_has_it() {
+    let (_temp, mut store) = create_test_store();
+    let blob = Blob::from("shared native and external bytes");
+    let hash = blob.hash();
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(hash, PackObjectType::Blob, blob.content().to_vec());
+    let (pack_data, index_data, _) = builder.build().unwrap();
+    store.install_pack(&pack_data, &index_data).unwrap();
+
+    let source = Arc::new(CountingBlobSource {
+        blob,
+        reads: AtomicUsize::new(0),
+    });
+    store.set_external_source(source.clone());
+    store.clear_recent_caches();
+
+    assert!(store.loose_blob_path(&hash).is_none());
+    assert!(store.promote_to_loose_uncompressed(&hash).unwrap());
+    assert!(store.loose_blob_path(&hash).is_some());
+    assert_eq!(source.reads.load(Ordering::Relaxed), 0);
 }
 
 #[test]
@@ -1279,11 +1386,11 @@ fn loose_blob_path_rejects_torn_cache_mirror() {
     );
 }
 
-/// The byte budget must evict LRU entries once cumulative cached bytes
+/// The byte budget must evict cold entries once cumulative cached bytes
 /// exceed the cap, so a read-only workload streaming many blobs can't
 /// retain `capacity × max-entry-bytes` of deep-cloned Vecs.
 #[test]
-fn test_recent_object_cache_byte_budget_evicts_lru() {
+fn test_recent_object_cache_byte_budget_evicts_cold_entry() {
     // Large per-entry count cap, tiny byte budget: eviction is driven
     // purely by bytes. Each value is `len` bytes.
     let mut cache = super::fs_store::RecentObjectCache::<u32, Vec<u8>>::with_byte_budget(
@@ -1294,15 +1401,15 @@ fn test_recent_object_cache_byte_budget_evicts_lru() {
 
     cache.insert(1, vec![0u8; 40]); // total 40
     cache.insert(2, vec![0u8; 40]); // total 80
-    // Touch key 1 so it becomes MRU; key 2 is now the LRU victim.
+    // Touch key 1 so the clock gives it a second chance; key 2 is cold.
     assert!(cache.contains(&1));
     cache.get(&1);
-    cache.insert(3, vec![0u8; 40]); // total would be 120 > 100 → evict LRU (key 2)
+    cache.insert(3, vec![0u8; 40]); // total would be 120 > 100 → evict key 2
 
     assert!(cache.contains(&1), "recently-touched entry must survive");
     assert!(
         !cache.contains(&2),
-        "LRU entry must be evicted when the byte budget is exceeded"
+        "cold entry must be evicted when the byte budget is exceeded"
     );
     assert!(
         cache.contains(&3),
@@ -1325,4 +1432,49 @@ fn test_recent_object_cache_byte_budget_keeps_single_oversize_entry() {
         cache.contains(&1),
         "a lone oversize entry is retained; the budget is a soft aggregate cap"
     );
+}
+
+#[test]
+fn test_recent_object_cache_all_hot_residents_do_not_reject_new_entry() {
+    let mut cache = super::fs_store::RecentObjectCache::<u32, ()>::with_capacity(2);
+    cache.insert(1, ());
+    cache.insert(2, ());
+    cache.get(&1);
+    cache.get(&2);
+
+    cache.insert(3, ());
+
+    assert!(
+        cache.contains(&3),
+        "the admitted entry must survive its first pass"
+    );
+    assert_ne!(
+        cache.contains(&1),
+        cache.contains(&2),
+        "exactly one prior resident must be evicted"
+    );
+}
+
+/// Cache hits at the production verification-cache scale must remain shared
+/// operations while still influencing second-chance eviction order.
+#[test]
+fn test_recent_object_cache_large_shared_read_gets_second_chance() {
+    const CAPACITY: u32 = 65_536;
+    let mut cache = super::fs_store::RecentObjectCache::<u32, ()>::with_capacity(CAPACITY as usize);
+    for key in 0..CAPACITY {
+        cache.insert(key, ());
+    }
+
+    let shared = &cache;
+    for _ in 0..1_000 {
+        assert!(shared.get(&0).is_some());
+    }
+
+    cache.insert(CAPACITY, ());
+    assert!(cache.contains(&0), "hot entry must remain cached");
+    assert!(
+        !cache.contains(&1),
+        "oldest untouched entry must be evicted"
+    );
+    assert!(cache.contains(&CAPACITY), "new entry must be retained");
 }

--- a/crates/repo/src/git_overlay_object_source.rs
+++ b/crates/repo/src/git_overlay_object_source.rs
@@ -4,7 +4,11 @@
 //! The SQLite map and state descriptors are identity metadata only. Blob and
 //! tree contents remain authoritative in `.git` and are translated on demand.
 
-use std::{fs, path::PathBuf};
+use std::{
+    fs,
+    path::PathBuf,
+    sync::{Mutex, MutexGuard},
+};
 
 use objects::{
     error::{HeddleError, Result},
@@ -21,11 +25,18 @@ const KIND_BLOB: i64 = 2;
 pub(crate) struct GitOverlayObjectSource {
     root: PathBuf,
     heddle_dir: PathBuf,
+    mapping: Mutex<Option<Connection>>,
+    git: Mutex<Option<SleyRepository>>,
 }
 
 impl GitOverlayObjectSource {
     pub(crate) fn new(root: PathBuf, heddle_dir: PathBuf) -> Self {
-        Self { root, heddle_dir }
+        Self {
+            root,
+            heddle_dir,
+            mapping: Mutex::new(None),
+            git: Mutex::new(None),
+        }
     }
 
     fn map_path(&self) -> PathBuf {
@@ -40,11 +51,10 @@ impl GitOverlayObjectSource {
     }
 
     fn git_for_heddle(&self, value: &str, kind: i64) -> Result<Option<String>> {
-        let path = self.map_path();
-        if !path.exists() {
+        let mut mapping = self.mapping()?;
+        let Some(connection) = self.open_mapping(&mut mapping)? else {
             return Ok(None);
-        }
-        let connection = Connection::open(&path).map_err(db_error)?;
+        };
         connection
             .query_row(
                 "SELECT git_sha FROM sha_map WHERE heddle_repr = ? AND kind = ?",
@@ -56,11 +66,10 @@ impl GitOverlayObjectSource {
     }
 
     fn heddle_for_git(&self, oid: &ObjectId, kind: i64) -> Result<Option<String>> {
-        let path = self.map_path();
-        if !path.exists() {
+        let mut mapping = self.mapping()?;
+        let Some(connection) = self.open_mapping(&mut mapping)? else {
             return Ok(None);
-        }
-        let connection = Connection::open(&path).map_err(db_error)?;
+        };
         connection
             .query_row(
                 "SELECT heddle_repr FROM sha_map WHERE git_sha = ? AND kind = ?",
@@ -72,12 +81,54 @@ impl GitOverlayObjectSource {
     }
 
     fn git(&self) -> Result<SleyRepository> {
-        SleyRepository::discover(&self.root).map_err(|error| {
+        let mut git = self.git.lock().map_err(|_| {
+            HeddleError::Config("Git-overlay repository cache lock was poisoned".to_string())
+        })?;
+        if let Some(repo) = git.as_ref() {
+            return Ok(repo.clone());
+        }
+        let repo = SleyRepository::discover(&self.root).map_err(|error| {
             HeddleError::Config(format!(
                 "open authoritative Git object database at {}: {error}",
                 self.root.display()
             ))
+        })?;
+        *git = Some(repo.clone());
+        Ok(repo)
+    }
+
+    fn refresh_git(&self) -> Result<SleyRepository> {
+        let repo = SleyRepository::discover(&self.root).map_err(|error| {
+            HeddleError::Config(format!(
+                "refresh authoritative Git object database at {}: {error}",
+                self.root.display()
+            ))
+        })?;
+        let mut git = self.git.lock().map_err(|_| {
+            HeddleError::Config("Git-overlay repository cache lock was poisoned".to_string())
+        })?;
+        *git = Some(repo.clone());
+        Ok(repo)
+    }
+
+    fn mapping(&self) -> Result<MutexGuard<'_, Option<Connection>>> {
+        self.mapping.lock().map_err(|_| {
+            HeddleError::Config("Git-overlay identity mapping cache lock was poisoned".to_string())
         })
+    }
+
+    fn open_mapping<'a>(
+        &self,
+        mapping: &'a mut Option<Connection>,
+    ) -> Result<Option<&'a Connection>> {
+        if mapping.is_none() {
+            let path = self.map_path();
+            if !path.exists() {
+                return Ok(None);
+            }
+            *mapping = Some(Connection::open(path).map_err(db_error)?);
+        }
+        Ok(mapping.as_ref())
     }
 }
 
@@ -90,7 +141,17 @@ impl ExternalObjectSource for GitOverlayObjectSource {
         let oid = ObjectId::from_hex(git.object_format(), &git_sha).map_err(|error| {
             HeddleError::Config(format!("parse mapped Git blob {git_sha}: {error}"))
         })?;
-        let object = git.read_object(&oid).map_err(git_read_error)?;
+        let object = match git.read_object(&oid) {
+            Ok(object) => object,
+            Err(sley::GitError::NotFound(_)) => match self.refresh_git()?.read_object(&oid) {
+                Ok(object) => object,
+                Err(sley::GitError::NotFound(_)) => {
+                    return Err(mapped_object_missing("blob", &git_sha));
+                }
+                Err(error) => return Err(git_read_error(error)),
+            },
+            Err(error) => return Err(git_read_error(error)),
+        };
         let blob = Blob::from_slice(&object.body);
         if blob.hash() != *hash {
             return Err(HeddleError::Corruption {
@@ -112,7 +173,17 @@ impl ExternalObjectSource for GitOverlayObjectSource {
         let children = if oid == ObjectId::empty_tree(git.object_format()) {
             Vec::new()
         } else {
-            git.read_tree(&oid).map_err(git_read_error)?.entries
+            match git.read_tree(&oid) {
+                Ok(tree) => tree.entries,
+                Err(sley::GitError::NotFound(_)) => match self.refresh_git()?.read_tree(&oid) {
+                    Ok(tree) => tree.entries,
+                    Err(sley::GitError::NotFound(_)) => {
+                        return Err(mapped_object_missing("tree", &git_sha));
+                    }
+                    Err(error) => return Err(git_read_error(error)),
+                },
+                Err(error) => return Err(git_read_error(error)),
+            }
         };
         let mut entries = Vec::with_capacity(children.len());
         for child in children {
@@ -226,10 +297,69 @@ fn missing_mapping(kind: &str, oid: &ObjectId, parent: &str) -> HeddleError {
     ))
 }
 
+fn mapped_object_missing(kind: &str, git_sha: &str) -> HeddleError {
+    HeddleError::NotFound(format!(
+        "Git-overlay identity map references missing authoritative Git {kind} {git_sha}"
+    ))
+}
+
 fn db_error(error: rusqlite::Error) -> HeddleError {
     HeddleError::Config(format!("read Git-overlay identity mapping: {error}"))
 }
 
 fn git_read_error(error: impl std::fmt::Display) -> HeddleError {
     HeddleError::Config(format!("read authoritative Git object: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapped_missing_git_objects_are_errors_after_refresh() {
+        let temp = tempfile::TempDir::new().unwrap();
+        SleyRepository::init(temp.path()).unwrap();
+        let heddle_dir = temp.path().join(".heddle");
+        let ingest_dir = heddle_dir.join("ingest");
+        fs::create_dir_all(&ingest_dir).unwrap();
+        let connection = Connection::open(ingest_dir.join("sha_map.sqlite")).unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE sha_map (
+                    git_sha TEXT PRIMARY KEY NOT NULL,
+                    kind INTEGER NOT NULL,
+                    heddle_repr TEXT NOT NULL,
+                    lossy_entries TEXT
+                );",
+            )
+            .unwrap();
+        let blob_hash = ContentHash::compute_typed("blob", b"mapped missing blob");
+        let tree_hash = ContentHash::compute_typed("tree", b"mapped missing tree");
+        let missing_blob_oid = "1111111111111111111111111111111111111111";
+        let missing_tree_oid = "2222222222222222222222222222222222222222";
+        for (git_sha, kind, heddle_repr) in [
+            (missing_blob_oid, KIND_BLOB, blob_hash.to_hex()),
+            (missing_tree_oid, KIND_TREE, tree_hash.to_hex()),
+        ] {
+            connection
+                .execute(
+                    "INSERT INTO sha_map (git_sha, kind, heddle_repr) VALUES (?, ?, ?)",
+                    params![git_sha, kind, heddle_repr],
+                )
+                .unwrap();
+        }
+        drop(connection);
+
+        let source = GitOverlayObjectSource::new(temp.path().to_path_buf(), heddle_dir);
+        for (kind, result) in [
+            ("blob", source.get_blob(&blob_hash).map(|_| ())),
+            ("tree", source.get_tree(&tree_hash).map(|_| ())),
+        ] {
+            let error = result.expect_err("mapped Git object absence must be visible");
+            assert!(
+                matches!(error, HeddleError::NotFound(ref message) if message.contains(kind) && message.contains("identity map")),
+                "{error}"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Scope

- Cache external filesystem-store object reads without materializing Git-authoritative objects.
- Refresh recent-object eviction and state enumeration behavior.
- Cache and refresh Git-overlay mapping/repository handles, with explicit errors for stale mapped objects.
- Excludes workflow changes and the object tree-walk test.

Part of #1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1302"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788917729&installation_model_id=21489&pr_number=1302&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1302&signature=2e26e3157bd44766b08f9637e949b9c6a13d2a4c44efc265451f96f57e2bbd9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->