### PR TITLE
fix(crypto): reconcile CI verdict body and signing spine v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ name = "heddle-crypto"
 version = "0.12.0"
 dependencies = [
  "base64 0.22.1",
+ "chrono",
  "ed25519-dalek 3.0.0",
  "getrandom 0.4.3",
  "heddle-objects",

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -11,6 +11,7 @@ categories.workspace = true
 
 [dependencies]
 base64.workspace = true
+chrono.workspace = true
 ed25519-dalek.workspace = true
 getrandom.workspace = true
 hex.workspace = true
@@ -19,10 +20,10 @@ p256.workspace = true
 pkcs8.workspace = true
 sec1.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-serde_json.workspace = true
 tempfile.workspace = true
 
 [lib]

--- a/crates/crypto/src/ci_verdict.rs
+++ b/crates/crypto/src/ci_verdict.rs
@@ -1,34 +1,80 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Signed, provenance-bound CI verdicts.
+//!
+//! A verdict signature binds the canonical [`CiVerdictBody`] content hash, the
+//! rewrite-stable change id, the exact evaluated tree, the signer kind, and the
+//! signing time. Trust in the embedded key and timestamp freshness are policy
+//! decisions for the caller; this module proves integrity and authenticity.
 
+mod body;
+mod body_details;
+
+pub use body::{
+    Basis, BasisKind, CI_VERDICT_BODY_SCHEMA_VERSION, CheckClass, CheckDescriptor, CiVerdictBody,
+    StateRef,
+};
+pub use body_details::{
+    Conclusion, Execution, FailureClass, FailureDetail, LogRef, Outcome, Repro,
+};
+use chrono::DateTime;
 use objects::object::{ChangeId, ContentHash};
 use serde::{Deserialize, Serialize};
 
 use crate::{Signer, SignerError, verify_payload_signature};
 
-/// NUL-terminated domain separator for CI verdict signatures.
-pub const CI_VERDICT_DOMAIN: &[u8; 21] = b"heddle-ci-verdict-v1\0";
+/// NUL-terminated domain separator for the v2 CI-verdict signing scheme.
+pub const CI_VERDICT_DOMAIN: &[u8; 21] = b"heddle-ci-verdict-v2\0";
 
 /// Current serialized [`SignedVerdict`] format version.
-pub const SIGNED_VERDICT_FORMAT_VERSION: u8 = 1;
+pub const SIGNED_VERDICT_FORMAT_VERSION: u8 = 2;
 
-const SIGNING_PAYLOAD_LEN: usize = CI_VERDICT_DOMAIN.len() + 32 + 16 + 32;
+const FIXED_PAYLOAD_LEN: usize = CI_VERDICT_DOMAIN.len() + 32 + 16 + 32;
 
-/// A CI verdict signature bound to immutable verdict content and source state.
-///
-/// The signature covers [`ci_verdict_signing_payload`]. The embedded public key
-/// proves integrity; callers must separately resolve that key against their
-/// trusted `ci-runner` key set.
+/// What kind of principal signed a verdict.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignerKind {
+    /// A trusted automation principal. Trust-set membership remains caller policy.
+    #[default]
+    ServiceAccount,
+    /// A human device key. Device verdicts are always advisory-only.
+    Device,
+}
+
+impl SignerKind {
+    /// Stable token used in both JSON and the signature preimage.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ServiceAccount => "service_account",
+            Self::Device => "device",
+        }
+    }
+
+    /// Whether this signer kind is forbidden from satisfying a required gate.
+    #[must_use]
+    pub const fn is_advisory_only(self) -> bool {
+        matches!(self, Self::Device)
+    }
+}
+
+/// A rich CI verdict body plus its provenance-bound signature.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SignedVerdict {
-    /// Serialized verdict format. Only version 1 is accepted.
+    /// Serialized envelope format. Only v2 is accepted.
     pub format_version: u8,
-    /// Hash of the complete CI verdict content.
+    /// Complete conclusion-bearing content covered by [`Self::content_hash`].
+    pub body: CiVerdictBody,
+    /// BLAKE3 hash of the body's canonical JSON bytes.
     pub content_hash: ContentHash,
     /// Rewrite-stable change identifier for the checked state.
     pub change_id: ChangeId,
-    /// Root tree digest for the exact source tree that was checked.
+    /// Root tree digest for the exact tree that was checked.
     pub tree_digest: ContentHash,
+    /// What kind of principal signed the verdict.
+    pub signer_kind: SignerKind,
+    /// RFC3339 timestamp, signed to prevent freshness-presentation rewrites.
+    pub signed_at: String,
     /// Signature algorithm understood by Heddle's shared signing spine.
     pub algorithm: String,
     /// Hex-encoded public key bytes.
