### PR TITLE
test(cli): first-use & resume transcript harness — measure decisions/commands, not latency — P1 of #473

### DIFF
--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -290,6 +290,8 @@ mod error_envelope_lint;
 mod exit_codes;
 #[path = "cli_integration/fault_injection.rs"]
 mod fault_injection;
+#[path = "cli_integration/first_use_resume_transcript.rs"]
+mod first_use_resume_transcript;
 #[path = "cli_integration/git_overlay_fixtures.rs"]
 mod git_overlay_fixtures;
 #[path = "cli_integration/git_overlay_interop_matrix.rs"]
@@ -365,6 +367,8 @@ mod thread_cleanup;
 mod thread_default_current;
 #[path = "cli_integration/timeline.rs"]
 mod timeline;
+#[path = "cli_integration/transcript_harness.rs"]
+mod transcript_harness;
 #[path = "cli_integration/try_cmd.rs"]
 mod try_cmd;
 #[path = "cli_integration/unrelated_histories_recovery.rs"]

--- a/crates/cli/tests/cli_integration/first_use_resume_transcript.rs
+++ b/crates/cli/tests/cli_integration/first_use_resume_transcript.rs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end ceremony gates for first use and resumed work.
+
+use std::fs;
+
+use tempfile::TempDir;
+
+use super::{
+    git_hermetic, heddle,
+    transcript_harness::{DecisionBudget, SessionTranscript},
+};
+
+const FIRST_USE_BUDGET: DecisionBudget = DecisionBudget {
+    max_commands: 3,
+    max_choices: 0,
+    max_total: 3,
+};
+const RESUME_BUDGET: DecisionBudget = DecisionBudget {
+    max_commands: 2,
+    max_choices: 0,
+    max_total: 2,
+};
+
+fn plain_git_with_pending_work() -> TempDir {
+    let repo = TempDir::new().expect("create first-use fixture");
+    git_hermetic(&["init", "-b", "main"], repo.path());
+    git_hermetic(&["config", "user.name", "Transcript Test"], repo.path());
+    git_hermetic(
+        &["config", "user.email", "transcript@example.com"],
+        repo.path(),
+    );
+    fs::write(repo.path().join("tracked.txt"), "seed\n").unwrap();
+    git_hermetic(&["add", "tracked.txt"], repo.path());
+    git_hermetic(&["commit", "-m", "seed"], repo.path());
+    fs::write(repo.path().join("pending.txt"), "first useful work\n").unwrap();
+    repo
+}
+
+fn record_first_use(extra_command: bool) -> SessionTranscript {
+    let repo = plain_git_with_pending_work();
+    let mut transcript = SessionTranscript::new("first use", repo.path());
+
+    let status = transcript.run(&["status", "--output", "json"]).json();
+    assert_eq!(status["repository_capability"], "plain-git");
+    assert_eq!(status["recommended_action"], "heddle init");
+
+    let init = transcript.run(&["init", "--output", "json"]).json();
+    assert_eq!(init["repository_mode"], "git-overlay");
+    assert_eq!(init["recommended_action"], "heddle capture -m \"...\"");
+
+    if extra_command {
+        transcript.run(&["help"]).assert_success();
+    }
+
+    let saved = transcript
+        .run(&[
+            "capture",
+            "-m",
+            "save first useful work",
+            "--output",
+            "json",
+        ])
+        .json();
+    assert_eq!(saved["output_kind"], "capture");
+    assert_eq!(saved["status"], "captured");
+    transcript
+}
+
+fn resumed_repo() -> (TempDir, std::path::PathBuf) {
+    let repo = TempDir::new().expect("create resume fixture");
+    heddle(&["init"], Some(repo.path())).expect("initialize resume fixture");
+    fs::write(repo.path().join("work.txt"), "before pause\n").unwrap();
+    heddle(&["capture", "-m", "save before pause"], Some(repo.path()))
+        .expect("save resume baseline");
+
+    let nested = repo.path().join("src/feature");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(repo.path().join("work.txt"), "continued after pause\n").unwrap();
+    (repo, nested)
+}
+
+fn record_resume() -> SessionTranscript {
+    let (_repo, nested) = resumed_repo();
+    let mut transcript = SessionTranscript::new("resume from nested directory", &nested);
+
+    let status = transcript.run(&["status", "--output", "json"]).json();
+    assert_eq!(status["thread"], "main");
+    assert_eq!(status["changed_path_count"], 1);
+    assert_eq!(status["recommended_action"], "heddle capture -m \"...\"");
+
+    let saved = transcript
+        .run(&["capture", "-m", "continue resumed work", "--output", "json"])
+        .json();
+    assert_eq!(saved["output_kind"], "capture");
+    assert_eq!(saved["status"], "captured");
+    transcript
+}
+
+#[test]
+fn first_use_transcript_stays_within_decision_budget() {
+    let extra_command =
+        std::env::var("HEDDLE_TRANSCRIPT_NEGATIVE_CONTROL").as_deref() == Ok("extra-command");
+    let transcript = record_first_use(extra_command);
+    println!("{transcript}");
+    transcript.assert_budget(FIRST_USE_BUDGET);
+}
+
+#[test]
+fn resume_transcript_stays_within_decision_budget() {
+    let transcript = record_resume();
+    println!("{transcript}");
+    transcript.assert_budget(RESUME_BUDGET);
+}
+
+#[test]
+fn first_use_budget_rejects_one_extra_command() {
+    let transcript = record_first_use(true);
+    let error = transcript
+        .check_budget(FIRST_USE_BUDGET)
+        .expect_err("one extra command must trip the first-use ceremony gate");
+    assert_eq!(error.observed().commands, 4);
+    assert_eq!(error.observed().choices, 0);
+    assert_eq!(error.observed().total(), 4);
+    assert!(
+        error
+            .to_string()
+            .contains("observed commands=4, choices=0, total=4")
+    );
+}

