### PR TITLE
perf(adopt): eliminate the eager git mirror; export/reconcile from store (closes #568, #561)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Changed
 
+- **Adopt no longer maintains an eager Git mirror.** Git projections are now
+  exported or reconstructed on demand from Heddle's authoritative object store,
+  while preserving commit, tag, note, and residual-object fidelity.
+
 - **Published wire compatibility is preserved.** Obsolete internal wire types
   were removed, while `HeadInfo`, `RefsList`, and `RefFilter` remain available
   in `heddle-wire` 0.11 for the live Weft refs service.

--- a/crates/cli-args/src/cli/cli_args/cli_base.rs
+++ b/crates/cli-args/src/cli/cli_args/cli_base.rs
@@ -107,7 +107,12 @@ impl Cli {
                 &cwd
             }
         };
-        repo::Repository::open(repo_path).context("open Heddle repository")
+        let repo = repo::Repository::open(repo_path).context("open Heddle repository")?;
+        let mode = Self::user_config_or_exit()
+            .worktree_status_options(Some(repo.config()))
+            .fsmonitor
+            .mode;
+        Ok(repo.with_fsmonitor_mode(mode))
     }
 }
 

--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -734,7 +734,7 @@ fn materialize_imported_attached_thread(
     })?;
 
     if bridge.heddle_repo.root().join(".git").exists() {
-        bridge.write_current_checkout_from_existing_mirror()?;
+        bridge.write_current_checkout_from_existing_projection()?;
     }
     Ok(())
 }

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -391,7 +391,7 @@ pub async fn cmd_thread(cli: &Cli, command: ThreadCommands) -> Result<()> {
         _ => {}
     }
 
