### PR TITLE
refactor(objects/fsck): iterative tree traversal + missing-tree events (part of #1262)

### DIFF
--- a/crates/core/src/fsck/mod.rs
+++ b/crates/core/src/fsck/mod.rs
@@ -3,6 +3,7 @@
 
 mod git_projection;
 mod objects;
+mod provenance;
 mod refs;
 mod state;
 #[cfg(test)]

--- a/crates/core/src/fsck/objects.rs
+++ b/crates/core/src/fsck/objects.rs
@@ -53,6 +53,14 @@ pub(crate) fn check_tree_objects(
             Ok(())
         }
         TreeIntegrityEvent::TreeRef { .. } => Ok(()),
+        TreeIntegrityEvent::MissingTree { hash, path, .. } => {
+            errors.push(make_error(
+                "missing_tree",
+                &format!("Tree path '{}' references missing tree", path),
+                Some(hash.short()),
+            ));
+            Ok(())
+        }
     })?;
 
     for blob_hash in blob_hashes {

--- a/crates/core/src/fsck/provenance.rs
+++ b/crates/core/src/fsck/provenance.rs
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Iterative validation of file-provenance trees.
+
+use std::{collections::HashSet, path::PathBuf};
+
+use objects::{
+    error::Result,
+    object::{ContentHash, EntryType, FileProvenance, Tree, TreeEntry},
+    store::ObjectStore,
+};
+use repo::Repository;
+
+use super::{FsckError, make_error};
+
+pub(super) fn check_provenance_tree(
+    repo: &Repository,
+    data_tree: &Tree,
+    provenance_root: ContentHash,
+    errors: &mut Vec<FsckError>,
+) -> Result<()> {
+    let mut stack = vec![(data_tree.clone(), provenance_root, PathBuf::new())];
+    let mut visited = HashSet::new();
+
+    while let Some((data_tree, provenance_hash, path)) = stack.pop() {
+        if !visited.insert((data_tree.hash(), provenance_hash)) {
+            continue;
+        }
+        let Some(provenance_tree) = repo.store().get_tree(&provenance_hash)? else {
+            errors.push(make_error(
+                "invalid_provenance",
+                &format!("Missing provenance tree for '{}'", path.display()),
+                Some(provenance_hash.short()),
+            ));
+            continue;
+        };
+
+        for entry in provenance_tree.entries().iter().rev() {
+            let entry_path = path.join(entry.name());
+            let Some(data_entry) = data_tree.get(entry.name()) else {
+                errors.push(make_error(
+                    "invalid_provenance",
+                    &format!(
+                        "Provenance path '{}' does not exist in the data tree",
+                        entry_path.display()
+                    ),
+                    None,
+                ));
+                continue;
+            };
+            match entry.entry_type() {
+                EntryType::Tree => {
+                    if !data_entry.is_tree() {
+                        errors.push(make_error(
+                            "invalid_provenance",
+                            &format!(
+                                "Provenance path '{}' points to a directory but data tree has a file",
+                                entry_path.display()
+                            ),
+                            None,
+                        ));
+                        continue;
+                    }
+                    let (Some(data_hash), Some(child_provenance_hash)) =
+                        (data_entry.tree_hash(), entry.tree_hash())
+                    else {
+                        continue;
+                    };
+                    if let Some(subtree) = repo.store().get_tree(&data_hash)? {
+                        stack.push((subtree, child_provenance_hash, entry_path));
+                    }
+                }
+                EntryType::Blob => {
+                    check_provenance_blob(repo, data_entry, entry, &entry_path, errors)?
+                }
+                EntryType::Symlink | EntryType::Gitlink | EntryType::Spoollink => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+fn check_provenance_blob(
+    repo: &Repository,
+    data_entry: &TreeEntry,
+    provenance_entry: &TreeEntry,
+    entry_path: &std::path::Path,
+    errors: &mut Vec<FsckError>,
+) -> Result<()> {
+    if !data_entry.is_blob() {
+        errors.push(make_error(
+            "invalid_provenance",
+            &format!(
+                "Provenance path '{}' points to a file but data tree has a directory",
+                entry_path.display()
+            ),
+            None,
+        ));
+        return Ok(());
+    }
+    let Some(provenance_hash) = provenance_entry.blob_hash() else {
+        return Ok(());
+    };
+    let Some(provenance_blob) = repo.store().get_blob(&provenance_hash)? else {
+        errors.push(make_error(
+            "invalid_provenance",
+            &format!("Missing provenance blob for '{}'", entry_path.display()),
+            Some(provenance_hash.short()),
+        ));
+        return Ok(());
+    };
+    let provenance: FileProvenance = match rmp_serde::from_slice(provenance_blob.content()) {
+        Ok(provenance) => provenance,
+        Err(error) => {
+            errors.push(make_error(
+                "invalid_provenance",
+                &format!(
+                    "Invalid provenance blob for '{}': {}",
+                    entry_path.display(),
+                    error
+                ),
+                Some(provenance_hash.short()),
+            ));
+            return Ok(());
+        }
+    };
+    if let Err(error) = provenance.validate() {
+        errors.push(make_error(
+            "invalid_provenance",
+            &format!(
+                "Invalid provenance spans for '{}': {}",
+                entry_path.display(),
+                error
+            ),
+            Some(provenance_hash.short()),
+        ));
+        return Ok(());
+    }
+    let Some(data_hash) = data_entry.blob_hash() else {
+        return Ok(());
+    };
+    if provenance.file_blob != data_hash {
+        errors.push(make_error(
+            "invalid_provenance",
+            &format!(
+                "Provenance for '{}' points to blob {} but file uses {}",
+                entry_path.display(),
+                provenance.file_blob.short(),
+                data_hash.short()
+            ),
+            Some(provenance_hash.short()),
+        ));
+        return Ok(());
+    }
+    if let Some(blob) = repo.store().get_blob(&data_hash)?
+        && let Ok(text) = std::str::from_utf8(blob.content())
+    {
+        let line_count = text.lines().count() as u32;
+        if provenance.line_count != line_count {
+            errors.push(make_error(
+                "invalid_provenance",
+                &format!(
+                    "Provenance for '{}' records {} lines but file has {}",
+                    entry_path.display(),
+                    provenance.line_count,
+                    line_count
+                ),
+                Some(provenance_hash.short()),
+            ));
+        }
+    }
+    Ok(())
+}

--- a/crates/core/src/fsck/state.rs
+++ b/crates/core/src/fsck/state.rs
@@ -1,17 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
-use std::{
-    collections::{HashMap, HashSet},
-    path::Path,
-};
+use std::collections::{HashMap, HashSet};
 
 use objects::{
     error::Result,
-    object::{ContentHash, SignatureStatus, State, Tree},
+    object::{SignatureStatus, State},
     store::ObjectStore,
 };
 use repo::Repository;
 
-use super::{FsckError, make_error};
+use super::{FsckError, make_error, provenance::check_provenance_tree};
 
 pub(crate) fn check_states(
     repo: &Repository,
@@ -31,20 +28,17 @@ pub(crate) fn check_states(
                 }
                 check_state_integrity(repo, &state, errors, thorough)?;
             }
-            None => {
-                errors.push(make_error(
-                    "missing_state",
-                    &format!("State {} is listed but cannot be read", state_id),
-                    Some(state_id.short()),
-                ));
-            }
+            None => errors.push(make_error(
+                "missing_state",
+                &format!("State {} is listed but cannot be read", state_id),
+                Some(state_id.short()),
+            )),
         }
     }
 
     if thorough {
         check_state_cycles(&parent_map, errors);
     }
-
     Ok(())
 }
 
@@ -61,7 +55,6 @@ fn check_state_integrity(
             Some(state.tree.short()),
         ));
     }