@@ -38,76 +84,159 @@ pub struct SignedVerdict {
 }
 
 impl SignedVerdict {
-    /// Verify the signature over every binding in this verdict.
+    /// Verify the body digest and signature over every provenance binding.
     ///
-    /// Trust in the embedded key is deliberately outside this primitive and is
-    /// established by the repository's `ci-runner` trust-set resolver.
+    /// Trust-set membership, freshness windows, and required-gate eligibility
+    /// remain caller policy. In particular, [`SignerKind::Device`] is advisory-only.
     pub fn verify(&self) -> Result<(), SignedVerdictError> {
-        if self.format_version != SIGNED_VERDICT_FORMAT_VERSION {
-            return Err(SignedVerdictError::UnsupportedVersion(self.format_version));
+        validate_versions(self.format_version, self.body.schema_version)?;
+        validate_signed_at(&self.signed_at)?;
+
+        let recomputed = self.body.content_hash();
+        if recomputed != self.content_hash {
+            return Err(SignedVerdictError::BodyDigestMismatch {
+                signed: self.content_hash,
+                recomputed,
+            });
         }
 
         let public_key =
             hex::decode(&self.public_key).map_err(SignedVerdictError::InvalidPublicKeyEncoding)?;
         let signature =
             hex::decode(&self.signature).map_err(SignedVerdictError::InvalidSignatureEncoding)?;
-        let payload =
-            ci_verdict_signing_payload(&self.content_hash, &self.change_id, &self.tree_digest);
+        let payload = ci_verdict_signing_payload(
+            &self.content_hash,
+            &self.change_id,
+            &self.tree_digest,
+            self.signer_kind,
+            &self.signed_at,
+        );
 
         verify_payload_signature(&payload, &self.algorithm, &public_key, &signature)
             .map_err(SignedVerdictError::from)
+    }
+
+    /// Whether policy must treat this verdict as advisory-only.
+    #[must_use]
+    pub const fn is_advisory_only(&self) -> bool {
+        self.signer_kind.is_advisory_only()
     }
 }
 
 /// Build the canonical bytes signed by a [`SignedVerdict`].
 ///
-/// Layout: NUL-terminated domain tag, 32-byte verdict content hash, 16-byte
-/// change id, then 32-byte root tree digest. All fields are fixed-width and
-/// retain their native byte order.
+/// Layout: `v2-tag || content-hash || change-id || tree-digest || signer-kind
+/// || NUL || signed-at || NUL`. The first four fields have fixed widths; the two
+/// trailing UTF-8 fields are framed by their fixed enum vocabulary/final NUL.
+#[must_use]
 pub fn ci_verdict_signing_payload(
     content_hash: &ContentHash,
     change_id: &ChangeId,
     tree_digest: &ContentHash,
-) -> [u8; SIGNING_PAYLOAD_LEN] {
-    let mut payload = [0; SIGNING_PAYLOAD_LEN];
-    let content_hash_start = CI_VERDICT_DOMAIN.len();
-    let change_id_start = content_hash_start + content_hash.as_bytes().len();
-    let tree_digest_start = change_id_start + change_id.as_bytes().len();
-
-    payload[..content_hash_start].copy_from_slice(CI_VERDICT_DOMAIN);
-    payload[content_hash_start..change_id_start].copy_from_slice(content_hash.as_bytes());
-    payload[change_id_start..tree_digest_start].copy_from_slice(change_id.as_bytes());
-    payload[tree_digest_start..].copy_from_slice(tree_digest.as_bytes());
+    signer_kind: SignerKind,
+    signed_at: &str,
+) -> Vec<u8> {
+    let mut payload =
+        Vec::with_capacity(FIXED_PAYLOAD_LEN + signer_kind.as_str().len() + signed_at.len() + 2);
+    payload.extend_from_slice(CI_VERDICT_DOMAIN);
+    payload.extend_from_slice(content_hash.as_bytes());
+    payload.extend_from_slice(change_id.as_bytes());
+    payload.extend_from_slice(tree_digest.as_bytes());
+    payload.extend_from_slice(signer_kind.as_str().as_bytes());
+    payload.push(0);
+    payload.extend_from_slice(signed_at.as_bytes());
+    payload.push(0);
     payload
 }
 
-/// Sign the canonical CI verdict payload with Heddle's shared [`Signer`].
+/// Sign a rich CI verdict with Heddle's shared [`Signer`] spine.
 pub fn signed_verdict_from_signer(
-    content_hash: &ContentHash,
+    body: CiVerdictBody,
     change_id: &ChangeId,
     tree_digest: &ContentHash,
+    signer_kind: SignerKind,
+    signed_at: String,
     signer: &dyn Signer,
 ) -> Result<SignedVerdict, SignedVerdictError> {
-    let payload = ci_verdict_signing_payload(content_hash, change_id, tree_digest);
+    validate_versions(SIGNED_VERDICT_FORMAT_VERSION, body.schema_version)?;
+    validate_signed_at(&signed_at)?;
+
+    let content_hash = body.content_hash();
+    let payload = ci_verdict_signing_payload(
+        &content_hash,
+        change_id,
+        tree_digest,
+        signer_kind,
+        &signed_at,
+    );
     let signature = signer.sign(&payload)?;
 
     Ok(SignedVerdict {
         format_version: SIGNED_VERDICT_FORMAT_VERSION,
-        content_hash: *content_hash,
+        body,
+        content_hash,
         change_id: *change_id,
         tree_digest: *tree_digest,
+        signer_kind,
+        signed_at,
         algorithm: signer.algorithm().to_string(),
         public_key: hex::encode(signer.public_key()),
         signature: hex::encode(signature),
     })
 }
 
+fn validate_versions(format_version: u8, schema_version: u32) -> Result<(), SignedVerdictError> {
+    if format_version != SIGNED_VERDICT_FORMAT_VERSION {
+        return Err(SignedVerdictError::UnsupportedFormatVersion {
+            found: format_version,
+            supported: SIGNED_VERDICT_FORMAT_VERSION,
+        });
+    }
+    if schema_version != CI_VERDICT_BODY_SCHEMA_VERSION {
+        return Err(SignedVerdictError::UnsupportedSchemaVersion {
+            found: schema_version,
+            supported: CI_VERDICT_BODY_SCHEMA_VERSION,
+        });
+    }
+    Ok(())
+}
+
+fn validate_signed_at(signed_at: &str) -> Result<(), SignedVerdictError> {
+    DateTime::parse_from_rfc3339(signed_at)
+        .map(|_| ())
+        .map_err(|error| SignedVerdictError::InvalidSignedAt(error.to_string()))
+}
+
 /// Errors returned while creating or verifying a signed CI verdict.
 #[derive(Debug, thiserror::Error)]
 pub enum SignedVerdictError {
-    /// The serialized verdict format is not supported by this reader.
-    #[error("unsupported signed verdict format version {0}")]
-    UnsupportedVersion(u8),
+    /// The serialized envelope format is not supported.
+    #[error("unsupported signed verdict format version {found}; expected {supported}")]
+    UnsupportedFormatVersion {
+        /// Version found in the envelope.
+        found: u8,
+        /// Only version accepted by this implementation.
+        supported: u8,
+    },
+    /// The embedded body schema cannot be verified by this implementation.
+    #[error("unsupported CI verdict body schema version {found}; expected {supported}")]
+    UnsupportedSchemaVersion {
+        /// Version found in the body.
+        found: u32,
+        /// Only version accepted by this implementation.
+        supported: u32,
+    },
+    /// The embedded body no longer hashes to the signed content hash.
+    #[error("CI verdict body digest mismatch: signed {signed}, recomputed {recomputed}")]
+    BodyDigestMismatch {
+        /// Digest carried by the signed envelope.
+        signed: ContentHash,
+        /// Digest recomputed from the embedded body.
+        recomputed: ContentHash,
+    },
+    /// The signed timestamp is not RFC3339.
+    #[error("CI verdict signed_at is not RFC3339: {0}")]
+    InvalidSignedAt(String),
     /// The embedded public key is not valid hexadecimal.
     #[error("signed verdict public key is not hexadecimal: {0}")]
     InvalidPublicKeyEncoding(hex::FromHexError),
@@ -117,135 +246,4 @@ pub enum SignedVerdictError {
     /// The shared signing backend rejected the operation.
     #[error("signed verdict cryptographic error: {0}")]
     Signer(#[from] SignerError),
-}
-
-#[cfg(test)]
-mod tests {
-    use serde_json::Value;
-
-    use super::*;
-    use crate::Ed25519Signer;
-
-    fn bindings() -> (ContentHash, ChangeId, ContentHash) {
-        (
-            ContentHash::from_bytes([1; 32]),
-            ChangeId::from_bytes([2; 16]),
-            ContentHash::from_bytes([3; 32]),
-        )
-    }
-
-    fn signed_verdict() -> SignedVerdict {
-        let signer = Ed25519Signer::from_seed(&[7; 32]).expect("create signer");
-        let (content_hash, change_id, tree_digest) = bindings();
-        signed_verdict_from_signer(&content_hash, &change_id, &tree_digest, &signer)
-            .expect("sign verdict")
-    }
-
-    #[test]
-    fn canonical_payload_pins_domain_and_binding_order() {
-        let (content_hash, change_id, tree_digest) = bindings();
-        let payload = ci_verdict_signing_payload(&content_hash, &change_id, &tree_digest);
-
-        assert_eq!(&payload[..21], b"heddle-ci-verdict-v1\0");
-        assert_eq!(&payload[21..53], &[1; 32]);
-        assert_eq!(&payload[53..69], &[2; 16]);
-        assert_eq!(&payload[69..101], &[3; 32]);
-    }
-
-    #[test]
-    fn signed_verdict_round_trips_losslessly_and_verifies() {
-        let verdict = signed_verdict();
-        let encoded = serde_json::to_vec(&verdict).expect("encode signed verdict");
-        let decoded: SignedVerdict =
-            serde_json::from_slice(&encoded).expect("decode signed verdict");
-
-        assert_eq!(decoded, verdict);
-        decoded.verify().expect("verify decoded verdict");
-    }
-
-    #[test]
-    fn verify_rejects_each_tampered_binding() {
-        let verdict = signed_verdict();
-        let mut tampered_content = verdict.clone();
-        tampered_content.content_hash = ContentHash::from_bytes([9; 32]);
-        let mut tampered_change = verdict.clone();
-        tampered_change.change_id = ChangeId::from_bytes([9; 16]);
-        let mut tampered_tree = verdict;
-        tampered_tree.tree_digest = ContentHash::from_bytes([9; 32]);
-
-        for tampered in [tampered_content, tampered_change, tampered_tree] {
-            assert!(matches!(
-                tampered.verify(),
-                Err(SignedVerdictError::Signer(SignerError::VerificationFailed))
-            ));
-        }
-    }
-
-    #[test]
-    fn verify_rejects_wrong_key_and_tampered_signature() {
-        let verdict = signed_verdict();
-        let wrong_signer = Ed25519Signer::from_seed(&[8; 32]).expect("create wrong signer");
-        let mut wrong_key = verdict.clone();
-        wrong_key.public_key = hex::encode(wrong_signer.public_key());
-        let mut tampered_signature = verdict;
-        let mut signature = hex::decode(&tampered_signature.signature).expect("decode signature");
-        signature[0] ^= 1;
-        tampered_signature.signature = hex::encode(signature);
-
-        for tampered in [wrong_key, tampered_signature] {
-            assert!(matches!(
-                tampered.verify(),
-                Err(SignedVerdictError::Signer(SignerError::VerificationFailed))
-            ));
-        }
-    }
-
-    #[test]
-    fn verify_rejects_untagged_signature_and_unknown_format() {
-        let signer = Ed25519Signer::from_seed(&[7; 32]).expect("create signer");
-        let (content_hash, change_id, tree_digest) = bindings();
-        let mut untagged_payload = Vec::with_capacity(80);
-        untagged_payload.extend_from_slice(content_hash.as_bytes());
-        untagged_payload.extend_from_slice(change_id.as_bytes());
-        untagged_payload.extend_from_slice(tree_digest.as_bytes());
-        let mut verdict = SignedVerdict {
-            format_version: SIGNED_VERDICT_FORMAT_VERSION,
-            content_hash,
-            change_id,
-            tree_digest,
-            algorithm: signer.algorithm().to_string(),
-            public_key: hex::encode(signer.public_key()),
-            signature: hex::encode(
-                signer
-                    .sign(&untagged_payload)
-                    .expect("sign untagged payload"),
-            ),
-        };
-
-        assert!(matches!(
-            verdict.verify(),
-            Err(SignedVerdictError::Signer(SignerError::VerificationFailed))
-        ));
-        verdict.format_version = 2;
-        assert!(matches!(
-            verdict.verify(),
-            Err(SignedVerdictError::UnsupportedVersion(2))
-        ));
-    }
-
-    #[test]
-    fn deserialize_rejects_every_missing_binding() {
-        let encoded = serde_json::to_value(signed_verdict()).expect("encode signed verdict");
-
-        for field in ["content_hash", "change_id", "tree_digest"] {
-            let mut incomplete = encoded.clone();
-            let Value::Object(ref mut object) = incomplete else {
-                panic!("signed verdict must encode as an object");
-            };
-            object.remove(field);
-
-            serde_json::from_value::<SignedVerdict>(incomplete)
-                .expect_err("missing binding must fail closed");
-        }
-    }
 }

--- a/crates/crypto/src/ci_verdict/body.rs
+++ b/crates/crypto/src/ci_verdict/body.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Canonical content model for a CI verdict.
+//!
+//! Canonical bytes are `serde_json` over these structs in declaration order.
+//! Maps are [`BTreeMap`]s, absent optional fields are omitted, and every schema
+//! change that moves the bytes must bump [`CI_VERDICT_BODY_SCHEMA_VERSION`].
+
+use std::collections::BTreeMap;
+
+use objects::object::ContentHash;
+use serde::{Deserialize, Serialize};
+
+use super::body_details::{Execution, LogRef, Outcome, Repro};
+
+/// Current canonical [`CiVerdictBody`] schema version.
+pub const CI_VERDICT_BODY_SCHEMA_VERSION: u32 = 1;
+
+/// The complete conclusion-bearing content of a CI verdict.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CiVerdictBody {
+    /// Canonical body schema version.
+    pub schema_version: u32,
+    /// Repository this verdict describes.
+    pub repo: String,
+    /// Source state that was evaluated.
+    pub state: StateRef,
+    /// Branch or speculative-merge basis actually evaluated.
+    pub basis: Basis,
+    /// Check identity and resolved parameters.
+    pub check: CheckDescriptor,
+    /// Terminal conclusion and optional failure detail.
+    pub outcome: Outcome,
+    /// Runner and timing metadata.
+    pub execution: Execution,
+    /// Finalized log reference; log bytes are never inlined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub log: Option<LogRef>,
+    /// Exact local reproduction recipe.
+    pub repro: Repro,
+    /// Canonical CheckSet digest used with `check.node_id` for authoritative gates.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub check_set_digest: Option<String>,
+}
+
+impl CiVerdictBody {
+    /// Deterministic bytes hashed into [`Self::content_hash`].
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        serde_json::to_vec(self).expect("CiVerdictBody is always serializable")
+    }
+
+    /// BLAKE3 [`ContentHash`] of the canonical body bytes.
+    #[must_use]
+    pub fn content_hash(&self) -> ContentHash {
+        ContentHash::compute(&self.canonical_bytes())
+    }
+}
+
+/// Reference to the immutable source state described by the body.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StateRef {
+    /// Transfer-stable source-state content digest.
+    pub content_hash: String,
+    /// Physical source-state identifier.
+    pub change_id: String,
+    /// Optional rewrite-stable lineage identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logical_change_id: Option<String>,
+}
+
+/// Exact tree evaluated and how it relates to a merge target.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Basis {
+    /// Branch-versus-merge discriminator.
+    pub kind: BasisKind,
+    /// Digest of the exact evaluated tree, including speculative merges.
+    pub evaluated_tree_digest: String,
+}
+
+/// Branch-versus-speculative-merge discriminator.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BasisKind {
+    /// The branch tree was evaluated as pushed.
+    #[default]
+    Branch,
+    /// The branch was evaluated after merging it with a target.
+    MergedWith {
+        /// Target state used for the speculative merge.
+        target_state: String,
+        /// Number of commits the branch was behind that target.
+        behind_count: u32,
+        /// Merge implementation version used to materialize the tree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        merge_algorithm_version: Option<String>,
+        /// Conflict policy applied while materializing the tree.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        conflict_policy: Option<String>,
+    },
+}
+
+/// Check identity, command, and resolved inputs.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct CheckDescriptor {
+    /// Unique check name within the repository definition.
+    pub name: String,
+    /// Whether the check gates, advises, or only informs.
+    pub class: CheckClass,
+    /// Digest of the authored check definition.
+    pub definition_digest: String,
+    /// Exact argument vector executed by the check.
+    pub command: Vec<String>,
+    /// Optional immutable container image digest.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image_digest: Option<String>,
+    /// Optional toolchain identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub toolchain: Option<String>,
+    /// Sorted resolved parameters, preventing cheap-check substitution.
+    pub params: BTreeMap<String, String>,
+    /// Service containers required by the check.
+    pub services: Vec<String>,
+    /// Check node within the body-level CheckSet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+}
+
+/// Whether a check gates a merge or only contributes advisory context.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckClass {
+    /// A non-green verdict blocks the merge when signer policy also allows it.
+    Required,
+    /// Reported but never gates.
+    #[default]
+    Advisory,
+    /// Context-only check, such as a metric.
+    Informational,
+}

