### PR TITLE
feat(conflict): structured conflict payload + rich ConflictResolved (Part of #1323; enables tapestry#399)

### DIFF
--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -7,7 +7,7 @@ use clap::{ArgAction, CommandFactory};
 pub use heddle_core::ActionTemplate;
 use heddle_core::{
     DiffReport, FsckReport, MachineOutputKind, QueryReport, ReportContract as CoreReportContract,
-    StatusReport, VerifyReport,
+    ResolveReport, StatusReport, VerifyReport,
 };
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -2406,14 +2406,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["resolve"],
         front_door(
-            json_discriminators(
-                documented_schemas(REF_MUTATION, &["resolve"]),
-                &[json_discriminator(
-                    Some("resolve"),
-                    "output_kind",
-                    "resolve",
-                )],
-            ),
+            documented_core_report_schema(REF_MUTATION, ResolveReport::CONTRACT),
             300,
         ),
     ),

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -17,7 +17,7 @@
 use std::{collections::BTreeMap, sync::OnceLock};
 
 use anyhow::{Result, anyhow};
-use heddle_core::{DiffReport, FsckReport, QueryReport, StatusReport, VerifyReport};
+use heddle_core::{DiffReport, FsckReport, QueryReport, ResolveReport, StatusReport, VerifyReport};
 use schemars::{JsonSchema, schema_for};
 use serde::Serialize;
 use serde_json::Value;
