### PR TITLE
refactor(repo): batched commit-graph persistence + recovery lookups (part of #1262)

### DIFF
--- a/crates/repo/src/clone_intent.rs
+++ b/crates/repo/src/clone_intent.rs
@@ -101,9 +101,10 @@ mod tests {
         let durability = CloneDurabilityBatch::begin(&root);
         let repo = Repository::init_clone(&root, RepositorySourceAuthority::Native).unwrap();
         assert!(!repo.heddle_dir().join("HEAD").exists());
+        let canonical_root = root.canonicalize().expect("canonical clone root");
         assert!(matches!(
             Repository::open(&root),
-            Err(HeddleError::IncompleteClone(path)) if path == root
+            Err(HeddleError::IncompleteClone(path)) if path == canonical_root
         ));
 
         let tree = Tree::new();
@@ -129,7 +130,7 @@ mod tests {
             .unwrap();
         assert!(matches!(
             Repository::open(&root),
-            Err(HeddleError::IncompleteClone(path)) if path == root
+            Err(HeddleError::IncompleteClone(path)) if path == canonical_root
         ));
 
         CloneIntent::clear(&root).unwrap();

--- a/crates/repo/src/commit_graph.rs
+++ b/crates/repo/src/commit_graph.rs
@@ -102,6 +102,38 @@ pub struct CommitGraphIndex<'source, S: ObjectSource + ?Sized = AnyStore> {
     persistence_dirty: bool,
 }
 
+/// A single history query over a graph whose complete ancestry has already
+/// been resolved.
+///
+/// Bloom mutations stay in memory for the lifetime of the session and are
+/// persisted together by [`Self::finish`]. This keeps a history walk from
+/// repeatedly traversing the same parent closure or rewriting the complete
+/// cache for every visited state.
+pub(crate) struct CommitGraphHistorySession<'graph, 'source, S: ObjectSource + ?Sized = AnyStore> {
+    graph: &'graph mut CommitGraphIndex<'source, S>,
+}
+
+impl<'graph, 'source, S> CommitGraphHistorySession<'graph, 'source, S>
+where
+    S: ObjectSource + ?Sized,
+{
+    pub(crate) fn node_metadata(&self, id: &StateId) -> Option<CachedNodeMetadata> {
+        self.graph.node_metadata(id)
+    }
+
+    pub(crate) fn ensure_bloom_populated(&mut self, id: StateId) -> Result<()> {
+        self.graph.ensure_bloom_populated_from_loaded(id)
+    }
+
+    pub(crate) fn node_bloom(&self, id: &StateId) -> Option<&[u8; 256]> {
+        self.graph.node_bloom(id)
+    }
+
+    pub(crate) fn finish(self) {
+        self.graph.persist_if_dirty();
+    }
+}
+
 impl<'source, S> CommitGraphIndex<'source, S>
 where
     S: ObjectStore + ObjectSource,
@@ -153,6 +185,16 @@ where
             cache: Box::new(cache),
             persistence_dirty,
         }
+    }
+
+    /// Resolve the complete ancestry for one history query and defer all cache
+    /// persistence until the returned session is finished.
+    pub(crate) fn history_session<'graph>(
+        &'graph mut self,
+        start: StateId,
+    ) -> Result<CommitGraphHistorySession<'graph, 'source, S>> {
+        self.ensure_loaded_in_memory(start)?;
+        Ok(CommitGraphHistorySession { graph: self })
     }
 
     /// Return cached metadata for a node if it has been loaded.
@@ -215,6 +257,13 @@ where
     }
 
     pub fn ensure_loaded(&mut self, state_id: StateId) -> Result<()> {
+        self.ensure_loaded_in_memory(state_id)?;
+        self.persist_if_dirty();
+
+        Ok(())
+    }
+
+    fn ensure_loaded_in_memory(&mut self, state_id: StateId) -> Result<()> {
         // Walk the complete cached parent closure even when the requested
         // node itself is already cached. A lazy Git descriptor can name
         // unavailable parents; later adoption must discover those parents
@@ -279,8 +328,6 @@ where
                 stack.push((parent, false));
             }
         }
-        self.persist_if_dirty();
-
         Ok(())
     }
 
@@ -295,7 +342,22 @@ where
             return Ok(());
         }
 