--- a/crates/crypto/src/ci_verdict/body_details.rs
+++ b/crates/crypto/src/ci_verdict/body_details.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Outcome, execution, and reproduction sections of a CI verdict body.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Terminal outcome of a check.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Outcome {
+    /// Terminal conclusion.
+    pub conclusion: Conclusion,
+    /// Structured triage detail when the check failed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure: Option<FailureDetail>,
+}
+
+/// Exhaustive terminal check conclusions.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Conclusion {
+    /// Check passed.
+    #[default]
+    Success,
+    /// Check failed with code or assertion evidence.
+    Failure,
+    /// Check was cancelled before completion.
+    Cancelled,
+    /// Check was intentionally skipped.
+    Skipped,
+    /// Check exceeded its deadline.
+    TimedOut,
+    /// Check could not run because of infrastructure.
+    InfraError,
+}
+
+/// Failure details suitable for routing a repair attempt.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct FailureDetail {
+    /// Broad failure class.
+    pub class: FailureClass,
+    /// Optional finer-grained failure subclass.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subclass: Option<String>,
+    /// Failing step or check name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failing_step: Option<String>,
+    /// ANSI-stripped, producer-capped, untrusted error excerpt.
+    pub excerpt: String,
+    /// Encoding of the excerpt, such as `utf8`.
+    pub excerpt_encoding: String,
+}
+
+/// Broad class of a check failure.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureClass {
+    /// Compile or build failure.
+    #[default]
+    Build,
+    /// Test assertion or panic.
+    Test,
+    /// Lint failure.
+    Lint,
+    /// Benchmark failure or regression.
+    Bench,
+    /// Runner or service infrastructure failure.
+    Infra,
+    /// Execution timeout.
+    Timeout,
+    /// Speculative merge conflict.
+    MergeConflict,
+}
+
+/// Runner, timing, and attestation metadata.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Execution {
+    /// Leased run identifier; absent for purely local execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pick_id: Option<String>,
+    /// One-based run attempt.
+    pub attempt: u32,
+    /// Runner principal identifier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner: Option<String>,
+    /// RFC3339 execution start.
+    pub started_at: String,
+    /// RFC3339 execution finish.
+    pub finished_at: String,
+    /// Wall-clock duration in milliseconds.
+    pub duration_ms: u64,
+    /// Suites that actually ran.
+    pub ran_suites: Vec<String>,
+    /// Suites intentionally skipped.
+    pub skipped_suites: Vec<String>,
+    /// Runner pool that produced the verdict.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runner_pool: Option<String>,
+    /// Runner trust tier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trust_tier: Option<String>,
+    /// Sandbox isolation tier.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub isolation_tier: Option<String>,
+    /// Proof that the evaluated tree was materialized.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub materialization_proof: Option<String>,
+    /// Names of secret grants; values never enter the verdict.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub secret_grants: Vec<String>,
+}
+
+/// Pointer to a finalized log blob.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct LogRef {
+    /// Digest of the log manifest.
+    pub manifest_digest: String,
+    /// Total log size in bytes.
+    pub size_bytes: u64,
+}
+
+/// Exact local reproduction recipe.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct Repro {
+    /// Argument vector to execute.
+    pub command: Vec<String>,
+    /// Sorted environment variables to set.
+    pub env: BTreeMap<String, String>,
+    /// Optional container image.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub image: Option<String>,
+    /// Required service containers.
+    pub services: Vec<String>,
+}

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -15,8 +15,10 @@ mod behavior_tests;
 use std::path::Path;
 
 pub use ci_verdict::{
-    CI_VERDICT_DOMAIN, SIGNED_VERDICT_FORMAT_VERSION, SignedVerdict, SignedVerdictError,
-    ci_verdict_signing_payload, signed_verdict_from_signer,
+    Basis, BasisKind, CI_VERDICT_BODY_SCHEMA_VERSION, CI_VERDICT_DOMAIN, CheckClass,
+    CheckDescriptor, CiVerdictBody, Conclusion, Execution, FailureClass, FailureDetail, LogRef,
+    Outcome, Repro, SIGNED_VERDICT_FORMAT_VERSION, SignedVerdict, SignedVerdictError, SignerKind,
+    StateRef, ci_verdict_signing_payload, signed_verdict_from_signer,
 };
 pub use ed25519::Ed25519Signer;
 pub use error::SignerError;

