### PR TITLE
docs(cli): Railway CLI lessons research note (Part of #473)

### DIFF
--- a/docs/spikes/railway-cli-lessons.md
+++ b/docs/spikes/railway-cli-lessons.md
@@ -1,0 +1,265 @@
+# Railway CLI: lessons for Heddle
+
+> **Research note (2026-08-11).** Railway's CLI and documentation are external,
+> evolving products. This note extracts durable design lessons rather than
+> treating Railway's current command names or internals as a contract. Source:
+> [railwayapp/cli](https://github.com/railwayapp/cli); user-facing reference:
+> [Railway CLI documentation](https://docs.railway.com/guides/cli).
+
+## Executive assessment
+
+Railway's CLI feels unusually good because it optimizes a coherent operator
+loop, not because it has a novel parser or an immaculate module graph:
+
+1. **Acquire context once.** `login`, `link`, and environment/service selection
+   turn an unscoped directory into a useful working context.
+2. **Use ordinary shell verbs for the hot loop.** `up`, `logs`, `status`, `run`,
+   and `shell` map directly to what a developer is trying to do.
+3. **Collapse control-plane complexity.** Project, environment, service,
+   deployment, domain, variable, and volume APIs are presented as a small local
+   tool rather than as GraphQL or dashboard navigation.
+4. **Make the first successful path short.** A user can link or initialize,
+   deploy, and inspect the result without first learning Railway's full object
+   model.
+5. **Preserve an escape hatch into the host shell.** Running a command with
+   remote variables or opening a service shell makes Railway part of an existing
+   workflow instead of a replacement for it.
+
+The important lesson is **progressive disclosure backed by strong context
+resolution**. The command names are only the visible edge of that system.
+
+## Structure and implementation
+
+Railway's public Rust implementation follows a pragmatic layered shape:
+
+- a Clap-derived command tree owns parsing and command discovery;
+- command modules own user-facing workflows;
+- a local project link and global credentials provide ambient context;
+- API/query modules translate those workflows into Railway control-plane calls;
+- terminal helpers handle prompts, spinners, selection, color, and streaming;
+- deployment paths package or stream source while log and shell paths stay
+  long-lived and interruption-aware.
+
+This is a sensible structure for a control-plane client. Commands remain easy to
+find and the backend schema is not allowed to become the command tree. More
+importantly, the implementation repeatedly resolves the same small context
+tuple—project, environment, service—so commands compose around a shared mental
+model.
+
+That architecture is good, but not uniformly exemplary. A module-per-command
+layout can still accumulate repeated context selection, presentation, and API
+orchestration. The world-class property is the consistency of the workflow
+surface, not the mere existence of `commands/`, GraphQL, or Clap.
+
+## Why it feels good
+
+### 1. It is job-shaped rather than resource-shaped
+
+The everyday surface foregrounds actions such as deploy, inspect logs, run with
+configuration, and open a shell. Resource management remains available, but a
+developer does not have to begin with CRUD syntax for deployments and services.
+
+This is the right abstraction boundary: users should state intent while the CLI
+performs the necessary discovery and API sequence.
+
+### 2. The linked directory behaves like a lightweight session
+
+Linking lets later commands infer the project. Environment and service can be
+selected or overridden, which removes repetitive identifiers without making
+the underlying context inaccessible. This creates a productive two-speed
+interface:
+
+- interactive humans rely on remembered context and selectors;
+- deliberate callers pass explicit project/environment/service inputs.
+
+Ambient context is a major source of Railway's speed. It is also where a CLI
+must be most disciplined: every consequential command should make the resolved
+target legible before or as it acts.
+
+### 3. It chooses powerful defaults at the moment of intent
+
+`up` is memorable because it expresses the desired state, not the transport
+mechanism. Log following behaves like a stream. `run` injects hosted
+configuration into a local process. These defaults eliminate ceremony while
+remaining close to familiar shell conventions.
+
+Good defaults are doing more work than aliases would. An alias only shortens a
+command; a good default removes a decision.
+
+### 4. It bridges local and hosted work
+
+The best commands are seams between a local repository and the hosted system:
+
+- deploy the current source;
+- execute a local program with hosted variables;
+- inspect a live service;
+- stream remote logs into the terminal;
+- move into a remote shell when local abstractions stop being sufficient.
+
+This is why the tool feels integrated rather than administrative. It carries
+the developer across boundaries without hiding that a boundary exists.
+
+### 5. Interactivity is used for ambiguity, not ceremony
+
+Selectors are valuable when several projects, environments, or services are
+valid. The prompt resolves a real ambiguity and teaches the domain objects at
+the same time. The corresponding flags preserve a non-interactive path.
+
+The general rule is: **prompt to choose among valid targets; never prompt merely
+to acknowledge that the user typed a command.**
+
+### 6. Output is operational
+
+Deploy progress, log streams, status summaries, and links answer immediate
+questions. The output tends to end at a useful next boundary—a URL, a live
+stream, a selected target, or an actionable error—rather than reproducing an
+API response.
+
+## What not to copy blindly
+
+Railway is optimized primarily for a human operating a hosted platform. Heddle
+also treats agents and automation as first-class callers. That difference makes
+several Railway-like choices unsafe as universal patterns:
+
+1. **Ambient selection can be invisible state.** Convenience becomes risk when
+   a mutation silently targets yesterday's service or environment.
+2. **Interactive fallback is not an automation contract.** A command that
+   prompts after omitted input can hang CI or an agent loop.
+3. **Polished text is not structured output.** Stable JSON schemas, clean
+   streams, and typed error envelopes require separate design and tests.
+4. **Short verbs can hide lifecycle distinctions.** `up` is excellent in a
+   deployment domain, but Heddle should not compress capture, commit, readiness,
+   landing, and publication into a magical verb; those are meaningful source
+   history boundaries.
+5. **A command-module directory is not sufficient architecture.** Shared target
+   resolution, effects, rendering, and contracts need explicit ownership or the
+   modules become inconsistent orchestration scripts.
+
+Railway should therefore be treated as a benchmark for human workflow quality,
+not as the complete benchmark for agent-safe CLI behavior.
+
+## Concrete lessons for Heddle
+
+### Keep and strengthen
+
+Heddle already has several practices that go beyond the Railway model and must
+not regress:
+
+- explicit text versus JSON output contracts;
+- typed machine-readable failures and disciplined stdout/stderr use;
+- operation identifiers for safe replay where supported;
+- preview, verification, and recovery semantics for meaningful mutations;
+- explicit principal and agent attribution;
+- a domain model that distinguishes capture, commit, ready, land, and push.
+
+These are not extra polish. They are the foundation of an agent-native CLI.
+
+### Adopt: a single resolved-context experience
+
+Railway's greatest transferable advantage is consistent context acquisition.
+For Heddle, every everyday command should consume one shared resolved-context
+model containing, as applicable:
+
+- repository and source authority;
+- current thread and checkout;
+- principal and active agent;
+- remote and hosted repository;
+- in-progress operation and writer authority.
+
+Text mode should reveal only the target details needed to make an action feel
+safe. JSON mode should expose the complete resolved context with stable field
+names. Resolution and precedence should be implemented once, not rediscovered
+inside each command.
+
+### Adopt: optimize the first useful loop
+
+The Railway-quality Heddle loop is not "show every capability." It is:
+
+```text
+status -> exact next action -> capture -> verify/ready -> land -> push
+```
+
+Each successful command should leave the user at a clear boundary and recommend
+at most one primary next action. `status` should remain the universal
+reorientation command, just as a linked Railway directory lets the user resume
+without reconstructing all context.
+
+### Adopt: selectors only where ambiguity is genuine
+
+For a TTY, Heddle can offer selection when multiple threads, remotes, or actors
+are valid and no safe default exists. The same path must:
+
+- fail immediately in non-interactive mode;
+- name the missing selector;
+- provide the exact explicit invocation;
+- never select a destructive target merely because it is first in a list.
+
+### Adopt: bridge commands as first-class product surfaces
+
+Railway's `run`, logs, and shell workflows are valuable because they join two
+systems. Heddle's corresponding high-leverage seams are source and
+collaboration bridges: Git overlay/native adoption, hosted sync, harness
+integration, and isolated agent worktrees. They should receive the same level
+of ergonomic attention as core storage commands.
+
+### Adopt: separate discovery from execution internally
+
+A command should be understandable as four stages:
+
+1. resolve context;
+2. produce a typed plan;
+3. execute effects;
+4. render a typed outcome.
+
+This separation lets text, JSON, preview, confirmation, idempotent replay, and
+tests share the same semantics. Railway demonstrates the value of shared
+context and workflow orchestration; Heddle should formalize the seam further
+because its safety and automation requirements are higher.
+
+## Recommended priority
+
+| Priority | Work | Expected effect |
+|---|---|---|
+| P0 | Audit all everyday commands against one resolved-context schema and precedence model | Removes inconsistent targeting and repeated discovery logic |
+| P0 | Keep `status` and every mutation explicit about target, result, and one next action | Creates the "resume anywhere" quality of a linked Railway directory |
+| P1 | Introduce reusable typed plan/outcome seams for commands that still mix resolution, effects, and rendering | Makes preview, JSON, replay, and error behavior consistent by construction |
+| P1 | Test TTY ambiguity and non-TTY fail-fast behavior for thread/remote/actor selection | Preserves human convenience without compromising agents or CI |
+| P1 | Run end-to-end first-use and resume-use transcripts, measuring decisions and commands rather than only latency | Finds ceremony that unit and contract tests cannot reveal |
+| P2 | Improve high-value bridge workflows before expanding the top-level command tree | Delivers integration value without command sprawl |
+
+## A world-class CLI construction checklist
+
+Railway's strengths and Heddle's stricter contract combine into a useful bar:
+
+- **Model:** command names express user jobs; domain boundaries remain explicit.
+- **Context:** infer repetitive context, expose what was resolved, allow explicit
+  overrides, and define precedence once.
+- **First run:** minimize decisions before the first useful result.
+- **Resume:** one orientation command explains current state and the next move.
+- **Interaction:** prompt only for genuine ambiguity; provide a complete
+  non-interactive equivalent.
+- **Output:** human output is concise and operational; machine output is stable,
+  typed, deterministic, and isolated from prose.
+- **Safety:** validate before effects, preview meaningful mutations, identify the
+  target, and make interruption recoverable.
+- **Composition:** work with shells, pipes, editors, agents, and hosted systems
+  rather than trying to replace them.
+- **Architecture:** separate resolution, planning, effects, and rendering;
+  organize around owned concepts rather than backend endpoints.
+- **Verification:** test workflows in TTY and non-TTY modes, with ambiguity,
+  interruption, stale context, bad credentials, narrow terminals, and large
+  real repositories.
+
+## Bottom line
+
+Railway's CLI is excellent because it makes the common hosted-development loop
+feel local, remembers just enough context, asks questions only when needed, and
+stops at operationally useful outcomes. The best lesson for Heddle is not to
+copy `up` or Railway's command tree. It is to make context resolution and the
+next useful action feel inevitable.
+
+Heddle should combine that human fluidity with guarantees Railway-style CLIs do
+not always prioritize: explicit lifecycle boundaries, stable structured output,
+typed recovery, replay safety, and agent attribution. That combination—not
+minimal keystrokes alone—is the credible path to a world-class agent-native
+CLI.


### PR DESCRIPTION
## Summary
Lands the Railway CLI DX research note informing the #473 north star.

## Closes
Closes HeddleCo/heddle#1330 — Part of #473

## Test evidence
- `diff docs/spikes/railway-cli-lessons.md /home/heddleco/HeddleCo/.heddleco-orchestrator/artifacts/railway-cli-lessons.md` is empty (byte-identical; 12808 bytes).
- No spikes nav/index (README, mkdocs.yml, SUMMARY.md) exists — no index entry required.
- Docs-lint: none found in repo CI workflows or root markdownlint config; no docs-lint step to run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789081367&installation_model_id=21489&pr_number=1331&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1331&signature=3c9d1a2b9bb6721b0e8c585cbaaa6602a390588f0fe3537583d492d0e4ab3ccc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->