### PR TITLE
Persist cross-file semantic graph deltas

### DIFF
--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -19,6 +19,7 @@ mod operation_id;
 mod redaction;
 mod risk_signal;
 mod semantic_change;
+mod semantic_edges;
 mod semantic_index;
 mod session;
 mod source;
@@ -71,6 +72,7 @@ pub use risk_signal::{
     SignalAnchor,
 };
 pub use semantic_change::{ChangeImportance, ModificationKind, SemanticChange};
+pub use semantic_edges::{BindingDelta, FileBindingDelta, ResolvedSemanticEdge, SemanticEdgeKind};
 pub use semantic_index::{
     ByteSpan, ImportBinding, ImportEntry, ImportKindTag, OccurrenceEntry, OccurrenceRole,
     ScopeEntry, ScopeKind, SemanticEntryKind, SemanticFileFacts, SemanticFileNode,
@@ -123,9 +125,8 @@ pub use timeline::{
     TimelineOperationIdParseError, TimelineOperationKind, TimelineStepId, TimelineToolCallStatus,
     TimelineToolPayloadMetadata, ToolCallFinishedV1, ToolCallStartedV1,
 };
-pub use tree::TreeDecodeError;
 pub use tree::{
-    EntryType, FileMode, Tree, TreeEntry, TreeEntryTarget, TreeError,
+    EntryType, FileMode, Tree, TreeDecodeError, TreeEntry, TreeEntryTarget, TreeError,
     validate_name as validate_tree_entry_name,
 };
 #[cfg(feature = "async-source")]

--- a/crates/object-model/src/object/semantic_edges.rs
+++ b/crates/object-model/src/object/semantic_edges.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+//! State-scoped resolved symbol edges stored as deltas over the first parent.
+
+use serde::{Deserialize, Serialize};
+
+use super::{ContentHash, SemanticIndexError};
+
+/// The relationship represented by a resolved source occurrence.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SemanticEdgeKind {
+    /// A non-call value reference.
+    RefersTo,
+    /// A function or method call.
+    Calls,
+    /// A type-position reference.
+    TypeRef,
+}
+
+/// A resolved occurrence-to-definition edge.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct ResolvedSemanticEdge {
+    /// Source-local occurrence id in the source file's semantic node.
+    pub source_occurrence: u32,
+    /// Repository-relative path containing the target definition.
+    pub target_path: String,
+    /// Content address of the target file's semantic node.
+    pub target_file_node: ContentHash,
+    /// Canonical index of the target definition in `SemanticFileNode::symbols`.
+    pub target_definition: u32,
+    /// Semantic relationship carried by this edge.
+    pub kind: SemanticEdgeKind,
+}
+
+/// Complete replacement edges for one source file in a binding delta.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FileBindingDelta {
+    /// Repository-relative source path.
+    pub path: String,
+    /// Current semantic file node, or `None` when this record removes a file.
+    pub file_node: Option<ContentHash>,
+    /// Complete replacement edge list for `path`, sorted canonically.
+    pub replace_edges: Vec<ResolvedSemanticEdge>,
+}
+
+impl FileBindingDelta {
+    /// Construct a canonical replacement record.
+    pub fn new(
+        path: impl Into<String>,
+        file_node: Option<ContentHash>,
+        mut replace_edges: Vec<ResolvedSemanticEdge>,
+    ) -> Self {
+        replace_edges.sort();
+        replace_edges.dedup();
+        Self {
+            path: path.into(),
+            file_node,
+            replace_edges,
+        }
+    }
+}
+
+/// Content-addressed state binding delta.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BindingDelta {
+    pub format_version: u8,
+    /// Content address of the first parent's binding delta.
+    pub parent: Option<ContentHash>,
+    /// Replacement records for the invalidation frontier, sorted by path.
+    pub files: Vec<FileBindingDelta>,
+}
+
+impl BindingDelta {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    /// Construct a canonical binding delta.
+    pub fn new(parent: Option<ContentHash>, mut files: Vec<FileBindingDelta>) -> Self {
+        files.sort_by(|a, b| a.path.cmp(&b.path));
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            parent,
+            files,
+        }
+    }
+
+    /// Encode this delta as named MessagePack.
+    pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {
+        rmp_serde::to_vec_named(self).map_err(|err| SemanticIndexError::Encoding(err.to_string()))
+    }
+
+    /// Decode and version-check a binding delta.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SemanticIndexError> {
+        let delta: Self = rmp_serde::from_slice(bytes)
+            .map_err(|err| SemanticIndexError::Encoding(err.to_string()))?;
+        if delta.format_version != Self::FORMAT_VERSION {
+            return Err(SemanticIndexError::UnsupportedVersion(delta.format_version));
+        }
+        Ok(delta)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hash(seed: u8) -> ContentHash {
+        ContentHash::from_bytes([seed; 32])
+    }
+
+    #[test]
+    fn binding_delta_roundtrips_and_canonicalizes() {
+        let edge = ResolvedSemanticEdge {
+            source_occurrence: 3,
+            target_path: "api.rs".to_string(),
+            target_file_node: hash(2),
+            target_definition: 1,
+            kind: SemanticEdgeKind::Calls,
+        };
+        let delta = BindingDelta::new(
+            Some(hash(9)),
+            vec![
+                FileBindingDelta::new("z.rs", Some(hash(1)), vec![edge.clone(), edge]),
+                FileBindingDelta::new("a.rs", None, Vec::new()),
+            ],
+        );
+
+        assert_eq!(delta.files[0].path, "a.rs");
+        assert_eq!(delta.files[1].replace_edges.len(), 1);
+        assert_eq!(
+            BindingDelta::decode(&delta.encode().unwrap()).unwrap(),
+            delta
+        );
+    }
+}

--- a/crates/object-model/src/object/semantic_index.rs
+++ b/crates/object-model/src/object/semantic_index.rs
@@ -585,6 +585,14 @@ pub struct SemanticIndexRoot {
     pub tree: ContentHash,
     /// The top tree node's `semantic_digest` — the whole-tree fingerprint.
     pub semantic_digest: ContentHash,
+    /// State-scoped resolved-edge delta rooted at this state. This is separate
+    /// from `tree`: syntax remains Merkle-shareable while bindings may depend
+    /// on repository placement and the first parent's edge set.
+    #[serde(default)]
+    pub binding_delta: Option<ContentHash>,
+    /// Heddle-owned resolver policy version used to produce `binding_delta`.
+    #[serde(default)]
+    pub resolver_version: u32,
 }
 
 impl SemanticIndexRoot {
@@ -602,7 +610,16 @@ impl SemanticIndexRoot {
             grammars,
             tree,
             semantic_digest,
+            binding_delta: None,
+            resolver_version: 0,
         }
+    }
+
+    /// Attach a resolved-edge delta to this state-scoped root.
+    pub fn with_binding_delta(mut self, binding_delta: ContentHash, resolver_version: u32) -> Self {
+        self.binding_delta = Some(binding_delta);
+        self.resolver_version = resolver_version;
+        self
     }
 
     pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -52,8 +52,14 @@ pub use repository_semantic_index::{ParentIndex, SemanticIndexBuilder};
 mod repository_semantic_query;
 pub use repository_semantic_query::SymbolDelta;
 #[cfg(feature = "tree-sitter-symbols")]