--- a/crates/crypto/tests/ci_verdict_body_tamper.rs
+++ b/crates/crypto/tests/ci_verdict_body_tamper.rs
@@ -1,0 +1,168 @@
+mod ci_verdict_support;
+
+use ci_verdict_support::{SIGNED_AT, maximal_body, sign};
+use crypto::{
+    BasisKind, CheckClass, CiVerdictBody, Conclusion, FailureClass, SignedVerdictError, SignerKind,
+};
+
+type Mutation = fn(&mut CiVerdictBody);
+
+#[test]
+fn tampering_each_body_field_is_a_body_digest_mismatch() {
+    let mutations: &[(&str, Mutation)] = &[
+        ("repo", |b| b.repo.push_str("-tampered")),
+        ("state.content_hash", |b| {
+            b.state.content_hash.push_str("-tampered");
+        }),
+        ("state.change_id", |b| {
+            b.state.change_id.push_str("-tampered");
+        }),
+        ("state.logical_change_id", |b| {
+            b.state.logical_change_id = None;
+        }),
+        ("basis.kind.target_state", |b| match &mut b.basis.kind {
+            BasisKind::MergedWith { target_state, .. } => target_state.push_str("-tampered"),
+            BasisKind::Branch => panic!("maximal fixture must have merge basis"),
+        }),
+        ("basis.kind.behind_count", |b| match &mut b.basis.kind {
+            BasisKind::MergedWith { behind_count, .. } => *behind_count += 1,
+            BasisKind::Branch => panic!("maximal fixture must have merge basis"),
+        }),
+        ("basis.kind.merge_algorithm_version", |b| {
+            match &mut b.basis.kind {
+                BasisKind::MergedWith {
+                    merge_algorithm_version,
+                    ..
+                } => *merge_algorithm_version = None,
+                BasisKind::Branch => panic!("maximal fixture must have merge basis"),
+            }
+        }),
+        ("basis.kind.conflict_policy", |b| match &mut b.basis.kind {
+            BasisKind::MergedWith {
+                conflict_policy, ..
+            } => *conflict_policy = None,
+            BasisKind::Branch => panic!("maximal fixture must have merge basis"),
+        }),
+        ("basis.evaluated_tree_digest", |b| {
+            b.basis.evaluated_tree_digest.push_str("-tampered");
+        }),
+        ("check.name", |b| b.check.name.push_str("-tampered")),
+        ("check.class", |b| b.check.class = CheckClass::Advisory),
+        ("check.definition_digest", |b| {
+            b.check.definition_digest.push_str("-tampered");
+        }),
+        ("check.command", |b| {
+            b.check.command.push("--release".into())
+        }),
+        ("check.image_digest", |b| b.check.image_digest = None),
+        ("check.toolchain", |b| b.check.toolchain = None),
+        ("check.params", |b| {
+            b.check.params.insert("features".into(), "all".into());
+        }),
+        ("check.services", |b| b.check.services.push("redis".into())),
+        ("check.node_id", |b| b.check.node_id = None),
+        ("outcome.conclusion", |b| {
+            b.outcome.conclusion = Conclusion::Success;
+        }),
+        ("outcome.failure", |b| b.outcome.failure = None),
+        ("outcome.failure.class", |b| {
+            b.outcome.failure.as_mut().expect("failure").class = FailureClass::Lint;
+        }),
+        ("outcome.failure.subclass", |b| {
+            b.outcome.failure.as_mut().expect("failure").subclass = None;
+        }),
+        ("outcome.failure.failing_step", |b| {
+            b.outcome.failure.as_mut().expect("failure").failing_step = None;
+        }),
+        ("outcome.failure.excerpt", |b| {
+            b.outcome
+                .failure
+                .as_mut()
+                .expect("failure")
+                .excerpt
+                .push_str(" tampered");
+        }),
+        ("outcome.failure.excerpt_encoding", |b| {
+            b.outcome
+                .failure
+                .as_mut()
+                .expect("failure")
+                .excerpt_encoding = "base64".into();
+        }),
+        ("execution.pick_id", |b| b.execution.pick_id = None),
+        ("execution.attempt", |b| b.execution.attempt += 1),
+        ("execution.runner", |b| b.execution.runner = None),
+        ("execution.started_at", |b| {
+            b.execution.started_at.push_str("-tampered");
+        }),
+        ("execution.finished_at", |b| {
+            b.execution.finished_at.push_str("-tampered");
+        }),
+        ("execution.duration_ms", |b| b.execution.duration_ms += 1),
+        ("execution.ran_suites", |b| {
+            b.execution.ran_suites.push("tampered".into());
+        }),
+        ("execution.skipped_suites", |b| {
+            b.execution.skipped_suites.push("tampered".into());
+        }),
+        ("execution.runner_pool", |b| b.execution.runner_pool = None),
+        ("execution.trust_tier", |b| b.execution.trust_tier = None),
+        ("execution.isolation_tier", |b| {
+            b.execution.isolation_tier = None;
+        }),
+        ("execution.materialization_proof", |b| {
+            b.execution.materialization_proof = None;
+        }),
+        ("execution.secret_grants", |b| {
+            b.execution.secret_grants.push("OTHER_SECRET".into());
+        }),
+        ("log", |b| b.log = None),
+        ("log.manifest_digest", |b| {
+            b.log
+                .as_mut()
+                .expect("log")
+                .manifest_digest
+                .push_str("-tampered");
+        }),
+        ("log.size_bytes", |b| {
+            b.log.as_mut().expect("log").size_bytes += 1;
+        }),
+        ("repro.command", |b| {
+            b.repro.command.push("--release".into())
+        }),
+        ("repro.env", |b| {
+            b.repro
+                .env
+                .insert("RUSTFLAGS".into(), "-C opt-level=0".into());
+        }),
+        ("repro.image", |b| b.repro.image = None),
+        ("repro.services", |b| b.repro.services.push("redis".into())),
+        ("check_set_digest", |b| b.check_set_digest = None),
+    ];
+
+    for (field, mutate) in mutations {
+        let mut signed = sign(maximal_body(), SignerKind::ServiceAccount, SIGNED_AT);
+        mutate(&mut signed.body);
+        assert!(
+            matches!(
+                signed.verify(),
+                Err(SignedVerdictError::BodyDigestMismatch { .. })
+            ),
+            "tampering {field} must be reported as a body digest mismatch"
+        );
+    }
+}
+
+#[test]
+fn recomputing_a_tampered_body_hash_still_breaks_the_signature() {
+    let mut signed = sign(maximal_body(), SignerKind::ServiceAccount, SIGNED_AT);
+    signed.body.check.class = CheckClass::Advisory;
+    signed.content_hash = signed.body.content_hash();
+
+    assert!(matches!(
+        signed.verify(),
+        Err(SignedVerdictError::Signer(
+            crypto::SignerError::VerificationFailed
+        ))
+    ));
+}

