### PR TITLE
feat(cli): TTY interactive selection for genuine ambiguity (thread/remote/actor) — P1 of #473

### DIFF
--- a/crates/cli/src/cli/commands/agent_presence.rs
+++ b/crates/cli/src/cli/commands/agent_presence.rs
@@ -170,7 +170,12 @@ pub async fn list(cli: &Cli, active_only: bool) -> Result<()> {
 pub async fn show(cli: &Cli, session_id: Option<String>) -> Result<()> {
     let repo = cli.open_repo()?;
     let registry = ActorPresenceStore::new(repo.heddle_dir());
-    let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
+    let entry = resolve_actor_entry(
+        &repo,
+        &registry,
+        session_id.as_deref(),
+        "heddle agent presence show <SESSION>",
+    )?;
     let show = show_actor_from_entry(&registry, &entry)?;
 
     if should_output_json(cli, None) {
@@ -272,7 +277,12 @@ fn render_actor_show(actor: &ActorEntryReport) {
 pub async fn complete(cli: &Cli, session_id: Option<String>) -> Result<()> {
     let repo = cli.open_repo()?;
     let registry = ActorPresenceStore::new(repo.heddle_dir());
-    let entry = resolve_actor_entry(&repo, &registry, session_id.as_deref())?;
+    let entry = resolve_actor_entry(
+        &repo,
+        &registry,
+        session_id.as_deref(),
+        "heddle agent presence complete --session <SESSION>",
+    )?;
     let plan = plan_actor_done(&entry);
     mark_actor_done(&registry, &plan.session_id)?;
     let summary = find_thread_summary(&repo, &plan.thread)?;
@@ -319,7 +329,12 @@ fn actor_done_recommended_action(thread: &str, coordination_status: &str) -> Opt
 pub async fn explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
     let repo = cli.open_repo()?;
     let registry = ActorPresenceStore::new(repo.heddle_dir());
-    let entry = match resolve_actor_entry(&repo, &registry, session_id.as_deref()) {
+    let entry = match resolve_actor_entry(
+        &repo,
+        &registry,
+        session_id.as_deref(),
+        "heddle agent presence explain <SESSION>",
+    ) {
         Ok(entry) => entry,
         Err(err) if session_id.is_none() && is_no_active_actor_error(&err) => {
             return explain_detected_actor_identity(cli, &repo);
@@ -503,6 +518,7 @@ fn resolve_actor_entry(
     repo: &Repository,
     registry: &ActorPresenceStore,
     session_id: Option<&str>,
+    command_template: &str,
 ) -> Result<ActorPresence> {
     if let Some(session_id) = session_id {
         return registry
@@ -517,30 +533,94 @@ fn resolve_actor_entry(
     // `head_ref()` / `.heddle/HEAD` directly. There must be exactly one answer
     // to "current lane?".
     let current_lane = repo.current_lane()?;
+    let active_entries = registry.active_entries()?;
+    let canonical_root = repo
+        .root()
+        .canonicalize()
+        .unwrap_or_else(|_| repo.root().to_path_buf());
 
-    if let Some(thread) = current_lane.as_deref()
-        && let Some(entry) = registry
-            .active_entries()?
-            .into_iter()
+    if let Some(thread) = current_lane.as_deref() {
+        let matching_thread = active_entries
+            .iter()
             .filter(|entry| entry.thread == thread)
-            .max_by_key(|entry| entry.started_at)
-    {
-        return Ok(entry);
+            .cloned()
+            .collect::<Vec<_>>();
+        let matching_thread_and_path = matching_thread
+            .iter()
+            .filter(|entry| actor_path_matches(entry, &canonical_root))
+            .cloned()
+            .collect::<Vec<_>>();
+        let preferred = if matching_thread_and_path.is_empty() {
+            matching_thread
+        } else {
+            matching_thread_and_path
+        };
+        if let Some(entry) = select_actor_candidate(preferred, command_template)? {
+            return Ok(entry);
+        }
     }
 
-    if let Some(entry) = registry.find_active_by_path(repo.root())? {
+    let matching_path = active_entries
+        .iter()
+        .filter(|entry| actor_path_matches(entry, &canonical_root))
+        .cloned()
+        .collect();
+    if let Some(entry) = select_actor_candidate(matching_path, command_template)? {
         return Ok(entry);
     }
 
     // The "any active actor" fallback only applies when this checkout is on a
     // lane. A detached checkout must not inherit unrelated active presence.
     if current_lane.is_some()
-        && let Some(entry) = registry.active_entries()?.into_iter().next()
+        && let Some(entry) = select_actor_candidate(active_entries, command_template)?
     {
         return Ok(entry);
     }
 
     Err(anyhow!(no_active_actor_advice()))
+}
+
+fn actor_path_matches(entry: &ActorPresence, canonical_root: &std::path::Path) -> bool {
+    entry
+        .path
+        .as_ref()
+        .map(|path| path.canonicalize().unwrap_or_else(|_| path.clone()) == canonical_root)
+        .unwrap_or(false)
+}
+
+fn select_actor_candidate(
+    mut candidates: Vec<ActorPresence>,
+    command_template: &str,
+) -> Result<Option<ActorPresence>> {
+    match candidates.len() {
+        0 => return Ok(None),
+        1 => return Ok(candidates.pop()),
+        _ => {}
+    }
+    candidates.sort_by(|left, right| left.session_id.cmp(&right.session_id));
+    let choices = candidates
+        .iter()
+        .map(|entry| {
+            let actor = match (&entry.provider, &entry.model) {
+                (Some(provider), Some(model)) => format!(" {provider}/{model}"),
+                (Some(provider), None) => format!(" {provider}"),
+                _ => String::new(),
+            };
+            super::interactive_select::SelectionChoice::new(
+                entry.session_id.clone(),
+                format!("{} (thread: {}){actor}", entry.session_id, entry.thread),
+            )
+        })
+        .collect();
+    let selected = super::interactive_select::select_ambiguous_target(
+        "actor",
+        "<SESSION>",
+        command_template,
+        choices,
+    )?;
+    Ok(candidates
+        .into_iter()
+        .find(|entry| entry.session_id == selected))
 }
 
 fn is_no_active_actor_error(err: &anyhow::Error) -> bool {

--- a/crates/cli/src/cli/commands/interactive_select.rs
+++ b/crates/cli/src/cli/commands/interactive_select.rs
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: Apache-2.0
+//! TTY-only selection for genuinely ambiguous CLI targets.
+
+use std::io::{BufRead, Write};
+
+use anyhow::{Context, Result, anyhow};
+
+use super::advice::RecoveryAdvice;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SelectionChoice {
+    pub value: String,
+    pub label: String,
+}
+
+impl SelectionChoice {
+    pub(crate) fn new(value: impl Into<String>, label: impl Into<String>) -> Self {
+        Self {
+            value: value.into(),
+            label: label.into(),
+        }
+    }
+}
+
+pub(crate) fn select_ambiguous_target(
+    target_kind: &'static str,
+    selector: &'static str,
+    command_template: &str,
+    choices: Vec<SelectionChoice>,
+) -> Result<String> {
+    let interactive = crate::cli::is_interactive_tty();
+    let stdin = std::io::stdin();
+    let stderr = std::io::stderr();
+    select_ambiguous_target_with_io(
+        target_kind,
+        selector,
+        command_template,
+        choices,
+        interactive,
+        &mut stdin.lock(),
+        &mut stderr.lock(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn select_ambiguous_target_with_io(
+    target_kind: &'static str,
+    selector: &'static str,
+    command_template: &str,
+    choices: Vec<SelectionChoice>,
+    interactive: bool,
+    input: &mut dyn BufRead,
+    output: &mut dyn Write,
+) -> Result<String> {
+    debug_assert!(choices.len() > 1, "selection requires genuine ambiguity");
+    if !interactive {
+        return Err(anyhow!(ambiguous_target_advice(
+            target_kind,
+            selector,
+            command_template,
+            &choices,
+        )));
+    }
+
+    writeln!(output, "Multiple {target_kind}s match. Select one:")?;
+    for (index, choice) in choices.iter().enumerate() {
+        writeln!(output, "  {}) {}", index + 1, choice.label)?;
+    }
+
+    loop {
+        write!(output, "Selection [1-{}] (q to cancel): ", choices.len())?;
+        output.flush()?;
+
+        let mut answer = String::new();
+        if input.read_line(&mut answer)? == 0 || answer.trim().eq_ignore_ascii_case("q") {
+            return Err(anyhow!(ambiguous_target_advice(
+                target_kind,
+                selector,
+                command_template,
+                &choices,
+            )));
+        }
+        if let Ok(index) = answer.trim().parse::<usize>()
+            && let Some(choice) = index.checked_sub(1).and_then(|index| choices.get(index))
+        {
+            return Ok(choice.value.clone());
+        }
+        writeln!(output, "Enter a number from 1 to {}.", choices.len())
+            .context("write interactive selection validation")?;
+    }
+}
+
+fn ambiguous_target_advice(
+    target_kind: &'static str,
+    selector: &'static str,
+    command_template: &str,
+    choices: &[SelectionChoice],
+) -> RecoveryAdvice {
+    let advice_kind = match target_kind {
+        "thread" => "ambiguous_thread_selection",
+        "remote" => "ambiguous_remote_selection",
+        "actor" => "ambiguous_actor_selection",
+        _ => "ambiguous_target_selection",
+    };
+    let recovery_commands = choices
+        .iter()
+        .map(|choice| command_template.replace(selector, &choice.value))
+        .collect();
+    RecoveryAdvice::safety_refusal(
+        advice_kind,
+        format!("Multiple {target_kind}s match; pass {selector} to select one explicitly"),
+        format!("Retry with `{command_template}`."),
+        format!("more than one {target_kind} is a valid target and no safe default exists"),
+        format!("continuing could target the wrong {target_kind}"),
+        "no target was selected and repository state was left unchanged",
+        command_template.to_string(),
+        recovery_commands,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+
+    fn choices() -> Vec<SelectionChoice> {
+        vec![
+            SelectionChoice::new("alpha", "alpha"),
+            SelectionChoice::new("beta", "beta"),
+        ]
+    }
+
+    #[test]
+    fn interactive_selection_returns_numbered_choice() {
+        let mut input = Cursor::new(b"2\n".to_vec());
+        let mut output = Vec::new();
+        let selected = select_ambiguous_target_with_io(
+            "thread",
+            "<THREAD>",
+            "heddle thread show <THREAD>",
+            choices(),
+            true,
+            &mut input,
+            &mut output,
+        )
+        .unwrap();
+
+        assert_eq!(selected, "beta");
+        let prompt = String::from_utf8(output).unwrap();
+        assert!(prompt.contains("Multiple threads match. Select one:"));
+        assert!(prompt.contains("Selection [1-2]"));
+    }
+
+    #[test]
+    fn non_interactive_selection_fails_without_reading_or_prompting() {
+        let mut input = Cursor::new(b"1\n".to_vec());
+        let mut output = Vec::new();
+        let error = select_ambiguous_target_with_io(
+            "thread",
+            "<THREAD>",
+            "heddle thread show <THREAD>",
+            choices(),
+            false,
+            &mut input,
+            &mut output,
+        )
+        .unwrap_err();
+
+        assert!(output.is_empty());
+        let advice = error.downcast_ref::<RecoveryAdvice>().unwrap();
+        assert_eq!(advice.kind, "ambiguous_thread_selection");
+        assert_eq!(advice.primary_command, "heddle thread show <THREAD>");
+    }
+}

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -36,6 +36,7 @@ mod hook;
 mod import_progress;
 mod init;
 mod integration;
+mod interactive_select;
 mod log;
 mod maintenance;
 mod marker;

--- a/crates/cli/src/cli/commands/remote/mod.rs
+++ b/crates/cli/src/cli/commands/remote/mod.rs
@@ -11,7 +11,7 @@ use heddle_core::{
     PushPath, PushPlan, PushPlanRequest, RemotePreflightBlocker, build_push_outcome,
     first_multi_thread_push_failure, format_multi_ref_push_progress, format_push_outcome_text,
     format_pushing_to, git_overlay_push_execution_facts,
-    heddle_single_push_execution_facts_from_local, is_native_transport_mismatch,
+    heddle_single_push_execution_facts_from_local, is_native_transport_mismatch, list_remotes,
     looks_like_git_remote_url, looks_like_remote_location, multi_ref_push_begin,
     multi_ref_thread_failed, multi_ref_thread_succeeded_local, multi_thread_push_execution_facts,
     named_thread_tip_mismatch_failure, plan_push, refuse_named_thread_tip_overwrite,
@@ -250,6 +250,7 @@ pub async fn cmd_push(
     if repo.capability() == RepositoryCapability::GitOverlay && state.is_some() {
         return Err(git_overlay_push_state_advice());
     }
+    let remote = select_push_remote_if_ambiguous(&repo, remote)?;
     if let Some(remote_name) = remote.as_deref() {
         ensure_remote_arg_resolves(&repo, remote_name)?;
     }
@@ -947,6 +948,62 @@ pub(super) fn classify_pull_remote_spec(
 enum RemoteAccess {
     Fetch,
     Push,
+}
+
+fn select_push_remote_if_ambiguous(
+    repo: &Repository,
+    requested: Option<String>,
+) -> Result<Option<String>> {
+    select_remote_if_ambiguous(repo, requested, RemoteAccess::Push, "heddle push <REMOTE>")
+}
+
+pub(super) fn select_pull_remote_if_ambiguous(
+    repo: &Repository,
+    requested: Option<String>,
+) -> Result<Option<String>> {
+    select_remote_if_ambiguous(repo, requested, RemoteAccess::Fetch, "heddle pull <REMOTE>")
+}
+
+fn select_remote_if_ambiguous(
+    repo: &Repository,
+    requested: Option<String>,
+    access: RemoteAccess,
+    command_template: &str,
+) -> Result<Option<String>> {
+    if requested.is_some() {
+        return Ok(requested);
+    }
+    let has_default = match access {
+        RemoteAccess::Fetch => resolved_default_remote_name(repo)?.is_some(),
+        RemoteAccess::Push if repo.capability() == RepositoryCapability::GitOverlay => {
+            resolve_default_push_remote_name(repo, None).is_ok()
+        }
+        RemoteAccess::Push => resolved_default_remote_name(repo)?.is_some(),
+    };
+    if has_default {
+        return Ok(None);
+    }
+
+    let choices = list_remotes(repo)?
+        .remotes
+        .into_iter()
+        .map(|remote| {
+            super::interactive_select::SelectionChoice::new(
+                remote.name.clone(),
+                format!("{} ({})", remote.name, remote.url),
+            )
+        })
+        .collect::<Vec<_>>();
+    if choices.len() <= 1 {
+        return Ok(None);
+    }
+    super::interactive_select::select_ambiguous_target(
+        "remote",
+        "<REMOTE>",
+        command_template,
+        choices,
+    )
+    .map(Some)
 }
 
 fn classify_remote_spec(

--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -229,6 +229,7 @@ pub async fn cmd_pull(
     insecure: bool,
 ) -> Result<()> {
     let repo = cli.open_repo()?;
+    let remote = super::select_pull_remote_if_ambiguous(&repo, remote)?;
     let default_remote = resolved_default_remote_name(&repo)?;
     let has_default_remote = default_remote.is_some();
     let configured_remote_name = match remote.as_deref() {

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -224,6 +224,7 @@ pub(crate) fn resolve_thread_name_or_current(
     command: &'static str,
     primary_command: impl Into<String>,
 ) -> Result<String> {
+    let primary_command = primary_command.into();
     if let Some(name) = name {
         return Ok(name);
     }
@@ -232,6 +233,23 @@ pub(crate) fn resolve_thread_name_or_current(
     }
     if let Some(thread) = current_thread(repo)? {
         return Ok(thread.thread);
+    }
+    let choices = repo
+        .refs()
+        .list_threads()?
+        .into_iter()
+        .map(|thread| {
+            let name = thread.to_string();
+            super::interactive_select::SelectionChoice::new(name.clone(), name)
+        })
+        .collect::<Vec<_>>();
+    if choices.len() > 1 {
+        return super::interactive_select::select_ambiguous_target(
+            "thread",
+            "<THREAD>",
+            &primary_command,
+            choices,
+        );
     }
     Err(anyhow!(RecoveryAdvice::no_current_thread(
         command,

--- a/crates/cli/src/cli/mod.rs
+++ b/crates/cli/src/cli/mod.rs
@@ -18,6 +18,14 @@ pub fn is_tty() -> bool {
     std::io::stdout().is_terminal()
 }
 
+/// Check whether the process has a real interactive terminal on every stream
+/// needed by a selection prompt.
+pub fn is_interactive_tty() -> bool {
+    std::io::stdin().is_terminal()
+        && std::io::stdout().is_terminal()
+        && std::io::stderr().is_terminal()
+}
+
 pub fn execution_context_from_cli(cli: &Cli) -> anyhow::Result<heddle_core::ExecutionContext> {
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd).to_path_buf();

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -314,6 +314,8 @@ mod hydrate;
 mod identity_resolution;
 #[path = "cli_integration/ignore_mechanics.rs"]
 mod ignore_mechanics;
+#[path = "cli_integration/interactive_selection.rs"]
+mod interactive_selection;
 #[path = "cli_integration/misc.rs"]
 mod misc;
 #[path = "cli_integration/native_scope_boundary.rs"]

--- a/crates/cli/tests/cli_integration/interactive_selection.rs
+++ b/crates/cli/tests/cli_integration/interactive_selection.rs
@@ -1,0 +1,174 @@
+use chrono::Utc;
+use objects::{
+    object::ThreadName,
+    store::{ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary},
+};
+use refs::Head;
+use repo::Repository;
+use tempfile::TempDir;
+
+use super::{heddle, heddle_output_with_stdin};
+
+fn detached_repo_with_threads() -> TempDir {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let repo = Repository::open(temp.path()).unwrap();
+    let state = repo.head().unwrap().expect("init creates a state");
+    repo.refs()
+        .set_thread(&ThreadName::new("alpha"), &state)
+        .unwrap();
+    repo.refs()
+        .set_thread(&ThreadName::new("beta"), &state)
+        .unwrap();
+    repo.refs().write_head(&Head::Detached { state }).unwrap();
+    temp
+}
+
+fn assert_non_tty_ambiguity(output: std::process::Output, kind: &str, command: &str) {
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stderr.contains(kind), "missing {kind}: {stderr}");
+    assert!(stderr.contains(command), "missing {command}: {stderr}");
+    assert!(!stderr.contains("Select one:"), "non-TTY prompt: {stderr}");
+    assert!(!stderr.contains("Selection ["), "non-TTY prompt: {stderr}");
+}
+
+#[test]
+fn piped_thread_ambiguity_never_prompts_or_consumes_a_selection() {
+    let temp = detached_repo_with_threads();
+    let output =
+        heddle_output_with_stdin(&["--output", "json", "thread", "show"], temp.path(), "2\n")
+            .unwrap();
+
+    assert_non_tty_ambiguity(
+        output,
+        "ambiguous_thread_selection",
+        "heddle thread show <THREAD>",
+    );
+}
+
+#[test]
+fn piped_remote_ambiguity_never_prompts_or_consumes_a_selection() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let repo = Repository::open(temp.path()).unwrap();
+    let mut remotes = cli_shared::remote::RemoteConfig::open(&repo).unwrap();
+    remotes
+        .add(
+            "alpha",
+            cli_shared::remote::Remote {
+                url: "file:///tmp/heddle-alpha".to_string(),
+                insecure: false,
+            },
+        )
+        .unwrap();
+    remotes
+        .add(
+            "beta",
+            cli_shared::remote::Remote {
+                url: "file:///tmp/heddle-beta".to_string(),
+                insecure: false,
+            },
+        )
+        .unwrap();
+    remotes.clear_default().unwrap();
+
+    let output =
+        heddle_output_with_stdin(&["--output", "json", "push"], temp.path(), "1\n").unwrap();
+    assert_non_tty_ambiguity(output, "ambiguous_remote_selection", "heddle push <REMOTE>");
+}
+
+fn active_actor(session_id: &str, root: &std::path::Path) -> ActorPresence {
+    ActorPresence {
+        session_id: session_id.to_string(),
+        client_instance_id: None,
+        native_actor_key: None,
+        native_parent_actor_key: None,
+        native_instance_key: None,
+        heddle_session_id: None,
+        thread_id: None,
+        thread: "main".to_string(),
+        anchor_state: None,
+        anchor_root: None,
+        path: Some(root.to_path_buf()),
+        base_state: "test-base".to_string(),
+        started_at: Utc::now(),
+        provider: Some("openai".to_string()),
+        model: Some("gpt-test".to_string()),
+        harness: Some("codex".to_string()),
+        thinking_level: None,
+        usage_summary: AgentUsageSummary::default(),
+        last_progress_at: None,
+        report_flush_state: None,
+        attach_reason: Some("test fixture".to_string()),
+        task_assignment_id: None,
+        attach_precedence: vec![],
+        winning_attach_rule: None,
+        probe_source: None,
+        probe_confidence: None,
+        status: ActorPresenceStatus::Active,
+        completed_at: None,
+        context_queries: vec![],
+    }
+}
+
+#[test]
+fn piped_actor_ambiguity_never_prompts_or_consumes_a_selection() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let repo = Repository::open(temp.path()).unwrap();
+    let actors = ActorPresenceStore::new(repo.heddle_dir());
+    actors
+        .save(&active_actor("agent-alpha", temp.path()))
+        .unwrap();
+    actors
+        .save(&active_actor("agent-beta", temp.path()))
+        .unwrap();
+
+    let output = heddle_output_with_stdin(
+        &["--output", "json", "agent", "presence", "show"],
+        temp.path(),
+        "1\n",
+    )
+    .unwrap();
+    assert_non_tty_ambiguity(
+        output,
+        "ambiguous_actor_selection",
+        "heddle agent presence show <SESSION>",
+    );
+}
+
+#[test]
+fn piped_actor_completion_never_picks_a_destructive_target() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    let repo = Repository::open(temp.path()).unwrap();
+    let actors = ActorPresenceStore::new(repo.heddle_dir());
+    actors
+        .save(&active_actor("agent-alpha", temp.path()))
+        .unwrap();
+    actors
+        .save(&active_actor("agent-beta", temp.path()))
+        .unwrap();
+
+    let output = heddle_output_with_stdin(
+        &["--output", "json", "agent", "presence", "complete"],
+        temp.path(),
+        "1\n",
+    )
+    .unwrap();
+    assert_non_tty_ambiguity(
+        output,
+        "ambiguous_actor_selection",
+        "heddle agent presence complete --session <SESSION>",
+    );
+    assert!(matches!(
+        actors.load("agent-alpha").unwrap().unwrap().status,
+        ActorPresenceStatus::Active
+    ));
+    assert!(matches!(
+        actors.load("agent-beta").unwrap().unwrap().status,
+        ActorPresenceStatus::Active
+    ));
+}


### PR DESCRIPTION
## Summary

Implements #1328 (dispatched codex). See issue for spec; agent-verified build+clippy locally (sandboxed — postgres integration by CI). Pending orchestrator audit + CI green before merge.

## Closes

Closes HeddleCo/heddle#1328

## Test evidence

```
Delivered + pushed by codex session; full audit + CI green pending.
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789230041&installation_model_id=21489&pr_number=1364&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1364&signature=fa87d412558aec8e874878ef84a4b8b1a5b7cd96eca62e3006eb5ec8d6a97140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->