### PR TITLE
refactor(core): move diff onto RenameCandidateIndex (part of #1262)

### DIFF
--- a/crates/core/src/diff/mod.rs
+++ b/crates/core/src/diff/mod.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 use anyhow::{Result, anyhow};
+use merge::RenameCandidateIndex;
 use objects::{
     HeddleError, RecoveryDetails,
     object::{
@@ -1920,6 +1921,8 @@ fn detect_clear_renames(
 struct RenameDetectionStats {
     blob_reads: usize,
     lcs_comparisons: usize,
+    total_possible_pairs: usize,
+    qualifying_candidate_pairs: usize,
 }
 
 struct PreparedRenameBlob {
@@ -1943,19 +1946,22 @@ fn detect_clear_renames_with_stats(
     unified: usize,
     stats: &mut RenameDetectionStats,
 ) -> Result<Vec<FileChange>> {
-    let deleted = changes
+    let mut deleted = changes
         .iter()
         .filter(|change| change.kind == "deleted")
         .map(|change| change.path.as_str())
         .collect::<Vec<_>>();
-    let added = changes
+    let mut added = changes
         .iter()
         .filter(|change| change.kind == "added")
         .map(|change| change.path.as_str())
         .collect::<Vec<_>>();
+    deleted.sort_unstable();
+    added.sort_unstable();
     if deleted.is_empty() || added.is_empty() {
         return Ok(changes);
     }
+    stats.total_possible_pairs = deleted.len().saturating_mul(added.len());
 
     // Snapshot each side's git mode so a candidate can be rejected when the
     // deleted and added sides differ in git *type class* (regular vs
@@ -1985,14 +1991,14 @@ fn detect_clear_renames_with_stats(
         }
     }
 
-    let mut candidates = Vec::new();
-    for old_path in &deleted {
+    let mut candidates = RenameCandidateIndex::new(deleted.len(), added.len());
+    for (old_index, old_path) in deleted.iter().enumerate() {
         stats.blob_reads += 1;
         let Some(old_blob) = blob_from_tree(repo, from_tree, old_path)? else {
             continue;
         };
         let old_blob = prepare_rename_blob(old_blob);
-        for new_path in &added {
+        for (new_index, new_path) in added.iter().enumerate() {
             // A delete + add at the *same* path is a type change
             // (regular ↔ symlink), not a rename — `expand_type_changes`
             // emits both halves and collapsing them back into a
@@ -2017,27 +2023,23 @@ fn detect_clear_renames_with_stats(
             };
             let score = rename_similarity(&old_blob, new_blob, stats);
             if score >= RENAME_SIMILARITY_THRESHOLD {
-                candidates.push((score, (*old_path).to_string(), (*new_path).to_string()));
+                candidates.push(old_index, new_index, score);
             }
         }
     }
+    stats.qualifying_candidate_pairs = candidates.candidate_count();
 
-    candidates.sort_by(|left, right| {
-        right
-            .0
-            .total_cmp(&left.0)
-            .then_with(|| left.1.cmp(&right.1))
-            .then_with(|| left.2.cmp(&right.2))
-    });
-
-    let mut used_old = BTreeSet::new();
-    let mut used_new = BTreeSet::new();
-    let mut renames: Vec<(String, String, f64)> = Vec::new();
-    for (score, old_path, new_path) in candidates {
-        if used_old.insert(old_path.clone()) && used_new.insert(new_path.clone()) {
-            renames.push((old_path, new_path, score));
-        }
-    }
+    let renames = candidates
+        .assign()
+        .into_iter()
+        .map(|assignment| {
+            (
+                deleted[assignment.source_index].to_string(),
+                added[assignment.target_index].to_string(),
+                assignment.score,
+            )
+        })
+        .collect::<Vec<_>>();
     if renames.is_empty() {
         return Ok(changes);
     }
@@ -2607,17 +2609,18 @@ fn change_file_modes(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        DiffStats, FileChange, FileEolState, LineCounts, LineDiff, RENAME_SIMILARITY_THRESHOLD,
-        RenameDetectionStats, change_line_counts, detect_clear_renames_with_stats, lcs_len,
-        prepare_rename_blob, rename_similarity, summarize_context, unified_hunks,
-    };
     use objects::{
         object::{Blob, FileMode, Tree, TreeEntry},
         store::ObjectStore,
     };
     use repo::Repository;
     use tempfile::TempDir;
+
+    use super::{
+        DiffStats, FileChange, FileEolState, LineCounts, LineDiff, RENAME_SIMILARITY_THRESHOLD,
+        RenameDetectionStats, change_line_counts, detect_clear_renames_with_stats, lcs_len,
+        prepare_rename_blob, rename_similarity, summarize_context, unified_hunks,
+    };
 
     type RenameSummary = Vec<(String, String, Option<String>, Option<f64>)>;
 
@@ -2759,6 +2762,12 @@ mod tests {
             stats.lcs_comparisons, FILE_COUNT,
             "only the one plausible modified target per deleted file should reach LCS"
         );
+        assert_eq!(stats.total_possible_pairs, FILE_COUNT * FILE_COUNT);
+        assert_eq!(
+            stats.qualifying_candidate_pairs, FILE_COUNT,
+            "only threshold-qualified pairs should enter deterministic assignment"
+        );
+        assert!(stats.qualifying_candidate_pairs < stats.total_possible_pairs);
     }
 
     #[test]


### PR DESCRIPTION
Migrates core diff rename detection onto the centralized `RenameCandidateIndex` introduced by #1299. Keeps candidate pruning and scoring in core while delegating deterministic one-to-one assignment, and records the candidate-pair accounting exercised by the existing core performance test.

Scope is limited to `crates/core/src/diff/mod.rs`; no workflow changes are included.

Part of #1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788928807&installation_model_id=21489&pr_number=1305&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1305&signature=87d00d313f0bf835878b41509f45ccf3d9b272114710ef749d687904061feadf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->