-        self.ensure_loaded(id)?;
+        self.ensure_loaded_in_memory(id)?;
+        self.ensure_bloom_populated_from_loaded(id)?;
+        self.persist_if_dirty();
+        Ok(())
+    }
+
+    fn ensure_bloom_populated_from_loaded(&mut self, id: StateId) -> Result<()> {
+        if self
+            .nodes
+            .get(&id)
+            .map(|node| node.bloom.is_some())
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+
         let Some(node) = self.nodes.get(&id) else {
             return Ok(());
         };
@@ -303,7 +365,6 @@ where
         let parent_id = node.parents.first().copied();
 
         let parent_tree = if let Some(pid) = parent_id {
-            self.ensure_loaded(pid)?;
             self.nodes
                 .get(&pid)
                 .map(|n| n.tree_hash)
@@ -320,7 +381,6 @@ where
         }
         self.nodes.get_mut(&id).unwrap().bloom = Some(bloom);
         self.persistence_dirty = true;
-        self.persist_if_dirty();
         Ok(())
     }
 

--- a/crates/repo/src/operation_dedup.rs
+++ b/crates/repo/src/operation_dedup.rs
@@ -52,14 +52,15 @@ pub const DEFAULT_RETENTION_SECS: i64 = 7 * 24 * 60 * 60;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DedupEntry {
     pub operation_id: OperationId,
-    /// Hosted method name or CLI verb name. Lets two distinct verbs share an
-    /// operation id without colliding (rare but supported).
+    /// Hosted method name or CLI verb name, including the replay encoding
+    /// generation when relevant. Operation IDs remain unique across the store;
+    /// reusing one under a different verb is a conflict.
     pub verb: String,
-    /// BLAKE3-256 of the request body bytes. The server is responsible for
-    /// producing a canonical encoding before hashing — usually the prost-
-    /// encoded protobuf bytes.
+    /// BLAKE3-256 of the request body bytes. The caller is responsible for
+    /// choosing a deterministic encoding and including its generation in the
+    /// verb whenever an encoding change would make cached data incompatible.
     pub request_hash: [u8; 32],
-    /// Cached response bytes. Same canonical encoding as the request.
+    /// Cached response bytes in the caller-owned encoding for this verb.
     /// Empty (`Vec::new()`) when [`pending`](Self::pending) is `true` —
     /// i.e. the slot is reserved but the response hasn't been recorded yet.
     pub response: Vec<u8>,

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -142,6 +142,12 @@ const GIT_CHECKPOINT_INTENT_FILE: &str = "git-checkpoint-intent.json";
 const GIT_OVERLAY_LOCAL_EXCLUDE_PATTERNS: &[&str] = &[".heddle/"];
 const HEDDLE_REPOSITORY_MEMBERS: &[&str] = &["HEAD", "objects", "objectstore", "oplog", "refs"];
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum RepositoryOpenMode {
+    Normal,
+    OplogRecovery,
+}
+
 fn git_discovery_across_filesystem() -> bool {
     std::env::var("GIT_DISCOVERY_ACROSS_FILESYSTEM")
         .is_ok_and(|value| !matches!(value.as_str(), "" | "0" | "false" | "no" | "off"))
@@ -679,6 +685,7 @@ impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
         store: S,
         config: RepoConfig,
         refs: RefManager,
+        mode: RepositoryOpenMode,
     ) -> Result<Self> {
         let actor = config
             .principal
@@ -686,8 +693,15 @@ impl<S: ObjectStore> Repository<RefManager, OpLog, S> {
             .map(|p| objects::object::Principal::new(&p.name, &p.email))
             .unwrap_or_else(|| objects::object::Principal::new("<unknown>", ""));
         let oplog = OpLog::new(&heddle_dir, actor.clone());
-        oplog.validate_current_format()?;
+        if mode == RepositoryOpenMode::Normal {
+            oplog.validate_structural_health()?;
+        }
         let shallow = ShallowInfo::load(&heddle_dir)?;
+        if mode == RepositoryOpenMode::OplogRecovery {
+            return Ok(Self::from_parts(
+                root, heddle_dir, store, refs, oplog, config, shallow,
+            ));
+        }
         // Inject the oplog-backed read + write chokepoints (heddle#330 §2.2):
         // every logical read reconciles against the committed oplog tail, and
         // `commit_and_publish` appends a ref-carrying record before publishing.
@@ -773,6 +787,19 @@ impl Repository {
     /// materialized views were lost before they reached stable storage.
     fn recover_snapshot_artifact_views(&self) -> Result<()> {
         let mut pending = self.store.snapshot_commit_descriptors()?;
+        if pending.is_empty() {
+            return Ok(());
+        }
+        // Classify every artifact against one fresh, validated transaction
+        // index. Reopening the complete packed oplog once per descriptor made
+        // repository open O(snapshot artifacts × oplog bytes). Exact-once
+        // recovery below remains the serialized authority if another process
+        // commits after this snapshot was taken.
+        let mut committed_transactions = self.oplog.committed_transaction_ids(
+            pending
+                .iter()
+                .map(|descriptor| descriptor.artifact.transaction_id.as_str()),
+        )?;
         pending.sort_by(|left, right| {
             left.artifact
                 .base_oplog_head_id
@@ -785,11 +812,7 @@ impl Repository {
             let mut remaining = Vec::new();
             for descriptor in pending {
                 let artifact = &descriptor.artifact;
-                if !self
-                    .oplog
-                    .committed_batch_records(&artifact.transaction_id)?
-                    .is_empty()
-                {
+                if committed_transactions.contains(&artifact.transaction_id) {
                     progressed = true;
                     continue;
                 }
@@ -823,7 +846,10 @@ impl Repository {
                 )?;
                 match outcome {
                     ConditionalCommitOutcome::Committed(_)
-                    | ConditionalCommitOutcome::AlreadyCommitted(_) => progressed = true,
+                    | ConditionalCommitOutcome::AlreadyCommitted(_) => {
+                        committed_transactions.insert(artifact.transaction_id.clone());
+                        progressed = true;
+                    }
                     ConditionalCommitOutcome::IsolationConflict { .. } => {
                         unreachable!("empty recovery isolation set cannot produce a conflict")
                     }
@@ -1103,8 +1129,22 @@ impl Repository {
     ///   authority), `.heddle/HEAD` (per-checkout), `.heddle/state/`
     ///   (per-checkout cached state).
     pub fn open(path: impl AsRef<Path>) -> Result<Self> {
+        Self::open_with_mode(path.as_ref(), RepositoryOpenMode::Normal)
+    }
+
+    /// Open only enough repository state to run explicit oplog recovery.
+    ///
+    /// This deliberately bypasses oplog validation, open hooks, ref-tail
+    /// reconciliation, and Git-overlay synchronization so an operator can
+    /// authorize salvage even when normal repository open correctly refuses a
+    /// damaged or non-contiguous generation.
+    pub fn open_for_oplog_recovery(path: impl AsRef<Path>) -> Result<Self> {
+        Self::open_with_mode(path.as_ref(), RepositoryOpenMode::OplogRecovery)
+    }
+
+    fn open_with_mode(path: &Path, mode: RepositoryOpenMode) -> Result<Self> {
         heddle_perf_contract::record_repository_open();
-        let requested_path = path.as_ref();
+        let requested_path = path;
         let start_path = requested_path.canonicalize().map_err(|error| {
             HeddleError::Io(enrich_fs_error(
                 requested_path,
@@ -1155,9 +1195,12 @@ impl Repository {
                     && git_root.starts_with(dir)
                     && !git_root.join(".heddle").exists()
                 {
+                    if mode == RepositoryOpenMode::OplogRecovery {
+                        return Err(HeddleError::RepositoryNotFound(git_root.clone()));
+                    }
                     ensure_git_overlay_exclude(git_root)?;
                     Self::bootstrap_git_overlay(git_root)?;
-                    return Self::open(git_root);
+                    return Self::open_with_mode(git_root, mode);
                 }
 
                 if pointer_path.is_file() {
@@ -1221,9 +1264,17 @@ impl Repository {
                     )?;
                     let local_head_path = heddle_path.join("HEAD");
                     let refs = RefManager::new(&shared_galeed_dir).with_local_head(local_head_path);
-                    let repo =
-                        Self::open_raw(dir.to_path_buf(), shared_galeed_dir, store, config, refs)?;
-                    repo.run_open_hooks()?;
+                    let repo = Self::open_raw(
+                        dir.to_path_buf(),
+                        shared_galeed_dir,
+                        store,
+                        config,
+                        refs,
+                        mode,
+                    )?;
+                    if mode == RepositoryOpenMode::Normal {
+                        repo.run_open_hooks()?;
+                    }
                     return Ok(repo);
                 }
 
@@ -1234,8 +1285,14 @@ impl Repository {
                     ensure_supported_repo_format(&config_path, &config)?;
                     let store = Self::build_store(&config, dir, &heddle_path, None)?;
                     let refs = RefManager::new(&heddle_path);
-                    let repo = Self::open_raw(dir.to_path_buf(), heddle_path, store, config, refs)?;
-                    repo.run_open_hooks()?;
+                    let repo =
+                        Self::open_raw(dir.to_path_buf(), heddle_path, store, config, refs, mode)?;
+                    if mode == RepositoryOpenMode::Normal {
+                        repo.run_open_hooks()?;
+                    }
+                    if mode == RepositoryOpenMode::OplogRecovery {
+                        return Ok(repo);
+                    }
                     if repo.capability() == RepositoryCapability::GitOverlay {
                         match detect_git_head_state(dir) {
                             Ok(Some(GitHeadState::Attached(thread))) => {
@@ -1270,7 +1327,7 @@ impl Repository {
                                     (Err(_), _) => true,
                                 };
                                 if stale {
-                                    repo.refs.write_head(&git_head)?;
+                                    repo.write_head_recorded(&git_head)?;
                                 }
                             }
                             Ok(Some(GitHeadState::Detached(git_oid))) => {
@@ -1283,7 +1340,7 @@ impl Repository {
                                         Err(_) => true,
                                     };
                                     if stale {
-                                        repo.refs.write_head(&git_head)?;
+                                        repo.write_head_recorded(&git_head)?;
                                     }
                                 }
                             }
@@ -1300,13 +1357,15 @@ impl Repository {
         // Observe-only commands (status/verify/doctor) must NOT call open on
         // plain Git — they take the plain-Git probe path so they never create
         // `.heddle`. See `verify_execution_context_from_cli`.
-        if let Some(git_root) = discovered_git_root {
+        if mode == RepositoryOpenMode::Normal
+            && let Some(git_root) = discovered_git_root
+        {
             ensure_git_overlay_exclude(&git_root)?;
             Self::bootstrap_git_overlay(&git_root)?;
-            return Self::open(git_root);
+            return Self::open_with_mode(&git_root, mode);
         }
 
-        Err(HeddleError::RepositoryNotFound(path.as_ref().to_path_buf()))
+        Err(HeddleError::RepositoryNotFound(path.to_path_buf()))
     }
 
     pub fn root(&self) -> &Path {

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -170,72 +170,87 @@ where
     use super::commit_graph::CommitGraphIndex;
 
     let mut graph = CommitGraphIndex::with_cache(source, cache);
-    let mut candidate_ids = Vec::new();
-    let mut current = query.start;
-
-    while let Some(state_id) = current {
-        if candidate_ids.len() >= query.limit {
-            break;
-        }
-
-        // `stop_at` (the exclusive `--since` bound) is checked
-        // BEFORE filters so the walk terminates at the bound even
-        // when the bound state itself is filtered out by `--agent`
-        // or `--path`. Without this, a `--since` whose resolved
-        // state doesn't match the active filter would silently
-        // degrade and matches older than the bound would leak.
-        if let Some(stop) = query.stop_at
-            && state_id == stop
-        {
-            break;
-        }
-        heddle_perf_contract::record_ancestors_visited(1);
-
-        graph
-            .ensure_loaded(state_id)
-            .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
-        let Some(meta) = graph.node_metadata(&state_id) else {
-            break;
-        };
-        current = meta.first_parent;
-
-        // Fast agent filter from cached metadata — no state load needed
-        if let Some(ref filter) = query.agent_model_substring {
-            match &meta.agent_model {
-                Some(model) if model.contains(filter.as_str()) => {}
-                _ => continue,
-            }
-        }
-
-        if query.changed_paths.is_empty() {
-            // No path filter — this is a match
-            candidate_ids.push(state_id);
-            trace!(state = %state_id, "history query matched state (no path filter)");
-            continue;
-        }
-
-        // Use bloom filter to skip expensive tree diffs
-        graph
-            .ensure_bloom_populated(state_id)
-            .map_err(|e| HeddleError::InvalidObject(e.to_string()))?;
-        if graph
-            .node_bloom(&state_id)
-            .is_some_and(|bloom| !query.changed_paths.bloom_maybe_matches(bloom))
-        {
-            // Bloom says "definitely not changed" — skip
-            continue;
-        }
-
-        // Bloom says "maybe" (or no bloom) — confirm with full tree diff
-        let Some(state) = HistoryObjectSource::new(source).get_state(&state_id)? else {
-            break;
-        };
-        if !state_matches_changed_paths(source, &state, &query.changed_paths)? {
-            continue;
-        }
-        trace!(state = %state_id, "history query matched state");
-        candidate_ids.push(state_id);
+    let Some(start) = query.start else {
+        return Ok(Vec::new());
+    };
+    if query.limit == 0 || query.stop_at == Some(start) {
+        return Ok(Vec::new());
     }
+
+    let mut session = graph
+        .history_session(start)
+        .map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+    let walk_result = (|| -> Result<Vec<StateId>> {
+        let mut candidate_ids = Vec::new();
+        let mut current = Some(start);
+
+        while let Some(state_id) = current {
+            if candidate_ids.len() >= query.limit {
+                break;
+            }
+
+            // `stop_at` (the exclusive `--since` bound) is checked
+            // BEFORE filters so the walk terminates at the bound even
+            // when the bound state itself is filtered out by `--agent`
+            // or `--path`. Without this, a `--since` whose resolved
+            // state doesn't match the active filter would silently
+            // degrade and matches older than the bound would leak.
+            if let Some(stop) = query.stop_at
+                && state_id == stop
+            {
+                break;
+            }
+            heddle_perf_contract::record_ancestors_visited(1);
+
+            let Some(meta) = session.node_metadata(&state_id) else {
+                break;
+            };
+            current = meta.first_parent;
+
+            // Fast agent filter from cached metadata — no state load needed
+            if let Some(ref filter) = query.agent_model_substring {
+                match &meta.agent_model {
+                    Some(model) if model.contains(filter.as_str()) => {}
+                    _ => continue,
+                }
+            }
+
+            if query.changed_paths.is_empty() {
+                // No path filter — this is a match
+                candidate_ids.push(state_id);
+                trace!(state = %state_id, "history query matched state (no path filter)");
+                continue;
+            }
+
+            // Use bloom filter to skip expensive tree diffs. The session has
+            // already resolved this node's parent closure, so this only
+            // computes missing filters and keeps them dirty in memory.
+            session
+                .ensure_bloom_populated(state_id)
+                .map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+            if session
+                .node_bloom(&state_id)
+                .is_some_and(|bloom| !query.changed_paths.bloom_maybe_matches(bloom))
+            {
+                // Bloom says "definitely not changed" — skip
+                continue;
+            }
+
+            // Bloom says "maybe" (or no bloom) — confirm with full tree diff
+            let Some(state) = HistoryObjectSource::new(source).get_state(&state_id)? else {
+                break;
+            };
+            if !state_matches_changed_paths(source, &state, &query.changed_paths)? {
+                continue;
+            }
+            trace!(state = %state_id, "history query matched state");
+            candidate_ids.push(state_id);
+        }
+
+        Ok(candidate_ids)
+    })();
+    session.finish();
+    let candidate_ids = walk_result?;
 
     // Load full State objects only for final matches
     let mut result = Vec::with_capacity(candidate_ids.len());
@@ -452,14 +467,16 @@ fn normalize_repo_relative_path(path: &str) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
+    use std::{cell::Cell, fs, rc::Rc};
 
+    use objects::{
+        object::{Attribution, Blob, Principal, State, Tree, TreeEntry},
+        store::{InMemoryStore, ObjectStore},
+    };
     #[cfg(feature = "async-source")]
     use objects::{
-        object::{
-            Attribution, Blob, ContentHash, EntryType, Principal, State, StateId, Tree, TreeEntry,
-        },
-        store::{AsyncObjectSource, InMemoryStore, ObjectStore},
+        object::{ContentHash, EntryType, StateId},
+        store::AsyncObjectSource,
     };
     use tempfile::TempDir;
 
@@ -467,7 +484,35 @@ mod tests {
         ChangedPathFilter, ChangedPathFilters, HistoryQuery, normalize_repo_relative_path,
         query_history_with_cache,
     };
-    use crate::{Repository, repository::commit_graph_persistence::NullCommitGraphCache};
+    use crate::{
+        Repository,
+        repository::commit_graph_persistence::{
+            CommitGraphCache, LoadedCommitGraph, NullCommitGraphCache,
+        },
+    };
+
+    #[derive(Clone, Default)]
+    struct CountingCommitGraphCache {
+        loads: Rc<Cell<usize>>,
+        saves: Rc<Cell<usize>>,
+        saved_nodes: Rc<Cell<usize>>,
+        saved_blooms: Rc<Cell<usize>>,
+    }
+
+    impl CommitGraphCache for CountingCommitGraphCache {
+        fn load(&self) -> anyhow::Result<Option<LoadedCommitGraph>> {
+            self.loads.set(self.loads.get() + 1);
+            Ok(None)
+        }
+
+        fn save(&self, nodes: &LoadedCommitGraph) -> anyhow::Result<()> {
+            self.saves.set(self.saves.get() + 1);
+            self.saved_nodes.set(nodes.len());
+            self.saved_blooms
+                .set(nodes.values().filter(|node| node.bloom.is_some()).count());
+            Ok(())
+        }
+    }
 
     #[test]
     fn changed_path_filter_matches_exact_paths_and_children() {
@@ -544,6 +589,62 @@ mod tests {
                 .map(|state| state.id())
                 .collect::<Vec<_>>(),
             expected
+        );
+    }
+
+    #[test]
+    fn path_filtered_history_batches_graph_persistence_across_a_long_walk() {
+        const HISTORY_LEN: usize = 64;
+
+        let store = InMemoryStore::new();
+        let attribution = Attribution::human(Principal::new("Test User", "test@example.com"));
+        let mut parent = None;
+        let mut expected = Vec::with_capacity(HISTORY_LEN);
+
+        for index in 0..HISTORY_LEN {
+            let blob = ObjectStore::put_blob(
+                &store,
+                &Blob::from_slice(format!("revision {index}\n").as_bytes()),
+            )
+            .unwrap();
+            let tree = Tree::from_entries(vec![
+                TreeEntry::file("tracked.txt".to_string(), blob, false).unwrap(),
+            ]);
+            let tree_hash = ObjectStore::put_tree(&store, &tree).unwrap();
+            let state = State::new(tree_hash, parent.into_iter().collect(), attribution.clone());
+            ObjectStore::put_state(&store, &state).unwrap();
+            parent = Some(state.id());
+            expected.push(state.id());
+        }
+        expected.reverse();
+
+        let cache = CountingCommitGraphCache::default();
+        let loads = Rc::clone(&cache.loads);
+        let saves = Rc::clone(&cache.saves);
+        let saved_nodes = Rc::clone(&cache.saved_nodes);
+        let saved_blooms = Rc::clone(&cache.saved_blooms);
+        let query = HistoryQuery::new(parent)
+            .with_limit(HISTORY_LEN)
+            .with_changed_paths(ChangedPathFilters::try_from_paths(["tracked.txt"]).unwrap());
+
+        let result = query_history_with_cache(&store, &query, cache).unwrap();
+
+        assert_eq!(
+            result.iter().map(State::id).collect::<Vec<_>>(),
+            expected,
+            "batching must preserve newest-to-oldest first-parent ordering"
+        );
+        assert_eq!(loads.get(), 1, "one query should open the cache once");
+        assert_eq!(
+            saves.get(),
+            1,
+            "all ancestry and Bloom mutations should persist as one graph snapshot"
+        );
+        assert_eq!(saved_nodes.get(), HISTORY_LEN);
+        assert_eq!(
+            saved_blooms.get(),
+            HISTORY_LEN,
+            "the one persisted snapshot should contain every Bloom mutation"
         );
     }
 


### PR DESCRIPTION
Scope:
- batch commit-graph ancestry and Bloom persistence across each history query
- use bulk oplog transaction lookup during snapshot-artifact recovery
- add explicit recovery-only repository open mode while preserving normal open validation
- keep HEAD repair writes on the recorded mutation path
- clarify operation-dedup encoding ownership and canonicalize incomplete-clone paths

Verification:
- workspace build and clippy (`-D warnings`)
- `heddle-repo` tests
- Feature contracts: repository/CLI alternate feature checks, telemetry build/clippy/tests
- nightly rustfmt on touched files

Part of #1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788926554&installation_model_id=21489&pr_number=1303&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1303&signature=934b32b44287f46a2ea3792e1dd9fd4f9ff9b277fd8f206cfed3d0a5459b710d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->