### PR TITLE
feat(iroh): persist node identity and accept claim connections

### DIFF
--- a/crates/cli/src/hosted_runtime/agent_node_identity.rs
+++ b/crates/cli/src/hosted_runtime/agent_node_identity.rs
@@ -1,0 +1,262 @@
+//! Persisted transport identity for the agent's Iroh endpoint.
+//!
+//! The claim URL names this endpoint by its cryptographic node id. Minting a
+//! fresh key at each bind therefore invalidates every outstanding URL. Keep a
+//! distinct transport key beside the agent's other credential material under
+//! `<heddle_home>` and fail closed if that key can no longer be trusted.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use iroh::{EndpointId, SecretKey};
+use objects::{fs_atomic::write_file_atomic_secret, lock::RepoLock};
+use serde::{Deserialize, Serialize};
+
+const IDENTITY_FORMAT: &str = "heddle-agent-node-identity";
+const IDENTITY_VERSION: u32 = 1;
+const IDENTITY_FILE: &str = "agent-node-identity.toml";
+
+#[derive(Clone, Debug)]
+pub(crate) struct AgentNodeIdentity {
+    secret_key: SecretKey,
+}
+
+impl AgentNodeIdentity {
+    pub(crate) fn secret_key(&self) -> SecretKey {
+        self.secret_key.clone()
+    }
+
+    pub(crate) fn node_id(&self) -> EndpointId {
+        self.secret_key.public()
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct OnDiskIdentity {
+    format: String,
+    version: u32,
+    secret_key: String,
+    node_id: String,
+}
+
+pub(crate) fn identity_path() -> PathBuf {
+    repo::identity::heddle_home_dir().join(IDENTITY_FILE)
+}
+
+/// Load the agent node identity, minting it exactly once when absent.
+///
+/// The write lock serializes first use by concurrent CLI processes. A corrupt
+/// or exposed identity is never replaced: silently doing so would print a new
+/// node id while old claim links still name the lost one.
+pub(crate) fn load_or_create() -> Result<AgentNodeIdentity> {
+    load_or_create_at(&identity_path())
+}
+
+fn load_or_create_at(path: &Path) -> Result<AgentNodeIdentity> {
+    if let Some(parent) = path.parent() {
+        objects::fs_atomic::create_private_dir_all(parent)
+            .with_context(|| format!("creating agent credential directory {}", parent.display()))?;
+    }
+    let lock = identity_lock(path);
+    let _guard = lock
+        .write()
+        .map_err(|error| anyhow::anyhow!("acquiring agent node identity lock: {error}"))?;
+    if let Some(identity) = load_at(path)? {
+        return Ok(identity);
+    }
+
+    let identity = AgentNodeIdentity {
+        secret_key: SecretKey::generate(),
+    };
+    persist_at(path, &identity)?;
+    Ok(identity)
+}
+
+fn load_at(path: &Path) -> Result<Option<AgentNodeIdentity>> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            bail!(
+                "agent node identity {} is not a regular file",
+                path.display()
+            )
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("inspecting agent node identity {}", path.display()));
+        }
+    }
+
+    crypto::reject_group_or_world_readable_key(path)
+        .with_context(|| format!("refusing exposed agent node identity {}", path.display()))?;
+    let contents = std::fs::read_to_string(path)
+        .with_context(|| format!("reading agent node identity {}", path.display()))?;
+    let stored: OnDiskIdentity = toml::from_str(&contents)
+        .with_context(|| format!("parsing agent node identity {}", path.display()))?;
+    if stored.format != IDENTITY_FORMAT {
+        bail!("{} is not a Heddle agent node identity", path.display());
+    }
+    if stored.version != IDENTITY_VERSION {
+        bail!(
+            "agent node identity {} has unsupported version {}",
+            path.display(),
+            stored.version
+        );
+    }
+
+    let secret_bytes = hex::decode(&stored.secret_key)
+        .with_context(|| format!("decoding secret key in {}", path.display()))?;
+    let secret_bytes: [u8; 32] = secret_bytes.try_into().map_err(|bytes: Vec<u8>| {
+        anyhow::anyhow!(
+            "agent node identity {} has a {}-byte secret key; expected 32",
+            path.display(),
+            bytes.len()
+        )
+    })?;
+    let secret_key = SecretKey::from_bytes(&secret_bytes);
+    let node_id = secret_key.public();
+    if stored.node_id != node_id.to_string() {
+        bail!(
+            "agent node identity {} has a public node id that does not match its secret key",
+            path.display()
+        );
+    }
+    Ok(Some(AgentNodeIdentity { secret_key }))
+}
+
+fn persist_at(path: &Path, identity: &AgentNodeIdentity) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        objects::fs_atomic::create_private_dir_all(parent)
+            .with_context(|| format!("creating agent credential directory {}", parent.display()))?;
+    }
+    let stored = OnDiskIdentity {
+        format: IDENTITY_FORMAT.to_string(),
+        version: IDENTITY_VERSION,
+        secret_key: hex::encode(identity.secret_key.to_bytes()),
+        node_id: identity.node_id().to_string(),
+    };
+    let contents = toml::to_string_pretty(&stored).context("serializing agent node identity")?;
+    write_file_atomic_secret(path, contents.as_bytes())
+        .with_context(|| format!("writing agent node identity {}", path.display()))?;
+    Ok(())
+}
+
+fn identity_lock(identity_path: &Path) -> RepoLock {
+    let parent = identity_path.parent().unwrap_or_else(|| Path::new("."));
+    RepoLock::at(parent.join("locks").join("agent-node-identity.lock"))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    #[test]
+    fn clean_agent_home_is_created_on_first_load() {
+        let temp = TempDir::new().expect("temp dir");
+        let home = temp.path().join("new-heddle-home");
+        let path = home.join(IDENTITY_FILE);
+
+        let identity = load_or_create_at(&path).expect("mint identity in clean home");
+
+        assert!(path.is_file());
+        assert_eq!(
+            identity.node_id(),
+            load_or_create_at(&path).expect("reload identity").node_id()
+        );
+    }
+
+    #[test]
+    fn node_id_survives_independent_loads() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(IDENTITY_FILE);
+
+        let first = load_or_create_at(&path).expect("mint identity");
+        let second = load_or_create_at(&path).expect("reload identity");
+
+        assert_eq!(first.node_id(), second.node_id());
+        assert_eq!(
+            first.secret_key().to_bytes(),
+            second.secret_key().to_bytes()
+        );
+    }
+
+    #[test]
+    fn concurrent_first_loads_choose_one_identity() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = Arc::new(temp.path().join(IDENTITY_FILE));
+        let barrier = Arc::new(Barrier::new(8));
+        let loads = (0..8)
+            .map(|_| {
+                let path = Arc::clone(&path);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    load_or_create_at(&path).expect("load identity").node_id()
+                })
+            })
+            .collect::<Vec<_>>();
+        let node_ids = loads
+            .into_iter()
+            .map(|load| load.join().expect("load thread"))
+            .collect::<Vec<_>>();
+
+        assert!(node_ids.iter().all(|node_id| *node_id == node_ids[0]));
+    }
+
+    #[test]
+    fn corrupt_identity_is_refused_without_replacement() {
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(IDENTITY_FILE);
+        let identity = load_or_create_at(&path).expect("mint identity");
+        let mut stored: OnDiskIdentity =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read identity"))
+                .expect("parse identity");
+        stored.node_id = SecretKey::generate().public().to_string();
+        let corrupt = toml::to_string_pretty(&stored).expect("encode corrupt identity");
+        std::fs::write(&path, corrupt).expect("corrupt identity");
+
+        let error = load_or_create_at(&path).expect_err("mismatch must fail closed");
+        assert!(error.to_string().contains("does not match"));
+        let after: OnDiskIdentity =
+            toml::from_str(&std::fs::read_to_string(&path).expect("read after refusal"))
+                .expect("parse after refusal");
+        assert_ne!(after.node_id, identity.node_id().to_string());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exposed_identity_is_refused() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(IDENTITY_FILE);
+        load_or_create_at(&path).expect("mint identity");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("expose identity");
+
+        let error = load_or_create_at(&path).expect_err("exposed key must fail closed");
+        assert!(error.to_string().contains("refusing exposed"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn persisted_identity_is_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let path = temp.path().join(IDENTITY_FILE);
+        load_or_create_at(&path).expect("mint identity");
+
+        let mode = std::fs::metadata(path)
+            .expect("identity metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/crates/cli/src/hosted_runtime/hosted/claim_protocol.rs
+++ b/crates/cli/src/hosted_runtime/hosted/claim_protocol.rs
@@ -1,0 +1,506 @@
+//! Inbound Iroh protocol seam for browser-to-agent claim calls.
+//!
+//! Claim request and response messages land with the account flow. This module
+//! owns the transport invariant they depend on now: a dedicated versioned
+//! ALPN, the same call framing used by Weft's Iroh surface, and a fail-closed
+//! authentication gate before a method-specific handler can observe a body.
+
+// `CallFailure` carries structured error detail and intentionally crosses the
+// protocol/handler seam by value, matching Weft's native Iroh dispatcher.
+#![allow(clippy::result_large_err)]
+
+use std::sync::Arc;
+
+use api::{
+    framing::{
+        MAX_CALL_CONTEXT, MAX_CONTROL_BODY, MAX_METHOD_PATH, decode_request_frame,
+        encode_failure_response, encode_success_response,
+    },
+    heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode},
+};
+use iroh::{
+    endpoint::{Connection, RecvStream, SendStream},
+    protocol::{AcceptError, ProtocolHandler},
+};
+
+pub(crate) const CLAIM_ALPN_V1: &[u8] = b"heddle-claim/1";
+pub(crate) const CLAIM_RESOLVE_METHOD: &str = "/heddle.claim.v1.ClaimService/Resolve";
+pub(crate) const CLAIM_CONSENT_METHOD: &str = "/heddle.claim.v1.ClaimService/Consent";
+
+const MAX_REQUEST_FRAME: usize = 6 + MAX_METHOD_PATH + MAX_CALL_CONTEXT + MAX_CONTROL_BODY;
+
+/// The identity established by successful Biscuit, PoP, and request-proof
+/// verification.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct VerifiedClaimPrincipal {
+    pub(crate) subject: String,
+}
+
+pub(crate) trait ClaimBiscuitVerifier: Send + Sync + std::fmt::Debug + 'static {
+    fn verify(
+        &self,
+        method: &str,
+        context: &CallContext,
+        body: &[u8],
+    ) -> impl std::future::Future<Output = Result<VerifiedClaimPrincipal, CallFailure>> + Send;
+}
+
+pub(crate) trait ClaimHandler: Send + Sync + std::fmt::Debug + 'static {
+    fn call(
+        &self,
+        method: &str,
+        principal: VerifiedClaimPrincipal,
+        body: &[u8],
+    ) -> impl std::future::Future<Output = Result<Vec<u8>, CallFailure>> + Send;
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct ClaimProtocol<V, H> {
+    verifier: Arc<V>,
+    handler: Arc<H>,
+}
+
+impl<V, H> ClaimProtocol<V, H> {
+    pub(crate) fn new(verifier: Arc<V>, handler: Arc<H>) -> Self {
+        Self { verifier, handler }
+    }
+}
+
+impl<V, H> ProtocolHandler for ClaimProtocol<V, H>
+where
+    V: ClaimBiscuitVerifier,
+    H: ClaimHandler,
+{
+    async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
+        let mut calls = tokio::task::JoinSet::new();
+        loop {
+            tokio::select! {
+                incoming = connection.accept_bi() => {
+                    let Ok((send, recv)) = incoming else {
+                        break;
+                    };
+                    let verifier = Arc::clone(&self.verifier);
+                    let handler = Arc::clone(&self.handler);
+                    calls.spawn(async move {
+                        handle_call(verifier.as_ref(), handler.as_ref(), send, recv).await
+                    });
+                }
+                completed = calls.join_next(), if !calls.is_empty() => {
+                    match completed {
+                        Some(Ok(Ok(()))) => {}
+                        Some(Ok(Err(error))) => {
+                            tracing::warn!(%error, "agent claim call failed");
+                        }
+                        Some(Err(error)) => {
+                            tracing::warn!(%error, "agent claim task failed");
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
+        while let Some(completed) = calls.join_next().await {
+            if let Err(error) = completed {
+                tracing::warn!(%error, "agent claim task failed while closing");
+            }
+        }
+        Ok(())
+    }
+}
+
+async fn handle_call<V, H>(
+    verifier: &V,
+    handler: &H,
+    mut send: SendStream,
+    mut recv: RecvStream,
+) -> Result<(), ClaimProtocolError>
+where
+    V: ClaimBiscuitVerifier,
+    H: ClaimHandler,
+{
+    let request = recv
+        .read_to_end(MAX_REQUEST_FRAME + 1)
+        .await
+        .map_err(ClaimProtocolError::transport)?;
+    let response = match decode_request_frame(&request) {
+        Ok(frame) => match validate_auth_shape(frame.method, &frame.context) {
+            Ok(()) => match verifier
+                .verify(frame.method, &frame.context, frame.body)
+                .await
+            {
+                Ok(principal) => handler
+                    .call(frame.method, principal, frame.body)
+                    .await
+                    .and_then(|body| {
+                        encode_success_response(&body)
+                            .map_err(|error| failure(CallFailureCode::Internal, error.to_string()))
+                    }),
+                Err(failure) => Err(failure),
+            },
+            Err(failure) => Err(failure),
+        },
+        Err(error) => Err(failure(CallFailureCode::InvalidArgument, error.to_string())),
+    };
+    let response = match response {
+        Ok(response) => response,
+        Err(failure) => encode_failure_response(&failure)
+            .map_err(|error| ClaimProtocolError::framing(error.to_string()))?,
+    };
+    send.write_all(&response)
+        .await
+        .map_err(ClaimProtocolError::transport)?;
+    send.finish().map_err(ClaimProtocolError::transport)?;
+    Ok(())
+}
+
+fn validate_auth_shape(method: &str, context: &CallContext) -> Result<(), CallFailure> {
+    if !matches!(method, CLAIM_RESOLVE_METHOD | CLAIM_CONSENT_METHOD) {
+        return Err(failure(
+            CallFailureCode::Unimplemented,
+            "unknown claim method",
+        ));
+    }
+    if context.bearer_capability.is_empty() {
+        return Err(failure(
+            CallFailureCode::Unauthenticated,
+            "a Biscuit bearer capability is required",
+        ));
+    }
+    if context.bearer_proof.is_none() {
+        return Err(failure(
+            CallFailureCode::Unauthenticated,
+            "Biscuit proof-of-possession is required",
+        ));
+    }
+    if context.request_proof.is_none() {
+        return Err(failure(
+            CallFailureCode::Unauthenticated,
+            "a body-bound request proof is required",
+        ));
+    }
+    Ok(())
+}
+
+fn failure(code: CallFailureCode, message: impl Into<String>) -> CallFailure {
+    CallFailure {
+        code: code as i32,
+        message: message.into(),
+        error: None,
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error("agent claim protocol: {0}")]
+struct ClaimProtocolError(String);
+
+impl ClaimProtocolError {
+    fn transport(error: impl std::fmt::Display) -> Self {
+        Self(error.to_string())
+    }
+
+    fn framing(error: impl std::fmt::Display) -> Self {
+        Self(error.to_string())
+    }
+}
+
+/// The normal hosted client is not itself a running claim ceremony. It still
+/// advertises and routes the ALPN so #1378 can install its handler on the same
+/// endpoint without reintroducing a second transport identity.
+#[derive(Clone, Debug)]
+pub(crate) struct ClaimUnavailable;
+
+impl ClaimBiscuitVerifier for ClaimUnavailable {
+    async fn verify(
+        &self,
+        _method: &str,
+        _context: &CallContext,
+        _body: &[u8],
+    ) -> Result<VerifiedClaimPrincipal, CallFailure> {
+        Err(failure(
+            CallFailureCode::Unavailable,
+            "no claim ceremony is active",
+        ))
+    }
+}
+
+impl ClaimHandler for ClaimUnavailable {
+    async fn call(
+        &self,
+        _method: &str,
+        _principal: VerifiedClaimPrincipal,
+        _body: &[u8],
+    ) -> Result<Vec<u8>, CallFailure> {
+        Err(failure(
+            CallFailureCode::Unavailable,
+            "no claim ceremony is active",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::Ipv4Addr,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    use api::{
+        framing::{ResponseFrame, decode_response_frame, encode_request_frame},
+        heddle::api::v1alpha1::{BearerProof, RequestProof},
+    };
+    use iroh::{Endpoint, RelayMode, endpoint::presets, protocol::Router};
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct ExactBiscuitVerifier {
+        calls: AtomicUsize,
+    }
+
+    impl ClaimBiscuitVerifier for ExactBiscuitVerifier {
+        async fn verify(
+            &self,
+            method: &str,
+            context: &CallContext,
+            body: &[u8],
+        ) -> Result<VerifiedClaimPrincipal, CallFailure> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if context.bearer_capability != b"valid-biscuit"
+                || context
+                    .bearer_proof
+                    .as_ref()
+                    .map(|proof| proof.signature.as_slice())
+                    != Some(b"valid-pop".as_slice())
+                || context
+                    .request_proof
+                    .as_ref()
+                    .map(|proof| proof.signature.as_slice())
+                    != Some(b"valid-request-proof".as_slice())
+            {
+                return Err(failure(
+                    CallFailureCode::Unauthenticated,
+                    "invalid Biscuit authentication",
+                ));
+            }
+            assert_eq!(method, CLAIM_RESOLVE_METHOD);
+            assert_eq!(body, b"resolve");
+            Ok(VerifiedClaimPrincipal {
+                subject: "agent:test".to_string(),
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct EchoClaimHandler {
+        calls: AtomicUsize,
+    }
+
+    impl ClaimHandler for EchoClaimHandler {
+        async fn call(
+            &self,
+            method: &str,
+            principal: VerifiedClaimPrincipal,
+            body: &[u8],
+        ) -> Result<Vec<u8>, CallFailure> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok([
+                principal.subject.as_bytes(),
+                b":",
+                method.as_bytes(),
+                b":",
+                body,
+            ]
+            .concat())
+        }
+    }
+
+    fn context(bearer: &[u8]) -> CallContext {
+        CallContext {
+            bearer_capability: bearer.to_vec(),
+            bearer_proof: Some(BearerProof {
+                timestamp_seconds: 1,
+                nonce: vec![1; 16],
+                signature: b"valid-pop".to_vec(),
+            }),
+            request_proof: Some(RequestProof {
+                algorithm: "ed25519".to_string(),
+                signing_identity: "principal:test".to_string(),
+                timestamp_millis: 1,
+                nonce: vec![2; 16],
+                signature: b"valid-request-proof".to_vec(),
+            }),
+            ..CallContext::default()
+        }
+    }
+
+    async fn request(
+        client: &Endpoint,
+        server: iroh::EndpointAddr,
+        alpn: &[u8],
+        context: CallContext,
+    ) -> Result<Vec<u8>, String> {
+        let connection = client
+            .connect(server, alpn)
+            .await
+            .map_err(|error| error.to_string())?;
+        let (mut send, mut recv) = connection
+            .open_bi()
+            .await
+            .map_err(|error| error.to_string())?;
+        let frame = encode_request_frame(CLAIM_RESOLVE_METHOD, &context, b"resolve")
+            .map_err(|error| error.to_string())?;
+        send.write_all(&frame)
+            .await
+            .map_err(|error| error.to_string())?;
+        send.finish().map_err(|error| error.to_string())?;
+        recv.read_to_end(MAX_CONTROL_BODY + 1)
+            .await
+            .map_err(|error| error.to_string())
+    }
+
+    async fn endpoints(
+        verifier: Arc<ExactBiscuitVerifier>,
+        handler: Arc<EchoClaimHandler>,
+    ) -> (Router, Endpoint, iroh::EndpointAddr) {
+        let server = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .expect("server bind addr")
+            .bind()
+            .await
+            .expect("server bind");
+        let address = server.addr();
+        let router = Router::builder(server)
+            .accept(CLAIM_ALPN_V1, ClaimProtocol::new(verifier, handler))
+            .spawn();
+        let client = Endpoint::builder(presets::Minimal)
+            .relay_mode(RelayMode::Disabled)
+            .bind_addr((Ipv4Addr::LOCALHOST, 0))
+            .expect("client bind addr")
+            .bind()
+            .await
+            .expect("client bind");
+        (router, client, address)
+    }
+
+    #[tokio::test]
+    async fn claim_alpn_routes_authenticated_calls() {
+        let verifier = Arc::new(ExactBiscuitVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let handler = Arc::new(EchoClaimHandler {
+            calls: AtomicUsize::new(0),
+        });
+        let (router, client, address) =
+            endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
+
+        let response = request(&client, address, CLAIM_ALPN_V1, context(b"valid-biscuit"))
+            .await
+            .expect("authenticated claim call");
+        let ResponseFrame::Success(body) = decode_response_frame(&response).expect("response")
+        else {
+            panic!("expected success response");
+        };
+        assert_eq!(
+            body,
+            [
+                b"agent:test:".as_slice(),
+                CLAIM_RESOLVE_METHOD.as_bytes(),
+                b":resolve",
+            ]
+            .concat()
+        );
+        assert_eq!(verifier.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 1);
+
+        client.close().await;
+        router.shutdown().await.expect("router shutdown");
+    }
+
+    #[tokio::test]
+    async fn incomplete_authentication_never_reaches_verifier_or_handler() {
+        let verifier = Arc::new(ExactBiscuitVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let handler = Arc::new(EchoClaimHandler {
+            calls: AtomicUsize::new(0),
+        });
+        let (router, client, address) =
+            endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
+
+        let mut contexts = vec![context(b"")];
+        let mut missing_pop = context(b"valid-biscuit");
+        missing_pop.bearer_proof = None;
+        contexts.push(missing_pop);
+        let mut missing_request_proof = context(b"valid-biscuit");
+        missing_request_proof.request_proof = None;
+        contexts.push(missing_request_proof);
+
+        for context in contexts {
+            let response = request(&client, address.clone(), CLAIM_ALPN_V1, context)
+                .await
+                .expect("claim refusal response");
+            let ResponseFrame::Failure(failure) =
+                decode_response_frame(&response).expect("failure response")
+            else {
+                panic!("expected authentication failure");
+            };
+            assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
+        }
+        assert_eq!(verifier.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 0);
+
+        client.close().await;
+        router.shutdown().await.expect("router shutdown");
+    }
+
+    #[tokio::test]
+    async fn rejected_biscuit_never_reaches_handler() {
+        let verifier = Arc::new(ExactBiscuitVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let handler = Arc::new(EchoClaimHandler {
+            calls: AtomicUsize::new(0),
+        });
+        let (router, client, address) =
+            endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
+
+        let response = request(&client, address, CLAIM_ALPN_V1, context(b"forged-biscuit"))
+            .await
+            .expect("claim refusal response");
+        let ResponseFrame::Failure(failure) =
+            decode_response_frame(&response).expect("failure response")
+        else {
+            panic!("expected authentication failure");
+        };
+        assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
+        assert_eq!(verifier.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 0);
+
+        client.close().await;
+        router.shutdown().await.expect("router shutdown");
+    }
+
+    #[tokio::test]
+    async fn unrelated_alpn_is_rejected_before_dispatch() {
+        let verifier = Arc::new(ExactBiscuitVerifier {
+            calls: AtomicUsize::new(0),
+        });
+        let handler = Arc::new(EchoClaimHandler {
+            calls: AtomicUsize::new(0),
+        });
+        let (router, client, address) =
+            endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
+
+        let error = client
+            .connect(address, b"not-heddle-claim")
+            .await
+            .expect_err("wrong ALPN must be rejected");
+        assert!(!error.to_string().is_empty());
+        assert_eq!(verifier.calls.load(Ordering::SeqCst), 0);
+        assert_eq!(handler.calls.load(Ordering::SeqCst), 0);
+
+        client.close().await;
+        router.shutdown().await.expect("router shutdown");
+    }
+}

--- a/crates/cli/src/hosted_runtime/hosted/connection.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection.rs
@@ -5,17 +5,21 @@ use cli_shared::ClientConfig;
 use iroh::{
     Endpoint, EndpointAddr, EndpointId, RelayMode,
     endpoint::{AckFrequencyConfig, QuicTransportConfig, presets},
+    protocol::Router,
 };
 use tokio::sync::Mutex;
 
 use super::{
-    HostedError, Result, VerifiedEndpointDescriptor, provider_transport::ProviderWebSocketTransport,
+    HostedError, Result, VerifiedEndpointDescriptor,
+    claim_protocol::{CLAIM_ALPN_V1, ClaimProtocol, ClaimUnavailable},
+    provider_transport::ProviderWebSocketTransport,
 };
 
 const DIRECT_CONNECT_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub(super) struct HostedConnection {
+    router: Router,
     pub(super) endpoint: Endpoint,
     pub(super) connection: iroh::endpoint::Connection,
     provider_transport: Option<ProviderWebSocketTransport>,
@@ -35,8 +39,16 @@ impl HostedConnection {
 
         if direct_address.ip_addrs().next().is_some() {
             let provider_transport = ProviderWebSocketTransport::new(config.clone());
-            let endpoint =
-                bind_endpoint(RelayMode::Disabled, Some(provider_transport.clone())).await?;
+            // The endpoint is now also an inbound claim listener. Keep its
+            // signed relays online even when the hosted connection itself can
+            // use a direct path, or a browser holding only the claim link
+            // cannot reach the advertised node id.
+            let relay_mode = if relays.is_empty() {
+                RelayMode::Disabled
+            } else {
+                RelayMode::custom(relays.clone())
+            };
+            let endpoint = bind_endpoint(relay_mode, Some(provider_transport.clone())).await?;
             if relays.is_empty() {
                 return Self::connect_inner(endpoint, direct_address, Some(provider_transport))
                     .await;
@@ -85,7 +97,9 @@ impl HostedConnection {
                 return Err(HostedError::transport(error));
             }
         };
+        let router = claim_router(endpoint.clone());
         Ok(Arc::new(Self {
+            router,
             endpoint,
             connection,
             provider_transport,
@@ -145,7 +159,9 @@ impl HostedConnection {
 
     pub(super) async fn close(&self) {
         self.connection.close(0u32.into(), b"Heddle client closed");
-        self.endpoint.close().await;
+        if let Err(error) = self.router.shutdown().await {
+            tracing::warn!(%error, "failed to shut down Heddle Iroh router");
+        }
     }
 }
 
@@ -153,13 +169,25 @@ async fn bind_endpoint(
     relay_mode: RelayMode,
     provider_transport: Option<ProviderWebSocketTransport>,
 ) -> Result<Endpoint> {
+    let identity = crate::hosted_runtime::agent_node_identity::load_or_create()
+        .map_err(HostedError::transport)?;
     let mut builder = Endpoint::builder(presets::Minimal)
         .transport_config(transport_config())
-        .relay_mode(relay_mode);
+        .relay_mode(relay_mode)
+        .secret_key(identity.secret_key());
     if let Some(provider_transport) = provider_transport {
         builder = builder.add_custom_transport(Arc::new(provider_transport));
     }
     builder.bind().await.map_err(HostedError::transport)
+}
+
+fn claim_router(endpoint: Endpoint) -> Router {
+    Router::builder(endpoint)
+        .accept(
+            CLAIM_ALPN_V1,
+            ClaimProtocol::new(Arc::new(ClaimUnavailable), Arc::new(ClaimUnavailable)),
+        )
+        .spawn()
 }
 
 impl Drop for HostedConnection {

--- a/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection_path_tests.rs
@@ -6,17 +6,52 @@ use std::{
 
 use api::{
     HOSTED_ALPN_V1,
-    heddle::api::v1alpha1::{EndpointDescriptor, SignedEndpointDescriptor},
+    framing::{ResponseFrame, decode_response_frame, encode_request_frame},
+    heddle::api::v1alpha1::{
+        CallContext, CallFailureCode, EndpointDescriptor, SignedEndpointDescriptor,
+    },
     signing::endpoint_descriptor_bytes,
 };
 use crypto::{Ed25519Signer, Signer};
 use iroh::{Endpoint, RelayMode, endpoint::presets};
 use n0_watcher::Watcher;
 
-use super::{DescriptorKeyring, VerifiedEndpointDescriptor, connection::HostedConnection};
+use super::{
+    DescriptorKeyring, VerifiedEndpointDescriptor,
+    claim_protocol::{CLAIM_ALPN_V1, CLAIM_RESOLVE_METHOD},
+    connection::HostedConnection,
+};
 
 const HOSTED_ENDPOINT_CLOSE_P95_BUDGET: Duration = Duration::from_millis(20);
 const DEFAULT_CLOSE_SAMPLE_COUNT: usize = 20;
+
+struct HeddleHomeEnvGuard {
+    previous: Option<std::ffi::OsString>,
+    _home: tempfile::TempDir,
+}
+
+impl HeddleHomeEnvGuard {
+    fn isolated() -> Self {
+        let home = tempfile::TempDir::new().expect("temp Heddle home");
+        let previous = std::env::var_os("HEDDLE_HOME");
+        unsafe {
+            std::env::set_var("HEDDLE_HOME", home.path());
+        }
+        Self {
+            previous,
+            _home: home,
+        }
+    }
+}
+
+impl Drop for HeddleHomeEnvGuard {
+    fn drop(&mut self) {
+        match self.previous.take() {
+            Some(value) => unsafe { std::env::set_var("HEDDLE_HOME", value) },
+            None => unsafe { std::env::remove_var("HEDDLE_HOME") },
+        }
+    }
+}
 
 fn require_release_build() {
     #[cfg(debug_assertions)]
@@ -60,7 +95,10 @@ fn verified_descriptor(
 
 #[tokio::test]
 #[ignore = "release-only hosted endpoint close performance contract"]
+#[allow(clippy::await_holding_lock)]
 async fn hosted_endpoint_close_release_contract() {
+    let _env_guard = cli_shared::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
     require_release_build();
     let _ = tracing_subscriber::fmt()
         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
@@ -162,7 +200,18 @@ fn percentile_ms(sorted_values: &[f64], percentile: usize) -> f64 {
 }
 
 #[tokio::test]
-async fn reachable_direct_address_never_initializes_advertised_relays() {
+#[allow(clippy::await_holding_lock)]
+async fn reachable_direct_address_keeps_the_claim_relay_online() {
+    use iroh_relay::server::{RelayConfig as RelayServerConfig, Server, ServerConfig};
+
+    let _env_guard = cli_shared::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
+    let mut relay_config = ServerConfig::default();
+    relay_config.relay = Some(RelayServerConfig::new((Ipv4Addr::LOCALHOST, 0)));
+    let relay = Server::spawn(relay_config).await.unwrap();
+    let relay_url: iroh::RelayUrl = format!("http://{}", relay.http_addr().unwrap())
+        .parse()
+        .unwrap();
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
         .relay_mode(RelayMode::Disabled)
@@ -173,7 +222,7 @@ async fn reachable_direct_address_never_initializes_advertised_relays() {
         .unwrap();
     let descriptor = verified_descriptor(
         server.id(),
-        vec!["https://usw1-1.relay.n0.iroh.link.".to_string()],
+        vec![relay_url.to_string()],
         server.addr().ip_addrs().map(ToString::to_string).collect(),
     );
     let server_task = tokio::spawn(async move {
@@ -191,17 +240,23 @@ async fn reachable_direct_address_never_initializes_advertised_relays() {
         HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
             .await
             .unwrap();
-    tokio::time::sleep(Duration::from_millis(20)).await;
+    tokio::time::timeout(Duration::from_secs(5), connection.endpoint.online())
+        .await
+        .expect("claim listener should register with the signed relay");
     assert!(
-        connection.endpoint.home_relay_status().get().is_empty(),
-        "a reachable signed direct address must not initialize a relay transport"
+        !connection.endpoint.home_relay_status().get().is_empty(),
+        "a direct hosted path must keep the inbound claim relay initialized"
     );
     connection.close().await;
     server_task.await.unwrap();
+    drop(relay);
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn direct_only_descriptor_uses_the_normal_connection_path() {
+    let _env_guard = cli_shared::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
         .relay_mode(RelayMode::Disabled)
@@ -235,7 +290,10 @@ async fn direct_only_descriptor_uses_the_normal_connection_path() {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn unreachable_direct_address_falls_back_to_signed_relay() {
+    let _env_guard = cli_shared::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
     use iroh_relay::server::{RelayConfig as RelayServerConfig, Server, ServerConfig};
 
     let mut relay_config = ServerConfig::default();
@@ -288,4 +346,68 @@ async fn unreachable_direct_address_falls_back_to_signed_relay() {
     connection.close().await;
     server_task.await.unwrap();
     drop(relay);
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn hosted_connection_uses_persisted_id_and_accepts_claim_alpn() {
+    let _env_guard = cli_shared::credentials::lock_test_env();
+    let _home = HeddleHomeEnvGuard::isolated();
+    let server = Endpoint::builder(presets::Minimal)
+        .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let descriptor = verified_descriptor(
+        server.id(),
+        Vec::new(),
+        server.addr().ip_addrs().map(ToString::to_string).collect(),
+    );
+    let server_task = tokio::spawn(async move {
+        let connection = server
+            .accept()
+            .await
+            .expect("incoming hosted connection")
+            .await
+            .unwrap();
+        connection.closed().await;
+        server.close().await;
+    });
+
+    let connection =
+        HostedConnection::connect_verified(&descriptor, &cli_shared::ClientConfig::default())
+            .await
+            .unwrap();
+    let persisted = crate::hosted_runtime::agent_node_identity::load_or_create()
+        .expect("persisted agent node identity");
+    assert_eq!(connection.endpoint_id(), persisted.node_id());
+
+    let claim_client = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let claim_connection = claim_client
+        .connect(connection.endpoint.addr(), CLAIM_ALPN_V1)
+        .await
+        .expect("claim ALPN connection");
+    let (mut send, mut recv) = claim_connection.open_bi().await.unwrap();
+    let frame = encode_request_frame(CLAIM_RESOLVE_METHOD, &CallContext::default(), b"resolve")
+        .expect("claim request frame");
+    send.write_all(&frame).await.unwrap();
+    send.finish().unwrap();
+    let response = recv.read_to_end(64 * 1024).await.unwrap();
+    let ResponseFrame::Failure(failure) = decode_response_frame(&response).unwrap() else {
+        panic!("missing Biscuit authentication must be refused");
+    };
+    assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
+
+    claim_client.close().await;
+    connection.close().await;
+    server_task.await.unwrap();
 }

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -5,6 +5,7 @@
 
 mod bootstrap;
 mod call;
+mod claim_protocol;
 mod collaboration;
 mod connection;
 #[cfg(test)]

--- a/crates/cli/src/hosted_runtime/mod.rs
+++ b/crates/cli/src/hosted_runtime/mod.rs
@@ -6,6 +6,7 @@
 //! hosted command implementations. It is deliberately not a public transport
 //! client surface.
 
+mod agent_node_identity;
 pub(crate) mod auth;
 pub(crate) mod auth_requests;
 pub(crate) mod credential_file;


### PR DESCRIPTION
Closes #1379.

## Scope

- `crates/cli/src/hosted_runtime/agent_node_identity.rs`
- `crates/cli/src/hosted_runtime/hosted/claim_protocol.rs`
- hosted connection/router integration and focused tests

## What changed

- Persist one distinct Iroh transport secret under `HEDDLE_HOME`, beside credential material. Creation is lock-serialized, atomic, and mode `0600`; corrupt, mismatched, exposed, symlinked, or non-regular identities fail closed and are never silently reminted.
- Bind every hosted Iroh endpoint with that persisted secret, so the advertised NodeId survives process restarts.
- Own an Iroh `Router` on the connected endpoint and accept `heddle-claim/1` with the same framed call shape used by the Weft Iroh transport.
- Gate Resolve/Consent dispatch on mandatory Biscuit bearer, PoP, request-proof shape, and verifier approval. The listener fails closed with Unavailable when no #1378 claim ceremony is active.
- Keep signed relays online even when the outbound hosted path is direct, so a browser holding NodeId plus relay can still reach the inbound claim listener.

## Negative cases proved

- corrupt/publicly-readable identity is refused without key replacement
- concurrent first bind converges on one NodeId
- missing Biscuit, PoP, or request proof never reaches verifier or handler
- forged Biscuit reaches the verifier but never the handler
- unrelated ALPN is rejected before dispatch
- a real HostedConnection accepts claim ALPN and refuses unauthenticated calls

## Verification

- `CARGO_TARGET_DIR=/home/scratch/heddle-1379-target CARGO_INCREMENTAL=0 cargo test --workspace --lib --no-fail-fast` — green
- `CARGO_TARGET_DIR=/tmp/heddle-1379-target cargo clippy -p heddle-cli --lib --tests -- -D warnings` — green
- `cargo fmt --all --check` and `git diff --check` — green
- `cargo test -p heddle-cli --tests --no-fail-fast` — issue-relevant and main CLI matrices green, including 680 unit tests and 919 CLI integration tests; the final pre-existing `ts_types_in_sync` target reports the two generated schema snapshots stale. This branch has no diff from `origin/main` in either generated snapshot and leaves that unrelated drift out of scope.

Commit: `f02cc768baaadf6208beb34ad6b465207474179c`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789285858&installation_model_id=21489&pr_number=1381&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1381&signature=baced7083742a020a80a09a3ece32cf969463d10e2fc8e1e4b1a7f909fa0b0c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->