### PR TITLE
feat(storage): S4 lineage-solid blob writer (Part of #1323)

### DIFF
--- a/crates/cli/examples/native_lineage_solid.rs
+++ b/crates/cli/examples/native_lineage_solid.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Real compact-repack falsifier for heddle#1337, derived from #1325.
+//! Full-format lineage-solid falsifier for heddle#1340, derived from #1325.
 
 #[path = "native_lineage_solid/blob_lineage.rs"]
 mod blob_lineage;
@@ -66,6 +66,7 @@ struct Comparisons {
 struct RegatedTotal {
     compact_metadata_bytes: u64,
     blob_lineage_frame_bytes: u64,
+    prototype_blob_lineage_frame_bytes: u64,
     index_bytes: u64,
     total_bytes: u64,
     git_pack_bytes: u64,
@@ -158,11 +159,12 @@ fn regate(
 ) -> RegatedTotal {
     let compact_metadata_bytes = compact.compact_tree_bytes + compact.compact_state_bytes;
     let index_bytes = compact.index_bytes;
-    let total_bytes = compact_metadata_bytes + blobs.compressed_bytes + index_bytes;
+    let total_bytes = compact_metadata_bytes + compact.compact_blob_bytes + index_bytes;
     let git_pack_and_idx_bytes = git.pack_bytes + git.idx_bytes;
     RegatedTotal {
         compact_metadata_bytes,
-        blob_lineage_frame_bytes: blobs.compressed_bytes,
+        blob_lineage_frame_bytes: compact.compact_blob_bytes,
+        prototype_blob_lineage_frame_bytes: blobs.compressed_bytes,
         index_bytes,
         total_bytes,
         git_pack_bytes: git.pack_bytes,

--- a/crates/cli/examples/native_lineage_solid/real_compact.rs
+++ b/crates/cli/examples/native_lineage_solid/real_compact.rs
@@ -17,8 +17,10 @@ use crate::{
 
 #[derive(Serialize)]
 pub struct RealCompactMeasurement {
+    pub source_blob_bytes: u64,
     pub source_tree_bytes: u64,
     pub source_state_bytes: u64,
+    pub compact_blob_bytes: u64,
     pub compact_tree_bytes: u64,
     pub compact_state_bytes: u64,
     pub index_bytes: u64,
@@ -33,7 +35,8 @@ pub fn measure_real_compact_repack(
     store: &FsStore,
     objects: &ObjectSet,
 ) -> Result<RealCompactMeasurement> {
-    let (source_tree_bytes, source_state_bytes) = source_metadata_bytes(store, objects)?;
+    let (source_blob_bytes, source_tree_bytes, source_state_bytes) =
+        source_object_bytes(store, objects)?;
     let (source_fingerprint, _) = fingerprint_objects(store, objects)?;
     run_repack(store)?;
     store.clear_recent_object_caches();
@@ -41,11 +44,18 @@ pub fn measure_real_compact_repack(
     if source_fingerprint != reconstructed_fingerprint {
         bail!("real compact writer changed native object bytes");
     }
-    let (compact_tree_bytes, compact_state_bytes, index_bytes, replacement_pack_bytes) =
-        physical_metadata_bytes(store)?;
+    let (
+        compact_blob_bytes,
+        compact_tree_bytes,
+        compact_state_bytes,
+        index_bytes,
+        replacement_pack_bytes,
+    ) = physical_object_bytes(store)?;
     Ok(RealCompactMeasurement {
+        source_blob_bytes,
         source_tree_bytes,
         source_state_bytes,
+        compact_blob_bytes,
         compact_tree_bytes,
         compact_state_bytes,
         index_bytes,
@@ -57,17 +67,18 @@ pub fn measure_real_compact_repack(
     })
 }
 
-fn source_metadata_bytes(store: &FsStore, objects: &ObjectSet) -> Result<(u64, u64)> {
+fn source_object_bytes(store: &FsStore, objects: &ObjectSet) -> Result<(u64, u64, u64)> {
+    let mut blobs = 0u64;
     let mut trees = 0u64;
     let mut states = 0u64;
     for object in objects.iter() {
         match object {
             ObjectRef::Tree(_) => trees += object.load(store)?.len() as u64,
             ObjectRef::State(_) => states += object.load(store)?.len() as u64,
-            ObjectRef::Blob(_) => {}
+            ObjectRef::Blob(_) => blobs += object.load(store)?.len() as u64,
         }
     }
-    Ok((trees, states))
+    Ok((blobs, trees, states))
 }
 
 fn run_repack(store: &FsStore) -> Result<()> {
@@ -83,7 +94,7 @@ fn run_repack(store: &FsStore) -> Result<()> {
     Ok(())
 }
 
-fn physical_metadata_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64)> {
+fn physical_object_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64, u64)> {
     let packs_dir = store.root().join("packs");
     let paths = fs::read_dir(&packs_dir)?
         .map(|entry| entry.map(|value| value.path()))
@@ -95,6 +106,7 @@ fn physical_metadata_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64)> {
             (pack, index)
         })
         .collect::<Vec<_>>();
+    let mut blob_bytes = 0u64;
     let mut tree_bytes = 0u64;
     let mut state_bytes = 0u64;
     let mut index_bytes = 0u64;
@@ -102,10 +114,11 @@ fn physical_metadata_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64)> {
     for (pack, index) in paths {
         let reader = PackReader::open(&pack, &index)
             .with_context(|| format!("open replacement pack {}", pack.display()))?;
+        blob_bytes += reader.encoded_payload_bytes(ObjectType::Blob)?;
         tree_bytes += reader.encoded_payload_bytes(ObjectType::Tree)?;
         state_bytes += reader.encoded_payload_bytes(ObjectType::State)?;
         index_bytes += fs::metadata(&index)?.len();
         pack_bytes += fs::metadata(&pack)?.len();
     }
-    Ok((tree_bytes, state_bytes, index_bytes, pack_bytes))
+    Ok((blob_bytes, tree_bytes, state_bytes, index_bytes, pack_bytes))
 }

--- a/crates/object-model/src/compact/blob.rs
+++ b/crates/object-model/src/compact/blob.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    Result,
+    io::{Reader, Writer},
+};
+use crate::object::ContentHash;
+
+const BLOB_MAGIC: &[u8; 4] = b"HCB2";
+
+/// One verified blob slice within a lineage-solid frame.
+pub type DecodedBlob<'a> = (ContentHash, &'a [u8]);
+
+/// Whether `bytes` begin with the lineage-solid blob-frame discriminator.
+pub fn is_blob_frame(bytes: &[u8]) -> bool {
+    bytes.starts_with(BLOB_MAGIC)
+}
+
+/// Encode blob bodies newest-to-oldest in one checksummed solid frame.
+///
+/// Lengths precede the concatenated bodies, giving the frame reader an exact
+/// `(offset, len)` for every object while zstd sees one continuous lineage.
+pub fn encode_blob_frame(blobs: &[&[u8]]) -> Result<Vec<u8>> {
+    let mut output = Writer::new(BLOB_MAGIC);
+    output.put_u64(blobs.len() as u64);
+    if let Some((first, rest)) = blobs.split_first() {
+        output.put_u64(first.len() as u64);
+        let mut previous = i64::try_from(first.len())
+            .map_err(|_| super::invalid("blob length exceeds signed delta range"))?;
+        for blob in rest {
+            let current = i64::try_from(blob.len())
+                .map_err(|_| super::invalid("blob length exceeds signed delta range"))?;
+            output.put_i64(current - previous);
+            previous = current;
+        }
+    }
+    for blob in blobs {
+        output.put_fixed(blob);
+    }
+    Ok(output.finish())
+}
+
+/// Decode and whole-frame-verify every indexed blob slice.
+pub fn decode_blob_frame(bytes: &[u8]) -> Result<Vec<DecodedBlob<'_>>> {
+    let mut input = Reader::verified(bytes, BLOB_MAGIC)?;
+    let count = input.get_count("blob frame")?;
+    let mut lengths = Vec::with_capacity(count);
+    if count > 0 {
+        let first = input.get_u64()?;
+        lengths.push(checked_length(first)?);
+        let mut previous = i64::try_from(first)
+            .map_err(|_| super::invalid("blob length exceeds signed delta range"))?;
+        for _ in 1..count {
+            let current = previous
+                .checked_add(input.get_i64()?)
+                .ok_or_else(|| super::invalid("blob length delta overflow"))?;
+            if current < 0 {
+                return Err(super::invalid("blob length delta became negative"));
+            }
+            lengths.push(checked_length(current as u64)?);
+            previous = current;
+        }
+    }
+    let minimum_remaining = lengths
+        .iter()
+        .try_fold(0usize, |total, len| total.checked_add(*len))
+        .ok_or_else(|| super::invalid("blob frame length overflow"))?;
+    if input.remaining() != minimum_remaining {
+        return Err(super::invalid(format!(
+            "blob lengths total {minimum_remaining}, frame has {} body bytes",
+            input.remaining()
+        )));
+    }
+    let mut blobs = Vec::with_capacity(count);
+    for len in lengths {
+        let body = input.take(len)?;
+        blobs.push((ContentHash::compute_typed("blob", body), body));
+    }
+    input.finish()?;
+    Ok(blobs)
+}
+
+fn checked_length(value: u64) -> Result<usize> {
+    usize::try_from(value).map_err(|_| super::invalid("blob length exceeds platform limits"))
+}

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Lossless columnar encodings used by background compact repacks.
 
+mod blob;
 mod dictionary;
 mod io;
 mod state;
 mod state_decode;
 mod tree;
 
+pub use blob::{decode_blob_frame, encode_blob_frame, is_blob_frame};
 pub use state::{encode_state_frame, is_state_frame};
 pub use state_decode::decode_state_frame;
 use thiserror::Error;

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -5,7 +5,10 @@ use std::collections::BTreeMap;
 use chrono::{TimeZone, Utc};
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
-use super::{decode_state_frame, decode_tree_frame, encode_state_frame, encode_tree_frame};
+use super::{
+    decode_blob_frame, decode_state_frame, decode_tree_frame, encode_blob_frame,
+    encode_state_frame, encode_tree_frame,
+};
 use crate::object::{
     Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal,
     SpoolId, State, StateId, Status, Tree, TreeEntry, Verification,
@@ -136,6 +139,32 @@ fn corrupt_frame_byte_rejects_every_contained_object() {
 
     for _ in &trees {
         let error = decode_tree_frame(&encoded).unwrap_err();
+        assert!(error.to_string().contains("checksum mismatch"));
+    }
+}
+
+#[test]
+fn blob_frame_round_trips_offsets_lengths_and_typed_hashes() {
+    let bodies = [b"newest body".as_slice(), b"older body".as_slice(), &[]];
+    let encoded = encode_blob_frame(&bodies).unwrap();
+    let decoded = decode_blob_frame(&encoded).unwrap();
+
+    assert_eq!(decoded.len(), bodies.len());
+    for ((hash, actual), expected) in decoded.iter().zip(bodies) {
+        assert_eq!(*actual, expected);
+        assert_eq!(*hash, ContentHash::compute_typed("blob", expected));
+    }
+}
+
+#[test]
+fn corrupt_blob_frame_byte_rejects_every_contained_object() {
+    let bodies = [b"first".as_slice(), b"second".as_slice()];
+    let mut encoded = encode_blob_frame(&bodies).unwrap();
+    let corrupt_at = encoded.len() / 2;
+    encoded[corrupt_at] ^= 0x01;
+
+    for _ in bodies {
+        let error = decode_blob_frame(&encoded).unwrap_err();
         assert!(error.to_string().contains("checksum mismatch"));
     }
 }

--- a/crates/objects/src/store/fs/repack/blob_lineage.rs
+++ b/crates/objects/src/store/fs/repack/blob_lineage.rs
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+};
+
+use super::{blob_renames::similarity_renames, staging::BuildError};
+use crate::{
+    object::{ContentHash, DiffKind, State, StateId, Tree, diff_trees},
+    store::{HeddleError, ObjectStore, fs::FsStore},
+};
+
+pub(super) fn blob_lineage_order(
+    store: &FsStore,
+    states: &HashMap<StateId, State>,
+    state_order: &[StateId],
+    blob_hashes: &[ContentHash],
+) -> Result<Vec<ContentHash>, BuildError> {
+    let allowed = blob_hashes.iter().copied().collect::<HashSet<_>>();
+    let mut walk = BlobWalk::default();
+    for child_id in state_order {
+        let child = &states[child_id];
+        if child.parents.is_empty() {
+            for (path, hash) in leaf_paths(store, child.tree)? {
+                if allowed.contains(&hash) {
+                    walk.record(&path, hash);
+                }
+            }
+        }
+        for parent_id in child.parents.iter().filter(|id| states.contains_key(id)) {
+            walk.diff_edge(store, child, &states[parent_id], &allowed)?;
+        }
+    }
+    let order = walk.finish(&allowed);
+    if order.len() != allowed.len() {
+        return Err(HeddleError::InvalidObject(format!(
+            "blob lineage contains {} objects, snapshot contains {}",
+            order.len(),
+            allowed.len()
+        ))
+        .into());
+    }
+    Ok(order)
+}
+
+#[derive(Default)]
+struct BlobWalk {
+    aliases: HashMap<String, String>,
+    histories: HashMap<String, Vec<ContentHash>>,
+}
+
+impl BlobWalk {
+    fn diff_edge(
+        &mut self,
+        store: &FsStore,
+        child: &State,
+        parent: &State,
+        allowed: &HashSet<ContentHash>,
+    ) -> Result<(), BuildError> {
+        let changes = diff_trees(store, &parent.tree, &child.tree)
+            .map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+        let mut added = Vec::new();
+        let mut deleted = Vec::new();
+        for change in changes.iter() {
+            match change.kind {
+                DiffKind::Modified => {
+                    if let Some(hash) = leaf_hash(store, child.tree, &change.path)?
+                        && allowed.contains(&hash)
+                    {
+                        self.record(&change.path, hash);
+                    }
+                    if let Some(hash) = leaf_hash(store, parent.tree, &change.path)?
+                        && allowed.contains(&hash)
+                    {
+                        self.record(&change.path, hash);
+                    }
+                }
+                DiffKind::Added => added.push(change.path.clone()),
+                DiffKind::Deleted => deleted.push(change.path.clone()),
+                DiffKind::Unchanged => {}
+            }
+        }
+        self.record_add_delete(store, child.tree, parent.tree, &added, &deleted, allowed)
+    }
+
+    fn record_add_delete(
+        &mut self,
+        store: &FsStore,
+        child_tree: ContentHash,
+        parent_tree: ContentHash,
+        added_paths: &[String],
+        deleted_paths: &[String],
+        allowed: &HashSet<ContentHash>,
+    ) -> Result<(), BuildError> {
+        let added = path_hashes(store, child_tree, added_paths, allowed)?;
+        let deleted = path_hashes(store, parent_tree, deleted_paths, allowed)?;
+        let mut used_added = HashSet::new();
+        let mut used_deleted = HashSet::new();
+        for old_path in deleted_paths {
+            let Some(old_hash) = deleted.get(old_path) else {
+                continue;
+            };
+            if let Some(new_path) = added_paths
+                .iter()
+                .find(|path| !used_added.contains(*path) && added.get(*path) == Some(old_hash))
+            {
+                self.record_rename(old_path, new_path, *old_hash, *old_hash);
+                used_deleted.insert(old_path.clone());
+                used_added.insert(new_path.clone());
+            }
+        }
+        let deleted_remaining = remaining_text(store, &deleted, &used_deleted)?;
+        let added_remaining = remaining_text(store, &added, &used_added)?;
+        for (old_index, new_index) in similarity_renames(&deleted_remaining, &added_remaining) {
+            let old_path = &deleted_remaining[old_index].0;
+            let new_path = &added_remaining[new_index].0;
+            self.record_rename(old_path, new_path, deleted[old_path], added[new_path]);
+            used_deleted.insert(old_path.clone());
+            used_added.insert(new_path.clone());
+        }
+        for (path, hash) in added {
+            if !used_added.contains(&path) {
+                self.record(&path, hash);
+            }
+        }
+        for (path, hash) in deleted {
+            if !used_deleted.contains(&path) {
+                self.record(&path, hash);
+            }
+        }
+        Ok(())
+    }
+
+    fn record_rename(
+        &mut self,
+        old_path: &str,
+        new_path: &str,
+        old_hash: ContentHash,
+        new_hash: ContentHash,
+    ) {
+        self.rename(old_path, new_path);
+        self.record(new_path, new_hash);
+        self.record(old_path, old_hash);
+    }
+
+    fn rename(&mut self, old: &str, new: &str) {
+        let old_key = self.canonical(old);
+        let new_key = self.canonical(new);
+        if old_key == new_key {
+            return;
+        }
+        self.aliases.insert(old_key.clone(), new_key.clone());
+        if let Some(old_history) = self.histories.remove(&old_key) {
+            self.histories
+                .entry(new_key)
+                .or_default()
+                .extend(old_history);
+        }
+    }
+
+    fn record(&mut self, path: &str, hash: ContentHash) {
+        let key = self.canonical(path);
+        self.histories.entry(key).or_default().push(hash);
+    }
+
+    fn canonical(&self, path: &str) -> String {
+        let mut current = path;
+        let mut seen = HashSet::new();
+        while let Some(next) = self.aliases.get(current) {
+            if !seen.insert(current) {
+                break;
+            }
+            current = next;
+        }
+        current.to_string()
+    }
+
+    fn finish(&self, all_blobs: &HashSet<ContentHash>) -> Vec<ContentHash> {
+        let mut paths = self.histories.keys().collect::<Vec<_>>();
+        paths.sort_by_key(|path| (extension(path), path.as_str()));
+        let mut seen = HashSet::new();
+        let mut order = Vec::with_capacity(all_blobs.len());
+        for path in paths {
+            for hash in &self.histories[path] {
+                if all_blobs.contains(hash) && seen.insert(*hash) {
+                    order.push(*hash);
+                }
+            }
+        }
+        let mut leftovers = all_blobs.difference(&seen).copied().collect::<Vec<_>>();
+        leftovers.sort();
+        order.extend(leftovers);
+        order
+    }
+}
+
+fn path_hashes(
+    store: &FsStore,
+    root: ContentHash,
+    paths: &[String],
+    allowed: &HashSet<ContentHash>,
+) -> Result<HashMap<String, ContentHash>, BuildError> {
+    paths
+        .iter()
+        .filter_map(|path| match leaf_hash(store, root, path) {
+            Ok(Some(hash)) if allowed.contains(&hash) => Some(Ok((path.clone(), hash))),
+            Ok(Some(_)) => None,
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
+        })
+        .collect()
+}
+
+fn remaining_text(
+    store: &FsStore,
+    paths: &HashMap<String, ContentHash>,
+    used: &HashSet<String>,
+) -> Result<Vec<(String, String)>, BuildError> {
+    let mut remaining = paths
+        .iter()
+        .filter(|(path, _)| !used.contains(*path))
+        .collect::<Vec<_>>();
+    remaining.sort_by_key(|(path, _)| path.as_str());
+    remaining
+        .into_iter()
+        .map(|(path, hash)| {
+            load_blob(store, *hash)
+                .map(|body| (path.clone(), String::from_utf8_lossy(&body).into_owned()))
+        })
+        .collect()
+}
+
+fn leaf_hash(
+    store: &FsStore,
+    root: ContentHash,
+    path: &str,
+) -> Result<Option<ContentHash>, BuildError> {
+    let mut tree = load_tree(store, root)?;
+    let mut components = Path::new(path).components().peekable();
+    while let Some(component) = components.next() {
+        let name = component.as_os_str().to_string_lossy();
+        let Some(entry) = tree.get(&name) else {
+            return Ok(None);
+        };
+        if components.peek().is_none() {
+            return Ok(entry.leaf_content_hash());
+        }
+        let Some(hash) = entry.tree_hash() else {
+            return Ok(None);
+        };
+        tree = load_tree(store, hash)?;
+    }
+    Ok(None)
+}
+
+fn leaf_paths(
+    store: &FsStore,
+    root: ContentHash,
+) -> Result<Vec<(String, ContentHash)>, BuildError> {
+    let mut output = Vec::new();
+    let mut stack = vec![(String::new(), root)];
+    while let Some((prefix, hash)) = stack.pop() {
+        for entry in load_tree(store, hash)?.entries().iter().rev() {
+            let path = if prefix.is_empty() {
+                entry.name().to_string()
+            } else {
+                format!("{prefix}/{}", entry.name())
+            };
+            if let Some(hash) = entry.tree_hash() {
+                stack.push((path, hash));
+            } else if let Some(hash) = entry.leaf_content_hash() {
+                output.push((path, hash));
+            }
+        }
+    }
+    Ok(output)
+}
+
+fn load_tree(store: &FsStore, hash: ContentHash) -> Result<Tree, BuildError> {
+    ObjectStore::get_tree(store, &hash)?
+        .ok_or_else(|| HeddleError::InvalidObject(format!("repack tree disappeared: {hash}")))
+        .map_err(BuildError::from)
+}
+
+fn load_blob(store: &FsStore, hash: ContentHash) -> Result<Vec<u8>, BuildError> {
+    ObjectStore::get_blob(store, &hash)?
+        .map(|blob| blob.into_content())
+        .ok_or_else(|| HeddleError::InvalidObject(format!("repack blob disappeared: {hash}")))
+        .map_err(BuildError::from)
+}
+
+fn extension(path: &str) -> &str {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| Path::new(name).extension())
+        .and_then(|value| value.to_str())
+        .unwrap_or("")
+}

--- a/crates/objects/src/store/fs/repack/blob_lineage_tests.rs
+++ b/crates/objects/src/store/fs/repack/blob_lineage_tests.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use super::{blob_lineage::blob_lineage_order, tests::create_store};
+use crate::{
+    object::{Attribution, Blob, Principal, State, Tree, TreeEntry},
+    store::ObjectStore,
+};
+
+#[test]
+fn lineage_tracks_exact_rename_and_orders_versions_newest_first() {
+    let (_temp, store) = create_store();
+    let old_blob = Blob::from("shared body\nold ending\n");
+    let new_blob = Blob::from("shared body\nnew ending\n");
+    let old_hash = store.put_blob(&old_blob).unwrap();
+    let new_hash = store.put_blob(&new_blob).unwrap();
+    let root_tree =
+        Tree::from_entries(vec![TreeEntry::file("before.rs", old_hash, false).unwrap()]);
+    let renamed_tree =
+        Tree::from_entries(vec![TreeEntry::file("after.rs", old_hash, false).unwrap()]);
+    let head_tree = Tree::from_entries(vec![TreeEntry::file("after.rs", new_hash, false).unwrap()]);
+    let root_tree_hash = store.put_tree(&root_tree).unwrap();
+    let renamed_tree_hash = store.put_tree(&renamed_tree).unwrap();
+    let head_tree_hash = store.put_tree(&head_tree).unwrap();
+    let attribution = Attribution::human(Principal::new("Lineage", "lineage@example.com"));
+    let root = State::new(root_tree_hash, vec![], attribution.clone());
+    let renamed = State::new(renamed_tree_hash, vec![root.id()], attribution.clone());
+    let head = State::new(head_tree_hash, vec![renamed.id()], attribution);
+    let root_id = root.id();
+    let renamed_id = renamed.id();
+    let head_id = head.id();
+    let states = HashMap::from([(root_id, root), (renamed_id, renamed), (head_id, head)]);
+
+    let order = blob_lineage_order(
+        &store,
+        &states,
+        &[head_id, renamed_id, root_id],
+        &[old_hash, new_hash],
+    )
+    .unwrap();
+
+    assert_eq!(order, vec![new_hash, old_hash]);
+}
+
+#[test]
+fn lineage_tracks_similarity_rename_with_content_change() {
+    let (_temp, store) = create_store();
+    let old_blob = Blob::from("shared\nbody\nkept\nold ending\n");
+    let new_blob = Blob::from("shared\nbody\nkept\nnew ending\n");
+    let old_hash = store.put_blob(&old_blob).unwrap();
+    let new_hash = store.put_blob(&new_blob).unwrap();
+    let root_tree =
+        Tree::from_entries(vec![TreeEntry::file("before.rs", old_hash, false).unwrap()]);
+    let head_tree = Tree::from_entries(vec![TreeEntry::file("after.rs", new_hash, false).unwrap()]);
+    let root_tree_hash = store.put_tree(&root_tree).unwrap();
+    let head_tree_hash = store.put_tree(&head_tree).unwrap();
+    let attribution = Attribution::human(Principal::new("Lineage", "lineage@example.com"));
+    let root = State::new(root_tree_hash, vec![], attribution.clone());
+    let head = State::new(head_tree_hash, vec![root.id()], attribution);
+    let root_id = root.id();
+    let head_id = head.id();
+    let states = HashMap::from([(root_id, root), (head_id, head)]);
+
+    let order =
+        blob_lineage_order(&store, &states, &[head_id, root_id], &[old_hash, new_hash]).unwrap();
+
+    assert_eq!(order, vec![new_hash, old_hash]);
+}

--- a/crates/objects/src/store/fs/repack/blob_renames.rs
+++ b/crates/objects/src/store/fs/repack/blob_renames.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::HashSet, path::Path};
+
+const RENAME_THRESHOLD: f64 = 0.6;
+
+pub(super) fn similarity_renames(
+    deleted: &[(String, String)],
+    added: &[(String, String)],
+) -> Vec<(usize, usize)> {
+    let deleted_prepared = deleted
+        .iter()
+        .map(|(_, content)| PreparedText::new(content))
+        .collect::<Vec<_>>();
+    let added_prepared = added
+        .iter()
+        .map(|(_, content)| PreparedText::new(content))
+        .collect::<Vec<_>>();
+    let mut candidates = Vec::new();
+    for (source, old) in deleted_prepared.iter().enumerate() {
+        for (target, new) in added_prepared.iter().enumerate() {
+            let old_language = language_family(&deleted[source].0);
+            let new_language = language_family(&added[target].0);
+            if old_language.is_some() && new_language.is_some() && old_language != new_language {
+                continue;
+            }
+            let score = old.similarity(new);
+            if score >= RENAME_THRESHOLD {
+                candidates.push(Candidate {
+                    source,
+                    target,
+                    score,
+                });
+            }
+        }
+    }
+    candidates.sort_by(|left, right| {
+        right
+            .score
+            .total_cmp(&left.score)
+            .then_with(|| left.source.cmp(&right.source))
+            .then_with(|| left.target.cmp(&right.target))
+    });
+    let mut used_sources = vec![false; deleted.len()];
+    let mut used_targets = vec![false; added.len()];
+    candidates
+        .into_iter()
+        .filter_map(|candidate| {
+            if used_sources[candidate.source] || used_targets[candidate.target] {
+                return None;
+            }
+            used_sources[candidate.source] = true;
+            used_targets[candidate.target] = true;
+            Some((candidate.source, candidate.target))
+        })
+        .collect()
+}
+
+fn language_family(path: &str) -> Option<&'static str> {
+    match Path::new(path).extension().and_then(|value| value.to_str()) {
+        Some("rs") => Some("rust"),
+        Some("py" | "pyi") => Some("python"),
+        Some("js" | "jsx" | "mjs" | "cjs") => Some("javascript"),
+        Some("ts" | "tsx") => Some("typescript"),
+        Some("go") => Some("go"),
+        Some("c" | "h") => Some("c"),
+        Some("cpp" | "cc" | "hpp" | "cxx") => Some("cpp"),
+        Some("java") => Some("java"),
+        Some("zig") => Some("zig"),
+        _ => None,
+    }
+}
+
+struct Candidate {
+    source: usize,
+    target: usize,
+    score: f64,
+}
+
+struct PreparedText {
+    lines: HashSet<String>,
+    tokens: HashSet<String>,
+}
+
+impl PreparedText {
+    fn new(content: &str) -> Self {
+        Self {
+            lines: content
+                .lines()
+                .filter(|line| !line.trim().is_empty())
+                .map(String::from)
+                .collect(),
+            tokens: content.split_whitespace().map(String::from).collect(),
+        }
+    }
+
+    fn similarity(&self, other: &Self) -> f64 {
+        let lines = set_similarity(&self.lines, &other.lines);
+        if lines == 0.0 {
+            set_similarity(&self.tokens, &other.tokens)
+        } else {
+            lines
+        }
+    }
+}
+
+fn set_similarity(left: &HashSet<String>, right: &HashSet<String>) -> f64 {
+    if left.is_empty() && right.is_empty() {
+        return 1.0;
+    }
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+    left.intersection(right).count() as f64 / left.union(right).count() as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::similarity_renames;
+
+    #[test]
+    fn rename_assignment_is_deterministic_and_one_to_one() {
+        let deleted = vec![
+            ("old-a".into(), "same\nbody\nkept\nstable\n".into()),
+            ("old-b".into(), "same\nbody\nkept\nstable\n".into()),
+        ];
+        let added = vec![
+            ("new-a".into(), "same\nbody\nkept\nchanged\n".into()),
+            ("new-b".into(), "same\nbody\nkept\nchanged\n".into()),
+        ];
+
+        assert_eq!(similarity_renames(&deleted, &added), vec![(0, 0), (1, 1)]);
+    }
+
+    #[test]
+    fn known_different_languages_are_not_rename_candidates() {
+        let deleted = vec![("old.rs".into(), "same content".into())];
+        let added = vec![("new.py".into(), "same content".into())];
+
+        assert!(similarity_renames(&deleted, &added).is_empty());
+    }
+}

--- a/crates/objects/src/store/fs/repack/blob_writer.rs
+++ b/crates/objects/src/store/fs/repack/blob_writer.rs
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+
+use heddle_object_model::compact::{decode_blob_frame, encode_blob_frame};
+
+use super::{compact::FRAME_LIMIT, staging::BuildError};
+use crate::{
+    object::ContentHash,
+    store::{
+        HeddleError, ObjectStore,
+        fs::FsStore,
+        pack::{
+            ObjectType, PackObjectId, RepackContext, StreamingPackBuilder, compress_compact_frame,
+        },
+    },
+};
+
+const FRAME_FIXED_BYTES: usize = 4 + 32;
+
+pub(super) fn add_blob_frames(
+    store: &FsStore,
+    builder: &mut StreamingPackBuilder<File>,
+    order: &[ContentHash],
+    context: &RepackContext,
+    corrupt_first: &mut bool,
+) -> Result<u64, BuildError> {
+    let mut ids = Vec::new();
+    let mut bodies = Vec::new();
+    let mut body_bytes = 0usize;
+    let mut length_bytes = 0usize;
+    let mut previous_len = None;
+    let mut logical_bytes = 0u64;
+    for hash in order {
+        let body = ObjectStore::get_blob(store, hash)?
+            .ok_or_else(|| HeddleError::InvalidObject(format!("repack blob disappeared: {hash}")))?
+            .into_content();
+        let body_len = body.len();
+        let encoded_len = encoded_length_bytes(previous_len, body_len)?;
+        let proposed = FRAME_FIXED_BYTES
+            .saturating_add(unsigned_varint_len(ids.len() + 1))
+            .saturating_add(length_bytes)
+            .saturating_add(encoded_len)
+            .saturating_add(body_bytes)
+            .saturating_add(body_len);
+        if !bodies.is_empty() && proposed > FRAME_LIMIT {
+            write_blob_frame(builder, &ids, &bodies, corrupt_first)?;
+            ids.clear();
+            bodies.clear();
+            body_bytes = 0;
+            length_bytes = 0;
+            previous_len = None;
+        }
+        let encoded_len = encoded_length_bytes(previous_len, body_len)?;
+        logical_bytes = logical_bytes.saturating_add(body.len() as u64);
+        body_bytes = body_bytes.saturating_add(body_len);
+        length_bytes = length_bytes.saturating_add(encoded_len);
+        previous_len = Some(body_len);
+        ids.push(PackObjectId::Hash(*hash));
+        bodies.push(body);
+        context
+            .checkpoint(body_len as u64)
+            .map_err(BuildError::Cancelled)?;
+    }
+    if !bodies.is_empty() {
+        write_blob_frame(builder, &ids, &bodies, corrupt_first)?;
+    }
+    Ok(logical_bytes)
+}
+
+fn encoded_length_bytes(previous: Option<usize>, current: usize) -> Result<usize, BuildError> {
+    let current = i64::try_from(current)
+        .map_err(|_| HeddleError::InvalidObject("blob length exceeds signed delta range".into()))?;
+    let value = match previous {
+        Some(previous) => {
+            let previous = i64::try_from(previous).map_err(|_| {
+                HeddleError::InvalidObject("blob length exceeds signed delta range".into())
+            })?;
+            ((current - previous) << 1) ^ ((current - previous) >> 63)
+        }
+        None => current,
+    } as u64;
+    Ok(unsigned_u64_varint_len(value))
+}
+
+fn unsigned_varint_len(value: usize) -> usize {
+    unsigned_u64_varint_len(value as u64)
+}
+
+fn unsigned_u64_varint_len(mut value: u64) -> usize {
+    let mut len = 1;
+    while value >= 0x80 {
+        value >>= 7;
+        len += 1;
+    }
+    len
+}
+
+fn write_blob_frame(
+    builder: &mut StreamingPackBuilder<File>,
+    ids: &[PackObjectId],
+    bodies: &[Vec<u8>],
+    corrupt_first: &mut bool,
+) -> Result<(), BuildError> {
+    if let ([PackObjectId::Hash(hash)], [body]) = (ids, bodies) {
+        let mut body = body.clone();
+        if *corrupt_first {
+            body.push(0xff);
+            *corrupt_first = false;
+        }
+        builder.add(*hash, ObjectType::Blob, body)?;
+        return Ok(());
+    }
+    let slices = bodies.iter().map(Vec::as_slice).collect::<Vec<_>>();
+    let mut frame = encode_blob_frame(&slices)
+        .map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+    verify_blob_frame(ids, &frame)?;
+    if *corrupt_first {
+        let index = frame.len() / 2;
+        frame[index] ^= 0x01;
+        *corrupt_first = false;
+    }
+    let stored = compress_compact_frame(&frame)?;
+    builder.add_shared_frame(ids, ObjectType::Blob, frame.len(), &stored)?;
+    Ok(())
+}
+
+fn verify_blob_frame(ids: &[PackObjectId], frame: &[u8]) -> Result<(), BuildError> {
+    let decoded =
+        decode_blob_frame(frame).map_err(|error| HeddleError::InvalidObject(error.to_string()))?;
+    if decoded.len() != ids.len() {
+        return Err(
+            HeddleError::InvalidObject("compact blob frame changed object count".into()).into(),
+        );
+    }
+    for (id, (hash, _)) in ids.iter().zip(decoded) {
+        if *id != PackObjectId::Hash(hash) {
+            return Err(
+                HeddleError::InvalidObject("compact blob frame changed a typed id".into()).into(),
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/objects/src/store/fs/repack/compact.rs
+++ b/crates/objects/src/store/fs/repack/compact.rs
@@ -9,7 +9,10 @@ use heddle_object_model::compact::{
     decode_state_frame, decode_tree_frame, encode_state_frame, encode_tree_frame, encoded_tree_size,
 };
 
-use super::{super::FsStore, staging::BuildError};
+use super::{
+    super::FsStore, blob_lineage::blob_lineage_order, blob_writer::add_blob_frames,
+    staging::BuildError,
+};
 use crate::{
     object::{ContentHash, State, StateId, Tree},
     store::{
@@ -25,22 +28,27 @@ mod state_writer;
 
 use state_writer::add_state_frames;
 
-const FRAME_LIMIT: usize = 12 * 1024 * 1024;
+pub(super) const FRAME_LIMIT: usize = 12 * 1024 * 1024;
 
 pub(super) fn add_compact_metadata(
     store: &FsStore,
     builder: &mut StreamingPackBuilder<File>,
     state_ids: &[StateId],
     tree_hashes: &[ContentHash],
+    blob_hashes: &[ContentHash],
     context: &RepackContext,
     corrupt_first: &mut bool,
 ) -> Result<u64, BuildError> {
     let states = load_states(store, state_ids)?;
     let state_order = newest_first_topology(&states)?;
     let tree_order = tree_path_order(store, tree_hashes, &states, &state_order)?;
+    let blob_order = blob_lineage_order(store, &states, &state_order, blob_hashes)?;
+    let blob_bytes = add_blob_frames(store, builder, &blob_order, context, corrupt_first)?;
     let state_bytes = add_state_frames(builder, &states, &state_order, context, corrupt_first)?;
     let tree_bytes = add_tree_frames(store, builder, &tree_order, context, corrupt_first)?;
-    Ok(state_bytes.saturating_add(tree_bytes))
+    Ok(blob_bytes
+        .saturating_add(state_bytes)
+        .saturating_add(tree_bytes))
 }
 
 fn load_states(store: &FsStore, ids: &[StateId]) -> Result<HashMap<StateId, State>, BuildError> {

--- a/crates/objects/src/store/fs/repack/mod.rs
+++ b/crates/objects/src/store/fs/repack/mod.rs
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Filesystem payload for the storage-agnostic repack scheduler.
 
+mod blob_lineage;
+#[cfg(test)]
+mod blob_lineage_tests;
+mod blob_renames;
+mod blob_writer;
 mod compact;
 mod cutover;
 mod operation;

--- a/crates/objects/src/store/fs/repack/operation.rs
+++ b/crates/objects/src/store/fs/repack/operation.rs
@@ -165,6 +165,7 @@ impl FsRepackOperation {
         let mut expected = HashSet::new();
         let mut state_ids = Vec::new();
         let mut tree_hashes = Vec::new();
+        let mut blob_hashes = Vec::new();
         #[cfg(test)]
         let mut corrupt_first = self.corrupt_first_object;
         #[cfg(not(test))]
@@ -179,6 +180,7 @@ impl FsRepackOperation {
                     return Ok(());
                 }
                 match (id, object_type) {
+                    (PackObjectId::Hash(hash), ObjectType::Blob) => blob_hashes.push(hash),
                     (PackObjectId::Hash(hash), ObjectType::Tree) => tree_hashes.push(hash),
                     (PackObjectId::StateId(state_id), ObjectType::State) => {
                         state_ids.push(state_id);
@@ -209,14 +211,7 @@ impl FsRepackOperation {
         for hash in &snapshot.loose_blobs {
             let id = PackObjectId::Hash(*hash);
             if expected.insert(id) {
-                let blob = ObjectStore::get_blob(&self.store, hash)?.ok_or_else(|| {
-                    HeddleError::InvalidObject(format!("loose blob disappeared: {hash}"))
-                })?;
-                let data = blob.content().to_vec();
-                let bytes = data.len() as u64;
-                builder.add(*hash, ObjectType::Blob, data)?;
-                logical_bytes = logical_bytes.saturating_add(bytes);
-                context.checkpoint(bytes).map_err(BuildError::Cancelled)?;
+                blob_hashes.push(*hash);
             }
         }
         for hash in &snapshot.loose_trees {
@@ -230,6 +225,7 @@ impl FsRepackOperation {
             &mut builder,
             &state_ids,
             &tree_hashes,
+            &blob_hashes,
             context,
             &mut corrupt_first,
         )?);

--- a/crates/objects/src/store/fs/repack/staging.rs
+++ b/crates/objects/src/store/fs/repack/staging.rs
@@ -79,6 +79,7 @@ impl Drop for RepackStaging {
     }
 }
 
+#[derive(Debug)]
 pub(super) enum BuildError {
     Store(HeddleError),
     Cancelled(RepackError),

--- a/crates/objects/src/store/fs/repack/tests/integrity.rs
+++ b/crates/objects/src/store/fs/repack/tests/integrity.rs
@@ -181,7 +181,9 @@ fn deliberately_corrupted_repack_output_is_rejected_before_cutover() {
         .wait()
         .unwrap_err();
     assert!(
-        matches!(error, RepackError::Operation(ref message) if message.contains("corruption")),
+        matches!(error, RepackError::Operation(ref message)
+            if message.contains("compact frame checksum mismatch")
+                || message.contains("object corruption")),
         "typed-hash validation should reject the output, got {error:?}"
     );
     assert_eq!(direct_pack_names(store.root()), before);

--- a/crates/objects/src/store/fs/repack/tests/mod.rs
+++ b/crates/objects/src/store/fs/repack/tests/mod.rs
@@ -21,7 +21,7 @@ use crate::store::{
     RepackLoadMonitor, RepackPolicy, RepackResourceLimits, RepackSchedule, RepackScheduler,
 };
 
-fn create_store() -> (TempDir, FsStore) {
+pub(super) fn create_store() -> (TempDir, FsStore) {
     let temp = TempDir::new().unwrap();
     let store = FsStore::new(temp.path().join(".heddle"));
     store.init().unwrap();

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -313,8 +313,8 @@ mod tests {
         );
         assert_eq!(
             blake3::hash(&index_data).to_hex().as_str(),
-            "5baf8125e8db75055da475cc41f4bcc6ec90d0452c266adf3ebc440cce38b32b",
-            "index bytes must match the pre-refactor main baseline"
+            "9ec20359e2a64121684af45f0dcabfdb726a9abfa4a7ce186904650a9f17c602",
+            "index bytes must match the v3 baseline after the v2-to-v3 format change in #1340"
         );
 
         let pack_path = packs_dir.join("fixture.pack");

--- a/crates/pack/src/store/pack/pack_index.rs
+++ b/crates/pack/src/store/pack/pack_index.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pack index for fast object lookup within packfiles.
 
+use std::collections::HashSet;
+
 use bytes::Bytes;
 
 use crate::store::{
@@ -12,8 +14,10 @@ use crate::store::{
 };
 
 pub(super) const INDEX_MAGIC: &[u8; 4] = b"LMI\0";
-pub(super) const INDEX_VERSION: u32 = 2;
-const INDEX_ENTRY_LEN: usize = 33 + 8;
+pub(super) const INDEX_VERSION: u32 = 3;
+pub(super) const INDEX_ENTRY_LEN: usize = 32 + 8;
+const STATE_ID_OFFSET_TAG: u64 = 1 << 63;
+const PACK_OFFSET_MASK: u64 = !STATE_ID_OFFSET_TAG;
 
 /// Entry in the pack index.
 #[derive(Debug, Clone, Copy)]
@@ -88,8 +92,7 @@ impl PackIndex {
         let mut result = Vec::new();
         index_header().write_vec(&mut result, self.entries.len() as u64);
         for entry in &self.entries {
-            entry.id.encode_tagged(&mut result);
-            result.extend_from_slice(&entry.offset.to_be_bytes());
+            result.extend_from_slice(&encode_index_entry(entry.id, entry.offset));
         }
         result
     }
@@ -132,12 +135,46 @@ impl EncodedIndex {
         let bytes = self.data.get(start..end).ok_or_else(|| {
             crate::store::StoreError::InvalidObject("Index data truncated".to_string())
         })?;
-        let (id, id_len) = PackObjectId::decode_tagged(bytes)?;
-        let offset = u64::from_be_bytes(bytes[id_len..].try_into().map_err(|_| {
-            crate::store::StoreError::InvalidObject("Invalid offset length".to_string())
-        })?);
-        Ok(IndexEntry { id, offset })
+        decode_index_entry(bytes)
     }
+}
+
+pub(super) fn encode_index_entry(id: PackObjectId, offset: u64) -> [u8; INDEX_ENTRY_LEN] {
+    assert!(
+        offset <= PACK_OFFSET_MASK,
+        "pack index offset exceeds the 63-bit format limit"
+    );
+    let mut bytes = [0u8; INDEX_ENTRY_LEN];
+    let tagged_offset = match id {
+        PackObjectId::Hash(hash) => {
+            bytes[..32].copy_from_slice(hash.as_bytes());
+            offset
+        }
+        PackObjectId::StateId(state_id) => {
+            bytes[..32].copy_from_slice(state_id.as_bytes());
+            offset | STATE_ID_OFFSET_TAG
+        }
+    };
+    bytes[32..].copy_from_slice(&tagged_offset.to_be_bytes());
+    bytes
+}
+
+fn decode_index_entry(bytes: &[u8]) -> Result<IndexEntry> {
+    let raw_id: [u8; 32] = bytes[..32].try_into().map_err(|_| {
+        crate::store::StoreError::InvalidObject("Invalid index id length".to_string())
+    })?;
+    let tagged_offset = u64::from_be_bytes(bytes[32..].try_into().map_err(|_| {
+        crate::store::StoreError::InvalidObject("Invalid offset length".to_string())
+    })?);
+    let id = if tagged_offset & STATE_ID_OFFSET_TAG == 0 {
+        PackObjectId::Hash(crate::object::ContentHash::from_bytes(raw_id))
+    } else {
+        PackObjectId::StateId(crate::object::StateId::from_bytes(raw_id))
+    };
+    Ok(IndexEntry {
+        id,
+        offset: tagged_offset & PACK_OFFSET_MASK,
+    })
 }
 
 impl PackIndex {
@@ -154,6 +191,17 @@ impl PackIndex {
     /// Return all ids in this index.
     pub fn ids(&self) -> Result<Vec<PackObjectId>> {
         Ok(self.entries()?.into_iter().map(|entry| entry.id).collect())
+    }
+
+    pub(super) fn aliased_offsets(&self) -> Result<HashSet<u64>> {
+        let mut seen = HashSet::new();
+        let mut aliases = HashSet::new();
+        for entry in self.entries()? {
+            if !seen.insert(entry.offset) {
+                aliases.insert(entry.offset);
+            }
+        }
+        Ok(aliases)
     }
 }
 

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -103,6 +103,7 @@ impl<'a> PackData<'a> {
 pub struct PackReader<'a> {
     data: PackData<'a>,
     index: PackIndex,
+    aliased_offsets: HashSet<u64>,
     content_end: usize,
     #[cfg(test)]
     compact_frame_reads: AtomicUsize,
@@ -140,9 +141,11 @@ impl PackReader<'static> {
             verify_container_layout(&pack_bytes, pack_container_spec())?
         };
         let index = PackIndex::from_owned_bytes(index_data)?;
+        let aliased_offsets = index.aliased_offsets()?;
         Ok(Self {
             data: PackData::Owned(pack_bytes),
             index,
+            aliased_offsets,
             content_end,
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
@@ -153,9 +156,11 @@ impl PackReader<'static> {
         let pack_data = pack_data.into();
         let (_, _, content_end) = verify_container(&pack_data, pack_container_spec())?;
         let index = PackIndex::from_bytes(index_data.as_ref())?;
+        let aliased_offsets = index.aliased_offsets()?;
         Ok(Self {
             data: PackData::Owned(pack_data),
             index,
+            aliased_offsets,
             content_end,
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
@@ -167,9 +172,11 @@ impl<'a> PackReader<'a> {
     pub fn from_slice(pack_data: &'a [u8], index_data: impl AsRef<[u8]>) -> Result<Self> {
         let (_, _, content_end) = verify_container(pack_data, pack_container_spec())?;
         let index = PackIndex::from_bytes(index_data.as_ref())?;
+        let aliased_offsets = index.aliased_offsets()?;
         Ok(Self {
             data: PackData::Borrowed(pack_data),
             index,
+            aliased_offsets,
             content_end,
             #[cfg(test)]
             compact_frame_reads: AtomicUsize::new(0),
@@ -341,9 +348,7 @@ impl<'a> PackReader<'a> {
                 ));
             }
             let header = decode_tagged_entry_header(self.content_from(offset)?)?;
-            if matches!(header.obj_type, ObjectType::Tree | ObjectType::State)
-                && self.read_compact_objects_at(offset)?.is_some()
-            {
+            if self.read_compact_objects_at(offset)?.is_some() {
                 return Ok(None);
             }
             let expected_size = usize::try_from(*expected_size).ok();
@@ -524,7 +529,9 @@ impl<'a> PackReader<'a> {
             self.content_from(header_start)?,
         )
         .ok_or_else(|| StoreError::InvalidObject("Truncated type+size varint".to_string()))?;
-        if matches!(obj_type, ObjectType::Tree | ObjectType::State) {
+        if (obj_type == ObjectType::Blob && self.aliased_offsets.contains(&(offset as u64)))
+            || matches!(obj_type, ObjectType::Tree | ObjectType::State)
+        {
             let Some((_, data)) = self.get_object(&id)? else {
                 return Ok(None);
             };
@@ -633,10 +640,14 @@ impl<'a> PackReader<'a> {
             stored_data.to_vec()
         };
 
-        if obj_type != ObjectType::Delta && is_compact_frame(&decompressed) {
+        let shared_blob =
+            obj_type == ObjectType::Blob && self.aliased_offsets.contains(&(offset as u64));
+        if obj_type != ObjectType::Delta && (shared_blob || is_compact_frame(&decompressed)) {
             #[cfg(test)]
             self.record_compact_frame_read();
-            if let Some(data) = decode_compact_object(requested_id, obj_type, &decompressed)? {
+            if let Some(data) =
+                decode_compact_object(requested_id, obj_type, &decompressed, shared_blob)?
+            {
                 return Ok(PackObjectRecord {
                     id: *requested_id,
                     obj_type,
@@ -677,7 +688,15 @@ impl<'a> PackReader<'a> {
             ));
         }
         let header = decode_tagged_entry_header(self.content_from(offset)?)?;
-        if !matches!(header.obj_type, ObjectType::Tree | ObjectType::State) {
+        if !matches!(
+            header.obj_type,
+            ObjectType::Blob | ObjectType::Tree | ObjectType::State
+        ) {
+            return Ok(None);
+        }
+        let shared_blob =
+            header.obj_type == ObjectType::Blob && self.aliased_offsets.contains(&(offset as u64));
+        if header.obj_type == ObjectType::Blob && !shared_blob {
             return Ok(None);
         }
         let data_start = checked_index_add(offset, header.header_len, "entry data start")?;
@@ -696,10 +715,10 @@ impl<'a> PackReader<'a> {
             )));
         }
         #[cfg(test)]
-        if is_compact_frame(&data) {
+        if shared_blob || is_compact_frame(&data) {
             self.record_compact_frame_read();
         }
-        decode_compact_objects(header.obj_type, &data)
+        decode_compact_objects(header.obj_type, &data, shared_blob)
     }
 
     fn read_delta_record(
@@ -826,7 +845,8 @@ fn verify_record_id_matches(requested: &PackObjectId, found: &PackObjectId) -> R
 }
 
 fn is_compact_frame(data: &[u8]) -> bool {
-    heddle_object_model::compact::is_tree_frame(data)
+    heddle_object_model::compact::is_blob_frame(data)
+        || heddle_object_model::compact::is_tree_frame(data)
         || heddle_object_model::compact::is_state_frame(data)
 }
 
@@ -834,8 +854,9 @@ fn decode_compact_object(
     requested_id: &PackObjectId,
     obj_type: ObjectType,
     data: &[u8],
+    require_blob_frame: bool,
 ) -> Result<Option<Vec<u8>>> {
-    let Some(objects) = decode_compact_objects(obj_type, data)? else {
+    let Some(objects) = decode_compact_objects(obj_type, data, require_blob_frame)? else {
         return Ok(None);
     };
     objects
@@ -848,11 +869,18 @@ fn decode_compact_object(
 fn decode_compact_objects(
     obj_type: ObjectType,
     data: &[u8],
+    require_blob_frame: bool,
 ) -> Result<Option<DecodedCompactObjects>> {
-    if !is_compact_frame(data) {
-        return Ok(None);
-    }
     match obj_type {
+        ObjectType::Blob if require_blob_frame => {
+            heddle_object_model::compact::decode_blob_frame(data)
+                .map_err(|error| StoreError::InvalidObject(error.to_string()))?
+                .into_iter()
+                .map(|(hash, body)| Ok((PackObjectId::Hash(hash), ObjectType::Blob, body.to_vec())))
+                .collect::<Result<Vec<_>>>()
+                .map(Some)
+        }
+        ObjectType::Blob => Ok(None),
         ObjectType::Tree if heddle_object_model::compact::is_tree_frame(data) => {
             heddle_object_model::compact::decode_tree_frame(data)
                 .map_err(|error| StoreError::InvalidObject(error.to_string()))?
@@ -879,9 +907,10 @@ fn decode_compact_objects(
                 .collect::<Result<Vec<_>>>()
                 .map(Some)
         }
-        _ => Err(StoreError::InvalidObject(
+        _ if is_compact_frame(data) => Err(StoreError::InvalidObject(
             "compact frame magic does not match its pack object type".into(),
         )),
+        _ => Ok(None),
     }
 }
 

--- a/crates/pack/src/store/pack/pack_tests.rs
+++ b/crates/pack/src/store/pack/pack_tests.rs
@@ -64,17 +64,17 @@ fn test_pack_container_header_codec_matches_v3_bytes() {
 }
 
 #[test]
-fn test_pack_index_header_codec_matches_legacy_bytes() {
-    let legacy = b"LMI\0\
-        \0\0\0\x02\
+fn test_pack_index_header_codec_matches_current_bytes() {
+    let current = b"LMI\0\
+        \0\0\0\x03\
         \0\0\0\0\0\0\0\0"
         .to_vec();
 
     let encoded = PackIndex::new().to_bytes();
 
-    assert_eq!(encoded, legacy);
+    assert_eq!(encoded, current);
     assert!(
-        PackIndex::from_bytes(&legacy)
+        PackIndex::from_bytes(&current)
             .unwrap()
             .ids()
             .unwrap()
@@ -91,6 +91,7 @@ fn test_pack_index_roundtrip() {
     index.sort();
 
     let bytes = index.to_bytes();
+    assert_eq!(bytes.len(), 16 + 3 * 40);
     let restored = PackIndex::from_bytes(&bytes).expect("Failed to deserialize index");
 
     assert_eq!(
@@ -117,6 +118,23 @@ fn test_pack_index_roundtrip() {
             .unwrap(),
         None
     );
+}
+
+#[test]
+fn test_pack_index_distinguishes_hash_and_state_with_identical_bytes() {
+    let bytes = [9; 32];
+    let hash_id = PackObjectId::Hash(ContentHash::from_bytes(bytes));
+    let state_id = PackObjectId::StateId(StateId::from_bytes(bytes));
+    let mut index = PackIndex::new();
+    index.add(hash_id, 100);
+    index.add(state_id, 200);
+    index.sort();
+
+    let encoded = index.to_bytes();
+    let restored = PackIndex::from_bytes(&encoded).unwrap();
+
+    assert_eq!(restored.find(&hash_id).unwrap(), Some(100));
+    assert_eq!(restored.find(&state_id).unwrap(), Some(200));
 }
 
 #[test]
@@ -739,7 +757,7 @@ fn test_delta_window_pack_bytes_are_stable() {
     );
     assert_eq!(
         blake3::hash(&index_data).to_string(),
-        "60f164bdc2dbb696c68f1c07a0b84e18f678fe915d7d446e43b1966f365b74f9"
+        "bd27a0fc4ce6c2614fcaef304b01472e98007d121041ffbe4961b275ea44c540"
     );
 }
 

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -518,7 +518,7 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
         Ok(())
     }
 
-    /// Add one compact frame shared by several logical tree or state ids.
+    /// Add one compact frame shared by several logical blob, tree, or state ids.
     ///
     /// `stored_data` is either the raw frame or a zstd frame whose decoded
     /// length is `uncompressed_size`. Every id is indexed at the same physical
@@ -536,9 +536,12 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
                 "compact frame must contain at least one object".to_string(),
             ));
         }
-        if !matches!(obj_type, ObjectType::Tree | ObjectType::State) {
+        if !matches!(
+            obj_type,
+            ObjectType::Blob | ObjectType::Tree | ObjectType::State
+        ) {
             return Err(StoreError::InvalidObject(
-                "shared compact frames may contain only trees or states".to_string(),
+                "shared compact frames may contain only blobs, trees, or states".to_string(),
             ));
         }
         let unique = ids.iter().copied().collect::<HashSet<_>>();
@@ -550,7 +553,7 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
         if ids.iter().any(|id| {
             !matches!(
                 (obj_type, id),
-                (ObjectType::Tree, PackObjectId::Hash(_))
+                (ObjectType::Blob | ObjectType::Tree, PackObjectId::Hash(_))
                     | (ObjectType::State, PackObjectId::StateId(_))
             )
         }) {
@@ -809,19 +812,16 @@ impl<W: Write + Read + Seek + SyncData> StreamingPackBuilder<W> {
 
 /// Write the index container header to `out`. Mirrors
 /// [`PackIndex::to_bytes`]'s prefix exactly (4-byte magic, 4-byte
-/// big-endian version, 8-byte big-endian count) so a reader written
-/// against the existing format works without modification.
+/// big-endian version, 8-byte big-endian count) so the streaming and
+/// in-memory builders produce the same index container.
 fn write_index_header<W: Write>(out: &mut W, count: u64) -> Result<()> {
     super::pack_index::index_header().write_to(out, count)
 }
 
-/// Append one `(id, offset)` index entry to `out`. The encoding
-/// matches [`PackIndex::to_bytes`]: tagged id immediately followed by
-/// an 8-byte big-endian offset.
+/// Append one `(id, offset)` index entry to `out` using the compact
+/// [`PackIndex::to_bytes`] encoding.
 fn write_index_entry<W: Write>(out: &mut W, id: PackObjectId, offset: u64) -> Result<()> {
-    let mut buf = Vec::with_capacity(33 + 8);
-    id.encode_tagged(&mut buf);
-    buf.extend_from_slice(&offset.to_be_bytes());
+    let buf = super::pack_index::encode_index_entry(id, offset);
     out.write_all(&buf).map_err(StoreError::from)
 }
 
@@ -1106,6 +1106,61 @@ mod tests {
     }
 
     #[test]
+    fn shared_lineage_blob_frame_reconstructs_each_indexed_object() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let bodies = [b"newest version".as_slice(), b"older version".as_slice()];
+        let ids = bodies
+            .iter()
+            .map(|body| PackObjectId::Hash(ContentHash::compute_typed("blob", body)))
+            .collect::<Vec<_>>();
+        let frame = heddle_object_model::compact::encode_blob_frame(&bodies).unwrap();
+        builder
+            .add_shared_frame(&ids, ObjectType::Blob, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, stats) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        assert_eq!(stats.object_count, bodies.len() as u64);
+        assert_eq!(
+            reader.encoded_payload_bytes(ObjectType::Blob).unwrap(),
+            frame.len() as u64
+        );
+        for (id, expected) in ids.iter().zip(bodies) {
+            let (object_type, actual) = reader.get_object(id).unwrap().unwrap();
+            assert_eq!(object_type, ObjectType::Blob);
+            assert_eq!(actual, expected);
+            let PackObjectId::Hash(hash) = id else {
+                unreachable!("blob ids are hashes")
+            };
+            assert_eq!(
+                reader.get_hashed_object_type(hash).unwrap(),
+                Some(ObjectType::Blob)
+            );
+            assert_eq!(
+                reader.get_hashed_object_size(hash).unwrap(),
+                Some(expected.len() as u64)
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_blob_starting_with_frame_magic_remains_ordinary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let body = b"HCB2 arbitrary user content".to_vec();
+        let hash = ContentHash::compute_typed("blob", &body);
+        builder.add(hash, ObjectType::Blob, body.clone()).unwrap();
+        let (pack, index, _) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        assert_eq!(
+            reader.get_object(&PackObjectId::Hash(hash)).unwrap(),
+            Some((ObjectType::Blob, body))
+        );
+    }
+
+    #[test]
     fn corrupt_compact_frame_byte_invalidates_every_contained_object() {
         use crate::object::{Tree, TreeEntry};
 
@@ -1125,6 +1180,35 @@ mod tests {
         frame[corrupt_at] ^= 0x01;
         builder
             .add_shared_frame(&ids, ObjectType::Tree, frame.len(), &frame)
+            .unwrap();
+        let (pack, index, _) = finalize_cursor(builder, &index_path);
+        let reader = PackReader::from_bytes(pack, index).unwrap();
+
+        for id in ids {
+            let error = reader.get_object(&id).unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("compact frame checksum mismatch"),
+                "unexpected error for {id:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn corrupt_blob_frame_byte_invalidates_every_contained_object() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let (mut builder, _, index_path) = fresh_builder(&tmp);
+        let bodies = [b"newest version".as_slice(), b"older version".as_slice()];
+        let ids = bodies
+            .iter()
+            .map(|body| PackObjectId::Hash(ContentHash::compute_typed("blob", body)))
+            .collect::<Vec<_>>();
+        let mut frame = heddle_object_model::compact::encode_blob_frame(&bodies).unwrap();
+        let corrupt_at = frame.len() / 2;
+        frame[corrupt_at] ^= 0x01;
+        builder
+            .add_shared_frame(&ids, ObjectType::Blob, frame.len(), &frame)
             .unwrap();
         let (pack, index, _) = finalize_cursor(builder, &index_path);
         let reader = PackReader::from_bytes(pack, index).unwrap();
@@ -1561,7 +1645,9 @@ mod tests {
         // Inspect bucket file sizes BEFORE finalize (which deletes them).
         b.pack_writer.as_mut().unwrap().flush().unwrap();
         let mut max_entries = 0usize;
-        let entry_size = 33 + 8; // tagged-hash + u64 offset
+        // Bucket files use the temporary tagged ID encoding; only the
+        // finalized index folds the tag into the offset.
+        let entry_size = 33 + 8;
         for path in b.bucket_paths.iter() {
             if path.exists() {
                 let size = std::fs::metadata(path).unwrap().len() as usize;


### PR DESCRIPTION
## Summary

- Build exact blob lineages from the state graph and tree diffs, including deterministic exact and similarity rename tracking plus extension/path clustering.
- Write newest-to-oldest lineage-solid blob frames with a 12 MiB bound, zstd level 19 long-distance compression, BLAKE3 frame integrity, and a compact v3 40-byte object index alongside the S2 metadata encoder.
- Read shared blob frames transparently, preserve singleton random access and S3 hot-tier behavior, and fail every alias when a shared frame is corrupt.

## Closes

Closes #1340
Part of #1323

## Test evidence

- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo build --locked --workspace
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo clippy --workspace --all-targets --locked -- -D warnings
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo fmt --all -- --check
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo test -p heddle-pack store::pack --locked (79 passed)
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo test -p heddle-objects store::fs::repack --locked (12 passed)
- TMPDIR=/home/scratch CARGO_TARGET_DIR=/home/scratch/heddle-1340-target cargo test -p heddle-object-model blob_frame --locked (2 passed)

| Corpus | Pinned revision | Heddle objects | Heddle bytes | Git pack bytes | Heddle / Git pack | S2 target | Byte-identical |
| --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
| semver | 4fea7f0d5a1c9fca85f764c02953643d7fd45b27 | 373 | 107,157 | 117,623 | 0.9110208 | 0.9111 | yes |
| ripgrep | 3fce3b5bb0236da2df6d99672afb8a719642eca7 | 13,790 | 2,803,888 | 3,380,197 | 0.8295043 | 0.8301 | yes |
| curl | f5378b88a974e565f767f2a041972aa942a69c5d | 287,550 | 47,102,814 | 53,893,244 | 0.8740022 | 0.8743 | yes |

The falsifier used the production writer and reader, reconstructed the full indexed object set twice for each corpus, matched source and reconstructed fingerprints, verified every blob frame checksum, and confirmed corrupt shared-frame bytes invalidate every contained object.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789142121&installation_model_id=21489&pr_number=1342&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1342&signature=36c402b44a4421ff358608a8b00dc0ec5755a51225a1f7a58c3b774bcd4b1f67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->