### PR TITLE
feat(object-model): DiscussionReference on DiscussionTurn (durable half of weft#1280)

### DIFF
--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -2896,6 +2896,7 @@ mod pull_bootstrap_tests {
                 author: principal.clone(),
                 body: "keep this invariant".to_string(),
                 posted_at: 1_700_000_001,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/object-model/src/object/discussion.rs
+++ b/crates/object-model/src/object/discussion.rs
@@ -113,6 +113,45 @@ pub struct DiscussionTurn {
     pub body: String,
     /// Unix epoch seconds.
     pub posted_at: i64,
+    /// Structured references occupying byte spans within [`Self::body`].
+    #[serde(default)]
+    pub references: Vec<DiscussionReference>,
+}
+
+/// One durable entity reference embedded in a discussion turn.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscussionReference {
+    /// Entity category used to resolve [`Self::id`].
+    pub kind: DiscussionReferenceKind,
+    /// Stable identity of the referent, never its display label.
+    pub id: String,
+    /// State where a file, line, or symbol reference was known to be valid.
+    pub at: Option<StateId>,
+    /// Inclusive UTF-8 byte offset into the turn body.
+    pub start: u32,
+    /// Exclusive UTF-8 byte offset into the turn body.
+    pub end: u32,
+}
+
+/// Kind of entity named by a [`DiscussionReference`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DiscussionReferenceKind {
+    /// Human user identity.
+    User,
+    /// Agent identity.
+    Agent,
+    /// Spool identity.
+    Spool,
+    /// Thread identity.
+    Thread,
+    /// State identity.
+    State,
+    /// File path relative to a state.
+    File,
+    /// File and line identity relative to a state.
+    Line,
+    /// File and symbol identity relative to a state.
+    Symbol,
 }
 
 impl DiscussionTurn {
@@ -180,6 +219,7 @@ mod tests {
                 author: sample_principal(),
                 body: "why does this branch exist?".into(),
                 posted_at: 1_700_000_000,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -50,8 +50,8 @@ pub use blob::Blob;
 pub use collaboration::*;
 pub use diff::{DiffKind, FileChange, FileChangeSet};
 pub use discussion::{
-    Discussion, DiscussionError, DiscussionId, DiscussionResolution, DiscussionTurn,
-    DiscussionsBlob, generate_discussion_id,
+    Discussion, DiscussionError, DiscussionId, DiscussionReference, DiscussionReferenceKind,
+    DiscussionResolution, DiscussionTurn, DiscussionsBlob, generate_discussion_id,
 };
 pub use hash::{ChangeId, ChangeIdParseError, ContentHash, StateId, StateIdParseError};
 pub use identifiers::{MarkerName, Scope, ThreadName};

--- a/crates/object-model/tests/discussion_references.rs
+++ b/crates/object-model/tests/discussion_references.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use heddle_object_model::object::{
+    DiscussionReference, DiscussionReferenceKind, DiscussionTurn, Principal, StateId,
+};
+use serde::Serialize;
+
+fn sample_principal() -> Principal {
+    Principal::new("Alice", "alice@example.com")
+}
+
+#[test]
+fn references_round_trip_with_utf8_byte_offsets() {
+    let body = "é @user @agent @spool @thread @state @file @line @symbol".to_string();
+    let state = StateId::from_bytes([9; 32]);
+    let reference = |kind, id: &str, token: &str, at| {
+        let start = body.find(token).unwrap();
+        DiscussionReference {
+            kind,
+            id: id.to_string(),
+            at,
+            start: u32::try_from(start).unwrap(),
+            end: u32::try_from(start + token.len()).unwrap(),
+        }
+    };
+    let references = vec![
+        reference(DiscussionReferenceKind::User, "user-1", "@user", None),
+        reference(DiscussionReferenceKind::Agent, "agent-1", "@agent", None),
+        reference(DiscussionReferenceKind::Spool, "spool-1", "@spool", None),
+        reference(DiscussionReferenceKind::Thread, "thread-1", "@thread", None),
+        reference(DiscussionReferenceKind::State, "state-1", "@state", None),
+        reference(
+            DiscussionReferenceKind::File,
+            "src/lib.rs",
+            "@file",
+            Some(state),
+        ),
+        reference(
+            DiscussionReferenceKind::Line,
+            "src/lib.rs#88",
+            "@line",
+            Some(state),
+        ),
+        reference(
+            DiscussionReferenceKind::Symbol,
+            "src/lib.rs#run",
+            "@symbol",
+            Some(state),
+        ),
+    ];
+    let turn = DiscussionTurn {
+        author: sample_principal(),
+        body,
+        posted_at: 1_700_000_001,
+        references,
+    };
+
+    let bytes = rmp_serde::to_vec_named(&turn).unwrap();
+    let decoded: DiscussionTurn = rmp_serde::from_slice(&bytes).unwrap();
+
+    assert_eq!(decoded, turn);
+    assert_eq!(decoded.references[2].at, None);
+    assert_eq!(decoded.references[6].at, Some(state));
+    assert_eq!(decoded.references[0].start, 3);
+    for (reference, token) in decoded.references.iter().zip([
+        "@user", "@agent", "@spool", "@thread", "@state", "@file", "@line", "@symbol",
+    ]) {
+        let span = reference.start as usize..reference.end as usize;
+        assert_eq!(decoded.body.get(span), Some(token));
+    }
+}
+
+#[test]
+fn old_turn_shape_decodes_with_empty_references() {
+    #[derive(Serialize)]
+    struct OldDiscussionTurn {
+        author: Principal,
+        body: String,
+        posted_at: i64,
+    }
+
+    let old_turn = OldDiscussionTurn {
+        author: sample_principal(),
+        body: "stored before discussion references".into(),
+        posted_at: 1_700_000_000,
+    };
+    let bytes = rmp_serde::to_vec_named(&old_turn).unwrap();
+    let decoded: DiscussionTurn = rmp_serde::from_slice(&bytes).unwrap();
+
+    assert!(decoded.references.is_empty());
+    assert_eq!(decoded.body, old_turn.body);
+}

--- a/crates/repo/src/collaboration_migration.rs
+++ b/crates/repo/src/collaboration_migration.rs
@@ -383,6 +383,7 @@ mod tests {
                 author: Principal::new("Ada", "ada@example.com"),
                 body: body.to_string(),
                 posted_at: 1_700_000_000,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/repo/src/discussion_anchor_travel.rs
+++ b/crates/repo/src/discussion_anchor_travel.rs
@@ -239,6 +239,7 @@ mod tests {
                 author: objects::object::Principal::new("a", "a@x"),
                 body: "body".into(),
                 posted_at: 1_700_000_000,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/repo/src/discussion_snapshot_travel.rs
+++ b/crates/repo/src/discussion_snapshot_travel.rs
@@ -227,6 +227,7 @@ mod tests {
                 author: Principal::new("Alice", "alice@example.com"),
                 body: "please check this".to_string(),
                 posted_at: 1_700_000_000,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -1875,6 +1875,7 @@ mod tests {
                 author: principal,
                 body: "Should this sync?".to_string(),
                 posted_at: 1_782_400_000,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,


### PR DESCRIPTION
## Summary

- Add durable `DiscussionReference` and `DiscussionReferenceKind` object-model types, with stable identity, optional state pin, and half-open UTF-8 byte offsets.
- Add backward-compatible `references` storage to `DiscussionTurn` using a serde default so existing named-MessagePack rows decode to an empty vector.
- Scope is limited to the Heddle durable object model, its serialization tests, and direct construction fixtures. Proto mapping and server-side validation remain in the separate weft half.

## Closes

Closes HeddleCo/heddle#1335.

Part of HeddleCo/weft#1280.

## Test evidence

- `cargo test --locked -p heddle-object-model --test discussion_references` — 2 passed: all eight kinds round-trip with intact fields and UTF-8 byte spans; old-shape named-MessagePack decodes with empty references.
- `cargo build --locked --workspace` — passed.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — passed.
- `rustfmt +nightly --edition 2024 --check` on all touched Rust files — passed.

Cargo commands ran beneath `/home/scratch` with `TMPDIR=/home/scratch` and isolated `CARGO_TARGET_DIR=/home/scratch/heddle-1335-target`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789099330&installation_model_id=21489&pr_number=1336&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1336&signature=fd4daea98cbb22616f44f046cd3b4979336afdbd76fe478ef8042875b47f0b70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->