### PR TITLE
fix(land): land fast-forwards from isolated checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Land resolves the target checkout from isolated threads.** A clean
+  fast-forward now lands when invoked inside the source thread checkout, while
+  genuine readiness-policy blockers retain their concrete recovery guidance.
+
 - **Offline identity registries require an authenticated current head.**
   Provenance verification now pins a verifier-local authority, registry digest,
   and monotonic epoch; validates the authority-signed checkpoint chain to

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -394,19 +394,11 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         return cmd_land_many(cli, args).await;
     }
 
-    // Open at CWD only to discover the active thread, then re-open at
-    // its metadata-recorded worktree. This makes `heddle land` work
-    // from anywhere — operators don't need to `cd` into a lightweight
-    // thread directory before landing. The capture/merge below run
-    // against `repo`, so they all see the same checkout. See
-    // `Repository::active_worktree_path`.
-    let cwd_repo = cli.open_repo()?;
-    let target_path = cwd_repo.active_worktree_path()?;
-    let repo = if target_path == *cwd_repo.root() {
-        cwd_repo
-    } else {
-        Repository::open(&target_path)?
-    };
+    // Resolve the integration target independently of CWD. A dedicated source
+    // checkout has its own local HEAD, so treating it as the target would ask
+    // the merge engine to integrate the thread into itself. Route through the
+    // shared main repository first, then honor its active target worktree.
+    let repo = open_land_target_repository(cli)?;
     // One land owns the target repository from recovery/preflight through
     // integration, Git checkpoint publication, and marker cleanup. This makes
     // the Prepared marker an operation-owned journal instead of a replaceable
@@ -1101,6 +1093,27 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
             },
         },
     )