--- a/crates/cli/tests/cli_integration/transcript_harness.rs
+++ b/crates/cli/tests/cli_integration/transcript_harness.rs
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Reusable, latency-free CLI journey transcripts and ceremony budgets.
+
+use std::{fmt, path::Path};
+
+use super::heddle_output;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct DecisionCounts {
+    pub commands: usize,
+    pub choices: usize,
+}
+
+impl DecisionCounts {
+    pub fn total(self) -> usize {
+        self.commands + self.choices
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct DecisionBudget {
+    pub max_commands: usize,
+    pub max_choices: usize,
+    pub max_total: usize,
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct RecordedCommand {
+    pub argv: Vec<String>,
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+impl RecordedCommand {
+    pub fn assert_success(&self) {
+        assert_eq!(
+            self.exit_code,
+            Some(0),
+            "command failed: heddle {}\nstdout: {}\nstderr: {}",
+            self.argv.join(" "),
+            self.stdout,
+            self.stderr
+        );
+    }
+
+    pub fn json(&self) -> serde_json::Value {
+        self.assert_success();
+        serde_json::from_str(&self.stdout).unwrap_or_else(|error| {
+            panic!(
+                "heddle {} did not emit JSON: {error}\nstdout: {}\nstderr: {}",
+                self.argv.join(" "),
+                self.stdout,
+                self.stderr
+            )
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+enum TranscriptEntry {
+    Command(RecordedCommand),
+    Choice { prompt: String, selection: String },
+}
+
+#[derive(Debug)]
+pub(super) struct BudgetExceeded {
+    journey: String,
+    observed: DecisionCounts,
+    budget: DecisionBudget,
+}
+
+impl BudgetExceeded {
+    pub fn observed(&self) -> DecisionCounts {
+        self.observed
+    }
+}
+
+impl fmt::Display for BudgetExceeded {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} ceremony exceeded: observed commands={}, choices={}, total={}; budget commands<={}, choices<={}, total<={}",
+            self.journey,
+            self.observed.commands,
+            self.observed.choices,
+            self.observed.total(),
+            self.budget.max_commands,
+            self.budget.max_choices,
+            self.budget.max_total
+        )
+    }
+}
+
+pub(super) struct SessionTranscript {
+    journey: String,
+    cwd: std::path::PathBuf,
+    entries: Vec<TranscriptEntry>,
+}
+
+impl SessionTranscript {
+    pub fn new(journey: impl Into<String>, cwd: &Path) -> Self {
+        Self {
+            journey: journey.into(),
+            cwd: cwd.to_path_buf(),
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn run(&mut self, args: &[&str]) -> RecordedCommand {
+        let output = heddle_output(args, Some(&self.cwd))
+            .unwrap_or_else(|error| panic!("failed to run heddle {}: {error}", args.join(" ")));
+        let command = RecordedCommand {
+            argv: args.iter().map(|arg| (*arg).to_string()).collect(),
+            exit_code: output.status.code(),
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+        };
+        self.entries.push(TranscriptEntry::Command(command.clone()));
+        command
+    }
+
+    pub fn record_choice(&mut self, prompt: impl Into<String>, selection: impl Into<String>) {
+        self.entries.push(TranscriptEntry::Choice {
+            prompt: prompt.into(),
+            selection: selection.into(),
+        });
+    }
+
+    pub fn counts(&self) -> DecisionCounts {
+        self.entries.iter().fold(
+            DecisionCounts {
+                commands: 0,
+                choices: 0,
+            },
+            |mut counts, entry| {
+                match entry {
+                    TranscriptEntry::Command(_) => counts.commands += 1,
+                    TranscriptEntry::Choice { .. } => counts.choices += 1,
+                }
+                counts
+            },
+        )
+    }
+
+    pub fn check_budget(&self, budget: DecisionBudget) -> Result<(), BudgetExceeded> {
+        let observed = self.counts();
+        if observed.commands <= budget.max_commands
+            && observed.choices <= budget.max_choices
+            && observed.total() <= budget.max_total
+        {
+            Ok(())
+        } else {
+            Err(BudgetExceeded {
+                journey: self.journey.clone(),
+                observed,
+                budget,
+            })
+        }
+    }
+
+    pub fn assert_budget(&self, budget: DecisionBudget) {
+        if let Err(error) = self.check_budget(budget) {
+            panic!("{error}\n{self}");
+        }
+    }
+}
+
+impl fmt::Display for SessionTranscript {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "# {}", self.journey)?;
+        for entry in &self.entries {
+            match entry {
+                TranscriptEntry::Command(command) => {
+                    writeln!(formatter, "$ heddle {}", command.argv.join(" "))?;
+                    writeln!(
+                        formatter,
+                        "[exit {}]",
+                        command
+                            .exit_code
+                            .map_or_else(|| "signal".to_string(), |code| code.to_string())
+                    )?;
+                    write_stream(formatter, "stdout", &command.stdout, &self.cwd)?;
+                    write_stream(formatter, "stderr", &command.stderr, &self.cwd)?;
+                }
+                TranscriptEntry::Choice { prompt, selection } => {
+                    writeln!(formatter, "? {prompt}")?;
+                    writeln!(formatter, "> {selection}")?;
+                }
+            }
+        }
+        let counts = self.counts();
+        writeln!(
+            formatter,
+            "# decisions: {} (commands: {}, choices: {})",
+            counts.total(),
+            counts.commands,
+            counts.choices
+        )
+    }
+}
+
+fn write_stream(
+    formatter: &mut fmt::Formatter<'_>,
+    name: &str,
+    stream: &str,
+    cwd: &Path,
+) -> fmt::Result {
+    if stream.is_empty() {
+        return Ok(());
+    }
+    let normalized = stream.replace(&cwd.display().to_string(), "<cwd>");
+    writeln!(formatter, "[{name}]")?;
+    writeln!(formatter, "{}", normalized.trim_end())
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn prompt_selection_counts_as_a_decision_without_inventing_a_command() {
+        let cwd = TempDir::new().unwrap();
+        let mut transcript = SessionTranscript::new("interactive selection", cwd.path());
+        transcript.record_choice("Select a thread", "feature/api");
+
+        assert_eq!(
+            transcript.counts(),
+            DecisionCounts {
+                commands: 0,
+                choices: 1,
+            }
+        );
+        let error = transcript
+            .check_budget(DecisionBudget {
+                max_commands: 0,
+                max_choices: 0,
+                max_total: 0,
+            })
+            .expect_err("a prompt choice must consume ceremony budget");
+        assert_eq!(error.observed().total(), 1);
+    }
+}


### PR DESCRIPTION
Closes #1329

Delivered by dispatched agent; opening PR to enter CI + review. See the issue for scope and the branch commit for the full change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789255979&installation_model_id=21489&pr_number=1376&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1376&signature=7f79db097d95a832fb3bdeecc6e24d2ea591b8beeceb9797cff4d8de95ed5a23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->