--- a/crates/crypto/tests/ci_verdict_envelope.rs
+++ b/crates/crypto/tests/ci_verdict_envelope.rs
@@ -1,0 +1,228 @@
+mod ci_verdict_support;
+
+use ci_verdict_support::{SIGNED_AT, bindings, passing_body, sign, test_signer};
+use crypto::{
+    CI_VERDICT_BODY_SCHEMA_VERSION, CI_VERDICT_DOMAIN, Ed25519Signer,
+    SIGNED_VERDICT_FORMAT_VERSION, SignedVerdict, SignedVerdictError, Signer, SignerError,
+    SignerKind, ci_verdict_signing_payload, signed_verdict_from_signer,
+};
+use objects::object::{ChangeId, ContentHash};
+use serde_json::Value;
+
+fn verification_failed(result: Result<(), SignedVerdictError>) -> bool {
+    matches!(
+        result,
+        Err(SignedVerdictError::Signer(SignerError::VerificationFailed))
+    )
+}
+
+#[test]
+fn v2_payload_pins_domain_and_every_binding_in_order() {
+    let body = passing_body();
+    let (change_id, tree_digest) = bindings();
+    let content_hash = body.content_hash();
+    let payload = ci_verdict_signing_payload(
+        &content_hash,
+        &change_id,
+        &tree_digest,
+        SignerKind::ServiceAccount,
+        SIGNED_AT,
+    );
+
+    assert_eq!(&payload[..21], b"heddle-ci-verdict-v2\0");
+    assert_eq!(&payload[21..53], content_hash.as_bytes());
+    assert_eq!(&payload[53..69], &[2; 16]);
+    assert_eq!(&payload[69..101], &[3; 32]);
+    assert_eq!(&payload[101..117], b"service_account\0");
+    assert_eq!(&payload[117..], b"2026-06-11T18:05:54Z\0");
+    assert_eq!(CI_VERDICT_DOMAIN, b"heddle-ci-verdict-v2\0");
+}
+
+#[test]
+fn signatures_from_the_colliding_v1_scheme_are_rejected() {
+    let mut signed = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+    let signer = test_signer();
+    let mut legacy_payload = Vec::new();
+    legacy_payload.extend_from_slice(b"heddle-ci-verdict-v1\0");
+    legacy_payload.extend_from_slice(signed.content_hash.as_bytes());
+    legacy_payload.extend_from_slice(signed.change_id.as_bytes());
+    legacy_payload.extend_from_slice(signed.tree_digest.as_bytes());
+    signed.signature = hex::encode(signer.sign(&legacy_payload).expect("sign legacy payload"));
+
+    assert!(verification_failed(signed.verify()));
+}
+
+#[test]
+fn each_signed_envelope_binding_rejects_tampering() {
+    let verdict = sign(passing_body(), SignerKind::Device, SIGNED_AT);
+
+    let mut content_hash = verdict.clone();
+    content_hash.content_hash = ContentHash::from_bytes([9; 32]);
+    assert!(matches!(
+        content_hash.verify(),
+        Err(SignedVerdictError::BodyDigestMismatch { .. })
+    ));
+
+    let mut change_id = verdict.clone();
+    change_id.change_id = ChangeId::from_bytes([9; 16]);
+    assert!(verification_failed(change_id.verify()));
+
+    let mut tree_digest = verdict.clone();
+    tree_digest.tree_digest = ContentHash::from_bytes([9; 32]);
+    assert!(verification_failed(tree_digest.verify()));
+
+    let mut signer_kind = verdict.clone();
+    signer_kind.signer_kind = SignerKind::ServiceAccount;
+    assert!(verification_failed(signer_kind.verify()));
+
+    let mut signed_at = verdict;
+    signed_at.signed_at = "2026-06-11T18:05:55Z".to_string();
+    assert!(verification_failed(signed_at.verify()));
+}
+
+#[test]
+fn key_algorithm_and_signature_tampering_are_rejected() {
+    let verdict = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+
+    let mut algorithm = verdict.clone();
+    algorithm.algorithm = "unknown".to_string();
+    assert!(matches!(
+        algorithm.verify(),
+        Err(SignedVerdictError::Signer(
+            SignerError::UnsupportedAlgorithm(_)
+        ))
+    ));
+
+    let mut public_key = verdict.clone();
+    let other = Ed25519Signer::from_seed(&[8; 32]).expect("other signer");
+    public_key.public_key = hex::encode(other.public_key());
+    assert!(verification_failed(public_key.verify()));
+
+    let mut signature = verdict;
+    let mut bytes = hex::decode(&signature.signature).expect("signature hex");
+    bytes[0] ^= 1;
+    signature.signature = hex::encode(bytes);
+    assert!(verification_failed(signature.verify()));
+}
+
+#[test]
+fn unsupported_versions_are_distinct_from_body_tampering() {
+    let verdict = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+
+    let mut old_envelope = verdict.clone();
+    old_envelope.format_version = 1;
+    assert!(matches!(
+        old_envelope.verify(),
+        Err(SignedVerdictError::UnsupportedFormatVersion {
+            found: 1,
+            supported: SIGNED_VERDICT_FORMAT_VERSION,
+        })
+    ));
+
+    let mut newer_schema = verdict.clone();
+    newer_schema.body.schema_version = CI_VERDICT_BODY_SCHEMA_VERSION + 1;
+    assert!(matches!(
+        newer_schema.verify(),
+        Err(SignedVerdictError::UnsupportedSchemaVersion { .. })
+    ));
+    assert!(!matches!(
+        newer_schema.verify(),
+        Err(SignedVerdictError::BodyDigestMismatch { .. })
+    ));
+
+    let mut old_schema = verdict;
+    old_schema.body.schema_version = 0;
+    assert!(matches!(
+        old_schema.verify(),
+        Err(SignedVerdictError::UnsupportedSchemaVersion {
+            found: 0,
+            supported: CI_VERDICT_BODY_SCHEMA_VERSION,
+        })
+    ));
+}
+
+#[test]
+fn signing_rejects_unsupported_schema_and_malformed_signed_at() {
+    let signer = test_signer();
+    let (change_id, tree_digest) = bindings();
+    let mut old_body = passing_body();
+    old_body.schema_version = 0;
+    assert!(matches!(
+        signed_verdict_from_signer(
+            old_body,
+            &change_id,
+            &tree_digest,
+            SignerKind::ServiceAccount,
+            SIGNED_AT.to_string(),
+            &signer,
+        ),
+        Err(SignedVerdictError::UnsupportedSchemaVersion { found: 0, .. })
+    ));
+
+    assert!(matches!(
+        signed_verdict_from_signer(
+            passing_body(),
+            &change_id,
+            &tree_digest,
+            SignerKind::ServiceAccount,
+            "not-a-timestamp".to_string(),
+            &signer,
+        ),
+        Err(SignedVerdictError::InvalidSignedAt(_))
+    ));
+
+    let mut malformed = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+    malformed.signed_at = "not-a-timestamp".to_string();
+    assert!(matches!(
+        malformed.verify(),
+        Err(SignedVerdictError::InvalidSignedAt(_))
+    ));
+}
+
+#[test]
+fn device_verdicts_are_explicitly_advisory_only() {
+    let device = sign(passing_body(), SignerKind::Device, SIGNED_AT);
+    let service = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+
+    assert!(device.is_advisory_only());
+    assert!(!service.is_advisory_only());
+}
+
+#[test]
+fn every_v2_envelope_field_is_required_on_the_wire() {
+    let encoded = serde_json::to_value(sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT))
+        .expect("encode verdict");
+
+    for field in [
+        "format_version",
+        "body",
+        "content_hash",
+        "change_id",
+        "tree_digest",
+        "signer_kind",
+        "signed_at",
+        "algorithm",
+        "public_key",
+        "signature",
+    ] {
+        let mut incomplete = encoded.clone();
+        let Value::Object(ref mut object) = incomplete else {
+            panic!("verdict must serialize as an object");
+        };
+        object.remove(field);
+        assert!(
+            serde_json::from_value::<SignedVerdict>(incomplete).is_err(),
+            "missing {field} must not deserialize through a fallback"
+        );
+    }
+}
+
+#[test]
+fn signed_verdict_round_trips_losslessly_and_verifies() {
+    let verdict = sign(passing_body(), SignerKind::ServiceAccount, SIGNED_AT);
+    let encoded = serde_json::to_vec(&verdict).expect("encode signed verdict");
+    let decoded: SignedVerdict = serde_json::from_slice(&encoded).expect("decode signed verdict");
+
+    assert_eq!(decoded, verdict);
+    decoded.verify().expect("verify decoded verdict");
+}