-    let repo = Repository::open(repo_path)?;
+    let repo = cli.open_repo()?;
     match command {
         ThreadCommands::Create {
             name,

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -103,7 +103,7 @@ fn verify_execution_context_from_cli(cli: &Cli, start: &Path) -> Result<VerifyEx
     };
     let mut builder = heddle_core::ExecutionContext::builder()
         .start_path(start.to_path_buf())
-        .config(config)
+        .config(config.clone())
         .verbosity(verbosity)
         .progress(std::sync::Arc::new(heddle_core::NoopProgress))
         .warnings(std::sync::Arc::new(heddle_core::NoopWarnings));
@@ -123,6 +123,11 @@ fn verify_execution_context_from_cli(cli: &Cli, start: &Path) -> Result<VerifyEx
         match Repository::open(start) {
             Ok(repo) => {
                 let repo_open_ms = open_start.elapsed().as_millis();
+                let mode = config
+                    .worktree_status_options(Some(repo.config()))
+                    .fsmonitor
+                    .mode;
+                let repo = repo.with_fsmonitor_mode(mode);
                 let repo_config = repo.config().clone();
                 (builder.repo(repo), Some(repo_config), repo_open_ms)
             }

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -527,7 +527,7 @@ fn assert_verify_check_rows(parsed: &Value) {
 }
 
 #[test]
-fn git_overlay_matrix_undo_reconciles_stale_mirror_after_push_pull() {
+fn git_overlay_matrix_undo_reconciles_checkout_without_persistent_mirror() {
     let temp = TempDir::new().unwrap();
     let work = temp.path().join("work");
     let origin = temp.path().join("origin.git");
@@ -568,18 +568,9 @@ fn git_overlay_matrix_undo_reconciles_stale_mirror_after_push_pull() {
         "second\n",
         "undoing Git publication must preserve the captured worktree"
     );
-    let mirror = work.join(".heddle/git");
-    assert_eq!(
-        git_stdout(
-            &work,
-            &[
-                "--git-dir",
-                mirror.to_str().unwrap(),
-                "rev-parse",
-                "refs/heads/main",
-            ],
-        ),
-        previous
+    assert!(
+        !work.join(".heddle/git").exists(),
+        "undo must not require a persistent Git mirror"
     );
 }
 

--- a/crates/cli/tests/cli_integration/git_projection_commands.rs
+++ b/crates/cli/tests/cli_integration/git_projection_commands.rs
@@ -591,18 +591,15 @@ fn test_cli_export_git_writes_bare_repo() {
 }
 
 /// heddle#1096 -- an ordinary Git-side commit pushed onto a Heddle-managed
-/// mirror branch is foreign: Heddle never published that OID under the ref name.
+/// destination branch is foreign: Heddle never published that OID under the ref name.
 /// Export must report the divergence and leave the foreign tip untouched, not
 /// misclassify it as a now-embargoed tip and force-rewind it.
 #[test]
-fn test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence() {
+fn test_cli_export_git_preserves_foreign_destination_push_and_reports_divergence() {
     let source = TempDir::new().unwrap();
     let dest_holder = TempDir::new().unwrap();
     let dest = dest_holder.path().join("export");
 
-    init_colocated_git_repo(source.path());
-    std::fs::write(source.path().join("file.txt"), "heddle tip\n").unwrap();
-    git_commit_all_in(source.path(), "Heddle tip");
     init_direct_git_overlay(source.path());
     std::fs::write(source.path().join("file.txt"), "Heddle projection tip\n").unwrap();
     heddle(
@@ -623,17 +620,18 @@ fn test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence() {
         String::from_utf8_lossy(&first.stderr),
     );
 
-    let mirror = open_git(source.path().join(".heddle/git")).expect("open bridge mirror");
-    let heddle_tip = find_reference(&mirror, "refs/heads/main")
+    let destination_repo = open_git(&dest).expect("open export destination");
+    let heddle_tip = find_reference(&destination_repo, "refs/heads/main")
         .expect("main after first export")
         .peel_to_id()
         .expect("peel Heddle tip");
-    let tree = mirror
+    assert!(!source.path().join(".heddle/git").exists());
+    let tree = destination_repo
         .read_commit(&heddle_tip)
         .expect("read Heddle tip")
         .tree;
     let foreign_tip = git_commit_with_tree(
-        &mirror,
+        &destination_repo,
         Some("refs/heads/main"),
         tree,
         "foreign push",
@@ -647,15 +645,15 @@ fn test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence() {
     .expect("second export");
     let stdout = String::from_utf8_lossy(&second.stdout);
     let stderr = String::from_utf8_lossy(&second.stderr);
-    let mirror_tip_after = find_reference(&mirror, "refs/heads/main")
+    let destination_tip_after = find_reference(&destination_repo, "refs/heads/main")
         .expect("main after second export")
         .peel_to_id()
-        .expect("peel mirror tip after second export");
+        .expect("peel destination tip after second export");
 
     let mut violations = Vec::new();
-    if mirror_tip_after != foreign_tip {
+    if destination_tip_after != foreign_tip {
         violations.push(format!(
-            "foreign tip was clobbered: expected {foreign_tip}, found {mirror_tip_after}"
+            "foreign tip was clobbered: expected {foreign_tip}, found {destination_tip_after}"
         ));
     }
     if second.status.code() != Some(74) {
@@ -664,20 +662,16 @@ fn test_cli_export_git_preserves_foreign_mirror_push_and_reports_divergence() {
             second.status.code()
         ));
     }
-    if !stdout.contains("[warn] 1 ref diverged; left untouched (heddle did not overwrite)") {
-        violations.push("stdout did not report one untouched diverged ref".to_string());
-    }
-    let expected_reason = format!(
-        "refs/heads/main: modified concurrently in git: found {foreign_tip}, heddle was publishing {heddle_tip}"
-    );
-    if !stdout.contains(&expected_reason) {
+    if !stdout.is_empty() {
         violations.push(format!(
-            "stdout did not classify the foreign tip as concurrent modification: expected `{expected_reason}`"
+            "a rejected export must not emit a success summary: {stdout}"
         ));
     }
-    if !stderr.contains("exported 0 refs, 1 diverged (concurrent git-side update): refs/heads/main")
-    {
-        violations.push("stderr did not summarize the diverged ref".to_string());
+    if !stderr.contains("Remote branch does not fast-forward the local Git checkpoint") {
+        violations.push("stderr did not report the remote non-fast-forward".to_string());
+    }
+    if !stderr.contains("Next: heddle pull") {
+        violations.push("stderr did not provide the safe recovery command".to_string());
     }
 
     assert!(
@@ -720,6 +714,10 @@ fn test_cli_import_git_from_external_repo() {
             .get_thread(&ThreadName::new("main"))
             .unwrap()
             .is_some()
+    );
+    assert!(
+        !heddle_repo_dir.path().join(".heddle/git").exists(),
+        "explicit Git import must not eagerly populate the retired mirror"
     );
 }
 

--- a/crates/cli/tests/cli_integration/perf_trace.rs
+++ b/crates/cli/tests/cli_integration/perf_trace.rs
@@ -47,6 +47,16 @@ fn setup_profile_repo_with_sensitive_input() -> TempDir {
     temp
 }
 
+fn seed_stale_monitor_endpoint(temp: &TempDir) {
+    let endpoint = temp.path().join(".heddle/state/monitor-helper.json");
+    std::fs::create_dir_all(endpoint.parent().expect("monitor state parent")).unwrap();
+    std::fs::write(
+        endpoint,
+        r#"{"version":1,"host":"127.0.0.1","port":9,"pid":null}"#,
+    )
+    .unwrap();
+}
+
 #[test]
 fn perf_trace_jsonl_status_keeps_stdout_json_and_stderr_parseable() {
     let temp = setup_profile_repo_with_sensitive_input();
@@ -174,6 +184,7 @@ fn perf_trace_jsonl_version_reports_startup_totals() {
 #[test]
 fn perf_trace_jsonl_thread_list_uses_named_phase_records() {
     let temp = setup_profile_repo_with_sensitive_input();
+    seed_stale_monitor_endpoint(&temp);
 
     let output = heddle_output_with_env(
         &["--output", "json", "thread", "list"],
@@ -216,6 +227,7 @@ fn perf_trace_jsonl_thread_list_uses_named_phase_records() {
 fn perf_trace_jsonl_verify_uses_named_phase_records() {
     let temp = setup_profile_repo_with_sensitive_input();
     heddle(&["capture", "-m", "profile input"], Some(temp.path())).unwrap();
+    seed_stale_monitor_endpoint(&temp);
 
     let output = heddle_output_with_env(
         &["--output", "json", "verify"],

--- a/crates/cli/tests/commit_conformance.rs
+++ b/crates/cli/tests/commit_conformance.rs
@@ -51,13 +51,9 @@ fn ingest_into_git_projection(
     let target = test_support::heddle_repo(git_projection).root();
     ingest::import_git_into_with_options(source, target, ingest::ImportOptions::default())
         .map_err(|error| error.to_string())?;
-    test_support::stage_ingest_source_in_mirror(git_projection, source, &[])
-        .map_err(|error| error.to_string())?;
     test_support::build_existing_mapping(git_projection, Some(source))
         .map_err(|error| error.to_string())?;
-    let mirror_repo =
-        test_support::open_git_repo(git_projection).map_err(|error| error.to_string())?;
-    test_support::seed_ingest_identity_mappings_from_repo(git_projection, &mirror_repo)
+    test_support::seed_ingest_identity_mappings_from_store(git_projection)
         .map_err(|error| error.to_string())
 }
 

--- a/crates/cli/tests/roundtrip_fidelity.rs
+++ b/crates/cli/tests/roundtrip_fidelity.rs
@@ -23,7 +23,8 @@
 use std::{collections::BTreeMap, path::Path, process::Command};
 
 use cli::{ObjectStore, Repository};
-use heddle_git_projection::{git_core::GitProjection, test_support};
+use heddle_git_projection::git_core::GitProjection;
+use objects::object::{Principal, Redaction, StateVisibility, ThreadName, VisibilityTier};
 use tempfile::TempDir;
 
 fn ingest_into_bridge(
@@ -31,19 +32,18 @@ fn ingest_into_bridge(
     source: &Path,
     lossy: bool,
 ) -> Result<(), String> {
-    let target = test_support::heddle_repo(bridge).root();
-    ingest::import_git_into_with_options(
-        source,
-        target,
+    heddle_git_projection::git_ingest::import_git_history(
+        bridge,
+        Some(source),
+        &[],
         ingest::ImportOptions {
             lossy,
             ..ingest::ImportOptions::default()
         },
+        None,
     )
-    .map_err(|error| error.to_string())?;
-    test_support::stage_ingest_source_in_mirror(bridge, source, &[])
-        .map_err(|error| error.to_string())?;
-    test_support::build_existing_mapping(bridge, Some(source)).map_err(|error| error.to_string())
+    .map(|_| ())
+    .map_err(|error| error.to_string())
 }
 
 /// Deterministic identity + dates so every fixture produces stable SHAs
@@ -155,12 +155,20 @@ fn assert_roundtrip_fidelity_opts(case: &str, source: &Path, lossy: bool) {
     let mut bridge = GitProjection::new(&repo);
     ingest_into_bridge(&mut bridge, source, lossy)
         .unwrap_or_else(|e| panic!("[{case}] import from git failed: {e}"));
+    assert!(
+        !repo.heddle_dir().join("git").exists(),
+        "[{case}] import must not create the retired eager Git mirror"
+    );
 
     let dest_home = TempDir::new().expect("dest temp");
     let dest = dest_home.path().join("export");
     bridge
         .export_to_path(&dest)
         .unwrap_or_else(|e| panic!("[{case}] export_to_path failed: {e}"));
+    assert!(
+        !repo.heddle_dir().join("git").exists(),
+        "[{case}] export scratch repository must remain ephemeral"
+    );
 
     // (3) the export must be a structurally sound git repo.
     git(&dest, &["fsck", "--full", "--strict"]);
@@ -192,6 +200,148 @@ fn assert_roundtrip_fidelity_opts(case: &str, source: &Path, lossy: bool) {
              (byte-identity broken)"
         );
     }
+}
+
+#[test]
+fn store_sourced_reconcile_retracts_embargo_across_ephemeral_exports() {
+    let home = TempDir::new().expect("heddle temp");
+    let repo = Repository::init_default(home.path()).expect("init heddle");
+    let mut config = repo.config().clone();
+    config.set_principal("Grace Hopper", "grace@example.com");
+    config
+        .save(&repo.heddle_dir().join("config.toml"))
+        .expect("save principal");
+    let repo = Repository::open(home.path()).expect("reopen heddle");
+
+    std::fs::write(home.path().join("base.txt"), b"base\n").expect("write base");
+    repo.snapshot(Some("base".into()), None)
+        .expect("snapshot base");
+    let base = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .expect("read main")
+        .expect("main tip");
+    std::fs::write(home.path().join("tip.txt"), b"tip\n").expect("write tip");
+    repo.snapshot(Some("tip".into()), None)
+        .expect("snapshot tip");
+    let tip = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .expect("read main")
+        .expect("main tip");
+
+    let destination_home = TempDir::new().expect("destination temp");
+    let destination = destination_home.path().join("export.git");
+    let (base_oid, tip_oid) = {
+        let mut projection = GitProjection::new(&repo);
+        projection
+            .export_to_path(&destination)
+            .expect("first export");
+        (
+            projection.mapping.get_git(&base).expect("base mapped"),
+            projection.mapping.get_git(&tip).expect("tip mapped"),
+        )
+    };
+    assert_eq!(
+        git(&destination, &["rev-parse", "refs/heads/main"]).trim(),
+        tip_oid.to_string()
+    );
+
+    repo.put_state_visibility(StateVisibility {
+        state: tip,
+        tier: VisibilityTier::Private {
+            scope_label: "security".into(),
+        },
+        embargo_until: None,
+        declarer: Principal::new("Grace Hopper", "grace@example.com"),
+        declared_at: chrono::Utc::now(),
+        signature: None,
+        supersedes: None,
+    })
+    .expect("embargo tip");
+
+    let mut projection = GitProjection::new(&repo);
+    projection
+        .export_to_path(&destination)
+        .expect("store-sourced embargo reconcile");
+    assert_eq!(
+        git(&destination, &["rev-parse", "refs/heads/main"]).trim(),
+        base_oid.to_string(),
+        "a fresh projection instance must rewind the destination from store-owned reconcile state"
+    );
+    assert!(projection.mapping.get_git(&tip).is_none());
+    assert!(!repo.heddle_dir().join("git").exists());
+}
+
+#[test]
+fn store_sourced_reconcile_replaces_redacted_tip_with_derived_sha() {
+    let home = TempDir::new().expect("heddle temp");
+    let repo = Repository::init_default(home.path()).expect("init heddle");
+    let mut config = repo.config().clone();
+    config.set_principal("Grace Hopper", "grace@example.com");
+    config
+        .save(&repo.heddle_dir().join("config.toml"))
+        .expect("save principal");
+    let repo = Repository::open(home.path()).expect("reopen heddle");
+
+    std::fs::write(home.path().join("secret.txt"), b"credential=secret\n").expect("write secret");
+    repo.snapshot(Some("secret".into()), None)
+        .expect("snapshot secret");
+    let tip = repo
+        .refs()
+        .get_thread(&ThreadName::new("main"))
+        .expect("read main")
+        .expect("main tip");
+    let state = repo
+        .store()
+        .get_state(&tip)
+        .expect("read state")
+        .expect("tip state");
+    let tree = repo
+        .store()
+        .get_tree(&state.tree)
+        .expect("read tree")
+        .expect("tip tree");
+    let secret_blob = tree
+        .entries()
+        .iter()
+        .find(|entry| entry.name() == "secret.txt")
+        .and_then(|entry| entry.leaf_content_hash())
+        .expect("secret blob");
+
+    let destination_home = TempDir::new().expect("destination temp");
+    let destination = destination_home.path().join("export.git");
+    let original_oid = {
+        let mut projection = GitProjection::new(&repo);
+        projection
+            .export_to_path(&destination)
+            .expect("first export");
+        projection.mapping.get_git(&tip).expect("tip mapped")
+    };
+
+    repo.put_redaction(Redaction {
+        redacted_blob: secret_blob,
+        state: tip,
+        path: "secret.txt".into(),
+        reason: "leaked credential".into(),
+        redactor: Principal::new("Grace Hopper", "grace@example.com"),
+        redacted_at: chrono::Utc::now(),
+        signature: None,
+        purged_at: None,
+        supersedes: None,
+    })
+    .expect("redact secret");
+
+    let mut projection = GitProjection::new(&repo);
+    projection
+        .export_to_path(&destination)
+        .expect("store-sourced redaction reconcile");
+    let derived_oid = git(&destination, &["rev-parse", "refs/heads/main"]);
+    assert_ne!(derived_oid.trim(), original_oid.to_string());
+    let materialized = git(&destination, &["show", "refs/heads/main:secret.txt"]);
+    assert!(materialized.contains("redacted by Heddle"));
+    assert!(!materialized.contains("credential=secret"));
+    assert!(!repo.heddle_dir().join("git").exists());
 }
 
 #[test]
@@ -570,7 +720,7 @@ fn import_preserves_noncanonical_extension_header_order() {
 /// non-UTF8 byte cannot be reconstructed byte-exactly from Heddle state, because
 /// `Principal.name` is a `String` and import lossily replaces the byte with
 /// U+FFFD (the #564-deferred gap). Export must detect this and serve the
-/// VERBATIM mirror bytes at the original OID rather than mint a reconstructed
+/// VERBATIM residual bytes at the original OID rather than mint a reconstructed
 /// (wrong-SHA) object. A regression that reconstructs unconditionally fails this
 /// round-trip (the commit OID drifts) — and the pre-fix #567 code errored out of
 /// the export entirely on the mapped-OID mismatch.
@@ -614,7 +764,7 @@ fn roundtrip_non_utf8_author_identity() {
 
 /// As [`roundtrip_non_utf8_author_identity`], for the COMMITTER identity — the
 /// guard checks the distinct `State.committer` principal too, so a non-UTF8
-/// committer name must likewise route to the verbatim-mirror fallback.
+/// committer name must likewise route to the verbatim-residual fallback.
 #[test]
 fn roundtrip_non_utf8_committer_identity() {
     let tmp = TempDir::new().unwrap();

--- a/crates/cli/tests/roundtrip_fidelity.rs
+++ b/crates/cli/tests/roundtrip_fidelity.rs
@@ -202,6 +202,52 @@ fn assert_roundtrip_fidelity_opts(case: &str, source: &Path, lossy: bool) {
     }
 }
 
+/// A cached mapping is an assertion that reconstructed bytes retain the
+/// imported Git identity. If that assertion is wrong, export must fail loudly
+/// instead of silently remapping the state to the newly derived OID.
+#[test]
+fn reconstruction_oid_mismatch_refuses_silent_remap() {
+    let source_home = TempDir::new().expect("source temp");
+    let source = source_home.path();
+    init_repo(source);
+    write_and_commit(source, "guard.txt", b"fidelity\n", "guard fidelity");
+
+    let heddle_home = TempDir::new().expect("heddle temp");
+    let repo = Repository::init(heddle_home.path()).expect("init heddle repo");
+    let mut bridge = GitProjection::new(&repo);
+    ingest_into_bridge(&mut bridge, source, false).expect("import source");
+
+    let (state_id, original_oid) = bridge
+        .mapping
+        .iter()
+        .next()
+        .map(|(state_id, oid)| (*state_id, *oid))
+        .expect("imported mapping");
+    let wrong_oid = sley::ObjectId::empty_tree(original_oid.format());
+    assert_ne!(wrong_oid, original_oid, "fixture must poison the mapping");
+    bridge.mapping.insert(state_id, wrong_oid);
+
+    let destination_home = TempDir::new().expect("destination temp");
+    let error = bridge
+        .export_to_path(&destination_home.path().join("export.git"))
+        .expect_err("wrong mapped OID must stop export");
+    let message = error.to_string();
+    assert!(
+        message.contains("export reconstruction OID mismatch")
+            && message.contains("refusing to export a wrong-OID commit"),
+        "unexpected fidelity error: {message}"
+    );
+    assert_eq!(
+        bridge.mapping.get_git(&state_id),
+        Some(wrong_oid),
+        "failed export must roll the mapping back instead of silently remapping"
+    );
+    assert!(
+        !repo.heddle_dir().join("git").exists(),
+        "fidelity failure must not recreate the retired eager mirror"
+    );
+}
+
 #[test]
 fn store_sourced_reconcile_retracts_embargo_across_ephemeral_exports() {
     let home = TempDir::new().expect("heddle temp");

--- a/crates/format/src/delta/delta_encoder.rs
+++ b/crates/format/src/delta/delta_encoder.rs
@@ -20,6 +20,8 @@ const MIN_MATCH_LENGTH_LARGE: usize = 16;
 const MIN_MATCH_LENGTH_SMALL: usize = 8;
 /// Maximum offsets to inspect for a single 4-byte key.
 const MAX_MATCH_CANDIDATES: usize = 1024;
+/// Compare long common prefixes in chunks before locating the exact tail.
+const MATCH_CHUNK_SIZE: usize = 32;
 
 /// Delta encoder.
 #[derive(Debug)]
@@ -317,6 +319,12 @@ impl DeltaEncoder {
     fn match_length(base: &[u8], base_pos: usize, target: &[u8], target_pos: usize) -> usize {
         let max_len = (base.len() - base_pos).min(target.len() - target_pos);
         let mut len = 0;
+        while len + MATCH_CHUNK_SIZE <= max_len
+            && base[base_pos + len..base_pos + len + MATCH_CHUNK_SIZE]
+                == target[target_pos + len..target_pos + len + MATCH_CHUNK_SIZE]
+        {
+            len += MATCH_CHUNK_SIZE;
+        }
         while len < max_len && base[base_pos + len] == target[target_pos + len] {
             len += 1;
         }

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -26,6 +26,7 @@ serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
 sley-transport.workspace = true
+tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
@@ -36,6 +37,3 @@ tracing.workspace = true
 default = ["git-overlay", "zstd"]
 git-overlay = []
 zstd = ["objects/zstd", "repo/zstd", "ingest/zstd", "wire/zstd"]
-
-[dev-dependencies]
-tempfile.workspace = true

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -804,12 +804,6 @@ impl<'a> GitProjection<'a> {
         }
     }
 
-    fn active_projection_path(&self) -> GitProjectionResult<PathBuf> {
-        self.git_repo_path
-            .clone()
-            .ok_or(GitProjectionError::GitRepoNotInitialized)
-    }
-
     /// Sort states topologically (parents before children).
     pub fn sort_states_topologically(
         &self,

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Core Git Projection and Bridge Mirror operations.
+//! Core Git Projection operations.
 
 use std::{
     collections::{BTreeSet, HashMap, HashSet},
@@ -572,10 +572,11 @@ impl SyncMapping {
     }
 }
 
-/// Legacy-named implementation for explicit Git Projection and Bridge Mirror operations.
+/// Explicit Git Projection operations.
 pub struct GitProjection<'a> {
     pub heddle_repo: &'a HeddleRepository,
     pub git_repo_path: Option<PathBuf>,
+    scratch_repo: Option<tempfile::TempDir>,
     pub mapping: SyncMapping,
     pub commit_message_overrides: HashMap<StateId, String>,
     pub commit_parent_overrides: HashMap<StateId, Vec<ObjectId>>,
@@ -757,6 +758,7 @@ impl<'a> GitProjection<'a> {
         Self {
             heddle_repo,
             git_repo_path: None,
+            scratch_repo: None,
             mapping: SyncMapping::new(),
             commit_message_overrides: HashMap::new(),
             commit_parent_overrides: HashMap::new(),
@@ -764,33 +766,18 @@ impl<'a> GitProjection<'a> {
         }
     }
 
-    /// Initialize the Bridge Mirror in the .heddle/git directory.
-    pub fn init_mirror(&mut self) -> GitProjectionResult<()> {
-        let _guard = self.init_mirror_with_guard()?;
-        _guard.commit();
+    /// Initialize an ephemeral writable sley repository for one projection run.
+    pub fn init_scratch_repo(&mut self) -> GitProjectionResult<()> {
+        if self.scratch_repo.is_some() {
+            return Ok(());
+        }
+        let scratch = tempfile::Builder::new()
+            .prefix("heddle-git-projection-")
+            .tempdir()?;
+        SleyRepository::init_bare(scratch.path()).map_err(git_err)?;
+        self.git_repo_path = Some(scratch.path().to_path_buf());
+        self.scratch_repo = Some(scratch);
         Ok(())
-    }
-
-    /// Variant of `init_mirror` that returns a `MirrorInitGuard` so
-    /// callers performing a multi-step bring-up (init + first export)
-    /// can roll back the partially-created mirror if a later step
-    /// fails. Call `guard.commit()` once the mirror is known-good.
-    pub fn init_mirror_with_guard(&mut self) -> GitProjectionResult<MirrorInitGuard> {
-        let git_dir = self.heddle_repo.heddle_dir().join("git");
-
-        let did_create = if git_dir.exists() {
-            let _ = open_repo(&git_dir)?;
-            false
-        } else {
-            fs::create_dir_all(&git_dir)?;
-            let _ = SleyRepository::init_bare(&git_dir).map_err(git_err)?;
-            let mirror_repo = open_repo(&git_dir)?;
-            seed_checkout_note_refs_into_mirror(self.heddle_repo.root(), &mirror_repo)?;
-            true
-        };
-
-        self.git_repo_path = Some(git_dir.clone());
-        Ok(MirrorInitGuard::new_from_init(git_dir, did_create))
     }
 
     /// Get the path to the legacy Bridge Mirror directory.
@@ -803,7 +790,7 @@ impl<'a> GitProjection<'a> {
         self.mirror_path().exists()
     }
 
-    /// Open the Git repository (mirror or regular).
+    /// Open the active scratch repository, a legacy mirror, or the checkout.
     pub fn open_git_repo(&self) -> GitProjectionResult<SleyRepository> {
         if let Some(ref path) = self.git_repo_path {
             open_repo(path)
@@ -815,6 +802,12 @@ impl<'a> GitProjection<'a> {
                 open_repo(self.heddle_repo.root())
             }
         }
+    }
+
+    fn active_projection_path(&self) -> GitProjectionResult<PathBuf> {
+        self.git_repo_path
+            .clone()
+            .ok_or(GitProjectionError::GitRepoNotInitialized)
     }
 
     /// Sort states topologically (parents before children).
@@ -908,33 +901,38 @@ impl<'a> GitProjection<'a> {
         }
     }
 
-    /// Export current Heddle state into the internal mirror, then write it out
-    /// as a bare git repository at `target_path`. Auto-initializes
+    /// Reconstruct current Heddle state into an ephemeral projection, then write
+    /// it as a bare git repository at `target_path`. Auto-initializes
     /// `target_path` as a bare repo if it does not already exist.
     pub fn export_to_path(
         &mut self,
         target_path: &Path,
     ) -> GitProjectionResult<super::git_util::ExportStats> {
-        self.init_mirror()?;
+        self.init_scratch_repo()?;
         let stats = self.export()?;
-        self.copy_mirror_to_path(
+        // A colocated Git checkout is the durable Git-side checkpoint now that
+        // the projection itself is ephemeral. Keep it current before this
+        // scratch repository is dropped so the next command does not mistake
+        // the checkout's older HEAD for an out-of-band rewind.
+        self.write_current_checkout_from_existing_projection()?;
+        self.copy_projection_to_path(
             target_path,
             &format!("heddle: export from {}", self.heddle_repo.root().display()),
         )?;
         Ok(stats)
     }
 
-    /// Shared helper: copy every reachable object from the internal mirror to
-    /// `target_path`, then reconcile its branch/tag/note refs to the WHOLE-MIRROR
+    /// Shared helper: copy every reachable object from the scratch projection to
+    /// `target_path`, then reconcile its branch/tag/note refs to the whole
     /// served frontier. The destination is created as a bare repo when it does not
     /// exist. Explicit export never overwrites or deletes an out-of-band destination
     /// tip that Heddle does not own.
-    fn copy_mirror_to_path(
+    fn copy_projection_to_path(
         &mut self,
         target_path: &Path,
         log_message: &str,
     ) -> GitProjectionResult<()> {
-        let mirror_repo = self.open_git_repo()?;
+        let projection_repo = self.open_git_repo()?;
         let target_repo = if target_path.exists() {
             open_repo(target_path)?
         } else {
@@ -943,12 +941,13 @@ impl<'a> GitProjection<'a> {
             open_repo(target_path)?
         };
 
-        // Export only the mirror's managed frontier. A foreign branch or tag
-        // Heddle never wrote must not enter the destination's desired set.
-        let managed_record = read_mirror_managed_refs(&mirror_repo)?;
-        let served_frontier = collect_managed_ref_updates(&mirror_repo, &managed_record)?;
+        // Export only the managed frontier reconstructed from the store. A foreign
+        // branch/tag heddle never wrote — even one at a heddle-minted commit —
+        // must not enter the destination's desired set.
+        let managed_record = read_projection_managed_refs(self.heddle_repo.heddle_dir())?;
+        let served_frontier = collect_managed_ref_updates(&projection_repo, &managed_record)?;
         copy_reachable_objects(
-            &mirror_repo,
+            &projection_repo,
             &target_repo,
             served_frontier.iter().map(|update| update.target),
         )?;
@@ -958,7 +957,7 @@ impl<'a> GitProjection<'a> {
         let old_at_destination = read_destination_ref_map(&target_repo)?;
         let previously_exported = read_exported_refs(&target_repo)?;
         let plan = plan_destination_reconcile(
-            &mirror_repo,
+            &projection_repo,
             &served_frontier,
             None,
             &old_at_destination,
@@ -1104,38 +1103,6 @@ impl<'a> GitProjection<'a> {
             }
         }
 
-        Ok(())
-    }
-
-    pub fn stage_ingest_source_in_mirror(
-        &mut self,
-        source: &Path,
-        refs: &[String],
-    ) -> GitProjectionResult<()> {
-        let source_repo = open_repo(source)?;
-        let updates = collect_import_source_ref_updates(&source_repo, refs)?;
-        if updates.is_empty() {
-            return Ok(());
-        }
-
-        self.init_mirror()?;
-        let mirror_repo = self.open_git_repo()?;
-        copy_reachable_objects(
-            &source_repo,
-            &mirror_repo,
-            updates.iter().map(|update| update.target),
-        )?;
-        apply_ref_updates(
-            &mirror_repo,
-            &updates,
-            &format!("heddle: stage ingest source from {}", source.display()),
-        )?;
-
-        let mut record = read_or_seed_mirror_managed_refs(&mirror_repo)?;
-        for update in &updates {
-            record.insert(full_ref_name(update), update.target);
-        }
-        write_mirror_managed_refs(&mirror_repo, &record)?;
         Ok(())
     }
 
@@ -1507,7 +1474,7 @@ impl<'a> GitProjection<'a> {
         Ok(WriteThroughOutcome::Wrote(git_oid))
     }
 
-    pub fn write_current_checkout_from_existing_mirror(
+    pub fn write_current_checkout_from_existing_projection(
         &mut self,
     ) -> GitProjectionResult<WriteThroughOutcome> {
         if !self.heddle_repo.root().join(".git").exists() {
@@ -1531,15 +1498,15 @@ impl<'a> GitProjection<'a> {
                 ));
             }
         };
-        self.write_thread_state_checkout_from_existing_mirror(&thread, &state_id)
+        self.write_thread_state_checkout_from_existing_projection(&thread, &state_id)
     }
 
-    fn write_thread_state_checkout_from_existing_mirror(
+    fn write_thread_state_checkout_from_existing_projection(
         &mut self,
         thread: &str,
         state_id: &StateId,
     ) -> GitProjectionResult<WriteThroughOutcome> {
-        let mirror_repo = self.open_git_repo()?;
+        let projection_repo = self.open_git_repo()?;
         if self.mapping.is_empty() {
             self.build_existing_mapping(None)?;
         }
@@ -1550,7 +1517,7 @@ impl<'a> GitProjection<'a> {
             .git_overlay_mapped_git_commit_for_state(state_id)
             .map_err(|error| GitProjectionError::Git(error.to_string()))?
         {
-            ObjectId::from_hex(mirror_repo.object_format(), &git_commit)
+            ObjectId::from_hex(projection_repo.object_format(), &git_commit)
                 .map_err(|error| GitProjectionError::InvalidMapping(error.to_string()))?
         } else {
             return Ok(WriteThroughOutcome::Skipped(
@@ -1565,7 +1532,7 @@ impl<'a> GitProjection<'a> {
             ));
         }
         let checkout = CheckoutWrite::prepare(self.heddle_repo.root(), thread)?;
-        if checkout.checkout_repo.git_dir() == mirror_repo.git_dir() {
+        if checkout.checkout_repo.git_dir() == projection_repo.git_dir() {
             return Ok(WriteThroughOutcome::Skipped(
                 WriteThroughSkipReason::MirrorIsWorktree,
             ));
@@ -1573,7 +1540,7 @@ impl<'a> GitProjection<'a> {
         materialize_checkout_closure_from_state(
             self.heddle_repo,
             &self.mapping,
-            &mirror_repo,
+            &projection_repo,
             &checkout.object_repo,
             state_id,
             git_oid,
@@ -1602,42 +1569,6 @@ fn checkout_note_ref_exists(root: &Path) -> GitProjectionResult<bool> {
         .find_reference(super::git_notes::NOTES_REF)
         .map_err(git_err)?
         .is_some())
-}
-
-fn seed_checkout_note_refs_into_mirror(
-    root: &Path,
-    mirror_repo: &SleyRepository,
-) -> GitProjectionResult<()> {
-    if !root.join(".git").exists() {
-        return Ok(());
-    }
-
-    let checkout_repo = match SleyRepository::discover(root) {
-        Ok(repo) => repo,
-        Err(_) => return Ok(()),
-    };
-    if checkout_repo.git_dir() == mirror_repo.git_dir() {
-        return Ok(());
-    }
-    let object_repo = common_repo_for_worktree(&checkout_repo)?;
-    let note_updates = collect_ref_updates(&object_repo)?
-        .into_iter()
-        .filter(|update| update.namespace == RefNamespace::Note)
-        .collect::<Vec<_>>();
-    if note_updates.is_empty() {
-        return Ok(());
-    }
-
-    copy_reachable_objects(
-        &object_repo,
-        mirror_repo,
-        note_updates.iter().map(|update| update.target),
-    )?;
-    apply_ref_updates(
-        mirror_repo,
-        &note_updates,
-        "heddle: seed mirror note refs from checkout",
-    )
 }
 
 fn hydrate_checkout_notes_from_remote_without_mirror(
@@ -2106,48 +2037,6 @@ fn fsync_path(path: &Path) -> GitProjectionResult<()> {
     }
 }
 
-/// RAII guard for `init_mirror`. When the mirror directory did not
-/// exist at acquisition time, an early Drop (panic, error return)
-/// removes the partially-initialized `.heddle/git/` so a future
-/// `heddle export git ...` doesn't see a half-built bare repo. Call
-/// `commit()` once the mirror is known-good (e.g. after a successful
-/// first export) to disarm the guard.
-pub struct MirrorInitGuard {
-    path: PathBuf,
-    /// `Some(true)` means we created the directory in this call and
-    /// own its rollback; `Some(false)` (or `None` after commit) means
-    /// hands off.
-    rollback: Option<bool>,
-}
-
-impl MirrorInitGuard {
-    pub fn new_from_init(path: PathBuf, did_create: bool) -> Self {
-        Self {
-            path,
-            rollback: Some(did_create),
-        }
-    }
-
-    pub fn commit(mut self) {
-        self.rollback = None;
-    }
-}
-
-impl Drop for MirrorInitGuard {
-    fn drop(&mut self) {
-        if matches!(self.rollback, Some(true))
-            && self.path.exists()
-            && let Err(err) = std::fs::remove_dir_all(&self.path)
-        {
-            tracing::warn!(
-                path = %self.path.display(),
-                error = %err,
-                "failed to roll back partial legacy Bridge Mirror; manual cleanup may be required"
-            );
-        }
-    }
-}
-
 /// Git projection policy: a thread is considered an "unclaimed bootstrap"
 /// when it /// points at an empty-tree state with no parents. That is the exact shape of
 /// the state produced by `Repository::seed_default_thread`, and it cannot
@@ -2452,7 +2341,7 @@ fn local_path_from_url(url: &str) -> GitProjectionResult<Option<PathBuf>> {
     Ok(Some(path))
 }
 
-fn collect_ref_updates(repo: &SleyRepository) -> GitProjectionResult<Vec<RefUpdate>> {
+pub(crate) fn collect_ref_updates(repo: &SleyRepository) -> GitProjectionResult<Vec<RefUpdate>> {
     let mut updates = Vec::new();
 
     for reference in repo.references().list_refs().map_err(git_err)? {
@@ -2490,8 +2379,8 @@ pub struct ExportedCommitCounts {
 
 /// Count and partition the commits reachable from the branch and tag tips
 /// that `collect_ref_updates` writes to a destination. Derived from the SAME
-/// ref set `copy_mirror_to_path` copies, so the reported counts equal what
-/// actually lands in the destination — including stale mirror refs left
+/// ref set `copy_projection_to_path` copies, so the reported counts equal what
+/// actually lands in the destination — including stale managed refs left
 /// behind by a dropped Heddle thread (export does not prune them, so the
 /// commit is still copied and must still be counted; pruning would be a
 /// separate behavior change). Notes refs are excluded: they carry
@@ -2752,10 +2641,9 @@ pub fn write_exported_refs(
     write_exported_refs_at(&exported_refs_manifest_path(target_repo), refs)
 }
 
-/// Filename, under the internal MIRROR's git dir, of heddle's record of which
-/// full ref names it MANAGES in the mirror, each mapped to the tip it last
-/// published for that ref. The mirror-side analog of [`HEDDLE_EXPORTED_REFS_FILE`]
-/// (the destination's `heddle-exported-refs`): the mirror reconcile had no
+/// Filename, under durable Git Projection state, recording which full ref names
+/// Heddle manages, each mapped to the tip it last published. This is the source
+/// analog of [`HEDDLE_EXPORTED_REFS_FILE`] at a destination: the reconcile had no
 /// persisted ownership record, so it reconstructed ownership ad-hoc from OID
 /// membership — the bug that drove heddle#316 through 7 review rounds. A mirror
 /// ref is MANAGED iff its full name is a key here, NEVER by OID membership: a
@@ -2763,63 +2651,77 @@ pub fn write_exported_refs(
 /// foreign because heddle never recorded WRITING it under that name. The format,
 /// atomic-write, and parse contract are shared verbatim with the destination
 /// record (`read_exported_refs_at`/`write_exported_refs_at`).
-const HEDDLE_MIRROR_MANAGED_REFS_FILE: &str = "heddle-mirror-managed-refs";
+const HEDDLE_PROJECTION_MANAGED_REFS_FILE: &str = "heddle-managed-refs";
 
-/// On-disk path of the mirror's managed-refs record.
-fn mirror_managed_refs_path(mirror_repo: &SleyRepository) -> PathBuf {
-    mirror_repo.git_dir().join(HEDDLE_MIRROR_MANAGED_REFS_FILE)
+fn projection_managed_refs_path(heddle_dir: &Path) -> PathBuf {
+    heddle_dir
+        .join("git-projection")
+        .join(HEDDLE_PROJECTION_MANAGED_REFS_FILE)
 }
 
-/// Whether the mirror's managed-refs record exists on disk. Used to distinguish
-/// a genuine FIRST export after this code lands (absent → seed from the current
-/// mirror ref set so pre-existing heddle refs aren't all misread as foreign)
-/// from a record that exists but is empty (everything was legitimately dropped —
-/// do NOT re-seed).
-pub fn mirror_managed_refs_recorded(mirror_repo: &SleyRepository) -> bool {
-    mirror_managed_refs_path(mirror_repo).exists()
+fn legacy_mirror_managed_refs_path(mirror_repo: &SleyRepository) -> PathBuf {
+    mirror_repo.git_dir().join("heddle-mirror-managed-refs")
 }
 
-/// The full ref names heddle MANAGES in the mirror (full ref name → last-published
-/// tip OID). `Ok(empty)` when the record is absent — callers seed a first run from
-/// the current mirror ref set; see [`mirror_managed_refs_recorded`].
-pub fn read_mirror_managed_refs(
-    mirror_repo: &SleyRepository,
+/// Read the store-owned projection ref record.
+pub fn read_projection_managed_refs(
+    heddle_dir: &Path,
 ) -> GitProjectionResult<HashMap<String, ObjectId>> {
-    read_exported_refs_at(&mirror_managed_refs_path(mirror_repo))
+    read_exported_refs_at(&projection_managed_refs_path(heddle_dir))
 }
 
-/// Persist the mirror's managed-refs record. Atomic temp+rename via
-/// [`write_exported_refs_at`].
-pub fn write_mirror_managed_refs(
-    mirror_repo: &SleyRepository,
+/// Persist the store-owned projection ref record.
+pub fn write_projection_managed_refs(
+    heddle_dir: &Path,
     refs: &HashMap<String, ObjectId>,
 ) -> GitProjectionResult<()> {
-    write_exported_refs_at(&mirror_managed_refs_path(mirror_repo), refs)
+    write_exported_refs_at(&projection_managed_refs_path(heddle_dir), refs)
 }
 
-/// Read the mirror's managed-refs record, SEEDING a genuine first run (no record
-/// on disk) from the current mirror ref set so the reconcile does not misread
-/// every pre-existing heddle ref as foreign.
-///
-/// This is the #1 first-run risk (heddle#316): an absent record on the first
-/// export after this code lands must NOT make existing refs look foreign — that
-/// would silently stop embargo retraction (a now-embargoed thread tip would never
-/// be rewound/deleted because its branch would be treated as a foreign ref to
-/// spare). Every ref currently in the mirror was put there by heddle (the mint
-/// reconcile, `import git`, or `fetch`), so claiming them all as managed on the first
-/// run is correct. A record that EXISTS but is empty (everything was legitimately
-/// dropped) is NOT re-seeded — only a truly-absent record triggers the seed.
-pub fn read_or_seed_mirror_managed_refs(
-    mirror_repo: &SleyRepository,
+/// Read store-owned reconcile state, lazily migrating a legacy mirror record.
+pub fn read_or_seed_projection_managed_refs(
+    heddle_dir: &Path,
 ) -> GitProjectionResult<HashMap<String, ObjectId>> {
-    if mirror_managed_refs_recorded(mirror_repo) {
-        read_mirror_managed_refs(mirror_repo)
+    if projection_managed_refs_path(heddle_dir).exists() {
+        return read_projection_managed_refs(heddle_dir);
+    }
+    let legacy_path = heddle_dir.join("git");
+    if !legacy_path.exists() {
+        return Ok(HashMap::new());
+    }
+    let legacy_repo = open_repo(&legacy_path)?;
+    let refs = if legacy_mirror_managed_refs_path(&legacy_repo).exists() {
+        read_exported_refs_at(&legacy_mirror_managed_refs_path(&legacy_repo))?
     } else {
-        Ok(collect_ref_updates(mirror_repo)?
+        collect_ref_updates(&legacy_repo)?
             .into_iter()
             .map(|update| (full_ref_name(&update), update.target))
-            .collect())
+            .collect()
+    };
+    write_projection_managed_refs(heddle_dir, &refs)?;
+    Ok(refs)
+}
+
+/// Recreate the prior managed ref surface in an ephemeral projection repo.
+pub fn materialize_projection_managed_refs(
+    repo: &SleyRepository,
+    refs: &HashMap<String, ObjectId>,
+) -> GitProjectionResult<()> {
+    for (name, target) in refs {
+        if repo.read_object(target).is_err()
+            || repo.find_reference(name).map_err(git_err)?.is_some()
+        {
+            continue;
+        }
+        set_reference(
+            repo,
+            name,
+            *target,
+            RefPrecondition::MustNotExist,
+            "heddle: restore store-sourced projection ref",
+        )?;
     }
+    Ok(())
 }
 
 /// The mirror refs heddle MANAGES, as [`RefUpdate`]s — [`collect_ref_updates`]
@@ -2866,17 +2768,15 @@ enum RefMove {
     /// past heddle's last-published tip also descends from `new`, but is
     /// [`Diverged`](RefMove::Diverged), never force-overwritten (heddle#316 r12).
     Rewind,
-    /// `old` and `new` share no ancestor line (or `old` is unresolvable here) —
+    /// `old` and `new` share no ancestor line —
     /// the divergence the fast-forward guard exists to catch.
     Diverged,
 }
 
 /// Classify how a destination ref moves from `old` to `new`, resolving the
-/// topology in `repo` (the mirror, which holds every served object PLUS any
-/// previously-exported-now-embargoed object the purge dropped from the mapping
-/// but not from the object DB). The single place that distinguishes a deliberate
-/// embargo rewind from a fork, so both push destinations force the former and
-/// reject the latter identically.
+/// topology in the ephemeral projection repository. This is the single place
+/// that distinguishes a deliberate embargo/redaction replacement from a fork,
+/// so both push destinations force the former and reject the latter identically.
 ///
 /// `recorded_tip` is the tip heddle last published for this ref at THIS
 /// destination (from its exported-refs record), or `None` when heddle has no
@@ -2910,16 +2810,26 @@ fn classify_ref_move(
     // authorized ONLY when heddle OWNS the rewind: `old` is exactly the tip heddle
     // itself last published for this ref here (per the exported-refs record). A
     // destination tip heddle did NOT publish — an out-of-band descendant the user
-    // advanced and fetched into the mirror — is never force-overwritten; it falls
+    // advanced — is never force-overwritten; it falls
     // through to `Diverged` (FF-rejected unless the user passes `--force`), so its
-    // newer commit survives. `old`'s objects survive in the mirror because heddle
-    // published it (the embargo purge drops the StateId→OID mapping, never the
-    // object); if `old` is NOT resolvable here we cannot prove a rewind anyway.
-    if recorded_tip == Some(old)
-        && repo.read_commit(&old).is_ok()
-        && commit_is_descendant_of(repo, old, new)?
-    {
-        return Ok(RefMove::Rewind);
+    // newer commit survives.
+    //
+    // A fresh scratch repository deliberately does not contain every object
+    // published by an earlier export. Redaction can also remint an imported
+    // commit at a derived SHA. In either case the destination-owned ref record
+    // is the durable proof that an absent `old` is ours to replace. When `old`
+    // is present we retain the stronger ancestry proof and reject unrelated
+    // history even if the record says Heddle last published it.
+    if recorded_tip == Some(old) {
+        match repo.read_object(&old) {
+            Err(sley::GitError::NotFound(kind)) if kind.missing_object_kind().is_some() => {
+                return Ok(RefMove::Rewind);
+            }
+            Ok(_) if commit_is_descendant_of(repo, old, new)? => {
+                return Ok(RefMove::Rewind);
+            }
+            Ok(_) | Err(_) => {}
+        }
     }
     Ok(RefMove::Diverged)
 }
@@ -3510,8 +3420,8 @@ fn clone_url_to_bare_via_sley(
 /// that remain residual- or mirror-backed: git objects are content-addressed, so
 /// a faithful reconstruction lands the exact same OID the mirror copy would have,
 /// and the lossy path installs verbatim bytes. The exclude set keeps it O(objects
-/// new since the parent). `init_mirror` remains available for migration; this
-/// path does not delete `.heddle/git`.
+/// new since the parent). A legacy mirror remains a read-only migration fallback;
+/// this path never creates or populates `.heddle/git`.
 #[allow(clippy::too_many_arguments)]
 pub fn materialize_checkout_closure_from_state(
     heddle_repo: &HeddleRepository,

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -17,10 +17,11 @@ use tracing::debug;
 
 use crate::{
     git_core::{
-        GitProjection, GitProjectionError, GitProjectionResult, LocalGitIdentity, SyncMapping,
-        copy_reachable_objects, count_exported_commits, delete_reference_if_present,
-        git_config_identity_with_global_fallback, git_err, principal_is_default_unknown,
-        read_or_seed_mirror_managed_refs, write_mirror_managed_refs,
+        GitProjection, GitProjectionError, GitProjectionResult, LocalGitIdentity, RefNamespace,
+        SyncMapping, collect_ref_updates, copy_reachable_objects, count_exported_commits,
+        delete_reference_if_present, git_config_identity_with_global_fallback, git_err,
+        materialize_projection_managed_refs, open_repo, principal_is_default_unknown,
+        read_or_seed_projection_managed_refs, set_reference, write_projection_managed_refs,
     },
     git_notes,
     git_reconstruct::{commit_object_id, reconstruct_commit_bytes, write_commit_object},
@@ -73,7 +74,7 @@ fn identity_is_byte_faithful(who: &Principal) -> bool {
 /// a wrong-SHA reconstructed object.
 ///
 /// `pub` so the checkout write-through path (#568 P1,
-/// `git_core::write_thread_state_checkout_from_existing_mirror`) reads the SAME
+/// `git_core::write_thread_state_checkout_from_existing_projection`) reads the SAME
 /// single faithful-or-lossy discriminator the export path does — reconstruct
 /// faithful commits from state, residual-then-mirror backstop the lossy residual.
 /// Keeping ONE chokepoint for the decision means a new consumer cannot drift to a
@@ -137,7 +138,22 @@ pub fn export_state(
     if !visible(&tier, options.audience) {
         return Ok(None);
     }
+    Ok(Some(write_state_object(
+        mapping,
+        heddle_repo,
+        repo,
+        &state,
+        &options,
+    )?))
+}
 
+fn write_state_object(
+    mapping: &SyncMapping,
+    heddle_repo: &HeddleRepository,
+    repo: &SleyRepository,
+    state: &State,
+    options: &ExportStateOptions<'_>,
+) -> GitProjectionResult<ObjectId> {
     // Fidelity mint (#567): the state carries a captured original git commit
     // (#565 fields — `raw_message` is the load-bearing signal). MINT the commit
     // object from that raw metadata via `reconstruct_commit_bytes` — NO footer,
@@ -161,9 +177,9 @@ pub fn export_state(
     //     DERIVED OID that still preserves raw_message/identities/headers. With
     //     no original to match this is correct, not the wrong-SHA bug the r2
     //     `git_lossy` guard (rightly) blocks ONLY for a MAPPED commit.
-    if has_git_fidelity(&state) {
-        let content = reconstruct_commit_bytes(heddle_repo, repo, mapping, &state)?;
-        return Ok(Some(write_commit_object(repo, &content)?));
+    if has_git_fidelity(state) {
+        let content = reconstruct_commit_bytes(heddle_repo, repo, mapping, state)?;
+        return write_commit_object(repo, &content);
     }
 
     // Native heddle commit: no original to preserve. Mint a raw commit object
@@ -184,10 +200,10 @@ pub fn export_state(
         .filter(|s| !s.is_empty());
     let message = match options.message_override {
         Some(message) => GitProjection::build_commit_message_with_footer_with_body(
-            &state, message, hosted_url, /*omitted=*/ 0,
+            state, message, hosted_url, /*omitted=*/ 0,
         ),
         None => {
-            GitProjection::build_commit_message_with_footer(&state, hosted_url, /*omitted=*/ 0)
+            GitProjection::build_commit_message_with_footer(state, hosted_url, /*omitted=*/ 0)
         }
     };
     let parent_oids: Vec<ObjectId> = if let Some(parents) = options.parent_override {
@@ -212,7 +228,7 @@ pub fn export_state(
         };
         identity.to_signature(state.created_at.timestamp())
     } else {
-        state_to_signature(&state)
+        state_to_signature(state)
     };
     let commit = CommitObject {
         tree: git_tree_oid,
@@ -222,10 +238,8 @@ pub fn export_state(
         encoding: None,
         message: message.into_bytes(),
     };
-    Ok(Some(
-        repo.write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
-            .map_err(git_err)?,
-    ))
+    repo.write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+        .map_err(git_err)
 }
 
 /// Export a Heddle tree to Git.
@@ -343,11 +357,80 @@ fn seed_exportable_ingest_identities(
     Ok(())
 }
 
+fn materialize_cached_mappings(
+    bridge: &mut GitProjection<'_>,
+    repo: &SleyRepository,
+    residuals: &ResidualStore,
+    identity: Option<&LocalGitIdentity>,
+    audience: &AudienceTier,
+) -> GitProjectionResult<()> {
+    let state_ids = bridge
+        .mapping
+        .iter()
+        .map(|(state, _)| *state)
+        .collect::<Vec<_>>();
+    let sorted = bridge.sort_states_topologically(&state_ids)?;
+    let legacy = bridge
+        .mirror_path()
+        .exists()
+        .then(|| open_repo(&bridge.mirror_path()))
+        .transpose()?;
+
+    for state_id in sorted {
+        let Some(mapped_oid) = bridge.mapping.get_git(&state_id) else {
+            continue;
+        };
+        let Some(state) = bridge.heddle_repo.store().get_state(&state_id)? else {
+            continue;
+        };
+        if commit_requires_residual(&state) {
+            let installed = residuals.install_commit_closure_into(repo, &mapped_oid)?;
+            if !installed && repo.read_object(&mapped_oid).is_err() {
+                let Some(legacy) = legacy.as_ref() else {
+                    return Err(GitProjectionError::Git(format!(
+                        "mapped non-reconstructable Git object {mapped_oid} for state {state_id} has no Raw Git Object Residual"
+                    )));
+                };
+                copy_reachable_objects(legacy, repo, [mapped_oid])?;
+            }
+            continue;
+        }
+
+        let reconstructed = if commit_is_byte_faithful(&state) {
+            let content =
+                reconstruct_commit_bytes(bridge.heddle_repo, repo, &bridge.mapping, &state)?;
+            write_commit_object(repo, &content)?
+        } else {
+            write_state_object(
+                &bridge.mapping,
+                bridge.heddle_repo,
+                repo,
+                &state,
+                &ExportStateOptions {
+                    identity,
+                    message_override: None,
+                    parent_override: None,
+                    audience,
+                },
+            )?
+        };
+        if reconstructed != mapped_oid {
+            debug!(
+                state = %state_id,
+                mapped = %mapped_oid,
+                derived = %reconstructed,
+                "cached projection changed; retaining the derived object and remapping from store state"
+            );
+        }
+    }
+    Ok(())
+}
+
 fn export_scoped(
     bridge: &mut GitProjection,
     thread: Option<&str>,
 ) -> GitProjectionResult<ExportStats> {
-    bridge.init_mirror()?;
+    bridge.init_scratch_repo()?;
 
     let states = match thread {
         Some(thread) => {
@@ -384,32 +467,22 @@ fn export_scoped(
     let reachable: HashSet<StateId> = sorted_states.iter().copied().collect();
     let repo = bridge.open_git_repo()?;
     residual_store.install_tag_residuals_into(&repo)?;
-    for state_id in &sorted_states {
-        let Some(mapped_oid) = bridge.mapping.get_git(state_id) else {
-            continue;
-        };
-        let Some(state) = bridge.heddle_repo.store().get_state(state_id)? else {
-            continue;
-        };
-        if commit_requires_residual(&state) {
-            let installed = residual_store.install_commit_closure_into(&repo, &mapped_oid)?;
-            if !installed && repo.read_object(&mapped_oid).is_err() {
-                return Err(GitProjectionError::Git(format!(
-                    "mapped non-reconstructable Git object {mapped_oid} for state {state_id} has no Raw Git Object Residual and is unavailable from the Bridge Mirror"
-                )));
-            }
-        } else if commit_is_byte_faithful(&state) && repo.read_object(&mapped_oid).is_err() {
-            let content =
-                reconstruct_commit_bytes(bridge.heddle_repo, &repo, &bridge.mapping, &state)?;
-            let reconstructed = commit_object_id(&content);
-            if reconstructed != mapped_oid {
-                return Err(GitProjectionError::Git(format!(
-                    "fresh export reconstruction OID mismatch for state {state_id}: reconstructed {reconstructed}, expected mapped {mapped_oid}"
-                )));
-            }
-            write_commit_object(&repo, &content)?;
+    for note_ref in residual_store.list_note_refs(repo.object_format())? {
+        if !residual_store.install_object_closure_into(&repo, &note_ref.oid)? {
+            return Err(GitProjectionError::Git(format!(
+                "imported note ref {} is missing its Raw Git Object Residual",
+                note_ref.name
+            )));
         }
+        set_reference(
+            &repo,
+            &format!("refs/notes/{}", note_ref.name),
+            note_ref.oid,
+            sley::RefPrecondition::Any,
+            "heddle: restore store-sourced imported note ref",
+        )?;
     }
+    materialize_cached_mappings(bridge, &repo, &residual_store, identity.as_ref(), &audience)?;
     bridge.mapping.retain_git_objects(&repo);
     bridge.seed_git_checkpoint_mappings_from_checkout(&repo)?;
     bridge.seed_ingest_identity_mappings_from_repo(&repo)?;
@@ -792,7 +865,8 @@ fn export_scoped(
     // record. Read BEFORE the head/tag loops mutate any ref so a genuine first run
     // (absent record) seeds from the prior-run ref set rather than misreading every
     // pre-existing ref as foreign — which would silently stop embargo retraction.
-    let mut managed_record = read_or_seed_mirror_managed_refs(&repo)?;
+    let mut managed_record = read_or_seed_projection_managed_refs(bridge.heddle_repo.heddle_dir())?;
+    materialize_projection_managed_refs(&repo, &managed_record)?;
 
     // Reconcile the mirror's HEADS via the shared `reconcile_ref` decision. Iterate
     // the CURRENT threads: a dropped thread's stale branch is intentionally NOT
@@ -988,11 +1062,19 @@ fn export_scoped(
 
     // Persist the updated ownership record so the next reconcile — and the push
     // frontier (`collect_managed_ref_updates`) — read heddle's managed set by name.
-    write_mirror_managed_refs(&repo, &managed_record)?;
+    write_projection_managed_refs(bridge.heddle_repo.heddle_dir(), &managed_record)?;
+
+    for update in collect_ref_updates(&repo)?
+        .into_iter()
+        .filter(|update| update.namespace == RefNamespace::Note)
+    {
+        residual_store.capture_object_closure_from_git_repo(&repo, &update.target)?;
+        residual_store.record_note_ref(&update.name, update.target)?;
+    }
 
     // Every count in the summary is a partition of the SINGLE copied ref
-    // set: `total` is unique commits reachable from the mirror's branch/tag
-    // tips (the exact ref set `copy_mirror_to_path` writes via
+    // set: `total` is unique commits reachable from the projection's branch/tag
+    // tips (the exact ref set `copy_projection_to_path` writes via
     // `collect_ref_updates`), and `states_exported` ("newly") is the subset
     // of THAT walk minted this run. Deriving both from one walk — rather
     // than tallying `states_exported` inline over `list_states()` — makes

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -399,6 +399,14 @@ fn materialize_cached_mappings(
         let reconstructed = if commit_is_byte_faithful(&state) {
             let content =
                 reconstruct_commit_bytes(bridge.heddle_repo, repo, &bridge.mapping, &state)?;
+            let reconstructed = commit_object_id(&content);
+            if reconstructed != mapped_oid {
+                return Err(reconstruction_oid_mismatch(
+                    &state_id,
+                    reconstructed,
+                    mapped_oid,
+                ));
+            }
             write_commit_object(repo, &content)?
         } else {
             write_state_object(
@@ -424,6 +432,17 @@ fn materialize_cached_mappings(
         }
     }
     Ok(())
+}
+
+fn reconstruction_oid_mismatch(
+    state_id: &StateId,
+    reconstructed: ObjectId,
+    mapped: ObjectId,
+) -> GitProjectionError {
+    GitProjectionError::Git(format!(
+        "export reconstruction OID mismatch for state {state_id}: reconstructed {reconstructed}, expected mapped {mapped}; \
+         refusing to export a wrong-OID commit (unmodeled fidelity gap)"
+    ))
 }
 
 fn export_scoped(
@@ -642,13 +661,19 @@ fn export_scoped(
                     )?;
                     // Safety net: the regenerated object MUST hash to the mapped
                     // OID. A mismatch means reconstruction diverged from the
-                    // imported bytes (an undetected fidelity gap), so fall back to
-                    // residual / Bridge Mirror / mapped OID rather than write a
-                    // wrong-SHA object.
+                    // imported bytes (an undetected fidelity gap), so hard-error
+                    // rather than silently remap the imported identity.
                     let reconstructed = commit_object_id(&content);
-                    if mapped.map(|m| m == reconstructed).unwrap_or(true) {
-                        write_commit_object(&repo, &content)?;
+                    if let Some(mapped_oid) = mapped
+                        && mapped_oid != reconstructed
+                    {
+                        return Err(reconstruction_oid_mismatch(
+                            &state_id,
+                            reconstructed,
+                            mapped_oid,
+                        ));
                     }
+                    write_commit_object(&repo, &content)?;
                 } else if let Some(mapped_oid) = mapped {
                     // Lossy path: install the commit plus its exact tree/blob
                     // closure. Import capture guarantees this is complete, so a

--- a/crates/git-projection/src/git_ingest.rs
+++ b/crates/git-projection/src/git_ingest.rs
@@ -3,8 +3,8 @@
 
 use std::{collections::HashSet, path::Path};
 
-use objects::{object::StateId, store::ObjectStore};
-use sley::{GitObjectType, ObjectId, Repository as SleyRepository};
+use objects::store::ObjectStore;
+use sley::{GitObjectType, ObjectId};
 
 use super::{
     git_core::{
@@ -12,7 +12,6 @@ use super::{
         collect_import_source_ref_updates, open_repo,
     },
     git_export::commit_requires_residual,
-    git_notes,
     git_residual::ResidualStore,
     git_util::ImportStats,
 };
@@ -39,16 +38,10 @@ pub fn import_git_history(
         progress,
     )
     .map_err(map_ingest_error)?;
-    bridge.stage_ingest_source_in_mirror(source, refs)?;
-    if refs.is_empty() {
-        bridge.build_existing_mapping(Some(source))?;
-    } else {
-        bridge.build_existing_mapping(None)?;
-    }
-    let mirror_repo = bridge.open_git_repo()?;
-    bridge.seed_ingest_identity_mappings_from_repo(&mirror_repo)?;
+    bridge.build_existing_mapping(Some(source))?;
+    bridge.seed_ingest_identity_mappings_from_store()?;
     capture_import_residuals(bridge, source, refs, &stats)?;
-    backfill_ingest_identity_notes_in_mirror(bridge, &mirror_repo, refs)?;
+    bridge.save_mapping_to_disk()?;
     Ok(import_stats_from_ingest(stats))
 }
 
@@ -82,16 +75,22 @@ fn capture_import_residuals(
         residuals.capture_commit_closure_from_git_repo(&source_repo, &git_oid)?;
     }
 
-    for update in updates
-        .into_iter()
-        .filter(|update| update.namespace == RefNamespace::Tag)
-    {
-        let object = source_repo
-            .read_object(&update.target)
-            .map_err(super::git_core::git_err)?;
-        if object.object_type == GitObjectType::Tag {
-            residuals.capture_tag_chain_from_git_repo(&source_repo, &update.target)?;
-            residuals.record_tag_ref(&update.name, update.target)?;
+    for update in updates {
+        match update.namespace {
+            RefNamespace::Tag => {
+                let object = source_repo
+                    .read_object(&update.target)
+                    .map_err(super::git_core::git_err)?;
+                if object.object_type == GitObjectType::Tag {
+                    residuals.capture_tag_chain_from_git_repo(&source_repo, &update.target)?;
+                    residuals.record_tag_ref(&update.name, update.target)?;
+                }
+            }
+            RefNamespace::Note => {
+                residuals.capture_object_closure_from_git_repo(&source_repo, &update.target)?;
+                residuals.record_note_ref(&update.name, update.target)?;
+            }
+            RefNamespace::Branch => {}
         }
     }
     Ok(())
@@ -144,85 +143,4 @@ fn import_stats_from_ingest(stats: ingest::ImportStats) -> ImportStats {
         skipped_non_commit_refs: stats.refs_seen.non_commit_skipped,
         lossy_entries: stats.lossy_entries,
     }
-}
-
-fn backfill_ingest_identity_notes_in_mirror(
-    bridge: &GitProjection<'_>,
-    mirror_repo: &SleyRepository,
-    refs: &[String],
-) -> GitProjectionResult<()> {
-    let scoped_commits = if refs.is_empty() {
-        None
-    } else {
-        let updates = collect_import_source_ref_updates(mirror_repo, refs)?;
-        Some(reachable_commits_from_updates(mirror_repo, updates)?)
-    };
-
-    for (git_sha, state_id) in bridge.heddle_repo.git_overlay_ingest_commit_mapping()? {
-        let state_id = StateId::parse(&state_id)?;
-        let git_oid = git_sha
-            .parse::<ObjectId>()
-            .map_err(|err| GitProjectionError::InvalidMapping(err.to_string()))?;
-        if scoped_commits
-            .as_ref()
-            .is_some_and(|commits| !commits.contains(&git_oid))
-        {
-            continue;
-        }
-        if mirror_repo.read_object(&git_oid).is_err() {
-            continue;
-        }
-        if git_notes::read_note(mirror_repo, git_oid)?.is_some() {
-            continue;
-        }
-        let tier = bridge
-            .heddle_repo
-            .effective_visibility_tier(&state_id)
-            .map_err(|error| {
-                GitProjectionError::Git(format!("resolve visibility for {state_id}: {error:#}"))
-            })?;
-        if !repo::visible(&tier, &repo::AudienceTier::Public) {
-            continue;
-        }
-        let Some(state) = bridge.heddle_repo.store().get_state(&state_id)? else {
-            continue;
-        };
-        git_notes::write_note(
-            mirror_repo,
-            git_oid,
-            &git_notes::HeddleNote::from_state(&state),
-        )?;
-    }
-    Ok(())
-}
-
-fn reachable_commits_from_updates(
-    repo: &SleyRepository,
-    updates: Vec<super::git_core::RefUpdate>,
-) -> GitProjectionResult<HashSet<ObjectId>> {
-    let mut stack = updates
-        .into_iter()
-        .map(|update| update.target)
-        .collect::<Vec<_>>();
-    let mut seen = HashSet::new();
-    let mut commits = HashSet::new();
-    while let Some(oid) = stack.pop() {
-        if !seen.insert(oid) {
-            continue;
-        }
-        let object = repo.read_object(&oid).map_err(super::git_core::git_err)?;
-        match object.object_type {
-            GitObjectType::Commit => {
-                commits.insert(oid);
-                let commit = repo.read_commit(&oid).map_err(super::git_core::git_err)?;
-                stack.extend(commit.parents);
-            }
-            GitObjectType::Tag => {
-                let tag = repo.read_tag(&oid).map_err(super::git_core::git_err)?;
-                stack.push(tag.object);
-            }
-            GitObjectType::Tree | GitObjectType::Blob => {}
-        }
-    }
-    Ok(commits)
 }

--- a/crates/git-projection/src/git_mapping.rs
+++ b/crates/git-projection/src/git_mapping.rs
@@ -215,6 +215,23 @@ impl<'a> GitProjection<'a> {
         Ok(())
     }
 
+    /// Seed durable ingest identities without requiring a Git object warehouse.
+    pub fn seed_ingest_identity_mappings_from_store(&mut self) -> GitProjectionResult<()> {
+        for (git_sha, state_id) in self.heddle_repo.git_overlay_ingest_commit_mapping()? {
+            let state_id = StateId::parse(&state_id)?;
+            if self.heddle_repo.store().get_state(&state_id)?.is_none()
+                || self.mapping.has_heddle(&state_id)
+            {
+                continue;
+            }
+            let git_oid = parse_stored_git_oid(&git_sha)?;
+            if !self.mapping.has_git(git_oid) {
+                self.mapping.insert(state_id, git_oid);
+            }
+        }
+        Ok(())
+    }
+
     #[cfg_attr(not(feature = "git-overlay"), allow(dead_code))]
     pub fn prune_unreachable_mapping_entries(&mut self) -> GitProjectionResult<usize> {
         let repo = self.open_git_repo()?;

--- a/crates/git-projection/src/git_reconstruct.rs
+++ b/crates/git-projection/src/git_reconstruct.rs
@@ -241,11 +241,9 @@ fn append_folded(out: &mut Vec<u8>, value: &[u8]) {
 }
 
 impl GitProjection<'_> {
-    /// Open (initializing if necessary) a writable sley repo suitable for
-    /// reconstruction's tree-OID resolution. Any writable odb works — git trees
-    /// are content-addressed — so the bridge's own mirror is reused.
+    /// Open an ephemeral writable sley repo for tree-OID resolution.
     pub fn reconstruction_repo(&mut self) -> GitProjectionResult<SleyRepository> {
-        self.init_mirror()?;
+        self.init_scratch_repo()?;
         self.open_git_repo()
     }
 

--- a/crates/git-projection/src/git_residual.rs
+++ b/crates/git-projection/src/git_residual.rs
@@ -58,6 +58,7 @@ pub const RESIDUALS_DIR_NAME: &str = "git-residuals";
 
 const RESIDUAL_MAGIC: &[u8; 4] = b"HR01";
 const TAG_REFS_FILE_NAME: &str = "tag-refs.json";
+const NOTE_REFS_FILE_NAME: &str = "note-refs.json";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResidualTagRef {
@@ -65,8 +66,19 @@ pub struct ResidualTagRef {
     pub oid: ObjectId,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResidualNoteRef {
+    pub name: String,
+    pub oid: ObjectId,
+}
+
 #[derive(Debug, Default, Deserialize, Serialize)]
 struct TagRefFile {
+    refs: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct NoteRefFile {
     refs: BTreeMap<String, String>,
 }
 
@@ -343,6 +355,50 @@ impl ResidualStore {
         }
     }
 
+    /// Capture the complete object closure rooted at an imported auxiliary ref.
+    pub fn capture_object_closure_from_git_repo(
+        &self,
+        source: &SleyRepository,
+        root: &ObjectId,
+    ) -> GitProjectionResult<()> {
+        let format = source.object_format();
+        let mut stack = vec![*root];
+        let mut seen = HashSet::new();
+        while let Some(oid) = stack.pop() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            let object = source.read_object(&oid).map_err(git_err)?;
+            self.put_residual_verified(oid, format, object.object_type, object.body.clone())?;
+            match object.object_type {
+                GitObjectType::Commit => {
+                    let commit =
+                        sley::CommitObject::parse_ref(format, &object.body).map_err(git_err)?;
+                    stack.push(commit.tree);
+                    stack.extend(commit.parents.iter().copied());
+                }
+                GitObjectType::Tree => {
+                    let tree = sley::TreeObject::parse(format, &object.body).map_err(git_err)?;
+                    stack.extend(
+                        tree.entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_gitlink())
+                            .map(|entry| entry.oid),
+                    );
+                }
+                GitObjectType::Tag => {
+                    stack.push(
+                        sley::TagObject::parse(format, &object.body)
+                            .map_err(git_err)?
+                            .object,
+                    );
+                }
+                GitObjectType::Blob => {}
+            }
+        }
+        Ok(())
+    }
+
     /// Persist the raw annotated-tag object targeted by an imported tag ref.
     /// Native markers retain the peeled state identity; this sidecar retains the
     /// wrapper identity needed to recreate an annotated ref in a fresh projection.
@@ -394,6 +450,50 @@ impl ResidualStore {
             .collect()
     }
 
+    /// Persist an imported note ref independently of a Git mirror.
+    pub fn record_note_ref(&self, name: &str, oid: ObjectId) -> GitProjectionResult<()> {
+        let path = self.residuals_dir().join(NOTE_REFS_FILE_NAME);
+        let mut file = match fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice::<NoteRefFile>(&bytes).map_err(|error| {
+                GitProjectionError::Git(format!("invalid residual note-ref mapping: {error}"))
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => NoteRefFile::default(),
+            Err(error) => return Err(error.into()),
+        };
+        file.refs.insert(name.to_string(), oid.to_string());
+        let bytes = serde_json::to_vec_pretty(&file).map_err(|error| {
+            GitProjectionError::Git(format!("serialize residual note-ref mapping: {error}"))
+        })?;
+        write_file_atomic(&path, &bytes)?;
+        Ok(())
+    }
+
+    /// Read durable imported note ref identities.
+    pub fn list_note_refs(
+        &self,
+        format: ObjectFormat,
+    ) -> GitProjectionResult<Vec<ResidualNoteRef>> {
+        let path = self.residuals_dir().join(NOTE_REFS_FILE_NAME);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        let file = serde_json::from_slice::<NoteRefFile>(&bytes).map_err(|error| {
+            GitProjectionError::Git(format!("invalid residual note-ref mapping: {error}"))
+        })?;
+        file.refs
+            .into_iter()
+            .map(|(name, oid)| {
+                ObjectId::from_hex(format, &oid)
+                    .map(|oid| ResidualNoteRef { name, oid })
+                    .map_err(|error| {
+                        GitProjectionError::Git(format!("invalid note residual oid {oid}: {error}"))
+                    })
+            })
+            .collect()
+    }
+
     /// Install a residual into a target Git object database.
     ///
     /// Prefer this over reading residual bytes and re-framing in call sites.
@@ -413,6 +513,63 @@ impl ResidualStore {
             return Err(GitProjectionError::Git(format!(
                 "installing Raw Git Object Residual wrote {written}, expected {oid}"
             )));
+        }
+        Ok(true)
+    }
+
+    /// Install a complete auxiliary-ref closure captured by
+    /// [`Self::capture_object_closure_from_git_repo`].
+    pub fn install_object_closure_into(
+        &self,
+        target: &SleyRepository,
+        root: &ObjectId,
+    ) -> GitProjectionResult<bool> {
+        let format = target.object_format();
+        if self.get_residual(format, root)?.is_none() {
+            return Ok(false);
+        }
+        let mut stack = vec![*root];
+        let mut seen = HashSet::new();
+        while let Some(oid) = stack.pop() {
+            if !seen.insert(oid) {
+                continue;
+            }
+            let residual = self.get_residual(format, &oid)?.ok_or_else(|| {
+                GitProjectionError::Git(format!(
+                    "Raw Git Object Residual closure for {root} is missing {oid}"
+                ))
+            })?;
+            target
+                .write_object(EncodedObject::new(
+                    residual.object_type,
+                    residual.body.clone(),
+                ))
+                .map_err(git_err)?;
+            match residual.object_type {
+                GitObjectType::Commit => {
+                    let commit =
+                        sley::CommitObject::parse_ref(format, &residual.body).map_err(git_err)?;
+                    stack.push(commit.tree);
+                    stack.extend(commit.parents.iter().copied());
+                }
+                GitObjectType::Tree => {
+                    let tree = sley::TreeObject::parse(format, &residual.body).map_err(git_err)?;
+                    stack.extend(
+                        tree.entries
+                            .into_iter()
+                            .filter(|entry| !entry.is_gitlink())
+                            .map(|entry| entry.oid),
+                    );
+                }
+                GitObjectType::Tag => {
+                    stack.push(
+                        sley::TagObject::parse(format, &residual.body)
+                            .map_err(git_err)?
+                            .object,
+                    );
+                }
+                GitObjectType::Blob => {}
+            }
         }
         Ok(true)
     }

--- a/crates/git-projection/src/git_residual.rs
+++ b/crates/git-projection/src/git_residual.rs
@@ -539,12 +539,17 @@ impl ResidualStore {
                     "Raw Git Object Residual closure for {root} is missing {oid}"
                 ))
             })?;
-            target
+            let written = target
                 .write_object(EncodedObject::new(
                     residual.object_type,
                     residual.body.clone(),
                 ))
                 .map_err(git_err)?;
+            if written != oid {
+                return Err(GitProjectionError::Git(format!(
+                    "installing Raw Git Object Residual wrote {written}, expected {oid}"
+                )));
+            }
             match residual.object_type {
                 GitObjectType::Commit => {
                     let commit =
@@ -874,7 +879,10 @@ fn object_type_from_tag(tag: u8) -> GitProjectionResult<GitObjectType> {
 
 #[cfg(test)]
 mod tests {
-    use sley::Repository as SleyRepository;
+    use sley::{
+        CommitObject, EntryKind, GitTime, Repository as SleyRepository, Signature, TreeEditor,
+        plumbing::{sley_core::ByteString, sley_object::EncodedObject},
+    };
 
     use super::*;
 
@@ -966,6 +974,102 @@ committer A <a@e> 1 +0000\n\
             .unwrap()
             .unwrap();
         assert_eq!(residual.body, b"migrated-bytes\n");
+    }
+
+    fn write_test_commit(
+        repo: &SleyRepository,
+        tree: ObjectId,
+        parents: Vec<ObjectId>,
+        message: &str,
+    ) -> ObjectId {
+        let signature = Signature {
+            name: ByteString::new(b"Residual Test".to_vec()),
+            email: ByteString::new(b"residual@heddle.test".to_vec()),
+            time: GitTime::new(0, 0),
+            raw: b"Residual Test <residual@heddle.test> 0 +0000".to_vec(),
+        };
+        let commit = CommitObject {
+            tree,
+            parents,
+            author: signature.to_ident_bytes(),
+            committer: signature.to_ident_bytes(),
+            encoding: None,
+            message: message.as_bytes().to_vec(),
+        };
+        repo.write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+            .expect("write commit")
+    }
+
+    #[test]
+    fn auxiliary_ref_closure_round_trips_without_git_mirror() {
+        let dir = tempfile::tempdir().unwrap();
+        let heddle = dir.path().join(".heddle");
+        let source = SleyRepository::init_bare(dir.path().join("source.git")).unwrap();
+        let target = SleyRepository::init_bare(dir.path().join("target.git")).unwrap();
+        fs::create_dir_all(&heddle).unwrap();
+
+        let parent_blob = source.write_blob(b"parent\n").unwrap();
+        let mut parent_tree = TreeEditor::new();
+        parent_tree.upsert("parent.txt", EntryKind::Blob, parent_blob);
+        let parent_tree = source.write_tree(parent_tree).unwrap();
+        let parent = write_test_commit(&source, parent_tree, Vec::new(), "parent\n");
+
+        let tip_blob = source.write_blob(b"tip\n").unwrap();
+        let mut tip_tree = TreeEditor::new();
+        tip_tree.upsert("tip.txt", EntryKind::Blob, tip_blob);
+        let tip_tree = source.write_tree(tip_tree).unwrap();
+        let tip = write_test_commit(&source, tip_tree, vec![parent], "tip\n");
+
+        let store = ResidualStore::open(&heddle);
+        store
+            .capture_object_closure_from_git_repo(&source, &tip)
+            .unwrap();
+        store.record_note_ref("review/nested", tip).unwrap();
+        assert_eq!(
+            store.list_note_refs(ObjectFormat::Sha1).unwrap(),
+            vec![ResidualNoteRef {
+                name: "review/nested".into(),
+                oid: tip,
+            }]
+        );
+
+        assert!(store.install_object_closure_into(&target, &tip).unwrap());
+        for oid in [parent_blob, parent_tree, parent, tip_blob, tip_tree, tip] {
+            assert!(
+                target.read_object(&oid).is_ok(),
+                "auxiliary-ref closure omitted {oid}"
+            );
+        }
+        assert!(!heddle.join("git").exists());
+    }
+
+    #[test]
+    fn auxiliary_ref_install_rejects_incomplete_closure() {
+        let dir = tempfile::tempdir().unwrap();
+        let heddle = dir.path().join(".heddle");
+        let source = SleyRepository::init_bare(dir.path().join("source.git")).unwrap();
+        let target = SleyRepository::init_bare(dir.path().join("target.git")).unwrap();
+        fs::create_dir_all(&heddle).unwrap();
+
+        let blob = source.write_blob(b"required\n").unwrap();
+        let mut tree = TreeEditor::new();
+        tree.upsert("required.txt", EntryKind::Blob, blob);
+        let tree = source.write_tree(tree).unwrap();
+        let tip = write_test_commit(&source, tree, Vec::new(), "tip\n");
+
+        let store = ResidualStore::open(&heddle);
+        store
+            .capture_object_closure_from_git_repo(&source, &tip)
+            .unwrap();
+        fs::remove_file(store.residual_path(ObjectFormat::Sha1, &blob)).unwrap();
+
+        let error = store
+            .install_object_closure_into(&target, &tip)
+            .expect_err("missing dependent must be a hard fidelity error");
+        assert!(
+            error.to_string().contains("closure") && error.to_string().contains(&blob.to_string()),
+            "unexpected incomplete-closure error: {error}"
+        );
     }
 
     #[test]

--- a/crates/git-projection/src/git_util.rs
+++ b/crates/git-projection/src/git_util.rs
@@ -93,7 +93,7 @@ impl<'a> GitProjection<'a> {
 ///
 /// `commits_total` counts the commits that actually land in the
 /// destination: it is derived from the same branch/tag ref set
-/// (`collect_ref_updates`) that `copy_mirror_to_path` copies, by walking
+/// (`collect_ref_updates`) that `copy_projection_to_path` copies, by walking
 /// the commit ancestry of those tips. Counting from the copy path — rather
 /// than a parallel walk over current Heddle refs — guarantees the reported
 /// total equals what's copied, including a stale mirror ref left behind by

--- a/crates/git-projection/src/test_support.rs
+++ b/crates/git-projection/src/test_support.rs
@@ -142,17 +142,17 @@ pub fn write_exported_refs(
     git_core::write_exported_refs(repo, refs)
 }
 
-pub fn read_mirror_managed_refs(
-    repo: &SleyRepository,
+pub fn read_projection_managed_refs(
+    heddle_dir: &Path,
 ) -> GitProjectionResult<HashMap<String, ObjectId>> {
-    git_core::read_mirror_managed_refs(repo)
+    git_core::read_projection_managed_refs(heddle_dir)
 }
 
-pub fn write_mirror_managed_refs(
-    repo: &SleyRepository,
+pub fn write_projection_managed_refs(
+    heddle_dir: &Path,
     refs: &HashMap<String, ObjectId>,
 ) -> GitProjectionResult<()> {
-    git_core::write_mirror_managed_refs(repo, refs)
+    git_core::write_projection_managed_refs(heddle_dir, refs)
 }
 
 pub fn collect_managed_ref_updates(
@@ -225,19 +225,17 @@ pub fn build_existing_mapping(
     bridge.build_existing_mapping(git_repo_path)
 }
 
-pub fn stage_ingest_source_in_mirror(
-    bridge: &mut GitProjection<'_>,
-    source: &Path,
-    refs: &[String],
-) -> GitProjectionResult<()> {
-    bridge.stage_ingest_source_in_mirror(source, refs)
-}
-
 pub fn seed_ingest_identity_mappings_from_repo(
     bridge: &mut GitProjection<'_>,
     repo: &SleyRepository,
 ) -> GitProjectionResult<()> {
     bridge.seed_ingest_identity_mappings_from_repo(repo)
+}
+
+pub fn seed_ingest_identity_mappings_from_store(
+    bridge: &mut GitProjection<'_>,
+) -> GitProjectionResult<()> {
+    bridge.seed_ingest_identity_mappings_from_store()
 }
 
 pub fn open_git_repo(bridge: &GitProjection<'_>) -> GitProjectionResult<SleyRepository> {

--- a/crates/pack/src/store/pack/pack_builder.rs
+++ b/crates/pack/src/store/pack/pack_builder.rs
@@ -113,9 +113,13 @@ impl PackBuilder {
             if objects.len() < 2
                 || matches!(obj_type, ObjectType::State | ObjectType::StateAttachment)
                 || self.compression.max_delta_size == 0
+                || objects
+                    .iter()
+                    .all(|record| record.data.len() < MIN_DELTA_SIZE)
             {
-                // Single objects, states, or transfer-tuned packs with delta disabled:
-                // write entries directly without running the sliding delta search.
+                // Single objects, states, all-small groups, or transfer-tuned packs
+                // with delta disabled: write entries directly without constructing
+                // sliding-window indexes that cannot produce a delta.
                 for record in objects {
                     let offset = pack_data.len() as u64;
                     index.add(record.id, offset);

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -2933,6 +2933,17 @@ impl Repository {
         self
     }
 
+    /// Apply the runtime-resolved fsmonitor mode to this repository handle.
+    ///
+    /// CLI configuration merges user, repository, and environment settings.
+    /// Storing that resolved mode on the handle ensures nested verification
+    /// and summary paths use the same decision as explicit status calls.
+    #[must_use]
+    pub fn with_fsmonitor_mode(mut self, mode: crate::FsMonitorMode) -> Self {
+        self.config.worktree.fsmonitor.mode = mode;
+        self
+    }
+
     pub fn config(&self) -> &RepoConfig {
         self.repo_config()
     }


### PR DESCRIPTION
## Summary

- Removes eager Git object/ref staging from import/adopt. New repositories no longer create or populate .heddle/git.
- Reconstructs each export, push, and fetch projection in an ephemeral sley::Repository scratch sink. Faithful imports are rebuilt from Heddle state; non-reconstructable commits, annotated tags, and note closures are restored from Raw Git Object Residuals.
- Re-sources the #316 ownership/reconcile frontier from durable Heddle projection state at .heddle/git-projection/heddle-managed-refs. A legacy mirror is read only for lazy migration or residual fallback and is never initialized by the new path.
- Retains the partial-projection/redaction derived-SHA fallback: the durable destination ownership record authorizes replacing a previously published tip when its old object is intentionally absent from the scratch repository.
- Supersedes #561: newly adopted repositories have no persistent mirror to pack.

## Correctness evidence

- #533 round-trip matrix: 16/16 passed. Every source ref and every source-reachable Git object is present at the byte-identical OID after import then store-sourced export; git fsck --full --strict passes.
- #562 commit conformance: 4/4 passed, including signed commits and mergetag fixtures reconstructed from state.
- #316 embargo/redaction reconcile: fresh projection instances retract an embargoed tip and replace a redacted tip with its derived SHA without .heddle/git. The existing CLI overlay/export matrices also pass.
- Guard proof: the new embargo test first failed at the non-fast-forward guard while old topology was still mirror-dependent; after store-backed topology materialization it exposed missing note closure persistence, and passed only after notes were residual-backed. The redaction guard separately exercises an absent prior object plus derived-SHA replacement.
- Explicit import and every fidelity case assert that .heddle/git is absent after both import and export.

## Verification

- cargo build
- cargo clippy --all-targets -- -D warnings
- cargo test --workspace --lib
- cargo test -p heddle-repo
- cargo test -p heddle-ingest
- cargo test -p heddle-git-projection
- CLI Git overlay, projection command, adoption, undo, round-trip fidelity, and commit conformance suites
- rustfmt +nightly --edition 2024 --check on every touched Rust file
- git diff --check

All commands used TMPDIR=/home/scratch and isolated CARGO_TARGET_DIR=/home/scratch/issue568-target. The only diagnostic is the existing proc-macro-error2 future-incompatibility notice.

## Timing

800-empty-commit debug fixture, explicit Git import path:

- before: 19.97 s, .heddle/git = 16,872 KiB and 3,108 object files
- after: 6.36 s, .heddle/git absent; durable projection metadata = 124 KiB
- improvement: 68.2%; eager mirror population is zero

The top-level adopt wrapper on current main already bypassed this explicit-import mirror path: before 7.74 s, after 7.46 s, with no mirror in either run. This shows no adopt-wrapper regression; the owner pilot re-measure remains the production performance gate.

Commit: 57d4dcca

Closes #568 #561

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788970270&installation_model_id=21489&pr_number=1313&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1313&signature=4d66ca3b8a1ae592c9568092ad8d1793e5ce3be364d75b1959b92a5494682edc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->