### PR TITLE
chore(deps): bump heddle-api 0.3.0 → 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2045,9 +2045,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.3.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722263983a39fca723f5263d5ec64604d8db468f4aa379d8c037c530ddcd7e4f"
+checksum = "5d7a59e258c91a1e15de848f30b309f1808da36bbb0bcc82b75062693631ea4e"
 dependencies = [
  "bytes",
  "hex",
@@ -2075,7 +2075,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "heddle-api 0.3.0",
+ "heddle-api 0.5.0",
  "heddle-cli-args",
  "heddle-cli-contract",
  "heddle-cli-render",
@@ -2145,7 +2145,7 @@ version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api 0.3.0",
+ "heddle-api 0.5.0",
  "heddle-cli-shared",
  "heddle-objects",
  "heddle-repo",

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.3.0" }
+api = { package = "heddle-api", version = "0.5.0" }
 clap.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.11" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -42,7 +42,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.11" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
-api = { package = "heddle-api", version = "0.3.0" }
+api = { package = "heddle-api", version = "0.5.0" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
 heddle-cli-args = { path = "../cli-args", version = "0.11", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.11", default-features = false }

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -101,8 +101,17 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
         "BindSignupInviteEmail",
         AgentAuthOperationDisposition::Denied,
     ),
+    // Durable invite claim mints a signup bearer; derived agents must not
+    // consume invite codes on behalf of a parent principal.
+    ("ClaimSignupInvite", AgentAuthOperationDisposition::Denied),
     (
         "IssueSignupEmailChallenge",
+        AgentAuthOperationDisposition::Denied,
+    ),
+    // Consumes a human invite to open an agent-rooted account; account
+    // provisioning stays parent-only even though the RPC is public.
+    (
+        "ProvisionAgentRootedAccount",
         AgentAuthOperationDisposition::Denied,
     ),
     (

--- a/crates/cli/tests/cli_integration/identity_resolution.rs
+++ b/crates/cli/tests/cli_integration/identity_resolution.rs
@@ -18,7 +18,12 @@ fn isolated_command(repo: &Path, home: &Path, heddle_home: &Path, args: &[&str])
         .env_remove("HEDDLE_PRINCIPAL_EMAIL")
         .env_remove("HEDDLE_AGENT_PROVIDER")
         .env_remove("HEDDLE_AGENT_MODEL")
-        .env_remove("NO_COLOR");
+        // Plain-text assertions below require uncolored output. The host may
+        // export CLICOLOR_FORCE=1 (which wins after NO_COLOR is cleared), so
+        // force color off rather than inheriting ambient color policy.
+        .env("NO_COLOR", "1")
+        .env_remove("CLICOLOR_FORCE")
+        .env_remove("FORCE_COLOR");
     command
 }
 


### PR DESCRIPTION
## Summary

Bump the direct `heddle-api` pins from **0.3.0** to **0.5.0** (exact pin, keep `package = \"heddle-api\"` rename) in:

- `crates/cli/Cargo.toml`
- `crates/cli-args/Cargo.toml`

Lockfile updated with `cargo update -p heddle-api@0.3.0 --precise 0.5.0` only (no hand-edit, no full lockfile regen).

### What 0.4 + 0.5 add (additive)

| Version | Surface |
| --- | --- |
| **0.4** | RPCs `ProvisionAgentRootedAccount`, `ClaimSignupInvite`, and bearer-mode `IssueSignupEmailChallenge` |
| **0.5** | `ThreadListItem.{task,base_state,parent_thread}` (and related thread summary fields already present on the wire) |

No new RPC/field features are implemented here — only keep the tree green on 0.5.0.

### Minimal call-site reconciliation

- `AUTH_SERVICE_AGENT_POLICY` in `device_flow.rs` now classifies the two new IdentityService RPCs as **Denied** for derived agents so the exhaustive descriptor-equality test still holds.
- `experiments/iroh-transport` **left on 0.2.1**: attempting 0.2→0.5 failed because `ListRefsResponse` changed from a batch message (`head_thread` / `head_state` / `refs[]`) to a streaming `oneof frame { item, page_end }` plus request pagination fields. That is a non-trivial experiment rewrite; not sunk into this main pin bump.
- Identity-resolution integration helper forces `NO_COLOR=1` and clears `CLICOLOR_FORCE` / `FORCE_COLOR` so plain-text principal assertions stay hermetic under host color forcing (unrelated to the API surface; required for green `cli_integration` in this env).

## Closes

Closes #1319

## Test evidence

SHA: `eb5a118f441e377edd4e3cd8ad92b66efe0b52b7`

Isolated target: `CARGO_TARGET_DIR=/home/scratch/heddle-api-050-target`, `TMPDIR=/home/scratch`, commands run from `/home/scratch`.

| Check | Result |
| --- | --- |
| `cargo build --locked --workspace --all-targets` | pass |
| `cargo clippy --locked --workspace --all-targets -- -D warnings` | pass |
| `cargo test --locked -p heddle-cli -p heddle-cli-args --lib --bins` | pass (609 + 5 + 16) |
| `cargo test --locked -p heddle-cli --test cli_integration` | pass (904 passed, 19 ignored) |
| `rustfmt +nightly --edition 2024` on touched `.rs` | clean |

Ready.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1320"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788997763&installation_model_id=21489&pr_number=1320&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1320&signature=deda19c4d9eff7304c46052e23629042826df8bcb125cbc3a91f8916ae89cb33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->