--- a/crates/crypto/tests/ci_verdict_support/mod.rs
+++ b/crates/crypto/tests/ci_verdict_support/mod.rs
@@ -1,0 +1,212 @@
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+use crypto::{
+    Basis, BasisKind, CI_VERDICT_BODY_SCHEMA_VERSION, CheckClass, CheckDescriptor, CiVerdictBody,
+    Conclusion, Ed25519Signer, Execution, FailureClass, FailureDetail, LogRef, Outcome, Repro,
+    SignedVerdict, SignerKind, StateRef, signed_verdict_from_signer,
+};
+use objects::object::{ChangeId, ContentHash};
+
+pub const SIGNED_AT: &str = "2026-06-11T18:05:54Z";
+
+pub fn bindings() -> (ChangeId, ContentHash) {
+    (
+        ChangeId::from_bytes([2; 16]),
+        ContentHash::from_bytes([3; 32]),
+    )
+}
+
+pub fn test_signer() -> Ed25519Signer {
+    Ed25519Signer::from_seed(&[1; 32]).expect("fixed test signer")
+}
+
+pub fn sign(body: CiVerdictBody, signer_kind: SignerKind, signed_at: &str) -> SignedVerdict {
+    let (change_id, tree_digest) = bindings();
+    signed_verdict_from_signer(
+        body,
+        &change_id,
+        &tree_digest,
+        signer_kind,
+        signed_at.to_string(),
+        &test_signer(),
+    )
+    .expect("fixture must sign")
+}
+
+pub fn passing_body() -> CiVerdictBody {
+    let mut params = BTreeMap::new();
+    params.insert("features".to_string(), "default".to_string());
+
+    CiVerdictBody {
+        schema_version: CI_VERDICT_BODY_SCHEMA_VERSION,
+        repo: "heddle/core/heddle".to_string(),
+        state: StateRef {
+            content_hash: "b3:9af2c0de".to_string(),
+            change_id: "hd-7m3k".to_string(),
+            logical_change_id: None,
+        },
+        basis: Basis {
+            kind: BasisKind::MergedWith {
+                target_state: "b3:1c0dba5e".to_string(),
+                behind_count: 3,
+                merge_algorithm_version: None,
+                conflict_policy: None,
+            },
+            evaluated_tree_digest: "b3:deadbeef".to_string(),
+        },
+        check: CheckDescriptor {
+            name: "check.test".to_string(),
+            class: CheckClass::Required,
+            definition_digest: "b3:c0ffee".to_string(),
+            command: vec!["cargo".into(), "test".into(), "--workspace".into()],
+            image_digest: None,
+            toolchain: Some("rustc 1.96.0".to_string()),
+            params,
+            services: vec![],
+            node_id: None,
+        },
+        outcome: Outcome {
+            conclusion: Conclusion::Success,
+            failure: None,
+        },
+        execution: Execution {
+            pick_id: Some("pk_01J".to_string()),
+            attempt: 1,
+            runner: Some("svc:runner-pool-a".to_string()),
+            started_at: "2026-06-11T18:02:11Z".to_string(),
+            finished_at: SIGNED_AT.to_string(),
+            duration_ms: 223_000,
+            ran_suites: vec!["workspace".into()],
+            skipped_suites: vec![],
+            runner_pool: None,
+            trust_tier: None,
+            isolation_tier: None,
+            materialization_proof: None,
+            secret_grants: vec![],
+        },
+        log: None,
+        repro: Repro {
+            command: vec![
+                "cargo".into(),
+                "test".into(),
+                "--locked".into(),
+                "--workspace".into(),
+            ],
+            env: BTreeMap::new(),
+            image: None,
+            services: vec![],
+        },
+        check_set_digest: None,
+    }
+}
+
+pub fn maximal_body() -> CiVerdictBody {
+    let mut body = passing_body();
+    body.repo = "heddle/core/weft".to_string();
+    body.state = StateRef {
+        content_hash: "b3:5e11a7c0".to_string(),
+        change_id: "hd-9q2x".to_string(),
+        logical_change_id: Some("lc-weft-postgres".to_string()),
+    };
+    body.basis = Basis {
+        kind: BasisKind::MergedWith {
+            target_state: "hd-main-0001".to_string(),
+            behind_count: 7,
+            merge_algorithm_version: Some("recursive-v2".to_string()),
+            conflict_policy: Some("refuse-on-conflict".to_string()),
+        },
+        evaluated_tree_digest: "b3:7eaf00d5".to_string(),
+    };
+    body.check = maximal_check();
+    body.outcome = Outcome {
+        conclusion: Conclusion::Failure,
+        failure: Some(FailureDetail {
+            class: FailureClass::Test,
+            subclass: Some("ignored_suite".to_string()),
+            failing_step: Some("check.postgres".to_string()),
+            excerpt: "test schema::migrations::applies ... FAILED".to_string(),
+            excerpt_encoding: "utf8".to_string(),
+        }),
+    };
+    body.execution = maximal_execution();
+    body.log = Some(LogRef {
+        manifest_digest: "b3:109111".to_string(),
+        size_bytes: 48_122,
+    });
+    body.repro = maximal_repro();
+    body.check_set_digest = Some("b3:cs0001".to_string());
+    body
+}
+
+fn maximal_check() -> CheckDescriptor {
+    CheckDescriptor {
+        name: "check.postgres".to_string(),
+        class: CheckClass::Required,
+        definition_digest: "b3:def111".to_string(),
+        command: vec![
+            "cargo".into(),
+            "test".into(),
+            "--features".into(),
+            "postgres".into(),
+            "--".into(),
+            "--ignored".into(),
+        ],
+        image_digest: Some("sha256:abc123".to_string()),
+        toolchain: Some("rustc 1.96.0".to_string()),
+        params: BTreeMap::from([
+            ("features".to_string(), "postgres".to_string()),
+            ("toolchain".to_string(), "stable".to_string()),
+        ]),
+        services: vec!["postgres".into()],
+        node_id: Some("node-postgres-suite".to_string()),
+    }
+}
+
+fn maximal_execution() -> Execution {
+    Execution {
+        pick_id: Some("pk_02K".to_string()),
+        attempt: 2,
+        runner: Some("svc:runner-pool-b".to_string()),
+        started_at: "2026-06-11T19:00:00Z".to_string(),
+        finished_at: "2026-06-11T19:04:30Z".to_string(),
+        duration_ms: 270_000,
+        ran_suites: vec!["postgres".into(), "migrations".into()],
+        skipped_suites: vec!["unit".into()],
+        runner_pool: Some("pool-b".to_string()),
+        trust_tier: Some("t1_container".to_string()),
+        isolation_tier: Some("t1_container".to_string()),
+        materialization_proof: Some("b3:merged7eaf00d5".to_string()),
+        secret_grants: vec!["DATABASE_URL".into()],
+    }
+}
+
+fn maximal_repro() -> Repro {
+    Repro {
+        command: vec![
+            "cargo".into(),
+            "test".into(),
+            "--locked".into(),
+            "--features".into(),
+            "postgres".into(),
+            "--".into(),
+            "--ignored".into(),
+        ],
+        env: BTreeMap::from([
+            ("CARGO_TERM_COLOR".to_string(), "never".to_string()),
+            ("RUST_BACKTRACE".to_string(), "1".to_string()),
+        ]),
+        image: Some("sha256:abc123".to_string()),
+        services: vec!["postgres".into()],
+    }
+}
+
+pub fn branch_basis_body() -> CiVerdictBody {
+    let mut body = passing_body();
+    body.basis = Basis {
+        kind: BasisKind::Branch,
+        evaluated_tree_digest: "b3:branchasis".to_string(),
+    };
+    body
+}

