### PR TITLE
PackBuilder configurable repack window + path-hint entrypoint (S1 of weft#1339)

### DIFF
--- a/crates/pack/src/store/pack/pack_builder.rs
+++ b/crates/pack/src/store/pack/pack_builder.rs
@@ -15,8 +15,8 @@ use crate::{object::ContentHash, store::Result};
 const MIN_DELTA_SIZE: usize = 64;
 /// Maximum depth for delta chains (matches Git's default).
 const MAX_DELTA_CHAIN_DEPTH: usize = 50;
-/// Number of recent objects to try as delta bases (Git default: 10).
-const WINDOW_SIZE: usize = 10;
+/// Default number of recent objects to try as delta bases (Git default: 10).
+const DEFAULT_DELTA_WINDOW: usize = 10;
 
 type GroupedPackMap = HashMap<ObjectType, Vec<PackObjectRecord>>;
 
@@ -24,6 +24,7 @@ type GroupedPackMap = HashMap<ObjectType, Vec<PackObjectRecord>>;
 pub struct PackBuilder {
     objects: Vec<PackObjectRecord>,
     compression: CompressionConfig,
+    delta_window: usize,
 }
 
 /// A recent object in the sliding window, with cached hash index for fast delta estimation.
@@ -40,6 +41,19 @@ impl PackBuilder {
         Self {
             objects: Vec::new(),
             compression,
+            delta_window: DEFAULT_DELTA_WINDOW,
+        }
+    }
+
+    /// Create a pack builder tuned for repacking an existing object corpus.
+    ///
+    /// `delta_window` controls how many recently sorted objects are considered
+    /// as delta bases. A zero-sized window disables delta-base selection.
+    pub fn for_repack(compression: CompressionConfig, delta_window: usize) -> Self {
+        Self {
+            objects: Vec::new(),
+            compression,
+            delta_window,
         }
     }
 
@@ -141,6 +155,7 @@ impl PackBuilder {
                     obj_type,
                     objects,
                     &self.compression,
+                    self.delta_window,
                 )?;
             }
         }
