### PR TITLE
feat(storage): S2 compact columnar tree+state encoding (Part of #1323)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,6 +2496,7 @@ dependencies = [
  "heddle-fs-prims",
  "heddle-object-model",
  "memmap2",
+ "rmp-serde",
  "tempfile",
  "tracing",
  "zstd",

--- a/crates/cli/examples/native_lineage_solid.rs
+++ b/crates/cli/examples/native_lineage_solid.rs
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Real compact-repack falsifier for heddle#1337, derived from #1325.
+
+#[path = "native_lineage_solid/blob_lineage.rs"]
+mod blob_lineage;
+#[path = "native_lineage_solid/blob_measure.rs"]
+mod blob_measure;
+#[path = "native_lineage_solid/blob_paths.rs"]
+mod blob_paths;
+#[path = "native_lineage_solid/git_baseline.rs"]
+mod git_baseline;
+#[path = "native_lineage_solid/lineage.rs"]
+mod lineage;
+#[path = "native_lineage_solid/measure.rs"]
+mod measure;
+#[path = "native_lineage_solid/model.rs"]
+mod model;
+#[path = "native_lineage_solid/real_compact.rs"]
+mod real_compact;
+#[path = "native_lineage_solid/tree_access.rs"]
+mod tree_access;
+
+use std::{env, fs, path::PathBuf};
+
+use anyhow::{Context, Result, bail};
+use objects::store::FsStore;
+use serde::Serialize;
+
+use crate::{
+    blob_measure::{BlobMeasurement, measure_blobs},
+    git_baseline::{GitBaseline, measure_git},
+    lineage::build_lineage_order,
+    model::{ObjectCounts, load_object_set},
+    real_compact::{RealCompactMeasurement, measure_real_compact_repack},
+};
+
+const DEFAULT_FRAME_BYTES: usize = 12 * 1024 * 1024;
+#[derive(Serialize)]
+struct Results {
+    repository: String,
+    frame_bytes: usize,
+    object_counts: ObjectCounts,
+    git: GitBaseline,
+    compact: RealCompactMeasurement,
+    blobs: BlobMeasurement,
+    lineage_walk: lineage::LineageStats,
+    comparisons: Comparisons,
+    regated_total: RegatedTotal,
+}
+
+#[derive(Serialize)]
+struct KindComparison {
+    git_raw_bytes: u64,
+    native_msgpack_bytes: u64,
+    compact_compressed_bytes: u64,
+    compact_compressed_to_git: f64,
+}
+
+#[derive(Serialize)]
+struct Comparisons {
+    trees: KindComparison,
+    states: KindComparison,
+}
+
+#[derive(Serialize)]
+struct RegatedTotal {
+    compact_metadata_bytes: u64,
+    blob_lineage_frame_bytes: u64,
+    index_bytes: u64,
+    total_bytes: u64,
+    git_pack_bytes: u64,
+    git_pack_and_idx_bytes: u64,
+    total_to_git_pack: f64,
+    total_to_git_pack_and_idx: f64,
+}
+
+fn main() -> Result<()> {
+    let (repo_root, git_dir, output_dir, frame_bytes) = parse_args()?;
+    fs::create_dir(&output_dir).with_context(|| {
+        format!(
+            "create fresh output directory {} (it must not already exist)",
+            output_dir.display()
+        )
+    })?;
+    let heddle_dir = repo_root.join(".heddle");
+    if !heddle_dir.is_dir() {
+        bail!(
+            "{} is not an adopted Heddle repository",
+            repo_root.display()
+        );
+    }
+    let store = FsStore::new(&heddle_dir);
+    store.reload_packs()?;
+    let objects = load_object_set(&store)?;
+    let counts = objects.counts();
+    eprintln!(
+        "native objects: {} states, {} trees, {} blobs",
+        counts.states, counts.trees, counts.blobs
+    );
+
+    let git = measure_git(&git_dir)?;
+    validate_corpus_counts(&counts, &git)?;
+    let lineage = build_lineage_order(&store, &objects)?;
+    measure::write_renames(&output_dir.join("renames.tsv"), &lineage.renames)?;
+    let blobs = measure_blobs(&store, &lineage.order, &output_dir, frame_bytes)?;
+    let compact = measure_real_compact_repack(&store, &objects)?;
+    let comparisons = comparisons(&git, &compact);
+    let regated_total = regate(&git, &compact, &blobs);
+    let results = Results {
+        repository: repo_root.display().to_string(),
+        frame_bytes,
+        object_counts: counts,
+        git,
+        compact,
+        blobs,
+        lineage_walk: lineage.stats,
+        comparisons,
+        regated_total,
+    };
+    let json = serde_json::to_vec_pretty(&results)?;
+    fs::write(output_dir.join("results.json"), &json)?;
+    println!("{}", String::from_utf8(json)?);
+    Ok(())
+}
+
+fn comparisons(git: &GitBaseline, compact: &RealCompactMeasurement) -> Comparisons {
+    Comparisons {
+        trees: compare(
+            git.trees.bytes,
+            compact.source_tree_bytes,
+            compact.compact_tree_bytes,
+        ),
+        states: compare(
+            git.commits.bytes,
+            compact.source_state_bytes,
+            compact.compact_state_bytes,
+        ),
+    }
+}
+
+fn compare(
+    git_raw_bytes: u64,
+    native_msgpack_bytes: u64,
+    compact_compressed_bytes: u64,
+) -> KindComparison {
+    KindComparison {
+        git_raw_bytes,
+        native_msgpack_bytes,
+        compact_compressed_bytes,
+        compact_compressed_to_git: ratio(compact_compressed_bytes, git_raw_bytes),
+    }
+}
+
+fn regate(
+    git: &GitBaseline,
+    compact: &RealCompactMeasurement,
+    blobs: &BlobMeasurement,
+) -> RegatedTotal {
+    let compact_metadata_bytes = compact.compact_tree_bytes + compact.compact_state_bytes;
+    let index_bytes = compact.index_bytes;
+    let total_bytes = compact_metadata_bytes + blobs.compressed_bytes + index_bytes;
+    let git_pack_and_idx_bytes = git.pack_bytes + git.idx_bytes;
+    RegatedTotal {
+        compact_metadata_bytes,
+        blob_lineage_frame_bytes: blobs.compressed_bytes,
+        index_bytes,
+        total_bytes,
+        git_pack_bytes: git.pack_bytes,
+        git_pack_and_idx_bytes,
+        total_to_git_pack: ratio(total_bytes, git.pack_bytes),
+        total_to_git_pack_and_idx: ratio(total_bytes, git_pack_and_idx_bytes),
+    }
+}
+
+fn validate_corpus_counts(counts: &ObjectCounts, git: &GitBaseline) -> Result<()> {
+    if counts.states as u64 != git.commits.objects
+        || counts.trees as u64 != git.trees.objects
+        || counts.blobs as u64 != git.blobs.objects
+    {
+        bail!("native and Git corpus object counts differ");
+    }
+    Ok(())
+}
+
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    numerator as f64 / denominator as f64
+}
+
+fn parse_args() -> Result<(PathBuf, PathBuf, PathBuf, usize)> {
+    let mut args = env::args_os().skip(1);
+    let usage =
+        "usage: native_lineage_solid <adopted-repo> <git-dir> <fresh-output-dir> [frame-mib]";
+    let repo_root = args.next().with_context(|| usage)?;
+    let git_dir = args.next().with_context(|| usage)?;
+    let output_dir = args.next().with_context(|| usage)?;
+    let frame_bytes = match args.next() {
+        Some(value) => value
+            .to_string_lossy()
+            .parse::<usize>()
+            .context("frame-mib must be a positive integer")?
+            .checked_mul(1024 * 1024)
+            .context("frame-mib overflow")?,
+        None => DEFAULT_FRAME_BYTES,
+    };
+    if frame_bytes == 0 || args.next().is_some() {
+        bail!(usage);
+    }
+    Ok((
+        repo_root.into(),
+        git_dir.into(),
+        output_dir.into(),
+        frame_bytes,
+    ))
+}

--- a/crates/cli/examples/native_lineage_solid/blob_lineage.rs
+++ b/crates/cli/examples/native_lineage_solid/blob_lineage.rs
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::Result;
+use objects::{
+    object::{ContentHash, DiffKind, State, StateId, diff_trees},
+    store::FsStore,
+};
+use semantic::{SimilarityMethod, detect_file_renames};
+
+use crate::{
+    blob_paths::{extension, path_text},
+    lineage::{LineageStats, RenameRecord},
+    model::ObjectSet,
+    tree_access::{leaf_hash, leaf_paths},
+};
+
+const RENAME_THRESHOLD: f64 = 0.6;
+
+pub fn blob_lineage_order(
+    store: &FsStore,
+    states: &HashMap<StateId, State>,
+    state_order: &[StateId],
+    objects: &ObjectSet,
+) -> Result<(Vec<ContentHash>, Vec<RenameRecord>, LineageStats)> {
+    let mut walk = BlobWalk::default();
+    for (index, child_id) in state_order.iter().enumerate() {
+        let child = &states[child_id];
+        if child.parents.is_empty() {
+            walk.root_states += 1;
+            for (path, hash) in leaf_paths(store, child.tree)? {
+                walk.record(&path, hash);
+            }
+        }
+        walk.merge_states += usize::from(child.parents.len() > 1);
+        for parent_id in child.parents.iter().filter(|id| states.contains_key(id)) {
+            walk.state_edges += 1;
+            walk.diff_edge(store, *child_id, child, *parent_id, &states[parent_id])?;
+        }
+        if (index + 1) % 500 == 0 || index + 1 == state_order.len() {
+            eprintln!("lineage walk: {}/{} states", index + 1, state_order.len());
+        }
+    }
+    let (order, lineage_blobs, leftovers) = walk.finish(&objects.blobs);
+    let stats = LineageStats {
+        state_edges_walked: walk.state_edges,
+        root_states: walk.root_states,
+        merge_states: walk.merge_states,
+        file_changes: walk.file_changes,
+        exact_renames: walk.exact_renames,
+        similarity_renames: walk.similarity_renames,
+        lineage_paths: walk.histories.len(),
+        lineage_blobs,
+        leftover_blobs: leftovers,
+        missing_parents: 0,
+    };
+    Ok((order, walk.renames, stats))
+}
+
+#[derive(Default)]
+struct BlobWalk {
+    aliases: HashMap<String, String>,
+    histories: HashMap<String, Vec<ContentHash>>,
+    renames: Vec<RenameRecord>,
+    state_edges: usize,
+    root_states: usize,
+    merge_states: usize,
+    file_changes: usize,
+    exact_renames: usize,
+    similarity_renames: usize,
+}
+
+impl BlobWalk {
+    fn diff_edge(
+        &mut self,
+        store: &FsStore,
+        child_id: StateId,
+        child: &State,
+        parent_id: StateId,
+        parent: &State,
+    ) -> Result<()> {
+        let changes = diff_trees(store, &parent.tree, &child.tree)?;
+        self.file_changes += changes.len();
+        let mut added = Vec::new();
+        let mut deleted = Vec::new();
+        for change in &changes {
+            match change.kind {
+                DiffKind::Modified => {
+                    if let Some(hash) = leaf_hash(store, child.tree, &change.path)? {
+                        self.record(&change.path, hash);
+                    }
+                    if let Some(hash) = leaf_hash(store, parent.tree, &change.path)? {
+                        self.record(&change.path, hash);
+                    }
+                }
+                DiffKind::Added => added.push(change.path.clone()),
+                DiffKind::Deleted => deleted.push(change.path.clone()),
+                DiffKind::Unchanged => {}
+            }
+        }
+        self.record_add_delete(
+            store,
+            (child_id, parent_id),
+            child,
+            parent,
+            &added,
+            &deleted,
+        )
+    }
+
+    fn record_add_delete(
+        &mut self,
+        store: &FsStore,
+        state_ids: (StateId, StateId),
+        child: &State,
+        parent: &State,
+        added: &[String],
+        deleted: &[String],
+    ) -> Result<()> {
+        let added_hashes = path_hashes(store, child.tree, added)?;
+        let deleted_hashes = path_hashes(store, parent.tree, deleted)?;
+        let mut renamed_added = HashSet::new();
+        let mut renamed_deleted = HashSet::new();
+        for (from, to, exact) in detect_renames(store, &added_hashes, &deleted_hashes)? {
+            let Some(old_hash) = deleted_hashes.get(&from).copied() else {
+                continue;
+            };
+            let Some(new_hash) = added_hashes.get(&to).copied() else {
+                continue;
+            };
+            self.exact_renames += usize::from(exact);
+            self.similarity_renames += usize::from(!exact);
+            self.rename(&from, &to);
+            self.record(&to, new_hash);
+            self.record(&from, old_hash);
+            renamed_added.insert(to.clone());
+            renamed_deleted.insert(from.clone());
+            self.renames.push(RenameRecord {
+                child: state_ids.0,
+                parent: state_ids.1,
+                from,
+                to,
+                exact,
+            });
+        }
+        for (path, hash) in added_hashes {
+            if !renamed_added.contains(&path) {
+                self.record(&path, hash);
+            }
+        }
+        for (path, hash) in deleted_hashes {
+            if !renamed_deleted.contains(&path) {
+                self.record(&path, hash);
+            }
+        }
+        Ok(())
+    }
+
+    fn rename(&mut self, old: &str, new: &str) {
+        let old_key = self.canonical(old);
+        let new_key = self.canonical(new);
+        if old_key == new_key {
+            return;
+        }
+        self.aliases.insert(old_key.clone(), new_key.clone());
+        if let Some(old_history) = self.histories.remove(&old_key) {
+            self.histories
+                .entry(new_key)
+                .or_default()
+                .extend(old_history);
+        }
+    }
+
+    fn record(&mut self, path: &str, hash: ContentHash) {
+        let key = self.canonical(path);
+        self.histories.entry(key).or_default().push(hash);
+    }
+
+    fn canonical(&self, path: &str) -> String {
+        let mut current = path;
+        let mut seen = HashSet::new();
+        while let Some(next) = self.aliases.get(current) {
+            if !seen.insert(current) {
+                break;
+            }
+            current = next;
+        }
+        current.to_string()
+    }
+
+    fn finish(&self, all_blobs: &[ContentHash]) -> (Vec<ContentHash>, usize, usize) {
+        let mut paths = self.histories.keys().collect::<Vec<_>>();
+        paths.sort_by_key(|path| (extension(path), path.as_str()));
+        let mut seen = HashSet::new();
+        let mut order = Vec::with_capacity(all_blobs.len());
+        for path in paths {
+            for hash in &self.histories[path] {
+                if seen.insert(*hash) {
+                    order.push(*hash);
+                }
+            }
+        }
+        let lineage_blobs = order.len();
+        for hash in all_blobs {
+            if seen.insert(*hash) {
+                order.push(*hash);
+            }
+        }
+        let leftovers = order.len() - lineage_blobs;
+        (order, lineage_blobs, leftovers)
+    }
+}
+
+fn detect_renames(
+    store: &FsStore,
+    added: &HashMap<String, ContentHash>,
+    deleted: &HashMap<String, ContentHash>,
+) -> Result<Vec<(String, String, bool)>> {
+    let mut added_paths = added.keys().cloned().collect::<Vec<_>>();
+    let mut deleted_paths = deleted.keys().cloned().collect::<Vec<_>>();
+    added_paths.sort();
+    deleted_paths.sort();
+    let mut used_added = HashSet::new();
+    let mut used_deleted = HashSet::new();
+    let mut output = Vec::new();
+    for from in &deleted_paths {
+        if let Some(to) = added_paths
+            .iter()
+            .find(|to| !used_added.contains(*to) && deleted[from] == added[*to])
+        {
+            used_deleted.insert(from.clone());
+            used_added.insert(to.clone());
+            output.push((from.clone(), to.clone(), true));
+        }
+    }
+    let added_remaining = remaining_paths(added, &used_added);
+    let deleted_remaining = remaining_paths(deleted, &used_deleted);
+    let semantic = detect_file_renames(
+        &path_text(store, &deleted_remaining)?,
+        &path_text(store, &added_remaining)?,
+        RENAME_THRESHOLD,
+        SimilarityMethod::Lines,
+    );
+    output.extend(semantic.into_iter().map(|(from, to)| {
+        (
+            from.to_string_lossy().into_owned(),
+            to.to_string_lossy().into_owned(),
+            false,
+        )
+    }));
+    Ok(output)
+}
+
+fn remaining_paths(
+    paths: &HashMap<String, ContentHash>,
+    used: &HashSet<String>,
+) -> HashMap<String, ContentHash> {
+    paths
+        .iter()
+        .filter(|(path, _)| !used.contains(*path))
+        .map(|(path, hash)| (path.clone(), *hash))
+        .collect()
+}
+
+fn path_hashes(
+    store: &FsStore,
+    root: ContentHash,
+    paths: &[String],
+) -> Result<HashMap<String, ContentHash>> {
+    paths
+        .iter()
+        .filter_map(|path| match leaf_hash(store, root, path) {
+            Ok(Some(hash)) => Some(Ok((path.clone(), hash))),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
+}

--- a/crates/cli/examples/native_lineage_solid/blob_measure.rs
+++ b/crates/cli/examples/native_lineage_solid/blob_measure.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs, path::Path, process::Command};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+use crate::{
+    measure::compress_frame,
+    model::{ObjectRef, ObjectSet},
+};
+
+#[derive(Default, Serialize)]
+pub struct RoundTripStats {
+    pub checked: usize,
+    pub typed_hash_mismatches: usize,
+    pub sample_ids: Vec<String>,
+}
+
+#[derive(Default, Serialize)]
+pub struct BlobMeasurement {
+    pub objects: usize,
+    pub source_bytes: u64,
+    pub compressed_bytes: u64,
+    pub frames: usize,
+    pub frame_integrity_checks: usize,
+    pub roundtrip: RoundTripStats,
+}
+
+pub fn measure_blobs(
+    store: &objects::store::FsStore,
+    order: &[ObjectRef],
+    output_dir: &Path,
+    frame_limit: usize,
+) -> Result<BlobMeasurement> {
+    let blobs = order
+        .iter()
+        .filter(|object| matches!(object, ObjectRef::Blob(_)))
+        .collect::<Vec<_>>();
+    let frames_dir = output_dir.join("blob-lineage.frames");
+    fs::create_dir(&frames_dir)?;
+    let mut measurement = BlobMeasurement::default();
+    let mut frame = Vec::with_capacity(frame_limit);
+    for (index, object) in blobs.iter().enumerate() {
+        let source = object.load(store)?;
+        if !frame.is_empty() && frame.len() + source.len() > frame_limit {
+            flush_frame(&frames_dir, &mut frame, &mut measurement)?;
+        }
+        frame.extend_from_slice(&source);
+        measurement.objects += 1;
+        measurement.source_bytes += source.len() as u64;
+        measurement.roundtrip.checked += 1;
+        if measurement.roundtrip.sample_ids.len() < 3 {
+            measurement.roundtrip.sample_ids.push(object.id());
+        }
+        report_progress("lineage blobs", index + 1, blobs.len());
+    }
+    flush_frame(&frames_dir, &mut frame, &mut measurement)?;
+    measurement.frame_integrity_checks = verify_frames(&frames_dir)?;
+    Ok(measurement)
+}
+
+pub fn fingerprint_objects(
+    store: &objects::store::FsStore,
+    objects: &ObjectSet,
+) -> Result<(blake3::Hash, usize)> {
+    let mut hasher = blake3::Hasher::new();
+    let mut checked = 0usize;
+    for object in objects.iter() {
+        let data = object.load(store)?;
+        hasher.update(object.kind().as_bytes());
+        hasher.update(object.id().as_bytes());
+        hasher.update(&(data.len() as u64).to_le_bytes());
+        hasher.update(&data);
+        checked += 1;
+        report_progress("real-writer roundtrip", checked, objects.counts().total);
+    }
+    Ok((hasher.finalize(), checked))
+}
+
+fn flush_frame(
+    directory: &Path,
+    frame: &mut Vec<u8>,
+    measurement: &mut BlobMeasurement,
+) -> Result<()> {
+    if frame.is_empty() {
+        return Ok(());
+    }
+    measurement.compressed_bytes += compress_frame(directory, measurement.frames, frame)?;
+    measurement.frames += 1;
+    frame.clear();
+    Ok(())
+}
+
+fn verify_frames(directory: &Path) -> Result<usize> {
+    let mut paths = fs::read_dir(directory)?
+        .map(|entry| entry.map(|value| value.path()))
+        .collect::<std::io::Result<Vec<_>>>()?;
+    paths.sort();
+    for path in &paths {
+        let status = Command::new("/usr/bin/zstd")
+            .env_clear()
+            .args(["-t", "-q"])
+            .arg(path)
+            .status()
+            .with_context(|| format!("test zstd frame {}", path.display()))?;
+        if !status.success() {
+            bail!("zstd test failed for {} with {status}", path.display());
+        }
+    }
+    Ok(paths.len())
+}
+
+fn report_progress(kind: &str, done: usize, total: usize) {
+    if done.is_multiple_of(10_000) || done == total {
+        eprintln!("{kind}: {done}/{total} objects");
+    }
+}

--- a/crates/cli/examples/native_lineage_solid/blob_paths.rs
+++ b/crates/cli/examples/native_lineage_solid/blob_paths.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use objects::{
+    object::ContentHash,
+    store::{FsStore, ObjectStore},
+};
+
+pub fn path_text(
+    store: &FsStore,
+    paths: &HashMap<String, ContentHash>,
+) -> Result<Vec<(PathBuf, String)>> {
+    let mut sorted = paths.iter().collect::<Vec<_>>();
+    sorted.sort_by_key(|(path, _)| path.as_str());
+    sorted
+        .into_iter()
+        .map(|(path, hash)| {
+            let bytes = store
+                .get_blob(hash)?
+                .with_context(|| format!("missing blob {hash}"))?;
+            Ok((
+                PathBuf::from(path),
+                String::from_utf8_lossy(bytes.content()).into_owned(),
+            ))
+        })
+        .collect()
+}
+
+pub fn extension(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| Path::new(name).extension())
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+}

