### PR TITLE
feat(cli): ensure and claim agent identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,9 +2174,9 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.5.0"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7a59e258c91a1e15de848f30b309f1808da36bbb0bcc82b75062693631ea4e"
+checksum = "4db7d9fae2fc727e06ad2685cc9271f27bcf5ede39bfa0f30b1f52fc44ab60cd"
 dependencies = [
  "bytes",
  "hex",
@@ -2231,7 +2231,8 @@ dependencies = [
  "clap_complete",
  "criterion",
  "futures",
- "heddle-api 0.5.0",
+ "getrandom 0.4.3",
+ "heddle-api 0.6.4",
  "heddle-ci-config",
  "heddle-ci-engine",
  "heddle-cli-args",
@@ -2303,7 +2304,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api 0.5.0",
+ "heddle-api 0.6.4",
  "heddle-cli-shared",
  "heddle-objects",
  "heddle-repo",

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -17771,6 +17771,140 @@
       "title": "GenericJsonObjectSchema",
       "type": "object"
     },
+    "identity claim-link": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "claim_url": {
+          "description": "Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "node_id": {
+          "description": "Stable lowercase-hex Iroh NodeId, present when a claim link is minted.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "outcome": {
+          "description": "`reused`, `derived`, `created_on_behalf`, or `claim_link_reissued`.",
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "identity_claim_link"
+          ],
+          "type": "string"
+        },
+        "server": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "outcome",
+        "server",
+        "subject"
+      ],
+      "title": "IdentityOutputSchema",
+      "type": "object"
+    },
+    "identity ensure": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "claim_url": {
+          "description": "Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "node_id": {
+          "description": "Stable lowercase-hex Iroh NodeId, present when a claim link is minted.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "outcome": {
+          "description": "`reused`, `derived`, `created_on_behalf`, or `claim_link_reissued`.",
+          "type": "string"
+        },
+        "output_kind": {
+          "enum": [
+            "identity_ensure"
+          ],
+          "type": "string"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "server": {
+          "type": "string"
+        },
+        "subject": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind",
+        "outcome",
+        "server",
+        "subject"
+      ],
+      "title": "IdentityOutputSchema",
+      "type": "object"
+    },
     "import git": {
       "$defs": {
         "ActionTemplateSchema": {
@@ -24125,6 +24259,153 @@
             "purge_list"
           ],
           "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "redact purge trust add": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "purge_trust_add"
+          ],
+          "type": "string"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "redact purge trust list": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "purge_trust_list"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "output_kind"
+      ],
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "redact purge trust remove": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "properties": {
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "purge_trust_remove"
+          ],
+          "type": "string"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -12207,6 +12207,12 @@
       "title": "CaptureSchema",
       "type": "object"
     },
