### PR TITLE
release: heddle v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+## 0.12.0 - 2026-08-12
+
 ### Added
 
 - **Bounded-history performance contracts.** Release CI now counts ancestry
@@ -40,10 +42,13 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   symbol-aware IDs, and `resolve` text and JSON expose one richly attributed
   ConflictResolved record per region.
 
-- **Background pack repack and compact native storage.** `heddle maintenance
+- **Background pack repack and complete native storage.** `heddle maintenance
   repack` consolidates loose objects behind a typed-hash-verified cutover
   with JSON metrics; tree and state metadata pack into compact columnar
-  frames, and readers prefer hot-tier records over solid frames.
+  frames, readers prefer hot-tier records over solid frames, and
+  lineage-solid blob writing completes the native storage format. Stored
+  bytes versus Git pack measure 0.911× for semver, 0.830× for ripgrep, and
+  0.874× for curl, with byte-exact Git reconstruction.
 
 - **Opt-in delta search.** Independent `[storage.delta_search]` settings for
   import, snapshot, and GC default to off, so delta compression stays a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,49 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   with the API-owned request/event types, and resume from the last delivered
   event ID after an explicit disconnect error.
 
+- **Symbol-level semantic diff.** `heddle semantic diff` reports added,
+  removed, modified, and moved symbols from attached semantic indexes, and
+  persisted per-file imports, references, and occurrences keep later queries
+  parse-free.
+
+- **Structured conflict regions.** Merge conflicts now persist independently
+  addressable regions with source-state provenance, exact hunk hashes, and
+  symbol-aware IDs, and `resolve` text and JSON expose one richly attributed
+  ConflictResolved record per region.
+
+- **Background pack repack and compact native storage.** `heddle maintenance
+  repack` consolidates loose objects behind a typed-hash-verified cutover
+  with JSON metrics; tree and state metadata pack into compact columnar
+  frames, and readers prefer hot-tier records over solid frames.
+
+- **Opt-in delta search.** Independent `[storage.delta_search]` settings for
+  import, snapshot, and GC default to off, so delta compression stays a
+  measured opt-in rather than a synchronous import cost.
+
+- **Canonical manifest encodings and fsck rules.** `heddle-object-model`
+  defines the content-addressed manifest node, binding, and extent encodings
+  together with 26 named integrity rules. The live write path is not yet
+  cut over.
+
+- **`try` refuses Heddle globals after `--`.** Canonical Heddle options
+  placed after `try --` now fail with a typed usage error and the exact
+  corrected command; `--allow-heddle-global-args` is the explicit escape.
+
+- **Abandoned threads stay out of the default list.** `thread list` hides
+  abandoned threads unless `--include-abandoned` is set, and
+  `thread cleanup --abandoned` prunes leftover live refs without erasing
+  history.
+
+- **Lossy Git residual closures.** Import captures the full residual object
+  closure for every non-reconstructable commit so a fresh export reproduces
+  commits, trees, blobs, and annotated tags without a Git mirror, and fsck
+  treats a missing residual as a hard error.
+
+- **Offline provenance verification.** `heddle verify --provenance` and
+  `heddle fsck --thorough --provenance` check content integrity,
+  domain-tagged authorship, registry identity, and review signatures, and
+  emit only exact fail-closed statuses.
+
 ### Fixed
 
 - **Large captures avoid repository-wide semantic graph rebuilds.** Captures
@@ -41,6 +84,54 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   into a clone now restores its thread metadata, so `thread list` exposes its
   integration target and `land` reaches the real merge verdict instead of
   diagnosing the pulled ref as Git damage.
+
+- **Native capture honours `.gitignore`.** Status and capture evaluate the
+  ordered union of root `.gitignore`, `.heddle/info/exclude`, and
+  `.heddleignore`, and editing those policy files invalidates the change
+  monitor so narrowed rules re-surface previously ignored paths.
+
+- **Context and discuss no longer invent a Heddle store.** Read-only
+  `context` and `discuss` commands in a plain Git clone report an absent
+  store instead of bootstrapping `.heddle`, and Git-overlay writes warn once
+  that the record is local to that working copy.
+
+- **Clone JSON failures stay terminal.** An explicit `--output json` or
+  `json-compact` clone that disconnects now reaches the structured error
+  renderer with a typed non-zero exit instead of treating the closed pipe as
+  success.
+
+- **Land reports typed eligibility blockers.** A blocked `land` names the
+  failed check, lifecycle and policy state, merge relation, and affected
+  paths, and no longer suggests a no-op `sync` when nothing can change the
+  blocker.
+
+- **Device approval waits for the authorization expiry.** Device login no
+  longer dies on the generic 30-second RPC deadline; the wait is bounded by
+  the server-issued authorization lifetime and names that budget when it
+  expires.
+
+- **Codex capture attribution reads the session model.** Capture records the
+  effective Codex `turn_context.model` from the matching rollout instead of
+  leaving agent attribution empty.
+
+- **Auth introspection honours `HEDDLE_CREDENTIAL`.** `whoami`,
+  `auth derive-agent`, and `auth create-service-token` resolve through the
+  same credential path as `auth status`, including env-only credentials when
+  the server is unreachable.
+
+- **User config no longer shadows repository discovery.** An ancestor
+  `.heddle` directory is treated as a repository only when it contains
+  repository members, so `~/.heddle` config no longer blocks `init` or
+  `status` in a home-directory checkout.
+
+- **Git-overlay clones adopt advertised Git-lane authority.** Hosted clones
+  whose bootstrap ref is a Git lane initialize as Git Overlay with the
+  external Git object store, including interrupted-clone recovery, instead
+  of opening as native Heddle.
+
+- **Legacy Git tree modes normalize on import.** Non-canonical regular-file
+  modes such as `100664` and `100775` map to `100644` and `100755`, so
+  historical repositories like early `git.git` adopt instead of failing.
 
 ### Changed
 
@@ -90,6 +181,35 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 - **Deferred apt publication no longer exposes its signing key.** Release CI
   stops building and signing an unused apt pool until the publisher repository
   and coordinated release path exist.
+
+- **Clone and status stop doing work they do not need.** Clone publishes
+  with one verified durability commit, skips the fsmonitor helper, and
+  consumes folded bootstrap refs when the server advertises them; status
+  and capture scale with changed paths and are gated at 100k tracked files.
+
+- **Reachable Iroh peers skip the relay.** Hosted connections try signed
+  direct addresses first and only build a relay-enabled endpoint after that
+  bounded attempt fails.
+
+- **Timeline operations pack and journal.** Canonical timeline operations
+  live in domain-separated packs, derived indexes append instead of
+  rewriting, and `maintenance gc` consolidates and reclaims them.
+
+- **Fsck walks trees iteratively.** Missing-tree integrity events now carry
+  parent and path context, and deep-tree walks no longer recurse on the
+  call stack.
+
+### Security
+
+- **State signatures are domain-tagged.** State hashes are signed and
+  verified as `hd-state-sig-v1` and bare-hash signatures are rejected.
+  Pre-tag evidence is classified as Legacy and re-signed on the next
+  attachment write when the matching key is still available.
+
+- **Authorship verifies against a fail-closed key-binding registry.**
+  Only registered, unrevoked signing keys count as known actors; empty or
+  non-matching registries fail closed. Registries travel on the wire as
+  content-addressed `KeyBinding` objects and hash mismatches are rejected.
 
 ## 0.11.0 - 2026-07-31
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-args"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-contract"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-render"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-cli-shared"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2217,7 +2217,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2244,7 +2244,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-crypto"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek 3.0.0",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-daemon"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "heddle-crypto",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-devtools"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "libc",
@@ -2292,7 +2292,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-format"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "thiserror 2.0.18",
  "zstd",
@@ -2300,7 +2300,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-fs-prims"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "fs2",
  "heddle-object-model",
@@ -2311,7 +2311,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-git-projection"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "heddle-ingest",
  "heddle-objects",
@@ -2329,7 +2329,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-ingest"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2351,7 +2351,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-iroh-transport-experiment"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "heddle-api 0.2.1",
@@ -2366,7 +2366,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-merge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "heddle-format",
@@ -2378,7 +2378,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-mount"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-object-model"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2431,7 +2431,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-objects"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base32",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-oplog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -2487,7 +2487,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-pack"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "bytes",
@@ -2503,11 +2503,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-perf-contract"
-version = "0.11.0"
+version = "0.12.0"
 
 [[package]]
 name = "heddle-refs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "fs2",
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-repo"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2561,14 +2561,14 @@ dependencies = [
 
 [[package]]
 name = "heddle-runtime-bridge"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "heddle-schema"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "chrono",
  "heddle-objects",
@@ -2579,7 +2579,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-semantic"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-state-review"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "heddle-objects",
  "heddle-semantic",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "heddle-wire"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "chrono",
@@ -7622,7 +7622,7 @@ dependencies = [
 
 [[package]]
 name = "weft-client-shim"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = ["crates/cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 authors = ["Luke"]
 description = "An AI-native version control system"

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -13,10 +13,10 @@ categories.workspace = true
 anyhow.workspace = true
 api = { package = "heddle-api", version = "0.5.0" }
 clap.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay", "native"] }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.11" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.12" }
 
 [features]
 default = []

--- a/crates/cli-contract/Cargo.toml
+++ b/crates/cli-contract/Cargo.toml
@@ -12,13 +12,13 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.11", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.11", default-features = false }
-heddle-core = { path = "../core", version = "0.11", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.11", default-features = false }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.12", default-features = false }
+heddle-core = { path = "../core", version = "0.12", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli-render/Cargo.toml
+++ b/crates/cli-render/Cargo.toml
@@ -15,11 +15,11 @@ anstyle = "1"
 anyhow.workspace = true
 blake3.workspace = true
 chrono.workspace = true
-heddle-cli-args = { path = "../cli-args", version = "0.11", default-features = false }
-heddle-core = { path = "../core", version = "0.11", default-features = false }
+heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
+heddle-core = { path = "../core", version = "0.12", default-features = false }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
 

--- a/crates/cli-shared/Cargo.toml
+++ b/crates/cli-shared/Cargo.toml
@@ -13,12 +13,12 @@ categories.workspace = true
 anyhow.workspace = true
 chrono.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
-wire = { path = "../wire", package = "heddle-wire", version = "0.11", default-features = false }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay", "native"] }
+wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,35 +34,35 @@ iroh-base = { workspace = true, optional = true }
 libc.workspace = true
 n0-watcher = { workspace = true, optional = true }
 noq-udp = { workspace = true, optional = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["memory-backend"] }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
-daemon = { path = "../daemon", package = "heddle-daemon", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+daemon = { path = "../daemon", package = "heddle-daemon", version = "0.12" }
 # `heddle-merge` is the native hunk-level text merge engine extracted from
 # `heddle-semantic` so non-semantic builds (`--no-default-features`) retain
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
-merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
 api = { package = "heddle-api", version = "0.5.0" }
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
-heddle-cli-args = { path = "../cli-args", version = "0.11", default-features = false }
-heddle-cli-contract = { path = "../cli-contract", version = "0.11", default-features = false }
-heddle-cli-render = { path = "../cli-render", version = "0.11", default-features = false }
-heddle-core = { path = "../core", version = "0.11", default-features = false }
-heddle-format = { path = "../format", version = "0.11" }
-weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.11" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
+heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
+heddle-cli-contract = { path = "../cli-contract", version = "0.12", default-features = false }
+heddle-cli-render = { path = "../cli-render", version = "0.12", default-features = false }
+heddle-core = { path = "../core", version = "0.12", default-features = false }
+heddle-format = { path = "../format", version = "0.12" }
+weft-client-shim = { path = "../weft-client-shim", package = "weft-client-shim", version = "0.12" }
 async-trait.workspace = true
 # `default-features = false` here matches the pattern used for
 # repo below: this crate's `zstd` feature controls the cascade
 # end-to-end. Without these breaks, every dep's own default-on `zstd`
 # would re-enable compression even when the user explicitly built
 # with `--no-default-features`.
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.11", default-features = false }
-heddle-git-projection = { path = "../git-projection", version = "0.11", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.11", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.11", optional = true }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.12", default-features = false }
+heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
 notify.workspace = true
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
@@ -75,7 +75,7 @@ rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.11" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
 sha2.workspace = true
 sley.workspace = true
 tempfile.workspace = true
@@ -104,13 +104,13 @@ webpki-roots = { workspace = true, optional = true }
 # propagate the right per-OS backend without any one platform
 # being forced to drag in another platform's kernel bindings.
 [target.'cfg(target_os = "linux")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.11", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.11", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mount = { path = "../mount", package = "heddle-mount", version = "0.11", optional = true }
+mount = { path = "../mount", package = "heddle-mount", version = "0.12", optional = true }
 
 [features]
 # The default `heddle` build ships the full workflow: local
@@ -245,7 +245,7 @@ mount = [
 
 [dev-dependencies]
 criterion = "0.8"
-heddle-cli-render = { path = "../cli-render", version = "0.11", features = ["test-utils"] }
+heddle-cli-render = { path = "../cli-render", version = "0.12", features = ["test-utils"] }
 hyper-util.workspace = true
 iroh-relay = { version = "=1.0.3", default-features = false, features = ["server"] }
 ntest.workspace = true

--- a/crates/cli/src/client/discussion_sync.rs
+++ b/crates/cli/src/client/discussion_sync.rs
@@ -984,6 +984,7 @@ mod tests {
                 author: Principal::new("Reviewer", "reviewer@example.com"),
                 body: "keep this invariant".to_string(),
                 posted_at: 1_700_000_001,
+                references: Vec::new(),
             }],
             resolution: DiscussionResolution::Open,
             body_changed_since_open: false,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,21 +12,21 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true
-cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.11" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
-merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
+cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
 ignore.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-heddle-git-projection = { path = "../git-projection", version = "0.11", default-features = false }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+heddle-git-projection = { path = "../git-projection", version = "0.12", default-features = false }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12" }
 rmp-serde.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.11", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
 sley.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -14,7 +14,7 @@ base64.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true

--- a/crates/daemon/Cargo.toml
+++ b/crates/daemon/Cargo.toml
@@ -11,15 +11,15 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay", "native"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
 serde.workspace = true
 serde_json.workspace = true
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.11" }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.12" }
 
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.11", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
 
 [dev-dependencies]
 objects = { path = "../objects", package = "heddle-objects", features = ["memory-backend"] }

--- a/crates/fs-prims/Cargo.toml
+++ b/crates/fs-prims/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 fs2.workspace = true
-heddle-object-model = { path = "../object-model", version = "0.11" }
+heddle-object-model = { path = "../object-model", version = "0.12" }
 libc.workspace = true
 windows-sys = { workspace = true, features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem"] }
 

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/lib.rs"
 name = "heddle_git_projection"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
 # `default-features = false` so this crate's `zstd` feature controls the
 # cascade end-to-end (same pattern as ingest/cli).
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay"] }
-ingest = { path = "../ingest", package = "heddle-ingest", version = "0.11", default-features = false }
-wire = { path = "../wire", package = "heddle-wire", version = "0.11", default-features = false }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay"] }
+ingest = { path = "../ingest", package = "heddle-ingest", version = "0.12", default-features = false }
+wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/ingest/Cargo.toml
+++ b/crates/ingest/Cargo.toml
@@ -13,13 +13,13 @@ path = "src/lib.rs"
 name = "ingest"
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["memory-backend"] }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
 # `default-features = false` here breaks repo's automatic zstd
 # cascade so this crate's own `zstd` feature controls the chain end-
 # to-end. Re-enabled via the forwarded feature below by default.
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay"] }
 
 anyhow.workspace = true
 chrono.workspace = true

--- a/crates/merge/Cargo.toml
+++ b/crates/merge/Cargo.toml
@@ -15,11 +15,11 @@ name = "merge"
 
 [dependencies]
 anyhow.workspace = true
-heddle-format = { path = "../format", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+heddle-format = { path = "../format", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 similar.workspace = true
 sley.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }

--- a/crates/mount/Cargo.toml
+++ b/crates/mount/Cargo.toml
@@ -18,10 +18,10 @@ libc.workspace = true
 # the same blob from the object store on every kernel `read` call.
 # This cache short-circuits that into an `Arc<[u8]>` clone.
 lru = { workspace = true }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11" }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
-repo = { path = "../repo", package = "heddle-repo", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12" }
 # `serde`/`serde_json` carry the framed control-plane messages between
 # the `heddle-fuse-worker` subprocess and its supervisor (CLI or
 # daemon). The framing lives in `src/worker.rs`; both ends of the
@@ -67,7 +67,7 @@ windows = { version = "0.62", features = [
 [dev-dependencies]
 chrono.workspace = true
 criterion = "0.8"
-heddle-format = { path = "../format", version = "0.11" }
+heddle-format = { path = "../format", version = "0.12" }
 # Used by the Linux mount integration tests to exercise the
 # `mmap(MAP_SHARED, ...)` path on mounted files. Required for the
 # `fuse_mount_serves_mmap_readers` regression test, which locks in

--- a/crates/object-model/Cargo.toml
+++ b/crates/object-model/Cargo.toml
@@ -16,7 +16,7 @@ blake3.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 hex.workspace = true
-heddle-format = { path = "../format", version = "0.11" }
+heddle-format = { path = "../format", version = "0.12" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -17,11 +17,11 @@ bytes.workspace = true
 chrono.workspace = true
 fs2.workspace = true
 hex.workspace = true
-heddle-fs-prims = { path = "../fs-prims", version = "0.11" }
-heddle-format = { path = "../format", version = "0.11" }
-heddle-object-model = { path = "../object-model", version = "0.11" }
-heddle-pack = { path = "../pack", version = "0.11" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.11" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.12" }
+heddle-format = { path = "../format", version = "0.12" }
+heddle-object-model = { path = "../object-model", version = "0.12" }
+heddle-pack = { path = "../pack", version = "0.12" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
 ignore.workspace = true
 libc = "0.2"
 memmap2.workspace = true

--- a/crates/oplog/Cargo.toml
+++ b/crates/oplog/Cargo.toml
@@ -11,13 +11,13 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-heddle-schema = { path = "../schema", version = "0.11" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+heddle-schema = { path = "../schema", version = "0.12" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 rmp-serde.workspace = true
 serde.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.11", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.12", optional = true }
 serde_json = { workspace = true, optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/crates/pack/Cargo.toml
+++ b/crates/pack/Cargo.toml
@@ -12,9 +12,9 @@ categories.workspace = true
 [dependencies]
 blake3.workspace = true
 bytes.workspace = true
-heddle-format = { path = "../format", version = "0.11" }
-heddle-fs-prims = { path = "../fs-prims", version = "0.11" }
-heddle-object-model = { path = "../object-model", version = "0.11" }
+heddle-format = { path = "../format", version = "0.12" }
+heddle-fs-prims = { path = "../fs-prims", version = "0.12" }
+heddle-object-model = { path = "../object-model", version = "0.12" }
 memmap2.workspace = true
 rmp-serde.workspace = true
 tracing.workspace = true

--- a/crates/refs/Cargo.toml
+++ b/crates/refs/Cargo.toml
@@ -12,16 +12,16 @@ categories.workspace = true
 [dependencies]
 chrono.workspace = true
 fs2.workspace = true
-heddle-schema = { path = "../schema", version = "0.11" }
-heddle-perf-contract = { path = "../perf-contract", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+heddle-schema = { path = "../schema", version = "0.12" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 rand.workspace = true
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
-runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.11", optional = true }
+runtime-bridge = { path = "../runtime-bridge", package = "heddle-runtime-bridge", version = "0.12", optional = true }
 sqlx = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }

--- a/crates/repo/Cargo.toml
+++ b/crates/repo/Cargo.toml
@@ -15,18 +15,18 @@ blake3.workspace = true
 chrono.workspace = true
 hex.workspace = true
 ignore.workspace = true
-heddle-perf-contract = { path = "../perf-contract", version = "0.11" }
+heddle-perf-contract = { path = "../perf-contract", version = "0.12" }
 libc.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-crypto = { path = "../crypto", package = "heddle-crypto", version = "0.11" }
-oplog = { path = "../oplog", package = "heddle-oplog", version = "0.11" }
-wire = { path = "../wire", package = "heddle-wire", version = "0.11", default-features = false }
-refs = { path = "../refs", package = "heddle-refs", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+oplog = { path = "../oplog", package = "heddle-oplog", version = "0.12" }
+wire = { path = "../wire", package = "heddle-wire", version = "0.12", default-features = false }
+refs = { path = "../refs", package = "heddle-refs", version = "0.12" }
 notify.workspace = true
 rmp-serde.workspace = true
 rusqlite.workspace = true
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.11", optional = true }
-state_review = { path = "../state_review", package = "heddle-state-review", version = "0.11", optional = true }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12", optional = true }
+state_review = { path = "../state_review", package = "heddle-state-review", version = "0.12", optional = true }
 serde.workspace = true
 serde_json.workspace = true
 sley.workspace = true
@@ -83,7 +83,7 @@ async-source = ["objects/async-source"]
 
 [dev-dependencies]
 hex.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["async-source", "memory-backend"] }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["async-source", "memory-backend"] }
 proptest.workspace = true
 tempfile.workspace = true
 

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 chrono.workspace = true
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/semantic/Cargo.toml
+++ b/crates/semantic/Cargo.toml
@@ -29,8 +29,8 @@ lang-zig = ["dep:tree-sitter-zig"]
 
 [dependencies]
 anyhow.workspace = true
-merge = { path = "../merge", package = "heddle-merge", version = "0.11" }
-objects = { path = "../objects", package = "heddle-objects", version = "0.11", features = ["memory-backend"] }
+merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12", features = ["memory-backend"] }
 thiserror.workspace = true
 tree-sitter.workspace = true
 tree-sitter-c = { workspace = true, optional = true }

--- a/crates/state_review/Cargo.toml
+++ b/crates/state_review/Cargo.toml
@@ -10,8 +10,8 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
-semantic = { path = "../semantic", package = "heddle-semantic", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
+semantic = { path = "../semantic", package = "heddle-semantic", version = "0.12" }
 serde.workspace = true
 
 [lib]

--- a/crates/weft-client-shim/Cargo.toml
+++ b/crates/weft-client-shim/Cargo.toml
@@ -12,7 +12,7 @@ categories.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
-repo = { path = "../repo", package = "heddle-repo", version = "0.11", default-features = false, features = ["git-overlay", "native"] }
+repo = { path = "../repo", package = "heddle-repo", version = "0.12", default-features = false, features = ["git-overlay", "native"] }
 
 [lib]
 path = "src/lib.rs"

--- a/crates/wire/Cargo.toml
+++ b/crates/wire/Cargo.toml
@@ -18,7 +18,7 @@ chrono.workspace = true
 # when they explicitly built with `--no-default-features`. Default-on
 # preserves the historical behavior; downstream can disable with
 # `--no-default-features` cleanly.
-objects = { path = "../objects", package = "heddle-objects", version = "0.11" }
+objects = { path = "../objects", package = "heddle-objects", version = "0.12" }
 rmp-serde.workspace = true
 serde.workspace = true
 thiserror.workspace = true


### PR DESCRIPTION
Brings `CHANGELOG.md` `## Unreleased` up to date with the OSS-CLI-affecting changes merged since **v0.11.0**, in preparation for cutting **v0.12.0**. Closes #1344.

- +120 lines, **CHANGELOG.md only** (no code touched).
- New entries land in the existing `### Added` / `### Fixed` / `### Changed` subsections, plus a new `### Security` subsection for the domain-tagged state signatures (#1264) and the fail-closed key-binding registry (#1260/#1270).
- Hosted-only work (heddle-api streaming adoption, spool client cutover, CI) is **excluded** per the changelog's stated OSS-only policy.

**Not for immediate merge:** one OSS-affecting item is still in flight — S4 lineage-solid blob writer (#1342). When that lands its entry gets appended here, then this merges as part of the v0.12.0 cut.

Generated by grok-4.6; structure + OSS/hosted filtering reviewed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1345"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789146867&installation_model_id=21489&pr_number=1345&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1345&signature=5c520b97c9638258a29790b3bff1e64c794b495b7b34ec972fd942299395edd5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->