+}
+
+fn open_land_target_repository(cli: &Cli) -> Result<Repository> {
+    let cwd_repo = cli.open_repo()?;
+    let main_repo = if cwd_repo.root().join(".heddle") == cwd_repo.heddle_dir() {
+        cwd_repo
+    } else {
+        let main_root = cwd_repo.heddle_dir().parent().ok_or_else(|| {
+            anyhow!(
+                "shared Heddle directory {} has no parent repository root",
+                cwd_repo.heddle_dir().display()
+            )
+        })?;
+        Repository::open(main_root)?
+    };
+    let target_path = main_repo.active_worktree_path()?;
+    if target_path == *main_repo.root() {
+        Ok(main_repo)
+    } else {
+        Ok(Repository::open(&target_path)?)
+    }
 }
 
 fn should_squash_land(args: &LandArgs, user_config: &UserConfig) -> bool {
@@ -2910,13 +2923,7 @@ fn finish_recovered_land(
 /// the land lock, captures work, syncs the remote, or merges. No server
 /// round-trip is made.
 fn emit_land_dry_run(cli: &Cli, args: &LandArgs) -> Result<()> {
-    let cwd_repo = cli.open_repo()?;
-    let target_path = cwd_repo.active_worktree_path()?;
-    let repo = if target_path == *cwd_repo.root() {
-        cwd_repo
-    } else {
-        Repository::open(&target_path)?
-    };
+    let repo = open_land_target_repository(cli)?;
 
     // Ordered set of threads a real land would process: `--thread` first
     // (when supplied), then each `--threads` peer, deduped.

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -871,6 +871,175 @@ fn land_auto_captures_and_merges_clean_thread() {
     );
 }
 
+#[test]
+fn land_from_isolated_checkout_integrates_ready_fast_forward() {
+    let main = setup_repo("base.txt", "base");
+    let started: Value = serde_json::from_str(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "start",
+                "feature/land-from-thread",
+                "--workspace",
+                "auto",
+            ],
+            Some(main.path()),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let thread = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
+
+    std::fs::write(thread.join("landed.txt"), "land from the thread checkout").unwrap();
+    heddle(&["capture", "-m", "feature work"], Some(&thread)).unwrap();
+
+    let ready: Value = serde_json::from_str(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "ready",
+                "--thread",
+                "feature/land-from-thread",
+            ],
+            Some(&thread),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(ready["status"], "completed", "{ready}");
+    assert_eq!(ready["report"]["merge_relation"], "fast_forward", "{ready}");
+    assert_eq!(ready["report"]["conflict_count"], 0, "{ready}");
+
+    let landed: Value = serde_json::from_str(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "land",
+                "--thread",
+                "feature/land-from-thread",
+            ],
+            Some(&thread),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(landed["status"], "landed", "{landed}");
+    assert_eq!(landed["integrated"], true, "{landed}");
+    assert_eq!(
+        std::fs::read_to_string(main.path().join("landed.txt")).unwrap(),
+        "land from the thread checkout"
+    );
+}
+
+#[test]
+fn ready_and_land_name_low_confidence_without_sync_loop() {
+    let main = setup_repo("base.txt", "base");
+    let started: Value = serde_json::from_str(
+        &heddle(
+            &[
+                "--output",
+                "json",
+                "start",
+                "feature/low-confidence",
+                "--workspace",
+                "auto",
+            ],
+            Some(main.path()),
+        )
+        .unwrap(),
+    )
+    .unwrap();
+    let thread = std::path::PathBuf::from(started["execution_path"].as_str().unwrap());
+
+    std::fs::write(thread.join("uncertain.txt"), "draft").unwrap();
+    let capture = heddle_output_with_env(
+        &["capture", "-m", "uncertain work", "--confidence", "0.40"],
+        Some(&thread),
+        &[
+            ("HEDDLE_AGENT_PROVIDER", "test-agent"),
+            ("HEDDLE_AGENT_MODEL", "test-model"),
+        ],
+    )
+    .unwrap();
+    assert!(
+        capture.status.success(),
+        "{}",
+        String::from_utf8_lossy(&capture.stderr)
+    );
+
+    let ready_output = heddle_output(
+        &[
+            "--output",
+            "json",
+            "ready",
+            "--thread",
+            "feature/low-confidence",
+        ],
+        Some(&thread),
+    )
+    .unwrap();
+    assert!(!ready_output.status.success());
+    let ready: Value = serde_json::from_slice(&ready_output.stdout).unwrap();
+    assert!(
+        ready["blockers"].as_array().is_some_and(|blockers| blockers
+            .iter()
+            .any(|blocker| blocker.as_str().is_some_and(|message| message
+                .contains("confidence 0.40 is below the auto-land threshold of 0.75")))),
+        "{ready}"
+    );
+    let ready_action = ready["recommended_action"]
+        .as_str()
+        .expect("ready recovery action");
+    assert!(
+        ready_action.contains("capture -m \"...\" --confidence <confidence>"),
+        "{ready}"
+    );
+    assert!(!ready_action.contains("sync"), "{ready}");
+
+    let land_output = heddle_output(
+        &[
+            "--output",
+            "json",
+            "land",
+            "--thread",
+            "feature/low-confidence",
+        ],
+        Some(&thread),
+    )
+    .unwrap();
+    assert!(!land_output.status.success());
+    let land: Value = serde_json::from_slice(&land_output.stdout).unwrap();
+    let confidence_blocker = land["blocker_details"]
+        .as_array()
+        .and_then(|details| {
+            details
+                .iter()
+                .find(|detail| detail["code"] == "auto_land_confidence_below_threshold")
+        })
+        .expect("typed confidence blocker");
+    assert_eq!(
+        confidence_blocker["code"], "auto_land_confidence_below_threshold",
+        "{land}"
+    );
+    assert!(
+        confidence_blocker["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("0.40 is below the 0.75 threshold")),
+        "{land}"
+    );
+    let action = land["recommended_action"]
+        .as_str()
+        .expect("recovery action");
+    assert!(
+        action.contains("capture -m \"...\" --confidence <confidence>"),
+        "{land}"
+    );
+    assert!(!action.contains("sync"), "{land}");
+}
+
 /// `heddle delegate` with per-task `task:provider:model` syntax —
 /// the YC-demo opener primitive. Three children, three different
 /// agents, one command. Pre-extension, every child shared the same


### PR DESCRIPTION
## Summary

- Resolve the integration target through the shared main repository when `heddle land` or `heddle land --dry-run` is invoked inside an isolated source checkout.
- Prevent the source checkout local HEAD from making land attempt a self-merge and incorrectly block a ready fast-forward.
- Cover both the ready/fast-forward/zero-conflict success path and a concrete low-confidence blocker whose guidance recaptures instead of looping through sync.

## Closes

Closes HeddleCo/heddle#1149

## Red commit

`4b21c9f0`

## Test evidence

```text
$ CARGO_TARGET_DIR=/tmp/heddle-1149-target cargo build --locked --workspace --all-targets
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 19s

$ CARGO_TARGET_DIR=/tmp/heddle-1149-clippy cargo clippy --locked --workspace --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.84s

$ CARGO_TARGET_DIR=/tmp/heddle-1149-clippy cargo test --locked --workspace --lib --bins
All workspace lib/bin suites passed (exit 0), including:
test result: ok. 670 passed; 0 failed; 0 ignored
test result: ok. 152 passed; 0 failed; 1 ignored
test result: ok. 675 passed; 0 failed; 3 ignored

$ cargo test --locked -p heddle-cli --test multi_agent_worktrees e2e::land_from_isolated_checkout_integrates_ready_fast_forward -- --exact --nocapture
test result: ok. 1 passed; 0 failed

$ cargo test --locked -p heddle-cli --test multi_agent_worktrees e2e::ready_and_land_name_low_confidence_without_sync_loop -- --exact --nocapture
test result: ok. 1 passed; 0 failed

$ rustfmt +nightly --edition 2024 --check crates/cli/src/cli/commands/workflow.rs crates/cli/tests/multi_agent_worktrees/e2e.rs
(exit 0)
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1380"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789283660&installation_model_id=21489&pr_number=1380&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1380&signature=134a4463f1b744d7a09b0ab7a8bab2db4a51b6f89f7fad979c76bc8dec9c4964"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->