--- a/crates/cli/examples/native_lineage_solid/git_baseline.rs
+++ b/crates/cli/examples/native_lineage_solid/git_baseline.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs, path::Path, process::Command};
+
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+
+#[derive(Default, Serialize)]
+pub struct GitTypeBytes {
+    pub objects: u64,
+    pub bytes: u64,
+}
+
+#[derive(Serialize)]
+pub struct GitBaseline {
+    pub repository: String,
+    pub revision: String,
+    pub commits: GitTypeBytes,
+    pub trees: GitTypeBytes,
+    pub blobs: GitTypeBytes,
+    pub tags: GitTypeBytes,
+    pub total_objects: u64,
+    pub pack_bytes: u64,
+    pub idx_bytes: u64,
+}
+
+pub fn measure_git(git_dir: &Path) -> Result<GitBaseline> {
+    let output = Command::new("git")
+        .env_clear()
+        .args([
+            "--git-dir",
+            &git_dir.to_string_lossy(),
+            "cat-file",
+            "--batch-all-objects",
+            "--batch-check=%(objecttype) %(objectsize)",
+        ])
+        .output()
+        .context("enumerate Git objects")?;
+    if !output.status.success() {
+        bail!("git cat-file failed with {}", output.status);
+    }
+    let mut baseline = GitBaseline {
+        repository: git_dir.display().to_string(),
+        revision: git_stdout(git_dir, &["rev-parse", "HEAD"])?
+            .trim()
+            .to_string(),
+        commits: GitTypeBytes::default(),
+        trees: GitTypeBytes::default(),
+        blobs: GitTypeBytes::default(),
+        tags: GitTypeBytes::default(),
+        total_objects: 0,
+        pack_bytes: extension_bytes(&git_dir.join("objects/pack"), "pack")?,
+        idx_bytes: extension_bytes(&git_dir.join("objects/pack"), "idx")?,
+    };
+    for line in String::from_utf8(output.stdout)?.lines() {
+        let (kind, size) = line
+            .split_once(' ')
+            .with_context(|| format!("invalid git cat-file row {line:?}"))?;
+        let size = size.parse::<u64>()?;
+        let bucket = match kind {
+            "commit" => &mut baseline.commits,
+            "tree" => &mut baseline.trees,
+            "blob" => &mut baseline.blobs,
+            "tag" => &mut baseline.tags,
+            value => bail!("unexpected Git object type {value}"),
+        };
+        bucket.objects += 1;
+        bucket.bytes += size;
+        baseline.total_objects += 1;
+    }
+    Ok(baseline)
+}
+
+fn git_stdout(git_dir: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .env_clear()
+        .arg("--git-dir")
+        .arg(git_dir)
+        .args(args)
+        .output()?;
+    if !output.status.success() {
+        bail!("git {} failed with {}", args.join(" "), output.status);
+    }
+    Ok(String::from_utf8(output.stdout)?)
+}
+
+fn extension_bytes(directory: &Path, extension: &str) -> Result<u64> {
+    let mut total = 0;
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry
+            .path()
+            .extension()
+            .is_some_and(|value| value == extension)
+        {
+            total += entry.metadata()?.len();
+        }
+    }
+    Ok(total)
+}

--- a/crates/cli/examples/native_lineage_solid/lineage.rs
+++ b/crates/cli/examples/native_lineage_solid/lineage.rs
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BinaryHeap, HashMap, HashSet};
+
+use anyhow::{Context, Result, bail};
+use objects::{
+    object::{ContentHash, State, StateId},
+    store::{FsStore, ObjectStore},
+};
+use serde::Serialize;
+
+use crate::{
+    blob_lineage::blob_lineage_order,
+    model::{ObjectRef, ObjectSet},
+    tree_access::get_tree,
+};
+
+#[derive(Serialize)]
+pub struct LineageStats {
+    pub state_edges_walked: usize,
+    pub root_states: usize,
+    pub merge_states: usize,
+    pub file_changes: usize,
+    pub exact_renames: usize,
+    pub similarity_renames: usize,
+    pub lineage_paths: usize,
+    pub lineage_blobs: usize,
+    pub leftover_blobs: usize,
+    pub missing_parents: usize,
+}
+
+pub struct RenameRecord {
+    pub child: StateId,
+    pub parent: StateId,
+    pub from: String,
+    pub to: String,
+    pub exact: bool,
+}
+
+pub struct LineageOrder {
+    pub order: Vec<ObjectRef>,
+    pub renames: Vec<RenameRecord>,
+    pub stats: LineageStats,
+}
+
+pub fn build_lineage_order(store: &FsStore, objects: &ObjectSet) -> Result<LineageOrder> {
+    let states = load_states(store, &objects.states)?;
+    let (state_order, missing_parents) = newest_first_topology(&states)?;
+    let tree_order = trees_in_history_order(store, &states, &state_order)?;
+    let (blob_order, renames, mut stats) =
+        blob_lineage_order(store, &states, &state_order, objects)?;
+    stats.missing_parents = missing_parents;
+    let order = state_order
+        .iter()
+        .copied()
+        .map(ObjectRef::State)
+        .chain(tree_order.into_iter().map(ObjectRef::Tree))
+        .chain(blob_order.into_iter().map(ObjectRef::Blob))
+        .collect::<Vec<_>>();
+    if order.len() != objects.counts().total {
+        bail!(
+            "lineage order has {} objects, store has {}",
+            order.len(),
+            objects.counts().total
+        );
+    }
+    Ok(LineageOrder {
+        order,
+        renames,
+        stats,
+    })
+}
+
+fn load_states(store: &FsStore, ids: &[StateId]) -> Result<HashMap<StateId, State>> {
+    ids.iter()
+        .map(|id| {
+            store
+                .get_state(id)?
+                .with_context(|| format!("missing state {}", id.to_string_full()))
+                .map(|state| (*id, state))
+        })
+        .collect()
+}
+
+fn newest_first_topology(states: &HashMap<StateId, State>) -> Result<(Vec<StateId>, usize)> {
+    let mut children = HashMap::<StateId, usize>::new();
+    let mut missing = 0;
+    for state in states.values() {
+        children.entry(state.id()).or_default();
+        for parent in &state.parents {
+            if states.contains_key(parent) {
+                *children.entry(*parent).or_default() += 1;
+            } else {
+                missing += 1;
+            }
+        }
+    }
+    let mut ready = BinaryHeap::new();
+    for (id, state) in states {
+        if children[id] == 0 {
+            ready.push((state.created_at.timestamp_millis(), *id));
+        }
+    }
+    let mut order = Vec::with_capacity(states.len());
+    while let Some((_, id)) = ready.pop() {
+        order.push(id);
+        for parent in &states[&id].parents {
+            let Some(count) = children.get_mut(parent) else {
+                continue;
+            };
+            *count -= 1;
+            if *count == 0 {
+                ready.push((states[parent].created_at.timestamp_millis(), *parent));
+            }
+        }
+    }
+    if order.len() != states.len() {
+        bail!("state graph is cyclic or incomplete");
+    }
+    Ok((order, missing))
+}
+
+fn trees_in_history_order(
+    store: &FsStore,
+    states: &HashMap<StateId, State>,
+    state_order: &[StateId],
+) -> Result<Vec<ContentHash>> {
+    let mut seen = HashSet::new();
+    let mut order = Vec::new();
+    for id in state_order {
+        let mut stack = vec![states[id].tree];
+        while let Some(hash) = stack.pop() {
+            if !seen.insert(hash) {
+                continue;
+            }
+            order.push(hash);
+            let tree = get_tree(store, hash)?;
+            stack.extend(
+                tree.entries()
+                    .iter()
+                    .rev()
+                    .filter_map(|entry| entry.tree_hash()),
+            );
+        }
+    }
+    Ok(order)
+}

--- a/crates/cli/examples/native_lineage_solid/measure.rs
+++ b/crates/cli/examples/native_lineage_solid/measure.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    fs::{self, File},
+    io::{BufWriter, Write},
+    path::Path,
+    process::Command,
+};
+
+use anyhow::{Context, Result, bail};
+
+use crate::lineage::RenameRecord;
+
+pub fn compress_frame(frames_dir: &Path, index: usize, bytes: &[u8]) -> Result<u64> {
+    let raw_path = frames_dir.join("current.raw");
+    let compressed_path = frames_dir.join(format!("{index:05}.zst"));
+    fs::write(&raw_path, bytes)?;
+    let status = Command::new("/usr/bin/zstd")
+        .env_clear()
+        .args(["-19", "--long=27", "-q", "-f"])
+        .arg(&raw_path)
+        .arg("-o")
+        .arg(&compressed_path)
+        .status()
+        .context("run /usr/bin/zstd -19 --long=27")?;
+    if !status.success() {
+        bail!("zstd failed for frame {} with {status}", raw_path.display());
+    }
+    fs::remove_file(&raw_path)?;
+    Ok(fs::metadata(compressed_path)?.len())
+}
+
+pub fn write_renames(path: &Path, renames: &[RenameRecord]) -> Result<()> {
+    let mut output = BufWriter::new(File::create(path)?);
+    writeln!(output, "child_state\tparent_state\tkind\tfrom\tto")?;
+    for rename in renames {
+        writeln!(
+            output,
+            "{}\t{}\t{}\t{}\t{}",
+            rename.child.to_string_full(),
+            rename.parent.to_string_full(),
+            if rename.exact { "exact" } else { "similarity" },
+            rename.from,
+            rename.to
+        )?;
+    }
+    Ok(())
+}