--- a/crates/crypto/tests/ci_verdict_vectors.rs
+++ b/crates/crypto/tests/ci_verdict_vectors.rs
@@ -1,0 +1,112 @@
+//! Cross-language golden vectors for the complete v2 verdict signing scheme.
+
+mod ci_verdict_support;
+
+use ci_verdict_support::{branch_basis_body, maximal_body, passing_body, test_signer};
+use crypto::{
+    CI_VERDICT_DOMAIN, CiVerdictBody, Signer, SignerKind, ci_verdict_signing_payload,
+    signed_verdict_from_signer,
+};
+use objects::object::{ChangeId, ContentHash};
+use serde_json::Value;
+
+fn fixture(name: &str) -> CiVerdictBody {
+    match name {
+        "passing_body" => passing_body(),
+        "maximal_body" => maximal_body(),
+        "branch_basis_body" => branch_basis_body(),
+        other => panic!("unknown golden-vector fixture {other:?}"),
+    }
+}
+
+fn signer_kind(name: &str) -> SignerKind {
+    match name {
+        "service_account" => SignerKind::ServiceAccount,
+        "device" => SignerKind::Device,
+        other => panic!("unknown golden-vector signer kind {other:?}"),
+    }
+}
+
+fn change_id(value: &Value) -> ChangeId {
+    let bytes = hex::decode(value.as_str().expect("change_id_hex")).expect("change id hex");
+    ChangeId::try_from_slice(&bytes).expect("16-byte change id")
+}
+
+#[test]
+fn golden_vectors_reproduce_canonical_body_hash_preimage_and_signature() {
+    let document: Value = serde_json::from_str(include_str!("fixtures/ci_verdict_v2.json"))
+        .expect("golden vectors are valid JSON");
+    let signer = test_signer();
+
+    assert_eq!(
+        hex::encode(CI_VERDICT_DOMAIN),
+        document["signing_payload_version_tag_hex"]
+            .as_str()
+            .expect("tag hex")
+    );
+    assert_eq!(
+        hex::encode(signer.public_key()),
+        document["test_key"]["public_key_hex"]
+            .as_str()
+            .expect("public key hex")
+    );
+
+    let vectors = document["vectors"].as_array().expect("vectors array");
+    assert!(
+        !vectors.is_empty(),
+        "at least one golden vector is required"
+    );
+    for vector in vectors {
+        let name = vector["name"].as_str().expect("vector name");
+        let body = fixture(vector["fixture"].as_str().expect("fixture name"));
+        let kind = signer_kind(vector["signer_kind"].as_str().expect("signer kind"));
+        let signed_at = vector["signed_at"].as_str().expect("signed_at");
+        let change_id = change_id(&vector["change_id_hex"]);
+        let tree_digest =
+            ContentHash::from_hex(vector["tree_digest_hex"].as_str().expect("tree_digest_hex"))
+                .expect("tree digest hex");
+
+        assert_eq!(
+            String::from_utf8(body.canonical_bytes()).expect("canonical JSON is UTF-8"),
+            vector["canonical_bytes_utf8"]
+                .as_str()
+                .expect("canonical bytes"),
+            "[{name}] canonical body bytes drifted"
+        );
+        let content_hash = body.content_hash();
+        assert_eq!(
+            content_hash.to_hex(),
+            vector["content_hash_hex"]
+                .as_str()
+                .expect("content_hash_hex"),
+            "[{name}] content hash drifted"
+        );
+        let payload =
+            ci_verdict_signing_payload(&content_hash, &change_id, &tree_digest, kind, signed_at);
+        assert_eq!(
+            hex::encode(payload),
+            vector["signing_preimage_hex"]
+                .as_str()
+                .expect("signing preimage"),
+            "[{name}] signing preimage drifted"
+        );
+
+        let signed = signed_verdict_from_signer(
+            body,
+            &change_id,
+            &tree_digest,
+            kind,
+            signed_at.to_string(),
+            &signer,
+        )
+        .expect("sign golden vector");
+        assert_eq!(
+            signed.signature,
+            vector["signature_hex"].as_str().expect("signature hex"),
+            "[{name}] signature drifted"
+        );
+        signed
+            .verify()
+            .unwrap_or_else(|error| panic!("[{name}] golden vector must verify: {error}"));
+    }
+}

