### PR TITLE
refactor(cli): phase 1 free deletions — remove duplicate/dead verbs (part of #473)

### DIFF
--- a/crates/cli/src/harness/mod.rs
+++ b/crates/cli/src/harness/mod.rs
@@ -2,7 +2,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs::{self, OpenOptions},
-    io::{BufRead, BufReader, BufWriter, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -49,7 +49,6 @@ use self::probe::{
 };
 use crate::{
     cli::{
-        Cli,
         commands::{
             snapshot::{
                 SnapshotAgentOverrides, create_snapshot, summarize_confidence,
@@ -142,36 +141,6 @@ fn detected_harness_argv_impl() -> Option<Vec<String>> {
 #[cfg(not(target_os = "linux"))]
 fn detected_harness_argv_impl() -> Option<Vec<String>> {
     None
-}
-
-pub fn cmd_harness_bridge(cli: &Cli) -> Result<()> {
-    let repo = cli.open_repo()?;
-    let mut runtime = init_harness_runtime(&repo)?;
-
-    let stdin = std::io::stdin();
-    let stdout = std::io::stdout();
-    let reader = BufReader::new(stdin.lock());
-    let mut writer = BufWriter::new(stdout.lock());
-
-    for line in reader.lines() {
-        let line = line?;
-        if line.trim().is_empty() {
-            continue;
-        }
-        let response = match serde_json::from_str::<BridgeRequest>(&line) {
-            Ok(request) => runtime.handle_request(request),
-            Err(err) => BridgeResponse::error(
-                None,
-                "invalid_request",
-                format!("failed to parse request: {err}"),
-            ),
-        };
-        serde_json::to_writer(&mut writer, &response)?;
-        writer.write_all(b"\n")?;
-        writer.flush()?;
-    }
-
-    Ok(())
 }
 
 pub(crate) fn relay_harness_event(
@@ -907,45 +876,6 @@ impl HarnessBridgeRuntime {
         }
     }
 
-    fn handle_request(&mut self, request: BridgeRequest) -> BridgeResponse {
-        let response = match request.method.as_str() {
-            "open_session" => self
-                .decode_params::<OpenSessionParams>(request.params)
-                .and_then(|params| self.open_session(params))
-                .and_then(to_json_value),
-            "update_progress" => self
-                .decode_params::<UpdateProgressParams>(request.params)
-                .and_then(|params| self.update_progress(params))
-                .and_then(to_json_value),
-            "record_usage" => self
-                .decode_params::<RecordUsageParams>(request.params)
-                .and_then(|params| self.record_usage(params))
-                .and_then(to_json_value),
-            "record_touched_paths" => self
-                .decode_params::<RecordTouchedPathsParams>(request.params)
-                .and_then(|params| self.record_touched_paths(params))
-                .and_then(to_json_value),
-            "close_session" => self
-                .decode_params::<CloseSessionParams>(request.params)
-                .and_then(|params| self.close_session(params))
-                .and_then(to_json_value),
-            "flush_reports" => self
-                .decode_params::<FlushReportsParams>(request.params)
-                .and_then(|params| self.flush_reports(params))
-                .and_then(to_json_value),
-            other => Err(anyhow!("unknown method '{other}'")),
-        };
-
-        match response {
-            Ok(result) => BridgeResponse::ok(request.id, result),
-            Err(err) => BridgeResponse::error(request.id, "bridge_error", err.to_string()),
-        }
-    }
-
-    fn decode_params<T: for<'de> Deserialize<'de>>(&self, value: Value) -> Result<T> {
-        serde_json::from_value(value).map_err(|err| anyhow!(err))
-    }
-
     fn open_session(&mut self, params: OpenSessionParams) -> Result<OpenSessionResult> {
         if self.user_config.harness.mode == HarnessMode::Off {
             return Err(anyhow!("harness integration is disabled in user config"));
@@ -1465,6 +1395,9 @@ impl HarnessBridgeRuntime {
         self.persist_report(report)
     }
 
+    // Exercised by unit tests; formerly reachable via the removed hidden
+    // JSON-lines harness bridge entrypoint (phase 1 free deletion).
+    #[cfg_attr(not(test), allow(dead_code))]
     fn record_touched_paths(
         &mut self,
         params: RecordTouchedPathsParams,
@@ -1526,6 +1459,9 @@ impl HarnessBridgeRuntime {
         })
     }
 
+    // Exercised by unit tests; formerly reachable via the removed hidden
+    // JSON-lines harness bridge entrypoint (phase 1 free deletion).
+    #[cfg_attr(not(test), allow(dead_code))]
     fn flush_reports(&mut self, params: FlushReportsParams) -> Result<FlushReportsResult> {
         let mut flushed = 0usize;
         let session_ids = match params.heddle_session_id {
@@ -2611,10 +2547,6 @@ fn inherited_harness_hint(key: &str) -> bool {
         || key.starts_with("OPENCODE_")
 }
 
-fn to_json_value<T: Serialize>(value: T) -> Result<Value> {
-    serde_json::to_value(value).map_err(|err| anyhow!(err))
-}
-
 fn normalize_paths<I>(paths: I) -> Vec<String>
 where
     I: IntoIterator<Item = String>,
@@ -2914,6 +2846,7 @@ impl SessionReportStore {
         Ok(())
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     fn list_pending(&self) -> Result<Vec<String>> {
         if !self.dir.exists() {
             return Ok(Vec::new());
@@ -2934,55 +2867,6 @@ impl SessionReportStore {
         ids.sort();
         Ok(ids)
     }
-}
-
-#[derive(Debug, Deserialize)]
-struct BridgeRequest {
-    #[serde(default)]
-    id: Option<String>,
-    method: String,
-    #[serde(default)]
-    params: Value,
-}
-
-#[derive(Debug, Serialize)]
-struct BridgeResponse {
-    #[serde(default)]
-    id: Option<String>,
-    ok: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    result: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<BridgeError>,
-}
-
-impl BridgeResponse {
-    fn ok(id: Option<String>, result: Value) -> Self {
-        Self {
-            id,
-            ok: true,
-            result: Some(result),
-            error: None,
-        }
-    }
-
-    fn error(id: Option<String>, code: impl Into<String>, message: impl Into<String>) -> Self {
-        Self {
-            id,
-            ok: false,
-            result: None,
-            error: Some(BridgeError {
-                code: code.into(),
-                message: message.into(),
-            }),
-        }
-    }
-}
-
-#[derive(Debug, Serialize)]
-struct BridgeError {
-    code: String,
-    message: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
@@ -3074,6 +2958,7 @@ struct RecordUsageParams {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[cfg_attr(not(test), allow(dead_code))]
 struct RecordTouchedPathsParams {
     heddle_session_id: String,
     #[serde(default)]
@@ -3094,6 +2979,7 @@ struct CloseSessionParams {
 }
 
 #[derive(Debug, Clone, Deserialize, Default)]
+#[cfg_attr(not(test), allow(dead_code))]
 struct FlushReportsParams {
     #[serde(default)]
     heddle_session_id: Option<String>,
@@ -3129,6 +3015,7 @@ struct CloseSessionResult {
 }
 
 #[derive(Debug, Serialize)]
+#[cfg_attr(not(test), allow(dead_code))]
 struct FlushReportsResult {
     flushed: usize,
 }


### PR DESCRIPTION
## Summary

Phase 1 of the whole-CLI consolidation (**Part of HeddleCo/heddle#473**): free deletions of byte-for-byte duplicate handlers and dead stubs.

Most of this phase already landed on main via **#488** (2026-06-04) and **#681** (phases 1–2). This PR re-audits every Phase 1 target against the current tree and finishes the one residual that was still dangling: the orphaned `cmd_harness_bridge` JSON-lines entrypoint + protocol shell after the hidden verb itself was removed.

### Verbs already removed (SKIPPED — already gone on main)

| Removed | Canonical | Status on this checkout |
|---|---|---|
| `diagnose` | `doctor` | **SKIPPED** — no enum arm / catalog entry; `doctor` is the live handler |
| `checkout` | `switch` / `thread switch` | **SKIPPED** — no top-level verb; phase 2 already demoted switch under `thread` |
| `compare` | `diff` | **SKIPPED** — no verb; `diff` absorbs two-state compare |
| `redo` | `undo --redo` | **SKIPPED** — no top-level verb; `--redo` flag on `undo` |
| hidden `gc` / `index` / `monitor` aliases | (real cmds stay under `maintenance` later) | **SKIPPED** — no top-level hidden aliases; real `maintenance gc` kept (phase 3) |
| `bisect` | — (dead stub) | **SKIPPED** — already removed |
| `store` group | — | **SKIPPED** — already removed |
| `commands` | `help --output json` | **SKIPPED** — catalog already served by `help --output json` / bare `heddle --output json` |
| `completion` | `shell completion` | **SKIPPED** — already under `shell` |
| `version` | `--version` / `-V` | **SKIPPED** — clap global; bare flag handled in `main` |

### Removed in this PR

| Removed | Notes |
|---|---|
| residual `cmd_harness_bridge` + JSON-lines protocol shell | Verb already deleted (#681); orphan entrypoint + `BridgeRequest`/`BridgeResponse` dispatcher removed. In-process `relay_harness_event` / runtime paths kept. Test-only session methods retained with `#[cfg_attr(not(test), allow(dead_code))]`. |

### Explicitly not touched (out of Phase 1 / off-limits)

- Real `maintenance gc` / future index/monitor leaves (umbrella is phase 3)
- Phase 2 synonym collapses (`inspect`→`show`, etc.)
- Phase 3–5 namespace unifications / conformance gate
- No deprecation aliases or compat shims

## Catalog / surface proof

- `heddle help --output json` → **187** catalog entries; top-level path components include **none** of: `diagnose`, `checkout`, `compare`, `redo`, `bisect`, `store`, `commands`, `completion`, `version`, `harness-bridge`, top-level `gc`/`index`/`monitor`.
- JSON validates (`python -m json` load).
- Unknown-verb probe: `diagnose`, `checkout`, `compare`, `redo`, `bisect`, `store`, `commands`, `completion`, `harness-bridge` all rejected by clap.
- Canonical still works: `doctor`, `diff`, `undo --redo`, `shell completion`, `--version`.
- `doctor_docs` source-string gate: no stale `heddle <removed-verb>` references.

## Closes

Part of HeddleCo/heddle#473

Does **not** close the epic (remaining phases 2–5 / README re-derive still open).

## Test evidence

SHA: `a84dc4168f3fce1713b427494d9bef20b9d55242`

Environment: `CARGO_TARGET_DIR=/home/scratch/issue-473-target`, `TMPDIR=/home/scratch/issue-473-tmp`

| Check | Result |
|---|---|
| `cargo build --locked --workspace --all-targets` | pass |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | pass |
| `cargo test --locked -p heddle-cli --lib` | **609** passed, 0 failed, 1 ignored |
| `cargo test --locked -p heddle-cli --lib harness::` | **53** passed |
| `cargo test --locked -p heddle-cli --test cli_integration` | **904** passed, 0 failed, 19 ignored (hermetic: `NO_COLOR=1 RUST_LOG=off`, color-force env cleared) |
| `cargo test --locked -p heddle-cli-contract --lib` | **125** passed (includes `source_strings_reference_only_current_top_level_verbs`) |
| Surface: `help --output json` reduced surface | no Phase 1 removed verbs; JSON valid |
| rustfmt +nightly --edition 2024 | touched file only |

Confidence: **0.88** — full build/clippy/lib/integration/contract green; residual-only code change; prior Phase 1 bulk already on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1318"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788994071&installation_model_id=21489&pr_number=1318&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1318&signature=8ba7cc15a62140a4932571e683cd6914995af5476edef935d42ffc15d823ccc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->