--- a/crates/cli/examples/native_lineage_solid/model.rs
+++ b/crates/cli/examples/native_lineage_solid/model.rs
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Context, Result, bail};
+use objects::{
+    object::{Blob, ContentHash, State, StateId, Tree},
+    store::{FsStore, ObjectStore},
+};
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ObjectRef {
+    State(StateId),
+    Tree(ContentHash),
+    Blob(ContentHash),
+}
+
+impl ObjectRef {
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::State(_) => "state",
+            Self::Tree(_) => "tree",
+            Self::Blob(_) => "blob",
+        }
+    }
+
+    pub fn id(&self) -> String {
+        match self {
+            Self::State(id) => id.to_string_full(),
+            Self::Tree(hash) | Self::Blob(hash) => hash.to_hex(),
+        }
+    }
+
+    pub fn load(&self, store: &FsStore) -> Result<Vec<u8>> {
+        let bytes = match self {
+            Self::State(id) => rmp_serde::to_vec_named(
+                &store
+                    .get_state(id)?
+                    .with_context(|| format!("missing native state {}", self.id()))?,
+            )?,
+            Self::Tree(hash) => rmp_serde::to_vec_named(
+                &store
+                    .get_tree(hash)?
+                    .with_context(|| format!("missing native tree {}", self.id()))?,
+            )?,
+            Self::Blob(hash) => store
+                .get_blob(hash)?
+                .with_context(|| format!("missing native blob {}", self.id()))?
+                .content()
+                .to_vec(),
+        };
+        self.validate(&bytes)?;
+        Ok(bytes)
+    }
+
+    fn validate(&self, bytes: &[u8]) -> Result<()> {
+        match self {
+            Self::State(expected) => {
+                let state: State = rmp_serde::from_slice(bytes)?;
+                let found = state.id();
+                if found != *expected {
+                    bail!("state payload hash mismatch: expected {expected}, found {found}");
+                }
+            }
+            Self::Tree(expected) => {
+                let tree: Tree = rmp_serde::from_slice(bytes)?;
+                tree.validate()?;
+                let found = tree.hash();
+                if found != *expected {
+                    bail!("tree payload hash mismatch: expected {expected}, found {found}");
+                }
+            }
+            Self::Blob(expected) => {
+                let found = Blob::from_slice(bytes).hash();
+                if found != *expected {
+                    bail!("blob payload hash mismatch: expected {expected}, found {found}");
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Serialize)]
+pub struct ObjectCounts {
+    pub states: usize,
+    pub trees: usize,
+    pub blobs: usize,
+    pub total: usize,
+}
+
+pub struct ObjectSet {
+    pub states: Vec<StateId>,
+    pub trees: Vec<ContentHash>,
+    pub blobs: Vec<ContentHash>,
+}
+
+impl ObjectSet {
+    pub fn counts(&self) -> ObjectCounts {
+        ObjectCounts {
+            states: self.states.len(),
+            trees: self.trees.len(),
+            blobs: self.blobs.len(),
+            total: self.states.len() + self.trees.len() + self.blobs.len(),
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = ObjectRef> + '_ {
+        self.states
+            .iter()
+            .copied()
+            .map(ObjectRef::State)
+            .chain(self.trees.iter().copied().map(ObjectRef::Tree))
+            .chain(self.blobs.iter().copied().map(ObjectRef::Blob))
+    }
+}
+
+pub fn load_object_set(store: &FsStore) -> Result<ObjectSet> {
+    let mut states = store.list_states()?;
+    let mut trees = store.list_trees()?;
+    let mut blobs = store.list_blobs()?;
+    states.sort();
+    states.dedup();
+    trees.sort();
+    trees.dedup();
+    blobs.sort();
+    blobs.dedup();
+    Ok(ObjectSet {
+        states,
+        trees,
+        blobs,
+    })
+}

--- a/crates/cli/examples/native_lineage_solid/real_compact.rs
+++ b/crates/cli/examples/native_lineage_solid/real_compact.rs
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fs, num::NonZeroUsize, sync::Arc};
+
+use anyhow::{Context, Result, bail};
+use objects::store::{
+    FsRepackOperation, FsStore, RepackPolicy, RepackResourceLimits, RepackSchedule,
+    RepackScheduler,
+    pack::{ObjectType, PackReader},
+};
+use serde::Serialize;
+
+use crate::{
+    blob_measure::fingerprint_objects,
+    model::{ObjectRef, ObjectSet},
+};
+
+#[derive(Serialize)]
+pub struct RealCompactMeasurement {
+    pub source_tree_bytes: u64,
+    pub source_state_bytes: u64,
+    pub compact_tree_bytes: u64,
+    pub compact_state_bytes: u64,
+    pub index_bytes: u64,
+    pub replacement_pack_bytes: u64,
+    pub roundtrip_checked: usize,
+    pub source_fingerprint: String,
+    pub reconstructed_fingerprint: String,
+    pub byte_identical: bool,
+}
+
+pub fn measure_real_compact_repack(
+    store: &FsStore,
+    objects: &ObjectSet,
+) -> Result<RealCompactMeasurement> {
+    let (source_tree_bytes, source_state_bytes) = source_metadata_bytes(store, objects)?;
+    let (source_fingerprint, _) = fingerprint_objects(store, objects)?;
+    run_repack(store)?;
+    store.clear_recent_object_caches();
+    let (reconstructed_fingerprint, roundtrip_checked) = fingerprint_objects(store, objects)?;
+    if source_fingerprint != reconstructed_fingerprint {
+        bail!("real compact writer changed native object bytes");
+    }
+    let (compact_tree_bytes, compact_state_bytes, index_bytes, replacement_pack_bytes) =
+        physical_metadata_bytes(store)?;
+    Ok(RealCompactMeasurement {
+        source_tree_bytes,
+        source_state_bytes,
+        compact_tree_bytes,
+        compact_state_bytes,
+        index_bytes,
+        replacement_pack_bytes,
+        roundtrip_checked,
+        source_fingerprint: source_fingerprint.to_hex().to_string(),
+        reconstructed_fingerprint: reconstructed_fingerprint.to_hex().to_string(),
+        byte_identical: true,
+    })
+}
+
+fn source_metadata_bytes(store: &FsStore, objects: &ObjectSet) -> Result<(u64, u64)> {
+    let mut trees = 0u64;
+    let mut states = 0u64;
+    for object in objects.iter() {
+        match object {
+            ObjectRef::Tree(_) => trees += object.load(store)?.len() as u64,
+            ObjectRef::State(_) => states += object.load(store)?.len() as u64,
+            ObjectRef::Blob(_) => {}
+        }
+    }
+    Ok((trees, states))
+}
+
+fn run_repack(store: &FsStore) -> Result<()> {
+    let scheduler = RepackScheduler::new(
+        RepackPolicy::default(),
+        RepackResourceLimits::new(NonZeroUsize::MIN).with_io_rate(None),
+    );
+    let operation = Arc::new(FsRepackOperation::new(store.clone()));
+    let RepackSchedule::Started(handle) = scheduler.repack_now(operation)? else {
+        bail!("real compact repack did not start");
+    };
+    handle.wait()?;
+    Ok(())
+}
+
+fn physical_metadata_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64)> {
+    let packs_dir = store.root().join("packs");
+    let paths = fs::read_dir(&packs_dir)?
+        .map(|entry| entry.map(|value| value.path()))
+        .collect::<std::io::Result<Vec<_>>>()?
+        .into_iter()
+        .filter(|path| path.extension().is_some_and(|value| value == "pack"))
+        .map(|pack| {
+            let index = pack.with_extension("idx");
+            (pack, index)
+        })
+        .collect::<Vec<_>>();
+    let mut tree_bytes = 0u64;
+    let mut state_bytes = 0u64;
+    let mut index_bytes = 0u64;
+    let mut pack_bytes = 0u64;
+    for (pack, index) in paths {
+        let reader = PackReader::open(&pack, &index)
+            .with_context(|| format!("open replacement pack {}", pack.display()))?;
+        tree_bytes += reader.encoded_payload_bytes(ObjectType::Tree)?;
+        state_bytes += reader.encoded_payload_bytes(ObjectType::State)?;
+        index_bytes += fs::metadata(&index)?.len();
+        pack_bytes += fs::metadata(&pack)?.len();
+    }
+    Ok((tree_bytes, state_bytes, index_bytes, pack_bytes))
+}

--- a/crates/cli/examples/native_lineage_solid/tree_access.rs
+++ b/crates/cli/examples/native_lineage_solid/tree_access.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use objects::{
+    object::{ContentHash, Tree},
+    store::{FsStore, ObjectStore},
+};
+
+pub fn leaf_hash(store: &FsStore, root: ContentHash, path: &str) -> Result<Option<ContentHash>> {
+    let mut tree = get_tree(store, root)?;
+    let mut components = Path::new(path).components().peekable();
+    while let Some(component) = components.next() {
+        let name = component.as_os_str().to_string_lossy();
+        let Some(entry) = tree.get(&name) else {
+            return Ok(None);
+        };
+        if components.peek().is_none() {
+            return Ok(entry.leaf_content_hash());
+        }
+        let Some(hash) = entry.tree_hash() else {
+            return Ok(None);
+        };
+        tree = get_tree(store, hash)?;
+    }
+    Ok(None)
+}
+
+pub fn leaf_paths(store: &FsStore, root: ContentHash) -> Result<Vec<(String, ContentHash)>> {
+    let mut output = Vec::new();
+    let mut stack = vec![(String::new(), root)];
+    while let Some((prefix, hash)) = stack.pop() {
+        for entry in get_tree(store, hash)?.entries().iter().rev() {
+            let path = if prefix.is_empty() {
+                entry.name().to_string()
+            } else {
+                format!("{prefix}/{}", entry.name())
+            };
+            if let Some(hash) = entry.tree_hash() {
+                stack.push((path, hash));
+            } else if let Some(hash) = entry.leaf_content_hash() {
+                output.push((path, hash));
+            }
+        }
+    }
+    Ok(output)
+}
+
+pub fn get_tree(store: &FsStore, hash: ContentHash) -> Result<Tree> {
+    store
+        .get_tree(&hash)?
+        .with_context(|| format!("missing tree {hash}"))
+}

--- a/crates/object-model/src/compact/dictionary.rs
+++ b/crates/object-model/src/compact/dictionary.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use crate::object::{Agent, Principal, State};
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct PrincipalKey(pub(super) Vec<u8>, pub(super) Vec<u8>);
+
+#[derive(Clone, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct AgentKey {
+    pub(super) provider: Vec<u8>,
+    pub(super) model: Vec<u8>,
+    pub(super) session_id: Option<Vec<u8>>,
+    pub(super) segment_id: Option<Vec<u8>>,
+    pub(super) policy_id: Option<Vec<u8>>,
+}
+
+pub(super) struct StateDictionaries {
+    pub(super) principals: Vec<PrincipalKey>,
+    pub(super) agents: Vec<AgentKey>,
+    principal_indices: BTreeMap<PrincipalKey, u64>,
+    agent_indices: BTreeMap<AgentKey, u64>,
+}
+
+impl StateDictionaries {
+    pub(super) fn from_states(states: &[State]) -> Self {
+        let mut value = Self {
+            principals: Vec::new(),
+            agents: Vec::new(),
+            principal_indices: BTreeMap::new(),
+            agent_indices: BTreeMap::new(),
+        };
+        for state in states {
+            value.intern_principal(&state.attribution.principal);
+            if let Some(committer) = &state.committer {
+                value.intern_principal(committer);
+            }
+            if let Some(agent) = &state.attribution.agent {
+                value.intern_agent(agent);
+            }
+        }
+        value
+    }
+
+    pub(super) fn principal_index(&self, principal: &Principal) -> u64 {
+        self.principal_indices[&principal_key(principal)]
+    }
+
+    pub(super) fn agent_index(&self, agent: &Agent) -> u64 {
+        self.agent_indices[&agent_key(agent)]
+    }
+
+    fn intern_principal(&mut self, principal: &Principal) {
+        let key = principal_key(principal);
+        if !self.principal_indices.contains_key(&key) {
+            let index = self.principals.len() as u64;
+            self.principals.push(key.clone());
+            self.principal_indices.insert(key, index);
+        }
+    }
+
+    fn intern_agent(&mut self, agent: &Agent) {
+        let key = agent_key(agent);
+        if !self.agent_indices.contains_key(&key) {
+            let index = self.agents.len() as u64;
+            self.agents.push(key.clone());
+            self.agent_indices.insert(key, index);
+        }
+    }
+}
+
+fn principal_key(value: &Principal) -> PrincipalKey {
+    PrincipalKey(
+        value.name.as_bytes().to_vec(),
+        value.email.as_bytes().to_vec(),
+    )
+}
+
+fn agent_key(value: &Agent) -> AgentKey {
+    AgentKey {
+        provider: value.provider.as_bytes().to_vec(),
+        model: value.model.as_bytes().to_vec(),
+        session_id: value
+            .session_id
+            .as_ref()
+            .map(|value| value.as_bytes().to_vec()),
+        segment_id: value
+            .segment_id
+            .as_ref()
+            .map(|value| value.as_bytes().to_vec()),
+        policy_id: value
+            .policy_id
+            .as_ref()
+            .map(|value| value.as_bytes().to_vec()),
+    }
+}