@@ -207,8 +222,10 @@ impl PackBuilder {
         obj_type: ObjectType,
         objects: Vec<PackObjectRecord>,
         compression: &CompressionConfig,
+        delta_window: usize,
     ) -> Result<()> {
-        let mut window: VecDeque<WindowEntry> = VecDeque::with_capacity(WINDOW_SIZE);
+        let mut window: VecDeque<WindowEntry> =
+            VecDeque::with_capacity(delta_window.min(objects.len()));
 
         for record in objects {
             let hash = match record.id {
@@ -289,17 +306,19 @@ impl PackBuilder {
                 &final_data,
             )?;
 
-            // Add to window (build index once, reuse for all future comparisons)
-            let entry_index = DeltaEncoder::build_index(&data);
-            if window.len() >= WINDOW_SIZE {
-                window.pop_front();
+            if delta_window > 0 {
+                // Build the index once, then reuse it for all future comparisons.
+                let entry_index = DeltaEncoder::build_index(&data);
+                if window.len() >= delta_window {
+                    window.pop_front();
+                }
+                window.push_back(WindowEntry {
+                    hash,
+                    data,
+                    index: entry_index,
+                    chain_depth,
+                });
             }
-            window.push_back(WindowEntry {
-                hash,
-                data,
-                index: entry_index,
-                chain_depth,
-            });
         }
 
         Ok(())

--- a/crates/pack/src/store/pack/pack_tests.rs
+++ b/crates/pack/src/store/pack/pack_tests.rs
@@ -761,6 +761,110 @@ fn test_delta_window_pack_bytes_are_stable() {
     );
 }
 
+#[derive(Clone)]
+struct RepackCorpusObject {
+    hash: ContentHash,
+    data: Vec<u8>,
+    path: String,
+}
+
+fn repack_window_corpus() -> Vec<RepackCorpusObject> {
+    const PATH_COUNT: usize = 19;
+    const VARIANT_COUNT: usize = 11;
+    const OBJECT_SIZE: usize = 512;
+
+    let mut objects = Vec::with_capacity(PATH_COUNT * VARIANT_COUNT * 2);
+    for generation in 0..2 {
+        for variant in 0..VARIANT_COUNT {
+            for path_index in 0..PATH_COUNT {
+                let mut data = Vec::with_capacity(OBJECT_SIZE);
+                for block_index in 0..(OBJECT_SIZE / 32) {
+                    let seed = format!("{path_index}:{variant}:{block_index}");
+                    data.extend_from_slice(blake3::hash(seed.as_bytes()).as_bytes());
+                }
+                if generation == 1 {
+                    for offset in (variant..OBJECT_SIZE).step_by(127) {
+                        data[offset] ^= 0x5a;
+                    }
+                }
+                objects.push(RepackCorpusObject {
+                    hash: ContentHash::compute(&data),
+                    data,
+                    path: format!("src/file_{path_index:02}.bin"),
+                });
+            }
+        }
+    }
+    objects
+}
+
+fn build_repack_corpus(
+    objects: &[RepackCorpusObject],
+    delta_window: usize,
+    with_path_hints: bool,
+) -> (Vec<u8>, Vec<u8>, super::PackStats) {
+    let compression = CompressionConfig {
+        enabled: false,
+        level: 0,
+        min_size: usize::MAX,
+        max_delta_size: usize::MAX,
+    };
+    let mut builder = PackBuilder::for_repack(compression, delta_window);
+    for object in objects {
+        builder.add_with_path_id(
+            PackObjectId::Hash(object.hash),
+            ObjectType::Blob,
+            object.data.clone(),
+            with_path_hints.then(|| object.path.clone()),
+        );
+    }
+    builder.build().unwrap()
+}
+
+#[test]
+fn repack_window_and_path_hints_improve_ratio_and_roundtrip() {
+    let objects = repack_window_corpus();
+    let (baseline_pack, _, baseline) = build_repack_corpus(&objects, 10, false);
+    let (wide_pack, wide_index, wide) = build_repack_corpus(&objects, 200, true);
+    let (no_hints_pack, _, no_hints) = build_repack_corpus(&objects, 200, false);
+    let (narrow_pack, _, narrow) = build_repack_corpus(&objects, 10, true);
+
+    eprintln!(
+        "baseline: deltas={}, bytes={}, ratio={:.6}; wide+hints: deltas={}, bytes={}, ratio={:.6}; no-hints: deltas={}, bytes={}, ratio={:.6}; narrow: deltas={}, bytes={}, ratio={:.6}",
+        baseline.delta_count,
+        baseline_pack.len(),
+        baseline.compression_ratio,
+        wide.delta_count,
+        wide_pack.len(),
+        wide.compression_ratio,
+        no_hints.delta_count,
+        no_hints_pack.len(),
+        no_hints.compression_ratio,
+        narrow.delta_count,
+        narrow_pack.len(),
+        narrow.compression_ratio,
+    );
+
+    assert!(wide.delta_count > baseline.delta_count);
+    assert!(wide_pack.len() < baseline_pack.len());
+    assert!(wide.compression_ratio < baseline.compression_ratio);
+    assert!(no_hints.compression_ratio > wide.compression_ratio);
+    assert!(no_hints_pack.len() > wide_pack.len());
+    assert!(narrow.compression_ratio > wide.compression_ratio);
+    assert!(narrow_pack.len() > wide_pack.len());
+
+    let reader = PackReader::from_bytes(wide_pack, wide_index).unwrap();
+    for object in &objects {
+        let (obj_type, data) = reader
+            .get_hashed_object(&object.hash)
+            .unwrap()
+            .expect("corpus object must be present");
+        assert_eq!(obj_type, ObjectType::Blob);
+        assert_eq!(ContentHash::compute(&data), object.hash);
+        assert_eq!(data, object.data);
+    }
+}
+
 #[test]
 fn test_single_object_no_delta() {
     // A single object should not produce any deltas


### PR DESCRIPTION
Closes #1363. Delivered by codex; agent-verified build+tests locally, CI authoritative. Pending audit + green before merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789232250&installation_model_id=21489&pr_number=1371&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1371&signature=c013eea806be406317e40b299d272a2977ef4ca38f354b2ba88f853f265a74ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->