@@ -60,6 +60,7 @@ macro_rules! schema_registry {
 fn report_contract_schema_verbs() -> &'static [&'static str] {
     &[
         QueryReport::CONTRACT.schema_name,
+        ResolveReport::CONTRACT.schema_name,
         DiffReport::CONTRACT.schema_name,
         FsckReport::CONTRACT.schema_name,
         StatusReport::CONTRACT.schema_name,
@@ -151,7 +152,6 @@ schema_registry! {
     (&["watch"], WatchLineSchema),
     (&["integration list", "integration doctor"], IntegrationStatusListSchema),
     (&["try"], TrySchema),
-    (&["resolve"], ResolveSchema),
     (&["maintenance inspect"], MaintenanceInspectSchema),
     (&["maintenance refresh"], MaintenanceRefreshSchema),
     (&["error"], ErrorEnvelopeSchema),
@@ -256,6 +256,9 @@ fn stabilize_land_output_shapes(verb: &str, schema: &mut Value) {
 fn schema_for_report_contract_verb(verb: &str) -> Option<Value> {
     match verb {
         verb if verb == QueryReport::CONTRACT.schema_name => Some((QueryReport::CONTRACT.schema)()),
+        verb if verb == ResolveReport::CONTRACT.schema_name => {
+            Some((ResolveReport::CONTRACT.schema)())
+        }
         verb if verb == DiffReport::CONTRACT.schema_name => Some((DiffReport::CONTRACT.schema)()),
         verb if verb == FsckReport::CONTRACT.schema_name => Some((FsckReport::CONTRACT.schema)()),
         verb if verb == StatusReport::CONTRACT.schema_name => {
@@ -990,20 +993,6 @@ pub struct BlameContextSnippetSchema {
     pub kind: String,
     pub content: String,
     pub revision_count: usize,
-}
-
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ResolveSchema {
-    pub output_kind: String,
-    pub message: Option<String>,
-    pub resolved: Option<Vec<String>>,
-    pub remaining: Option<Vec<String>>,
-    pub conflicts: Option<Vec<String>>,
-    pub continued: Option<bool>,
-    pub continuation_status: Option<String>,
-    pub continuation_message: Option<String>,
-    pub next_action: Option<String>,
-    pub recommended_action: Option<String>,
 }
 
 #[allow(dead_code, clippy::large_enum_variant)]

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -5,41 +5,21 @@ use std::fs;
 
 use anyhow::{Context, Result, anyhow};
 use heddle_core::{
+    ConflictRegionReport, ConflictResolutionReport, ResolveReport,
     contains_line_start_conflict_markers, path_is_active_conflict, unresolved_conflict_paths,
 };
-use objects::{object::Attribution, store::ObjectStore};
+use objects::{
+    object::{Attribution, StructuredConflict},
+    store::ObjectStore,
+};
 use oplog::{ConflictResolutionMode, OpLogBackend, OpRecord};
 use repo::{MergeState, Repository};
-use serde::Serialize;
 
 use super::{action_line::print_next_step, advice::RecoveryAdvice, snapshot::resolve_attribution};
 use crate::{
     cli::{Cli, should_output_json},
     config::UserConfig,
 };
-
-#[derive(Serialize)]
-struct ResolveOutput {
-    output_kind: &'static str,
-    message: String,
-    resolved: Vec<String>,
-    remaining: Vec<String>,
-    continued: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    continuation_status: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    continuation_message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    next_action: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    recommended_action: Option<String>,
-}
-
-#[derive(Serialize)]
-struct ConflictList {
-    output_kind: &'static str,
-    conflicts: Vec<String>,
-}
 
 #[allow(clippy::too_many_arguments)]
 pub fn cmd_resolve(
@@ -86,11 +66,14 @@ fn cmd_resolve_abort(
     if should_output_json(cli, Some(repo.config())) {
         println!(
             "{}",
-            serde_json::to_string(&ResolveOutput {
-                output_kind: "resolve",
-                message: "Merge aborted".to_string(),
+            serde_json::to_string(&ResolveReport {
+                output_kind: "resolve".to_string(),
+                message: Some("Merge aborted".to_string()),
                 resolved: vec![],
                 remaining: vec![],
+                conflict_paths: vec![],
+                conflicts: vec![],
+                resolutions: vec![],
                 continued: false,
                 continuation_status: None,
                 continuation_message: None,
@@ -133,13 +116,24 @@ fn cmd_resolve_list(
 ) -> Result<()> {
     let merge_state = load_merge_state_or_advice(merge_manager, "list merge conflicts")?;
     let unresolved = unresolved_paths(&merge_state);
+    let conflicts = structured_conflicts_for_paths(repo, &merge_state, &unresolved)?;
 
     if should_output_json(cli, Some(repo.config())) {
         println!(
             "{}",
-            serde_json::to_string(&ConflictList {
-                output_kind: "resolve",
-                conflicts: unresolved.clone(),
+            serde_json::to_string(&ResolveReport {
+                output_kind: "resolve".to_string(),
+                message: None,
+                resolved: Vec::new(),
+                remaining: unresolved.clone(),
+                conflict_paths: unresolved.clone(),
+                conflicts,
+                resolutions: Vec::new(),
+                continued: false,
+                continuation_status: None,
+                continuation_message: None,
+                next_action: None,
+                recommended_action: None,
             })?
         );
     } else if unresolved.is_empty() {
@@ -147,6 +141,9 @@ fn cmd_resolve_list(
     } else {
         for path in &unresolved {
             println!("{}", path);
+            for conflict in conflicts.iter().filter(|conflict| &conflict.path == path) {
+                print_conflict_region(conflict);
+            }
         }
     }
 
@@ -169,12 +166,16 @@ fn cmd_resolve_all(
     }
     let resolver = resolve_attribution(repo, &UserConfig::load_default()?)?;
     let mode = manual_resolution_mode(ours, theirs);
+    let conflicts = structured_conflicts_for_paths(repo, &merge_state, &unresolved)?;
+    let mut resolutions = Vec::new();
 
     for path in &unresolved {
         resolve_file_with_version(repo, &merge_state, path, ours, theirs)?;
         ensure_resolved_file_has_no_conflict_markers(repo, path, ours || theirs, force)?;
         merge_manager.resolve(path)?;
-        record_conflict_resolved(repo, path, &resolver, mode)?;
+        resolutions.extend(record_conflicts_resolved(
+            repo, path, &conflicts, &resolver, mode,
+        )?);
     }
 
     let remaining = merge_manager.unresolved()?;
@@ -183,15 +184,21 @@ fn cmd_resolve_all(
         format!("Resolved {} conflict(s)", unresolved.len()),
         unresolved.clone(),
         remaining.clone(),
+        unresolved.clone(),
+        conflicts,
+        resolutions,
         continuation,
     );
 
     if should_output_json(cli, Some(repo.config())) {
         println!("{}", serde_json::to_string(&output)?);
     } else {
-        println!("{}", output.message);
+        println!("{}", output.message.as_deref().unwrap_or_default());
         for path in &unresolved {
             println!("  {}", path);
+        }
+        for resolution in &output.resolutions {
+            print_resolution(resolution);
         }
         if !remaining.is_empty() {
             println!("Remaining: {} conflict(s)", remaining.len());
@@ -217,10 +224,12 @@ fn cmd_resolve_file(
     }
     let resolver = resolve_attribution(repo, &UserConfig::load_default()?)?;
     let mode = manual_resolution_mode(ours, theirs);
+    let conflict_paths = vec![path.to_string()];
+    let conflicts = structured_conflicts_for_paths(repo, &merge_state, &conflict_paths)?;
     resolve_file_with_version(repo, &merge_state, path, ours, theirs)?;
     ensure_resolved_file_has_no_conflict_markers(repo, path, ours || theirs, force)?;
     merge_manager.resolve(path)?;
-    record_conflict_resolved(repo, path, &resolver, mode)?;
+    let resolutions = record_conflicts_resolved(repo, path, &conflicts, &resolver, mode)?;
 
     let remaining = merge_manager.unresolved()?;
     let continuation = continue_if_resolution_complete(repo, remaining.is_empty())?;
@@ -228,15 +237,21 @@ fn cmd_resolve_file(
         format!("Resolved {}", path),
         vec![path.to_string()],
         remaining.clone(),
+        conflict_paths,
+        conflicts,
+        resolutions,
         continuation,
     );
 
     if should_output_json(cli, Some(repo.config())) {
         println!("{}", serde_json::to_string(&output)?);
     } else {
-        println!("{}", output.message);
+        println!("{}", output.message.as_deref().unwrap_or_default());
         if !remaining.is_empty() {
             println!("{} conflict(s) remaining", remaining.len());
+        }
+        for resolution in &output.resolutions {
+            print_resolution(resolution);
         }
         print_continuation(&output);
     }
@@ -265,29 +280,122 @@ fn manual_resolution_mode(ours: bool, theirs: bool) -> ConflictResolutionMode {
     }
 }
 
-fn record_conflict_resolved(
+fn record_conflicts_resolved(
     repo: &Repository,
-    conflict_id: &str,
+    path: &str,
+    conflicts: &[ConflictRegionReport],
     resolver: &Attribution,
     mode: ConflictResolutionMode,
-) -> Result<()> {
+) -> Result<Vec<ConflictResolutionReport>> {
+    let conflict_ids: Vec<String> = conflicts
+        .iter()
+        .filter(|conflict| conflict.path == path)
+        .map(|conflict| conflict.id.clone())
+        .collect();
+    let conflict_ids = if conflict_ids.is_empty() {
+        vec![path.to_string()]
+    } else {
+        conflict_ids
+    };
     repo.oplog().record_batch_scoped(
-        vec![OpRecord::conflict_resolved(
-            conflict_id,
-            resolver.clone(),
-            mode,
-        )],
+        conflict_ids
+            .iter()
+            .map(|conflict_id| OpRecord::conflict_resolved(conflict_id, resolver.clone(), mode))
+            .collect(),
         Some(&repo.op_scope()),
     )?;
+    Ok(conflict_ids
+        .into_iter()
+        .map(|conflict_id| ConflictResolutionReport::new(conflict_id, path, resolver, mode))
+        .collect())
+}
+
+fn structured_conflicts_for_paths(
+    repo: &Repository,
+    merge_state: &MergeState,
+    paths: &[String],
+) -> Result<Vec<ConflictRegionReport>> {
+    let Some(payload_id) = merge_state.structured_conflicts else {
+        return Ok(Vec::new());
+    };
+    let blob = repo.require_blob(&payload_id)?;
+    if blob.hash() != payload_id {
+        return Err(anyhow!(
+            "structured conflict payload {} failed BLAKE3 verification",
+            payload_id
+        ));
+    }
+    let payload = StructuredConflict::decode(blob.content())?;
+    for conflict in &payload.conflicts {
+        verify_conflict_side(repo, &conflict.base)?;
+        verify_conflict_side(repo, &conflict.ours)?;
+        verify_conflict_side(repo, &conflict.theirs)?;
+    }
+    Ok(payload
+        .conflicts
+        .iter()
+        .filter(|conflict| paths.contains(&conflict.path))
+        .map(Into::into)
+        .collect())
+}
+
+fn verify_conflict_side(repo: &Repository, side: &objects::object::ConflictSide) -> Result<()> {
+    let bytes = match side.blob_id {
+        Some(blob_id) => repo.require_blob(&blob_id)?.content().to_vec(),
+        None => Vec::new(),
+    };
+    side.verify_blob(&bytes)?;
     Ok(())
+}
+
+fn print_conflict_region(conflict: &ConflictRegionReport) {
+    let symbol = conflict
+        .symbol
+        .as_deref()
+        .map(|symbol| format!(" ({symbol})"))
+        .unwrap_or_default();
+    println!(
+        "  {}{} lines {}..{}",
+        conflict.id, symbol, conflict.merged_range.start_line, conflict.merged_range.end_line
+    );
+    print_conflict_side("base", &conflict.base);
+    print_conflict_side("ours", &conflict.ours);
+    print_conflict_side("theirs", &conflict.theirs);
+}
+
+fn print_conflict_side(label: &str, side: &heddle_core::ConflictSideReport) {
+    println!(
+        "    {label}: state {} blob {} lines {}..{} hunk {}",
+        side.source_state,
+        side.blob_id.as_deref().unwrap_or("<absent>"),
+        side.range.start_line,
+        side.range.end_line,
+        side.hunk_hash
+    );
+}
+
+fn print_resolution(resolution: &ConflictResolutionReport) {
+    let actor = resolution
+        .resolver
+        .agent
+        .as_ref()
+        .map(|agent| format!("{}/{}", agent.provider, agent.model))
+        .unwrap_or_else(|| resolution.resolver.principal.name.clone());
+    println!(
+        "  {}: {} by {}",
+        resolution.conflict_id, resolution.mode, actor
+    );
 }
 
 fn resolve_output(
     message: String,
     resolved: Vec<String>,
     remaining: Vec<String>,
+    conflict_paths: Vec<String>,
+    conflicts: Vec<ConflictRegionReport>,
+    resolutions: Vec<ConflictResolutionReport>,
     continuation: Option<super::operator_core::OperatorCommandOutput>,
-) -> ResolveOutput {
+) -> ResolveReport {
     let continued = continuation.is_some();
     let continuation_status = continuation.as_ref().map(|output| output.status.clone());
     let continuation_message = continuation.as_ref().map(|output| output.message.clone());
@@ -302,11 +410,14 @@ fn resolve_output(
     } else {
         message
     };
-    ResolveOutput {
-        output_kind: "resolve",
-        message,
+    ResolveReport {
+        output_kind: "resolve".to_string(),
+        message: Some(message),
         resolved,
         remaining,
+        conflict_paths,
+        conflicts,
+        resolutions,
         continued,
         continuation_status,
         continuation_message,
@@ -315,7 +426,7 @@ fn resolve_output(
     }
 }
 
-fn print_continuation(output: &ResolveOutput) {
+fn print_continuation(output: &ResolveReport) {
     if let Some(message) = output.continuation_message.as_deref() {
         println!("{message}");
     }

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -17,7 +17,7 @@ use heddle_core::{
 };
 use objects::{
     fs_ops::remove_path_recursively,
-    object::{StateId, ThreadName},
+    object::{Blob, StateId, ThreadName},
     store::{ActorPresenceStore, ObjectStore, WriterLeaseStatus, WriterLeaseStore},
 };
 use oplog::{OpLogRecorder, OpRecord, ThreadUpdateSnapshots};
@@ -760,11 +760,31 @@ fn persist_refresh_conflict_state(
     base: Option<objects::object::StateId>,
     paths: Vec<String>,
 ) -> Result<()> {
+    let structured_conflicts = if let Some(base_id) = base {
+        let base_tree = tree_for_state(thread_repo, &base_id)?;
+        let our_tree = tree_for_state(thread_repo, &ours)?;
+        let their_tree = tree_for_state(thread_repo, &theirs)?;
+        let payload = heddle_core::merge::build_conflict_payload(
+            thread_repo,
+            (base_id, &base_tree),
+            (ours, &our_tree),
+            (theirs, &their_tree),
+            &tree,
+            &paths,
+        )?;
+        Some(
+            thread_repo
+                .store()
+                .put_blob(&Blob::new(payload.encode()?))?,
+        )
+    } else {
+        None
+    };
     super::merge::apply_merged_tree_external(thread_repo, &tree)?;
     ensure_refresh_conflict_markers_materialized(thread_repo, &ours, &theirs, &paths)?;
     thread_repo
         .merge_state_manager()
-        .start(ours, theirs, base, paths)?;
+        .start(ours, theirs, base, paths, structured_conflicts)?;
     Ok(())
 }
 

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6100,7 +6100,7 @@ fn resolve_with_no_remaining_conflicts_keeps_full_typed_advice() {
     let head = repo.current_state().unwrap().unwrap().state_id;
     let merge_state = repo.merge_state_manager();
     merge_state
-        .start(head, head, None, vec!["tracked.txt".to_string()])
+        .start(head, head, None, vec!["tracked.txt".to_string()], None)
         .unwrap();
     merge_state.resolve("tracked.txt").unwrap();
 

--- a/crates/cli/tests/conflict_resolution.rs
+++ b/crates/cli/tests/conflict_resolution.rs
@@ -315,6 +315,7 @@ fn merge_state_start_persists_initial_conflict_set() {
             theirs,
             Some(base),
             vec!["a.txt".into(), "b.txt".into()],
+            None,
         )
         .unwrap();
 
@@ -334,7 +335,13 @@ fn merge_state_resolve_one_path_at_a_time() {
     let (ours, theirs, _) = sample_ids();
 
     manager
-        .start(ours, theirs, None, vec!["a.txt".into(), "b.txt".into()])
+        .start(
+            ours,
+            theirs,
+            None,
+            vec!["a.txt".into(), "b.txt".into()],
+            None,
+        )
         .unwrap();
 
     manager.resolve("a.txt").unwrap();
@@ -350,7 +357,7 @@ fn merge_state_finish_fails_when_anything_unresolved() {
     let (ours, theirs, _) = sample_ids();
 
     manager
-        .start(ours, theirs, None, vec!["a.txt".into()])
+        .start(ours, theirs, None, vec!["a.txt".into()], None)
         .unwrap();
     let err = manager.finish().unwrap_err();
     assert!(
@@ -370,7 +377,7 @@ fn merge_state_finish_clears_state_when_everything_resolved() {
     let (ours, theirs, _) = sample_ids();
 
     manager
-        .start(ours, theirs, None, vec!["a.txt".into()])
+        .start(ours, theirs, None, vec!["a.txt".into()], None)
         .unwrap();
     manager.resolve("a.txt").unwrap();
     let final_state = manager.finish().unwrap();
@@ -385,7 +392,13 @@ fn merge_state_abort_drops_state_without_requiring_resolution() {
     let (ours, theirs, _) = sample_ids();
 
     manager
-        .start(ours, theirs, None, vec!["a.txt".into(), "b.txt".into()])
+        .start(
+            ours,
+            theirs,
+            None,
+            vec!["a.txt".into(), "b.txt".into()],
+            None,
+        )
         .unwrap();
     let aborted = manager.abort().unwrap();
     assert_eq!(aborted.theirs, theirs);
@@ -408,6 +421,7 @@ fn merge_state_carry_forward_repoints_ours_without_ending_merge() {
             theirs,
             Some(base),
             vec!["a.txt".into(), "b.txt".into()],
+            None,
         )
         .unwrap();
     // Resolve one path so we can verify it survives the carry-forward.
@@ -438,6 +452,7 @@ fn merge_state_resolve_all_marks_remaining_paths() {
             theirs,
             None,
             vec!["a.txt".into(), "b.txt".into(), "c.txt".into()],
+            None,
         )
         .unwrap();
     manager.resolve("b.txt").unwrap();

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -6,6 +6,7 @@
 use std::{fs, process::Command, str};
 
 use ntest::timeout;
+use objects::object::{StateAttachmentBody, StructuredConflict};
 use oplog::{ConflictResolutionMode, OpLogBackend, OpRecord};
 use repo::Repository;
 use serde_json::Value;
@@ -127,8 +128,8 @@ mod resolve {
         create_conflict(&temp);
         fs::write(temp.path().join("file.txt"), "resolved content").unwrap();
 
-        heddle_with_env(
-            &["resolve", "file.txt"],
+        let resolved = heddle_with_env(
+            &["--output", "json", "resolve", "file.txt"],
             Some(temp.path()),
             &[
                 ("HEDDLE_PRINCIPAL_NAME", "Resolution Owner"),
@@ -138,6 +139,15 @@ mod resolve {
             ],
         )
         .unwrap();
+        let resolved: Value = serde_json::from_str(&resolved).expect("resolve JSON");
+        let resolution = &resolved["resolutions"][0];
+        assert_eq!(resolution["path"], "file.txt", "{resolved}");
+        assert_eq!(resolution["mode"], "edit", "{resolved}");
+        assert_eq!(resolution["resolver"]["kind"], "agent", "{resolved}");
+        assert_eq!(
+            resolution["resolver"]["agent"]["provider"], "openai",
+            "{resolved}"
+        );
 
         let entries = recent_oplog_entries(&temp);
         let event = entries
@@ -152,7 +162,8 @@ mod resolve {
                 _ => None,
             })
             .expect("production resolve must append ConflictResolved");
-        assert_eq!(event.0, "file.txt");
+        assert!(event.0.starts_with("conflict-"), "{}", event.0);
+        assert_eq!(event.0, resolution["conflict_id"].as_str().unwrap());
         assert_eq!(event.1, "edit");
         assert_eq!(*event.3, ConflictResolutionMode::Edit);
         assert_eq!(event.2.principal.name, "Resolution Owner");
@@ -239,7 +250,7 @@ mod resolve {
     }
 
     #[test]
-    #[timeout(15000)]
+    #[timeout(30000)]
     #[serial]
     fn test_thread_refresh_conflict_continue_then_land_resolved_thread() {
         let temp = TempDir::new().unwrap();
@@ -252,6 +263,19 @@ mod resolve {
         assert_eq!(resolved["output_kind"], "resolve", "{resolved}");
         assert_eq!(resolved["continued"], true, "{resolved}");
         assert_eq!(resolved["continuation_status"], "continued", "{resolved}");
+        let repo = Repository::open(temp.path()).unwrap();
+        let merged_state = repo.head().unwrap().expect("resolved merge state");
+        let attachment = repo
+            .latest_state_attachment(
+                &merged_state,
+                repo::StateAttachmentKind::StructuredConflicts,
+            )
+            .unwrap()
+            .expect("structured conflicts retained on resolved state");
+        assert!(matches!(
+            attachment.body,
+            StateAttachmentBody::StructuredConflicts(_)
+        ));
 
         heddle(&["thread", "switch", "main"], Some(temp.path())).expect("switch main");
         let landed = heddle(
@@ -283,7 +307,56 @@ mod resolve {
 
         let output: Value = serde_json::from_str(&result.unwrap()).expect("resolve list JSON");
         assert_eq!(output["output_kind"], "resolve", "{output}");
-        assert_eq!(output["conflicts"][0], "file.txt", "{output}");
+        assert_eq!(output["conflict_paths"][0], "file.txt", "{output}");
+        let conflict = &output["conflicts"][0];
+        assert_eq!(conflict["path"], "file.txt", "{output}");
+        assert!(
+            conflict["id"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("conflict-")),
+            "{output}"
+        );
+        for side in ["base", "ours", "theirs"] {
+            assert!(conflict[side]["source_state"].is_string(), "{output}");
+            assert!(conflict[side]["blob_id"].is_string(), "{output}");
+            assert!(conflict[side]["hunk_hash"].is_string(), "{output}");
+            assert!(
+                conflict[side]["range"]["start_line"].is_number(),
+                "{output}"
+            );
+            assert!(conflict[side]["range"]["end_line"].is_number(), "{output}");
+        }
+
+        let repo = Repository::open(temp.path()).unwrap();
+        let merge_state = repo.merge_state_manager().load().unwrap().unwrap();
+        let payload_id = merge_state
+            .structured_conflicts
+            .expect("structured conflict payload id");
+        let payload_blob = repo.require_blob(&payload_id).unwrap();
+        assert_eq!(payload_blob.hash(), payload_id);
+        let payload = StructuredConflict::decode(payload_blob.content()).unwrap();
+        assert_eq!(payload.conflicts.len(), 1);
+        for side in [
+            &payload.conflicts[0].base,
+            &payload.conflicts[0].ours,
+            &payload.conflicts[0].theirs,
+        ] {
+            let blob = repo.require_blob(&side.blob_id.unwrap()).unwrap();
+            side.verify_blob(blob.content()).unwrap();
+        }
+    }
+
+    #[test]
+    #[timeout(15000)]
+    fn resolve_schema_exposes_structured_regions_and_resolution_records() {
+        let schema = heddle(&["schemas", "resolve"], None).expect("resolve schema");
+        let schema: Value = serde_json::from_str(&schema).expect("resolve JSON Schema");
+        let properties = &schema["properties"];
+        assert_eq!(properties["conflicts"]["type"], "array", "{schema}");
+        assert_eq!(properties["resolutions"]["type"], "array", "{schema}");
+        let defs = schema["$defs"].as_object().expect("schema definitions");
+        assert!(defs.contains_key("ConflictRegionReport"), "{schema}");
+        assert!(defs.contains_key("ConflictResolutionReport"), "{schema}");
     }
 
     #[test]
@@ -305,7 +378,7 @@ mod resolve {
                 resolution,
                 mode: ConflictResolutionMode::Ours,
                 ..
-            } if conflict_id == "file.txt" && resolution == "ours"
+            } if conflict_id.starts_with("conflict-") && resolution == "ours"
         )));
     }
 
@@ -332,7 +405,7 @@ mod resolve {
                 resolution,
                 mode: ConflictResolutionMode::Theirs,
                 ..
-            } if conflict_id == "file.txt" && resolution == "theirs"
+            } if conflict_id.starts_with("conflict-") && resolution == "theirs"
         )));
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod query;
 pub mod rebase_plan;
 pub mod redact_plan;
 pub mod remote;
+pub mod resolve;
 pub mod resolve_plan;
 pub mod retro_plan;
 pub mod revert_plan;
@@ -246,6 +247,11 @@ pub use remote::{
     resolved_default_remote_name, show_plain_git_remote, show_remote, summarize_pull_outcome,
     summarize_push_outcome, transport_error_message, transport_mismatch_blocker,
     uses_git_overlay_mirror_rpc, uses_local_git_overlay_transport,
+};
+pub use resolve::{
+    AgentReport, ConflictRangeReport, ConflictRegionReport, ConflictResolutionModeReport,
+    ConflictResolutionReport, ConflictSideReport, PrincipalReport, ResolveReport,
+    ResolverAttributionReport, ResolverKindReport,
 };
 pub use resolve_plan::{
     ResolveSideSelection, contains_line_start_conflict_markers, path_is_active_conflict,

--- a/crates/core/src/merge/mod.rs
+++ b/crates/core/src/merge/mod.rs
@@ -27,7 +27,7 @@ use merge::{
     detect_renames_between_trees, merge_trees,
 };
 use objects::{
-    object::{Attribution, ContentHash, StateId, ThreadName, Tree},
+    object::{Attribution, Blob, ContentHash, StateId, ThreadName, Tree},
     store::{ActorPresenceStatus, ActorPresenceStore, ObjectStore},
 };
 use oplog::{OpBatch, OpLogBackend, OpLogRecorder, OpRecord};
@@ -52,12 +52,14 @@ mod apply;
 mod git_commit;
 mod plan;
 mod relation;
+mod structured;
 mod worktree_safety;
 
 pub use apply::apply_merged_tree;
 pub use git_commit::{GitCommitInfo, GitCommitPreview};
 pub use plan::MergePlan;
 pub use relation::{MergeRelation, MergeRelationKind};
+pub use structured::build_conflict_payload;
 pub use worktree_safety::ensure_worktree_clean;
 
 /// CLI merge planning must hydrate partial-clone blobs before content merge.
@@ -1199,11 +1201,19 @@ pub fn merge_thread_into_current_transactional(
     apply_merged_tree(repo, &merge_result.tree)?;
 
     if !merge_result.conflicts.is_empty() {
+        let structured_conflicts = merge_plan
+            .structured_conflicts()
+            .map(|payload| -> Result<ContentHash> {
+                let bytes = payload.encode()?;
+                Ok(repo.store().put_blob(&Blob::new(bytes))?)
+            })
+            .transpose()?;
         merge_manager.start(
             current_state.state_id,
             merge_target_id,
             Some(merge_base_id),
             merge_result.conflicts.clone(),
+            structured_conflicts,
         )?;
         // Conflicted merge: the merge wrote a partial tree containing
         // conflict markers. Reporting either `current..target` or

--- a/crates/core/src/merge/plan.rs
+++ b/crates/core/src/merge/plan.rs
@@ -3,7 +3,10 @@
 
 use anyhow::{Result, anyhow};
 use merge::{ConflictLabels, TreeMergeResult, merge_trees};
-use objects::{object::StateId, store::ObjectStore};
+use objects::{
+    object::{StateId, StructuredConflict},
+    store::ObjectStore,
+};
 use repo::{CommitGraphIndex, Repository};
 
 use super::{
@@ -16,6 +19,7 @@ use super::{
 pub struct MergePlan {
     relation: MergeRelation,
     merge_result: Option<TreeMergeResult>,
+    structured_conflicts: Option<StructuredConflict>,
 }
 
 impl MergePlan {
@@ -61,6 +65,10 @@ impl MergePlan {
         self.merge_result.as_ref()
     }
 
+    pub fn structured_conflicts(&self) -> Option<&StructuredConflict> {
+        self.structured_conflicts.as_ref()
+    }
+
     fn build(
         repo: &Repository,
         graph: &mut CommitGraphIndex<'_>,
@@ -79,6 +87,7 @@ impl MergePlan {
                     0,
                 ),
                 merge_result: None,
+                structured_conflicts: None,
             });
         }
 
@@ -92,6 +101,7 @@ impl MergePlan {
                     0,
                 ),
                 merge_result: None,
+                structured_conflicts: None,
             });
         }
 
@@ -121,6 +131,18 @@ impl MergePlan {
         } else {
             MergeRelationKind::Conflicted
         };
+        let structured_conflicts = if merge_result.conflicts.is_empty() {
+            None
+        } else {
+            Some(super::structured::build_conflict_payload(
+                repo,
+                (merge_base_id, &base_tree),
+                (*current_state_id, &current_tree),
+                (*target_state_id, &target_tree),
+                &merge_result.tree,
+                &merge_result.conflicts,
+            )?)
+        };
 
         Ok(Self {
             relation: MergeRelation::new(
@@ -131,6 +153,7 @@ impl MergePlan {
                 merge_result.conflicts.len(),
             ),
             merge_result: Some(merge_result),
+            structured_conflicts,
         })
     }
 }

--- a/crates/core/src/merge/structured.rs
+++ b/crates/core/src/merge/structured.rs
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Projection from merge-engine hunks into the durable conflict object model.
+
+use std::{collections::HashMap, path::Path};
+
+use anyhow::{Context, Result};
+use merge::{ConflictLineRange, TextConflictRegion, text_conflict_regions};
+use objects::object::{
+    ConflictRange, ConflictRegion, ConflictSide, ContentHash, StateId, StructuredConflict, Tree,
+};
+use repo::Repository;
+
+pub fn build_conflict_payload(
+    repo: &Repository,
+    base: (StateId, &Tree),
+    ours: (StateId, &Tree),
+    theirs: (StateId, &Tree),
+    merged_tree: &Tree,
+    conflict_paths: &[String],
+) -> Result<StructuredConflict> {
+    let mut conflicts = Vec::new();
+    let mut occurrences = HashMap::new();
+    for path in conflict_paths {
+        let Some(merged) = blob_at_path(repo, merged_tree, path)? else {
+            continue;
+        };
+        let base_blob = blob_at_path(repo, base.1, path)?.unwrap_or_default();
+        let our_blob = blob_at_path(repo, ours.1, path)?.unwrap_or_default();
+        let their_blob = blob_at_path(repo, theirs.1, path)?.unwrap_or_default();
+        let marker_ranges = marker_ranges(&merged.bytes);
+        if marker_ranges.is_empty() {
+            continue;
+        }
+        let analyzed = text_conflict_regions(&base_blob.bytes, &our_blob.bytes, &their_blob.bytes);
+        let regions = align_regions(analyzed, &marker_ranges, &base_blob, &our_blob, &their_blob);
+        for region in regions {
+            let symbol = conflict_symbol(path, &our_blob.bytes, region.ours)
+                .or_else(|| conflict_symbol(path, &their_blob.bytes, region.theirs))
+                .or_else(|| conflict_symbol(path, &base_blob.bytes, region.base));
+            let base_side = conflict_side(base.0, &base_blob, region.base)?;
+            let our_side = conflict_side(ours.0, &our_blob, region.ours)?;
+            let their_side = conflict_side(theirs.0, &their_blob, region.theirs)?;
+            let occurrence_key = (
+                path.clone(),
+                symbol.clone(),
+                base_side.hunk_hash,
+                our_side.hunk_hash,
+                their_side.hunk_hash,
+            );
+            let occurrence = occurrences.entry(occurrence_key).or_insert(0u32);
+            conflicts.push(
+                ConflictRegion::new(
+                    path,
+                    symbol,
+                    *occurrence,
+                    conflict_range(region.merged)?,
+                    base_side,
+                    our_side,
+                    their_side,
+                )
+                .context("construct structured conflict region")?,
+            );
+            *occurrence += 1;
+        }
+    }
+    let payload = StructuredConflict::new(conflicts);
+    payload.validate()?;
+    Ok(payload)
+}
+
+#[derive(Default)]
+struct BlobAtPath {
+    id: Option<ContentHash>,
+    bytes: Vec<u8>,
+}
+
+fn blob_at_path(repo: &Repository, root: &Tree, path: &str) -> Result<Option<BlobAtPath>> {
+    let mut tree = root.clone();
+    let mut components = Path::new(path).components().peekable();
+    while let Some(component) = components.next() {
+        let Some(name) = component.as_os_str().to_str() else {
+            return Ok(None);
+        };
+        let Some(entry) = tree.get(name) else {
+            return Ok(None);
+        };
+        if components.peek().is_some() {
+            let Some(tree_hash) = entry.tree_hash() else {
+                return Ok(None);
+            };
+            tree = repo.require_tree(&tree_hash)?;
+            continue;
+        }
+        let Some(blob_id) = entry.leaf_content_hash() else {
+            return Ok(None);
+        };
+        let blob = repo.require_blob(&blob_id)?;
+        return Ok(Some(BlobAtPath {
+            id: Some(blob_id),
+            bytes: blob.content().to_vec(),
+        }));
+    }
+    Ok(None)
+}
+
+fn align_regions(
+    analyzed: Vec<TextConflictRegion>,
+    marker_ranges: &[ConflictLineRange],
+    base: &BlobAtPath,
+    ours: &BlobAtPath,
+    theirs: &BlobAtPath,
+) -> Vec<TextConflictRegion> {
+    if analyzed.len() == marker_ranges.len() {
+        return analyzed
+            .into_iter()
+            .zip(marker_ranges)
+            .map(|(mut region, marker)| {
+                region.merged = *marker;
+                region
+            })
+            .collect();
+    }
+    marker_ranges
+        .iter()
+        .map(|merged| TextConflictRegion {
+            base: whole_range(&base.bytes),
+            ours: whole_range(&ours.bytes),
+            theirs: whole_range(&theirs.bytes),
+            merged: *merged,
+        })
+        .collect()
+}
+
+fn marker_ranges(bytes: &[u8]) -> Vec<ConflictLineRange> {
+    let lines: Vec<&[u8]> = bytes.split_inclusive(|byte| *byte == b'\n').collect();
+    let mut ranges = Vec::new();
+    let mut start = None;
+    for (index, line) in lines.iter().enumerate() {
+        if line.starts_with(b"<<<<<<< ") {
+            start = Some(index);
+        } else if line.starts_with(b">>>>>>> ")
+            && let Some(start) = start.take()
+        {
+            ranges.push(ConflictLineRange {
+                start,
+                end: index + 1,
+            });
+        }
+    }
+    ranges
+}
+
+fn whole_range(bytes: &[u8]) -> ConflictLineRange {
+    ConflictLineRange {
+        start: 0,
+        end: bytes.split_inclusive(|byte| *byte == b'\n').count(),
+    }
+}
+
+fn conflict_side(
+    state: StateId,
+    blob: &BlobAtPath,
+    range: ConflictLineRange,
+) -> Result<ConflictSide> {
+    ConflictSide::new(state, blob.id, conflict_range(range)?, &blob.bytes)
+        .context("construct structured conflict side")
+}
+
+fn conflict_range(range: ConflictLineRange) -> Result<ConflictRange> {
+    ConflictRange::new(range.start, range.end).context("convert structured conflict range")
+}
+
+#[cfg(feature = "semantic")]
+fn conflict_symbol(path: &str, bytes: &[u8], range: ConflictLineRange) -> Option<String> {
+    let start = u32::try_from(range.start).ok()?.saturating_add(1);
+    let end = u32::try_from(range.end.max(range.start + 1)).ok()?;
+    semantic::symbol_resolver::extract_definitions(bytes, Path::new(path))
+        .ok()?
+        .into_iter()
+        .filter(|definition| definition.start_line <= start && definition.end_line >= end)
+        .min_by_key(|definition| definition.end_line - definition.start_line)
+        .map(|definition| match definition.parent_name {
+            Some(parent) => format!("{parent}::{}", definition.name),
+            None => definition.name,
+        })
+}
+
+#[cfg(not(feature = "semantic"))]
+fn conflict_symbol(_path: &str, _bytes: &[u8], _range: ConflictLineRange) -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_ranges_are_zero_based_and_half_open() {
+        let marked = b"before\n<<<<<<< OURS\nours\n=======\ntheirs\n>>>>>>> THEIRS\nafter\n";
+        assert_eq!(
+            marker_ranges(marked),
+            vec![ConflictLineRange { start: 1, end: 6 }]
+        );
+    }
+}

--- a/crates/core/src/resolve.rs
+++ b/crates/core/src/resolve.rs
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed report contract for inspectable conflict resolution.
+
+use objects::object::{Agent, Attribution, ConflictRange, ConflictRegion, ConflictSide, Principal};
+use oplog::ConflictResolutionMode;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::{
+    HeddleReport, MachineOutputKind, OutputDiscriminator, ReportContract, schema_for_report,
+};
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct ResolveReport {
+    pub output_kind: String,
+    pub message: Option<String>,
+    pub resolved: Vec<String>,
+    pub remaining: Vec<String>,
+    /// Path-level compatibility/progress surface, including structural conflicts.
+    pub conflict_paths: Vec<String>,
+    /// Content conflicts expanded into independently addressable regions.
+    pub conflicts: Vec<ConflictRegionReport>,
+    /// Resolution operations produced by this command invocation.
+    pub resolutions: Vec<ConflictResolutionReport>,
+    pub continued: bool,
+    pub continuation_status: Option<String>,
+    pub continuation_message: Option<String>,
+    pub next_action: Option<String>,
+    pub recommended_action: Option<String>,
+}
+
+impl ResolveReport {
+    pub const CONTRACT: ReportContract = ReportContract {
+        schema_name: "resolve",
+        machine_output_kind: MachineOutputKind::Json,
+        output_discriminator: Some(OutputDiscriminator {
+            field: "output_kind",
+            value: "resolve",
+        }),
+        schema: schema_for_report::<Self>,
+    };
+}
+
+impl HeddleReport for ResolveReport {
+    const CONTRACT: ReportContract = Self::CONTRACT;
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct ConflictRegionReport {
+    pub id: String,
+    pub path: String,
+    pub symbol: Option<String>,
+    pub occurrence: u32,
+    pub merged_range: ConflictRangeReport,
+    pub base: ConflictSideReport,
+    pub ours: ConflictSideReport,
+    pub theirs: ConflictSideReport,
+}
+
+impl From<&ConflictRegion> for ConflictRegionReport {
+    fn from(conflict: &ConflictRegion) -> Self {
+        Self {
+            id: conflict.id.clone(),
+            path: conflict.path.clone(),
+            symbol: conflict.symbol.clone(),
+            occurrence: conflict.occurrence,
+            merged_range: conflict.merged_range.into(),
+            base: (&conflict.base).into(),
+            ours: (&conflict.ours).into(),
+            theirs: (&conflict.theirs).into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Serialize, JsonSchema)]
+pub struct ConflictRangeReport {
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+impl From<ConflictRange> for ConflictRangeReport {
+    fn from(range: ConflictRange) -> Self {
+        Self {
+            start_line: range.start_line,
+            end_line: range.end_line,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct ConflictSideReport {
+    pub source_state: String,
+    pub blob_id: Option<String>,
+    pub range: ConflictRangeReport,
+    pub hunk_hash: String,
+}
+
+impl From<&ConflictSide> for ConflictSideReport {
+    fn from(side: &ConflictSide) -> Self {
+        Self {
+            source_state: side.source_state.to_string_full(),
+            blob_id: side.blob_id.map(|id| id.to_hex()),
+            range: side.range.into(),
+            hunk_hash: side.hunk_hash.to_hex(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct ConflictResolutionReport {
+    pub conflict_id: String,
+    pub path: String,
+    pub resolution: String,
+    pub mode: ConflictResolutionModeReport,
+    pub resolver: ResolverAttributionReport,
+}
+
+impl ConflictResolutionReport {
+    pub fn new(
+        conflict_id: impl Into<String>,
+        path: impl Into<String>,
+        resolver: &Attribution,
+        mode: ConflictResolutionMode,
+    ) -> Self {
+        Self {
+            conflict_id: conflict_id.into(),
+            path: path.into(),
+            resolution: mode.as_str().to_string(),
+            mode: mode.into(),
+            resolver: resolver.into(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ConflictResolutionModeReport {
+    Ours,
+    Theirs,
+    Edit,
+    Auto,
+}
+
+impl From<ConflictResolutionMode> for ConflictResolutionModeReport {
+    fn from(mode: ConflictResolutionMode) -> Self {
+        match mode {
+            ConflictResolutionMode::Ours => Self::Ours,
+            ConflictResolutionMode::Theirs => Self::Theirs,
+            ConflictResolutionMode::Edit => Self::Edit,
+            ConflictResolutionMode::Auto => Self::Auto,
+        }
+    }
+}
+
+impl std::fmt::Display for ConflictResolutionModeReport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            Self::Ours => "ours",
+            Self::Theirs => "theirs",
+            Self::Edit => "edit",
+            Self::Auto => "auto",
+        };
+        formatter.write_str(value)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct ResolverAttributionReport {
+    pub kind: ResolverKindReport,
+    pub principal: PrincipalReport,
+    pub agent: Option<AgentReport>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolverKindReport {
+    Human,
+    Agent,
+}
+
+impl From<&Attribution> for ResolverAttributionReport {
+    fn from(attribution: &Attribution) -> Self {
+        Self {
+            kind: if attribution.agent.is_some() {
+                ResolverKindReport::Agent
+            } else {
+                ResolverKindReport::Human
+            },
+            principal: (&attribution.principal).into(),
+            agent: attribution.agent.as_ref().map(Into::into),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct PrincipalReport {
+    pub name: String,
+    pub email: String,
+}
+
+impl From<&Principal> for PrincipalReport {
+    fn from(principal: &Principal) -> Self {
+        Self {
+            name: principal.name.clone(),
+            email: principal.email.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct AgentReport {
+    pub provider: String,
+    pub model: String,
+    pub session_id: Option<String>,
+    pub segment_id: Option<String>,
+    pub policy_id: Option<String>,
+}
+
+impl From<&Agent> for AgentReport {
+    fn from(agent: &Agent) -> Self {
+        Self {
+            provider: agent.provider.clone(),
+            model: agent.model.clone(),
+            session_id: agent.session_id.clone(),
+            segment_id: agent.segment_id.clone(),
+            policy_id: agent.policy_id.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolver_kind_distinguishes_human_and_agent_without_dropping_identity() {
+        let principal = Principal::new("Ada", "ada@example.com");
+        let human = ResolverAttributionReport::from(&Attribution::human(principal.clone()));
+        assert_eq!(human.kind, ResolverKindReport::Human);
+        assert!(human.agent.is_none());
+
+        let agent = ResolverAttributionReport::from(&Attribution::with_agent(
+            principal,
+            Agent::new("openai", "gpt-resolver"),
+        ));
+        assert_eq!(agent.kind, ResolverKindReport::Agent);
+        assert_eq!(agent.principal.email, "ada@example.com");
+        assert_eq!(agent.agent.unwrap().provider, "openai");
+    }
+
+    #[test]
+    fn resolution_report_preserves_automatic_vs_edited_mode() {
+        let resolver = Attribution::human(Principal::new("Ada", "ada@example.com"));
+        let automatic = ConflictResolutionReport::new(
+            "conflict-a",
+            "src/lib.rs",
+            &resolver,
+            ConflictResolutionMode::Auto,
+        );
+        let edited = ConflictResolutionReport::new(
+            "conflict-b",
+            "src/lib.rs",
+            &resolver,
+            ConflictResolutionMode::Edit,
+        );
+        assert_eq!(automatic.mode, ConflictResolutionModeReport::Auto);
+        assert_eq!(edited.mode, ConflictResolutionModeReport::Edit);
+    }
+}

--- a/crates/merge/src/diff3.rs
+++ b/crates/merge/src/diff3.rs
@@ -25,7 +25,7 @@
 use similar::{Algorithm, DiffOp};
 
 use super::{
-    MergeOutcome,
+    ConflictLineRange, MergeOutcome, TextConflictRegion,
     lines::{build_alignment, split_lines},
     markers::{ConflictMarkers, emit_conflict, emit_lines},
     whitespace::compare_trailing_ws,
@@ -66,6 +66,27 @@ pub(super) fn run(
         &their_align,
         markers,
     )
+    .0
+}
+
+pub(super) fn regions(base: &[u8], ours: &[u8], theirs: &[u8]) -> Vec<TextConflictRegion> {
+    if base == ours || base == theirs || ours == theirs {
+        return Vec::new();
+    }
+    let base_lines = split_lines(base);
+    let our_lines = split_lines(ours);
+    let their_lines = split_lines(theirs);
+    let our_align = build_alignment(&base_lines, &our_lines);
+    let their_align = build_alignment(&base_lines, &their_lines);
+    walk_and_emit(
+        &base_lines,
+        &our_lines,
+        &their_lines,
+        &our_align,
+        &their_align,
+        ConflictMarkers::DEFAULT,
+    )
+    .1
 }
 
 fn walk_and_emit(
@@ -75,9 +96,9 @@ fn walk_and_emit(
     our_align: &[Option<usize>],
     their_align: &[Option<usize>],
     markers: ConflictMarkers<'_>,
-) -> MergeOutcome {
+) -> (MergeOutcome, Vec<TextConflictRegion>) {
     let mut output = Vec::new();
-    let mut conflicts = 0usize;
+    let mut regions = Vec::new();
     let mut i = 0usize;
     let mut our_pos = 0usize;
     let mut their_pos = 0usize;
@@ -110,10 +131,25 @@ fn walk_and_emit(
 
         emit_hunk(
             &mut output,
-            &mut conflicts,
+            &mut regions,
             &base[hunk_start..j],
             &ours[our_pos..end_our],
             &theirs[their_pos..end_their],
+            TextConflictRegion {
+                base: ConflictLineRange {
+                    start: hunk_start,
+                    end: j,
+                },
+                ours: ConflictLineRange {
+                    start: our_pos,
+                    end: end_our,
+                },
+                theirs: ConflictLineRange {
+                    start: their_pos,
+                    end: end_their,
+                },
+                merged: ConflictLineRange { start: 0, end: 0 },
+            },
             markers,
         );
 
@@ -126,30 +162,47 @@ fn walk_and_emit(
     if our_pos < ours.len() || their_pos < theirs.len() {
         emit_hunk(
             &mut output,
-            &mut conflicts,
+            &mut regions,
             &[],
             &ours[our_pos..],
             &theirs[their_pos..],
+            TextConflictRegion {
+                base: ConflictLineRange {
+                    start: base.len(),
+                    end: base.len(),
+                },
+                ours: ConflictLineRange {
+                    start: our_pos,
+                    end: ours.len(),
+                },
+                theirs: ConflictLineRange {
+                    start: their_pos,
+                    end: theirs.len(),
+                },
+                merged: ConflictLineRange { start: 0, end: 0 },
+            },
             markers,
         );
     }
 
-    if conflicts == 0 {
+    let outcome = if regions.is_empty() {
         MergeOutcome::Clean(output)
     } else {
         MergeOutcome::Conflicts {
             merged_bytes_with_markers: output,
-            conflict_count: conflicts,
+            conflict_count: regions.len(),
         }
-    }
+    };
+    (outcome, regions)
 }
 
 fn emit_hunk(
     out: &mut Vec<u8>,
-    conflicts: &mut usize,
+    regions: &mut Vec<TextConflictRegion>,
     base_slice: &[&[u8]],
     our_slice: &[&[u8]],
     their_slice: &[&[u8]],
+    mut region: TextConflictRegion,
     markers: ConflictMarkers<'_>,
 ) {
     if our_slice == base_slice {
@@ -174,9 +227,19 @@ fn emit_hunk(
         emit_lines(out, our_slice);
         emit_lines(out, their_slice);
     } else {
+        let merged_start = output_line_count(out);
         emit_conflict(out, our_slice, their_slice, markers);
-        *conflicts += 1;
+        region.merged = ConflictLineRange {
+            start: merged_start,
+            end: output_line_count(out),
+        };
+        regions.push(region);
     }
+}
+
+fn output_line_count(bytes: &[u8]) -> usize {
+    bytes.iter().filter(|byte| **byte == b'\n').count()
+        + usize::from(bytes.last().is_some_and(|byte| *byte != b'\n'))
 }
 
 /// Classification of what a side does to a single base line.

--- a/crates/merge/src/lib.rs
+++ b/crates/merge/src/lib.rs
@@ -63,6 +63,22 @@ pub use tree_merge::{
     detect_renames_between_trees, merge_trees,
 };
 
+/// Zero-based, half-open line range in a merge input or rendered output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ConflictLineRange {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Source and marker ranges for one diff3 conflict hunk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TextConflictRegion {
+    pub base: ConflictLineRange,
+    pub ours: ConflictLineRange,
+    pub theirs: ConflictLineRange,
+    pub merged: ConflictLineRange,
+}
+
 /// Outcome of a three-way line-based merge.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum MergeOutcome {
@@ -113,4 +129,15 @@ pub fn text_hunk_merge_with_markers(
         return MergeOutcome::Binary;
     }
     diff3::run(base, ours, theirs, markers)
+}
+
+/// Analyze the independently conflicting regions selected by the diff3 engine.
+///
+/// The returned ranges use the same zero-based, half-open convention as slices.
+/// Binary inputs have no line-level diff3 regions and return an empty vector.
+pub fn text_conflict_regions(base: &[u8], ours: &[u8], theirs: &[u8]) -> Vec<TextConflictRegion> {
+    if preflight::any_binary(base, ours, theirs) {
+        return Vec::new();
+    }
+    diff3::regions(base, ours, theirs)
 }

--- a/crates/merge/src/tests.rs
+++ b/crates/merge/src/tests.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Unit tests for the native hunk-level merge engine.
 
-use super::{ConflictMarkers, MergeOutcome, text_hunk_merge, text_hunk_merge_with_markers};
+use super::{
+    ConflictLineRange, ConflictMarkers, MergeOutcome, text_conflict_regions, text_hunk_merge,
+    text_hunk_merge_with_markers,
+};
 
 /// Count `<<<<<<<` marker occurrences at column 0 (one per conflict triple).
 fn count_conflicts(bytes: &[u8]) -> usize {
@@ -511,4 +514,21 @@ fn same_anchor_eof_appends_concat() {
         }
         other => panic!("expected Clean (concat EOF appends), got {other:?}"),
     }
+}
+
+#[test]
+fn conflict_regions_preserve_each_source_and_rendered_hunk_range() {
+    let base = b"keep-0\nbase-a\nkeep-1\nbase-b\nkeep-2\n";
+    let ours = b"keep-0\nours-a\nkeep-1\nours-b\nkeep-2\n";
+    let theirs = b"keep-0\ntheirs-a\nkeep-1\ntheirs-b\nkeep-2\n";
+
+    let regions = text_conflict_regions(base, ours, theirs);
+
+    assert_eq!(regions.len(), 2);
+    assert_eq!(regions[0].base, ConflictLineRange { start: 1, end: 2 });
+    assert_eq!(regions[0].ours, regions[0].base);
+    assert_eq!(regions[0].theirs, regions[0].base);
+    assert_eq!(regions[0].merged, ConflictLineRange { start: 1, end: 6 });
+    assert_eq!(regions[1].base, ConflictLineRange { start: 3, end: 4 });
+    assert_eq!(regions[1].merged, ConflictLineRange { start: 7, end: 12 });
 }

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -33,6 +33,8 @@ mod state_provenance;
 mod state_review;
 mod state_visibility;
 mod structured_conflict;
+#[cfg(test)]
+mod structured_conflict_tests;
 mod suggestion_core;
 mod timeline;
 mod tree;
@@ -111,7 +113,7 @@ pub use state_visibility::{
     StateVisibilityError,
 };
 pub use structured_conflict::{
-    ConflictError, ConflictResolution, ConflictSide, ConflictSymbol, StructuredConflict,
+    ConflictError, ConflictRange, ConflictRegion, ConflictSide, StructuredConflict,
 };
 pub use suggestion_core::{
     ContextSuggestion, ContextSuggestionTier, HIGH_SUGGESTION_THRESHOLD,

--- a/crates/object-model/src/object/structured_conflict.rs
+++ b/crates/object-model/src/object/structured_conflict.rs
@@ -1,168 +1,310 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Merge conflicts as structured data.
-//!
-//! Today, merge conflicts surface only as text markers in the working tree
-//! (`<<<<<<<` / `=======` / `>>>>>>>`). That works for humans with editors,
-//! and is unworkable for agents that need to resolve conflicts
-//! programmatically without parsing markers.
-//!
-//! [`StructuredConflict`] makes the conflict itself first-class: the
-//! conflicting symbol, the three sides (base / ours / theirs), and any
-//! candidate resolutions an upstream module suggested. The text-marker
-//! representation in the working tree is *one rendering* of this object, not
-//! its source of truth — see `crates/repo/src/merge_state.rs::render_text_markers`.
+//! Merge conflicts as content-addressed, inspectable regions.
+
+use std::collections::HashSet;
 
 use serde::{Deserialize, Serialize};
 
 use crate::object::{
+    blob::Blob,
     hash::{ContentHash, StateId},
-    state_review::SymbolAnchor,
 };
+
+const CONFLICT_ID_DOMAIN: &[u8] = b"heddle-conflict-region-v1\0";
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct StructuredConflict {
     pub format_version: u8,
-    pub conflicts: Vec<ConflictSymbol>,
+    pub conflicts: Vec<ConflictRegion>,
 }
 
-versioned_msgpack_blob! {
-    blob: StructuredConflict,
-    item: ConflictSymbol,
-    field: conflicts,
-    error: ConflictError,
-    codec_err: Encoding,
-    version: 1,
-}
+impl StructuredConflict {
+    pub const FORMAT_VERSION: u8 = 2;
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ConflictSymbol {
-    /// Stable id for this specific conflict (e.g., a UUID); used by
-    /// `heddle conflict resolve <id>` to address it without parsing
-    /// file paths or line numbers.
-    pub id: String,
-    pub anchor: SymbolAnchor,
-    pub base: ConflictSide,
-    pub ours: ConflictSide,
-    pub theirs: ConflictSide,
-    /// Auto-detected candidate resolutions, in display order. The list may
-    /// be empty when no candidate is obvious.
-    #[serde(default)]
-    pub candidate_resolutions: Vec<ConflictResolution>,
-}
+    pub fn new(conflicts: Vec<ConflictRegion>) -> Self {
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            conflicts,
+        }
+    }
 
-impl ConflictSymbol {
+    pub fn encode(&self) -> Result<Vec<u8>, ConflictError> {
+        rmp_serde::to_vec(self).map_err(|err| ConflictError::Encoding(err.to_string()))
+    }
+
+    pub fn decode(bytes: &[u8]) -> Result<Self, ConflictError> {
+        let blob: Self =
+            rmp_serde::from_slice(bytes).map_err(|err| ConflictError::Encoding(err.to_string()))?;
+        blob.validate()?;
+        Ok(blob)
+    }
+
     pub fn validate(&self) -> Result<(), ConflictError> {
-        if self.id.is_empty() {
-            return Err(ConflictError::EmptyId);
+        if self.format_version != Self::FORMAT_VERSION {
+            return Err(ConflictError::UnsupportedVersion(self.format_version));
         }
-        if self.anchor.file.is_empty() {
-            return Err(ConflictError::EmptyAnchorFile);
-        }
-        if self.anchor.symbol.is_empty() {
-            return Err(ConflictError::EmptyAnchorSymbol);
+        let mut ids = HashSet::new();
+        for conflict in &self.conflicts {
+            conflict.validate()?;
+            if !ids.insert(&conflict.id) {
+                return Err(ConflictError::DuplicateId(conflict.id.clone()));
+            }
         }
         Ok(())
     }
 }
 
+/// One independently addressable conflict region in a file.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ConflictSide {
-    /// The state this side originated from. `None` is permitted only for the
-    /// base when there is no common ancestor.
+pub struct ConflictRegion {
+    /// Deterministic BLAKE3 address derived from the anchor and three hunk hashes.
+    pub id: String,
+    pub path: String,
+    /// Stable semantic address when the source language can be parsed.
     #[serde(default)]
-    pub source_state: Option<StateId>,
-    pub body: String,
-    pub body_hash: ContentHash,
+    pub symbol: Option<String>,
+    /// Disambiguates byte-identical conflicts under the same anchor.
+    pub occurrence: u32,
+    /// Range occupied by the rendered marker block.
+    pub merged_range: ConflictRange,
+    pub base: ConflictSide,
+    pub ours: ConflictSide,
+    pub theirs: ConflictSide,
 }
 
-impl ConflictSide {
-    pub fn from_body(source_state: Option<StateId>, body: impl Into<String>) -> Self {
-        let body = body.into();
-        let body_hash = ContentHash::compute(body.as_bytes());
-        Self {
-            source_state,
-            body,
-            body_hash,
+impl ConflictRegion {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        path: impl Into<String>,
+        symbol: Option<String>,
+        occurrence: u32,
+        merged_range: ConflictRange,
+        base: ConflictSide,
+        ours: ConflictSide,
+        theirs: ConflictSide,
+    ) -> Result<Self, ConflictError> {
+        let path = path.into();
+        let id = stable_conflict_id(
+            &path,
+            symbol.as_deref(),
+            occurrence,
+            &base.hunk_hash,
+            &ours.hunk_hash,
+            &theirs.hunk_hash,
+        );
+        let conflict = Self {
+            id,
+            path,
+            symbol,
+            occurrence,
+            merged_range,
+            base,
+            ours,
+            theirs,
+        };
+        conflict.validate()?;
+        Ok(conflict)
+    }
+
+    pub fn validate(&self) -> Result<(), ConflictError> {
+        if self.path.is_empty() {
+            return Err(ConflictError::EmptyPath);
         }
+        if self.symbol.as_ref().is_some_and(String::is_empty) {
+            return Err(ConflictError::EmptySymbol);
+        }
+        self.merged_range.validate()?;
+        if self.merged_range.is_empty() {
+            return Err(ConflictError::EmptyMergedRange);
+        }
+        self.base.validate()?;
+        self.ours.validate()?;
+        self.theirs.validate()?;
+        let expected = stable_conflict_id(
+            &self.path,
+            self.symbol.as_deref(),
+            self.occurrence,
+            &self.base.hunk_hash,
+            &self.ours.hunk_hash,
+            &self.theirs.hunk_hash,
+        );
+        if self.id != expected {
+            return Err(ConflictError::IdMismatch {
+                actual: self.id.clone(),
+                expected,
+            });
+        }
+        Ok(())
     }
 }
 
+/// Zero-based, half-open line range (`start_line..end_line`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConflictRange {
+    pub start_line: u32,
+    pub end_line: u32,
+}
+
+impl ConflictRange {
+    pub fn new(start_line: usize, end_line: usize) -> Result<Self, ConflictError> {
+        let start_line = u32::try_from(start_line).map_err(|_| ConflictError::RangeOverflow)?;
+        let end_line = u32::try_from(end_line).map_err(|_| ConflictError::RangeOverflow)?;
+        let range = Self {
+            start_line,
+            end_line,
+        };
+        range.validate()?;
+        Ok(range)
+    }
+
+    pub fn validate(self) -> Result<(), ConflictError> {
+        if self.start_line > self.end_line {
+            return Err(ConflictError::InvalidRange {
+                start: self.start_line,
+                end: self.end_line,
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Provenance and integrity information for one side of a conflict region.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum ConflictResolution {
-    TakeOurs,
-    TakeTheirs,
-    TakeBase,
-    Custom { body: String, rationale: String },
+pub struct ConflictSide {
+    pub source_state: StateId,
+    /// `None` means the path was absent in this source state.
+    #[serde(default)]
+    pub blob_id: Option<ContentHash>,
+    pub range: ConflictRange,
+    /// BLAKE3 of the exact bytes selected by `range` from `blob_id`.
+    pub hunk_hash: ContentHash,
+}
+
+impl ConflictSide {
+    pub fn new(
+        source_state: StateId,
+        blob_id: Option<ContentHash>,
+        range: ConflictRange,
+        blob_bytes: &[u8],
+    ) -> Result<Self, ConflictError> {
+        let hunk = slice_lines(blob_bytes, range)?;
+        let side = Self {
+            source_state,
+            blob_id,
+            range,
+            hunk_hash: ContentHash::compute(hunk),
+        };
+        side.verify_blob(blob_bytes)?;
+        Ok(side)
+    }
+
+    pub fn validate(&self) -> Result<(), ConflictError> {
+        self.range.validate()?;
+        if self.blob_id.is_none() && !self.range.is_empty() {
+            return Err(ConflictError::AbsentBlobHasLines);
+        }
+        Ok(())
+    }
+
+    /// Verify both the whole-blob address and the selected hunk hash.
+    pub fn verify_blob(&self, blob_bytes: &[u8]) -> Result<(), ConflictError> {
+        match self.blob_id {
+            Some(expected) if Blob::from_slice(blob_bytes).hash() != expected => {
+                return Err(ConflictError::BlobHashMismatch);
+            }
+            None if !blob_bytes.is_empty() => return Err(ConflictError::UnexpectedBlobBytes),
+            _ => {}
+        }
+        let hunk = slice_lines(blob_bytes, self.range)?;
+        if ContentHash::compute(hunk) != self.hunk_hash {
+            return Err(ConflictError::HunkHashMismatch);
+        }
+        Ok(())
+    }
+}
+
+impl ConflictRange {
+    fn is_empty(self) -> bool {
+        self.start_line == self.end_line
+    }
+}
+
+fn stable_conflict_id(
+    path: &str,
+    symbol: Option<&str>,
+    occurrence: u32,
+    base: &ContentHash,
+    ours: &ContentHash,
+    theirs: &ContentHash,
+) -> String {
+    let mut bytes = Vec::with_capacity(CONFLICT_ID_DOMAIN.len() + path.len() + 128);
+    bytes.extend_from_slice(CONFLICT_ID_DOMAIN);
+    push_field(&mut bytes, path.as_bytes());
+    push_field(&mut bytes, symbol.unwrap_or("").as_bytes());
+    bytes.extend_from_slice(&occurrence.to_le_bytes());
+    bytes.extend_from_slice(base.as_bytes());
+    bytes.extend_from_slice(ours.as_bytes());
+    bytes.extend_from_slice(theirs.as_bytes());
+    format!("conflict-{}", ContentHash::compute(&bytes).to_hex())
+}
+
+fn push_field(bytes: &mut Vec<u8>, field: &[u8]) {
+    bytes.extend_from_slice(&(field.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(field);
+}
+
+fn slice_lines(bytes: &[u8], range: ConflictRange) -> Result<&[u8], ConflictError> {
+    range.validate()?;
+    let start = line_offset(bytes, range.start_line).ok_or(ConflictError::RangeOutOfBounds)?;
+    let end = line_offset(bytes, range.end_line).ok_or(ConflictError::RangeOutOfBounds)?;
+    Ok(&bytes[start..end])
+}
+
+fn line_offset(bytes: &[u8], line: u32) -> Option<usize> {
+    if line == 0 {
+        return Some(0);
+    }
+    let mut current = 0u32;
+    for (index, byte) in bytes.iter().enumerate() {
+        if *byte == b'\n' {
+            current += 1;
+            if current == line {
+                return Some(index + 1);
+            }
+        }
+    }
+    (current == line || (bytes.last().is_some_and(|byte| *byte != b'\n') && current + 1 == line))
+        .then_some(bytes.len())
 }
 
 #[derive(Debug, thiserror::Error)]
 pub enum ConflictError {
     #[error("unsupported structured conflict version {0}")]
     UnsupportedVersion(u8),
-    #[error("conflict id must not be empty")]
-    EmptyId,
-    #[error("conflict anchor must reference a non-empty file")]
-    EmptyAnchorFile,
-    #[error("conflict anchor must reference a non-empty symbol")]
-    EmptyAnchorSymbol,
+    #[error("conflict path must not be empty")]
+    EmptyPath,
+    #[error("conflict symbol must be absent rather than empty")]
+    EmptySymbol,
+    #[error("rendered conflict marker range must not be empty")]
+    EmptyMergedRange,
+    #[error("duplicate conflict id {0}")]
+    DuplicateId(String),
+    #[error("conflict id {actual} does not match stable address {expected}")]
+    IdMismatch { actual: String, expected: String },
+    #[error("conflict range {start}..{end} is invalid")]
+    InvalidRange { start: u32, end: u32 },
+    #[error("conflict range exceeds u32 line addressing")]
+    RangeOverflow,
+    #[error("conflict range exceeds source blob")]
+    RangeOutOfBounds,
+    #[error("an absent source blob cannot contain hunk lines")]
+    AbsentBlobHasLines,
+    #[error("source blob bytes do not match the recorded BLAKE3 id")]
+    BlobHashMismatch,
+    #[error("source hunk bytes do not match the recorded BLAKE3 hash")]
+    HunkHashMismatch,
+    #[error("bytes were supplied for an absent source blob")]
+    UnexpectedBlobBytes,
     #[error("structured conflict encoding error: {0}")]
     Encoding(String),
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn sample_conflict() -> ConflictSymbol {
-        ConflictSymbol {
-            id: "c-1".into(),
-            anchor: SymbolAnchor::new("src/lib.rs", "merge_target"),
-            base: ConflictSide::from_body(Some(StateId::from_bytes([1; 32])), "fn x() { 0 }"),
-            ours: ConflictSide::from_body(Some(StateId::from_bytes([2; 32])), "fn x() { 1 }"),
-            theirs: ConflictSide::from_body(Some(StateId::from_bytes([3; 32])), "fn x() { 2 }"),
-            candidate_resolutions: vec![
-                ConflictResolution::TakeOurs,
-                ConflictResolution::TakeTheirs,
-            ],
-        }
-    }
-
-    #[test]
-    fn three_way_conflict_roundtrip() {
-        let blob = StructuredConflict::new(vec![sample_conflict()]);
-        let bytes = blob.encode().unwrap();
-        let decoded = StructuredConflict::decode(&bytes).unwrap();
-        assert_eq!(blob, decoded);
-    }
-
-    #[test]
-    fn empty_conflicts_list_validates() {
-        let blob = StructuredConflict::new(vec![]);
-        blob.validate().unwrap();
-    }
-
-    #[test]
-    fn empty_id_rejected() {
-        let mut c = sample_conflict();
-        c.id = String::new();
-        assert!(matches!(c.validate(), Err(ConflictError::EmptyId)));
-    }
-
-    #[test]
-    fn body_hash_matches_body() {
-        let side = ConflictSide::from_body(None, "fn x() { 0 }");
-        assert_eq!(side.body_hash, ContentHash::compute(b"fn x() { 0 }"));
-    }
-
-    #[test]
-    fn future_version_rejected() {
-        let blob = StructuredConflict {
-            format_version: StructuredConflict::FORMAT_VERSION + 1,
-            conflicts: vec![],
-        };
-        assert!(matches!(
-            blob.validate(),
-            Err(ConflictError::UnsupportedVersion(_))
-        ));
-    }
 }

--- a/crates/object-model/src/object/structured_conflict_tests.rs
+++ b/crates/object-model/src/object/structured_conflict_tests.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Blob, ConflictError, ConflictRange, ConflictRegion, ConflictSide, StateId};
+use crate::object::StructuredConflict;
+
+fn side(state: u8, body: &[u8], start: usize, end: usize) -> ConflictSide {
+    ConflictSide::new(
+        StateId::from_bytes([state; 32]),
+        Some(Blob::from_slice(body).hash()),
+        ConflictRange::new(start, end).unwrap(),
+        body,
+    )
+    .unwrap()
+}
+
+fn sample_conflict() -> ConflictRegion {
+    ConflictRegion::new(
+        "src/lib.rs",
+        Some("merge_target".into()),
+        0,
+        ConflictRange::new(8, 13).unwrap(),
+        side(1, b"zero\nbase\ntail\n", 1, 2),
+        side(2, b"zero\nours\ntail\n", 1, 2),
+        side(3, b"zero\ntheirs\ntail\n", 1, 2),
+    )
+    .unwrap()
+}
+
+#[test]
+fn three_way_conflict_roundtrip_is_lossless_and_verifiable() {
+    let payload = StructuredConflict::new(vec![sample_conflict()]);
+    let bytes = payload.encode().unwrap();
+    let blob_id = Blob::from_slice(&bytes).hash();
+    let decoded = StructuredConflict::decode(&bytes).unwrap();
+    assert_eq!(payload, decoded);
+    assert_eq!(blob_id, Blob::new(decoded.encode().unwrap()).hash());
+    decoded.conflicts[0]
+        .ours
+        .verify_blob(b"zero\nours\ntail\n")
+        .unwrap();
+}
+
+#[test]
+fn stable_id_survives_unrelated_line_shifts_and_blob_rewrites() {
+    let first = sample_conflict();
+    let shifted = ConflictRegion::new(
+        "src/lib.rs",
+        Some("merge_target".into()),
+        0,
+        ConflictRange::new(20, 25).unwrap(),
+        side(4, b"new\nzero\nbase\ntail\n", 2, 3),
+        side(5, b"new\nzero\nours\ntail\n", 2, 3),
+        side(6, b"new\nzero\ntheirs\ntail\n", 2, 3),
+    )
+    .unwrap();
+    assert_eq!(first.id, shifted.id);
+}
+
+#[test]
+fn tampered_hunk_fails_closed() {
+    let conflict = sample_conflict();
+    assert!(matches!(
+        conflict.ours.verify_blob(b"zero\nother\ntail\n"),
+        Err(ConflictError::BlobHashMismatch)
+    ));
+    let mut tampered = conflict;
+    tampered.ours.hunk_hash = crate::object::ContentHash::compute(b"tampered");
+    assert!(matches!(
+        tampered.validate(),
+        Err(ConflictError::IdMismatch { .. })
+    ));
+}
+
+#[test]
+fn legacy_format_is_rejected_at_the_version_gate() {
+    let payload = StructuredConflict {
+        format_version: 1,
+        conflicts: vec![],
+    };
+    let bytes = payload.encode().unwrap();
+    assert!(matches!(
+        StructuredConflict::decode(&bytes),
+        Err(ConflictError::UnsupportedVersion(1))
+    ));
+}

--- a/crates/repo/src/merge_state.rs
+++ b/crates/repo/src/merge_state.rs
@@ -3,7 +3,11 @@
 
 use std::{fs, path::PathBuf};
 
-use objects::{fs_atomic::write_file_atomic, lock::RepoLock, object::StateId};
+use objects::{
+    fs_atomic::write_file_atomic,
+    lock::RepoLock,
+    object::{ContentHash, StateId},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::{Repository, Result};
@@ -15,6 +19,9 @@ pub struct MergeState {
     pub base: Option<StateId>,
     pub conflicts: Vec<String>,
     pub resolved: Vec<String>,
+    /// Content-addressed [`StructuredConflict`](objects::object::StructuredConflict) blob.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub structured_conflicts: Option<ContentHash>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_root: Option<PathBuf>,
 }
@@ -53,6 +60,7 @@ impl MergeStateManager {
         theirs: StateId,
         base: Option<StateId>,
         conflicts: Vec<String>,
+        structured_conflicts: Option<ContentHash>,
     ) -> Result<()> {
         let _lock = self.write_lock()?;
         let state = MergeState {
@@ -61,6 +69,7 @@ impl MergeStateManager {
             base,
             conflicts,
             resolved: Vec::new(),
+            structured_conflicts,
             worktree_root: self.worktree_root.clone(),
         };
         self.write_state(&state)?;
@@ -171,7 +180,7 @@ impl MergeStateManager {
     /// alive, but its "our" side now reflects the just-committed
     /// checkpoint so subsequent `--ours` resolves pull from the latest
     /// WIP rather than the pre-merge baseline. `theirs`, `base`,
-    /// `conflicts`, and `resolved` are preserved untouched.
+    /// `conflicts`, `resolved`, and `structured_conflicts` are preserved untouched.
     pub fn carry_forward(&self, new_ours: StateId) -> Result<MergeState> {
         let _lock = self.write_lock()?;
         let mut state = self
@@ -266,6 +275,7 @@ mod tests {
                 theirs,
                 Some(base),
                 vec!["a.txt".to_string(), "b.txt".to_string()],
+                Some(ContentHash::compute(b"structured-conflicts")),
             )
             .unwrap();
         manager.resolve("a.txt").unwrap();
@@ -275,6 +285,10 @@ mod tests {
         assert_eq!(state.theirs, theirs);
         assert_eq!(state.base, Some(base));
         assert_eq!(state.resolved, vec!["a.txt".to_string()]);
+        assert_eq!(
+            state.structured_conflicts,
+            Some(ContentHash::compute(b"structured-conflicts"))
+        );
     }
 
     #[test]
@@ -288,6 +302,7 @@ mod tests {
                 theirs,
                 None,
                 vec!["a.txt".to_string(), "b.txt".to_string()],
+                None,
             )
             .unwrap();
         let newly_resolved = manager.resolve_all().unwrap();

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -1099,6 +1099,15 @@ impl Repository {
                         true,
                         None,
                     )?;
+                    if let Some(conflicts) = merge_state.structured_conflicts {
+                        self.store.put_state_attachment(&StateAttachment {
+                            state_id: state.id(),
+                            body: StateAttachmentBody::StructuredConflicts(conflicts),
+                            attribution: attribution.clone(),
+                            created_at: chrono::Utc::now(),
+                            supersedes: None,
+                        })?;
+                    }
                     self.merge_state_manager().finish()?;
                     let tree = self.store.get_tree(&state.tree)?.ok_or_else(|| {
                         HeddleError::NotFound("merge snapshot tree missing".to_string())

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -783,6 +783,7 @@ fn snapshot_failure_leaves_ref_unchanged() {
             theirs,
             None,
             vec!["unresolved.txt".to_string()],
+            None,
         )
         .unwrap();
 

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3499,8 +3499,14 @@ no record exists — public-by-absence):
 `heddle resolve --output json` emits:
 
 ```json
-{"output_kind": "resolve", "message": "Resolved src/lib.rs; completed integration", "resolved": ["src/lib.rs"], "remaining": [], "continued": true, "continuation_status": "continued", "continuation_message": "Completed the in-progress Heddle integration", "next_action": "heddle land --thread feature/auth", "recommended_action": "heddle land --thread feature/auth"}
+{"output_kind": "resolve", "message": "Resolved src/lib.rs; completed integration", "resolved": ["src/lib.rs"], "remaining": [], "conflict_paths": ["src/lib.rs"], "conflicts": [{"id": "conflict-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "path": "src/lib.rs", "symbol": "merge_target", "occurrence": 0, "merged_range": {"start_line": 8, "end_line": 13}, "base": {"source_state": "hs-0000000000000000000000000000000000000000000000000000", "blob_id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}, "ours": {"source_state": "hs-1111111111111111111111111111111111111111111111111111", "blob_id": "2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}, "theirs": {"source_state": "hs-2222222222222222222222222222222222222222222222222222", "blob_id": "4123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "5123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}}], "resolutions": [{"conflict_id": "conflict-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "path": "src/lib.rs", "resolution": "edit", "mode": "edit", "resolver": {"kind": "agent", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "openai", "model": "gpt-5", "session_id": null, "segment_id": null, "policy_id": null}}}], "continued": true, "continuation_status": "continued", "continuation_message": "Completed the in-progress Heddle integration", "next_action": "heddle land --thread feature/auth", "recommended_action": "heddle land --thread feature/auth"}
 ```
+
+`conflicts` is the verified, content-addressed payload for the paths touched by
+the command. Ranges are zero-based and half-open; every side names its source
+state, source blob (or `null` when absent), and BLAKE3 hunk hash. `resolutions`
+records the stable region id, resolution mode (`ours`, `theirs`, `edit`, or
+`auto`), and complete human/agent attribution written to the operation log.
 
 `heddle retro --output json` emits the same shape with bounded session data;
 `timeline_steps` is `[]` unless expanded with `--full`. `heddle retro

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7407,13 +7407,13 @@ the `discuss_show` discriminator:
 {"valid": true, "errors": [], "warnings": [], "objects_checked": 42, "git_projection_checked": false, "repair_target": null, "repaired": false, "repairs": []}
 ```
 
-`heddle oplog recover --output json` emits a non-mutating health report for a
-repository whose V5 manifest-selected oplog containers pass strict repository
-open validation. Damaged selected generations fail at that validation boundary
-instead of relying on the removed single-file `oplog.bin` auto-salvage path:
+`heddle oplog recover --output json` emits the health or explicit salvage
+report for the manifest-selected oplog containers. Optional recovery detail
+fields appear when the invocation repaired damage or found a durable report
+from an earlier recovery:
 
 ```json
-{"output_kind":"oplog_recover","already_healthy":true,"prior_recovery":false,"entries_recovered":0,"damaged_byte_start":0,"damaged_byte_end":0}
+{"output_kind":"oplog_recover","already_healthy":true,"prior_recovery":true,"strategy":"forward-greedy","entries_recovered":2,"entries_lost":1,"damaged_byte_start":256,"damaged_byte_end":320,"sidecar_path":".heddle/oplog/oplog.segments/0000000000000001.bin.oplog.recovery","suffix_segments_discarded":0,"suffix_entries_discarded":0}
 ```
 
 `heddle hook list|install|uninstall|events --output json` emit:
@@ -7531,8 +7531,14 @@ no record exists — public-by-absence):
 `heddle resolve --output json` emits:
 
 ```json
-{"output_kind": "resolve", "message": "Resolved src/lib.rs; completed integration", "resolved": ["src/lib.rs"], "remaining": [], "continued": true, "continuation_status": "continued", "continuation_message": "Completed the in-progress Heddle integration", "next_action": "heddle land --thread feature/auth", "recommended_action": "heddle land --thread feature/auth"}
+{"output_kind": "resolve", "message": "Resolved src/lib.rs; completed integration", "resolved": ["src/lib.rs"], "remaining": [], "conflict_paths": ["src/lib.rs"], "conflicts": [{"id": "conflict-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "path": "src/lib.rs", "symbol": "merge_target", "occurrence": 0, "merged_range": {"start_line": 8, "end_line": 13}, "base": {"source_state": "hs-0000000000000000000000000000000000000000000000000000", "blob_id": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}, "ours": {"source_state": "hs-1111111111111111111111111111111111111111111111111111", "blob_id": "2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}, "theirs": {"source_state": "hs-2222222222222222222222222222222222222222222222222222", "blob_id": "4123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "range": {"start_line": 8, "end_line": 9}, "hunk_hash": "5123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"}}], "resolutions": [{"conflict_id": "conflict-1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "path": "src/lib.rs", "resolution": "edit", "mode": "edit", "resolver": {"kind": "agent", "principal": {"name": "A. Engineer", "email": "a@example.com"}, "agent": {"provider": "openai", "model": "gpt-5", "session_id": null, "segment_id": null, "policy_id": null}}}], "continued": true, "continuation_status": "continued", "continuation_message": "Completed the in-progress Heddle integration", "next_action": "heddle land --thread feature/auth", "recommended_action": "heddle land --thread feature/auth"}
 ```
+
+`conflicts` is the verified, content-addressed payload for the paths touched by
+the command. Ranges are zero-based and half-open; every side names its source
+state, source blob (or `null` when absent), and BLAKE3 hunk hash. `resolutions`
+records the stable region id, resolution mode (`ours`, `theirs`, `edit`, or
+`auto`), and complete human/agent attribution written to the operation log.
 
 `heddle retro --output json` emits the same shape with bounded session data;
 `timeline_steps` is `[]` unless expanded with `--full`. `heddle retro


### PR DESCRIPTION
## Summary

- Models a versioned, content-addressed conflict payload with independently addressable regions, zero-based half-open ranges, source state and blob provenance, exact hunk hashes, and stable symbol-aware IDs.
- Persists the payload through active merge state and onto the resolved state attachment, and records one richly attributed ConflictResolved operation per region with ours/theirs/edit/auto mode fidelity.
- Exposes conflicts and resolution records through one typed ResolveReport used by text and JSON rendering, with a registered runtime schema for clients such as tapestry#399.

## Closes

Part of HeddleCo/heddle#1332

## Test evidence

- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-object-model structured_conflict
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-merge conflict_regions_preserve_each_source_and_rendered_hunk_range
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-cli --test production_features resolve::test_resolve_list_conflicts -- --exact
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-cli --test production_features resolve::test_thread_refresh_conflict_continue_then_land_resolved_thread -- --exact --nocapture
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-cli --test comprehensive resolve_comprehensive:: -- --test-threads=1
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo test --locked -p heddle-cli --test conflict_resolution merge_state_
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo build --locked --workspace
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1332-target cargo clippy --locked --workspace --all-targets -- -D warnings
- rustfmt +nightly --edition 2024 on every touched Rust file
- heddle schemas resolve exposes region, range, provenance, resolution-mode, and resolver-kind definitions
- heddle doctor schemas --output json: verified=true, issues=[]

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789091766&installation_model_id=21489&pr_number=1334&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1334&signature=bfbb328a79ec0d34f3c4197c0a680a7798b8b0855db8dcf1d1d6e9eea4ba28b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->