--- a/crates/object-model/src/compact/io.rs
+++ b/crates/object-model/src/compact/io.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Result, invalid};
+
+pub(super) const FRAME_CHECKSUM_LEN: usize = 32;
+
+pub(super) struct Writer {
+    bytes: Vec<u8>,
+}
+
+impl Writer {
+    pub(super) fn new(magic: &[u8; 4]) -> Self {
+        Self {
+            bytes: magic.to_vec(),
+        }
+    }
+
+    pub(super) fn put_u8(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    pub(super) fn put_bool(&mut self, value: bool) {
+        self.put_u8(u8::from(value));
+    }
+
+    pub(super) fn put_fixed(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    pub(super) fn put_u64(&mut self, mut value: u64) {
+        while value >= 0x80 {
+            self.put_u8((value as u8) | 0x80);
+            value >>= 7;
+        }
+        self.put_u8(value as u8);
+    }
+
+    pub(super) fn put_i64(&mut self, value: i64) {
+        self.put_u64(((value << 1) ^ (value >> 63)) as u64);
+    }
+
+    pub(super) fn put_bytes(&mut self, value: &[u8]) {
+        self.put_u64(value.len() as u64);
+        self.put_fixed(value);
+    }
+
+    pub(super) fn put_optional_bytes(&mut self, value: Option<&[u8]>) {
+        match value {
+            Some(value) => {
+                self.put_u8(1);
+                self.put_bytes(value);
+            }
+            None => self.put_u8(0),
+        }
+    }
+
+    pub(super) fn finish(mut self) -> Vec<u8> {
+        let checksum = blake3::hash(&self.bytes);
+        self.bytes.extend_from_slice(checksum.as_bytes());
+        self.bytes
+    }
+}
+
+pub(super) struct Reader<'a> {
+    bytes: &'a [u8],
+    position: usize,
+}
+
+impl<'a> Reader<'a> {
+    pub(super) fn verified(bytes: &'a [u8], magic: &[u8; 4]) -> Result<Self> {
+        let content_len = bytes
+            .len()
+            .checked_sub(FRAME_CHECKSUM_LEN)
+            .ok_or_else(|| invalid("frame is shorter than its checksum"))?;
+        let (content, checksum) = bytes.split_at(content_len);
+        if content.get(..4) != Some(magic) {
+            return Err(invalid("frame magic does not match its object kind"));
+        }
+        if blake3::hash(content).as_bytes() != checksum {
+            return Err(invalid("compact frame checksum mismatch"));
+        }
+        Ok(Self {
+            bytes: content,
+            position: magic.len(),
+        })
+    }
+
+    pub(super) fn take(&mut self, len: usize) -> Result<&'a [u8]> {
+        let end = self
+            .position
+            .checked_add(len)
+            .ok_or_else(|| invalid("compact offset overflow"))?;
+        if end > self.bytes.len() {
+            return Err(invalid(format!(
+                "truncated compact payload at byte {}",
+                self.position
+            )));
+        }
+        let value = &self.bytes[self.position..end];
+        self.position = end;
+        Ok(value)
+    }
+
+    pub(super) fn get_u8(&mut self) -> Result<u8> {
+        Ok(self.take(1)?[0])
+    }
+
+    pub(super) fn get_bool(&mut self) -> Result<bool> {
+        match self.get_u8()? {
+            0 => Ok(false),
+            1 => Ok(true),
+            value => Err(invalid(format!("invalid compact boolean {value}"))),
+        }
+    }
+
+    pub(super) fn get_fixed<const N: usize>(&mut self) -> Result<[u8; N]> {
+        let mut value = [0; N];
+        value.copy_from_slice(self.take(N)?);
+        Ok(value)
+    }
+
+    pub(super) fn get_u64(&mut self) -> Result<u64> {
+        let mut value = 0u64;
+        for shift in (0..=63).step_by(7) {
+            let byte = self.get_u8()?;
+            if shift == 63 && byte > 1 {
+                return Err(invalid("compact varint overflow"));
+            }
+            value |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Ok(value);
+            }
+        }
+        Err(invalid("compact varint overflow"))
+    }
+
+    pub(super) fn get_i64(&mut self) -> Result<i64> {
+        let value = self.get_u64()?;
+        Ok(((value >> 1) as i64) ^ (-((value & 1) as i64)))
+    }
+
+    pub(super) fn get_count(&mut self, field: &str) -> Result<usize> {
+        let count = usize::try_from(self.get_u64()?)
+            .map_err(|_| invalid(format!("{field} count exceeds platform limits")))?;
+        if count > self.remaining() {
+            return Err(invalid(format!(
+                "{field} count {count} exceeds remaining frame bytes {}",
+                self.remaining()
+            )));
+        }
+        Ok(count)
+    }
+
+    pub(super) fn get_bytes(&mut self) -> Result<Vec<u8>> {
+        let len = usize::try_from(self.get_u64()?)
+            .map_err(|_| invalid("compact byte length exceeds platform limits"))?;
+        Ok(self.take(len)?.to_vec())
+    }
+
+    pub(super) fn get_optional_bytes(&mut self) -> Result<Option<Vec<u8>>> {
+        match self.get_u8()? {
+            0 => Ok(None),
+            1 => Ok(Some(self.get_bytes()?)),
+            value => Err(invalid(format!("invalid compact option tag {value}"))),
+        }
+    }
+
+    pub(super) fn remaining(&self) -> usize {
+        self.bytes.len() - self.position
+    }
+
+    pub(super) fn finish(self) -> Result<()> {
+        if self.position != self.bytes.len() {
+            return Err(invalid(format!(
+                "{} trailing bytes in compact payload",
+                self.bytes.len() - self.position
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub(super) fn varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Lossless columnar encodings used by background compact repacks.
+
+mod dictionary;
+mod io;
+mod state;
+mod state_decode;
+mod tree;
+
+pub use state::{encode_state_frame, is_state_frame};
+pub use state_decode::decode_state_frame;
+use thiserror::Error;
+pub use tree::{decode_tree_frame, encode_tree_frame, encoded_tree_size, is_tree_frame};
+
+/// Compact metadata encoding failure.
+#[derive(Debug, Error)]
+pub enum CompactError {
+    /// The frame is malformed, truncated, or internally inconsistent.
+    #[error("invalid compact frame: {0}")]
+    Invalid(String),
+    /// A decoded tree violates the native tree invariants.
+    #[error(transparent)]
+    Tree(#[from] crate::object::TreeError),
+    /// A decoded Git object id is invalid.
+    #[error("invalid compact git object id: {0}")]
+    GitObjectId(String),
+    /// A decoded spool id is invalid.
+    #[error("invalid compact spool id: {0}")]
+    SpoolId(String),
+    /// A compact verification value cannot be serialized losslessly.
+    #[error(transparent)]
+    MessagePackEncode(#[from] rmp_serde::encode::Error),
+    /// A compact verification value cannot be deserialized losslessly.
+    #[error(transparent)]
+    MessagePackDecode(#[from] rmp_serde::decode::Error),
+}
+
+pub(crate) type Result<T> = std::result::Result<T, CompactError>;
+
+pub(crate) fn invalid(message: impl Into<String>) -> CompactError {
+    CompactError::Invalid(message.into())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/object-model/src/compact/state.rs
+++ b/crates/object-model/src/compact/state.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    Result,
+    dictionary::{PrincipalKey, StateDictionaries},
+    io::Writer,
+};
+use crate::object::{ChangeLineageKind, State};
+
+pub(super) const STATE_MAGIC: &[u8; 4] = b"HCS1";
+
+/// Whether `bytes` begin with the compact-state frame discriminator.
+pub fn is_state_frame(bytes: &[u8]) -> bool {
+    bytes.starts_with(STATE_MAGIC)
+}
+
+/// Encode states as lossless columns, omitting only the derivable state id.
+pub fn encode_state_frame(states: &[State]) -> Result<Vec<u8>> {
+    let dictionaries = StateDictionaries::from_states(states);
+    let mut output = Writer::new(STATE_MAGIC);
+    output.put_u64(states.len() as u64);
+    encode_dictionaries(&mut output, &dictionaries);
+    encode_structure(&mut output, states);
+    encode_attribution(&mut output, states, &dictionaries);
+    encode_intent_and_verification(&mut output, states)?;
+    encode_timestamps(&mut output, states);
+    encode_fidelity(&mut output, states, &dictionaries);
+    encode_lineage(&mut output, states);
+    Ok(output.finish())
+}
+
+fn encode_structure(output: &mut Writer, states: &[State]) {
+    for state in states {
+        output.put_fixed(state.change_id.as_bytes());
+    }
+    for state in states {
+        output.put_fixed(state.tree.as_bytes());
+    }
+    for state in states {
+        output.put_u64(state.parents.len() as u64);
+        for parent in &state.parents {
+            output.put_fixed(parent.as_bytes());
+        }
+    }
+}
+
+fn encode_attribution(output: &mut Writer, states: &[State], dictionaries: &StateDictionaries) {
+    for state in states {
+        output.put_u64(dictionaries.principal_index(&state.attribution.principal));
+    }
+    for state in states {
+        output.put_u64(
+            state
+                .attribution
+                .agent
+                .as_ref()
+                .map(|agent| dictionaries.agent_index(agent) + 1)
+                .unwrap_or(0),
+        );
+    }
+}
+
+fn encode_intent_and_verification(output: &mut Writer, states: &[State]) -> Result<()> {
+    for state in states {
+        output.put_optional_bytes(state.intent.as_deref().map(str::as_bytes));
+    }
+    for state in states {
+        put_optional_f32(output, state.confidence);
+    }
+    for state in states {
+        encode_verification(output, state)?;
+    }
+    for state in states {
+        output.put_u8(state.status.to_byte());
+    }
+    Ok(())
+}
+
+fn encode_timestamps(output: &mut Writer, states: &[State]) {
+    let mut previous = 0i64;
+    for (index, state) in states.iter().enumerate() {
+        let seconds = state.created_at.timestamp();
+        output.put_i64(if index == 0 {
+            seconds
+        } else {
+            seconds - previous
+        });
+        output.put_u64(u64::from(state.created_at.timestamp_subsec_nanos()));
+        previous = seconds;
+    }
+    for state in states {
+        match state.authored_at {
+            Some(timestamp) => {
+                output.put_u8(1);
+                output.put_i64(timestamp.timestamp() - state.created_at.timestamp());
+                output.put_u64(u64::from(timestamp.timestamp_subsec_nanos()));
+            }
+            None => output.put_u8(0),
+        }
+    }
+    for state in states {
+        output.put_i64(i64::from(state.authored_tz_offset));
+        output.put_i64(i64::from(state.committer_tz_offset));
+    }
+}
+
+fn encode_fidelity(output: &mut Writer, states: &[State], dictionaries: &StateDictionaries) {
+    for state in states {
+        match state.provenance {
+            Some(hash) => {
+                output.put_u8(1);
+                output.put_fixed(hash.as_bytes());
+            }
+            None => output.put_u8(0),
+        }
+    }
+    for state in states {
+        output.put_u64(
+            state
+                .committer
+                .as_ref()
+                .map(|value| dictionaries.principal_index(value) + 1)
+                .unwrap_or(0),
+        );
+    }
+    for state in states {
+        output.put_optional_bytes(state.raw_message.as_deref());
+    }
+    for state in states {
+        output.put_u64(state.extra_headers.len() as u64);
+        for (name, value) in &state.extra_headers {
+            output.put_bytes(name);
+            output.put_bytes(value);
+        }
+    }
+    for state in states {
+        output.put_bool(state.git_lossy);
+    }
+}
+
+fn encode_lineage(output: &mut Writer, states: &[State]) {
+    for state in states {
+        output.put_u64(state.lineage.len() as u64);
+        for lineage in &state.lineage {
+            output.put_u8(lineage_kind_tag(lineage.kind));
+            output.put_fixed(lineage.source_change.as_bytes());
+            output.put_fixed(lineage.source_state.as_bytes());
+        }
+    }
+}
+
+fn encode_verification(output: &mut Writer, state: &State) -> Result<()> {
+    let Some(value) = &state.verification else {
+        output.put_u8(0);
+        return Ok(());
+    };
+    output.put_u8(1);
+    put_optional_bool(output, value.tests_passed);
+    put_optional_u32(output, value.tests_failed);
+    put_optional_f32(output, value.coverage_pct);
+    put_optional_f32(output, value.coverage_delta);
+    put_optional_u32(output, value.lint_warnings);
+    output.put_u64(value.custom.len() as u64);
+    for (key, json) in &value.custom {
+        output.put_bytes(key.as_bytes());
+        output.put_bytes(&rmp_serde::to_vec(json)?);
+    }
+    Ok(())
+}
+
+fn encode_dictionaries(output: &mut Writer, dictionaries: &StateDictionaries) {
+    output.put_u64(dictionaries.principals.len() as u64);
+    for PrincipalKey(name, email) in &dictionaries.principals {
+        output.put_bytes(name);
+        output.put_bytes(email);
+    }
+    output.put_u64(dictionaries.agents.len() as u64);
+    for agent in &dictionaries.agents {
+        output.put_bytes(&agent.provider);
+        output.put_bytes(&agent.model);
+        output.put_optional_bytes(agent.session_id.as_deref());
+        output.put_optional_bytes(agent.segment_id.as_deref());
+        output.put_optional_bytes(agent.policy_id.as_deref());
+    }
+}
+
+fn put_optional_bool(output: &mut Writer, value: Option<bool>) {
+    output.put_u8(match value {
+        None => 0,
+        Some(false) => 1,
+        Some(true) => 2,
+    });
+}
+
+fn put_optional_u32(output: &mut Writer, value: Option<u32>) {
+    output.put_u64(value.map(u64::from).map(|value| value + 1).unwrap_or(0));
+}
+
+fn put_optional_f32(output: &mut Writer, value: Option<f32>) {
+    match value {
+        Some(value) => {
+            output.put_u8(1);
+            output.put_fixed(&value.to_le_bytes());
+        }
+        None => output.put_u8(0),
+    }
+}
+
+pub(super) fn lineage_kind_tag(kind: ChangeLineageKind) -> u8 {
+    match kind {
+        ChangeLineageKind::CherryPick => 1,
+        ChangeLineageKind::Collapse => 2,
+        ChangeLineageKind::Revert => 3,
+        ChangeLineageKind::GitProjection => 4,
+    }
+}

--- a/crates/object-model/src/compact/state_decode.rs
+++ b/crates/object-model/src/compact/state_decode.rs
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, TimeZone, Utc};
+
+use super::{
+    Result,
+    dictionary::{AgentKey, PrincipalKey},
+    invalid,
+    io::Reader,
+    state::STATE_MAGIC,
+};
+use crate::object::{
+    Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal, State,
+    StateId, Status, Verification,
+};
+
+/// Decode and whole-frame-verify every state, recomputing each state id.
+pub fn decode_state_frame(bytes: &[u8]) -> Result<Vec<State>> {
+    let mut input = Reader::verified(bytes, STATE_MAGIC)?;
+    let count = input.get_count("state frame")?;
+    let (principals, agents) = decode_dictionaries(&mut input)?;
+    let mut states = (0..count).map(|_| blank_state()).collect::<Vec<_>>();
+    decode_structure(&mut input, &mut states)?;
+    decode_attribution(&mut input, &mut states, &principals, &agents)?;
+    decode_intent_and_verification(&mut input, &mut states)?;
+    decode_timestamps(&mut input, &mut states)?;
+    decode_fidelity(&mut input, &mut states, &principals)?;
+    decode_lineage(&mut input, &mut states)?;
+    input.finish()?;
+    for state in &mut states {
+        state.state_id = state.id();
+    }
+    Ok(states)
+}
+
+fn decode_structure(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> {
+    for state in &mut *states {
+        state.change_id = ChangeId::from_bytes(input.get_fixed()?);
+    }
+    for state in &mut *states {
+        state.tree = ContentHash::from_bytes(input.get_fixed()?);
+    }
+    for state in states {
+        let count = input.get_count("state parent")?;
+        state.parents = (0..count)
+            .map(|_| Ok(StateId::from_bytes(input.get_fixed()?)))
+            .collect::<Result<Vec<_>>>()?;
+    }
+    Ok(())
+}
+
+fn decode_attribution(
+    input: &mut Reader<'_>,
+    states: &mut [State],
+    principals: &[Principal],
+    agents: &[Agent],
+) -> Result<()> {
+    for state in &mut *states {
+        state.attribution.principal = principal_at(principals, input.get_u64()?)?;
+    }
+    for state in states {
+        state.attribution.agent = optional_at(agents, input.get_u64()?)?;
+    }
+    Ok(())
+}
+
+fn decode_intent_and_verification(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> {
+    for state in &mut *states {
+        state.intent = input
+            .get_optional_bytes()?
+            .map(String::from_utf8)
+            .transpose()
+            .map_err(|_| invalid("state intent is not UTF-8"))?;
+    }
+    for state in &mut *states {
+        state.confidence = get_optional_f32(input)?;
+    }
+    for state in &mut *states {
+        state.verification = decode_verification(input)?;
+    }
+    for state in states {
+        state.status =
+            Status::from_byte(input.get_u8()?).ok_or_else(|| invalid("invalid state status"))?;
+    }
+    Ok(())
+}
+
+fn decode_timestamps(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> {
+    let mut previous = 0i64;
+    for (index, state) in states.iter_mut().enumerate() {
+        let encoded = input.get_i64()?;
+        let seconds = if index == 0 {
+            encoded
+        } else {
+            previous
+                .checked_add(encoded)
+                .ok_or_else(|| invalid("created timestamp delta overflow"))?
+        };
+        state.created_at = timestamp(seconds, get_u32(input, "created timestamp nanos")?)?;
+        previous = seconds;
+    }
+    for state in &mut *states {
+        state.authored_at = match input.get_u8()? {
+            0 => None,
+            1 => {
+                let seconds = state
+                    .created_at
+                    .timestamp()
+                    .checked_add(input.get_i64()?)
+                    .ok_or_else(|| invalid("authored timestamp delta overflow"))?;
+                Some(timestamp(
+                    seconds,
+                    get_u32(input, "authored timestamp nanos")?,
+                )?)
+            }
+            value => return Err(invalid(format!("invalid authored timestamp tag {value}"))),
+        };
+    }
+    for state in states {
+        state.authored_tz_offset = get_i32(input, "author timezone")?;
+        state.committer_tz_offset = get_i32(input, "committer timezone")?;
+    }
+    Ok(())
+}
+
+fn decode_fidelity(
+    input: &mut Reader<'_>,
+    states: &mut [State],
+    principals: &[Principal],
+) -> Result<()> {
+    for state in &mut *states {
+        state.provenance = match input.get_u8()? {
+            0 => None,
+            1 => Some(ContentHash::from_bytes(input.get_fixed()?)),
+            value => return Err(invalid(format!("invalid provenance option tag {value}"))),
+        };
+    }
+    for state in &mut *states {
+        state.committer = optional_at(principals, input.get_u64()?)?;
+    }
+    for state in &mut *states {
+        state.raw_message = input.get_optional_bytes()?;
+    }
+    for state in &mut *states {
+        let count = input.get_count("extra header")?;
+        state.extra_headers = (0..count)
+            .map(|_| Ok((input.get_bytes()?, input.get_bytes()?)))
+            .collect::<Result<Vec<_>>>()?;
+    }
+    for state in states {
+        state.git_lossy = input.get_bool()?;
+    }
+    Ok(())
+}
+
+fn decode_lineage(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> {
+    for state in states {
+        let count = input.get_count("state lineage")?;
+        state.lineage = (0..count)
+            .map(|_| {
+                Ok(ChangeLineage {
+                    kind: decode_lineage_kind(input.get_u8()?)?,
+                    source_change: ChangeId::from_bytes(input.get_fixed()?),
+                    source_state: StateId::from_bytes(input.get_fixed()?),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+    }
+    Ok(())
+}
+
+fn decode_verification(input: &mut Reader<'_>) -> Result<Option<Verification>> {
+    match input.get_u8()? {
+        0 => Ok(None),
+        1 => {
+            let tests_passed = get_optional_bool(input)?;
+            let tests_failed = get_optional_u32(input)?;
+            let coverage_pct = get_optional_f32(input)?;
+            let coverage_delta = get_optional_f32(input)?;
+            let lint_warnings = get_optional_u32(input)?;
+            let count = input.get_count("verification custom")?;
+            let mut custom = BTreeMap::new();
+            for _ in 0..count {
+                let key = String::from_utf8(input.get_bytes()?)
+                    .map_err(|_| invalid("verification key is not UTF-8"))?;
+                custom.insert(key, rmp_serde::from_slice(&input.get_bytes()?)?);
+            }
+            Ok(Some(Verification {
+                tests_passed,
+                tests_failed,
+                coverage_pct,
+                coverage_delta,
+                lint_warnings,
+                custom,
+            }))
+        }
+        value => Err(invalid(format!("invalid verification option tag {value}"))),
+    }
+}
+
+fn decode_dictionaries(input: &mut Reader<'_>) -> Result<(Vec<Principal>, Vec<Agent>)> {
+    let principals = (0..input.get_count("principal dictionary")?)
+        .map(|_| principal_from_key(PrincipalKey(input.get_bytes()?, input.get_bytes()?)))
+        .collect::<Result<Vec<_>>>()?;
+    let agents = (0..input.get_count("agent dictionary")?)
+        .map(|_| {
+            agent_from_key(AgentKey {
+                provider: input.get_bytes()?,
+                model: input.get_bytes()?,
+                session_id: input.get_optional_bytes()?,
+                segment_id: input.get_optional_bytes()?,
+                policy_id: input.get_optional_bytes()?,
+            })
+        })
+        .collect::<Result<Vec<_>>>()?;
+    Ok((principals, agents))
+}
+
+fn principal_from_key(value: PrincipalKey) -> Result<Principal> {
+    Ok(Principal {
+        name: String::from_utf8(value.0).map_err(|_| invalid("principal name is not UTF-8"))?,
+        email: String::from_utf8(value.1).map_err(|_| invalid("principal email is not UTF-8"))?,
+    })
+}
+
+fn agent_from_key(value: AgentKey) -> Result<Agent> {
+    Ok(Agent {
+        provider: String::from_utf8(value.provider)
+            .map_err(|_| invalid("agent provider is not UTF-8"))?,
+        model: String::from_utf8(value.model).map_err(|_| invalid("agent model is not UTF-8"))?,
+        session_id: optional_string(value.session_id, "agent session id")?,
+        segment_id: optional_string(value.segment_id, "agent segment id")?,
+        policy_id: optional_string(value.policy_id, "agent policy id")?,
+    })
+}
+
+fn optional_string(value: Option<Vec<u8>>, field: &str) -> Result<Option<String>> {
+    value
+        .map(String::from_utf8)
+        .transpose()
+        .map_err(|_| invalid(format!("{field} is not UTF-8")))
+}
+
+fn principal_at(values: &[Principal], index: u64) -> Result<Principal> {
+    values
+        .get(index_usize(index)?)
+        .cloned()
+        .ok_or_else(|| invalid("principal dictionary index is out of range"))
+}
+
+fn optional_at<T: Clone>(values: &[T], encoded: u64) -> Result<Option<T>> {
+    if encoded == 0 {
+        return Ok(None);
+    }
+    Ok(Some(
+        values
+            .get(index_usize(encoded - 1)?)
+            .cloned()
+            .ok_or_else(|| invalid("dictionary index is out of range"))?,
+    ))
+}
+
+fn index_usize(value: u64) -> Result<usize> {
+    usize::try_from(value).map_err(|_| invalid("dictionary index exceeds platform limits"))
+}
+
+fn get_optional_bool(input: &mut Reader<'_>) -> Result<Option<bool>> {
+    match input.get_u8()? {
+        0 => Ok(None),
+        1 => Ok(Some(false)),
+        2 => Ok(Some(true)),
+        value => Err(invalid(format!("invalid optional boolean {value}"))),
+    }
+}
+
+fn get_optional_u32(input: &mut Reader<'_>) -> Result<Option<u32>> {
+    match input.get_u64()? {
+        0 => Ok(None),
+        value => Ok(Some(
+            u32::try_from(value - 1).map_err(|_| invalid("optional u32 exceeds its range"))?,
+        )),
+    }
+}
+
+fn get_optional_f32(input: &mut Reader<'_>) -> Result<Option<f32>> {
+    match input.get_u8()? {
+        0 => Ok(None),
+        1 => Ok(Some(f32::from_le_bytes(input.get_fixed()?))),
+        value => Err(invalid(format!("invalid optional f32 tag {value}"))),
+    }
+}
+
+fn get_u32(input: &mut Reader<'_>, field: &str) -> Result<u32> {
+    u32::try_from(input.get_u64()?).map_err(|_| invalid(format!("{field} exceeds u32")))
+}
+
+fn get_i32(input: &mut Reader<'_>, field: &str) -> Result<i32> {
+    i32::try_from(input.get_i64()?).map_err(|_| invalid(format!("{field} exceeds i32")))
+}
+
+fn timestamp(seconds: i64, nanos: u32) -> Result<DateTime<Utc>> {
+    Utc.timestamp_opt(seconds, nanos)
+        .single()
+        .ok_or_else(|| invalid("compact timestamp is out of range"))
+}
+
+fn decode_lineage_kind(value: u8) -> Result<ChangeLineageKind> {
+    match value {
+        1 => Ok(ChangeLineageKind::CherryPick),
+        2 => Ok(ChangeLineageKind::Collapse),
+        3 => Ok(ChangeLineageKind::Revert),
+        4 => Ok(ChangeLineageKind::GitProjection),
+        value => Err(invalid(format!("invalid lineage kind {value}"))),
+    }
+}
+
+fn blank_state() -> State {
+    State {
+        state_id: StateId::default(),
+        change_id: ChangeId::from_bytes([0; 16]),
+        tree: ContentHash::from_bytes([0; 32]),
+        parents: Vec::new(),
+        attribution: Attribution::human(Principal::new("", "")),
+        intent: None,
+        confidence: None,
+        created_at: DateTime::UNIX_EPOCH,
+        verification: None,
+        status: Status::Draft,
+        provenance: None,
+        authored_at: None,
+        committer: None,
+        authored_tz_offset: 0,
+        committer_tz_offset: 0,
+        raw_message: None,
+        git_lossy: false,
+        extra_headers: Vec::new(),
+        lineage: Vec::new(),
+    }
+}

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use chrono::{TimeZone, Utc};
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+
+use super::{decode_state_frame, decode_tree_frame, encode_state_frame, encode_tree_frame};
+use crate::object::{
+    Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal,
+    SpoolId, State, StateId, Status, Tree, TreeEntry, Verification,
+};
+
+#[test]
+fn tree_frame_round_trips_every_entry_kind_and_native_bytes() {
+    let content = ContentHash::from_bytes([1; 32]);
+    let nested = ContentHash::from_bytes([2; 32]);
+    let spool_state = StateId::from_bytes([3; 32]);
+    let sha1 = GitObjectId::from_raw(GitObjectFormat::Sha1, &[4; 20]).unwrap();
+    let sha256 = GitObjectId::from_raw(GitObjectFormat::Sha256, &[5; 32]).unwrap();
+    let trees = vec![
+        Tree::from_entries(vec![
+            TreeEntry::file("a", content, false).unwrap(),
+            TreeEntry::file("b", content, true).unwrap(),
+            TreeEntry::directory("c", nested).unwrap(),
+            TreeEntry::symlink("d", content).unwrap(),
+            TreeEntry::gitlink("e", sha1).unwrap(),
+            TreeEntry::gitlink("f", sha256).unwrap(),
+            TreeEntry::spoollink("g", SpoolId::parse("acme/child").unwrap(), spool_state).unwrap(),
+        ]),
+        Tree::from_entries(vec![TreeEntry::file("same", content, false).unwrap()]),
+    ];
+
+    let encoded = encode_tree_frame(&trees).unwrap();
+    let decoded = decode_tree_frame(&encoded).unwrap();
+
+    assert_eq!(decoded, trees);
+    for (actual, expected) in decoded.iter().zip(&trees) {
+        assert_eq!(actual.hash(), expected.hash());
+        assert_eq!(
+            rmp_serde::to_vec_named(actual).unwrap(),
+            rmp_serde::to_vec_named(expected).unwrap()
+        );
+    }
+}
+
+#[test]
+fn state_frame_round_trips_every_fidelity_field_and_recomputes_id() {
+    let principal = Principal::new("Author", "author@example.com");
+    let committer = Principal::new("Committer", "committer@example.com");
+    let agent = Agent::new("openai", "gpt-test")
+        .with_session("session", "segment")
+        .with_policy("policy");
+    let mut custom = BTreeMap::new();
+    custom.insert(
+        "nested".to_string(),
+        serde_json::json!({"bytes": [1, 2, 3]}),
+    );
+    let mut first = State::new(
+        ContentHash::from_bytes([10; 32]),
+        vec![StateId::from_bytes([11; 32])],
+        Attribution::with_agent(principal, agent),
+    );
+    first.change_id = ChangeId::from_bytes([12; 16]);
+    first.intent = Some("intent".to_string());
+    first.confidence = Some(f32::from_bits(0x7fc0_0123));
+    first.created_at = Utc.timestamp_opt(1_700_000_000, 123_456_789).unwrap();
+    first.authored_at = Some(Utc.timestamp_opt(1_699_999_900, 987_654_321).unwrap());
+    first.verification = Some(Verification {
+        tests_passed: Some(false),
+        tests_failed: Some(7),
+        coverage_pct: Some(92.5),
+        coverage_delta: Some(f32::from_bits(0xffc0_0456)),
+        lint_warnings: Some(3),
+        custom,
+    });
+    first.status = Status::Published;
+    first.provenance = Some(ContentHash::from_bytes([13; 32]));
+    first.committer = Some(committer);
+    first.authored_tz_offset = -7 * 3600;
+    first.committer_tz_offset = 12 * 3600 + 45 * 60;
+    first.raw_message = Some(b"raw\0message\xff".to_vec());
+    first.git_lossy = true;
+    first.extra_headers = vec![
+        (b"x-custom".to_vec(), b"first\xff".to_vec()),
+        (b"gpgsig".to_vec(), b"signed\n continuation".to_vec()),
+    ];
+    first.lineage = vec![ChangeLineage {
+        kind: ChangeLineageKind::GitProjection,
+        source_change: ChangeId::from_bytes([14; 16]),
+        source_state: StateId::from_bytes([15; 32]),
+    }];
+    first.state_id = first.id();
+    let mut second = State::new(
+        ContentHash::from_bytes([20; 32]),
+        vec![first.state_id],
+        Attribution::human(Principal::new("Author", "author@example.com")),
+    );
+    second.created_at = Utc.timestamp_opt(1_700_000_001, 0).unwrap();
+    second.state_id = second.id();
+    let states = vec![first, second];
+
+    let encoded = encode_state_frame(&states).unwrap();
+    let decoded = decode_state_frame(&encoded).unwrap();
+
+    for (actual, expected) in decoded.iter().zip(&states) {
+        assert_eq!(actual.id(), expected.id());
+        assert_eq!(
+            rmp_serde::to_vec_named(actual).unwrap(),
+            rmp_serde::to_vec_named(expected).unwrap()
+        );
+    }
+    assert_eq!(decoded[0].confidence.unwrap().to_bits(), 0x7fc0_0123);
+    assert_eq!(
+        decoded[0]
+            .verification
+            .as_ref()
+            .unwrap()
+            .coverage_delta
+            .unwrap()
+            .to_bits(),
+        0xffc0_0456
+    );
+}
+
+#[test]
+fn corrupt_frame_byte_rejects_every_contained_object() {
+    let hash = ContentHash::from_bytes([21; 32]);
+    let trees = vec![
+        Tree::from_entries(vec![TreeEntry::file("a", hash, false).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::file("b", hash, true).unwrap()]),
+    ];
+    let mut encoded = encode_tree_frame(&trees).unwrap();
+    let corrupt_at = encoded.len() / 2;
+    encoded[corrupt_at] ^= 0x01;
+
+    for _ in &trees {
+        let error = decode_tree_frame(&encoded).unwrap_err();
+        assert!(error.to_string().contains("checksum mismatch"));
+    }
+}

--- a/crates/object-model/src/compact/tree.rs
+++ b/crates/object-model/src/compact/tree.rs
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+
+use super::{
+    Result, invalid,
+    io::{Reader, Writer, varint_len},
+};
+use crate::object::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry};
+
+const TREE_MAGIC: &[u8; 4] = b"HCT1";
+
+/// Whether `bytes` begin with the compact-tree frame discriminator.
+pub fn is_tree_frame(bytes: &[u8]) -> bool {
+    bytes.starts_with(TREE_MAGIC)
+}
+
+/// Exact raw-frame size for `tree`, including its per-tree entry count.
+pub fn encoded_tree_size(tree: &Tree) -> usize {
+    varint_len(tree.len())
+        + tree.len() * 2
+        + tree
+            .entries()
+            .iter()
+            .map(|entry| varint_len(entry.name().len()) + entry.name().len() + target_len(entry))
+            .sum::<usize>()
+}
+
+/// Encode name-sorted trees as columnar mode/kind/name/target payloads.
+pub fn encode_tree_frame(trees: &[Tree]) -> Result<Vec<u8>> {
+    let mut output = Writer::new(TREE_MAGIC);
+    output.put_u64(trees.len() as u64);
+    for tree in trees {
+        tree.validate()?;
+        output.put_u64(tree.len() as u64);
+        for entry in tree.entries() {
+            output.put_u8(entry.mode().to_byte());
+        }
+        for entry in tree.entries() {
+            output.put_u8(entry.entry_type().to_byte());
+        }
+        for entry in tree.entries() {
+            output.put_bytes(entry.name().as_bytes());
+        }
+        for entry in tree.entries() {
+            encode_target(&mut output, entry);
+        }
+    }
+    Ok(output.finish())
+}
+
+/// Decode and whole-frame-verify every tree in a compact frame.
+pub fn decode_tree_frame(bytes: &[u8]) -> Result<Vec<Tree>> {
+    let mut input = Reader::verified(bytes, TREE_MAGIC)?;
+    let tree_count = input.get_count("tree frame")?;
+    let mut trees = Vec::with_capacity(tree_count);
+    for _ in 0..tree_count {
+        trees.push(decode_tree(&mut input)?);
+    }
+    input.finish()?;
+    Ok(trees)
+}
+
+fn decode_tree(input: &mut Reader<'_>) -> Result<Tree> {
+    let count = input.get_count("tree entry")?;
+    let modes = (0..count)
+        .map(|_| decode_mode(input.get_u8()?))
+        .collect::<Result<Vec<_>>>()?;
+    let kinds = (0..count)
+        .map(|_| decode_kind(input.get_u8()?))
+        .collect::<Result<Vec<_>>>()?;
+    let names = (0..count)
+        .map(|_| {
+            String::from_utf8(input.get_bytes()?).map_err(|_| invalid("tree name is not UTF-8"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let mut entries = Vec::with_capacity(count);
+    for index in 0..count {
+        entries.push(decode_entry(
+            input,
+            names[index].clone(),
+            kinds[index],
+            modes[index],
+        )?);
+    }
+    let tree = Tree::from_entries(entries);
+    tree.validate()?;
+    Ok(tree)
+}
+
+fn encode_target(output: &mut Writer, entry: &TreeEntry) {
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            output.put_fixed(entry.require_content_hash().as_bytes());
+        }
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().expect("gitlink target");
+            output.put_u8(git_format_tag(target.format()));
+            output.put_fixed(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().expect("spoollink target");
+            output.put_bytes(spool.as_str().as_bytes());
+            output.put_fixed(state.as_bytes());
+        }
+    }
+}
+
+fn decode_entry(
+    input: &mut Reader<'_>,
+    name: String,
+    kind: EntryType,
+    mode: FileMode,
+) -> Result<TreeEntry> {
+    let entry = match kind {
+        EntryType::Blob => TreeEntry::file(
+            name,
+            ContentHash::from_bytes(input.get_fixed()?),
+            mode == FileMode::Executable,
+        )?,
+        EntryType::Tree => TreeEntry::directory(name, ContentHash::from_bytes(input.get_fixed()?))?,
+        EntryType::Symlink => {
+            TreeEntry::symlink(name, ContentHash::from_bytes(input.get_fixed()?))?
+        }
+        EntryType::Gitlink => {
+            let format = decode_git_format(input.get_u8()?)?;
+            let oid_len = match format {
+                GitObjectFormat::Sha1 => 20,
+                GitObjectFormat::Sha256 => 32,
+            };
+            let target = GitObjectId::from_raw(format, input.take(oid_len)?)
+                .map_err(|error| super::CompactError::GitObjectId(error.to_string()))?;
+            TreeEntry::gitlink(name, target)?
+        }
+        EntryType::Spoollink => {
+            let spool = String::from_utf8(input.get_bytes()?)
+                .map_err(|_| invalid("spool id is not UTF-8"))?;
+            TreeEntry::spoollink(
+                name,
+                SpoolId::parse(spool)
+                    .map_err(|error| super::CompactError::SpoolId(error.to_string()))?,
+                StateId::from_bytes(input.get_fixed()?),
+            )?
+        }
+    };
+    if entry.mode() != mode {
+        return Err(invalid(format!(
+            "tree kind/mode mismatch for {}: {kind:?}/{mode:?}",
+            entry.name()
+        )));
+    }
+    Ok(entry)
+}
+
+fn target_len(entry: &TreeEntry) -> usize {
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => 32,
+        EntryType::Gitlink => {
+            1 + entry
+                .gitlink_target()
+                .expect("gitlink target")
+                .as_bytes()
+                .len()
+        }
+        EntryType::Spoollink => {
+            let (spool, _) = entry.spoollink_target().expect("spoollink target");
+            varint_len(spool.as_str().len()) + spool.as_str().len() + 32
+        }
+    }
+}
+
+fn decode_mode(value: u8) -> Result<FileMode> {
+    FileMode::from_byte(value).ok_or_else(|| invalid(format!("invalid tree mode {value}")))
+}
+
+fn decode_kind(value: u8) -> Result<EntryType> {
+    EntryType::from_byte(value).ok_or_else(|| invalid(format!("invalid tree kind {value}")))
+}
+
+fn git_format_tag(format: GitObjectFormat) -> u8 {
+    match format {
+        GitObjectFormat::Sha1 => 1,
+        GitObjectFormat::Sha256 => 2,
+    }
+}
+
+fn decode_git_format(value: u8) -> Result<GitObjectFormat> {
+    match value {
+        1 => Ok(GitObjectFormat::Sha1),
+        2 => Ok(GitObjectFormat::Sha256),
+        _ => Err(invalid(format!("invalid git object format {value}"))),
+    }
+}

--- a/crates/object-model/src/lib.rs
+++ b/crates/object-model/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Heddle's content-addressed object model and stable codecs.
 
+pub mod compact;
 pub mod error;
 pub mod object;
 

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -296,12 +296,7 @@ impl FsStore {
 /// installed ids regardless of how the bytes reach the store.
 fn validate_and_list_pack(reader: &crate::store::pack::PackReader) -> Result<Vec<PackObjectId>> {
     let ids = reader.list_ids()?;
-    for id in &ids {
-        let Some((obj_type, data)) = reader.get_object_bytes(id)? else {
-            continue;
-        };
-        validate_pack_entry(id, obj_type, data.as_ref())?;
-    }
+    reader.visit_objects(|id, object_type, data| validate_pack_entry(&id, object_type, data))?;
     Ok(ids)
 }
 
@@ -310,23 +305,25 @@ fn state_entries_from_pack(
     ids: &[PackObjectId],
 ) -> Result<Vec<(StateId, Vec<u8>)>> {
     let mut states = Vec::new();
-    for id in ids {
-        let PackObjectId::StateId(change_id) = id else {
-            continue;
-        };
-        let Some((obj_type, data)) = reader.get_object(id)? else {
-            continue;
-        };
-        if obj_type != ObjectType::State {
-            return Err(HeddleError::InvalidObject(format!(
-                "pack id {} is indexed as {:?}, expected State",
-                change_id.to_string_full(),
-                obj_type
-            )));
+    let expected = ids.iter().copied().collect::<HashSet<_>>();
+    reader.visit_objects(|id, object_type, data| {
+        if !expected.contains(&id) {
+            return Err(HeddleError::InvalidObject(
+                "pack visitor yielded an unindexed object".into(),
+            ));
         }
-        validate_state_serialized(&data, *change_id)?;
-        states.push((*change_id, data));
-    }
+        if let PackObjectId::StateId(state_id) = id {
+            if object_type != ObjectType::State {
+                return Err(HeddleError::InvalidObject(format!(
+                    "pack id {} is indexed as {object_type:?}, expected State",
+                    state_id.to_string_full()
+                )));
+            }
+            validate_state_serialized(data, state_id)?;
+            states.push((state_id, data.to_vec()));
+        }
+        Ok(())
+    })?;
     Ok(states)
 }
 
@@ -335,12 +332,13 @@ fn attachment_entries_from_pack(
     ids: &[PackObjectId],
 ) -> Result<Vec<StateAttachment>> {
     let mut attachments = Vec::new();
-    for id in ids {
-        let Some((ObjectType::StateAttachment, data)) = reader.get_object(id)? else {
-            continue;
-        };
-        attachments.push(rmp_serde::from_slice(&data)?);
-    }
+    let expected = ids.iter().copied().collect::<HashSet<_>>();
+    reader.visit_objects(|id, object_type, data| {
+        if expected.contains(&id) && object_type == ObjectType::StateAttachment {
+            attachments.push(rmp_serde::from_slice(data)?);
+        }
+        Ok(())
+    })?;
     Ok(attachments)
 }
 
@@ -1448,13 +1446,10 @@ impl ObjectStore for FsStore {
         let reader = crate::store::pack::PackReader::from_slice(pack_data, index_data)?;
         let ids = validate_and_list_pack(&reader)?;
         let state_entries = state_entries_from_pack(&reader, &ids)?;
+        let attachment_entries = attachment_entries_from_pack(&reader, &ids)?;
         self.install_pack_files(pack_data, index_data)?;
         self.write_packed_state_mirrors_batch(state_entries)?;
-        for id in &ids {
-            let Some((ObjectType::StateAttachment, data)) = reader.get_object(id)? else {
-                continue;
-            };
-            let attachment: StateAttachment = rmp_serde::from_slice(&data)?;
+        for attachment in attachment_entries {
             self.put_state_attachment(&attachment)?;
         }
         self.clear_recent_object_caches();
@@ -1539,13 +1534,7 @@ impl ObjectStore for FsStore {
             let index = path.with_extension("idx");
             let valid = crate::store::pack::PackReader::open(&path, &index)
                 .and_then(|reader| {
-                    for id in reader.list_ids()? {
-                        let (kind, bytes) = reader.get_object(&id)?.ok_or_else(|| {
-                            HeddleError::InvalidObject(format!("pack index lost object {id:?}"))
-                        })?;
-                        validate_pack_entry(&id, kind, &bytes)?;
-                    }
-                    Ok(())
+                    reader.visit_objects(|id, kind, bytes| validate_pack_entry(&id, kind, bytes))
                 })
                 .is_ok();
             if !valid {

--- a/crates/objects/src/store/fs/repack/compact.rs
+++ b/crates/objects/src/store/fs/repack/compact.rs
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{BinaryHeap, HashMap, HashSet},
+    fs::File,
+};
+
+use heddle_object_model::compact::{
+    decode_state_frame, decode_tree_frame, encode_state_frame, encode_tree_frame, encoded_tree_size,
+};
+
+use super::{super::FsStore, staging::BuildError};
+use crate::{
+    object::{ContentHash, State, StateId, Tree},
+    store::{
+        HeddleError, ObjectStore,
+        pack::{
+            ObjectType, PackObjectId, RepackContext, StreamingPackBuilder, compress_compact_frame,
+        },
+    },
+};
+
+#[path = "compact_state_writer.rs"]
+mod state_writer;
+
+use state_writer::add_state_frames;
+
+const FRAME_LIMIT: usize = 12 * 1024 * 1024;
+
+pub(super) fn add_compact_metadata(
+    store: &FsStore,
+    builder: &mut StreamingPackBuilder<File>,
+    state_ids: &[StateId],
+    tree_hashes: &[ContentHash],
+    context: &RepackContext,
+    corrupt_first: &mut bool,
+) -> Result<u64, BuildError> {
+    let states = load_states(store, state_ids)?;
+    let state_order = newest_first_topology(&states)?;
+    let tree_order = tree_path_order(store, tree_hashes, &states, &state_order)?;
+    let state_bytes = add_state_frames(builder, &states, &state_order, context, corrupt_first)?;
+    let tree_bytes = add_tree_frames(store, builder, &tree_order, context, corrupt_first)?;
+    Ok(state_bytes.saturating_add(tree_bytes))
+}
+
+fn load_states(store: &FsStore, ids: &[StateId]) -> Result<HashMap<StateId, State>, BuildError> {
+    ids.iter()
+        .map(|id| {
+            ObjectStore::get_state(store, id)?
+                .ok_or_else(|| {
+                    HeddleError::InvalidObject(format!(
+                        "repack state disappeared: {}",
+                        id.to_string_full()
+                    ))
+                })
+                .map(|state| (*id, state))
+        })
+        .collect::<crate::store::Result<_>>()
+        .map_err(BuildError::from)
+}
+
+fn newest_first_topology(states: &HashMap<StateId, State>) -> Result<Vec<StateId>, BuildError> {
+    let mut children = HashMap::<StateId, usize>::new();
+    for state in states.values() {
+        children.entry(state.state_id).or_default();
+        for parent in &state.parents {
+            if states.contains_key(parent) {
+                *children.entry(*parent).or_default() += 1;
+            }
+        }
+    }
+    let mut ready = BinaryHeap::new();
+    for (id, state) in states {
+        if children[id] == 0 {
+            ready.push((state.created_at, *id));
+        }
+    }
+    let mut order = Vec::with_capacity(states.len());
+    while let Some((_, id)) = ready.pop() {
+        order.push(id);
+        for parent in &states[&id].parents {
+            let Some(count) = children.get_mut(parent) else {
+                continue;
+            };
+            *count -= 1;
+            if *count == 0 {
+                ready.push((states[parent].created_at, *parent));
+            }
+        }
+    }
+    if order.len() != states.len() {
+        return Err(HeddleError::InvalidObject(
+            "repack state graph is cyclic or incomplete".to_string(),
+        )
+        .into());
+    }
+    Ok(order)
+}
+
+fn tree_path_order(
+    store: &FsStore,
+    hashes: &[ContentHash],
+    states: &HashMap<StateId, State>,
+    state_order: &[StateId],
+) -> Result<Vec<ContentHash>, BuildError> {
+    let allowed = hashes.iter().copied().collect::<HashSet<_>>();
+    let mut seen = HashSet::with_capacity(allowed.len());
+    let mut group_indices = HashMap::<String, usize>::new();
+    let mut groups = Vec::<Vec<ContentHash>>::new();
+    for state_id in state_order {
+        visit_tree(
+            store,
+            states[state_id].tree,
+            &allowed,
+            &mut seen,
+            &mut group_indices,
+            &mut groups,
+        )?;
+    }
+    let mut order = groups.into_iter().flatten().collect::<Vec<_>>();
+    let mut leftovers = allowed.difference(&seen).copied().collect::<Vec<_>>();
+    leftovers.sort();
+    order.extend(leftovers);
+    Ok(order)
+}
+
+fn visit_tree(
+    store: &FsStore,
+    root: ContentHash,
+    allowed: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    group_indices: &mut HashMap<String, usize>,
+    groups: &mut Vec<Vec<ContentHash>>,
+) -> Result<(), BuildError> {
+    let mut stack = vec![(root, String::new())];
+    while let Some((hash, path)) = stack.pop() {
+        if !allowed.contains(&hash) {
+            return Err(HeddleError::InvalidObject(format!(
+                "state references tree outside repack snapshot: {hash}"
+            ))
+            .into());
+        }
+        if !seen.insert(hash) {
+            continue;
+        }
+        let index = *group_indices.entry(path.clone()).or_insert_with(|| {
+            groups.push(Vec::new());
+            groups.len() - 1
+        });
+        groups[index].push(hash);
+        let tree = load_tree(store, hash)?;
+        for entry in tree.entries().iter().rev() {
+            if let Some(child) = entry.tree_hash() {
+                let child_path = if path.is_empty() {
+                    entry.name().to_string()
+                } else {
+                    format!("{path}/{}", entry.name())
+                };
+                stack.push((child, child_path));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn add_tree_frames(
+    store: &FsStore,
+    builder: &mut StreamingPackBuilder<File>,
+    order: &[ContentHash],
+    context: &RepackContext,
+    corrupt_first: &mut bool,
+) -> Result<u64, BuildError> {
+    let mut trees = Vec::new();
+    let mut ids = Vec::new();
+    let mut tree_bytes = 0usize;
+    let mut logical_bytes = 0u64;
+    for hash in order {
+        let tree = load_tree(store, *hash)?;
+        let tree_size = encoded_tree_size(&tree);
+        let proposed_size = 4usize
+            .saturating_add(unsigned_varint_len(trees.len() + 1))
+            .saturating_add(tree_bytes)
+            .saturating_add(tree_size)
+            .saturating_add(32);
+        if !trees.is_empty() && proposed_size > FRAME_LIMIT {
+            write_tree_frame(builder, &ids, &trees, corrupt_first)?;
+            trees.clear();
+            ids.clear();
+            tree_bytes = 0;
+        }
+        let source = rmp_serde::to_vec_named(&tree).map_err(HeddleError::from)?;
+        logical_bytes = logical_bytes.saturating_add(source.len() as u64);
+        tree_bytes = tree_bytes.saturating_add(tree_size);
+        trees.push(tree);
+        ids.push(PackObjectId::Hash(*hash));
+        context
+            .checkpoint(tree_size as u64)
+            .map_err(BuildError::Cancelled)?;
+    }
+    if !trees.is_empty() {
+        write_tree_frame(builder, &ids, &trees, corrupt_first)?;
+    }
+    Ok(logical_bytes)
+}
+
+fn unsigned_varint_len(mut value: usize) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
+fn write_tree_frame(
+    builder: &mut StreamingPackBuilder<File>,
+    ids: &[PackObjectId],
+    trees: &[Tree],
+    corrupt_first: &mut bool,
+) -> Result<(), BuildError> {
+    let mut frame = encode_tree_frame(trees).map_err(compact_error)?;
+    verify_tree_frame(ids, trees, &frame)?;
+    corrupt_if_requested(&mut frame, corrupt_first);
+    let stored = compress_compact_frame(&frame)?;
+    builder.add_shared_frame(ids, ObjectType::Tree, frame.len(), &stored)?;
+    Ok(())
+}
+
+fn verify_tree_frame(
+    ids: &[PackObjectId],
+    expected: &[Tree],
+    frame: &[u8],
+) -> Result<(), BuildError> {
+    let decoded = decode_tree_frame(frame).map_err(compact_error)?;
+    if decoded != expected || decoded.len() != ids.len() {
+        return Err(
+            HeddleError::InvalidObject("compact tree frame changed object values".into()).into(),
+        );
+    }
+    for (id, tree) in ids.iter().zip(decoded) {
+        if *id != PackObjectId::Hash(tree.hash()) {
+            return Err(
+                HeddleError::InvalidObject("compact tree frame changed a typed id".into()).into(),
+            );
+        }
+    }
+    Ok(())
+}
+
+fn load_tree(store: &FsStore, hash: ContentHash) -> Result<Tree, BuildError> {
+    ObjectStore::get_tree(store, &hash)?
+        .ok_or_else(|| HeddleError::InvalidObject(format!("repack tree disappeared: {hash}")))
+        .map_err(BuildError::from)
+}
+
+fn compact_error(error: heddle_object_model::compact::CompactError) -> BuildError {
+    HeddleError::InvalidObject(error.to_string()).into()
+}
+
+fn corrupt_if_requested(frame: &mut [u8], corrupt_first: &mut bool) {
+    if *corrupt_first {
+        let index = frame.len() / 2;
+        frame[index] ^= 0x01;
+        *corrupt_first = false;
+    }
+}

--- a/crates/objects/src/store/fs/repack/compact_state_writer.rs
+++ b/crates/objects/src/store/fs/repack/compact_state_writer.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+pub(super) fn add_state_frames(
+    builder: &mut StreamingPackBuilder<File>,
+    states: &HashMap<StateId, State>,
+    order: &[StateId],
+    context: &RepackContext,
+    corrupt_first: &mut bool,
+) -> Result<u64, BuildError> {
+    let mut batch = Vec::new();
+    let mut source_bytes = 0usize;
+    let mut logical_bytes = 0u64;
+    for id in order {
+        let state = states[id].clone();
+        let bytes = rmp_serde::to_vec_named(&state).map_err(HeddleError::from)?;
+        source_bytes = source_bytes.saturating_add(bytes.len());
+        logical_bytes = logical_bytes.saturating_add(bytes.len() as u64);
+        batch.push((*id, state));
+        context
+            .checkpoint(bytes.len() as u64)
+            .map_err(BuildError::Cancelled)?;
+        if source_bytes >= FRAME_LIMIT {
+            write_state_batch(builder, &batch, corrupt_first)?;
+            batch.clear();
+            source_bytes = 0;
+        }
+    }
+    write_state_batch(builder, &batch, corrupt_first)?;
+    Ok(logical_bytes)
+}
+
+fn write_state_batch(
+    builder: &mut StreamingPackBuilder<File>,
+    records: &[(StateId, State)],
+    corrupt_first: &mut bool,
+) -> Result<(), BuildError> {
+    if records.is_empty() {
+        return Ok(());
+    }
+    let states = records
+        .iter()
+        .map(|(_, state)| state.clone())
+        .collect::<Vec<_>>();
+    let mut frame = encode_state_frame(&states).map_err(compact_error)?;
+    if frame.len() > FRAME_LIMIT && records.len() > 1 {
+        let middle = records.len() / 2;
+        write_state_batch(builder, &records[..middle], corrupt_first)?;
+        return write_state_batch(builder, &records[middle..], corrupt_first);
+    }
+    verify_state_frame(records, &frame)?;
+    corrupt_if_requested(&mut frame, corrupt_first);
+    let stored = compress_compact_frame(&frame)?;
+    let ids = records
+        .iter()
+        .map(|(id, _)| PackObjectId::StateId(*id))
+        .collect::<Vec<_>>();
+    builder.add_shared_frame(&ids, ObjectType::State, frame.len(), &stored)?;
+    Ok(())
+}
+
+fn verify_state_frame(records: &[(StateId, State)], frame: &[u8]) -> Result<(), BuildError> {
+    let decoded = decode_state_frame(frame).map_err(compact_error)?;
+    if decoded.len() != records.len() {
+        return Err(
+            HeddleError::InvalidObject("compact state frame changed object count".into()).into(),
+        );
+    }
+    for ((id, expected), actual) in records.iter().zip(decoded) {
+        if actual.id() != *id {
+            return Err(HeddleError::InvalidObject(
+                "compact state frame changed its typed id".into(),
+            )
+            .into());
+        }
+        let actual_bytes = rmp_serde::to_vec_named(&actual).map_err(HeddleError::from)?;
+        let expected_bytes = rmp_serde::to_vec_named(expected).map_err(HeddleError::from)?;
+        if actual_bytes != expected_bytes {
+            return Err(HeddleError::InvalidObject(
+                "compact state frame changed native bytes".into(),
+            )
+            .into());
+        }
+    }
+    Ok(())
+}

--- a/crates/objects/src/store/fs/repack/mod.rs
+++ b/crates/objects/src/store/fs/repack/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Filesystem payload for the storage-agnostic repack scheduler.
 
+mod compact;
 mod cutover;
 mod operation;
 mod staging;

--- a/crates/objects/src/store/fs/repack/operation.rs
+++ b/crates/objects/src/store/fs/repack/operation.rs
@@ -8,6 +8,7 @@ use super::{
         fs_io::list_hashes_from_dir,
         fs_paths::{blobs_dir, packs_dir, trees_dir},
     },
+    compact::add_compact_metadata,
     cutover::{
         acquire_repack_lock, cutover, file_len, hash_file, object_file_len, preserve_commit_markers,
     },
@@ -16,17 +17,17 @@ use super::{
 use crate::store::{
     HeddleError, ObjectStore, Result,
     pack::{
-        ObjectType, PackObjectId, RepackContext, RepackError, RepackInventory, RepackOperation,
-        RepackOutcome, StreamingPackBuilder,
+        ObjectType, PackObjectId, PackReader, RepackContext, RepackError, RepackInventory,
+        RepackOperation, RepackOutcome, StreamingPackBuilder,
     },
 };
 
-/// Existing LMPK encoder wired behind the generic background repack seam.
+/// Compact native encoder wired behind the generic background repack seam.
 ///
 /// It streams one object at a time (bounded memory), verifies every typed id
 /// and the exact expected object set, then installs the immutable replacement
-/// before retiring source packs under the pack-manager write lock. S2/S4
-/// replace this operation; the scheduler itself has no native-pack knowledge.
+/// before retiring source packs under the pack-manager write lock. The
+/// scheduler itself has no native-pack knowledge.
 pub struct FsRepackOperation {
     store: FsStore,
     #[cfg(test)]
@@ -161,39 +162,49 @@ impl FsRepackOperation {
             compression,
             staging.buckets.clone(),
         )?;
-        let loose_tree_set = snapshot.loose_trees.iter().copied().collect::<HashSet<_>>();
         let mut expected = HashSet::new();
+        let mut state_ids = Vec::new();
+        let mut tree_hashes = Vec::new();
         #[cfg(test)]
-        let mut first = true;
+        let mut corrupt_first = self.corrupt_first_object;
+        #[cfg(not(test))]
+        let mut corrupt_first = false;
+        let mut logical_bytes = 0u64;
 
-        for id in &snapshot.ids {
-            if !expected.insert(*id) {
-                continue;
+        for (pack, index) in &snapshot.old_pack_files {
+            let reader = PackReader::open(pack, index)?;
+            let mut checkpoint_error = None;
+            let visit = reader.visit_objects(|id, object_type, data| {
+                if !expected.insert(id) {
+                    return Ok(());
+                }
+                match (id, object_type) {
+                    (PackObjectId::Hash(hash), ObjectType::Tree) => tree_hashes.push(hash),
+                    (PackObjectId::StateId(state_id), ObjectType::State) => {
+                        state_ids.push(state_id);
+                    }
+                    _ => {
+                        let mut data = data.to_vec();
+                        if corrupt_first {
+                            data.push(0xff);
+                            corrupt_first = false;
+                        }
+                        logical_bytes = logical_bytes.saturating_add(data.len() as u64);
+                        builder.add_id(id, object_type, data)?;
+                    }
+                }
+                if let Err(error) = context.checkpoint(data.len() as u64) {
+                    checkpoint_error = Some(error);
+                    return Err(HeddleError::InvalidObject(
+                        "repack source walk interrupted".to_string(),
+                    ));
+                }
+                Ok(())
+            });
+            if let Some(error) = checkpoint_error {
+                return Err(BuildError::Cancelled(error));
             }
-            let Some((object_type, mut data)) = self.read_snapshot_object(id)? else {
-                return Err(HeddleError::InvalidObject(format!(
-                    "repack source object disappeared: {id:?}"
-                ))
-                .into());
-            };
-            if let PackObjectId::Hash(hash) = id
-                && object_type == ObjectType::Tree
-                && loose_tree_set.contains(hash)
-                && let Some(loose) = ObjectStore::get_tree_serialized(&self.store, hash)?
-            {
-                data = loose;
-            }
-            #[cfg(test)]
-            if self.corrupt_first_object && first {
-                data.push(0xff);
-            }
-            #[cfg(test)]
-            {
-                first = false;
-            }
-            let bytes = data.len() as u64;
-            builder.add_id(*id, object_type, data)?;
-            context.checkpoint(bytes).map_err(BuildError::Cancelled)?;
+            visit?;
         }
         for hash in &snapshot.loose_blobs {
             let id = PackObjectId::Hash(*hash);
@@ -204,31 +215,26 @@ impl FsRepackOperation {
                 let data = blob.content().to_vec();
                 let bytes = data.len() as u64;
                 builder.add(*hash, ObjectType::Blob, data)?;
+                logical_bytes = logical_bytes.saturating_add(bytes);
                 context.checkpoint(bytes).map_err(BuildError::Cancelled)?;
             }
         }
         for hash in &snapshot.loose_trees {
             let id = PackObjectId::Hash(*hash);
             if expected.insert(id) {
-                let data =
-                    ObjectStore::get_tree_serialized(&self.store, hash)?.ok_or_else(|| {
-                        HeddleError::InvalidObject(format!("loose tree disappeared: {hash}"))
-                    })?;
-                let bytes = data.len() as u64;
-                builder.add(*hash, ObjectType::Tree, data)?;
-                context.checkpoint(bytes).map_err(BuildError::Cancelled)?;
+                tree_hashes.push(*hash);
             }
         }
-        let (_, stats) = builder.finalize()?;
-        Ok((expected, stats.total_uncompressed))
-    }
-
-    fn read_snapshot_object(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Vec<u8>)>> {
-        let manager =
-            self.store.pack_manager().read().map_err(|_| {
-                HeddleError::Config("Failed to acquire pack manager lock".to_string())
-            })?;
-        manager.get_object(id)
+        logical_bytes = logical_bytes.saturating_add(add_compact_metadata(
+            &self.store,
+            &mut builder,
+            &state_ids,
+            &tree_hashes,
+            context,
+            &mut corrupt_first,
+        )?);
+        builder.finalize()?;
+        Ok((expected, logical_bytes))
     }
 }
 

--- a/crates/objects/src/store/fs/repack/staging.rs
+++ b/crates/objects/src/store/fs/repack/staging.rs
@@ -109,14 +109,21 @@ pub(super) fn verify_staged(
             "replacement pack object set differs from the source snapshot",
         ));
     }
-    for id in ids {
-        let (object_type, data) = reader
-            .get_object(&id)
-            .map_err(RepackError::operation)?
-            .ok_or_else(|| RepackError::message(format!("replacement object missing: {id:?}")))?;
-        validate_pack_entry(&id, object_type, &data).map_err(RepackError::operation)?;
-        context.checkpoint(data.len() as u64)?;
+    let mut checkpoint_error = None;
+    let verification = reader.visit_objects(|id, object_type, data| {
+        validate_pack_entry(&id, object_type, data)?;
+        if let Err(error) = context.checkpoint(data.len() as u64) {
+            checkpoint_error = Some(error);
+            return Err(HeddleError::InvalidObject(
+                "compact verification interrupted".to_string(),
+            ));
+        }
+        Ok(())
+    });
+    if let Some(error) = checkpoint_error {
+        return Err(error);
     }
+    verification.map_err(RepackError::operation)?;
     Ok(())
 }
 

--- a/crates/objects/src/store/fs/repack/tests/integrity.rs
+++ b/crates/objects/src/store/fs/repack/tests/integrity.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{fs, num::NonZeroUsize, sync::Arc};
 
 use chrono::{TimeZone, Utc};
 use heddle_format::compression::CompressionConfig;
@@ -11,7 +11,7 @@ use crate::{
     store::{
         FsRepackOperation, ObjectStore, RepackError, RepackOperation, RepackPolicy,
         RepackResourceLimits, RepackScheduler,
-        pack::{ObjectType, PackBuilder, PackObjectId},
+        pack::{ObjectType, PackBuilder, PackObjectId, PackReader},
     },
 };
 
@@ -27,6 +27,13 @@ fn repack_preserves_every_typed_identity_byte_identically() {
     let attribution = Attribution::human(Principal::new("Repack", "repack@example.com"));
     let state = State::new(tree_hash, vec![], attribution.clone()).with_intent("integrity");
     let state_id = state.id();
+    let tree_two = Tree::from_entries(vec![
+        TreeEntry::file("payload.txt", blob_hash, true).unwrap(),
+    ]);
+    let tree_two_hash = tree_two.hash();
+    let state_two = State::new(tree_two_hash, vec![state_id], attribution.clone())
+        .with_intent("second directory version");
+    let state_two_id = state_two.id();
     let mut action = Action::new(
         None,
         state_id,
@@ -54,6 +61,16 @@ fn repack_preserves_every_typed_identity_byte_identically() {
             rmp_serde::to_vec_named(&state).unwrap(),
         ),
         (
+            PackObjectId::Hash(tree_two_hash),
+            ObjectType::Tree,
+            rmp_serde::to_vec_named(&tree_two).unwrap(),
+        ),
+        (
+            PackObjectId::StateId(state_two_id),
+            ObjectType::State,
+            rmp_serde::to_vec_named(&state_two).unwrap(),
+        ),
+        (
             PackObjectId::Hash(*action_id.as_hash()),
             ObjectType::Action,
             rmp_serde::to_vec_named(&action).unwrap(),
@@ -71,7 +88,23 @@ fn repack_preserves_every_typed_identity_byte_identically() {
     let report = started_handle(scheduler(None).repack_now(operation).unwrap())
         .wait()
         .unwrap();
-    assert_eq!(report.objects_repacked, 4);
+    assert_eq!(report.objects_repacked, 6);
+    let pack_name = direct_pack_names(store.root())
+        .into_iter()
+        .find(|name| name.ends_with(".pack"))
+        .expect("replacement pack");
+    let pack_path = store.root().join("packs").join(pack_name);
+    let index_path = pack_path.with_extension("idx");
+    let pack_bytes = fs::read(&pack_path).unwrap();
+    assert_eq!(u64::from_be_bytes(pack_bytes[8..16].try_into().unwrap()), 4);
+    assert_eq!(
+        PackReader::open(&pack_path, &index_path)
+            .unwrap()
+            .list_ids()
+            .unwrap()
+            .len(),
+        expected.len()
+    );
     stale_reader.clear_recent_object_caches();
 
     for (id, expected_type, expected_bytes) in &expected {
@@ -163,4 +196,45 @@ fn deliberately_corrupted_repack_output_is_rejected_before_cutover() {
         .wait()
         .unwrap();
     assert_eq!(store.get_blob(&hash).unwrap().unwrap().hash(), hash);
+}
+
+#[test]
+fn corrupted_compact_metadata_frame_is_rejected_before_cutover() {
+    let (_temp, store) = create_store();
+    let tree = Tree::from_entries(Vec::new());
+    let tree_hash = tree.hash();
+    let state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Compact", "compact@example.com")),
+    );
+    let state_id = state.id();
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add_id(
+        PackObjectId::Hash(tree_hash),
+        ObjectType::Tree,
+        rmp_serde::to_vec_named(&tree).unwrap(),
+    );
+    builder.add_id(
+        PackObjectId::StateId(state_id),
+        ObjectType::State,
+        rmp_serde::to_vec_named(&state).unwrap(),
+    );
+    let (pack, index, _) = builder.build().unwrap();
+    store.install_pack(&pack, &index).unwrap();
+    let before = direct_pack_names(store.root());
+
+    let corrupt = Arc::new(FsRepackOperation::new(store.clone()).with_corrupted_output());
+    let error = started_handle(scheduler(None).repack_now(corrupt).unwrap())
+        .wait()
+        .unwrap_err();
+
+    assert!(
+        matches!(error, RepackError::Operation(ref message) if message.contains("compact frame checksum mismatch")),
+        "whole-frame verification should reject corrupt compact metadata, got {error:?}"
+    );
+    assert_eq!(direct_pack_names(store.root()), before);
+    store.clear_recent_object_caches();
+    assert_eq!(store.get_tree(&tree_hash).unwrap().unwrap(), tree);
+    assert_eq!(store.get_state(&state_id).unwrap().unwrap().id(), state_id);
 }

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -16,6 +16,7 @@ heddle-format = { path = "../format", version = "0.11" }
 heddle-fs-prims = { path = "../fs-prims", version = "0.11" }
 heddle-object-model = { path = "../object-model", version = "0.11" }
 memmap2.workspace = true
+rmp-serde.workspace = true
 tracing.workspace = true
 zstd = { workspace = true, optional = true }
 

--- a/crates/pack/src/store/pack/compact_frame.rs
+++ b/crates/pack/src/store/pack/compact_frame.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::store::Result;
+
+/// Compress one compact metadata frame with the measured lineage-solid policy.
+///
+/// Level 19 plus a 2^27-byte long-distance window matches the #1325 falsifier.
+/// Incompressible input remains raw so the pack reader's size discriminator is
+/// unambiguous. Builds without `zstd` retain the lossless compact encoding but
+/// store its frames raw.
+pub fn compress_compact_frame(data: &[u8]) -> Result<Vec<u8>> {
+    #[cfg(feature = "zstd")]
+    {
+        use std::io::Write;
+
+        let mut compressed = Vec::new();
+        let mut encoder = zstd::stream::write::Encoder::new(&mut compressed, 19)?;
+        encoder.window_log(27)?;
+        encoder.long_distance_matching(true)?;
+        encoder.include_checksum(true)?;
+        encoder.set_pledged_src_size(Some(data.len() as u64))?;
+        encoder.write_all(data)?;
+        encoder.finish()?;
+        if compressed.len() < data.len() {
+            return Ok(compressed);
+        }
+    }
+    Ok(data.to_vec())
+}
+
+#[cfg(all(test, feature = "zstd"))]
+mod tests {
+    use super::*;
+    use crate::store::pack::{decompress_pack_payload, has_zstd_magic};
+
+    #[test]
+    fn solid_compression_round_trips_and_carries_a_zstd_checksum() {
+        let input = b"directory version\n".repeat(32_768);
+        let compressed = compress_compact_frame(&input).unwrap();
+        assert!(has_zstd_magic(&compressed));
+        assert!(compressed.len() < input.len());
+        assert_eq!(
+            decompress_pack_payload(&compressed, input.len()).unwrap(),
+            input
+        );
+    }
+}

--- a/crates/pack/src/store/pack/mod.rs
+++ b/crates/pack/src/store/pack/mod.rs
@@ -4,6 +4,7 @@
 //! Packfiles bundle multiple objects together with delta compression,
 //! achieving 50-70% space savings for repositories with many similar objects.
 
+mod compact_frame;
 mod manager;
 mod pack_builder;
 mod pack_index;
@@ -17,6 +18,7 @@ mod versioned_header;
 #[cfg(test)]
 mod pack_tests;
 
+pub use compact_frame::compress_compact_frame;
 pub use manager::PackManager;
 pub use pack_builder::PackBuilder;
 pub use pack_index::PackIndex;

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pack reader for extracting objects from packfiles.
 
-use std::{collections::HashSet, fs::File, io::Read, path::Path};
+use std::{
+    collections::{BTreeSet, HashSet},
+    fs::File,
+    io::Read,
+    path::Path,
+};
 
 use bytes::Bytes;
 use heddle_format::delta::{DeltaDecoder, MAX_DELTA_OUTPUT_SIZE};
@@ -20,6 +25,9 @@ use crate::{
 const MAX_PACK_DELTA_OUTPUT_SIZE: usize = MAX_DELTA_OUTPUT_SIZE;
 const MAX_DELTA_CHAIN_DEPTH: usize = 50;
 const MMAP_THRESHOLD_BYTES: u64 = 256 * 1024;
+
+type DecodedCompactObject = (PackObjectId, ObjectType, Vec<u8>);
+type DecodedCompactObjects = Vec<DecodedCompactObject>;
 
 fn read_file_bytes_for_pack(path: &Path) -> Result<Bytes> {
     let file = File::open(path)?;
@@ -165,6 +173,77 @@ impl<'a> PackReader<'a> {
         Ok(self.index.find(id)?.is_some())
     }
 
+    /// Compressed payload bytes used by unique physical records of `obj_type`.
+    ///
+    /// Shared compact frames have one record offset indexed by many logical
+    /// ids, so offsets are deduplicated before bytes are counted.
+    pub fn encoded_payload_bytes(&self, obj_type: ObjectType) -> Result<u64> {
+        let mut offsets = BTreeSet::new();
+        for id in self.index.ids()? {
+            if let Some(offset) = self.index.find(&id)? {
+                offsets.insert(checked_index_offset(offset)?);
+            }
+        }
+        let mut bytes = 0u64;
+        for offset in offsets {
+            let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+            if header.obj_type == obj_type {
+                bytes = bytes.saturating_add(header.compressed_size as u64);
+            }
+        }
+        Ok(bytes)
+    }
+
+    /// Visit every logical object while decoding each shared frame once.
+    ///
+    /// The index-to-frame membership is checked exactly before objects are
+    /// yielded, closing both missing-entry and stale-alias corruption paths.
+    pub fn visit_objects(
+        &self,
+        mut visitor: impl FnMut(PackObjectId, ObjectType, &[u8]) -> Result<()>,
+    ) -> Result<()> {
+        let mut locations = std::collections::BTreeMap::<usize, Vec<PackObjectId>>::new();
+        for id in self.index.ids()? {
+            let offset = self
+                .index
+                .find(&id)?
+                .ok_or_else(|| StoreError::InvalidObject("indexed object disappeared".into()))?;
+            locations
+                .entry(checked_index_offset(offset)?)
+                .or_default()
+                .push(id);
+        }
+        for (offset, indexed_ids) in locations {
+            if let Some(objects) = self.read_compact_objects_at(offset)? {
+                let actual = objects.iter().map(|(id, _, _)| *id).collect::<HashSet<_>>();
+                let indexed = indexed_ids.iter().copied().collect::<HashSet<_>>();
+                if actual != indexed
+                    || actual.len() != objects.len()
+                    || indexed.len() != indexed_ids.len()
+                {
+                    return Err(StoreError::InvalidObject(
+                        "compact frame object set differs from its index".into(),
+                    ));
+                }
+                for (id, object_type, data) in objects {
+                    visitor(id, object_type, &data)?;
+                }
+                continue;
+            }
+            if indexed_ids.len() != 1 {
+                return Err(StoreError::InvalidObject(
+                    "ordinary pack record is indexed by multiple object ids".into(),
+                ));
+            }
+            let id = indexed_ids[0];
+            let (object_type, data) = self
+                .get_object(&id)?
+                .ok_or_else(|| StoreError::InvalidObject("indexed object is missing".into()))?;
+            visitor(id, object_type, &data)?;
+        }
+        Ok(())
+    }
+
     /// Copy a validated subset of non-delta encoded entries into a standalone
     /// hosted transport pack without decoding or recompressing their bodies.
     ///
@@ -204,6 +283,11 @@ impl<'a> PackReader<'a> {
                 ));
             }
             let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+            if matches!(header.obj_type, ObjectType::Tree | ObjectType::State)
+                && self.read_compact_objects_at(offset)?.is_some()
+            {
+                return Ok(None);
+            }
             let expected_size = usize::try_from(*expected_size).ok();
             if header.id != *expected_id
                 || header.obj_type != *expected_type
@@ -269,8 +353,7 @@ impl<'a> PackReader<'a> {
             None => return Ok(None),
         };
 
-        let record = self.read_record_at_depth(offset, 0)?;
-        verify_record_id_matches(id, &record.id)?;
+        let record = self.read_record_at_depth(id, offset, 0)?;
         Ok(Some((record.obj_type, record.data)))
     }
 
@@ -319,7 +402,6 @@ impl<'a> PackReader<'a> {
         // `get_object` for the long-form rationale). 32-byte
         // compare; cheaper than the size+varint decode that follows.
         let (record_id, id_len) = PackObjectId::decode_tagged(self.content_from(offset)?)?;
-        verify_record_id_matches(id, &record_id)?;
         let header_start = checked_index_add(offset, id_len, "record header start")?;
         let (obj_type, uncompressed_size, type_len) =
             varint::decode_type_and_size(self.content_from(header_start)?).ok_or_else(|| {
@@ -334,16 +416,20 @@ impl<'a> PackReader<'a> {
         // Fast path: non-delta entry stored uncompressed. The most
         // common shape for snapshot-time packs (the builder skips
         // the delta search for unrelated blobs).
-        if obj_type != ObjectType::Delta && compressed_size == uncompressed_size {
+        if record_id == *id && obj_type != ObjectType::Delta && compressed_size == uncompressed_size
+        {
             let data_start = checked_index_add(varint_start, comp_len, "entry data start")?;
             let data_end = checked_data_end(data_start, compressed_size, self.content_end)?;
-            return Ok(Some((obj_type, self.data.slice(data_start..data_end))));
+            let data = &self.data.as_slice()[data_start..data_end];
+            if !is_compact_frame(data) {
+                return Ok(Some((obj_type, self.data.slice(data_start..data_end))));
+            }
         }
 
         // Slow path: defer to the full record reader (it handles
         // decompression + delta chains) and Bytes-wrap the Vec.
         // Bytes::from(Vec) is a single Arc allocation, no body copy.
-        let record = self.read_record_at_depth(offset, 0)?;
+        let record = self.read_record_at_depth(id, offset, 0)?;
         Ok(Some((record.obj_type, Bytes::from(record.data))))
     }
 
@@ -375,12 +461,18 @@ impl<'a> PackReader<'a> {
             ));
         }
         let (record_id, id_len) = PackObjectId::decode_tagged(self.content_from(offset)?)?;
-        verify_record_id_matches(&id, &record_id)?;
         let header_start = checked_index_add(offset, id_len, "record header start")?;
         let (obj_type, uncompressed_size, _type_len) = super::varint::decode_type_and_size(
             self.content_from(header_start)?,
         )
         .ok_or_else(|| StoreError::InvalidObject("Truncated type+size varint".to_string()))?;
+        if matches!(obj_type, ObjectType::Tree | ObjectType::State) {
+            let Some((_, data)) = self.get_object(&id)? else {
+                return Ok(None);
+            };
+            return Ok(Some(data.len() as u64));
+        }
+        verify_record_id_matches(&id, &record_id)?;
         if obj_type == ObjectType::Delta {
             // Delta entries record the *resolved* output size in the
             // type+size varint already (see `read_record_at_depth`'s
@@ -409,7 +501,11 @@ impl<'a> PackReader<'a> {
         }
 
         let header = decode_tagged_entry_header(self.content_from(offset)?)?;
-        verify_record_id_matches(requested_id, &header.id)?;
+        if header.id != *requested_id {
+            return self
+                .read_record_at_depth(requested_id, offset, depth)
+                .map(|record| record.obj_type);
+        }
         if header.obj_type != ObjectType::Delta {
             return Ok(header.obj_type);
         }
@@ -423,7 +519,12 @@ impl<'a> PackReader<'a> {
         self.read_object_type_at_depth(&base_id, checked_index_offset(base_offset)?, depth + 1)
     }
 
-    fn read_record_at_depth(&self, offset: usize, depth: usize) -> Result<PackObjectRecord> {
+    fn read_record_at_depth(
+        &self,
+        requested_id: &PackObjectId,
+        offset: usize,
+        depth: usize,
+    ) -> Result<PackObjectRecord> {
         if offset >= self.content_end {
             return Err(StoreError::InvalidObject(
                 "Entry offset out of bounds".to_string(),
@@ -474,6 +575,18 @@ impl<'a> PackReader<'a> {
             stored_data.to_vec()
         };
 
+        if obj_type != ObjectType::Delta
+            && let Some(data) = decode_compact_object(requested_id, obj_type, &decompressed)?
+        {
+            return Ok(PackObjectRecord {
+                id: *requested_id,
+                obj_type,
+                data,
+                delta_base: None,
+                path_hint: None,
+            });
+        }
+        verify_record_id_matches(requested_id, &id)?;
         let (resolved_type, final_data) = if obj_type == ObjectType::Delta {
             self.read_delta_record(base_id, &decompressed, uncompressed_size, depth)?
         } else {
@@ -495,6 +608,34 @@ impl<'a> PackReader<'a> {
             delta_base: None,
             path_hint: None,
         })
+    }
+
+    fn read_compact_objects_at(&self, offset: usize) -> Result<Option<DecodedCompactObjects>> {
+        if offset >= self.content_end {
+            return Err(StoreError::InvalidObject(
+                "Entry offset out of bounds".to_string(),
+            ));
+        }
+        let header = decode_tagged_entry_header(self.content_from(offset)?)?;
+        if !matches!(header.obj_type, ObjectType::Tree | ObjectType::State) {
+            return Ok(None);
+        }
+        let data_start = checked_index_add(offset, header.header_len, "entry data start")?;
+        let data_end = checked_data_end(data_start, header.compressed_size, self.content_end)?;
+        let stored = &self.data.as_slice()[data_start..data_end];
+        let data = if header.compressed_size != header.uncompressed_size {
+            decompress_pack_payload(stored, header.uncompressed_size)?
+        } else {
+            stored.to_vec()
+        };
+        if data.len() != header.uncompressed_size {
+            return Err(StoreError::InvalidObject(format!(
+                "Size mismatch: expected {}, got {}",
+                header.uncompressed_size,
+                data.len()
+            )));
+        }
+        decode_compact_objects(header.obj_type, &data)
     }
 
     fn read_delta_record(
@@ -524,7 +665,8 @@ impl<'a> PackReader<'a> {
             .find(&PackObjectId::Hash(base_hash))?
             .ok_or_else(|| StoreError::NotFound(base_hash.to_string()))?;
         let base_offset = checked_index_offset(base_offset)?;
-        let base_record = self.read_record_at_depth(base_offset, depth + 1)?;
+        let base_id = PackObjectId::Hash(base_hash);
+        let base_record = self.read_record_at_depth(&base_id, base_offset, depth + 1)?;
         let base_type = base_record.obj_type;
         let base_data = base_record.data;
 
@@ -617,6 +759,72 @@ fn verify_record_id_matches(requested: &PackObjectId, found: &PackObjectId) -> R
          — index is stale or corrupt; the loose-store path will re-promote on \
          the next read"
     )))
+}
+
+fn is_compact_frame(data: &[u8]) -> bool {
+    heddle_object_model::compact::is_tree_frame(data)
+        || heddle_object_model::compact::is_state_frame(data)
+}
+
+fn decode_compact_object(
+    requested_id: &PackObjectId,
+    obj_type: ObjectType,
+    data: &[u8],
+) -> Result<Option<Vec<u8>>> {
+    let Some(objects) = decode_compact_objects(obj_type, data)? else {
+        return Ok(None);
+    };
+    objects
+        .into_iter()
+        .find_map(|(id, _, bytes)| (id == *requested_id).then_some(bytes))
+        .map(Some)
+        .ok_or_else(|| compact_index_miss(requested_id))
+}
+
+fn decode_compact_objects(
+    obj_type: ObjectType,
+    data: &[u8],
+) -> Result<Option<DecodedCompactObjects>> {
+    if !is_compact_frame(data) {
+        return Ok(None);
+    }
+    match obj_type {
+        ObjectType::Tree if heddle_object_model::compact::is_tree_frame(data) => {
+            heddle_object_model::compact::decode_tree_frame(data)
+                .map_err(|error| StoreError::InvalidObject(error.to_string()))?
+                .into_iter()
+                .map(|tree| {
+                    let id = PackObjectId::Hash(tree.hash());
+                    let bytes = rmp_serde::to_vec_named(&tree)
+                        .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
+                    Ok((id, ObjectType::Tree, bytes))
+                })
+                .collect::<Result<Vec<_>>>()
+                .map(Some)
+        }
+        ObjectType::State if heddle_object_model::compact::is_state_frame(data) => {
+            heddle_object_model::compact::decode_state_frame(data)
+                .map_err(|error| StoreError::InvalidObject(error.to_string()))?
+                .into_iter()
+                .map(|state| {
+                    let id = PackObjectId::StateId(state.state_id);
+                    let bytes = rmp_serde::to_vec_named(&state)
+                        .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
+                    Ok((id, ObjectType::State, bytes))
+                })
+                .collect::<Result<Vec<_>>>()
+                .map(Some)
+        }
+        _ => Err(StoreError::InvalidObject(
+            "compact frame magic does not match its pack object type".into(),
+        )),
+    }
+}
+
+fn compact_index_miss(id: &PackObjectId) -> StoreError {
+    StoreError::InvalidObject(format!(
+        "compact frame does not contain indexed object {id:?}"
+    ))
 }
 
 #[cfg(test)]

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -59,6 +59,7 @@
 //!   the second pass.
 
 use std::{
+    collections::HashSet,
     fs::{File, OpenOptions},
     io::{self, BufWriter, Cursor, Read, Seek, SeekFrom, Write},
     path::PathBuf,
@@ -136,6 +137,7 @@ pub struct StreamingPackBuilder<W: Write + Read + Seek> {
     /// Logical append position. Avoids flushing the buffered writer before
     /// every object just to ask the file for its current offset.
     pack_position: u64,
+    record_count: u64,
     object_count: u64,
     declared_object_count: Option<u64>,
     total_uncompressed: u64,
@@ -313,6 +315,7 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
             pack_writer: Some(BufWriter::new(pack_writer)),
             header_offset,
             pack_position: header_offset + header_bytes.len() as u64,
+            record_count: 0,
             object_count: 0,
             declared_object_count,
             total_uncompressed: 0,
@@ -509,18 +512,100 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
             }
         }
 
-        // Append the index entry (id || u64 BE offset) to the bucket
-        // matching the id's first inner byte. The bucket file is opened
-        // lazily so a sparse pack only creates files it actually uses.
-        let bucket_idx = bucket_index_for(&id);
-        let bucket = self.get_or_open_bucket(bucket_idx)?;
-        let mut idx_entry = Vec::with_capacity(33 + 8);
-        id.encode_tagged(&mut idx_entry);
-        idx_entry.extend_from_slice(&offset.to_be_bytes());
-        bucket.write_all(&idx_entry).map_err(StoreError::from)?;
-
+        self.add_index_entry(id, offset)?;
+        self.record_count += 1;
         self.object_count += 1;
         Ok(())
+    }
+
+    /// Add one compact frame shared by several logical tree or state ids.
+    ///
+    /// `stored_data` is either the raw frame or a zstd frame whose decoded
+    /// length is `uncompressed_size`. Every id is indexed at the same physical
+    /// record; [`super::PackReader`] verifies and decodes the complete frame
+    /// before selecting the requested logical object.
+    pub fn add_shared_frame(
+        &mut self,
+        ids: &[PackObjectId],
+        obj_type: ObjectType,
+        uncompressed_size: usize,
+        stored_data: &[u8],
+    ) -> Result<()> {
+        if ids.is_empty() {
+            return Err(StoreError::InvalidObject(
+                "compact frame must contain at least one object".to_string(),
+            ));
+        }
+        if !matches!(obj_type, ObjectType::Tree | ObjectType::State) {
+            return Err(StoreError::InvalidObject(
+                "shared compact frames may contain only trees or states".to_string(),
+            ));
+        }
+        let unique = ids.iter().copied().collect::<HashSet<_>>();
+        if unique.len() != ids.len() {
+            return Err(StoreError::InvalidObject(
+                "compact frame contains duplicate object ids".to_string(),
+            ));
+        }
+        if ids.iter().any(|id| {
+            !matches!(
+                (obj_type, id),
+                (ObjectType::Tree, PackObjectId::Hash(_))
+                    | (ObjectType::State, PackObjectId::StateId(_))
+            )
+        }) {
+            return Err(StoreError::InvalidObject(
+                "compact frame id kind does not match its object type".to_string(),
+            ));
+        }
+
+        let entry_start = self.pack_position;
+        let offset = entry_start
+            .checked_sub(self.header_offset)
+            .expect("header offset should precede compact frame");
+        let mut header = Vec::with_capacity(48);
+        ids[0].encode_tagged(&mut header);
+        super::varint::encode_type_and_size(obj_type, uncompressed_size as u64, &mut header);
+        super::varint::encode_varint(stored_data.len() as u64, &mut header);
+        let writer = self
+            .pack_writer
+            .as_mut()
+            .expect("add_shared_frame called after finalize");
+        writer.write_all(&header).map_err(StoreError::from)?;
+        writer.write_all(stored_data).map_err(StoreError::from)?;
+        self.pack_position = self
+            .pack_position
+            .checked_add((header.len() + stored_data.len()) as u64)
+            .ok_or_else(|| {
+                StoreError::InvalidObject("streaming pack position overflow".to_string())
+            })?;
+        self.total_uncompressed = self
+            .total_uncompressed
+            .saturating_add(uncompressed_size as u64);
+        self.total_compressed = self
+            .total_compressed
+            .saturating_add(stored_data.len() as u64);
+        self.record_count = self
+            .record_count
+            .checked_add(1)
+            .ok_or_else(|| StoreError::InvalidObject("pack record count overflow".to_string()))?;
+        for id in ids {
+            self.add_index_entry(*id, offset)?;
+        }
+        self.object_count = self
+            .object_count
+            .checked_add(ids.len() as u64)
+            .ok_or_else(|| StoreError::InvalidObject("pack object count overflow".to_string()))?;
+        Ok(())
+    }
+
+    fn add_index_entry(&mut self, id: PackObjectId, offset: u64) -> Result<()> {
+        let bucket_idx = bucket_index_for(&id);
+        let bucket = self.get_or_open_bucket(bucket_idx)?;
+        let mut entry = Vec::with_capacity(33 + 8);
+        id.encode_tagged(&mut entry);
+        entry.extend_from_slice(&offset.to_be_bytes());
+        bucket.write_all(&entry).map_err(StoreError::from)
     }
 
     fn get_or_open_bucket(&mut self, idx: usize) -> Result<&mut BufWriter<File>> {
@@ -602,10 +687,10 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
             .into_inner()
             .map_err(|e| StoreError::from(std::io::Error::other(e.to_string())))?;
         if let Some(expected) = self.declared_object_count {
-            if expected != self.object_count {
+            if expected != self.record_count {
                 return Err(StoreError::InvalidObject(format!(
-                    "streaming pack declared {expected} object(s) but added {}",
-                    self.object_count
+                    "streaming pack declared {expected} record(s) but added {}",
+                    self.record_count
                 )));
             }
         } else {
@@ -613,7 +698,7 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
                 .seek(SeekFrom::Start(self.header_offset))
                 .map_err(StoreError::from)?;
             let mut header_bytes = Vec::with_capacity(16);
-            write_container_header(&mut header_bytes, pack_container_spec(), self.object_count);
+            write_container_header(&mut header_bytes, pack_container_spec(), self.record_count);
             writer.write_all(&header_bytes).map_err(StoreError::from)?;
         }
 
@@ -936,6 +1021,93 @@ mod tests {
     }
 
     #[test]
+    fn shared_compact_tree_frame_reconstructs_each_indexed_object() {
+        use crate::object::{Tree, TreeEntry};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let blob = deterministic_hash(0x33);
+        let trees = vec![
+            Tree::from_entries(vec![TreeEntry::file("a", blob, false).unwrap()]),
+            Tree::from_entries(vec![TreeEntry::file("b", blob, true).unwrap()]),
+        ];
+        let ids = trees
+            .iter()
+            .map(|tree| PackObjectId::Hash(tree.hash()))
+            .collect::<Vec<_>>();
+        let frame = heddle_object_model::compact::encode_tree_frame(&trees).unwrap();
+        builder
+            .add_shared_frame(&ids, ObjectType::Tree, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, stats) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        assert_eq!(stats.object_count, 2);
+        assert_eq!(
+            reader.encoded_payload_bytes(ObjectType::Tree).unwrap(),
+            frame.len() as u64
+        );
+        let hosted = ids
+            .iter()
+            .zip(&trees)
+            .map(|(id, tree)| {
+                (
+                    *id,
+                    ObjectType::Tree,
+                    rmp_serde::to_vec_named(tree).unwrap().len() as u64,
+                )
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            reader
+                .copy_hosted_encoded_subset(&hosted)
+                .unwrap()
+                .is_none(),
+            "repository-local compact frames must use the hosted fallback"
+        );
+        for (id, tree) in ids.iter().zip(&trees) {
+            let (object_type, bytes) = reader.get_object(id).unwrap().unwrap();
+            assert_eq!(object_type, ObjectType::Tree);
+            assert_eq!(bytes, rmp_serde::to_vec_named(tree).unwrap());
+        }
+    }
+
+    #[test]
+    fn corrupt_compact_frame_byte_invalidates_every_contained_object() {
+        use crate::object::{Tree, TreeEntry};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let blob = deterministic_hash(0x44);
+        let trees = vec![
+            Tree::from_entries(vec![TreeEntry::file("a", blob, false).unwrap()]),
+            Tree::from_entries(vec![TreeEntry::file("b", blob, true).unwrap()]),
+        ];
+        let ids = trees
+            .iter()
+            .map(|tree| PackObjectId::Hash(tree.hash()))
+            .collect::<Vec<_>>();
+        let mut frame = heddle_object_model::compact::encode_tree_frame(&trees).unwrap();
+        let corrupt_at = frame.len() / 2;
+        frame[corrupt_at] ^= 0x01;
+        builder
+            .add_shared_frame(&ids, ObjectType::Tree, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, _) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        for id in ids {
+            let error = reader.get_object(&id).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("compact frame checksum mismatch"),
+                "unexpected error for {id:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn mixed_hash_and_changeid_ids_all_retrievable() {
         let tmp = tempfile::TempDir::new().unwrap();
         let (mut b, _, idx_path) = fresh_builder(&tmp);
@@ -1225,7 +1397,7 @@ mod tests {
         assert!(
             error
                 .to_string()
-                .contains("streaming pack declared 2 object(s) but added 1")
+                .contains("streaming pack declared 2 record(s) but added 1")
         );
     }
 


### PR DESCRIPTION
## Summary

- Add checksummed, lossless columnar tree and state frames: tree mode/kind/name/target columns, principal and agent dictionaries, delta-varint timestamps, every current Git-fidelity and lineage field, and recomputed state IDs.
- Add shared physical Tree/State records to LMPK with logical index aliases, exact frame/index membership verification, canonical named-MessagePack reconstruction, and zstd level 19 long-distance compression.
- Plug compact metadata into the S1 background `FsRepackOperation`, grouping directory versions newest-to-oldest in bounded frames while retaining S1 staging, verification, and atomic cutover.
- Restore the #1325 lineage-solid falsifier harness from Heddle commit `6bde37fc2f66b2d2d052a4239867b1fc83f6d371` and re-gate its pinned corpora against the real production compact writer.

## Closes

Part of HeddleCo/heddle#1323

## Test evidence

All three pinned corpora completed a real compact repack with identical typed-object fingerprints before and after. The total is actual compact metadata + #1325 lineage-solid blob frames + actual compact index, compared with the pinned Git pack.

| Corpus | Revision | Native objects | Trees / native | States / native | Compact total / Git pack | Byte-identical |
| --- | --- | ---: | ---: | ---: | ---: | --- |
| ripgrep | `3fce3b5bb0236da2df6d99672afb8a719642eca7` | 13,790 | 10.04% | 44.33% | 2,805,825 / 3,380,197 = 83.01% | yes |
| curl | `f5378b88a974e565f767f2a041972aa942a69c5d` | 287,550 | 1.85% | 41.68% | 47,117,705 / 53,893,244 = 87.43% | yes |
| semver-cli | `4fea7f0d5a1c9fca85f764c02953643d7fd45b27` | 373 | 28.31% | 56.55% | 107,166 / 117,623 = 91.11% | yes |

- `cargo test -p heddle-object-model compact`
- `cargo test -p heddle-pack --features zstd`
- `cargo test -p heddle-objects --features zstd`
- `cargo test -p heddle-cli --test commit_conformance`
- `cargo test -p heddle-wire`
- `cargo build --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- Nightly rustfmt on touched Rust files and `git diff --check HEAD`

All Cargo gates used isolated `TMPDIR=/home/scratch` and `CARGO_TARGET_DIR=/home/scratch/heddle-1337-target`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789109297&installation_model_id=21489&pr_number=1338&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1338&signature=4b9cf5021be77693cec44446649624e81455743c3e55d21bf4f3ee19391c385d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->