+mod repository_symbol_graph;
+mod repository_symbol_graph_query;
+pub use repository_symbol_graph_query::ResolvedSemanticEdgeSet;
+#[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
 mod repository_state_visibility;
+#[cfg(all(test, feature = "tree-sitter-symbols"))]
+mod repository_symbol_graph_tests;
 mod revision_address;
 pub use repository_state_visibility::{
     DefaultVisibilityBinding, PutVisibilityOutcome, VisibilityCommitKind, VisibilityCommitOutcome,

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -446,7 +446,13 @@ impl Repository {
             None => SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION),
         };
         match builder.build_root(tree, parent.as_ref()) {
-            Ok((_, root_hash)) => Ok(Some(root_hash)),
+            Ok((root, _)) => match self.persist_resolved_semantic_edges(prior, root) {
+                Ok(root_hash) => Ok(Some(root_hash)),
+                Err(err) => {
+                    warn!(error = %err, "semantic graph: resolution failed; skipping index");
+                    Ok(None)
+                }
+            },
             Err(err) => {
                 warn!(error = %err, "semantic index: build failed; skipping");
                 Ok(None)
@@ -458,7 +464,9 @@ impl Repository {
     /// version match this binary's. A stale root is served as a MISS so a
     /// bump recomputes.
     fn index_is_current(&self, root: &SemanticIndexRoot) -> bool {
-        root.extractor_version == EXTRACTOR_VERSION
+        root.binding_delta.is_some()
+            && root.resolver_version == semantic::cross_file_resolution::RESOLVER_VERSION
+            && root.extractor_version == EXTRACTOR_VERSION
             && root
                 .grammars
                 .iter()
@@ -563,7 +571,8 @@ impl Repository {
             return Ok(None);
         };
         let mut builder = SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION);
-        let (_, root_hash) = builder.build_root(&tree, None)?;
+        let (root, _) = builder.build_root(&tree, None)?;
+        let root_hash = self.persist_resolved_semantic_edges(None, root)?;
         self.attach_semantic_index(state_id, &state, root_hash)?;
         Ok(Some(self.load_index_root(&root_hash)?))
     }
@@ -662,7 +671,9 @@ impl Repository {
         let ordered = self.order_states_oldest_first(states)?;
         let mut count = 0;
         for state_id in ordered {
-            let already = self.attached_semantic_index(&state_id)?.is_some();
+            let already = self
+                .attached_semantic_index(&state_id)?
+                .is_some_and(|root| self.index_is_current(&root));
             if already && !all {
                 continue; // restartable: skip states that already have one.
             }

--- a/crates/repo/src/repository_symbol_graph.rs
+++ b/crates/repo/src/repository_symbol_graph.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Cross-file resolution and state-scoped binding-delta persistence.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use objects::{
+    object::{
+        BindingDelta, ContentHash, FileBindingDelta, SemanticEntryKind, SemanticFileNode,
+        SemanticIndexRoot,
+    },
+    store::ObjectStore,
+};
+use semantic::cross_file_resolution::{
+    RESOLVER_VERSION, RepositorySemanticFile, resolve_repository,
+};
+
+use crate::{HeddleError, Repository, Result};
+
+impl Repository {
+    /// Resolve the semantic root and persist a delta over the first parent's
+    /// edge set, returning a replacement semantic-root blob hash.
+    pub(crate) fn persist_resolved_semantic_edges(
+        &self,
+        parent_state: Option<&objects::object::State>,
+        root: SemanticIndexRoot,
+    ) -> Result<ContentHash> {
+        let current_files = self.semantic_files(&root)?;
+        let current_resolution = resolve_repository(&current_files);
+        let parent_root = parent_state
+            .map(|state| self.attached_semantic_index(&state.id()))
+            .transpose()?
+            .flatten();
+        let parent_delta = parent_root
+            .as_ref()
+            .filter(|root| root.resolver_version == RESOLVER_VERSION)
+            .and_then(|root| root.binding_delta);
+
+        let frontier = if parent_delta.is_some() {
+            let parent_files = self.semantic_files(parent_root.as_ref().expect("checked above"))?;
+            let parent_resolution = resolve_repository(&parent_files);
+            invalidation_frontier(
+                &parent_files,
+                &current_files,
+                &parent_resolution,
+                &current_resolution,
+            )
+        } else {
+            current_files.keys().cloned().collect()
+        };
+
+        let files = frontier
+            .into_iter()
+            .map(|path| match current_files.get(&path) {
+                Some(file) => FileBindingDelta::new(
+                    path.clone(),
+                    Some(file.node_hash),
+                    current_resolution
+                        .get(&path)
+                        .map(|resolution| resolution.edges.clone())
+                        .unwrap_or_default(),
+                ),
+                None => FileBindingDelta::new(path, None, Vec::new()),
+            })
+            .collect();
+        let delta = BindingDelta::new(parent_delta, files);
+        let delta_bytes = delta.encode()?;
+        let delta_hash = ContentHash::compute_typed("blob", &delta_bytes);
+        let rooted = root.with_binding_delta(delta_hash, RESOLVER_VERSION);
+        let root_bytes = rooted.encode()?;
+        let root_hash = ContentHash::compute_typed("blob", &root_bytes);
+        self.store()
+            .put_blobs_packed(vec![(delta_hash, delta_bytes), (root_hash, root_bytes)])?;
+        Ok(root_hash)
+    }
+
+    pub(crate) fn semantic_files(
+        &self,
+        root: &SemanticIndexRoot,
+    ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
+        let mut files = BTreeMap::new();
+        let mut stack = vec![(String::new(), root.tree, 0usize)];
+        while let Some((prefix, hash, depth)) = stack.pop() {
+            if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
+                return Err(HeddleError::InvalidObject(
+                    "semantic index tree exceeds max depth".to_string(),
+                ));
+            }
+            for entry in self.load_semantic_tree(&hash)?.entries.into_iter().rev() {
+                let path = if prefix.is_empty() {
+                    entry.name
+                } else {
+                    format!("{prefix}/{}", entry.name)
+                };
+                match entry.kind {
+                    SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
+                    SemanticEntryKind::File => {
+                        let node: SemanticFileNode = self.load_semantic_file(&entry.node)?;
+                        files.insert(
+                            path,
+                            RepositorySemanticFile {
+                                node_hash: entry.node,
+                                node,
+                            },
+                        );
+                    }
+                    SemanticEntryKind::Opaque => {}
+                }
+            }
+        }
+        Ok(files)
+    }
+}
+
+fn invalidation_frontier(
+    parent_files: &BTreeMap<String, RepositorySemanticFile>,
+    current_files: &BTreeMap<String, RepositorySemanticFile>,
+    parent: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
+    current: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
+) -> BTreeSet<String> {
+    let all_paths = parent_files
+        .keys()
+        .chain(current_files.keys())
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let changed = all_paths
+        .into_iter()
+        .filter(|path| {
+            parent_files.get(path).map(|file| file.node_hash)
+                != current_files.get(path).map(|file| file.node_hash)
+        })
+        .collect::<BTreeSet<_>>();
+    let reverse = reverse_dependencies(parent, current);
+    let mut frontier = changed.clone();
+    let mut queue = VecDeque::from_iter(changed);
+    while let Some(path) = queue.pop_front() {
+        if let Some(importers) = reverse.get(&path) {
+            for importer in importers {
+                if frontier.insert(importer.clone()) {
+                    queue.push_back(importer.clone());
+                }
+            }
+        }
+    }
+    frontier
+}
+
+fn reverse_dependencies(
+    parent: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
+    current: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let mut reverse = BTreeMap::<String, BTreeSet<String>>::new();
+    for (importer, resolution) in parent.iter().chain(current) {
+        for dependency in &resolution.dependencies {
+            reverse
+                .entry(dependency.clone())
+                .or_default()
+                .insert(importer.clone());
+        }
+    }
+    reverse
+}

--- a/crates/repo/src/repository_symbol_graph_query.rs
+++ b/crates/repo/src/repository_symbol_graph_query.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Parse-free reconstruction and lookup for persisted semantic edge deltas.
+
+use std::collections::{BTreeMap, HashSet};
+
+use objects::{
+    object::{BindingDelta, ContentHash, ResolvedSemanticEdge, StateId},
+    store::ObjectStore,
+};
+
+use crate::{HeddleError, Repository, Result};
+
+/// Fully reconstructed source-file → resolved-edge set for one state.
+pub type ResolvedSemanticEdgeSet = BTreeMap<String, Vec<ResolvedSemanticEdge>>;
+
+const MAX_BINDING_DELTA_DEPTH: usize = 65_536;
+
+impl Repository {
+    /// Load the edge delta directly attached through a state's semantic root.
+    pub fn semantic_edge_delta(&self, state_id: &StateId) -> Result<Option<BindingDelta>> {
+        let Some(root) = self.attached_semantic_index(state_id)? else {
+            return Ok(None);
+        };
+        root.binding_delta
+            .map(|hash| self.load_binding_delta(&hash))
+            .transpose()
+    }
+
+    /// Reconstruct the complete resolved edge set by overlaying parent deltas.
+    pub fn resolved_semantic_edges(
+        &self,
+        state_id: &StateId,
+    ) -> Result<Option<ResolvedSemanticEdgeSet>> {
+        let Some(root) = self.attached_semantic_index(state_id)? else {
+            return Ok(None);
+        };
+        root.binding_delta
+            .map(|hash| self.materialize_binding_delta(&hash))
+            .transpose()
+    }
+
+    /// Resolve one source-local occurrence from the persisted graph.
+    pub fn resolved_semantic_occurrence(
+        &self,
+        state_id: &StateId,
+        source_path: &str,
+        source_occurrence: u32,
+    ) -> Result<Option<ResolvedSemanticEdge>> {
+        Ok(self
+            .resolved_semantic_edges(state_id)?
+            .and_then(|edges| edges.get(source_path).cloned())
+            .and_then(|edges| {
+                edges
+                    .into_iter()
+                    .find(|edge| edge.source_occurrence == source_occurrence)
+            }))
+    }
+
+    pub(crate) fn load_binding_delta(&self, hash: &ContentHash) -> Result<BindingDelta> {
+        let blob = self
+            .store()
+            .get_blob(hash)?
+            .ok_or_else(|| HeddleError::NotFound(format!("semantic binding delta {hash}")))?;
+        BindingDelta::decode(blob.content())
+            .map_err(|err| HeddleError::InvalidObject(err.to_string()))
+    }
+
+    pub(crate) fn materialize_binding_delta(
+        &self,
+        head: &ContentHash,
+    ) -> Result<ResolvedSemanticEdgeSet> {
+        let mut chain = Vec::new();
+        let mut seen = HashSet::new();
+        let mut cursor = Some(*head);
+        while let Some(hash) = cursor {
+            if chain.len() >= MAX_BINDING_DELTA_DEPTH {
+                return Err(HeddleError::InvalidObject(format!(
+                    "semantic binding delta chain exceeds max depth {MAX_BINDING_DELTA_DEPTH}"
+                )));
+            }
+            if !seen.insert(hash) {
+                return Err(HeddleError::InvalidObject(
+                    "semantic binding delta chain contains a cycle".to_string(),
+                ));
+            }
+            let delta = self.load_binding_delta(&hash)?;
+            cursor = delta.parent;
+            chain.push(delta);
+        }
+
+        let mut edges = BTreeMap::new();
+        for delta in chain.into_iter().rev() {
+            for file in delta.files {
+                if file.file_node.is_some() {
+                    edges.insert(file.path, file.replace_edges);
+                } else {
+                    edges.remove(&file.path);
+                }
+            }
+        }
+        Ok(edges)
+    }
+}

--- a/crates/repo/src/repository_symbol_graph_tests.rs
+++ b/crates/repo/src/repository_symbol_graph_tests.rs
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::BTreeSet;
+
+use objects::{
+    object::{Attribution, OccurrenceRole, Principal, StateId},
+    store::ObjectStore,
+};
+use tempfile::TempDir;
+
+use crate::{Repository, ResolvedSemanticEdgeSet};
+
+fn repo() -> (TempDir, Repository) {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    (temp, repo)
+}
+
+fn snapshot(repo: &Repository, temp: &TempDir, files: &[(&str, &str)]) -> StateId {
+    for (path, content) in files {
+        let path = temp.path().join(path);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(path, content).unwrap();
+    }
+    repo.snapshot_with_attribution(
+        Some("semantic graph".to_string()),
+        None,
+        Attribution::human(Principal::new("Test", "test@example.com")),
+    )
+    .unwrap()
+    .id()
+}
+
+fn call_id(repo: &Repository, state: &StateId, path: &str, name: &str) -> u32 {
+    repo.semantic_file_node(state, path)
+        .unwrap()
+        .unwrap()
+        .occurrences
+        .into_iter()
+        .find(|occurrence| occurrence.role == OccurrenceRole::Call && occurrence.name == name)
+        .unwrap()
+        .local_id
+}
+
+fn overlay(
+    mut parent: ResolvedSemanticEdgeSet,
+    delta: objects::object::BindingDelta,
+) -> ResolvedSemanticEdgeSet {
+    for file in delta.files {
+        if file.file_node.is_some() {
+            parent.insert(file.path, file.replace_edges);
+        } else {
+            parent.remove(&file.path);
+        }
+    }
+    parent
+}
+
+#[test]
+fn rust_cross_file_roundtrip_and_frontier_delta_are_exact() {
+    let (temp, repo) = repo();
+    let first = snapshot(
+        &repo,
+        &temp,
+        &[
+            ("src/api.rs", "pub fn greet() -> u8 { 1 }\n"),
+            (
+                "src/client.rs",
+                "use crate::api::greet;\npub fn run() { greet(); missing(); }\n",
+            ),
+            (
+                "src/qualified.rs",
+                "pub fn run_qualified() { crate::api::greet(); }\n",
+            ),
+            ("src/stable_api.rs", "pub fn stable() {}\n"),
+            (
+                "src/stable_client.rs",
+                "use crate::stable_api::stable;\npub fn run_stable() { stable(); }\n",
+            ),
+        ],
+    );
+    let first_edges = repo.resolved_semantic_edges(&first).unwrap().unwrap();
+    let greet = call_id(&repo, &first, "src/client.rs", "greet");
+    let missing = call_id(&repo, &first, "src/client.rs", "missing");
+    assert_eq!(
+        repo.resolved_semantic_occurrence(&first, "src/client.rs", greet)
+            .unwrap()
+            .unwrap()
+            .target_path,
+        "src/api.rs"
+    );
+    assert!(
+        repo.resolved_semantic_occurrence(&first, "src/client.rs", missing)
+            .unwrap()
+            .is_none(),
+        "an unknown name must remain unresolved"
+    );
+
+    let second = snapshot(
+        &repo,
+        &temp,
+        &[("src/api.rs", "pub fn greet() -> u8 { 2 }\n")],
+    );
+    let second_edges = repo.resolved_semantic_edges(&second).unwrap().unwrap();
+    let delta = repo.semantic_edge_delta(&second).unwrap().unwrap();
+    let delta_paths = delta
+        .files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        delta_paths,
+        BTreeSet::from(["src/api.rs", "src/client.rs", "src/qualified.rs"]),
+        "only the changed file and its importer belong to the frontier"
+    );
+    assert_eq!(overlay(first_edges.clone(), delta), second_edges);
+    assert_eq!(
+        first_edges["src/stable_client.rs"], second_edges["src/stable_client.rs"],
+        "unrelated unchanged edges are inherited, not re-stored"
+    );
+
+    let first_root = repo.attached_semantic_index(&first).unwrap().unwrap();
+    let second_root = repo.attached_semantic_index(&second).unwrap().unwrap();
+    let second_delta = repo
+        .load_binding_delta(&second_root.binding_delta.unwrap())
+        .unwrap();
+    assert_eq!(second_delta.parent, first_root.binding_delta);
+    assert!(
+        repo.store()
+            .has_blob(&second_root.binding_delta.unwrap())
+            .unwrap(),
+        "the attached delta is a content-addressed blob"
+    );
+}
+
+#[test]
+fn typescript_named_import_resolves_across_files() {
+    let (temp, repo) = repo();
+    let state = snapshot(
+        &repo,
+        &temp,
+        &[
+            ("src/api.ts", "export function greet(): void {}\n"),
+            (
+                "src/client.ts",
+                "import { greet as hello } from './api';\nexport function run() { hello(); unknown(); }\n",
+            ),
+        ],
+    );
+    let hello = call_id(&repo, &state, "src/client.ts", "hello");
+    let unknown = call_id(&repo, &state, "src/client.ts", "unknown");
+    assert_eq!(
+        repo.resolved_semantic_occurrence(&state, "src/client.ts", hello)
+            .unwrap()
+            .unwrap()
+            .target_path,
+        "src/api.ts"
+    );
+    assert!(
+        repo.resolved_semantic_occurrence(&state, "src/client.ts", unknown)
+            .unwrap()
+            .is_none()
+    );
+}

--- a/crates/semantic/src/cross_file_resolution/mod.rs
+++ b/crates/semantic/src/cross_file_resolution/mod.rs
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic repository-level binding over persisted per-file facts.
+
+mod rust;
+mod scope;
+mod typescript;
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use objects::object::{
+    ContentHash, ImportBinding, ImportEntry, OccurrenceEntry, OccurrenceRole, ResolvedSemanticEdge,
+    SemanticEdgeKind, SemanticFileNode, SymbolKindTag, SymbolNamespace,
+};
+
+/// Bump whenever binding policy changes so persisted edges rebuild cleanly.
+pub const RESOLVER_VERSION: u32 = 1;
+
+/// One content-addressed semantic file placed at a repository path.
+#[derive(Clone, Debug)]
+pub struct RepositorySemanticFile {
+    pub node_hash: ContentHash,
+    pub node: SemanticFileNode,
+}
+
+/// Resolution output for one source file.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FileResolution {
+    /// Repository files named by resolvable imports from this file.
+    pub dependencies: BTreeSet<String>,
+    /// Successfully bound occurrences. Unresolved occurrences are absent.
+    pub edges: Vec<ResolvedSemanticEdge>,
+}
+
+/// Resolve Rust and TypeScript/JavaScript occurrences across repository files.
+///
+/// Binding is deliberately conservative: ambiguous definitions and imports
+/// remain unresolved rather than selecting a target by iteration order.
+pub fn resolve_repository(
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> BTreeMap<String, FileResolution> {
+    files
+        .iter()
+        .map(|(path, file)| {
+            let mut dependencies = dependencies_for(path, &file.node, files);
+            let mut edges = file
+                .node
+                .occurrences
+                .iter()
+                .filter(|occurrence| occurrence.role != OccurrenceRole::Definition)
+                .filter_map(|occurrence| resolve_occurrence(path, file, occurrence, files))
+                .collect::<Vec<_>>();
+            edges.sort();
+            edges.dedup();
+            dependencies.extend(
+                edges
+                    .iter()
+                    .filter(|edge| edge.target_path != *path)
+                    .map(|edge| edge.target_path.clone()),
+            );
+            (
+                path.clone(),
+                FileResolution {
+                    dependencies,
+                    edges,
+                },
+            )
+        })
+        .collect()
+}
+
+fn dependencies_for(
+    source_path: &str,
+    source: &SemanticFileNode,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> BTreeSet<String> {
+    source
+        .imports
+        .iter()
+        .filter_map(|import| resolve_module(source_path, source, &import.module_specifier, files))
+        .collect()
+}
+
+fn resolve_occurrence(
+    source_path: &str,
+    source: &RepositorySemanticFile,
+    occurrence: &OccurrenceEntry,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> Option<ResolvedSemanticEdge> {
+    let target = if occurrence.qualifier.is_empty() {
+        definition(files, source_path, &occurrence.name, occurrence.namespace).or_else(|| {
+            if local_definition_shadows(&source.node, occurrence) {
+                None
+            } else {
+                resolve_imported_name(source_path, &source.node, occurrence, files)
+            }
+        })
+    } else {
+        resolve_qualified_name(source_path, &source.node, occurrence, files)
+    }?;
+    Some(ResolvedSemanticEdge {
+        source_occurrence: occurrence.local_id,
+        target_path: target.path,
+        target_file_node: target.file_node,
+        target_definition: target.definition,
+        kind: match occurrence.role {
+            OccurrenceRole::Call => SemanticEdgeKind::Calls,
+            OccurrenceRole::TypeReference => SemanticEdgeKind::TypeRef,
+            OccurrenceRole::Reference => SemanticEdgeKind::RefersTo,
+            OccurrenceRole::Definition => return None,
+        },
+    })
+}
+
+fn resolve_imported_name(
+    source_path: &str,
+    source: &SemanticFileNode,
+    occurrence: &OccurrenceEntry,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> Option<Target> {
+    let candidates = visible_bindings(source, occurrence, &occurrence.name)
+        .filter(|(_, binding)| binding.local == occurrence.name && binding.imported != "*")
+        .filter_map(|(import, binding)| {
+            let path = resolve_module(source_path, source, &import.module_specifier, files)?;
+            definition(files, &path, &binding.imported, occurrence.namespace)
+        })
+        .collect::<BTreeSet<_>>();
+    exactly_one(candidates)
+}
+
+fn resolve_qualified_name(
+    source_path: &str,
+    source: &SemanticFileNode,
+    occurrence: &OccurrenceEntry,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> Option<Target> {
+    let first = occurrence.qualifier.first()?;
+    let imported = visible_bindings(source, occurrence, first)
+        .filter(|(_, binding)| binding.local == *first)
+        .filter(|(_, binding)| binding.imported == "*" || source.language == "rust")
+        .filter_map(|(import, binding)| {
+            let specifier = if source.language == "rust" && binding.imported != "*" {
+                format!("{}::{}", import.module_specifier, binding.imported)
+            } else {
+                import.module_specifier.clone()
+            };
+            resolve_module(source_path, source, &specifier, files)
+        })
+        .collect::<BTreeSet<_>>();
+    let path = exactly_one(imported).or_else(|| {
+        (source.language == "rust" && matches!(first.as_str(), "crate" | "self" | "super"))
+            .then(|| occurrence.qualifier.join("::"))
+            .and_then(|qualifier| resolve_module(source_path, source, &qualifier, files))
+    })?;
+    definition(files, &path, &occurrence.name, occurrence.namespace)
+}
+
+fn visible_bindings<'a>(
+    source: &'a SemanticFileNode,
+    occurrence: &'a OccurrenceEntry,
+    local_name: &'a str,
+) -> impl Iterator<Item = (&'a ImportEntry, &'a ImportBinding)> {
+    let occurrence_namespace = occurrence.namespace;
+    let nearest = source
+        .imports
+        .iter()
+        .filter(|import| {
+            scope::contains(source, import.scope, occurrence.scope)
+                && import.bindings.iter().any(|binding| {
+                    binding.local == local_name
+                        && namespaces_overlap(binding.namespace, occurrence.namespace)
+                })
+        })
+        .map(|import| scope::depth(source, import.scope))
+        .max();
+    source
+        .imports
+        .iter()
+        .filter(move |import| {
+            nearest.is_some_and(|depth| {
+                scope::contains(source, import.scope, occurrence.scope)
+                    && scope::depth(source, import.scope) == depth
+            })
+        })
+        .flat_map(move |import| {
+            import
+                .bindings
+                .iter()
+                .filter(move |binding| namespaces_overlap(binding.namespace, occurrence_namespace))
+                .map(move |binding| (import, binding))
+        })
+}
+
+fn local_definition_shadows(source: &SemanticFileNode, occurrence: &OccurrenceEntry) -> bool {
+    source.occurrences.iter().any(|candidate| {
+        candidate.role == OccurrenceRole::Definition
+            && candidate.name == occurrence.name
+            && namespaces_overlap(candidate.namespace, occurrence.namespace)
+            && candidate.span.start <= occurrence.span.start
+            && scope::contains(source, candidate.scope, occurrence.scope)
+    })
+}
+
+fn resolve_module(
+    source_path: &str,
+    source: &SemanticFileNode,
+    specifier: &str,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> Option<String> {
+    let candidates = match source.language.as_str() {
+        "rust" => rust::module_candidates(source_path, specifier),
+        "typescript" | "javascript" => typescript::module_candidates(source_path, specifier),
+        _ => Vec::new(),
+    };
+    candidates
+        .into_iter()
+        .find(|candidate| files.contains_key(candidate))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Target {
+    path: String,
+    file_node: ContentHash,
+    definition: u32,
+}
+
+fn definition(
+    files: &BTreeMap<String, RepositorySemanticFile>,
+    path: &str,
+    name: &str,
+    namespace: SymbolNamespace,
+) -> Option<Target> {
+    let file = files.get(path)?;
+    let candidates = file
+        .node
+        .symbols
+        .iter()
+        .enumerate()
+        .filter(|(_, symbol)| symbol.container_path.is_empty() && symbol.name == name)
+        .filter(|(_, symbol)| namespaces_overlap(symbol_namespace(symbol.kind), namespace))
+        .map(|(index, _)| Target {
+            path: path.to_string(),
+            file_node: file.node_hash,
+            definition: index as u32,
+        })
+        .collect::<BTreeSet<_>>();
+    exactly_one(candidates)
+}
+
+fn symbol_namespace(kind: SymbolKindTag) -> SymbolNamespace {
+    match kind {
+        SymbolKindTag::Function | SymbolKindTag::Const | SymbolKindTag::Other => {
+            SymbolNamespace::Value
+        }
+        SymbolKindTag::Type
+        | SymbolKindTag::Enum
+        | SymbolKindTag::Trait
+        | SymbolKindTag::Class
+        | SymbolKindTag::Interface
+        | SymbolKindTag::TypeAlias => SymbolNamespace::Type,
+        SymbolKindTag::Module => SymbolNamespace::Both,
+    }
+}
+
+fn namespaces_overlap(a: SymbolNamespace, b: SymbolNamespace) -> bool {
+    a == SymbolNamespace::Both || b == SymbolNamespace::Both || a == b
+}
+
+fn exactly_one<T: Ord>(values: BTreeSet<T>) -> Option<T> {
+    if values.len() == 1 {
+        values.into_iter().next()
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/semantic/src/cross_file_resolution/rust.rs
+++ b/crates/semantic/src/cross_file_resolution/rust.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Component, Path, PathBuf};
+
+pub(super) fn module_candidates(source_path: &str, specifier: &str) -> Vec<String> {
+    let source = Path::new(source_path);
+    let root = crate_root(source);
+    let module_dir = module_dir(source);
+    let mut segments = specifier.split("::").filter(|part| !part.is_empty());
+    let first = segments.next();
+    let mut base = match first {
+        Some("crate") => root,
+        Some("self") => module_dir,
+        Some("super") => {
+            let mut base = module_dir;
+            base.pop();
+            base
+        }
+        Some(segment) => {
+            let mut base = root;
+            base.push(segment);
+            base
+        }
+        None => return Vec::new(),
+    };
+    for segment in segments {
+        if segment == "super" {
+            base.pop();
+        } else if segment != "self" {
+            base.push(segment);
+        }
+    }
+    candidates(base, &["rs"])
+}
+
+fn crate_root(path: &Path) -> PathBuf {
+    let components = path.components().collect::<Vec<_>>();
+    let src = components
+        .iter()
+        .rposition(|component| component.as_os_str() == "src");
+    match src {
+        Some(index) => components[..=index].iter().collect(),
+        None => PathBuf::new(),
+    }
+}
+
+fn module_dir(path: &Path) -> PathBuf {
+    let mut dir = path.parent().unwrap_or_else(|| Path::new("")).to_path_buf();
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("");
+    if !matches!(stem, "lib" | "main" | "mod") {
+        dir.push(stem);
+    }
+    dir
+}
+
+fn candidates(base: PathBuf, extensions: &[&str]) -> Vec<String> {
+    let normalized = normalize(base);
+    let mut out = extensions
+        .iter()
+        .map(|extension| normalized.with_extension(extension))
+        .collect::<Vec<_>>();
+    out.extend(
+        extensions
+            .iter()
+            .map(|extension| normalized.join(format!("mod.{extension}"))),
+    );
+    out.into_iter()
+        .filter_map(|path| path.to_str().map(str::to_string))
+        .collect()
+}
+
+fn normalize(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_crate_and_super_modules() {
+        assert_eq!(
+            module_candidates("src/client.rs", "crate::api")[0],
+            "src/api.rs"
+        );
+        assert_eq!(
+            module_candidates("src/client/worker.rs", "super::api")[0],
+            "src/client/api.rs"
+        );
+    }
+}

--- a/crates/semantic/src/cross_file_resolution/scope.rs
+++ b/crates/semantic/src/cross_file_resolution/scope.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use objects::object::SemanticFileNode;
+
+pub(super) fn contains(source: &SemanticFileNode, ancestor: u32, mut scope: u32) -> bool {
+    loop {
+        if scope == ancestor {
+            return true;
+        }
+        let Some(parent) = source
+            .scopes
+            .iter()
+            .find(|entry| entry.local_id == scope)
+            .and_then(|entry| entry.parent)
+        else {
+            return false;
+        };
+        scope = parent;
+    }
+}
+
+pub(super) fn depth(source: &SemanticFileNode, mut scope: u32) -> usize {
+    let mut depth = 0;
+    while let Some(parent) = source
+        .scopes
+        .iter()
+        .find(|entry| entry.local_id == scope)
+        .and_then(|entry| entry.parent)
+    {
+        depth += 1;
+        scope = parent;
+    }
+    depth
+}

--- a/crates/semantic/src/cross_file_resolution/tests.rs
+++ b/crates/semantic/src/cross_file_resolution/tests.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use objects::object::{ContentHash, SemanticFileFacts, SemanticFileNode};
+
+use super::*;
+use crate::{
+    parser::Language,
+    semantic_index::{EXTRACTOR_VERSION, extract_semantic_file, grammar_version, language_name},
+};
+
+fn file(source: &str, language: Language) -> RepositorySemanticFile {
+    let extracted = extract_semantic_file(source.as_bytes(), language).expect("source parses");
+    let source_hash = ContentHash::compute(source.as_bytes());
+    let node = SemanticFileNode::new(
+        language_name(language),
+        grammar_version(language),
+        EXTRACTOR_VERSION,
+        source_hash,
+        extracted.scaffold_hash,
+        SemanticFileFacts {
+            symbols: extracted.symbols,
+            scopes: extracted.scopes,
+            imports: extracted.imports,
+            occurrences: extracted.occurrences,
+        },
+    );
+    let node_hash = ContentHash::compute(&node.encode().unwrap());
+    RepositorySemanticFile { node_hash, node }
+}
+
+#[test]
+fn rust_imported_call_resolves_and_missing_name_stays_unresolved() {
+    let mut files = BTreeMap::new();
+    files.insert(
+        "src/api.rs".to_string(),
+        file("pub fn greet() {}\n", Language::Rust),
+    );
+    files.insert(
+        "src/client.rs".to_string(),
+        file(
+            "use crate::api::greet;\nfn run() { greet(); missing(); }\n",
+            Language::Rust,
+        ),
+    );
+
+    let resolution = resolve_repository(&files);
+    let client = &resolution["src/client.rs"];
+    assert_eq!(
+        client.dependencies,
+        BTreeSet::from(["src/api.rs".to_string()])
+    );
+    assert_eq!(
+        client.edges.len(),
+        1,
+        "missing must not bind to another name"
+    );
+    assert_eq!(client.edges[0].target_path, "src/api.rs");
+    let target = &files["src/api.rs"].node.symbols[client.edges[0].target_definition as usize];
+    assert_eq!(target.name, "greet");
+}
+
+#[test]
+fn rust_qualified_path_resolves() {
+    let mut files = BTreeMap::new();
+    files.insert(
+        "src/api.rs".to_string(),
+        file("pub fn greet() {}\n", Language::Rust),
+    );
+    files.insert(
+        "src/qualified.rs".to_string(),
+        file("fn run() { crate::api::greet(); }\n", Language::Rust),
+    );
+    let resolution = resolve_repository(&files);
+    assert_eq!(resolution["src/qualified.rs"].edges.len(), 1);
+    assert_eq!(
+        resolution["src/qualified.rs"].edges[0].target_path,
+        "src/api.rs"
+    );
+}
+
+#[cfg(feature = "lang-typescript")]
+#[test]
+fn typescript_aliased_import_resolves_across_files() {
+    let mut files = BTreeMap::new();
+    files.insert(
+        "src/api.ts".to_string(),
+        file("export function greet() {}\n", Language::TypeScript),
+    );
+    files.insert(
+        "src/client.ts".to_string(),
+        file(
+            "import { greet as hello } from './api';\nexport function run() { hello(); }\n",
+            Language::TypeScript,
+        ),
+    );
+
+    let resolution = resolve_repository(&files);
+    let client = &resolution["src/client.ts"];
+    assert_eq!(client.edges.len(), 1);
+    assert_eq!(client.edges[0].target_path, "src/api.ts");
+    let target = &files["src/api.ts"].node.symbols[client.edges[0].target_definition as usize];
+    assert_eq!(target.name, "greet");
+}

--- a/crates/semantic/src/cross_file_resolution/typescript.rs
+++ b/crates/semantic/src/cross_file_resolution/typescript.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Component, Path, PathBuf};
+
+const EXTENSIONS: [&str; 4] = ["ts", "tsx", "js", "jsx"];
+
+pub(super) fn module_candidates(source_path: &str, specifier: &str) -> Vec<String> {
+    if !specifier.starts_with('.') {
+        return Vec::new();
+    }
+    let base = normalize(
+        Path::new(source_path)
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join(specifier),
+    );
+    let mut out = Vec::new();
+    if base.extension().is_some() {
+        push(&mut out, &base);
+    } else {
+        for extension in EXTENSIONS {
+            push(&mut out, &base.with_extension(extension));
+        }
+        for extension in EXTENSIONS {
+            push(&mut out, &base.join(format!("index.{extension}")));
+        }
+    }
+    out
+}
+
+fn push(out: &mut Vec<String>, path: &Path) {
+    if let Some(path) = path.to_str() {
+        out.push(path.to_string());
+    }
+}
+
+fn normalize(path: PathBuf) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolves_relative_modules_and_index_files() {
+        let candidates = module_candidates("src/client/main.ts", "../api");
+        assert_eq!(candidates[0], "src/api.ts");
+        assert!(candidates.contains(&"src/api/index.ts".to_string()));
+        assert!(module_candidates("src/main.ts", "react").is_empty());
+    }
+}

--- a/crates/semantic/src/lib.rs
+++ b/crates/semantic/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod analysis;
 pub mod cache;
+pub mod cross_file_resolution;
 pub mod diff;
 pub mod merge_driver;
 pub mod parser;

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -3,7 +3,7 @@ use std::collections::{HashSet, VecDeque};
 
 use objects::{
     object::{
-        ContentHash, SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State,
+        BindingDelta, ContentHash, SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State,
         StateAttachment, StateAttachmentBody, StateAttachmentId, StateAttachmentKind, StateId,
         TreeEntryTarget,
     },
@@ -579,6 +579,9 @@ fn walk_semantic_index_closure(
                     // Emit the leaf (file node) blob; it has no children.
                     emit_semantic_blob(store, hash, excluded, seen, visit)?;
                 }
+                SemanticChild::BindingDelta(hash) => {
+                    walk_binding_delta_closure(store, hash, excluded, seen, visit)?;
+                }
             }
         }
     }
@@ -590,6 +593,7 @@ fn walk_semantic_index_closure(
 enum SemanticChild {
     Interior(ContentHash),
     Leaf(ContentHash),
+    BindingDelta(ContentHash),
 }
 
 /// Decode a semantic-closure node — the root (which points at a tree node) or a
@@ -602,7 +606,11 @@ fn decode_semantic_container(
     // tree-node shape. Content-addressed hashes make this unambiguous in
     // practice; a blob that decodes as neither is corrupt.
     if let Ok(root) = SemanticIndexRoot::decode(blob.content()) {
-        return Ok(vec![SemanticChild::Interior(root.tree)]);
+        let mut children = vec![SemanticChild::Interior(root.tree)];
+        if let Some(binding_delta) = root.binding_delta {
+            children.push(SemanticChild::BindingDelta(binding_delta));
+        }
+        return Ok(children);
     }
     let node = SemanticTreeNode::decode(blob.content())
         .map_err(|err| ProtocolError::Serialization(format!("semantic node {node_hash}: {err}")))?;
@@ -616,6 +624,30 @@ fn decode_semantic_container(
             SemanticEntryKind::Opaque => None,
         })
         .collect())
+}
+
+fn walk_binding_delta_closure(
+    store: &impl ObjectStore,
+    head: ContentHash,
+    excluded: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<()> {
+    let mut cursor = Some(head);
+    while let Some(hash) = cursor {
+        if !emit_semantic_blob(store, hash, excluded, seen, visit)? {
+            break;
+        }
+        let blob = store
+            .get_blob(&hash)?
+            .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
+        cursor = BindingDelta::decode(blob.content())
+            .map_err(|err| {
+                ProtocolError::Serialization(format!("semantic binding delta {hash}: {err}"))
+            })?
+            .parent;
+    }
+    Ok(())
 }
 
 /// Emit a semantic node blob as state metadata. Returns `true` when the blob
@@ -673,8 +705,32 @@ fn collect_semantic_hashes(
                 SemanticChild::Leaf(hash) => {
                     excluded.insert(hash);
                 }
+                SemanticChild::BindingDelta(hash) => {
+                    collect_binding_delta_hashes(store, hash, excluded)?;
+                }
             }
         }
+    }
+    Ok(())
+}
+
+fn collect_binding_delta_hashes(
+    store: &impl ObjectStore,
+    head: ContentHash,
+    excluded: &mut HashSet<ContentHash>,
+) -> Result<()> {
+    let mut cursor = Some(head);
+    while let Some(hash) = cursor {
+        if !excluded.insert(hash) {
+            break;
+        }
+        let Some(blob) = store.get_blob(&hash)? else {
+            break;
+        };
+        cursor = match BindingDelta::decode(blob.content()) {
+            Ok(delta) => delta.parent,
+            Err(_) => break,
+        };
     }
     Ok(())
 }
@@ -1905,7 +1961,7 @@ mod tests {
     fn semantic_index_attachment_excluded_from_push_pack_but_kept_for_pull() {
         use std::collections::BTreeMap;
 
-        use objects::object::{SemanticIndexRoot, SemanticTreeNode};
+        use objects::object::{BindingDelta, SemanticIndexRoot, SemanticTreeNode};
 
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
@@ -1918,7 +1974,18 @@ mod tests {
             .store()
             .put_blob(&Blob::new(node.encode().unwrap()))
             .expect("put semantic tree node");
-        let root = SemanticIndexRoot::new(1, BTreeMap::new(), node_hash, node_digest);
+        let base_delta = BindingDelta::new(None, Vec::new());
+        let base_delta_hash = repo
+            .store()
+            .put_blob(&Blob::new(base_delta.encode().unwrap()))
+            .expect("put base binding delta");
+        let delta = BindingDelta::new(Some(base_delta_hash), Vec::new());
+        let delta_hash = repo
+            .store()
+            .put_blob(&Blob::new(delta.encode().unwrap()))
+            .expect("put binding delta");
+        let root = SemanticIndexRoot::new(1, BTreeMap::new(), node_hash, node_digest)
+            .with_binding_delta(delta_hash, 1);
         let root_hash = repo
             .store()
             .put_blob(&Blob::new(root.encode().unwrap()))
@@ -1965,7 +2032,7 @@ mod tests {
         // The semantic-index CONTENT blobs are ordinary content-addressed
         // objects and still ride the pack in both directions — only the
         // attachment record is sidecar'd on push.
-        for content in [root_hash, node_hash] {
+        for content in [root_hash, node_hash, delta_hash, base_delta_hash] {
             let obj = plan
                 .iter()
                 .find(|p| p.id == ObjectId::Hash(content))

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -580,7 +580,12 @@ fn walk_semantic_index_closure(
                     emit_semantic_blob(store, hash, excluded, seen, visit)?;
                 }
                 SemanticChild::BindingDelta(hash) => {
-                    walk_binding_delta_closure(store, hash, excluded, seen, visit)?;
+                    // Binding deltas are state-scoped attachments. Emit this
+                    // state's direct delta; ancestor states contribute their
+                    // own deltas when (and only when) the state walk reaches
+                    // them. Following `delta.parent` here would cross a
+                    // shallow-clone boundary.
+                    emit_binding_delta(store, hash, excluded, seen, visit)?;
                 }
             }
         }
@@ -588,8 +593,7 @@ fn walk_semantic_index_closure(
     Ok(())
 }
 
-/// The two child kinds encountered walking the semantic closure: an interior
-/// node to descend into, or a leaf (file node) blob to emit.
+/// Child kinds encountered while walking a state's semantic closure.
 enum SemanticChild {
     Interior(ContentHash),
     Leaf(ContentHash),
@@ -626,27 +630,22 @@ fn decode_semantic_container(
         .collect())
 }
 
-fn walk_binding_delta_closure(
+fn emit_binding_delta(
     store: &impl ObjectStore,
-    head: ContentHash,
+    hash: ContentHash,
     excluded: &HashSet<ContentHash>,
     seen: &mut HashSet<ContentHash>,
     visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
 ) -> Result<()> {
-    let mut cursor = Some(head);
-    while let Some(hash) = cursor {
-        if !emit_semantic_blob(store, hash, excluded, seen, visit)? {
-            break;
-        }
-        let blob = store
-            .get_blob(&hash)?
-            .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
-        cursor = BindingDelta::decode(blob.content())
-            .map_err(|err| {
-                ProtocolError::Serialization(format!("semantic binding delta {hash}: {err}"))
-            })?
-            .parent;
+    if !emit_semantic_blob(store, hash, excluded, seen, visit)? {
+        return Ok(());
     }
+    let blob = store
+        .get_blob(&hash)?
+        .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
+    BindingDelta::decode(blob.content()).map_err(|err| {
+        ProtocolError::Serialization(format!("semantic binding delta {hash}: {err}"))
+    })?;
     Ok(())
 }
 
@@ -706,31 +705,10 @@ fn collect_semantic_hashes(
                     excluded.insert(hash);
                 }
                 SemanticChild::BindingDelta(hash) => {
-                    collect_binding_delta_hashes(store, hash, excluded)?;
+                    excluded.insert(hash);
                 }
             }
         }
-    }
-    Ok(())
-}
-
-fn collect_binding_delta_hashes(
-    store: &impl ObjectStore,
-    head: ContentHash,
-    excluded: &mut HashSet<ContentHash>,
-) -> Result<()> {
-    let mut cursor = Some(head);
-    while let Some(hash) = cursor {
-        if !excluded.insert(hash) {
-            break;
-        }
-        let Some(blob) = store.get_blob(&hash)? else {
-            break;
-        };
-        cursor = match BindingDelta::decode(blob.content()) {
-            Ok(delta) => delta.parent,
-            Err(_) => break,
-        };
     }
     Ok(())
 }
@@ -1539,6 +1517,10 @@ mod tests {
 
     #[test]
     fn depth_and_exclude_options_match_between_full_and_plan() {
+        use std::collections::BTreeMap;
+
+        use objects::object::{BindingDelta, SemanticIndexRoot, SemanticTreeNode};
+
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         let path = temp.path().join("story.txt");
@@ -1549,6 +1531,38 @@ mod tests {
         let middle = repo.snapshot(Some("middle".to_string()), None).unwrap();
         std::fs::write(&path, "tip\n").unwrap();
         let tip = repo.snapshot(Some("tip".to_string()), None).unwrap();
+
+        let (semantic_tree, semantic_digest) = SemanticTreeNode::new(Vec::new());
+        let semantic_tree_hash = repo
+            .store()
+            .put_blob(&Blob::new(semantic_tree.encode().unwrap()))
+            .unwrap();
+        let attach_delta = |state: StateId, parent: Option<ContentHash>| {
+            let delta = BindingDelta::new(parent, Vec::new());
+            let delta_hash = repo
+                .store()
+                .put_blob(&Blob::new(delta.encode().unwrap()))
+                .unwrap();
+            let root =
+                SemanticIndexRoot::new(1, BTreeMap::new(), semantic_tree_hash, semantic_digest)
+                    .with_binding_delta(delta_hash, 1);
+            let root_hash = repo
+                .store()
+                .put_blob(&Blob::new(root.encode().unwrap()))
+                .unwrap();
+            repo.put_state_attachment(&StateAttachment {
+                state_id: state,
+                body: StateAttachmentBody::SemanticIndex(root_hash),
+                attribution: test_attribution(),
+                created_at: Utc::now(),
+                supersedes: None,
+            })
+            .unwrap();
+            delta_hash
+        };
+        let base_delta = attach_delta(base.state_id, None);
+        let middle_delta = attach_delta(middle.state_id, Some(base_delta));
+        let tip_delta = attach_delta(tip.state_id, Some(middle_delta));
 
         let depth_zero = assert_plan_parity(
             &repo,
@@ -1561,6 +1575,9 @@ mod tests {
         assert!(depth_zero.contains(&(ObjectId::StateId(tip.state_id), ObjectType::State)));
         assert!(!depth_zero.contains(&(ObjectId::StateId(middle.state_id), ObjectType::State)));
         assert!(!depth_zero.contains(&(ObjectId::StateId(base.state_id), ObjectType::State)));
+        assert!(depth_zero.contains(&(ObjectId::Hash(tip_delta), ObjectType::Blob)));
+        assert!(!depth_zero.contains(&(ObjectId::Hash(middle_delta), ObjectType::Blob)));
+        assert!(!depth_zero.contains(&(ObjectId::Hash(base_delta), ObjectType::Blob)));
 
         let depth_one = assert_plan_parity(
             &repo,
@@ -1573,6 +1590,9 @@ mod tests {
         assert!(depth_one.contains(&(ObjectId::StateId(tip.state_id), ObjectType::State)));
         assert!(depth_one.contains(&(ObjectId::StateId(middle.state_id), ObjectType::State)));
         assert!(!depth_one.contains(&(ObjectId::StateId(base.state_id), ObjectType::State)));
+        assert!(depth_one.contains(&(ObjectId::Hash(tip_delta), ObjectType::Blob)));
+        assert!(depth_one.contains(&(ObjectId::Hash(middle_delta), ObjectType::Blob)));
+        assert!(!depth_one.contains(&(ObjectId::Hash(base_delta), ObjectType::Blob)));
 
         let exclude_middle = assert_plan_parity(
             &repo,
@@ -1961,7 +1981,9 @@ mod tests {
     fn semantic_index_attachment_excluded_from_push_pack_but_kept_for_pull() {
         use std::collections::BTreeMap;
 
-        use objects::object::{BindingDelta, SemanticIndexRoot, SemanticTreeNode};
+        use objects::object::{
+            BindingDelta, FileBindingDelta, SemanticIndexRoot, SemanticTreeNode,
+        };
 
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
@@ -1974,7 +1996,14 @@ mod tests {
             .store()
             .put_blob(&Blob::new(node.encode().unwrap()))
             .expect("put semantic tree node");
-        let base_delta = BindingDelta::new(None, Vec::new());
+        let base_delta = BindingDelta::new(
+            None,
+            vec![FileBindingDelta::new(
+                "unreachable-parent.rs",
+                None,
+                Vec::new(),
+            )],
+        );
         let base_delta_hash = repo
             .store()
             .put_blob(&Blob::new(base_delta.encode().unwrap()))
@@ -2032,7 +2061,7 @@ mod tests {
         // The semantic-index CONTENT blobs are ordinary content-addressed
         // objects and still ride the pack in both directions — only the
         // attachment record is sidecar'd on push.
-        for content in [root_hash, node_hash, delta_hash, base_delta_hash] {
+        for content in [root_hash, node_hash, delta_hash] {
             let obj = plan
                 .iter()
                 .find(|p| p.id == ObjectId::Hash(content))
@@ -2041,6 +2070,12 @@ mod tests {
             assert!(obj.obj_type.packable_for_push());
             assert!(obj.obj_type.packable_for_pull());
         }
+        assert!(
+            !plan
+                .iter()
+                .any(|object| object.id == ObjectId::Hash(base_delta_hash)),
+            "a binding delta belonging to an unreachable parent state must not ride this state's closure"
+        );
 
         // Partitioning the plan by push-packability puts the record on the
         // sidecar side and never in the pack side.


### PR DESCRIPTION
Closes #1274

## Summary

- resolve Rust and TypeScript/JavaScript references against the persisted per-file definitions, imports, scopes, and occurrences
- persist canonical content-addressed binding deltas through the semantic-index state attachment, inheriting unrelated unchanged files from the first parent
- reconstruct complete edge sets without parsing source and carry binding-delta closure objects through wire sync

The invalidation frontier follows the #1272 resolver-extension decision: it includes changed/deleted files plus their transitive importers from the old and new dependency views. Unrelated unchanged file edges remain inherited. Ambiguous or missing definitions remain unresolved.

## Evidence

- Round-trip and delta correctness: `repository_symbol_graph_tests::rust_cross_file_roundtrip_and_frontier_delta_are_exact`
- Cross-file Rust and unresolved behavior: `cross_file_resolution::tests::rust_imported_call_resolves_and_missing_name_stays_unresolved`
- Cross-file qualified Rust: `cross_file_resolution::tests::rust_qualified_path_resolves`
- Cross-file TypeScript aliases and unresolved behavior: `repository_symbol_graph_tests::typescript_named_import_resolves_across_files`
- Binding object codec: `semantic_edges::tests::binding_delta_roundtrips_and_canonicalizes`
- Wire closure coverage: `object_graph::tests::semantic_index_attachment_excluded_from_push_pack_but_kept_for_pull`
- `cargo build --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked --workspace --lib --bins`
- `cargo test --locked -p heddle-semantic -p heddle-repo --all-features` (semantic: 312 passed; repo: 674 passed plus integrations)
- Feature matrices: repo native/git-overlay, CLI native/git-overlay, telemetry build and telemetry clippy all passed
- CLI telemetry integration matrix: 902 passed, 19 ignored; the three monitor/inotify cases affected by concurrent host FD exhaustion each passed serially in their required default mode
- `rustfmt +nightly --edition 2024 --config skip_children=true --check` on all touched Rust files
- Commit: `a9a0298b67c49b1b7330517815bf413f0c0a7d91`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1304"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788926565&installation_model_id=21489&pr_number=1304&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1304&signature=0a8ea5d9bc9da37d78f9eeac76a83ca9f1d5a1b4e2569cc7f2f85829bba4e720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->