+    "ci run": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "additionalProperties": true,
+      "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
     "clone": {
       "$defs": {
         "ActionTemplateSchema": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -1190,6 +1190,34 @@ export interface HookUninstallSchema {
   [key: string]: unknown;
 }
 
+export interface IdentityClaimLinkSchema {
+  /** Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue. */
+  claim_url?: string | null;
+  /** Stable lowercase-hex Iroh NodeId, present when a claim link is minted. */
+  node_id?: string | null;
+  /** `reused`, `derived`, `created_on_behalf`, or `claim_link_reissued`. */
+  outcome: string;
+  output_kind: "identity_claim_link";
+  server: string;
+  subject: string;
+}
+
+export interface IdentityEnsureSchema {
+  /** Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue. */
+  claim_url?: string | null;
+  idempotency_status?: string | null;
+  /** Stable lowercase-hex Iroh NodeId, present when a claim link is minted. */
+  node_id?: string | null;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  /** `reused`, `derived`, `created_on_behalf`, or `claim_link_reissued`. */
+  outcome: string;
+  output_kind: "identity_ensure";
+  replayed?: boolean | null;
+  server: string;
+  subject: string;
+}
+
 export interface ImportGitSchema {
   action?: string | null;
   already_in_sync: boolean;
@@ -1813,6 +1841,29 @@ export interface RedactPurgeApplySchema {
 
 export interface RedactPurgeListSchema {
   output_kind: "purge_list";
+  [key: string]: unknown;
+}
+
+export interface RedactPurgeTrustAddSchema {
+  idempotency_status?: string | null;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "purge_trust_add";
+  replayed?: boolean | null;
+  [key: string]: unknown;
+}
+
+export interface RedactPurgeTrustListSchema {
+  output_kind: "purge_trust_list";
+  [key: string]: unknown;
+}
+
+export interface RedactPurgeTrustRemoveSchema {
+  idempotency_status?: string | null;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  output_kind: "purge_trust_remove";
+  replayed?: boolean | null;
   [key: string]: unknown;
 }
 
@@ -3441,6 +3492,8 @@ export interface HeddleVerbOutputs {
   "hook install": HookInstallSchema;
   "hook list": HookListSchema;
   "hook uninstall": HookUninstallSchema;
+  "identity claim-link": IdentityClaimLinkSchema;
+  "identity ensure": IdentityEnsureSchema;
   "import git": ImportGitSchema;
   init: InitSchema;
   "integration doctor": IntegrationDoctorSchema;
@@ -3468,6 +3521,9 @@ export interface HeddleVerbOutputs {
   "redact list": RedactListSchema;
   "redact purge apply": RedactPurgeApplySchema;
   "redact purge list": RedactPurgeListSchema;
+  "redact purge trust add": RedactPurgeTrustAddSchema;
+  "redact purge trust list": RedactPurgeTrustListSchema;
+  "redact purge trust remove": RedactPurgeTrustRemoveSchema;
   "redact show": RedactShowSchema;
   "redact trust add": RedactTrustAddSchema;
   "redact trust list": RedactTrustListSchema;
@@ -3605,6 +3661,8 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "hook install",
   "hook list",
   "hook uninstall",
+  "identity claim-link",
+  "identity ensure",
   "import git",
   "init",
   "integration doctor",
@@ -3632,6 +3690,9 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "redact list",
   "redact purge apply",
   "redact purge list",
+  "redact purge trust add",
+  "redact purge trust list",
+  "redact purge trust remove",
   "redact show",
   "redact trust add",
   "redact trust list",

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -554,6 +554,8 @@ export interface ChangesInfo {
   modified: string[];
 }
 
+export type CiRunSchema = Record<string, unknown>;
+
 export interface CloneGitSchema {
   action: string;
   branch: string;
@@ -3454,6 +3456,7 @@ export interface HeddleVerbOutputs {
   "auth trust replace": AuthTrustReplaceSchema;
   "auth trust show": AuthTrustShowSchema;
   capture: CaptureSchema;
+  "ci run": CiRunSchema;
   clone: CloneSchema;
   collapse: CollapseSchema;
   commit: CommitSchema;
@@ -3623,6 +3626,7 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "auth trust replace",
   "auth trust show",
   "capture",
+  "ci run",
   "clone",
   "collapse",
   "commit",

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.5.0" }
+api = { package = "heddle-api", version = "0.6.4" }
 clap.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.12" }

--- a/crates/cli-args/src/cli/cli_args/commands_client.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_client.rs
@@ -121,6 +121,38 @@ pub enum AuthCommands {
 }
 
 #[derive(Subcommand, Clone, Debug)]
+pub enum IdentityCommands {
+    /// Ensure this machine has an agent identity, reusing an account first
+    Ensure {
+        /// Heddle server address (defaults to the configured server).
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Human invite consumed only when no account credential exists.
+        #[arg(long)]
+        invite: Option<String>,
+    },
+
+    /// Reissue the short-lived browser claim link for an unclaimed identity
+    ClaimLink {
+        /// Heddle server address (defaults to the account's server).
+        #[arg(long)]
+        server: Option<String>,
+
+        /// Link lifetime in seconds.
+        #[arg(long = "ttl", default_value_t = 900)]
+        ttl_secs: u64,
+    },
+
+    /// Keep the Iroh claim endpoint online for an outstanding link.
+    #[command(hide = true)]
+    Serve {
+        #[arg(long)]
+        server: String,
+    },
+}
+
+#[derive(Subcommand, Clone, Debug)]
 pub enum AuthTrustCommands {
     /// Show the descriptor trust controlling a server connection
     Show(AuthTrustShowArgs),
@@ -155,7 +187,7 @@ pub struct AuthTrustReplaceArgs {
 mod tests {
     use clap::Parser;
 
-    use crate::cli::{AuthCommands, AuthTrustCommands, Cli, Commands};
+    use crate::cli::{AuthCommands, AuthTrustCommands, Cli, Commands, IdentityCommands};
 
     #[test]
     fn trust_replace_parses_compare_and_swap_inputs() {
@@ -246,6 +278,28 @@ mod tests {
     fn interactive_login_needs_no_flags() {
         Cli::try_parse_from(["heddle", "auth", "login"])
             .expect("interactive login may resolve the configured default server");
+    }
+
+    #[test]
+    fn identity_ensure_accepts_an_optional_fallback_invite() {
+        let cli = Cli::try_parse_from([
+            "heddle",
+            "identity",
+            "ensure",
+            "--server",
+            "api.heddle.test",
+            "--invite",
+            "invite-secret",
+        ])
+        .expect("identity ensure parses");
+        let Commands::Identity {
+            command: IdentityCommands::Ensure { server, invite },
+        } = cli.command
+        else {
+            panic!("expected identity ensure");
+        };
+        assert_eq!(server.as_deref(), Some("api.heddle.test"));
+        assert_eq!(invite.as_deref(), Some("invite-secret"));
     }
 
     #[test]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -3,8 +3,6 @@
 
 use clap::{Args, Subcommand};
 
-#[cfg(feature = "client")]
-use super::AuthCommands;
 #[cfg(feature = "semantic")]
 use super::SemanticCommands;
 use super::{
@@ -18,6 +16,8 @@ use super::{
         WatchArgs,
     },
 };
+#[cfg(feature = "client")]
+use super::{AuthCommands, IdentityCommands};
 #[cfg(feature = "git-overlay")]
 use super::{ExportCommands, ImportCommands};
 
@@ -446,6 +446,13 @@ Examples:
     Auth {
         #[command(subcommand)]
         command: AuthCommands,
+    },
+
+    /// Ensure and claim this machine's hosted agent identity.
+    #[cfg(feature = "client")]
+    Identity {
+        #[command(subcommand)]
+        command: IdentityCommands,
     },
 
     /// Report the acting identity (principal, token kind, scopes, operation

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -51,7 +51,7 @@ pub use commands_args::{
 };
 pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
-pub use commands_client::{AgentTemplateArg, AuthCommands, AuthTrustCommands};
+pub use commands_client::{AgentTemplateArg, AuthCommands, AuthTrustCommands, IdentityCommands};
 pub use commands_context::ContextCommands;
 #[cfg(all(feature = "git-overlay", feature = "ingest"))]
 pub use commands_context::ContextReasonCommands;

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -12,8 +12,6 @@ use heddle_core::{
 use schemars::JsonSchema;
 use serde::Serialize;
 
-#[cfg(feature = "client")]
-use crate::cli::AuthCommands;
 #[cfg(feature = "semantic")]
 use crate::cli::SemanticCommands;
 #[cfg(feature = "git-overlay")]
@@ -29,6 +27,8 @@ use crate::cli::{
     },
     render::shell_quote,
 };
+#[cfg(feature = "client")]
+use crate::cli::{AuthCommands, IdentityCommands};
 #[cfg(feature = "git-overlay")]
 use crate::cli::{ExportCommands, ImportCommands};
 
@@ -782,6 +782,16 @@ const CONFIG_MUTATION_NO_OP_ID: CommandContract = CommandContract {
     ..CONFIG_MUTATION
 };
 
+const NETWORK_CONFIG_MUTATION: CommandContract = CommandContract {
+    network_io: true,
+    ..CONFIG_MUTATION
+};
+
+const NETWORK_CONFIG_MUTATION_NO_OP_ID: CommandContract = CommandContract {
+    network_io: true,
+    ..CONFIG_MUTATION_NO_OP_ID
+};
+
 const CONFIG_MUTATION_TEXT: CommandContract = CommandContract {
     supports_json: false,
     supports_op_id: false,
@@ -1502,6 +1512,45 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ),
             "client",
         ),
+    ),
+    entry(
+        &["identity"],
+        category(feature_gated(user_scoped(GROUP), "client"), "repo"),
+    ),
+    entry(
+        &["identity", "ensure"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(user_scoped(NETWORK_CONFIG_MUTATION), &["identity ensure"]),
+                &[json_discriminator(
+                    Some("identity ensure"),
+                    "output_kind",
+                    "identity_ensure",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["identity", "claim-link"],
+        feature_gated(
+            json_discriminators(
+                documented_schemas(
+                    user_scoped(NETWORK_CONFIG_MUTATION_NO_OP_ID),
+                    &["identity claim-link"],
+                ),
+                &[json_discriminator(
+                    Some("identity claim-link"),
+                    "output_kind",
+                    "identity_claim_link",
+                )],
+            ),
+            "client",
+        ),
+    ),
+    entry(
+        &["identity", "serve"],
+        feature_gated(user_scoped(NETWORK_CONFIG_MUTATION_TEXT), "client"),
     ),
     entry(
         &["whoami"],
@@ -4685,6 +4734,12 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             },
             AuthCommands::DeriveAgent { .. } => vec!["auth", "derive-agent"],
             AuthCommands::CreateServiceToken { .. } => vec!["auth", "create-service-token"],
+        },
+        #[cfg(feature = "client")]
+        Commands::Identity { command } => match command {
+            IdentityCommands::Ensure { .. } => vec!["identity", "ensure"],
+            IdentityCommands::ClaimLink { .. } => vec!["identity", "claim-link"],
+            IdentityCommands::Serve { .. } => vec!["identity", "serve"],
         },
         #[cfg(feature = "client")]
         Commands::Whoami { .. } => vec!["whoami"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -170,6 +170,15 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
         ],
     ),
     #[cfg(feature = "client")]
+    sample(&["identity", "ensure"], &["identity", "ensure"]),
+    #[cfg(feature = "client")]
+    sample(&["identity", "claim-link"], &["identity", "claim-link"]),
+    #[cfg(feature = "client")]
+    sample(
+        &["identity", "serve"],
+        &["identity", "serve", "--server", "api.heddle.test"],
+    ),
+    #[cfg(feature = "client")]
     sample(&["whoami"], &["whoami"]),
     #[cfg(feature = "git-overlay")]
     sample(&["import", "git"], &["import", "git"]),
@@ -1666,6 +1675,8 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "auth trust show",
             "auth trust replace",
             "auth create-service-token",
+            "identity ensure",
+            "identity claim-link",
             // heddle whoami (H6, weft#642): the machine-readable
             // acting-identity verb emits `output_kind: "whoami"`, so it
             // advertises its discriminator here alongside the other
@@ -2350,8 +2361,11 @@ fn op_id_persistence_reads_contract_table() {
 
 #[test]
 fn feature_gated_command_roots_are_catalog_owned() {
-    // `auth` and `whoami` are the client-gated top-level roots: their clap
+    // These are the client-gated top-level roots: their clap
     // variants are `#[cfg(feature = "client")]` and their catalog entries carry
     // `feature_gate = "client"`. Any new feature-gated root MUST be listed here.
-    assert_eq!(feature_gated_command_roots(), &["auth", "whoami"]);
+    assert_eq!(
+        feature_gated_command_roots(),
+        &["auth", "identity", "whoami"]
+    );
 }

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -146,6 +146,7 @@ schema_registry! {
     (&["auth trust show", "auth trust replace"], AuthTrustSchema),
     (&["whoami"], WhoamiSchema),
     (&["auth create-service-token"], AuthCreateServiceTokenSchema),
+    (&["identity ensure", "identity claim-link"], IdentityOutputSchema),
     (&["agent provenance begin", "agent provenance end", "agent provenance show"], AgentProvenanceEnvelopeSchema),
     (&["agent provenance segment"], AgentProvenanceSegmentEnvelopeSchema),
     (&["agent provenance list"], AgentProvenanceListSchema),
@@ -794,6 +795,19 @@ pub struct AuthCreateServiceTokenSchema {
     /// and proof key live inside this file and never appear in the contract.
     pub credential_path: String,
     pub expires_in_days: u32,
+}
+
+#[derive(Debug, Serialize, JsonSchema)]
+pub struct IdentityOutputSchema {
+    pub output_kind: String,
+    /// `reused`, `derived`, `created_on_behalf`, or `claim_link_reissued`.
+    pub outcome: String,
+    pub server: String,
+    pub subject: String,
+    /// Stable lowercase-hex Iroh NodeId, present when a claim link is minted.
+    pub node_id: Option<String>,
+    /// Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue.
+    pub claim_url: Option<String>,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
+getrandom.workspace = true
 biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
@@ -44,7 +45,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.12" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
-api = { package = "heddle-api", version = "0.5.0" }
+api = { package = "heddle-api", version = "0.6.4" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
 heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.12", default-features = false }

--- a/crates/cli/src/extensions.rs
+++ b/crates/cli/src/extensions.rs
@@ -17,7 +17,9 @@ use async_trait::async_trait;
 use weft_client_shim::{CliContext, WeftExtensions};
 
 use crate::{
-    cli::{AgentTemplateArg, AuthCommands, AuthTrustCommands, commands::cmd_auth},
+    cli::{
+        AgentTemplateArg, AuthCommands, AuthTrustCommands, IdentityCommands, commands::cmd_auth,
+    },
     hosted_runtime::{
         auth_requests::{AuthCommand, AuthTrustCommand},
         device_flow::AgentTemplate,
@@ -39,6 +41,15 @@ impl WeftExtensions for EnabledWeftExtensions {
 
     async fn whoami(&self, ctx: &(dyn CliContext + 'static), server: Option<String>) -> Result<()> {
         crate::hosted_runtime::whoami::cmd_whoami(ctx, server).await
+    }
+
+    async fn identity(
+        &self,
+        ctx: &(dyn CliContext + 'static),
+        command: &(dyn Any + Send + Sync),
+    ) -> Result<()> {
+        let command = downcast::<IdentityCommands>(command, "IdentityCommands")?;
+        crate::hosted_runtime::identity::cmd_identity(ctx, command.clone()).await
     }
 }
 

--- a/crates/cli/src/hosted_runtime/agent_node_identity.rs
+++ b/crates/cli/src/hosted_runtime/agent_node_identity.rs
@@ -186,6 +186,22 @@ mod tests {
     }
 
     #[test]
+    fn node_id_is_the_same_lower_hex_ed25519_public_key_used_for_consent() {
+        let temp = TempDir::new().expect("temp dir");
+        let identity = load_or_create_at(&temp.path().join(IDENTITY_FILE)).expect("identity");
+        let signer = crypto::Ed25519Signer::from_seed(&identity.secret_key().to_bytes())
+            .expect("consent signer");
+        let node_id = identity.node_id().to_string();
+        assert_eq!(node_id.len(), 64);
+        assert!(
+            node_id
+                .bytes()
+                .all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+        );
+        assert_eq!(node_id, hex::encode(crypto::Signer::public_key(&signer)));
+    }
+
+    #[test]
     fn concurrent_first_loads_choose_one_identity() {
         let temp = TempDir::new().expect("temp dir");
         let path = Arc::new(temp.path().join(IDENTITY_FILE));

--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -123,6 +123,7 @@ pub async fn cmd_auth(ctx: &dyn CliContext, command: AuthCommand) -> Result<()> 
             allowed_operations,
             template,
             out.as_deref(),
+            false,
         ),
         AuthCommand::CreateServiceToken {
             name,
@@ -215,7 +216,7 @@ fn emit_auth_trust(ctx: &dyn CliContext, output: AuthTrustOutput) -> Result<()> 
 /// Derive an offline child credential with a fresh PoP key, then either install
 /// it as the active credential or write a portable token + child-key bundle.
 #[allow(clippy::too_many_arguments)]
-fn cmd_auth_derive_agent(
+pub(crate) fn cmd_auth_derive_agent(
     server: &str,
     agent_id: Option<String>,
     ttl_secs: u64,
@@ -223,6 +224,7 @@ fn cmd_auth_derive_agent(
     requested_operations: Vec<String>,
     template: Option<AgentTemplate>,
     out: Option<&Path>,
+    quiet: bool,
 ) -> Result<()> {
     if ttl_secs == 0 {
         bail!("--ttl must be greater than zero seconds");
@@ -353,26 +355,28 @@ fn cmd_auth_derive_agent(
         },
     )?;
 
-    println!("Derived and installed agent token {agent_id} for {server}.");
-    println!("Parent source: {}", parent.source.label());
-    println!("Expires: {expires_at}");
-    if let Some(template) = template {
-        println!("Template: {} ceiling", template.as_str());
+    if !quiet {
+        println!("Derived and installed agent token {agent_id} for {server}.");
+        println!("Parent source: {}", parent.source.label());
+        println!("Expires: {expires_at}");
+        if let Some(template) = template {
+            println!("Template: {} ceiling", template.as_str());
+        }
+        println!("Allowed operations: {}", allowed_operations.join(", "));
+        if declared_scopes.is_empty() {
+            println!("Scopes: none (full resource authority inherited from parent)");
+        } else {
+            println!(
+                "Scopes: {} (enforced server-side per request)",
+                declared_scopes
+                    .iter()
+                    .map(|(kind, path)| format!("{kind}:{path}"))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
+        }
+        println!("{DERIVED_TOKEN_SECURITY_NOTE}");
     }
-    println!("Allowed operations: {}", allowed_operations.join(", "));
-    if declared_scopes.is_empty() {
-        println!("Scopes: none (full resource authority inherited from parent)");
-    } else {
-        println!(
-            "Scopes: {} (enforced server-side per request)",
-            declared_scopes
-                .iter()
-                .map(|(kind, path)| format!("{kind}:{path}"))
-                .collect::<Vec<_>>()
-                .join(", ")
-        );
-    }
-    println!("{DERIVED_TOKEN_SECURITY_NOTE}");
     Ok(())
 }
 
@@ -1874,6 +1878,7 @@ mod tests {
                 vec!["Push".to_string()],
                 None,
                 None,
+                false,
             )
             .expect("derive and install parent agent");
             let installed = credentials::get_server_credential(server)
@@ -1922,6 +1927,7 @@ mod tests {
                 vec!["Push".to_string()],
                 None,
                 None,
+                false,
             )
             .expect("derive narrower subagent");
             let subagent = credentials::get_server_credential(server)
@@ -1960,6 +1966,7 @@ mod tests {
                 vec!["Push".to_string()],
                 None,
                 None,
+                false,
             )
             .expect_err("subagent scope widening must be rejected");
             assert!(error.to_string().contains("would widen"));
@@ -1982,6 +1989,7 @@ mod tests {
                 vec!["Push".to_string()],
                 None,
                 Some(&out),
+                false,
             )
             .expect("derive portable child credential");
 
@@ -2029,6 +2037,7 @@ mod tests {
                 vec!["Push".to_string()],
                 None,
                 Some(&out),
+                false,
             )
             .expect_err("an existing credential file must not be overwritten");
             assert!(error.to_string().contains("already exists"));

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -1,0 +1,269 @@
+//! Data-only browser claim resolution and promotion consent.
+
+// The transport contract owns `CallFailure` by value at this seam.
+#![allow(clippy::result_large_err)]
+
+use anyhow::Result;
+use api::heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use crypto::{Ed25519Signer, Signer as _};
+use serde::{Deserialize, Serialize};
+
+use super::{
+    auth::headless_token_metadata,
+    hosted::claim_protocol::{
+        CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimSecretVerifier,
+        VerifiedClaimPrincipal,
+    },
+    identity_state::{self, ClaimState},
+};
+
+const CONSENT_TTL_MILLIS: i64 = 5 * 60 * 1_000;
+
+#[derive(Clone, Debug)]
+pub(crate) struct StoredClaimAuthorization;
+
+impl ClaimSecretVerifier for StoredClaimAuthorization {
+    async fn verify(
+        &self,
+        _method: &str,
+        context: &CallContext,
+        _body: &[u8],
+    ) -> Result<VerifiedClaimPrincipal, CallFailure> {
+        let state = identity_state::load().map_err(internal_failure)?;
+        let Some(state) = state else {
+            return Err(auth_failure());
+        };
+        if !state.accepts(
+            &context.bearer_capability,
+            chrono::Utc::now().timestamp_millis(),
+        ) {
+            return Err(auth_failure());
+        }
+        Ok(VerifiedClaimPrincipal {
+            subject: state.account_id.clone(),
+            authorization_hash: state.authorization_hash().to_string(),
+        })
+    }
+}
+
+impl ClaimHandler for StoredClaimAuthorization {
+    async fn call(
+        &self,
+        method: &str,
+        principal: VerifiedClaimPrincipal,
+        body: &[u8],
+    ) -> Result<Vec<u8>, CallFailure> {
+        // Serialize the generation check and consent write. Without this
+        // lock, two browser requests verified against the same one-time
+        // secret could both load Active state before either consumed it.
+        let _guard = identity_state::write_lock().map_err(internal_failure)?;
+        let mut state = identity_state::load()
+            .map_err(internal_failure)?
+            .ok_or_else(auth_failure)?;
+        if state.account_id != principal.subject
+            || state.authorization_hash() != principal.authorization_hash
+        {
+            return Err(auth_failure());
+        }
+        match method {
+            CLAIM_RESOLVE_METHOD => resolved_reply(&state, body),
+            CLAIM_CONSENT_METHOD => consent_reply(&mut state, body),
+            _ => Err(failure(
+                CallFailureCode::Unimplemented,
+                "unknown claim method",
+            )),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(
+    tag = "kind",
+    rename_all = "lowercase",
+    rename_all_fields = "camelCase",
+    deny_unknown_fields
+)]
+enum ClaimRequest {
+    Resolve,
+    Consent {
+        handle: String,
+        credential_id: String,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+enum ClaimReply {
+    Resolved { agent: AgentAccountSummary },
+    Consented { consent: AgentConsent },
+    Refused { refusal: &'static str },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentAccountSummary {
+    pet_name: String,
+    created_at: String,
+    last_active_at: Option<String>,
+    spools: Vec<serde_json::Value>,
+    repos: Vec<serde_json::Value>,
+    change_count: Option<u64>,
+    agent_label: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentConsent {
+    pub(crate) node_id: String,
+    pub(crate) statement: String,
+    pub(crate) signature: String,
+    pub(crate) expires_at: i64,
+}
+
+pub(crate) fn resolved_reply(state: &ClaimState, body: &[u8]) -> Result<Vec<u8>, CallFailure> {
+    if !matches!(parse_request(body)?, ClaimRequest::Resolve) {
+        return Err(invalid_failure("resolve body has the wrong kind"));
+    }
+    let reply = if state.is_consented() {
+        ClaimReply::Refused { refusal: "claimed" }
+    } else {
+        ClaimReply::Resolved {
+            agent: AgentAccountSummary {
+                pet_name: state.pet_name.clone(),
+                created_at: state.created_at.clone(),
+                last_active_at: None,
+                spools: Vec::new(),
+                repos: Vec::new(),
+                change_count: None,
+                agent_label: None,
+            },
+        }
+    };
+    serde_json::to_vec(&reply).map_err(internal_failure)
+}
+
+pub(crate) fn consent_reply(state: &mut ClaimState, body: &[u8]) -> Result<Vec<u8>, CallFailure> {
+    let ClaimRequest::Consent {
+        handle,
+        credential_id,
+    } = parse_request(body)?
+    else {
+        return Err(invalid_failure("consent body has the wrong kind"));
+    };
+    if state.is_consented() {
+        return serde_json::to_vec(&ClaimReply::Refused { refusal: "claimed" })
+            .map_err(internal_failure);
+    }
+    validate_handle(&handle)?;
+    validate_credential_id(&credential_id)?;
+    let now = chrono::Utc::now().timestamp_millis();
+    let expires_at = (now + CONSENT_TTL_MILLIS).min(state.expires_at_millis);
+    if expires_at <= now {
+        return Err(auth_failure());
+    }
+    let signer = claim_signer(state)?;
+    let consent = signed_consent(state, &handle, &credential_id, expires_at, &signer)?;
+    state.mark_consented();
+    identity_state::store(state).map_err(internal_failure)?;
+    serde_json::to_vec(&ClaimReply::Consented { consent }).map_err(internal_failure)
+}
+
+pub(crate) fn signed_consent(
+    state: &ClaimState,
+    handle: &str,
+    credential_id: &str,
+    expires_at: i64,
+    signer: &Ed25519Signer,
+) -> Result<AgentConsent, CallFailure> {
+    let statement = serde_json::json!({
+        "accountId": state.account_id,
+        "credentialId": credential_id,
+        "expiresAt": expires_at,
+        "handle": handle,
+        "nodeId": state.node_id,
+        "purpose": "heddle-agent-account-promotion-v1"
+    })
+    .to_string();
+    let signature = URL_SAFE_NO_PAD.encode(
+        signer
+            .sign(statement.as_bytes())
+            .map_err(internal_failure)?,
+    );
+    Ok(AgentConsent {
+        node_id: state.node_id.clone(),
+        statement,
+        signature,
+        expires_at,
+    })
+}
+
+fn claim_signer(state: &ClaimState) -> Result<Ed25519Signer, CallFailure> {
+    let store = cli_shared::credentials::load_credentials().map_err(internal_failure)?;
+    let credential = store.servers.get(&state.server).ok_or_else(auth_failure)?;
+    let metadata = headless_token_metadata(&credential.token).map_err(internal_failure)?;
+    if !metadata.is_derived || metadata.subject != state.subject {
+        return Err(auth_failure());
+    }
+    let pem = credential
+        .private_key_pem
+        .as_deref()
+        .ok_or_else(auth_failure)?;
+    let signer = Ed25519Signer::from_pem(pem).map_err(internal_failure)?;
+    if hex::encode(signer.public_key()) != state.node_id
+        || !metadata
+            .proof_public_key_hex
+            .eq_ignore_ascii_case(&state.node_id)
+    {
+        return Err(auth_failure());
+    }
+    Ok(signer)
+}
+
+fn parse_request(body: &[u8]) -> Result<ClaimRequest, CallFailure> {
+    serde_json::from_slice(body).map_err(|_| invalid_failure("invalid claim request body"))
+}
+
+pub(crate) fn validate_handle(handle: &str) -> Result<(), CallFailure> {
+    if !(3..=63).contains(&handle.len())
+        || !handle
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        || handle.starts_with('-')
+        || handle.ends_with('-')
+    {
+        return Err(invalid_failure("invalid promotion handle"));
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_credential_id(id: &str) -> Result<(), CallFailure> {
+    if id.is_empty() || id.len() > 1024 || URL_SAFE_NO_PAD.decode(id).is_err() {
+        return Err(invalid_failure("invalid WebAuthn credential id"));
+    }
+    Ok(())
+}
+
+fn auth_failure() -> CallFailure {
+    failure(
+        CallFailureCode::Unauthenticated,
+        "claim authorization failed",
+    )
+}
+
+fn invalid_failure(message: &str) -> CallFailure {
+    failure(CallFailureCode::InvalidArgument, message)
+}
+
+fn internal_failure(error: impl std::fmt::Display) -> CallFailure {
+    tracing::warn!(%error, "claim authorization failed internally");
+    failure(CallFailureCode::Internal, "claim authorization failed")
+}
+
+fn failure(code: CallFailureCode, message: impl Into<String>) -> CallFailure {
+    CallFailure {
+        code: code as i32,
+        message: message.into(),
+        error: None,
+    }
+}

--- a/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
@@ -1,0 +1,69 @@
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use crypto::{Ed25519Signer, Signer as _};
+
+use super::{
+    claim_authorization::{
+        consent_reply, resolved_reply, signed_consent, validate_credential_id, validate_handle,
+    },
+    identity_state::ClaimState,
+};
+
+fn state(node_id: String) -> ClaimState {
+    ClaimState::new(
+        "api.heddle.test".into(),
+        "account-7".into(),
+        "subject-7".into(),
+        "steady-heron".into(),
+        node_id,
+    )
+}
+
+#[test]
+fn signed_consent_binds_handle_and_credential_id() {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let consent = signed_consent(
+        &state(hex::encode(signer.public_key())),
+        "human-handle",
+        "Y3JlZGVudGlhbA",
+        123_456,
+        &signer,
+    )
+    .expect("signed consent");
+    let statement: serde_json::Value =
+        serde_json::from_str(&consent.statement).expect("statement JSON");
+    assert_eq!(statement["handle"], "human-handle");
+    assert_eq!(statement["credentialId"], "Y3JlZGVudGlhbA");
+    let signature = URL_SAFE_NO_PAD
+        .decode(&consent.signature)
+        .expect("signature encoding");
+    Ed25519Signer::verify_with_public_key(
+        consent.statement.as_bytes(),
+        signer.public_key(),
+        &signature,
+    )
+    .expect("signature verifies");
+}
+
+#[test]
+fn malformed_promotion_inputs_are_rejected() {
+    assert!(validate_handle("UPPERCASE").is_err());
+    assert!(validate_handle("-leading").is_err());
+    assert!(validate_credential_id("not+base64url").is_err());
+}
+
+#[test]
+fn consumed_link_refuses_resolve_and_second_consent() {
+    let mut state = state("11".repeat(32));
+    state.mark_consented();
+    let resolve = resolved_reply(&state, br#"{"kind":"resolve"}"#).expect("resolve refusal");
+    let consent = consent_reply(
+        &mut state,
+        br#"{"kind":"consent","handle":"human-handle","credentialId":"Y3JlZA"}"#,
+    )
+    .expect("consent refusal");
+    for reply in [resolve, consent] {
+        let reply: serde_json::Value = serde_json::from_slice(&reply).expect("reply JSON");
+        assert_eq!(reply["kind"], "refused");
+        assert_eq!(reply["refusal"], "claimed");
+    }
+}

--- a/crates/cli/src/hosted_runtime/hosted/claim_protocol.rs
+++ b/crates/cli/src/hosted_runtime/hosted/claim_protocol.rs
@@ -3,7 +3,7 @@
 //! Claim request and response messages land with the account flow. This module
 //! owns the transport invariant they depend on now: a dedicated versioned
 //! ALPN, the same call framing used by Weft's Iroh surface, and a fail-closed
-//! authentication gate before a method-specific handler can observe a body.
+//! claim-secret gate before a method-specific handler can observe a body.
 
 // `CallFailure` carries structured error detail and intentionally crosses the
 // protocol/handler seam by value, matching Weft's native Iroh dispatcher.
@@ -29,14 +29,14 @@ pub(crate) const CLAIM_CONSENT_METHOD: &str = "/heddle.claim.v1.ClaimService/Con
 
 const MAX_REQUEST_FRAME: usize = 6 + MAX_METHOD_PATH + MAX_CALL_CONTEXT + MAX_CONTROL_BODY;
 
-/// The identity established by successful Biscuit, PoP, and request-proof
-/// verification.
+/// The account identity established by a valid short-lived claim secret.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct VerifiedClaimPrincipal {
     pub(crate) subject: String,
+    pub(crate) authorization_hash: String,
 }
 
-pub(crate) trait ClaimBiscuitVerifier: Send + Sync + std::fmt::Debug + 'static {
+pub(crate) trait ClaimSecretVerifier: Send + Sync + std::fmt::Debug + 'static {
     fn verify(
         &self,
         method: &str,
@@ -68,7 +68,7 @@ impl<V, H> ClaimProtocol<V, H> {
 
 impl<V, H> ProtocolHandler for ClaimProtocol<V, H>
 where
-    V: ClaimBiscuitVerifier,
+    V: ClaimSecretVerifier,
     H: ClaimHandler,
 {
     async fn accept(&self, connection: Connection) -> Result<(), AcceptError> {
@@ -115,7 +115,7 @@ async fn handle_call<V, H>(
     mut recv: RecvStream,
 ) -> Result<(), ClaimProtocolError>
 where
-    V: ClaimBiscuitVerifier,
+    V: ClaimSecretVerifier,
     H: ClaimHandler,
 {
     let request = recv
@@ -163,19 +163,7 @@ fn validate_auth_shape(method: &str, context: &CallContext) -> Result<(), CallFa
     if context.bearer_capability.is_empty() {
         return Err(failure(
             CallFailureCode::Unauthenticated,
-            "a Biscuit bearer capability is required",
-        ));
-    }
-    if context.bearer_proof.is_none() {
-        return Err(failure(
-            CallFailureCode::Unauthenticated,
-            "Biscuit proof-of-possession is required",
-        ));
-    }
-    if context.request_proof.is_none() {
-        return Err(failure(
-            CallFailureCode::Unauthenticated,
-            "a body-bound request proof is required",
+            "a claim secret is required",
         ));
     }
     Ok(())
@@ -203,40 +191,6 @@ impl ClaimProtocolError {
     }
 }
 
-/// The normal hosted client is not itself a running claim ceremony. It still
-/// advertises and routes the ALPN so #1378 can install its handler on the same
-/// endpoint without reintroducing a second transport identity.
-#[derive(Clone, Debug)]
-pub(crate) struct ClaimUnavailable;
-
-impl ClaimBiscuitVerifier for ClaimUnavailable {
-    async fn verify(
-        &self,
-        _method: &str,
-        _context: &CallContext,
-        _body: &[u8],
-    ) -> Result<VerifiedClaimPrincipal, CallFailure> {
-        Err(failure(
-            CallFailureCode::Unavailable,
-            "no claim ceremony is active",
-        ))
-    }
-}
-
-impl ClaimHandler for ClaimUnavailable {
-    async fn call(
-        &self,
-        _method: &str,
-        _principal: VerifiedClaimPrincipal,
-        _body: &[u8],
-    ) -> Result<Vec<u8>, CallFailure> {
-        Err(failure(
-            CallFailureCode::Unavailable,
-            "no claim ceremony is active",
-        ))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use std::{
@@ -246,18 +200,18 @@ mod tests {
 
     use api::{
         framing::{ResponseFrame, decode_response_frame, encode_request_frame},
-        heddle::api::v1alpha1::{BearerProof, RequestProof},
+        heddle::api::v1alpha1::CallContext,
     };
     use iroh::{Endpoint, RelayMode, endpoint::presets, protocol::Router};
 
     use super::*;
 
     #[derive(Debug)]
-    struct ExactBiscuitVerifier {
+    struct ExactSecretVerifier {
         calls: AtomicUsize,
     }
 
-    impl ClaimBiscuitVerifier for ExactBiscuitVerifier {
+    impl ClaimSecretVerifier for ExactSecretVerifier {
         async fn verify(
             &self,
             method: &str,
@@ -265,27 +219,17 @@ mod tests {
             body: &[u8],
         ) -> Result<VerifiedClaimPrincipal, CallFailure> {
             self.calls.fetch_add(1, Ordering::SeqCst);
-            if context.bearer_capability != b"valid-biscuit"
-                || context
-                    .bearer_proof
-                    .as_ref()
-                    .map(|proof| proof.signature.as_slice())
-                    != Some(b"valid-pop".as_slice())
-                || context
-                    .request_proof
-                    .as_ref()
-                    .map(|proof| proof.signature.as_slice())
-                    != Some(b"valid-request-proof".as_slice())
-            {
+            if context.bearer_capability != b"valid-secret" {
                 return Err(failure(
                     CallFailureCode::Unauthenticated,
-                    "invalid Biscuit authentication",
+                    "invalid claim secret",
                 ));
             }
             assert_eq!(method, CLAIM_RESOLVE_METHOD);
             assert_eq!(body, b"resolve");
             Ok(VerifiedClaimPrincipal {
                 subject: "agent:test".to_string(),
+                authorization_hash: "test-generation".to_string(),
             })
         }
     }
@@ -317,18 +261,6 @@ mod tests {
     fn context(bearer: &[u8]) -> CallContext {
         CallContext {
             bearer_capability: bearer.to_vec(),
-            bearer_proof: Some(BearerProof {
-                timestamp_seconds: 1,
-                nonce: vec![1; 16],
-                signature: b"valid-pop".to_vec(),
-            }),
-            request_proof: Some(RequestProof {
-                algorithm: "ed25519".to_string(),
-                signing_identity: "principal:test".to_string(),
-                timestamp_millis: 1,
-                nonce: vec![2; 16],
-                signature: b"valid-request-proof".to_vec(),
-            }),
             ..CallContext::default()
         }
     }
@@ -359,7 +291,7 @@ mod tests {
     }
 
     async fn endpoints(
-        verifier: Arc<ExactBiscuitVerifier>,
+        verifier: Arc<ExactSecretVerifier>,
         handler: Arc<EchoClaimHandler>,
     ) -> (Router, Endpoint, iroh::EndpointAddr) {
         let server = Endpoint::builder(presets::Minimal)
@@ -385,7 +317,7 @@ mod tests {
 
     #[tokio::test]
     async fn claim_alpn_routes_authenticated_calls() {
-        let verifier = Arc::new(ExactBiscuitVerifier {
+        let verifier = Arc::new(ExactSecretVerifier {
             calls: AtomicUsize::new(0),
         });
         let handler = Arc::new(EchoClaimHandler {
@@ -394,7 +326,7 @@ mod tests {
         let (router, client, address) =
             endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
 
-        let response = request(&client, address, CLAIM_ALPN_V1, context(b"valid-biscuit"))
+        let response = request(&client, address, CLAIM_ALPN_V1, context(b"valid-secret"))
             .await
             .expect("authenticated claim call");
         let ResponseFrame::Success(body) = decode_response_frame(&response).expect("response")
@@ -418,8 +350,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incomplete_authentication_never_reaches_verifier_or_handler() {
-        let verifier = Arc::new(ExactBiscuitVerifier {
+    async fn missing_secret_never_reaches_verifier_or_handler() {
+        let verifier = Arc::new(ExactSecretVerifier {
             calls: AtomicUsize::new(0),
         });
         let handler = Arc::new(EchoClaimHandler {
@@ -428,25 +360,15 @@ mod tests {
         let (router, client, address) =
             endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
 
-        let mut contexts = vec![context(b"")];
-        let mut missing_pop = context(b"valid-biscuit");
-        missing_pop.bearer_proof = None;
-        contexts.push(missing_pop);
-        let mut missing_request_proof = context(b"valid-biscuit");
-        missing_request_proof.request_proof = None;
-        contexts.push(missing_request_proof);
-
-        for context in contexts {
-            let response = request(&client, address.clone(), CLAIM_ALPN_V1, context)
-                .await
-                .expect("claim refusal response");
-            let ResponseFrame::Failure(failure) =
-                decode_response_frame(&response).expect("failure response")
-            else {
-                panic!("expected authentication failure");
-            };
-            assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
-        }
+        let response = request(&client, address, CLAIM_ALPN_V1, context(b""))
+            .await
+            .expect("claim refusal response");
+        let ResponseFrame::Failure(failure) =
+            decode_response_frame(&response).expect("failure response")
+        else {
+            panic!("expected authentication failure");
+        };
+        assert_eq!(failure.code, CallFailureCode::Unauthenticated as i32);
         assert_eq!(verifier.calls.load(Ordering::SeqCst), 0);
         assert_eq!(handler.calls.load(Ordering::SeqCst), 0);
 
@@ -455,8 +377,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_biscuit_never_reaches_handler() {
-        let verifier = Arc::new(ExactBiscuitVerifier {
+    async fn rejected_secret_never_reaches_handler() {
+        let verifier = Arc::new(ExactSecretVerifier {
             calls: AtomicUsize::new(0),
         });
         let handler = Arc::new(EchoClaimHandler {
@@ -465,7 +387,7 @@ mod tests {
         let (router, client, address) =
             endpoints(Arc::clone(&verifier), Arc::clone(&handler)).await;
 
-        let response = request(&client, address, CLAIM_ALPN_V1, context(b"forged-biscuit"))
+        let response = request(&client, address, CLAIM_ALPN_V1, context(b"forged-secret"))
             .await
             .expect("claim refusal response");
         let ResponseFrame::Failure(failure) =
@@ -483,7 +405,7 @@ mod tests {
 
     #[tokio::test]
     async fn unrelated_alpn_is_rejected_before_dispatch() {
-        let verifier = Arc::new(ExactBiscuitVerifier {
+        let verifier = Arc::new(ExactSecretVerifier {
             calls: AtomicUsize::new(0),
         });
         let handler = Arc::new(EchoClaimHandler {

--- a/crates/cli/src/hosted_runtime/hosted/collaboration.rs
+++ b/crates/cli/src/hosted_runtime/hosted/collaboration.rs
@@ -143,6 +143,7 @@ impl HostedClient {
             discussion_id: discussion_id.to_string(),
             body: body.to_string(),
             client_operation_id,
+            references: Vec::new(),
         };
         let response = self
             .routes()
@@ -276,6 +277,7 @@ mod tests {
                 author_name: "alice".into(),
                 author_email: "a@x".into(),
                 body: "lgtm".into(),
+                references: Vec::new(),
                 posted_at: Some(prost_types::Timestamp {
                     seconds: 42,
                     nanos: 0,

--- a/crates/cli/src/hosted_runtime/hosted/connection.rs
+++ b/crates/cli/src/hosted_runtime/hosted/connection.rs
@@ -11,7 +11,7 @@ use tokio::sync::Mutex;
 
 use super::{
     HostedError, Result, VerifiedEndpointDescriptor,
-    claim_protocol::{CLAIM_ALPN_V1, ClaimProtocol, ClaimUnavailable},
+    claim_protocol::{CLAIM_ALPN_V1, ClaimProtocol},
     provider_transport::ProviderWebSocketTransport,
 };
 
@@ -182,10 +182,12 @@ async fn bind_endpoint(
 }
 
 fn claim_router(endpoint: Endpoint) -> Router {
+    let authorization =
+        Arc::new(crate::hosted_runtime::claim_authorization::StoredClaimAuthorization);
     Router::builder(endpoint)
         .accept(
             CLAIM_ALPN_V1,
-            ClaimProtocol::new(Arc::new(ClaimUnavailable), Arc::new(ClaimUnavailable)),
+            ClaimProtocol::new(Arc::clone(&authorization), authorization),
         )
         .spawn()
 }

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -85,6 +85,13 @@ impl HostedRoutes<'_> {
         AccessTokenResponse
     );
     unary_method!(
+        provision_agent_rooted_account,
+        "IdentityService",
+        "ProvisionAgentRootedAccount",
+        ProvisionAgentRootedAccountRequest,
+        ProvisionAgentRootedAccountResponse
+    );
+    unary_method!(
         who_am_i,
         "IdentityService",
         "WhoAmI",

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -5,7 +5,7 @@
 
 mod bootstrap;
 mod call;
-mod claim_protocol;
+pub(crate) mod claim_protocol;
 mod collaboration;
 mod connection;
 #[cfg(test)]

--- a/crates/cli/src/hosted_runtime/hosted/session.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session.rs
@@ -13,6 +13,10 @@ use super::{
 
 pub enum HostedAuthMode {
     Unauthenticated,
+    ProofOnly {
+        proof_key_pem: String,
+        signing_identity: String,
+    },
     CredentialFallback,
 }
 
@@ -34,6 +38,10 @@ impl HostedSession {
             resolved_credential_subject,
         ) = match mode {
             HostedAuthMode::Unauthenticated => (None, None, None, None),
+            HostedAuthMode::ProofOnly {
+                proof_key_pem,
+                signing_identity,
+            } => (None, Some(proof_key_pem), None, Some(signing_identity)),
             HostedAuthMode::CredentialFallback => {
                 let resolved = resolve_hosted_credential(server_key.as_deref())?;
                 (
@@ -62,22 +70,23 @@ impl HostedSession {
             config = config.with_auth_proof_key_pem(pem);
         }
         if config.auth_proof_key_pem.is_some() {
-            let token = config.token.as_ref().ok_or_else(|| {
-                anyhow::anyhow!(
-                    "hosted request signing has a proof key but no authenticated bearer token"
-                )
-            })?;
-            let subject = crate::hosted_runtime::device_flow::authenticated_subject(&token.id)
-                .context("reading the hosted bearer token's authenticated principal")?;
-            if resolved_credential_subject
-                .as_deref()
-                .is_some_and(|stored| stored != subject.as_str())
-            {
-                anyhow::bail!(
-                    "resolved credential subject does not match the bearer token's authenticated principal"
-                );
+            if let Some(token) = config.token.as_ref() {
+                let subject = crate::hosted_runtime::device_flow::authenticated_subject(&token.id)
+                    .context("reading the hosted bearer token's authenticated principal")?;
+                if resolved_credential_subject
+                    .as_deref()
+                    .is_some_and(|stored| stored != subject.as_str())
+                {
+                    anyhow::bail!(
+                        "resolved credential subject does not match the bearer token's authenticated principal"
+                    );
+                }
+                config = config.with_authenticated_principal(format!("principal:{subject}"));
+            } else if let Some(identity) = resolved_credential_subject {
+                config = config.with_authenticated_principal(identity);
+            } else {
+                anyhow::bail!("hosted request signing has no stable signing identity");
             }
-            config = config.with_authenticated_principal(format!("principal:{subject}"));
         }
         Ok(Self {
             config,

--- a/crates/cli/src/hosted_runtime/hosted/user.rs
+++ b/crates/cli/src/hosted_runtime/hosted/user.rs
@@ -5,7 +5,8 @@ use api::heddle::api::v1alpha1::{
     DeleteRepositoryRequest, GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
     Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest, IssuedCredentialResponse,
     ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
-    ListThreadApprovalsRequest, MonorepoNode, ResolveMonorepoRequest, RevokeApprovalRequest,
+    ListThreadApprovalsRequest, MonorepoNode, ProvisionAgentRootedAccountRequest,
+    ProvisionAgentRootedAccountResponse, ResolveMonorepoRequest, RevokeApprovalRequest,
     RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SpoolVisibility,
     SupportAccessGrant, ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest,
     UpdateRepositoryRequest, grant_target_ref::Target as GrantTargetKind,
@@ -60,6 +61,16 @@ macro_rules! workflow_call {
 }
 
 impl HostedClient {
+    pub async fn provision_agent_rooted_account(
+        &mut self,
+        request: ProvisionAgentRootedAccountRequest,
+    ) -> Result<ProvisionAgentRootedAccountResponse, ProtocolError> {
+        self.routes()
+            .provision_agent_rooted_account(&request)
+            .await
+            .map_err(hosted_to_protocol_error)
+    }
+
     /// Resolve the acting identity for the bound bearer (subject, staff/service
     /// markers, session, server-side scope, and directly-held resource roles).
     /// Read-only; drives `heddle whoami`.

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -1,0 +1,292 @@
+//! Reuse-first machine identity and browser claim-link commands.
+
+use anyhow::{Context, Result, bail};
+use api::heddle::api::v1alpha1::ProvisionAgentRootedAccountRequest;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use cli_shared::{UserConfig, credentials::ServerCredential};
+use crypto::{Ed25519Signer, Signer as _};
+use serde::Serialize;
+use weft_client_shim::CliContext;
+
+use crate::cli::IdentityCommands;
+
+use super::{
+    HostedAuthMode, HostedSession, agent_node_identity,
+    auth::{cmd_auth_derive_agent, headless_token_metadata, resolve_server},
+    hosted::resolve_hosted_credential,
+    identity_server,
+    identity_state::{self, ClaimState},
+};
+
+const DEFAULT_AGENT_TTL_SECS: u64 = 60 * 60;
+const MAX_CLAIM_TTL_SECS: u64 = 60 * 60;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum EnsureAction {
+    Reuse,
+    Derive,
+    Provision,
+    RequireInvite,
+}
+
+#[derive(Serialize)]
+struct IdentityOutput<'a> {
+    output_kind: &'a str,
+    outcome: &'a str,
+    server: &'a str,
+    subject: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    node_id: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    claim_url: Option<&'a str>,
+}
+
+pub(crate) async fn cmd_identity(
+    ctx: &(dyn CliContext + 'static),
+    command: IdentityCommands,
+) -> Result<()> {
+    match command {
+        IdentityCommands::Ensure { server, invite } => ensure(ctx, server, invite).await,
+        IdentityCommands::ClaimLink { server, ttl_secs } => claim_link(ctx, server, ttl_secs).await,
+        IdentityCommands::Serve { server } => identity_server::serve(server).await,
+    }
+}
+
+async fn ensure(
+    ctx: &(dyn CliContext + 'static),
+    server: Option<String>,
+    invite: Option<String>,
+) -> Result<()> {
+    let server = resolve_server(server.as_deref())?;
+    let resolved = resolve_hosted_credential(Some(&server))?;
+    let metadata = resolved
+        .token
+        .as_ref()
+        .map(|token| headless_token_metadata(&token.id))
+        .transpose()?;
+    match ensure_action(
+        metadata.as_ref().map(|value| value.is_derived),
+        invite.is_some(),
+    ) {
+        EnsureAction::Reuse => {
+            let metadata = metadata
+                .ok_or_else(|| anyhow::anyhow!("identity decision lost credential metadata"))?;
+            print_identity(
+                ctx,
+                "identity_ensure",
+                "reused",
+                &server,
+                &metadata.subject,
+                None,
+                None,
+            )
+        }
+        EnsureAction::Derive => {
+            cmd_auth_derive_agent(
+                &server,
+                None,
+                DEFAULT_AGENT_TTL_SECS,
+                Vec::new(),
+                Vec::new(),
+                None,
+                None,
+                true,
+            )?;
+            let store = cli_shared::credentials::load_credentials()?;
+            let derived = store.servers.get(&server).ok_or_else(|| {
+                anyhow::anyhow!("derived credential was not installed for {server}")
+            })?;
+            let metadata = headless_token_metadata(&derived.token)?;
+            print_identity(
+                ctx,
+                "identity_ensure",
+                "derived",
+                &server,
+                &metadata.subject,
+                None,
+                None,
+            )
+        }
+        EnsureAction::Provision => {
+            let invite = invite.ok_or_else(|| anyhow::anyhow!("identity decision lost invite"))?;
+            provision_and_claim(ctx, server, invite).await
+        }
+        EnsureAction::RequireInvite => bail!(
+            "no existing account credential for {server}; supply --invite to create a placeholder human account"
+        ),
+    }
+}
+
+pub(crate) fn ensure_action(derived: Option<bool>, has_invite: bool) -> EnsureAction {
+    match derived {
+        Some(true) => EnsureAction::Reuse,
+        Some(false) => EnsureAction::Derive,
+        None if has_invite => EnsureAction::Provision,
+        None => EnsureAction::RequireInvite,
+    }
+}
+
+async fn provision_and_claim(
+    ctx: &(dyn CliContext + 'static),
+    server: String,
+    invite: String,
+) -> Result<()> {
+    let identity = agent_node_identity::load_or_create()?;
+    let signer = Ed25519Signer::from_seed(&identity.secret_key().to_bytes())
+        .context("deriving the agent credential key from the persisted node identity")?;
+    let node_id = identity.node_id().to_string();
+    if hex::encode(signer.public_key()) != node_id {
+        bail!("persisted Iroh node key does not map to the agent credential key");
+    }
+    let proof_pem = signer.to_pem().context("exporting agent proof key")?;
+    let user_config = UserConfig::load_default()?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.clone()),
+        HostedAuthMode::ProofOnly {
+            proof_key_pem: proof_pem.clone(),
+            signing_identity: format!("principal:agent-key:{node_id}"),
+        },
+    )?;
+    let mut client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    let operation_id = match ctx.operation_id_wire() {
+        value if value.is_empty() => uuid::Uuid::new_v4().to_string(),
+        value => value,
+    };
+    let response = client
+        .provision_agent_rooted_account(ProvisionAgentRootedAccountRequest {
+            invite_code: invite,
+            agent_public_key: signer.public_key().to_vec(),
+            client_operation_id: operation_id,
+        })
+        .await
+        .map_err(|error| anyhow::anyhow!("provisioning agent-rooted account: {error}"));
+    client.close().await;
+    let response = response?;
+    let token = String::from_utf8(response.agent_capability)
+        .context("server returned a non-text agent capability")?;
+    let metadata =
+        headless_token_metadata(&token).context("validating the returned agent capability")?;
+    if !metadata.is_derived || !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id) {
+        bail!("server returned an agent capability not derived for this node key");
+    }
+    cli_shared::credentials::store_server_credential(
+        &server,
+        ServerCredential {
+            token,
+            subject: metadata.subject.clone(),
+            device_id: None,
+            credential_id: None,
+            private_key_pem: Some(proof_pem),
+            expires_at: metadata.expires_at,
+        },
+    )?;
+    let state = ClaimState::new(
+        server.clone(),
+        response.account_id,
+        metadata.subject.clone(),
+        response.handle,
+        node_id,
+    );
+    identity_state::store(&state)?;
+    let (node_id, url) = reissue(&server, 900)?;
+    identity_server::ensure_running(&server).await?;
+    print_identity(
+        ctx,
+        "identity_ensure",
+        "created_on_behalf",
+        &server,
+        &metadata.subject,
+        Some(&node_id),
+        Some(&url),
+    )
+}
+
+async fn claim_link(
+    ctx: &(dyn CliContext + 'static),
+    server: Option<String>,
+    ttl_secs: u64,
+) -> Result<()> {
+    let state = identity_state::load()?.ok_or_else(|| {
+        anyhow::anyhow!("no agent-created placeholder account exists on this machine")
+    })?;
+    let server = server.unwrap_or_else(|| state.server.clone());
+    if server != state.server {
+        bail!("claim state belongs to {}, not {server}", state.server);
+    }
+    let subject = state.subject.clone();
+    let (node_id, url) = reissue(&server, ttl_secs)?;
+    identity_server::ensure_running(&server).await?;
+    print_identity(
+        ctx,
+        "identity_claim_link",
+        "claim_link_reissued",
+        &server,
+        &subject,
+        Some(&node_id),
+        Some(&url),
+    )
+}
+
+fn reissue(server: &str, ttl_secs: u64) -> Result<(String, String)> {
+    if ttl_secs == 0 || ttl_secs > MAX_CLAIM_TTL_SECS {
+        bail!("--ttl must be between 1 and {MAX_CLAIM_TTL_SECS} seconds");
+    }
+    let mut state = identity_state::load()?
+        .ok_or_else(|| anyhow::anyhow!("no claimable agent identity is stored"))?;
+    if state.server != server {
+        bail!("claim state belongs to {}, not {server}", state.server);
+    }
+    let mut secret = [0_u8; 32];
+    getrandom::fill(&mut secret).context("generating claim secret")?;
+    let ttl_millis = i64::try_from(ttl_secs)?
+        .checked_mul(1_000)
+        .context("claim TTL overflow")?;
+    let expires = chrono::Utc::now()
+        .timestamp_millis()
+        .checked_add(ttl_millis)
+        .context("claim expiry overflow")?;
+    state.reissue(&secret, expires);
+    identity_state::store(&state)?;
+    let encoded_secret = URL_SAFE_NO_PAD.encode(secret);
+    let url = format!(
+        "https://heddle.sh/claim/hcl1.{}.{}",
+        state.node_id, encoded_secret
+    );
+    Ok((state.node_id, url))
+}
+
+fn print_identity(
+    ctx: &(dyn CliContext + 'static),
+    output_kind: &str,
+    outcome: &str,
+    server: &str,
+    subject: &str,
+    node_id: Option<&str>,
+    claim_url: Option<&str>,
+) -> Result<()> {
+    if ctx.should_output_json(None) {
+        println!(
+            "{}",
+            serde_json::to_string(&IdentityOutput {
+                output_kind,
+                outcome,
+                server,
+                subject,
+                node_id,
+                claim_url,
+            })?
+        );
+    } else {
+        println!("Identity: {outcome}");
+        println!("Server: {server}");
+        println!("Subject: {subject}");
+        if let Some(node_id) = node_id {
+            println!("NodeId: {node_id}");
+        }
+        if let Some(claim_url) = claim_url {
+            println!("\nOpen this short-lived claim link:\n\n{claim_url}\n");
+        }
+    }
+    Ok(())
+}

--- a/crates/cli/src/hosted_runtime/identity_server.rs
+++ b/crates/cli/src/hosted_runtime/identity_server.rs
@@ -1,0 +1,98 @@
+//! Detached lifetime management for the claim authorization endpoint.
+
+use std::{
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, bail};
+use cli_shared::UserConfig;
+use objects::lock::RepoLock;
+
+use super::{HostedAuthMode, HostedSession, identity_state};
+
+pub(crate) async fn ensure_running(server: &str) -> Result<()> {
+    let lock = server_lock();
+    if let Some(guard) = lock.try_write()? {
+        let _ = std::fs::remove_file(ready_path());
+        drop(guard);
+        spawn(server)?;
+    }
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if std::fs::read_to_string(ready_path()).is_ok_and(|ready| ready == server) {
+            return Ok(());
+        }
+    }
+    bail!("claim endpoint did not become ready")
+}
+
+fn spawn(server: &str) -> Result<()> {
+    let current_exe = std::env::current_exe().context("locating heddle executable")?;
+    let mut command = Command::new(current_exe);
+    command
+        .env_clear()
+        .env("HEDDLE_HOME", repo::identity::heddle_home_dir())
+        .args(["identity", "serve", "--server", server])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    #[cfg(target_os = "linux")]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: `setsid` has no arguments or memory effects. Failure is
+        // propagated and prevents the background endpoint from starting.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    command
+        .spawn()
+        .context("starting claim authorization endpoint")?;
+    Ok(())
+}
+
+pub(crate) async fn serve(server: String) -> Result<()> {
+    let _guard = match server_lock().try_write()? {
+        Some(guard) => guard,
+        None => return Ok(()),
+    };
+    let state = identity_state::load()?.ok_or_else(|| anyhow::anyhow!("claim state is absent"))?;
+    if state.server != server {
+        bail!("claim state belongs to {}, not {server}", state.server);
+    }
+    let user_config = UserConfig::load_default()?;
+    let session = HostedSession::build(
+        &user_config,
+        Some(server.clone()),
+        HostedAuthMode::CredentialFallback,
+    )?;
+    let client = session.connect(([127, 0, 0, 1], 0).into()).await?;
+    objects::fs_atomic::write_file_atomic(&ready_path(), server.as_bytes())
+        .context("publishing claim endpoint readiness")?;
+    loop {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        let Some(state) = identity_state::load()? else {
+            break;
+        };
+        if !state.is_active(chrono::Utc::now().timestamp_millis()) {
+            break;
+        }
+    }
+    client.close().await;
+    let _ = std::fs::remove_file(ready_path());
+    Ok(())
+}
+
+fn ready_path() -> std::path::PathBuf {
+    repo::identity::heddle_home_dir().join("agent-claim-server.ready")
+}
+
+fn server_lock() -> RepoLock {
+    RepoLock::at(repo::identity::heddle_home_dir().join("locks/agent-claim-server.lock"))
+}

--- a/crates/cli/src/hosted_runtime/identity_state.rs
+++ b/crates/cli/src/hosted_runtime/identity_state.rs
@@ -1,0 +1,192 @@
+//! Persisted authorization state for the browser-to-agent claim ceremony.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use objects::{
+    fs_atomic::write_file_atomic_secret,
+    lock::{RepoLock, WriteLockGuard},
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+const STATE_FORMAT: &str = "heddle-agent-claim";
+const STATE_VERSION: u32 = 1;
+const STATE_FILE: &str = "agent-claim.toml";
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ClaimStatus {
+    Active,
+    Consented,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct ClaimState {
+    format: String,
+    version: u32,
+    pub(crate) server: String,
+    pub(crate) account_id: String,
+    pub(crate) subject: String,
+    pub(crate) pet_name: String,
+    pub(crate) node_id: String,
+    pub(crate) created_at: String,
+    secret_hash: String,
+    pub(crate) expires_at_millis: i64,
+    status: ClaimStatus,
+}
+
+impl ClaimState {
+    pub(crate) fn new(
+        server: String,
+        account_id: String,
+        subject: String,
+        pet_name: String,
+        node_id: String,
+    ) -> Self {
+        Self {
+            format: STATE_FORMAT.to_string(),
+            version: STATE_VERSION,
+            server,
+            account_id,
+            subject,
+            pet_name,
+            node_id,
+            created_at: chrono::Utc::now().to_rfc3339(),
+            secret_hash: String::new(),
+            expires_at_millis: 0,
+            status: ClaimStatus::Consented,
+        }
+    }
+
+    pub(crate) fn reissue(&mut self, secret: &[u8], expires_at_millis: i64) {
+        self.secret_hash = hex::encode(Sha256::digest(secret));
+        self.expires_at_millis = expires_at_millis;
+        self.status = ClaimStatus::Active;
+    }
+
+    pub(crate) fn is_active(&self, now: i64) -> bool {
+        matches!(self.status, ClaimStatus::Active) && now < self.expires_at_millis
+    }
+
+    pub(crate) fn accepts(&self, secret: &[u8], now: i64) -> bool {
+        if now >= self.expires_at_millis {
+            return false;
+        }
+        let Ok(expected) = hex::decode(&self.secret_hash) else {
+            return false;
+        };
+        constant_time_eq(&expected, Sha256::digest(secret).as_slice())
+    }
+
+    pub(crate) fn authorization_hash(&self) -> &str {
+        &self.secret_hash
+    }
+
+    pub(crate) fn is_consented(&self) -> bool {
+        matches!(self.status, ClaimStatus::Consented)
+    }
+
+    pub(crate) fn mark_consented(&mut self) {
+        self.status = ClaimStatus::Consented;
+    }
+}
+
+pub(crate) fn state_path() -> PathBuf {
+    repo::identity::heddle_home_dir().join(STATE_FILE)
+}
+
+pub(crate) fn load() -> Result<Option<ClaimState>> {
+    load_at(&state_path())
+}
+
+pub(crate) fn store(state: &ClaimState) -> Result<()> {
+    store_at(&state_path(), state)
+}
+
+pub(crate) fn write_lock() -> Result<WriteLockGuard> {
+    claim_lock(&state_path())
+        .write()
+        .map_err(|error| anyhow::anyhow!(error))
+}
+
+fn load_at(path: &Path) -> Result<Option<ClaimState>> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error).with_context(|| format!("reading {}", path.display())),
+    };
+    crypto::reject_group_or_world_readable_key(path)
+        .with_context(|| format!("refusing exposed claim state {}", path.display()))?;
+    let state: ClaimState =
+        toml::from_str(&contents).with_context(|| format!("parsing {}", path.display()))?;
+    if state.format != STATE_FORMAT || state.version != STATE_VERSION {
+        bail!("{} is not supported Heddle claim state", path.display());
+    }
+    Ok(Some(state))
+}
+
+fn store_at(path: &Path, state: &ClaimState) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        objects::fs_atomic::create_private_dir_all(parent)?;
+    }
+    let _guard = claim_lock(path)
+        .write()
+        .map_err(|error| anyhow::anyhow!(error))?;
+    let encoded = toml::to_string_pretty(state).context("serializing claim state")?;
+    write_file_atomic_secret(path, encoded.as_bytes())
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+fn claim_lock(path: &Path) -> RepoLock {
+    RepoLock::at(
+        path.parent()
+            .unwrap_or_else(|| Path::new("."))
+            .join("locks/agent-claim.lock"),
+    )
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let mut difference = left.len() ^ right.len();
+    for index in 0..left.len().max(right.len()) {
+        difference |= usize::from(*left.get(index).unwrap_or(&0) ^ *right.get(index).unwrap_or(&0));
+    }
+    difference == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> ClaimState {
+        ClaimState::new(
+            "api.heddle.test".into(),
+            "account-1".into(),
+            "subject-1".into(),
+            "quiet-otter".into(),
+            "11".repeat(32),
+        )
+    }
+
+    #[test]
+    fn reissue_invalidates_the_previous_secret() {
+        let mut state = state();
+        state.reissue(b"first-secret", 2_000);
+        assert!(state.accepts(b"first-secret", 1_000));
+        state.reissue(b"second-secret", 2_000);
+        assert!(!state.accepts(b"first-secret", 1_000));
+        assert!(state.accepts(b"second-secret", 1_000));
+    }
+
+    #[test]
+    fn expired_secret_is_rejected_and_not_persisted_in_plaintext() {
+        let directory = tempfile::tempdir().expect("temporary directory");
+        let path = directory.path().join("claim.toml");
+        let mut state = state();
+        state.reissue(b"super-secret-value", 2_000);
+        assert!(!state.accepts(b"super-secret-value", 2_000));
+        store_at(&path, &state).expect("store claim state");
+        let contents = std::fs::read_to_string(path).expect("read claim state");
+        assert!(!contents.contains("super-secret-value"));
+    }
+}

--- a/crates/cli/src/hosted_runtime/identity_tests.rs
+++ b/crates/cli/src/hosted_runtime/identity_tests.rs
@@ -1,0 +1,13 @@
+use super::identity::{EnsureAction, ensure_action};
+
+#[test]
+fn invite_is_never_selected_when_any_credential_exists() {
+    assert_eq!(ensure_action(Some(true), true), EnsureAction::Reuse);
+    assert_eq!(ensure_action(Some(false), true), EnsureAction::Derive);
+}
+
+#[test]
+fn provisioning_is_only_the_no_credential_fallback() {
+    assert_eq!(ensure_action(None, true), EnsureAction::Provision);
+    assert_eq!(ensure_action(None, false), EnsureAction::RequireInvite);
+}

--- a/crates/cli/src/hosted_runtime/mod.rs
+++ b/crates/cli/src/hosted_runtime/mod.rs
@@ -9,9 +9,17 @@
 mod agent_node_identity;
 pub(crate) mod auth;
 pub(crate) mod auth_requests;
+mod claim_authorization;
+#[cfg(test)]
+mod claim_authorization_tests;
 pub(crate) mod credential_file;
 pub(crate) mod device_flow;
 pub(crate) mod hosted;
+pub(crate) mod identity;
+mod identity_server;
+mod identity_state;
+#[cfg(test)]
+mod identity_tests;
 pub(crate) mod websocket;
 pub(crate) mod whoami;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -676,6 +676,12 @@ async fn async_main() -> Result<()> {
         }
 
         #[cfg(feature = "client")]
+        Commands::Identity { command } => {
+            let cmd = command.clone();
+            hosted.identity(&cli, &cmd).await
+        }
+
+        #[cfg(feature = "client")]
         Commands::Whoami { server } => {
             let server = server.clone();
             hosted.whoami(&cli, server).await

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -198,6 +198,7 @@ const UNSWEPT_TODO: &[&str] = &[
     "agent release",
     "agent reserve",
     "context reason git",
+    "ci run",
     "collapse",
     "daemon serve",
     "daemon status",

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -75,6 +75,8 @@ const SWEPT: &[&str] = &[
     "auth trust show",
     "auth trust replace",
     "auth create-service-token",
+    "identity ensure",
+    "identity claim-link",
     "revert",
     "redact apply",
     "redact list",

--- a/crates/weft-client-shim/src/lib.rs
+++ b/crates/weft-client-shim/src/lib.rs
@@ -72,6 +72,14 @@ pub trait WeftExtensions: Send + Sync {
         command: &(dyn Any + Send + Sync),
     ) -> Result<()>;
 
+    /// `heddle identity <subcommand>` — reuse-first machine identity and the
+    /// data-only browser claim endpoint.
+    async fn identity(
+        &self,
+        ctx: &(dyn CliContext + 'static),
+        command: &(dyn Any + Send + Sync),
+    ) -> Result<()>;
+
     /// `heddle whoami` — resolve and report the acting identity (principal,
     /// token kind, scopes, operation ceiling, TTL, signing + reachability).
     /// `server` is the optional `--server` override.

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1903,6 +1903,18 @@ the same ready envelope.
 
 ---
 
+## `heddle ci run --output json`
+
+Local device-signed check verdicts. The payload is an array of signed
+verdict envelopes; the machine contract keeps this verb opaque while
+the verdict schema is still settling.
+
+```json
+[]
+```
+
+---
+
 ## `heddle identity ensure --output json`
 
 ```json
@@ -3118,46 +3130,46 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
   "command_contract_schema_coverage": {
     "accepted_opaque_schema_examples": [
       "help",
+      "ci run",
       "redact apply",
       "redact list",
       "redact show",
       "redact trust add",
       "redact trust list",
-      "redact trust remove",
-      "redact purge apply"
+      "redact trust remove"
     ],
-    "accepted_opaque_schema_verbs_total": 43,
+    "accepted_opaque_schema_verbs_total": 44,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
+      "ci run",
       "redact apply",
       "redact list",
       "redact show",
       "redact trust add",
       "redact trust list",
-      "redact trust remove",
-      "redact purge apply"
+      "redact trust remove"
     ],
-    "advanced_scope_json_commands_total": 115,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 43,
-    "advanced_scope_mutating_commands_total": 67,
-    "advanced_scope_mutating_commands_with_accepted_opaque_schema": 24,
-    "catalog_commands_total": 196,
-    "catalog_mutating_commands_total": 96,
-    "json_commands_total": 155,
-    "json_commands_with_accepted_opaque_schema": 43,
+    "advanced_scope_json_commands_total": 116,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 44,
+    "advanced_scope_mutating_commands_total": 68,
+    "advanced_scope_mutating_commands_with_accepted_opaque_schema": 25,
+    "catalog_commands_total": 198,
+    "catalog_mutating_commands_total": 97,
+    "json_commands_total": 156,
+    "json_commands_with_accepted_opaque_schema": 44,
     "json_commands_with_schema": 112,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 91,
+    "json_mutating_commands_total": 92,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 91,
-    "mutating_commands_with_accepted_opaque_schema": 24,
+    "mutating_commands_total": 92,
+    "mutating_commands_with_accepted_opaque_schema": 25,
     "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 43,
+    "opaque_schema_verbs_total": 44,
     "status": "available",
-    "summary": "196 command(s), 155 JSON command(s), 96 mutating command(s), 91 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
+    "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
@@ -3195,7 +3207,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "192 command(s), 153 JSON command(s), 93 mutating command(s), 89 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
+  "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1903,6 +1903,36 @@ the same ready envelope.
 
 ---
 
+## `heddle identity ensure --output json`
+
+```json
+{
+  "output_kind": "identity_ensure",
+  "outcome": "created_on_behalf",
+  "server": "api.heddle.sh",
+  "subject": "account-01K2N",
+  "node_id": "b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121",
+  "claim_url": "https://heddle.sh/claim/hcl1.b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121.c2hvcnQtbGl2ZWQtY2xhaW0tc2VjcmV0"
+}
+```
+
+---
+
+## `heddle identity claim-link --output json`
+
+```json
+{
+  "output_kind": "identity_claim_link",
+  "outcome": "claim_link_reissued",
+  "server": "api.heddle.sh",
+  "subject": "account-01K2N",
+  "node_id": "b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121",
+  "claim_url": "https://heddle.sh/claim/hcl1.b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121.bmV3LXNob3J0LWxpdmVkLWNsYWltLXNlY3JldA"
+}
+```
+
+---
+
 ## `heddle whoami --output json`
 
 ```json
@@ -3108,26 +3138,26 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust remove",
       "redact purge apply"
     ],
-    "advanced_scope_json_commands_total": 113,
+    "advanced_scope_json_commands_total": 115,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 43,
-    "advanced_scope_mutating_commands_total": 65,
+    "advanced_scope_mutating_commands_total": 67,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 24,
-    "catalog_commands_total": 192,
-    "catalog_mutating_commands_total": 93,
-    "json_commands_total": 153,
+    "catalog_commands_total": 196,
+    "catalog_mutating_commands_total": 96,
+    "json_commands_total": 155,
     "json_commands_with_accepted_opaque_schema": 43,
-    "json_commands_with_schema": 110,
+    "json_commands_with_schema": 112,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 89,
+    "json_mutating_commands_total": 91,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 89,
+    "mutating_commands_total": 91,
     "mutating_commands_with_accepted_opaque_schema": 24,
-    "mutating_commands_with_schema": 65,
+    "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 43,
     "status": "available",
-    "summary": "192 command(s), 153 JSON command(s), 93 mutating command(s), 89 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
+    "summary": "196 command(s), 155 JSON command(s), 96 mutating command(s), 91 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],


### PR DESCRIPTION
Closes #1378

## Summary
- add reuse-first identity ensure: reuse derived credentials, derive from an existing root credential, and consume an invite only when no account credential exists
- provision agent-rooted placeholder accounts with the persisted Iroh NodeId key, mint/reissue short-lived heddle.sh claim links, and invalidate prior secrets
- serve the data-only heddle-claim/1 Iroh authorization endpoint, returning account context and signing handle + WebAuthn credential promotion consent
- register JSON schemas and regenerate npm schema artifacts

## Security and negative coverage
- reject missing, forged, expired, and reissued claim secrets before handler dispatch
- reject malformed handles and WebAuthn credential IDs
- bind consent signatures to the exact account, NodeId, handle, credential ID, and expiry
- serialize consent consumption so concurrent requests cannot both use the one-time secret
- persist only the claim-secret hash in a private state file

## Verification
- CARGO_HOME=/tmp/cargo-h1378 CARGO_TARGET_DIR=/home/scratch/heddle-1378-target CARGO_INCREMENTAL=0 RUST_TEST_THREADS=2 cargo test --workspace --all-features -q
- CARGO_HOME=/tmp/cargo-h1378 CARGO_TARGET_DIR=/home/scratch/heddle-1378-target CARGO_INCREMENTAL=0 cargo clippy -p heddle-cli -p heddle-cli-args -p heddle-cli-contract -p weft-client-shim --features heddle-cli/client --all-targets -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789295050&installation_model_id=21489&pr_number=1382&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1382&signature=850e555d92f927568405629f998a053f66887c8b5d8dacecd52e2243f84e24d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->