--- a/crates/crypto/tests/fixtures/ci_verdict_v2.json
+++ b/crates/crypto/tests/fixtures/ci_verdict_v2.json
@@ -1,0 +1,56 @@
+{
+  "$comment": [
+    "Golden signing vectors for Heddle CI verdict v2.",
+    "Canonical body bytes are declaration-ordered serde_json with sorted maps and omitted absent options.",
+    "content_hash is raw BLAKE3-256(canonical_bytes).",
+    "preimage = tag || content_hash[32] || change_id[16] || tree_digest[32] || signer_kind || NUL || signed_at || NUL.",
+    "The fixed ed25519 seed is for tests only and must never be used in production."
+  ],
+  "body_schema_version": 1,
+  "signed_verdict_format_version": 2,
+  "signing_payload_version_tag_ascii": "heddle-ci-verdict-v2",
+  "signing_payload_version_tag_hex": "686564646c652d63692d766572646963742d763200",
+  "test_key": {
+    "kind": "ed25519",
+    "seed_hex": "0101010101010101010101010101010101010101010101010101010101010101",
+    "public_key_hex": "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+  },
+  "vectors": [
+    {
+      "name": "minimal",
+      "fixture": "passing_body",
+      "signer_kind": "service_account",
+      "signed_at": "2026-06-11T18:05:54Z",
+      "change_id_hex": "02020202020202020202020202020202",
+      "tree_digest_hex": "0303030303030303030303030303030303030303030303030303030303030303",
+      "canonical_bytes_utf8": "{\"schema_version\":1,\"repo\":\"heddle/core/heddle\",\"state\":{\"content_hash\":\"b3:9af2c0de\",\"change_id\":\"hd-7m3k\"},\"basis\":{\"kind\":{\"merged_with\":{\"target_state\":\"b3:1c0dba5e\",\"behind_count\":3}},\"evaluated_tree_digest\":\"b3:deadbeef\"},\"check\":{\"name\":\"check.test\",\"class\":\"required\",\"definition_digest\":\"b3:c0ffee\",\"command\":[\"cargo\",\"test\",\"--workspace\"],\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"default\"},\"services\":[]},\"outcome\":{\"conclusion\":\"success\"},\"execution\":{\"pick_id\":\"pk_01J\",\"attempt\":1,\"runner\":\"svc:runner-pool-a\",\"started_at\":\"2026-06-11T18:02:11Z\",\"finished_at\":\"2026-06-11T18:05:54Z\",\"duration_ms\":223000,\"ran_suites\":[\"workspace\"],\"skipped_suites\":[]},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--workspace\"],\"env\":{},\"services\":[]}}",
+      "content_hash_hex": "07c0245b4d8a3ed469ed6045b1dbd6403fec96dc4ecc8689564186eee3d9f86b",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320007c0245b4d8a3ed469ed6045b1dbd6403fec96dc4ecc8689564186eee3d9f86b020202020202020202020202020202020303030303030303030303030303030303030303030303030303030303030303736572766963655f6163636f756e7400323032362d30362d31315431383a30353a35345a00",
+      "signature_hex": "87116991fe65bb02f111bf0b17e6c8284802efae34192afe66e97690da8275176871d17e25e086328e41d5ccf653b4647ba2f3bde016c561764eb28f1ef68c05"
+    },
+    {
+      "name": "maximal_device",
+      "fixture": "maximal_body",
+      "signer_kind": "device",
+      "signed_at": "2026-06-11T19:04:30Z",
+      "change_id_hex": "02020202020202020202020202020202",
+      "tree_digest_hex": "0303030303030303030303030303030303030303030303030303030303030303",
+      "canonical_bytes_utf8": "{\"schema_version\":1,\"repo\":\"heddle/core/weft\",\"state\":{\"content_hash\":\"b3:5e11a7c0\",\"change_id\":\"hd-9q2x\",\"logical_change_id\":\"lc-weft-postgres\"},\"basis\":{\"kind\":{\"merged_with\":{\"target_state\":\"hd-main-0001\",\"behind_count\":7,\"merge_algorithm_version\":\"recursive-v2\",\"conflict_policy\":\"refuse-on-conflict\"}},\"evaluated_tree_digest\":\"b3:7eaf00d5\"},\"check\":{\"name\":\"check.postgres\",\"class\":\"required\",\"definition_digest\":\"b3:def111\",\"command\":[\"cargo\",\"test\",\"--features\",\"postgres\",\"--\",\"--ignored\"],\"image_digest\":\"sha256:abc123\",\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"postgres\",\"toolchain\":\"stable\"},\"services\":[\"postgres\"],\"node_id\":\"node-postgres-suite\"},\"outcome\":{\"conclusion\":\"failure\",\"failure\":{\"class\":\"test\",\"subclass\":\"ignored_suite\",\"failing_step\":\"check.postgres\",\"excerpt\":\"test schema::migrations::applies ... FAILED\",\"excerpt_encoding\":\"utf8\"}},\"execution\":{\"pick_id\":\"pk_02K\",\"attempt\":2,\"runner\":\"svc:runner-pool-b\",\"started_at\":\"2026-06-11T19:00:00Z\",\"finished_at\":\"2026-06-11T19:04:30Z\",\"duration_ms\":270000,\"ran_suites\":[\"postgres\",\"migrations\"],\"skipped_suites\":[\"unit\"],\"runner_pool\":\"pool-b\",\"trust_tier\":\"t1_container\",\"isolation_tier\":\"t1_container\",\"materialization_proof\":\"b3:merged7eaf00d5\",\"secret_grants\":[\"DATABASE_URL\"]},\"log\":{\"manifest_digest\":\"b3:109111\",\"size_bytes\":48122},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--features\",\"postgres\",\"--\",\"--ignored\"],\"env\":{\"CARGO_TERM_COLOR\":\"never\",\"RUST_BACKTRACE\":\"1\"},\"image\":\"sha256:abc123\",\"services\":[\"postgres\"]},\"check_set_digest\":\"b3:cs0001\"}",
+      "content_hash_hex": "0fb5382254c883065771c347b9f2dc5e80b200b57d09b14f2627a4d1017cd43c",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d7632000fb5382254c883065771c347b9f2dc5e80b200b57d09b14f2627a4d1017cd43c02020202020202020202020202020202030303030303030303030303030303030303030303030303030303030303030364657669636500323032362d30362d31315431393a30343a33305a00",
+      "signature_hex": "c7805352d9f07c7271f93659218aa2b6f627b1f4b7e7c4f48f3b5dd8fa5be57d445b310ef631cf8ad04c7f8a5c5907f1097d0531c61aada349a0af44fad95108"
+    },
+    {
+      "name": "branch_basis",
+      "fixture": "branch_basis_body",
+      "signer_kind": "service_account",
+      "signed_at": "2026-06-11T18:05:54Z",
+      "change_id_hex": "02020202020202020202020202020202",
+      "tree_digest_hex": "0303030303030303030303030303030303030303030303030303030303030303",
+      "canonical_bytes_utf8": "{\"schema_version\":1,\"repo\":\"heddle/core/heddle\",\"state\":{\"content_hash\":\"b3:9af2c0de\",\"change_id\":\"hd-7m3k\"},\"basis\":{\"kind\":\"branch\",\"evaluated_tree_digest\":\"b3:branchasis\"},\"check\":{\"name\":\"check.test\",\"class\":\"required\",\"definition_digest\":\"b3:c0ffee\",\"command\":[\"cargo\",\"test\",\"--workspace\"],\"toolchain\":\"rustc 1.96.0\",\"params\":{\"features\":\"default\"},\"services\":[]},\"outcome\":{\"conclusion\":\"success\"},\"execution\":{\"pick_id\":\"pk_01J\",\"attempt\":1,\"runner\":\"svc:runner-pool-a\",\"started_at\":\"2026-06-11T18:02:11Z\",\"finished_at\":\"2026-06-11T18:05:54Z\",\"duration_ms\":223000,\"ran_suites\":[\"workspace\"],\"skipped_suites\":[]},\"repro\":{\"command\":[\"cargo\",\"test\",\"--locked\",\"--workspace\"],\"env\":{},\"services\":[]}}",
+      "content_hash_hex": "67d394f30f78ec12e804541419f7f88100d2664ac473bfaa657a481ce32fdbe6",
+      "signing_preimage_hex": "686564646c652d63692d766572646963742d76320067d394f30f78ec12e804541419f7f88100d2664ac473bfaa657a481ce32fdbe6020202020202020202020202020202020303030303030303030303030303030303030303030303030303030303030303736572766963655f6163636f756e7400323032362d30362d31315431383a30353a35345a00",
+      "signature_hex": "1992c3e150f90038e02838df41454b4c5dfe1cad5387262987498e13e19ef6a14dbe1d71fa4e27262b08bb3980916d9ef828cf29e1309c67197de6f9be895701"
+    }
+  ]
+}


### PR DESCRIPTION
Implements HeddleCo/treadle#13.

## Summary

- defines `content_hash` as Heddle `ContentHash` over canonical `CiVerdictBody` bytes
- adopts treadle's rich verdict body, including branch/merged basis, structured outcome/failure, execution attestation, logs, and repro data
- retains Heddle's shared `Signer` spine plus explicit `change_id` and `tree_digest` bindings
- signs `signer_kind` and RFC3339 `signed_at`; device signatures are explicitly advisory-only
- replaces the colliding v1 domain with `heddle-ci-verdict-v2\0` and accepts only envelope v2/body schema v1
- adds cross-language golden vectors plus negative coverage for every body field, every envelope binding, the old v1 preimage, missing fields, and unsupported versions

## Local verification

Passed:

- `cargo test --locked -p heddle-crypto --tests`
- `cargo build --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd`
- `cargo check --locked -p heddle-repo --no-default-features --features native,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd`
- `cargo check --locked -p heddle-cli --no-default-features --features native,semantic,zstd`
- `cargo build --locked -p heddle-cli --features telemetry --tests --bin heddle`
- `cargo clippy --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry --lib --bins --tests --examples -- -D warnings`
- `rustfmt +nightly --edition 2024 --check` on every touched Rust file
- `git diff --check`

Known baseline failures, reproduced on detached `origin/main` at `e23f4ea8`:

- the exact telemetry test command `cargo test --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry` reaches `ts_types_in_sync`, where `generated_typescript_is_in_sync` and `generated_json_is_in_sync` fail because the committed generated schemas are stale
- repository-wide `cargo +nightly fmt --all -- --check` reports existing import-order drift in untouched cli-render/core files

Postgres integration was not selected by CI's affected-package rules for this crypto-only change. GitHub Actions was not relied on because of the current billing block/Blacksmith instability.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1383"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789313459&installation_model_id=21489&pr_number=1383&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1383&signature=1cdf262d6802b2eed5303f8aa38b04f669757bd050037b00417fa2c10407d622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->