-
     for parent in &state.parents {
         if !repo.store().has_state(parent)? {
             errors.push(make_error(
@@ -71,7 +64,6 @@ fn check_state_integrity(
             ));
         }
     }
-
     if thorough && repo.verify_state_signature(&state.state_id)? == SignatureStatus::Invalid {
         errors.push(make_error(
             "invalid_signature",
@@ -82,7 +74,6 @@ fn check_state_integrity(
             Some(state.state_id.short()),
         ));
     }
-
     if thorough && let Some(provenance_root) = state.provenance {
         if !repo.store().has_tree(&provenance_root)? {
             errors.push(make_error(
@@ -95,152 +86,9 @@ fn check_state_integrity(
                 Some(provenance_root.short()),
             ));
         } else if let Some(tree) = repo.store().get_tree(&state.tree)? {
-            check_provenance_tree(repo, &tree, &provenance_root, Path::new(""), errors)?;
+            check_provenance_tree(repo, &tree, provenance_root, errors)?;
         }
     }
-
-    Ok(())
-}
-
-fn check_provenance_tree(
-    repo: &Repository,
-    data_tree: &Tree,
-    provenance_root: &ContentHash,
-    path: &Path,
-    errors: &mut Vec<FsckError>,
-) -> Result<()> {
-    let Some(provenance_tree) = repo.store().get_tree(provenance_root)? else {
-        return Ok(());
-    };
-
-    for entry in provenance_tree.entries() {
-        let entry_path = path.join(entry.name());
-        let Some(data_entry) = data_tree.get(entry.name()) else {
-            errors.push(make_error(
-                "invalid_provenance",
-                &format!(
-                    "Provenance path '{}' does not exist in the data tree",
-                    entry_path.display()
-                ),
-                None,
-            ));
-            continue;
-        };
-
-        match entry.entry_type() {
-            objects::object::EntryType::Tree => {
-                if !data_entry.is_tree() {
-                    errors.push(make_error(
-                        "invalid_provenance",
-                        &format!(
-                            "Provenance path '{}' points to a directory but data tree has a file",
-                            entry_path.display()
-                        ),
-                        None,
-                    ));
-                    continue;
-                }
-                let Some(data_hash) = data_entry.tree_hash() else {
-                    continue;
-                };
-                let Some(provenance_hash) = entry.tree_hash() else {
-                    continue;
-                };
-                if let Some(subtree) = repo.store().get_tree(&data_hash)? {
-                    check_provenance_tree(repo, &subtree, &provenance_hash, &entry_path, errors)?;
-                }
-            }
-            objects::object::EntryType::Blob => {
-                if !data_entry.is_blob() {
-                    errors.push(make_error(
-                        "invalid_provenance",
-                        &format!(
-                            "Provenance path '{}' points to a file but data tree has a directory",
-                            entry_path.display()
-                        ),
-                        None,
-                    ));
-                    continue;
-                }
-                let Some(provenance_hash) = entry.blob_hash() else {
-                    continue;
-                };
-                let Some(provenance_blob) = repo.store().get_blob(&provenance_hash)? else {
-                    errors.push(make_error(
-                        "invalid_provenance",
-                        &format!("Missing provenance blob for '{}'", entry_path.display()),
-                        Some(provenance_hash.short()),
-                    ));
-                    continue;
-                };
-                let provenance: objects::object::FileProvenance =
-                    match rmp_serde::from_slice(provenance_blob.content()) {
-                        Ok(provenance) => provenance,
-                        Err(error) => {
-                            errors.push(make_error(
-                                "invalid_provenance",
-                                &format!(
-                                    "Invalid provenance blob for '{}': {}",
-                                    entry_path.display(),
-                                    error
-                                ),
-                                Some(provenance_hash.short()),
-                            ));
-                            continue;
-                        }
-                    };
-                if let Err(error) = provenance.validate() {
-                    errors.push(make_error(
-                        "invalid_provenance",
-                        &format!(
-                            "Invalid provenance spans for '{}': {}",
-                            entry_path.display(),
-                            error
-                        ),
-                        Some(provenance_hash.short()),
-                    ));
-                    continue;
-                }
-                let Some(data_hash) = data_entry.blob_hash() else {
-                    continue;
-                };
-                if provenance.file_blob != data_hash {
-                    errors.push(make_error(
-                        "invalid_provenance",
-                        &format!(
-                            "Provenance for '{}' points to blob {} but file uses {}",
-                            entry_path.display(),
-                            provenance.file_blob.short(),
-                            data_hash.short()
-                        ),
-                        Some(provenance_hash.short()),
-                    ));
-                    continue;
-                }
-                if let Some(blob) = repo.store().get_blob(&data_hash)?
-                    && let Ok(text) = std::str::from_utf8(blob.content())
-                {
-                    let line_count = text.lines().count() as u32;
-                    if provenance.line_count != line_count {
-                        errors.push(make_error(
-                            "invalid_provenance",
-                            &format!(
-                                "Provenance for '{}' records {} lines but file has {}",
-                                entry_path.display(),
-                                provenance.line_count,
-                                line_count
-                            ),
-                            Some(provenance_hash.short()),
-                        ));
-                    }
-                }
-            }
-            objects::object::EntryType::Symlink => {}
-            objects::object::EntryType::Gitlink => {}
-            objects::object::EntryType::Spoollink => {}
-        }
-    }
-
     Ok(())
 }
 
@@ -248,56 +96,93 @@ fn check_state_cycles(
     parent_map: &HashMap<objects::object::StateId, Vec<objects::object::StateId>>,
     errors: &mut Vec<FsckError>,
 ) {
-    let mut visiting = HashSet::new();
-    let mut visited = HashSet::new();
+    #[derive(Clone, Copy, Eq, PartialEq)]
+    enum VisitState {
+        Visiting,
+        Visited,
+    }
+
+    let mut states = HashMap::with_capacity(parent_map.len());
     let mut reported = HashSet::new();
-
-    for state_id in parent_map.keys().copied() {
-        detect_cycle(
-            state_id,
-            parent_map,
-            &mut visiting,
-            &mut visited,
-            &mut reported,
-            errors,
-        );
-    }
-}
-
-fn detect_cycle(
-    state_id: objects::object::StateId,
-    parent_map: &HashMap<objects::object::StateId, Vec<objects::object::StateId>>,
-    visiting: &mut HashSet<objects::object::StateId>,
-    visited: &mut HashSet<objects::object::StateId>,
-    reported: &mut HashSet<objects::object::StateId>,
-    errors: &mut Vec<FsckError>,
-) {
-    if visited.contains(&state_id) {
-        return;
-    }
-
-    if !visiting.insert(state_id) {
-        if reported.insert(state_id) {
-            errors.push(make_error(
-                "state_cycle",
-                &format!(
-                    "State parent graph contains a cycle involving {}",
-                    state_id.short()
-                ),
-                Some(state_id.short()),
-            ));
+    for start in parent_map.keys().copied() {
+        if states.contains_key(&start) {
+            continue;
         }
-        return;
-    }
+        states.insert(start, VisitState::Visiting);
+        let mut stack = vec![(start, 0usize)];
 
-    if let Some(parents) = parent_map.get(&state_id) {
-        for parent in parents {
-            if parent_map.contains_key(parent) {
-                detect_cycle(*parent, parent_map, visiting, visited, reported, errors);
+        while let Some((state_id, next_parent)) = stack.last_mut() {
+            let parents = parent_map.get(state_id).map(Vec::as_slice).unwrap_or(&[]);
+            let next = parents.get(*next_parent).copied();
+            *next_parent += usize::from(next.is_some());
+
+            let Some(parent) = next else {
+                let completed = *state_id;
+                stack.pop();
+                states.insert(completed, VisitState::Visited);
+                continue;
+            };
+            if !parent_map.contains_key(&parent) {
+                continue;
+            }
+            match states.get(&parent).copied() {
+                Some(VisitState::Visited) => {}
+                Some(VisitState::Visiting) => {
+                    if reported.insert(parent) {
+                        errors.push(make_error(
+                            "state_cycle",
+                            &format!(
+                                "State parent graph contains a cycle involving {}",
+                                parent.short()
+                            ),
+                            Some(parent.short()),
+                        ));
+                    }
+                }
+                None => {
+                    states.insert(parent, VisitState::Visiting);
+                    stack.push((parent, 0));
+                }
             }
         }
     }
+}
 
-    visiting.remove(&state_id);
-    visited.insert(state_id);
+#[cfg(test)]
+mod cycle_tests {
+    use super::*;
+
+    fn state_id(index: usize) -> objects::object::StateId {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&(index as u64).to_le_bytes());
+        objects::object::StateId::from_bytes(bytes)
+    }
+
+    #[test]
+    fn deep_parent_chain_is_checked_without_recursion() {
+        let mut parents = HashMap::new();
+        for index in 0..50_000 {
+            parents.insert(
+                state_id(index),
+                (index > 0)
+                    .then(|| state_id(index - 1))
+                    .into_iter()
+                    .collect(),
+            );
+        }
+        let mut errors = Vec::new();
+        check_state_cycles(&parents, &mut errors);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn cycle_is_reported_once() {
+        let first = state_id(1);
+        let second = state_id(2);
+        let parents = HashMap::from([(first, vec![second]), (second, vec![first])]);
+        let mut errors = Vec::new();
+        check_state_cycles(&parents, &mut errors);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].kind, "state_cycle");
+    }
 }

--- a/crates/core/src/fsck/tests.rs
+++ b/crates/core/src/fsck/tests.rs
@@ -227,10 +227,9 @@ fn test_fsck_does_not_require_gitlink_target_object() {
     assert!(warnings.is_empty(), "warnings={warnings:?}");
 }
 
-/// Fixture exercising every tree/blob fsck finding class. Expected values were
-/// captured from the pre-refactor `check_trees` + `check_blobs` pair.
+/// Fixture exercising every tree/blob fsck finding class.
 #[test]
-fn test_tree_blob_checks_characterization() {
+fn test_tree_blob_checks_report_missing_references() {
     use objects::object::ContentHash;
 
     let (_temp, repo) = setup_repo();
@@ -256,7 +255,7 @@ fn test_tree_blob_checks_characterization() {
         .put_tree(&shared_tree)
         .expect("put shared tree");
 
-    // Dangling subtree ref (missing child tree — fsck stays silent).
+    // Dangling subtree ref must be reported rather than silently skipped.
     let dangling_tree_hash = ContentHash::compute(b"missing-subtree");
     let dangling_parent = Tree::from_entries(vec![
         objects::object::TreeEntry::directory("missing", dangling_tree_hash).unwrap(),
@@ -298,16 +297,20 @@ fn test_tree_blob_checks_characterization() {
     let error_kinds: Vec<_> = errors.iter().map(|error| error.kind.as_str()).collect();
     assert_eq!(
         error_kinds,
-        vec!["missing_blob", "missing_blob"],
-        "tree-phase then blob-phase ordering must be preserved"
+        vec!["missing_blob", "missing_tree", "missing_blob"],
+        "tree-phase findings must precede blob-content findings"
     );
 
     assert_eq!(
         errors[0].message,
         "Tree entry 'absent.txt' references missing blob"
     );
-    assert_eq!(errors[1].message, "Tree references missing blob");
-    assert_eq!(errors[0].object, errors[1].object, "same missing blob hash");
+    assert_eq!(
+        errors[1].message,
+        "Tree path 'missing' references missing tree"
+    );
+    assert_eq!(errors[2].message, "Tree references missing blob");
+    assert_eq!(errors[0].object, errors[2].object, "same missing blob hash");
 
     assert_eq!(warnings.len(), 1);
     assert!(

--- a/crates/object-model/src/object/tree_walk.rs
+++ b/crates/object-model/src/object/tree_walk.rs
@@ -3,9 +3,8 @@
 
 use std::collections::HashSet;
 
-use crate::error::Result;
-
 use super::{ContentHash, ObjectSource, Tree, TreeEntry};
+use crate::error::Result;
 
 /// Events emitted while walking reachable trees for integrity checks.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -19,12 +18,20 @@ pub enum TreeIntegrityEvent<'a> {
         parent_hash: ContentHash,
         entry: &'a TreeEntry,
     },
+    /// A root or referenced subtree could not be loaded.
+    MissingTree {
+        hash: ContentHash,
+        parent_hash: Option<ContentHash>,
+        path: String,
+    },
 }
 
 /// Walk all trees reachable from `roots`, deduplicating visited trees.
 ///
-/// Missing root or subtree trees are skipped silently. Gitlink entries are not
-/// descended into. Visitation order is depth-first, sorted tree entry order.
+/// Missing root or subtree trees emit [`TreeIntegrityEvent::MissingTree`].
+/// Gitlink entries are not descended into. Visitation order is depth-first,
+/// sorted tree entry order. The implementation uses explicit frames so tree
+/// depth cannot overflow the process stack.
 pub fn walk_tree_integrity<S, V>(
     source: &S,
     roots: impl IntoIterator<Item = ContentHash>,
@@ -36,15 +43,21 @@ where
 {
     let mut visited = HashSet::new();
     for root in roots {
-        walk_tree_recursive(source, &root, "", &mut visited, visitor)?;
+        walk_tree_iterative(source, root, &mut visited, visitor)?;
     }
     Ok(())
 }
 
-fn walk_tree_recursive<S, V>(
+struct WalkFrame {
+    hash: ContentHash,
+    tree: Tree,
+    path_prefix: String,
+    next_entry: usize,
+}
+
+fn walk_tree_iterative<S, V>(
     source: &S,
-    tree_hash: &ContentHash,
-    path_prefix: &str,
+    root_hash: ContentHash,
     visited: &mut HashSet<ContentHash>,
     visitor: &mut V,
 ) -> Result<()>
@@ -52,38 +65,76 @@ where
     S: ObjectSource + ?Sized,
     V: FnMut(TreeIntegrityEvent<'_>) -> Result<()>,
 {
-    if visited.contains(tree_hash) {
+    if !visited.insert(root_hash) {
         return Ok(());
     }
-    visited.insert(*tree_hash);
 
-    let Some(tree) = source.get_tree(tree_hash)? else {
+    let Some(root_tree) = source.get_tree(&root_hash)? else {
+        visitor(TreeIntegrityEvent::MissingTree {
+            hash: root_hash,
+            parent_hash: None,
+            path: String::new(),
+        })?;
         return Ok(());
     };
 
     visitor(TreeIntegrityEvent::EnterTree {
-        hash: *tree_hash,
-        tree: &tree,
+        hash: root_hash,
+        tree: &root_tree,
     })?;
 
-    for entry in tree.entries() {
-        let path = if path_prefix.is_empty() {
+    let mut stack = vec![WalkFrame {
+        hash: root_hash,
+        tree: root_tree,
+        path_prefix: String::new(),
+        next_entry: 0,
+    }];
+
+    while let Some(frame) = stack.last_mut() {
+        let Some(entry) = frame.tree.entries().get(frame.next_entry).cloned() else {
+            stack.pop();
+            continue;
+        };
+        frame.next_entry += 1;
+
+        let path = if frame.path_prefix.is_empty() {
             entry.name().to_string()
         } else {
-            format!("{path_prefix}/{}", entry.name())
+            format!("{}/{}", frame.path_prefix, entry.name())
         };
 
         if entry.blob_hash().is_some() {
             visitor(TreeIntegrityEvent::BlobLeaf {
-                entry,
-                path: path.clone(),
+                entry: &entry,
+                path,
             })?;
         } else if let Some(child_hash) = entry.tree_hash() {
             visitor(TreeIntegrityEvent::TreeRef {
-                parent_hash: *tree_hash,
-                entry,
+                parent_hash: frame.hash,
+                entry: &entry,
             })?;
-            walk_tree_recursive(source, &child_hash, &path, visited, visitor)?;
+
+            if !visited.insert(child_hash) {
+                continue;
+            }
+            let Some(child_tree) = source.get_tree(&child_hash)? else {
+                visitor(TreeIntegrityEvent::MissingTree {
+                    hash: child_hash,
+                    parent_hash: Some(frame.hash),
+                    path,
+                })?;
+                continue;
+            };
+            visitor(TreeIntegrityEvent::EnterTree {
+                hash: child_hash,
+                tree: &child_tree,
+            })?;
+            stack.push(WalkFrame {
+                hash: child_hash,
+                tree: child_tree,
+                path_prefix: path,
+                next_entry: 0,
+            });
         }
     }
 

--- a/crates/objects/src/object_model_store_tests/tree_walk.rs
+++ b/crates/objects/src/object_model_store_tests/tree_walk.rs
@@ -1,6 +1,7 @@
-use crate::object::*;
-use crate::object::{Blob, Tree, TreeEntry};
-use crate::store::{InMemoryStore, ObjectStore};
+use crate::{
+    object::{Blob, Tree, TreeEntry, *},
+    store::{InMemoryStore, ObjectStore},
+};
 
 #[test]
 fn walk_tree_integrity_dedups_shared_subtrees() {
@@ -25,6 +26,7 @@ fn walk_tree_integrity_dedups_shared_subtrees() {
             TreeIntegrityEvent::EnterTree { .. } => enter_count += 1,
             TreeIntegrityEvent::BlobLeaf { path, .. } => blob_leaves.push(path),
             TreeIntegrityEvent::TreeRef { .. } => {}
+            TreeIntegrityEvent::MissingTree { .. } => {}
         }
         Ok(())
     })
@@ -38,20 +40,55 @@ fn walk_tree_integrity_dedups_shared_subtrees() {
 }
 
 #[test]
-fn walk_tree_integrity_skips_missing_subtree_silently() {
+fn walk_tree_integrity_reports_missing_subtree() {
     let store = InMemoryStore::new();
     let missing = ContentHash::compute(b"missing-tree");
     let root = Tree::from_entries(vec![TreeEntry::directory("gone", missing).unwrap()]);
     let root_hash = store.put_tree(&root).unwrap();
 
-    let mut enter_count = 0;
+    let mut events = Vec::new();
     walk_tree_integrity(&store, [root_hash], &mut |event| {
-        if let TreeIntegrityEvent::EnterTree { .. } = event {
-            enter_count += 1;
+        match event {
+            TreeIntegrityEvent::EnterTree { .. } => events.push("enter"),
+            TreeIntegrityEvent::TreeRef { .. } => events.push("ref"),
+            TreeIntegrityEvent::MissingTree {
+                hash,
+                parent_hash,
+                path,
+            } => {
+                assert_eq!(hash, missing);
+                assert_eq!(parent_hash, Some(root_hash));
+                assert_eq!(path, "gone");
+                events.push("missing");
+            }
+            TreeIntegrityEvent::BlobLeaf { .. } => events.push("blob"),
         }
         Ok(())
     })
     .unwrap();
 
-    assert_eq!(enter_count, 1);
+    assert_eq!(events, vec!["enter", "ref", "missing"]);
+}
+
+#[test]
+fn walk_tree_integrity_handles_deep_trees_iteratively() {
+    let store = InMemoryStore::new();
+    let mut child_hash = store.put_tree(&Tree::new()).unwrap();
+    for depth in 0..10_000 {
+        let tree = Tree::from_entries(vec![
+            TreeEntry::directory(format!("d{depth}"), child_hash).unwrap(),
+        ]);
+        child_hash = store.put_tree(&tree).unwrap();
+    }
+
+    let mut entered = 0;
+    walk_tree_integrity(&store, [child_hash], &mut |event| {
+        if matches!(event, TreeIntegrityEvent::EnterTree { .. }) {
+            entered += 1;
+        }
+        Ok(())
+    })
+    .unwrap();
+
+    assert_eq!(entered, 10_001);
 }


### PR DESCRIPTION
Scope:
- replace recursive object-tree integrity walking with iterative traversal
- emit missing-tree integrity events with parent/path context
- build core fsck tree and provenance validation on the shared traversal
- add deep-tree, missing-subtree, provenance, and state-cycle coverage

Part of #1262

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788932374&installation_model_id=21489&pr_number=1307&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1307&signature=05495362eda5aa662abb53335339e9a1e00bd208deb6e0d70479f67c281ca74a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->