### PR TITLE
feat(storage): S3 compact-frame reader + hot tier (Part of #1323)

### DIFF
--- a/crates/objects/src/store/fs/repack/tests/hot_tier.rs
+++ b/crates/objects/src/store/fs/repack/tests/hot_tier.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{sync::Arc, time::Duration};
+
+use super::{GateLoad, create_store, direct_pack_names, scheduler, started_handle};
+use crate::{
+    object::{Attribution, ContentHash, Principal, State, Tree, TreeEntry},
+    store::{
+        FsRepackOperation, FsStore, ObjectStore,
+        pack::{ObjectType, PackObjectId, PackReadTier},
+    },
+};
+
+fn metadata(seed: usize, parent: Option<crate::object::StateId>) -> (Tree, State) {
+    let contents = format!("hot-tier-{seed}");
+    let blob = ContentHash::compute_typed("blob", contents.as_bytes());
+    let tree = Tree::from_entries(vec![
+        TreeEntry::file(format!("file-{seed}.txt"), blob, seed.is_multiple_of(2)).unwrap(),
+    ]);
+    let parents = parent.into_iter().collect();
+    let state = State::new(
+        tree.hash(),
+        parents,
+        Attribution::human(Principal::new("Hot Tier", "hot-tier@example.com")),
+    )
+    .with_intent(format!("metadata version {seed}"));
+    (tree, state)
+}
+
+fn read_tier(store: &FsStore, id: PackObjectId) -> PackReadTier {
+    store
+        .pack_manager()
+        .read()
+        .unwrap()
+        .object_read_tier(&id)
+        .unwrap()
+        .expect("object tier")
+}
+
+#[test]
+fn recent_metadata_stays_random_access_until_solidification() {
+    let (_temp, store) = create_store();
+    let (tree_one, state_one) = metadata(1, None);
+    let (tree_two, state_two) = metadata(2, Some(state_one.id()));
+    store
+        .put_snapshot_objects_packed(Vec::new(), &tree_one, &state_one)
+        .unwrap();
+    store
+        .put_snapshot_objects_packed(Vec::new(), &tree_two, &state_two)
+        .unwrap();
+
+    let tree_one_id = PackObjectId::Hash(tree_one.hash());
+    let state_one_id = PackObjectId::StateId(state_one.id());
+    assert_eq!(read_tier(&store, tree_one_id), PackReadTier::Hot);
+    assert_eq!(read_tier(&store, state_one_id), PackReadTier::Hot);
+
+    let operation = Arc::new(FsRepackOperation::new(store.clone()));
+    let report = started_handle(scheduler(None).repack_now(operation).unwrap())
+        .wait()
+        .unwrap();
+    assert_eq!(report.objects_repacked, 4);
+    let solid_store = FsStore::new(store.root());
+    assert_eq!(
+        read_tier(&solid_store, tree_one_id),
+        PackReadTier::SolidFrame,
+        "packs after solidification: {:?}",
+        direct_pack_names(store.root())
+    );
+    assert_eq!(
+        read_tier(&solid_store, state_one_id),
+        PackReadTier::SolidFrame
+    );
+
+    solid_store.clear_recent_object_caches();
+    assert_eq!(
+        solid_store.get_tree(&tree_one.hash()).unwrap().unwrap(),
+        tree_one
+    );
+    let (_, state_bytes) = solid_store
+        .get_pack_object(&state_one_id)
+        .unwrap()
+        .expect("solid state frame");
+    assert_eq!(
+        state_bytes,
+        rmp_serde::to_vec_named(&state_one).unwrap(),
+        "solid-frame extraction must preserve canonical native bytes"
+    );
+
+    let (recent_tree, recent_state) = metadata(3, Some(state_two.id()));
+    solid_store
+        .put_snapshot_objects_packed(Vec::new(), &recent_tree, &recent_state)
+        .unwrap();
+    let recent_tree_id = PackObjectId::Hash(recent_tree.hash());
+    let recent_state_id = PackObjectId::StateId(recent_state.id());
+    assert_eq!(read_tier(&solid_store, recent_tree_id), PackReadTier::Hot);
+    assert_eq!(read_tier(&solid_store, recent_state_id), PackReadTier::Hot);
+
+    solid_store.clear_recent_object_caches();
+    assert_eq!(
+        solid_store.get_tree(&recent_tree.hash()).unwrap().unwrap(),
+        recent_tree
+    );
+    let (object_type, recent_state_bytes) = solid_store
+        .get_pack_object(&recent_state_id)
+        .unwrap()
+        .expect("hot state record");
+    assert_eq!(object_type, ObjectType::State);
+    assert_eq!(
+        recent_state_bytes,
+        rmp_serde::to_vec_named(&recent_state).unwrap()
+    );
+}
+
+#[test]
+fn metadata_installed_during_repack_survives_as_hot_tier() {
+    let (_temp, store) = create_store();
+    let mut parent = None;
+    let mut first_tree = None;
+    for seed in 0..16 {
+        let (tree, state) = metadata(seed, parent);
+        first_tree.get_or_insert_with(|| tree.clone());
+        store
+            .put_snapshot_objects_packed(Vec::new(), &tree, &state)
+            .unwrap();
+        parent = Some(state.id());
+    }
+
+    let (load, paused) = GateLoad::new(8);
+    let operation = Arc::new(FsRepackOperation::new(store.clone()));
+    let handle = started_handle(scheduler(Some(load.clone())).repack_now(operation).unwrap());
+    paused.recv_timeout(Duration::from_secs(5)).unwrap();
+
+    let (concurrent_tree, concurrent_state) = metadata(99, parent);
+    store
+        .put_snapshot_objects_packed(Vec::new(), &concurrent_tree, &concurrent_state)
+        .unwrap();
+    load.release();
+    handle.wait().unwrap();
+
+    let reopened = FsStore::new(store.root());
+    let old_tree_id = PackObjectId::Hash(first_tree.unwrap().hash());
+    let concurrent_tree_id = PackObjectId::Hash(concurrent_tree.hash());
+    let concurrent_state_id = PackObjectId::StateId(concurrent_state.id());
+    assert_eq!(
+        read_tier(&reopened, old_tree_id),
+        PackReadTier::SolidFrame,
+        "packs after concurrent solidification: {:?}",
+        direct_pack_names(store.root())
+    );
+    assert_eq!(read_tier(&reopened, concurrent_tree_id), PackReadTier::Hot);
+    assert_eq!(read_tier(&reopened, concurrent_state_id), PackReadTier::Hot);
+    assert_eq!(
+        direct_pack_names(store.root())
+            .iter()
+            .filter(|name| name.ends_with(".pack"))
+            .count(),
+        2,
+        "cutover must retain the concurrently installed hot pack"
+    );
+
+    reopened.clear_recent_object_caches();
+    assert_eq!(
+        reopened.get_tree(&concurrent_tree.hash()).unwrap().unwrap(),
+        concurrent_tree
+    );
+    assert_eq!(
+        reopened
+            .get_state(&concurrent_state.id())
+            .unwrap()
+            .unwrap()
+            .id(),
+        concurrent_state.id()
+    );
+}

--- a/crates/objects/src/store/fs/repack/tests/mod.rs
+++ b/crates/objects/src/store/fs/repack/tests/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod concurrency;
+mod hot_tier;
 mod integrity;
 
 use std::{

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -14,7 +14,7 @@ use crate::{
     object::ContentHash,
     store::{
         Result,
-        pack::{ObjectType, PackObjectId, PackReader},
+        pack::{ObjectType, PackObjectId, PackReadTier, PackReader},
     },
 };
 
@@ -30,8 +30,14 @@ pub struct PackManager {
 
 #[derive(Default)]
 struct ObjectLocationIndex {
-    locations: HashMap<PackObjectId, usize>,
+    locations: HashMap<PackObjectId, ObjectLocation>,
     complete: bool,
+}
+
+#[derive(Clone, Copy)]
+struct ObjectLocation {
+    pack_index: usize,
+    tier: PackReadTier,
 }
 
 struct CachedPack {
@@ -149,13 +155,11 @@ impl PackManager {
             let Some(reader) = pack.verified_reader() else {
                 continue;
             };
-            let Ok(ids) = reader.list_ids() else {
+            let Ok(objects) = reader.indexed_read_tiers() else {
                 continue;
             };
-            for id in ids {
-                // Preserve the historical first-pack-wins lookup behavior for
-                // duplicate immutable objects.
-                locations.entry(id).or_insert(pack_index);
+            for (id, tier) in objects {
+                remember_location(&mut locations, id, pack_index, tier);
             }
         }
         ObjectLocationIndex {
@@ -178,7 +182,7 @@ impl PackManager {
                 .read()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(location) = index.locations.get(id) {
-                return Ok(Some(*location));
+                return Ok(Some(location.pack_index));
             }
             if index.complete {
                 return Ok(None);
@@ -194,16 +198,16 @@ impl PackManager {
                 let Some(reader) = pack.reader() else {
                     continue;
                 };
-                let Ok(ids) = reader.list_ids() else {
+                let Ok(objects) = reader.indexed_read_tiers() else {
                     continue;
                 };
-                for object_id in ids {
-                    index.locations.entry(object_id).or_insert(pack_index);
+                for (object_id, tier) in objects {
+                    remember_location(&mut index.locations, object_id, pack_index, tier);
                 }
             }
             index.complete = true;
         }
-        Ok(index.locations.get(id).copied())
+        Ok(index.locations.get(id).map(|location| location.pack_index))
     }
 
     /// Add a complete pack/index pair to the in-memory format index.
@@ -212,7 +216,7 @@ impl PackManager {
             return Ok(());
         }
         let reader = PackReader::open(&pack_path, &index_path)?;
-        let ids = reader.list_ids()?;
+        let objects = reader.indexed_read_tiers()?;
         let pack_index = self.packs.len();
         let cached = CachedPack::validated(pack_path, index_path, reader);
         self.packs.push(cached);
@@ -221,8 +225,8 @@ impl PackManager {
             .write()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         if index.complete {
-            for id in ids {
-                index.locations.entry(id).or_insert(pack_index);
+            for (id, tier) in objects {
+                remember_location(&mut index.locations, id, pack_index, tier);
             }
         }
         Ok(())
@@ -276,6 +280,19 @@ impl PackManager {
             trace!("Found object in pack");
         }
         Ok(object)
+    }
+
+    /// Return the physical tier that will serve `id`.
+    ///
+    /// When both layouts contain the same immutable object, lookup always
+    /// selects the hot random-access record before a solid frame.
+    pub fn object_read_tier(&self, id: &PackObjectId) -> Result<Option<PackReadTier>> {
+        let _ = self.object_location(id)?;
+        let index = self
+            .object_locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        Ok(index.locations.get(id).map(|location| location.tier))
     }
 
     /// Read `id` from one specific discovered pack without building the
@@ -401,6 +418,26 @@ impl PackManager {
 
     pub fn packs_dir(&self) -> &Path {
         &self.packs_dir
+    }
+}
+
+fn remember_location(
+    locations: &mut HashMap<PackObjectId, ObjectLocation>,
+    id: PackObjectId,
+    pack_index: usize,
+    tier: PackReadTier,
+) {
+    let candidate = ObjectLocation { pack_index, tier };
+    match locations.get_mut(&id) {
+        Some(existing)
+            if existing.tier == PackReadTier::SolidFrame && tier == PackReadTier::Hot =>
+        {
+            *existing = candidate;
+        }
+        Some(_) => {}
+        None => {
+            locations.insert(id, candidate);
+        }
     }
 }
 

--- a/crates/pack/src/store/pack/manager_tests.rs
+++ b/crates/pack/src/store/pack/manager_tests.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use std::{fs::OpenOptions, sync::Arc};
+
 use heddle_format::compression::CompressionConfig;
 use tempfile::TempDir;
 
 use super::PackManager;
 use crate::{
-    object::ContentHash,
-    store::pack::{ObjectType, PackBuilder},
+    object::{ContentHash, Tree, TreeEntry},
+    store::pack::{ObjectType, PackBuilder, PackObjectId, PackReadTier, StreamingPackBuilder},
 };
 
 fn write_pack(
@@ -30,6 +32,49 @@ fn write_pack(
 
 fn cached_location_count(manager: &PackManager) -> usize {
     manager.object_locations.read().unwrap().locations.len()
+}
+
+fn write_solid_tree_pack(root: &std::path::Path, name: &str, trees: &[Tree]) {
+    let pack_path = root.join(format!("{name}.pack"));
+    let index_path = root.join(format!("{name}.idx"));
+    let bucket_dir = root.join(format!("{name}-buckets"));
+    let file = OpenOptions::new()
+        .create_new(true)
+        .read(true)
+        .write(true)
+        .open(&pack_path)
+        .unwrap();
+    let mut builder =
+        StreamingPackBuilder::new(file, index_path, CompressionConfig::disabled(), bucket_dir)
+            .unwrap();
+    let ids = trees
+        .iter()
+        .map(|tree| PackObjectId::Hash(tree.hash()))
+        .collect::<Vec<_>>();
+    let frame = heddle_object_model::compact::encode_tree_frame(trees).unwrap();
+    builder
+        .add_shared_frame(&ids, ObjectType::Tree, frame.len(), &frame)
+        .unwrap();
+    let _ = builder.finalize().unwrap();
+}
+
+fn write_hot_tree_pack(
+    root: &std::path::Path,
+    name: &str,
+    tree: &Tree,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    let mut builder = PackBuilder::new(CompressionConfig::disabled());
+    builder.add(
+        tree.hash(),
+        ObjectType::Tree,
+        rmp_serde::to_vec_named(tree).unwrap(),
+    );
+    let (pack, index, _) = builder.build().unwrap();
+    let pack_path = root.join(format!("{name}.pack"));
+    let index_path = root.join(format!("{name}.idx"));
+    std::fs::write(&pack_path, pack).unwrap();
+    std::fs::write(&index_path, index).unwrap();
+    (pack_path, index_path)
 }
 
 #[test]
@@ -77,4 +122,67 @@ fn adding_a_pack_extends_a_completed_lazy_index() {
     assert_eq!(cached_location_count(&manager), 1);
     assert!(manager.has_object(&id));
     assert!(manager.get_hashed_object(&id).unwrap().is_some());
+}
+
+#[test]
+fn random_access_record_wins_over_solid_frame_for_concurrent_reads() {
+    let temp = TempDir::new().unwrap();
+    let blob = ContentHash::compute_typed("blob", b"hot-tier-payload");
+    let trees = vec![
+        Tree::from_entries(vec![TreeEntry::file("a", blob, false).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::file("b", blob, true).unwrap()]),
+    ];
+    write_solid_tree_pack(temp.path(), "a-solid", &trees);
+    let mut manager = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
+    let hot_id = PackObjectId::Hash(trees[0].hash());
+    let solid_id = PackObjectId::Hash(trees[1].hash());
+    assert_eq!(
+        manager.object_read_tier(&hot_id).unwrap(),
+        Some(PackReadTier::SolidFrame)
+    );
+
+    let (hot_pack, hot_index) = write_hot_tree_pack(temp.path(), "z-hot", &trees[0]);
+    manager.add_pack(hot_pack, hot_index).unwrap();
+    assert_eq!(
+        manager.object_read_tier(&hot_id).unwrap(),
+        Some(PackReadTier::Hot)
+    );
+    assert_eq!(
+        manager.object_read_tier(&solid_id).unwrap(),
+        Some(PackReadTier::SolidFrame)
+    );
+    let manager = Arc::new(manager);
+
+    let expected = Arc::new(rmp_serde::to_vec_named(&trees[0]).unwrap());
+    let readers = (0..8)
+        .map(|_| {
+            let manager = Arc::clone(&manager);
+            let expected = Arc::clone(&expected);
+            std::thread::spawn(move || {
+                for _ in 0..32 {
+                    let (object_type, bytes) = manager.get_object(&hot_id).unwrap().unwrap();
+                    assert_eq!(object_type, ObjectType::Tree);
+                    assert_eq!(bytes, *expected);
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    for reader in readers {
+        reader.join().unwrap();
+    }
+
+    let solid = manager
+        .packs
+        .iter()
+        .find(|pack| pack.pack_path.ends_with("a-solid.pack"))
+        .unwrap()
+        .reader()
+        .unwrap();
+    assert_eq!(
+        solid.compact_frame_read_count(),
+        0,
+        "hot-tier point reads must not decompress the duplicate solid frame"
+    );
+    assert!(manager.get_object(&solid_id).unwrap().is_some());
+    assert_eq!(solid.compact_frame_read_count(), 1);
 }

--- a/crates/pack/src/store/pack/mod.rs
+++ b/crates/pack/src/store/pack/mod.rs
@@ -22,7 +22,7 @@ pub use compact_frame::compress_compact_frame;
 pub use manager::PackManager;
 pub use pack_builder::PackBuilder;
 pub use pack_index::PackIndex;
-pub use pack_reader::{EncodedPackSubset, PackReader};
+pub use pack_reader::{EncodedPackSubset, PackReadTier, PackReader};
 pub use repack::{
     CancellationToken, LoadMonitor, RepackContext, RepackError, RepackHandle, RepackInventory,
     RepackOperation, RepackOutcome, RepackPolicy, RepackReason, RepackReport, RepackResourceLimits,

--- a/crates/pack/src/store/pack/pack_index.rs
+++ b/crates/pack/src/store/pack/pack_index.rs
@@ -141,14 +141,19 @@ impl EncodedIndex {
 }
 
 impl PackIndex {
-    /// Return all ids in this index.
-    pub fn ids(&self) -> Result<Vec<PackObjectId>> {
+    /// Return all decoded index entries.
+    pub(super) fn entries(&self) -> Result<Vec<IndexEntry>> {
         if let Some(encoded) = &self.encoded {
             return (0..encoded.count)
-                .map(|index| encoded.entry(index).map(|entry| entry.id))
+                .map(|index| encoded.entry(index))
                 .collect();
         }
-        Ok(self.entries.iter().map(|entry| entry.id).collect())
+        Ok(self.entries.clone())
+    }
+
+    /// Return all ids in this index.
+    pub fn ids(&self) -> Result<Vec<PackObjectId>> {
+        Ok(self.entries()?.into_iter().map(|entry| entry.id).collect())
     }
 }
 

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pack reader for extracting objects from packfiles.
 
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
-    collections::{BTreeSet, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     fs::File,
     io::Read,
     path::Path,
@@ -28,6 +30,19 @@ const MMAP_THRESHOLD_BYTES: u64 = 256 * 1024;
 
 type DecodedCompactObject = (PackObjectId, ObjectType, Vec<u8>);
 type DecodedCompactObjects = Vec<DecodedCompactObject>;
+
+/// Physical read tier for an indexed pack object.
+///
+/// Hot records have one independently addressable record per logical object.
+/// Solid-frame records share one payload across several logical objects and
+/// therefore require a frame decompression on a cache-cold read.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PackReadTier {
+    /// Independently addressable, random-access record.
+    Hot,
+    /// Compact payload shared by several tree or state ids.
+    SolidFrame,
+}
 
 fn read_file_bytes_for_pack(path: &Path) -> Result<Bytes> {
     let file = File::open(path)?;
@@ -89,6 +104,8 @@ pub struct PackReader<'a> {
     data: PackData<'a>,
     index: PackIndex,
     content_end: usize,
+    #[cfg(test)]
+    compact_frame_reads: AtomicUsize,
 }
 
 #[derive(Debug, Clone)]
@@ -127,6 +144,8 @@ impl PackReader<'static> {
             data: PackData::Owned(pack_bytes),
             index,
             content_end,
+            #[cfg(test)]
+            compact_frame_reads: AtomicUsize::new(0),
         })
     }
 
@@ -138,6 +157,8 @@ impl PackReader<'static> {
             data: PackData::Owned(pack_data),
             index,
             content_end,
+            #[cfg(test)]
+            compact_frame_reads: AtomicUsize::new(0),
         })
     }
 }
@@ -150,12 +171,49 @@ impl<'a> PackReader<'a> {
             data: PackData::Borrowed(pack_data),
             index,
             content_end,
+            #[cfg(test)]
+            compact_frame_reads: AtomicUsize::new(0),
         })
     }
 
     /// List all object ids in this pack.
     pub fn list_ids(&self) -> Result<Vec<PackObjectId>> {
         self.index.ids()
+    }
+
+    /// List logical ids together with their physical read tier.
+    ///
+    /// A shared compact frame is represented by several index aliases at one
+    /// record offset. Direct records have a unique offset and form the hot,
+    /// random-access tier. A one-object compact frame is intentionally treated
+    /// as hot here: it has no read amplification over a direct record.
+    pub(super) fn indexed_read_tiers(&self) -> Result<Vec<(PackObjectId, PackReadTier)>> {
+        let entries = self.index.entries()?;
+        let mut aliases = HashMap::<u64, usize>::with_capacity(entries.len());
+        for entry in &entries {
+            *aliases.entry(entry.offset).or_default() += 1;
+        }
+        Ok(entries
+            .into_iter()
+            .map(|entry| {
+                let tier = if aliases[&entry.offset] > 1 {
+                    PackReadTier::SolidFrame
+                } else {
+                    PackReadTier::Hot
+                };
+                (entry.id, tier)
+            })
+            .collect())
+    }
+
+    #[cfg(test)]
+    pub(super) fn compact_frame_read_count(&self) -> usize {
+        self.compact_frame_reads.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    fn record_compact_frame_read(&self) {
+        self.compact_frame_reads.fetch_add(1, Ordering::Relaxed);
     }
 
     pub fn list_hashes(&self) -> Result<Vec<ContentHash>> {
@@ -575,16 +633,18 @@ impl<'a> PackReader<'a> {
             stored_data.to_vec()
         };
 
-        if obj_type != ObjectType::Delta
-            && let Some(data) = decode_compact_object(requested_id, obj_type, &decompressed)?
-        {
-            return Ok(PackObjectRecord {
-                id: *requested_id,
-                obj_type,
-                data,
-                delta_base: None,
-                path_hint: None,
-            });
+        if obj_type != ObjectType::Delta && is_compact_frame(&decompressed) {
+            #[cfg(test)]
+            self.record_compact_frame_read();
+            if let Some(data) = decode_compact_object(requested_id, obj_type, &decompressed)? {
+                return Ok(PackObjectRecord {
+                    id: *requested_id,
+                    obj_type,
+                    data,
+                    delta_base: None,
+                    path_hint: None,
+                });
+            }
         }
         verify_record_id_matches(requested_id, &id)?;
         let (resolved_type, final_data) = if obj_type == ObjectType::Delta {
@@ -634,6 +694,10 @@ impl<'a> PackReader<'a> {
                 header.uncompressed_size,
                 data.len()
             )));
+        }
+        #[cfg(test)]
+        if is_compact_frame(&data) {
+            self.record_compact_frame_read();
         }
         decode_compact_objects(header.obj_type, &data)
     }

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -1073,6 +1073,39 @@ mod tests {
     }
 
     #[test]
+    fn compact_tree_extraction_rejects_an_index_alias_with_the_wrong_typed_hash() {
+        use crate::object::{Tree, TreeEntry};
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let blob = deterministic_hash(0x34);
+        let trees = vec![
+            Tree::from_entries(vec![TreeEntry::file("a", blob, false).unwrap()]),
+            Tree::from_entries(vec![TreeEntry::file("b", blob, true).unwrap()]),
+        ];
+        let wrong_hash = ContentHash::compute_typed("tree", b"not the second tree");
+        assert_ne!(wrong_hash, trees[1].hash());
+        let ids = vec![
+            PackObjectId::Hash(trees[0].hash()),
+            PackObjectId::Hash(wrong_hash),
+        ];
+        let frame = heddle_object_model::compact::encode_tree_frame(&trees).unwrap();
+        builder
+            .add_shared_frame(&ids, ObjectType::Tree, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, _) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        let error = reader.get_object(&ids[1]).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("does not contain indexed object"),
+            "extraction must derive and verify the tree's typed hash: {error}"
+        );
+    }
+
+    #[test]
     fn corrupt_compact_frame_byte_invalidates_every_contained_object() {
         use crate::object::{Tree, TreeEntry};
 


### PR DESCRIPTION
## Summary

- Classify indexed pack objects as hot random-access records or shared solid-frame records from their physical index offsets.
- Make eager, lazy, and incrementally updated pack lookup prefer a hot record whenever both tiers contain the same immutable object, independent of pack filename order.
- Preserve the compact reader’s byte-identical reconstruction and typed-hash verification, with explicit forged-alias coverage plus hot-to-solid and concurrent-cutover tests.
- Prove concurrent hot point reads never touch the duplicate solid frame, while frame-only reads still decode and verify normally.

## Closes

Part of HeddleCo/heddle#1323

## Test evidence

- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1339-target cargo test -p heddle-pack -p heddle-objects --features zstd` (82 pack tests + 189 object tests, all green)
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1339-target cargo build --locked --workspace`
- `TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1339-target cargo clippy --workspace --all-targets --locked -- -D warnings`
- Nightly rustfmt (`--edition 2024`) on all touched Rust files
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789135829&installation_model_id=21489&pr_number=1341&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1341&signature=fffddae76afd83d634af8f250a555cb3e6f3f3ba5a088aa69529bc4245d7456e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->