### PR TITLE
feat(ci): add local check executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,6 +2190,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "heddle-ci-config"
+version = "0.12.0"
+dependencies = [
+ "heddle-object-model",
+ "regex",
+ "serde",
+ "thiserror 2.0.18",
+ "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "heddle-ci-engine"
+version = "0.12.0"
+dependencies = [
+ "heddle-ci-config",
+ "heddle-crypto",
+ "libc",
+ "regex",
+ "tempfile",
+ "thiserror 2.0.18",
+ "wait-timeout",
+]
+
+[[package]]
 name = "heddle-cli"
 version = "0.12.0"
 dependencies = [
@@ -2205,6 +2229,8 @@ dependencies = [
  "criterion",
  "futures",
  "heddle-api 0.5.0",
+ "heddle-ci-config",
+ "heddle-ci-engine",
  "heddle-cli-args",
  "heddle-cli-contract",
  "heddle-cli-render",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
     "crates/cli-contract",
     "crates/cli-render",
     "crates/cli-shared",
+    "crates/ci-config",
+    "crates/ci-engine",
     "crates/core",
     "crates/crypto",
     "crates/daemon",
@@ -88,6 +90,7 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 opentelemetry_sdk = "0.32"
 rand = "0.10"
 regex-lite = "0.1"
+regex = "1"
 reqwest = { version = "0.13.4", default-features = false, features = ["blocking", "json", "rustls-no-provider"] }
 rmp-serde = "1"
 rusqlite = { version = "0.39", features = ["bundled"] }
@@ -143,6 +146,7 @@ tree-sitter-typescript = "0.23"
 tree-sitter-zig = "=1.1.2"
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 walkdir = "2"
+wait-timeout = "0.2"
 webpki-roots = "1.0"
 windows-sys = "0.61"
 zstd = "0.13"

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,119 @@
+# treadle#14 — HARVEST + WIRE plan
+
+## Scope and command surface
+
+Land the local/dogfood executor in heddle with no weft dependency:
+
+```text
+heddle ci run --local [--state <STATE>] [--config <PATH>] [--check <NAME>]...
+```
+
+- `--local` is the explicit execution-mode selector required by treadle#14. No
+  hosted or fallback mode is added in this change.
+- Without `--state`, checks run in the selected Heddle checkout and are bound to
+  a Heddle tree built from that working tree.
+- With `--state`, Heddle resolves the state, visibility-gates its checkout into
+  an isolated temporary directory, and runs the same engine there.
+- The default definition is the repository metadata file
+  `<shared .heddle>/ci.toml`; `--config` overrides it. This deliberately uses
+  `Repository::heddle_dir()` rather than assuming `.heddle` is a directory in
+  every checkout (isolated Heddle checkouts use a `.heddle` pointer file).
+- `--check` is repeatable and preserves definition order. An unknown name is a
+  hard usage error.
+- Human output is the treadle check summary table. Heddle's global
+  `--output json` emits the complete signed-verdict array.
+- Exit nonzero when any authored `required` check ends in `failure`,
+  `timed_out`, or `infra_error`. Advisory/informational failures remain visible
+  but do not make the command fail.
+
+## HARVEST
+
+Lift the established treadle model rather than create another CI scheme:
+
+1. `crates/config` becomes `crates/ci-config`:
+   - schema-v1 `[meta]` + ordered `[[check]]` model;
+   - argv-only commands, class, timeout, env, services, cache paths, retry,
+     triggers, supersede, and isolation fields;
+   - duplicate/empty-command/regex/cron validation and unknown-key warnings;
+   - definition digest computed with Heddle's canonical typed blob hash.
+2. `crates/engine` becomes `crates/ci-engine`:
+   - `exec.rs`: sequential execution, deterministic argv, timeout, bounded
+     combined capture, retries, and verdict-body assembly;
+   - `proc_group.rs`: Unix process-group creation/kill so timeout reaps the
+     entire `sh -> cargo -> rustc` tree;
+   - `ansi.rs`: CSI/OSC/control stripping;
+   - `classify.rs`: disposition-first Build/Test/Lint/Infra/Timeout classifier
+     and 4 KiB UTF-8-safe tail excerpt;
+   - `cache.rs`, `env.rs`, `service.rs`: explicit cache exports, hermetic child
+     environment, and out-of-process service-provider boundary.
+3. `crates/check-cli` becomes the `heddle ci run --local` orchestration:
+   definition resolution, check filtering, engine invocation, signing, table
+   rendering, JSON rendering, advisory warnings, and exit decision.
+4. The treadle runner is not copied into heddle. Its useful local-mode
+   invariants are wired directly: state-addressed materialization, one shared
+   engine for local/runner parity, and signing only after execution facts exist.
+
+## WIRE into heddle
+
+1. Use `heddle-crypto`'s merged verdict-v2 types and
+   `signed_verdict_from_signer`; do not migrate treadle's parallel schema or
+   signing implementation.
+2. Require the linked Heddle device identity. Do not accept an ephemeral key,
+   arbitrary key file, or the per-repository auto-minted capture key. Stamp
+   `SignerKind::Device`, making every local verdict advisory-only by v2 policy,
+   and verify every envelope before emitting it.
+3. Bind a working-tree run to real Heddle identities:
+   - build the checkout tree using `Repository::build_tree`;
+   - derive a non-persisted projection of the current state with that exact tree
+     and its existing rewrite-stable `ChangeId`;
+   - bind the body and v2 signature to the projected state id, `ChangeId`, and
+     exact tree digest;
+   - rebuild after the checks and refuse to sign if tracked/evaluated bytes
+     changed during execution.
+4. Bind `--state` to the resolved stored state id, its `ChangeId`, and stored
+   tree digest. Run it from a visibility-gated temporary checkout and clean the
+   temporary materialization record afterward.
+5. Keep caches outside the evaluated tree under `.heddle/cache/ci`; a cache is
+   an accelerator, never evidence. Local mode uses treadle's `NoopProvider`, so
+   a definition requesting services produces an honest `infra_error` verdict.
+   Docker/service execution remains available at the engine boundary but is not
+   silently enabled by the local CLI.
+6. Register `ci` / `ci run` in the CLI argument surface, dispatch, command
+   contract, and contract tests. Use the existing global output-mode contract.
+
+## Classifier decision from the required re-read
+
+`FailureClass::Bench` and `FailureClass::MergeConflict` exist in verdict-v2, but
+treadle's process-output classifier never emits them. `default_features` also
+appears only as an example/fixture subclass; the classifier does not derive it.
+Keep that exact behavior. A plain process exit has no sound basis for inferring
+benchmark regression, speculative-merge conflict, or the semantic reason a
+build failed, so this harvest will not invent those classifications.
+
+## Verification
+
+1. Focused config, engine, and CLI executor tests, including:
+   parsing/filtering; pass/fail/advisory exit behavior; ANSI stripping;
+   classification; excerpt cap; timeout; process-group kill on Unix; real v2
+   device signature verification; working-tree identity binding; explicit-state
+   materialization; and mutation refusal.
+2. `cargo +nightly fmt` on touched Rust files.
+3. `cargo build`.
+4. `cargo clippy --all-targets -- -D warnings` for the new crates and CLI.
+5. Focused executor tests (and broader tests as time permits).
+
+## Explicitly deferred
+
+- Weft scheduling, leasing, upload, supersession, trust-set evaluation, and
+  authoritative gating.
+- Container/microVM isolation and automatic Docker service activation.
+- Merge-basis materialization and `FailureClass::MergeConflict` production.
+- Canonical protected-policy CheckSet compilation / `check_set_digest` and node
+  ids.
+- Log/artifact upload and operational attempt sidecars.
+- Bench/default-features failure subclasses; treadle has schema vocabulary but
+  no sound classifier implementation to harvest.
+
+These deferrals do not add fallbacks or compatibility shims. The delivered path
+is one local executor, one Heddle verdict-v2 signing path, and one explicit trust
+level (`device` / advisory-only).

--- a/crates/ci-config/Cargo.toml
+++ b/crates/ci-config/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "heddle-ci-config"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Typed local CI definitions for Heddle"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+heddle-object-model = { path = "../object-model", version = "0.12" }
+regex.workspace = true
+serde.workspace = true
+thiserror.workspace = true
+toml.workspace = true
+
+[lib]
+path = "src/lib.rs"
+name = "ci_config"

--- a/crates/ci-config/src/lib.rs
+++ b/crates/ci-config/src/lib.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Typed, schema-versioned `.heddle/ci.toml` definitions.
+
+mod model;
+mod parse;
+
+pub use model::{
+    Check, CheckClass, CiConfig, DEFAULT_TIMEOUT_SECS, Meta, Retry, SUPPORTED_SCHEMA, Service,
+    Trigger,
+};
+pub use parse::{ConfigError, definition_digest, parse};

--- a/crates/ci-config/src/model.rs
+++ b/crates/ci-config/src/model.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Parsed CI-definition model.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// The only definition schema accepted by this build.
+pub const SUPPORTED_SCHEMA: u32 = 1;
+/// Default per-check timeout: one hour.
+pub const DEFAULT_TIMEOUT_SECS: u64 = 3600;
+
+/// A parsed and validated `.heddle/ci.toml`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CiConfig {
+    /// Definition metadata.
+    pub meta: Meta,
+    /// Checks in authored order.
+    pub checks: Vec<Check>,
+    /// Non-fatal unknown-key warnings.
+    pub warnings: Vec<String>,
+}
+
+/// Definition metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Meta {
+    /// Definition schema version.
+    pub schema: u32,
+}
+
+/// One authored check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Check {
+    /// Unique name within the definition.
+    pub name: String,
+    /// Gating class.
+    pub class: CheckClass,
+    /// Exact argv to execute.
+    pub command: Vec<String>,
+    /// Per-check deadline in seconds.
+    pub timeout_secs: u64,
+    /// Explicit environment overrides.
+    pub env: BTreeMap<String, String>,
+    /// Requested service containers.
+    pub services: Vec<Service>,
+    /// Persistent cache slots.
+    pub cache_paths: Vec<String>,
+    /// Flake retry policy.
+    pub retry: Retry,
+    /// Check triggers.
+    pub triggers: Vec<Trigger>,
+    /// Whether a newer state supersedes an in-flight run.
+    pub supersede: bool,
+    /// Optional isolation class.
+    pub isolation: Option<String>,
+}
+
+/// Whether a check gates, advises, or only informs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CheckClass {
+    /// A non-green result is a required-check failure.
+    Required,
+    /// Result is advisory.
+    Advisory,
+    /// Result is context only.
+    Informational,
+}
+
+/// A service container requested by a check.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct Service {
+    /// Local service name.
+    pub name: String,
+    /// Container image reference.
+    pub image: String,
+    /// Ports published one-to-one.
+    #[serde(default)]
+    pub ports: Vec<u16>,
+    /// Service environment.
+    #[serde(default)]
+    pub env: BTreeMap<String, String>,
+    /// Optional readiness-probe argv.
+    #[serde(default)]
+    pub ready_cmd: Option<Vec<String>>,
+}
+
+/// Flake retry policy.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Retry {
+    /// Maximum retries after the initial attempt.
+    pub max: u32,
+    /// Regexes which identify retryable output.
+    pub flake_signatures: Vec<String>,
+}
+
+/// A check trigger.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Trigger {
+    /// Every push.
+    Push,
+    /// Explicit dispatch.
+    Manual,
+    /// Five-field cron expression.
+    Cron(String),
+}
+
+impl Trigger {
+    /// Canonical serialized token.
+    #[must_use]
+    pub fn as_str(&self) -> String {
+        match self {
+            Self::Push => "push".to_string(),
+            Self::Manual => "manual".to_string(),
+            Self::Cron(expression) => format!("cron:{expression}"),
+        }
+    }
+}

--- a/crates/ci-config/src/parse.rs
+++ b/crates/ci-config/src/parse.rs
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Parsing, validation, and digesting for CI definitions.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use heddle_object_model::object::Blob;
+use regex::Regex;
+use serde::Deserialize;
+use thiserror::Error;
+
+use crate::model::{
+    Check, CheckClass, CiConfig, DEFAULT_TIMEOUT_SECS, Meta, Retry, SUPPORTED_SCHEMA, Service,
+    Trigger,
+};
+
+/// A definition parse or validation error.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// TOML syntax or shape is invalid.
+    #[error("invalid TOML: {0}")]
+    Toml(String),
+    /// Schema version is unsupported.
+    #[error("unsupported schema version {found}: this build supports schema {supported}")]
+    UnsupportedSchema {
+        /// Version in the definition.
+        found: u32,
+        /// Version supported by this build.
+        supported: u32,
+    },
+    /// Check names must be unique.
+    #[error("duplicate check name {name:?}")]
+    DuplicateCheckName {
+        /// Repeated name.
+        name: String,
+    },
+    /// Commands are non-empty argv arrays.
+    #[error("check {name:?} has an empty command; provide an argv array")]
+    EmptyCommand {
+        /// Offending check.
+        name: String,
+    },
+    /// A flake regex did not compile.
+    #[error("check {name:?} has invalid flake signature {pattern:?}: {reason}")]
+    InvalidFlakeRegex {
+        /// Offending check.
+        name: String,
+        /// Regex source.
+        pattern: String,
+        /// Regex compiler error.
+        reason: String,
+    },
+    /// Trigger token is unknown.
+    #[error("check {name:?} has unknown trigger {trigger:?}")]
+    UnknownTrigger {
+        /// Offending check.
+        name: String,
+        /// Authored trigger.
+        trigger: String,
+    },
+    /// Cron syntax is invalid.
+    #[error("check {name:?} has invalid cron expression {expression:?}: {reason}")]
+    InvalidCron {
+        /// Offending check.
+        name: String,
+        /// Authored expression.
+        expression: String,
+        /// Validation detail.
+        reason: String,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct RawConfig {
+    meta: Meta,
+    #[serde(default, rename = "check")]
+    checks: Vec<RawCheck>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCheck {
+    name: String,
+    #[serde(default)]
+    class: Option<CheckClass>,
+    #[serde(default)]
+    command: Vec<String>,
+    #[serde(default)]
+    timeout_secs: Option<u64>,
+    #[serde(default)]
+    env: BTreeMap<String, String>,
+    #[serde(default)]
+    services: Vec<Service>,
+    #[serde(default)]
+    cache_paths: Vec<String>,
+    #[serde(default)]
+    retry: Option<RawRetry>,
+    #[serde(default)]
+    triggers: Vec<String>,
+    #[serde(default)]
+    supersede: Option<bool>,
+    #[serde(default)]
+    isolation: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawRetry {
+    #[serde(default)]
+    max: u32,
+    #[serde(default)]
+    flake_signatures: Vec<String>,
+}
+
+const TOP_LEVEL_KEYS: &[&str] = &["meta", "check"];
+const CHECK_KEYS: &[&str] = &[
+    "name",
+    "class",
+    "command",
+    "timeout_secs",
+    "env",
+    "services",
+    "cache_paths",
+    "retry",
+    "triggers",
+    "supersede",
+    "isolation",
+];
+
+/// Parse and validate a definition.
+pub fn parse(source: &str) -> Result<CiConfig, ConfigError> {
+    let table: toml::Table = source
+        .parse()
+        .map_err(|error: toml::de::Error| ConfigError::Toml(error.to_string()))?;
+    let raw: RawConfig =
+        toml::from_str(source).map_err(|error| ConfigError::Toml(error.to_string()))?;
+    if raw.meta.schema != SUPPORTED_SCHEMA {
+        return Err(ConfigError::UnsupportedSchema {
+            found: raw.meta.schema,
+            supported: SUPPORTED_SCHEMA,
+        });
+    }
+
+    let warnings = unknown_key_warnings(&table);
+    let mut names = BTreeSet::new();
+    let mut checks = Vec::with_capacity(raw.checks.len());
+    for raw_check in raw.checks {
+        if !names.insert(raw_check.name.clone()) {
+            return Err(ConfigError::DuplicateCheckName {
+                name: raw_check.name,
+            });
+        }
+        checks.push(validate_check(raw_check)?);
+    }
+    Ok(CiConfig {
+        meta: raw.meta,
+        checks,
+        warnings,
+    })
+}
+
+fn validate_check(raw: RawCheck) -> Result<Check, ConfigError> {
+    if raw.command.is_empty() {
+        return Err(ConfigError::EmptyCommand { name: raw.name });
+    }
+    let retry = raw.retry.unwrap_or_default();
+    for pattern in &retry.flake_signatures {
+        Regex::new(pattern).map_err(|error| ConfigError::InvalidFlakeRegex {
+            name: raw.name.clone(),
+            pattern: pattern.clone(),
+            reason: error.to_string(),
+        })?;
+    }
+    let triggers = raw
+        .triggers
+        .iter()
+        .map(|token| parse_trigger(&raw.name, token))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Check {
+        name: raw.name,
+        class: raw.class.unwrap_or(CheckClass::Required),
+        command: raw.command,
+        timeout_secs: raw.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS),
+        env: raw.env,
+        services: raw.services,
+        cache_paths: raw.cache_paths,
+        retry: Retry {
+            max: retry.max,
+            flake_signatures: retry.flake_signatures,
+        },
+        triggers,
+        supersede: raw.supersede.unwrap_or(true),
+        isolation: raw.isolation,
+    })
+}
+
+fn parse_trigger(name: &str, token: &str) -> Result<Trigger, ConfigError> {
+    match token {
+        "push" => Ok(Trigger::Push),
+        "manual" => Ok(Trigger::Manual),
+        _ => match token.strip_prefix("cron:") {
+            Some(expression) => {
+                validate_cron(name, expression)?;
+                Ok(Trigger::Cron(expression.to_string()))
+            }
+            None => Err(ConfigError::UnknownTrigger {
+                name: name.to_string(),
+                trigger: token.to_string(),
+            }),
+        },
+    }
+}
+
+fn validate_cron(name: &str, expression: &str) -> Result<(), ConfigError> {
+    let fields: Vec<_> = expression.split_whitespace().collect();
+    let valid = fields.len() == 5
+        && fields.iter().all(|field| {
+            !field.is_empty()
+                && field
+                    .bytes()
+                    .all(|byte| byte.is_ascii_digit() || matches!(byte, b'*' | b',' | b'-' | b'/'))
+        });
+    if valid {
+        Ok(())
+    } else {
+        Err(ConfigError::InvalidCron {
+            name: name.to_string(),
+            expression: expression.to_string(),
+            reason: "expected five numeric cron fields using *, comma, dash, or slash".to_string(),
+        })
+    }
+}
+
+fn unknown_key_warnings(table: &toml::Table) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for key in table.keys() {
+        if !TOP_LEVEL_KEYS.contains(&key.as_str()) {
+            warnings.push(format!("unknown top-level key {key:?} (ignored)"));
+        }
+    }
+    if let Some(toml::Value::Array(checks)) = table.get("check") {
+        for check in checks.iter().filter_map(toml::Value::as_table) {
+            let name = check
+                .get("name")
+                .and_then(toml::Value::as_str)
+                .unwrap_or("<unnamed>");
+            for key in check.keys() {
+                if !CHECK_KEYS.contains(&key.as_str()) {
+                    warnings.push(format!("unknown key {key:?} in check {name:?} (ignored)"));
+                }
+            }
+        }
+    }
+    warnings
+}
+
+/// Heddle's canonical typed-blob hash of the raw definition bytes.
+#[must_use]
+pub fn definition_digest(raw: &[u8]) -> String {
+    Blob::from_slice(raw).hash().to_hex()
+}

--- a/crates/ci-config/tests/config.rs
+++ b/crates/ci-config/tests/config.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use ci_config::{CheckClass, ConfigError, Trigger, definition_digest, parse};
+use heddle_object_model::object::Blob;
+
+#[test]
+fn parses_the_treadle_definition_model() {
+    let config = parse(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "build"
+class = "advisory"
+command = ["cargo", "build", "--locked"]
+timeout_secs = 30
+triggers = ["push", "cron:0 2 * * 1"]
+[check.retry]
+max = 1
+flake_signatures = ["dns error"]
+"#,
+    )
+    .unwrap();
+    assert_eq!(config.checks.len(), 1);
+    assert_eq!(config.checks[0].class, CheckClass::Advisory);
+    assert_eq!(config.checks[0].retry.max, 1);
+    assert!(matches!(config.checks[0].triggers[0], Trigger::Push));
+}
+
+#[test]
+fn rejects_duplicate_names_and_empty_argv() {
+    let duplicate = parse(
+        "[meta]\nschema=1\n[[check]]\nname='x'\ncommand=['true']\n[[check]]\nname='x'\ncommand=['true']\n",
+    )
+    .unwrap_err();
+    assert!(matches!(duplicate, ConfigError::DuplicateCheckName { .. }));
+
+    let empty = parse("[meta]\nschema=1\n[[check]]\nname='x'\n").unwrap_err();
+    assert!(matches!(empty, ConfigError::EmptyCommand { .. }));
+}
+
+#[test]
+fn digest_is_the_heddle_blob_hash() {
+    let raw = b"[meta]\nschema = 1\n";
+    assert_eq!(
+        definition_digest(raw),
+        Blob::from_slice(raw).hash().to_hex()
+    );
+}

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "heddle-ci-engine"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+description = "Local check executor for Heddle CI"
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.12" }
+crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
+regex.workspace = true
+tempfile.workspace = true
+thiserror.workspace = true
+wait-timeout.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[lib]
+path = "src/lib.rs"
+name = "ci_engine"

--- a/crates/ci-engine/src/ansi.rs
+++ b/crates/ci-engine/src/ansi.rs
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Apache-2.0
+//! ANSI and terminal-control stripping for untrusted check output.
+
+const ESC: char = '\u{1b}';
+const BEL: char = '\u{07}';
+
+/// Remove CSI, OSC, two-byte escape sequences, and stray controls.
+/// Newlines and tabs are preserved.
+#[must_use]
+pub fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(character) = chars.next() {
+        if character == ESC {
+            consume_escape(&mut chars);
+        } else if !is_strippable_control(character) {
+            output.push(character);
+        }
+    }
+    output
+}
+
+fn consume_escape<I>(chars: &mut std::iter::Peekable<I>)
+where
+    I: Iterator<Item = char>,
+{
+    match chars.peek().copied() {
+        Some('[') => {
+            chars.next();
+            for character in chars.by_ref() {
+                if ('\u{40}'..='\u{7e}').contains(&character) {
+                    break;
+                }
+            }
+        }
+        Some(']') => {
+            chars.next();
+            while let Some(character) = chars.next() {
+                if character == BEL {
+                    break;
+                }
+                if character == ESC {
+                    if chars.peek() == Some(&'\\') {
+                        chars.next();
+                    }
+                    break;
+                }
+            }
+        }
+        Some(character) if ('\u{20}'..='\u{7e}').contains(&character) => {
+            chars.next();
+            if matches!(character, '(' | ')' | '*' | '+' | '%' | '#') {
+                chars.next();
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_strippable_control(character: char) -> bool {
+    (character.is_control() && character != '\n' && character != '\t') || character == '\u{7f}'
+}

--- a/crates/ci-engine/src/body.rs
+++ b/crates/ci-engine/src/body.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Verdict-body assembly from resolved execution facts.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use ci_config::{Check, CheckClass as ConfigCheckClass};
+use crypto::{
+    CI_VERDICT_BODY_SCHEMA_VERSION, CheckClass, CheckDescriptor, CiVerdictBody, Conclusion,
+    Execution, FailureDetail, Outcome, Repro,
+};
+
+use crate::model::ExecutionContext;
+
+pub(crate) struct BodyInputs<'a> {
+    pub(crate) conclusion: Conclusion,
+    pub(crate) failure: Option<FailureDetail>,
+    pub(crate) environment: &'a BTreeMap<String, String>,
+    pub(crate) ran_suites: Vec<String>,
+    pub(crate) skipped_suites: Vec<String>,
+    pub(crate) started_at: String,
+    pub(crate) finished_at: String,
+    pub(crate) duration: Duration,
+}
+
+pub(crate) fn build_body(
+    check: &Check,
+    context: &ExecutionContext,
+    inputs: BodyInputs<'_>,
+) -> CiVerdictBody {
+    let services: Vec<_> = check
+        .services
+        .iter()
+        .map(|service| service.name.clone())
+        .collect();
+    CiVerdictBody {
+        schema_version: CI_VERDICT_BODY_SCHEMA_VERSION,
+        repo: context.repo.clone(),
+        state: context.state.clone(),
+        basis: context.basis.clone(),
+        check: CheckDescriptor {
+            name: check.name.clone(),
+            class: map_class(check.class),
+            definition_digest: context.definition_digest.clone(),
+            command: check.command.clone(),
+            image_digest: context.image_digest.clone(),
+            toolchain: context.toolchain.clone(),
+            params: BTreeMap::new(),
+            services: services.clone(),
+            node_id: None,
+        },
+        outcome: Outcome {
+            conclusion: inputs.conclusion,
+            failure: inputs.failure,
+        },
+        execution: Execution {
+            pick_id: context.pick_id.clone(),
+            attempt: context.attempt,
+            runner: context.runner.clone(),
+            started_at: inputs.started_at,
+            finished_at: inputs.finished_at,
+            duration_ms: u64::try_from(inputs.duration.as_millis()).unwrap_or(u64::MAX),
+            ran_suites: inputs.ran_suites,
+            skipped_suites: inputs.skipped_suites,
+            runner_pool: None,
+            trust_tier: None,
+            isolation_tier: None,
+            materialization_proof: None,
+            secret_grants: Vec::new(),
+        },
+        log: None,
+        repro: Repro {
+            command: check.command.clone(),
+            env: inputs.environment.clone(),
+            image: None,
+            services,
+        },
+        check_set_digest: None,
+    }
+}
+
+fn map_class(class: ConfigCheckClass) -> CheckClass {
+    match class {
+        ConfigCheckClass::Required => CheckClass::Required,
+        ConfigCheckClass::Advisory => CheckClass::Advisory,
+        ConfigCheckClass::Informational => CheckClass::Informational,
+    }
+}

--- a/crates/ci-engine/src/cache.rs
+++ b/crates/ci-engine/src/cache.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Explicit persistent cache-directory exports.
+
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+/// Prefix for every cache-directory environment variable.
+pub const CACHE_ENV_PREFIX: &str = "HCI_CACHE_";
+
+/// Prepared cache slots for one check.
+#[derive(Debug, Clone, Default)]
+pub struct PreparedCaches {
+    /// Environment exports.
+    pub env: BTreeMap<String, String>,
+    /// Directories successfully created.
+    pub dirs: Vec<PathBuf>,
+}
+
+/// Create declared cache slots under `cache_root`.
+/// A failed cache creation degrades to a cold build.
+#[must_use]
+pub fn prepare_caches(paths: &[String], cache_root: &Path) -> PreparedCaches {
+    let mut prepared = PreparedCaches::default();
+    let mut used = BTreeMap::<String, u32>::new();
+    for path in paths {
+        let base = slot_name(path);
+        let slot = match used.get_mut(&base) {
+            Some(count) => {
+                *count += 1;
+                format!("{base}_{count}")
+            }
+            None => {
+                used.insert(base.clone(), 0);
+                base
+            }
+        };
+        let directory = cache_root.join(&slot);
+        if std::fs::create_dir_all(&directory).is_err() {
+            continue;
+        }
+        prepared.env.insert(
+            format!("{CACHE_ENV_PREFIX}{slot}"),
+            directory.display().to_string(),
+        );
+        prepared.dirs.push(directory);
+    }
+    prepared
+}
+
+fn slot_name(path: &str) -> String {
+    let mut output = String::with_capacity(path.len());
+    let mut separated = true;
+    for character in path.chars() {
+        if character.is_ascii_alphanumeric() {
+            output.push(character.to_ascii_uppercase());
+            separated = false;
+        } else if !separated {
+            output.push('_');
+            separated = true;
+        }
+    }
+    while output.ends_with('_') {
+        output.pop();
+    }
+    if output.is_empty() {
+        "CACHE".to_string()
+    } else {
+        output
+    }
+}

--- a/crates/ci-engine/src/classify.rs
+++ b/crates/ci-engine/src/classify.rs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Failure classification and bounded excerpt extraction.
+
+use std::sync::OnceLock;
+
+use crypto::FailureClass;
+use regex::Regex;
+
+/// Maximum bytes stored in a verdict failure excerpt.
+pub const EXCERPT_CAP_BYTES: usize = 4096;
+const CONTEXT_LINES: usize = 6;
+
+/// Terminal process disposition before output classification.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Disposition {
+    /// Process exited successfully.
+    Success,
+    /// Process exited nonzero.
+    Exited(i32),
+    /// Process exceeded its deadline.
+    TimedOut,
+    /// Process could not run or be observed.
+    #[default]
+    InfraError,
+}
+
+fn typed_build_error() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"error\[E\d+\]").expect("valid static regex"))
+}
+
+fn could_not_compile() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| Regex::new(r"error: could not compile").expect("valid static regex"))
+}
+
+fn test_failure() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"test result: FAILED|panicked at|assertion .*failed|\bFAILED\b")
+            .expect("valid static regex")
+    })
+}
+
+fn lint_failure() -> &'static Regex {
+    static REGEX: OnceLock<Regex> = OnceLock::new();
+    REGEX.get_or_init(|| {
+        Regex::new(r"-D warnings|clippy::[a-z_]+|requested on the command line")
+            .expect("valid static regex")
+    })
+}
+
+/// Classify a process result. Disposition always wins over captured text.
+#[must_use]
+pub fn classify(disposition: Disposition, output: &str) -> Option<FailureClass> {
+    match disposition {
+        Disposition::Success => None,
+        Disposition::TimedOut => Some(FailureClass::Timeout),
+        Disposition::InfraError => Some(FailureClass::Infra),
+        Disposition::Exited(_) => Some(classify_output(output)),
+    }
+}
+
+fn classify_output(output: &str) -> FailureClass {
+    if typed_build_error().is_match(output) {
+        FailureClass::Build
+    } else if lint_failure().is_match(output) {
+        FailureClass::Lint
+    } else if could_not_compile().is_match(output) {
+        FailureClass::Build
+    } else {
+        FailureClass::Test
+    }
+}
+
+/// Extract the last causal-looking region and cap it without splitting UTF-8.
+#[must_use]
+pub fn extract_excerpt(output: &str, class: FailureClass) -> String {
+    let lines: Vec<_> = output.lines().collect();
+    let anchor = last_anchor(&lines, class);
+    let excerpt = match anchor {
+        Some(index) => {
+            let start = index.saturating_sub(2);
+            let end = (index + CONTEXT_LINES + 1).min(lines.len());
+            lines[start..end].join("\n")
+        }
+        None => lines[lines.len().saturating_sub(CONTEXT_LINES + 1)..].join("\n"),
+    };
+    cap_bytes(&excerpt, EXCERPT_CAP_BYTES)
+}
+
+fn last_anchor(lines: &[&str], class: FailureClass) -> Option<usize> {
+    let matches_class = |line: &&str| match class {
+        FailureClass::Build => {
+            typed_build_error().is_match(line) || could_not_compile().is_match(line)
+        }
+        FailureClass::Lint => lint_failure().is_match(line),
+        _ => test_failure().is_match(line),
+    };
+    lines
+        .iter()
+        .rposition(matches_class)
+        .or_else(|| lines.iter().rposition(|line| line.contains("error")))
+}
+
+pub(crate) fn cap_bytes(value: &str, cap: usize) -> String {
+    if value.len() <= cap {
+        return value.to_string();
+    }
+    const MARKER: &str = "\n… [excerpt truncated]";
+    let mut end = cap.saturating_sub(MARKER.len());
+    while end > 0 && !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}{MARKER}", &value[..end])
+}

--- a/crates/ci-engine/src/env.rs
+++ b/crates/ci-engine/src/env.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Hermetic check environment construction.
+
+use std::collections::BTreeMap;
+
+/// Host variables needed to locate ordinary POSIX/Rust tooling.
+pub const BASE_ALLOWLIST: &[&str] = &[
+    "PATH",
+    "HOME",
+    "USER",
+    "SHELL",
+    "TERM",
+    "LANG",
+    "LC_ALL",
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+];
+/// Deterministic Git author/committer name.
+pub const GIT_IDENTITY_NAME: &str = "heddle ci";
+/// Deterministic Git author/committer email.
+pub const GIT_IDENTITY_EMAIL: &str = "ci@heddle.invalid";
+
+/// Builder for the exact environment both executed and recorded in `repro`.
+#[derive(Debug, Clone)]
+pub struct HermeticEnv {
+    git_hermetic: bool,
+    host: BTreeMap<String, String>,
+}
+
+impl HermeticEnv {
+    /// Capture the allowed variables from the current process.
+    #[must_use]
+    pub fn new() -> Self {
+        let host = BASE_ALLOWLIST
+            .iter()
+            .filter_map(|name| {
+                std::env::var(name)
+                    .ok()
+                    .map(|value| ((*name).to_string(), value))
+            })
+            .collect();
+        Self {
+            git_hermetic: true,
+            host,
+        }
+    }
+
+    /// Construct from an explicit host map, primarily for tests.
+    #[must_use]
+    pub fn with_host(host: BTreeMap<String, String>) -> Self {
+        Self {
+            git_hermetic: true,
+            host,
+        }
+    }
+
+    /// Enable or disable deterministic Git configuration.
+    #[must_use]
+    pub fn git_hermetic(mut self, enabled: bool) -> Self {
+        self.git_hermetic = enabled;
+        self
+    }
+
+    /// Produce the sorted effective environment.
+    #[must_use]
+    pub fn build(
+        &self,
+        check: &BTreeMap<String, String>,
+        services: &BTreeMap<String, String>,
+        caches: &BTreeMap<String, String>,
+    ) -> BTreeMap<String, String> {
+        let mut output = self.host.clone();
+        if self.git_hermetic {
+            output.insert("GIT_CONFIG_GLOBAL".into(), "/dev/null".into());
+            output.insert("GIT_CONFIG_SYSTEM".into(), "/dev/null".into());
+            output.insert("GIT_AUTHOR_NAME".into(), GIT_IDENTITY_NAME.into());
+            output.insert("GIT_AUTHOR_EMAIL".into(), GIT_IDENTITY_EMAIL.into());
+            output.insert("GIT_COMMITTER_NAME".into(), GIT_IDENTITY_NAME.into());
+            output.insert("GIT_COMMITTER_EMAIL".into(), GIT_IDENTITY_EMAIL.into());
+        }
+        for source in [services, caches, check] {
+            output.extend(
+                source
+                    .iter()
+                    .map(|(key, value)| (key.clone(), value.clone())),
+            );
+        }
+        output
+    }
+}
+
+impl Default for HermeticEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/ci-engine/src/exec.rs
+++ b/crates/ci-engine/src/exec.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Sequential local check orchestration.
+
+use std::{collections::BTreeMap, path::Path, time::Instant};
+
+use ci_config::{Check, CiConfig, Trigger};
+use crypto::{Conclusion, FailureClass};
+
+use crate::{
+    cache::prepare_caches,
+    classify::{Disposition, classify},
+    env::HermeticEnv,
+    model::{AttemptRecord, CheckResult, ExecutionContext, RunControls, RunOptions},
+    proc_group::ProcGroupRegistry,
+    process::{RunOutput, run_process},
+    result::{CompletedRun, finalize, infra_result, skipped_result},
+};
+
+/// Run every check with default controls.
+#[must_use]
+pub fn run_checks(
+    config: &CiConfig,
+    context: &ExecutionContext,
+    options: &RunOptions<'_>,
+) -> Vec<CheckResult> {
+    run_checks_with(config, context, options, &RunControls::default())
+}
+
+/// Run checks with explicit trigger/cache/environment controls.
+#[must_use]
+pub fn run_checks_with(
+    config: &CiConfig,
+    context: &ExecutionContext,
+    options: &RunOptions<'_>,
+    controls: &RunControls<'_>,
+) -> Vec<CheckResult> {
+    let default_environment = HermeticEnv::new();
+    let environment = controls.hermetic_env.unwrap_or(&default_environment);
+    let default_cache_root = options.workdir.join(".hci-cache");
+    let cache_root = controls.cache_root.unwrap_or(&default_cache_root);
+    let resolved = ResolvedRun {
+        options,
+        environment,
+        cache_root,
+        proc_groups: controls.proc_groups.as_ref(),
+    };
+    config
+        .checks
+        .iter()
+        .map(|check| match &controls.trigger {
+            Some(trigger) if !check_runs_for_trigger(&check.triggers, trigger) => {
+                skipped_result(check, context, &resolved)
+            }
+            _ => run_one_check(check, context, &resolved),
+        })
+        .collect()
+}
+
+pub(crate) struct ResolvedRun<'a> {
+    pub(crate) options: &'a RunOptions<'a>,
+    pub(crate) environment: &'a HermeticEnv,
+    pub(crate) cache_root: &'a Path,
+    pub(crate) proc_groups: Option<&'a ProcGroupRegistry>,
+}
+
+fn run_one_check(check: &Check, context: &ExecutionContext, run: &ResolvedRun<'_>) -> CheckResult {
+    let started_at = (run.options.now_rfc3339)();
+    let started = Instant::now();
+    let caches = prepare_caches(&check.cache_paths, run.cache_root);
+    let services = match run.options.services.up(&check.services) {
+        Ok(services) => services,
+        Err(error) => {
+            return infra_result(check, context, run, started_at, started.elapsed(), &error);
+        }
+    };
+    let service_environment = check
+        .services
+        .iter()
+        .flat_map(|service| {
+            service
+                .env
+                .iter()
+                .map(|entry| (entry.0.clone(), entry.1.clone()))
+        })
+        .collect();
+    let environment = run
+        .environment
+        .build(&check.env, &service_environment, &caches.env);
+    let (last, attempts) = run_attempts(check, run, &environment);
+    let _ = run.options.services.down(services);
+    finalize(
+        check,
+        context,
+        CompletedRun {
+            output: last,
+            attempts,
+            environment,
+            started_at,
+            finished_at: (run.options.now_rfc3339)(),
+            duration: started.elapsed(),
+        },
+    )
+}
+
+fn run_attempts(
+    check: &Check,
+    run: &ResolvedRun<'_>,
+    environment: &BTreeMap<String, String>,
+) -> (RunOutput, Vec<AttemptRecord>) {
+    let mut last = RunOutput::default();
+    let mut records = Vec::new();
+    for attempt in 1..=check.retry.max.saturating_add(1) {
+        let started = Instant::now();
+        last = run_process(check, run.options.workdir, environment, run.proc_groups);
+        let flake = last.disposition != Disposition::Success
+            && matches_flake_signature(check, &last.combined_output);
+        records.push(AttemptRecord {
+            attempt,
+            conclusion: disposition_conclusion(last.disposition, &last.combined_output),
+            duration_ms: u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX),
+            flake_matched: flake,
+        });
+        if last.disposition == Disposition::Success || !flake {
+            break;
+        }
+    }
+    (last, records)
+}
+
+fn matches_flake_signature(check: &Check, output: &str) -> bool {
+    check.retry.flake_signatures.iter().any(|pattern| {
+        regex::Regex::new(pattern)
+            .map(|regex| regex.is_match(output))
+            .unwrap_or(false)
+    })
+}
+
+fn disposition_conclusion(disposition: Disposition, output: &str) -> Conclusion {
+    match classify(disposition, output) {
+        None => Conclusion::Success,
+        Some(FailureClass::Timeout) => Conclusion::TimedOut,
+        Some(FailureClass::Infra) => Conclusion::InfraError,
+        Some(_) => Conclusion::Failure,
+    }
+}
+
+fn check_runs_for_trigger(check: &[Trigger], pick: &Trigger) -> bool {
+    if check.is_empty() {
+        return matches!(pick, Trigger::Push);
+    }
+    check.iter().any(|trigger| {
+        matches!(
+            (trigger, pick),
+            (Trigger::Push, Trigger::Push)
+                | (Trigger::Manual, Trigger::Manual)
+                | (Trigger::Cron(_), Trigger::Cron(_))
+        )
+    })
+}

--- a/crates/ci-engine/src/lib.rs
+++ b/crates/ci-engine/src/lib.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Local CI check executor harvested from HeddleCo/treadle.
+
+mod ansi;
+mod body;
+mod cache;
+mod classify;
+mod env;
+mod exec;
+mod model;
+mod proc_group;
+mod process;
+mod result;
+mod service;
+
+pub use ansi::strip_ansi;
+pub use cache::{CACHE_ENV_PREFIX, PreparedCaches, prepare_caches};
+pub use classify::{Disposition, EXCERPT_CAP_BYTES, classify, extract_excerpt};
+pub use env::{BASE_ALLOWLIST, GIT_IDENTITY_EMAIL, GIT_IDENTITY_NAME, HermeticEnv};
+pub use exec::{run_checks, run_checks_with};
+pub use model::{AttemptRecord, CheckResult, ExecutionContext, RunControls, RunOptions};
+pub use proc_group::ProcGroupRegistry;
+pub use service::{
+    CommandOutcome, CommandRunner, DockerProvider, FakeProvider, NoopProvider, RealCommandRunner,
+    RunningServices, ServiceError, ServiceProvider,
+};

--- a/crates/ci-engine/src/model.rs
+++ b/crates/ci-engine/src/model.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Public executor inputs and outputs.
+
+use std::path::Path;
+
+use ci_config::Trigger;
+use crypto::{Basis, CiVerdictBody, Conclusion, StateRef};
+
+use crate::{HermeticEnv, ProcGroupRegistry, ServiceProvider};
+
+/// Facts about the exact state/tree being evaluated.
+#[derive(Debug, Clone)]
+pub struct ExecutionContext {
+    /// Repository identifier.
+    pub repo: String,
+    /// State reference carried in the verdict body.
+    pub state: StateRef,
+    /// Exact evaluated tree and basis.
+    pub basis: Basis,
+    /// Typed-blob digest of the raw definition.
+    pub definition_digest: String,
+    /// Optional toolchain string.
+    pub toolchain: Option<String>,
+    /// Hosted pick id; absent locally.
+    pub pick_id: Option<String>,
+    /// One-based run attempt.
+    pub attempt: u32,
+    /// Hosted runner identity; absent locally.
+    pub runner: Option<String>,
+    /// Immutable image digest, when used.
+    pub image_digest: Option<String>,
+}
+
+/// Stable options for an executor invocation.
+pub struct RunOptions<'a> {
+    /// Directory in which argv executes.
+    pub workdir: &'a Path,
+    /// Service lifecycle provider.
+    pub services: &'a dyn ServiceProvider,
+    /// Injected RFC3339 clock.
+    pub now_rfc3339: &'a dyn Fn() -> String,
+}
+
+/// Additive execution controls.
+#[derive(Default)]
+pub struct RunControls<'a> {
+    /// Optional trigger filter.
+    pub trigger: Option<Trigger>,
+    /// Cache root outside the evaluated source tree.
+    pub cache_root: Option<&'a Path>,
+    /// Optional injected hermetic environment.
+    pub hermetic_env: Option<&'a HermeticEnv>,
+    /// Optional group registry for runner drain.
+    pub proc_groups: Option<ProcGroupRegistry>,
+}
+
+/// Operational record for one flake-retry attempt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttemptRecord {
+    /// One-based attempt index.
+    pub attempt: u32,
+    /// Attempt conclusion.
+    pub conclusion: Conclusion,
+    /// Wall time in milliseconds.
+    pub duration_ms: u64,
+    /// Whether output matched a flake signature.
+    pub flake_matched: bool,
+}
+
+/// One check's verdict body and operational sidecars.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    /// Signable verdict-v2 body.
+    pub body: CiVerdictBody,
+    /// ANSI-stripped combined output.
+    pub combined_output: String,
+    /// Attempts performed.
+    pub attempts: u32,
+    /// Attempt records, not part of the signed body.
+    pub attempt_records: Vec<AttemptRecord>,
+}
+
+impl CheckResult {
+    /// Terminal conclusion.
+    #[must_use]
+    pub fn conclusion(&self) -> Conclusion {
+        self.body.outcome.conclusion
+    }
+
+    /// Whether a successful result needed a flake retry.
+    #[must_use]
+    pub fn recovered_after_flake(&self) -> bool {
+        self.conclusion() == Conclusion::Success
+            && self
+                .attempt_records
+                .iter()
+                .any(|attempt| attempt.flake_matched)
+    }
+}

--- a/crates/ci-engine/src/proc_group.rs
+++ b/crates/ci-engine/src/proc_group.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared registry for hard teardown of live check process groups.
+
+use std::{
+    collections::BTreeSet,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Default, Debug)]
+struct Inner {
+    live: BTreeSet<i32>,
+    torn_down: bool,
+}
+
+/// Concurrency-safe set of process-group ids.
+#[derive(Clone, Default, Debug)]
+pub struct ProcGroupRegistry {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl ProcGroupRegistry {
+    /// Construct an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a group unless teardown already happened.
+    #[must_use]
+    pub fn register_active(&self, process_group: i32) -> bool {
+        let mut inner = self.inner.lock().expect("process-group registry poisoned");
+        if inner.torn_down {
+            false
+        } else {
+            inner.live.insert(process_group);
+            true
+        }
+    }
+
+    /// Remove a reaped group.
+    pub fn unregister(&self, process_group: i32) {
+        self.inner
+            .lock()
+            .expect("process-group registry poisoned")
+            .live
+            .remove(&process_group);
+    }
+
+    /// Number of active groups.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("process-group registry poisoned")
+            .live
+            .len()
+    }
+
+    /// Whether no group is active.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Kill one Unix process group best-effort.
+    #[cfg(unix)]
+    pub fn kill_group(process_group: i32) {
+        // SAFETY: negative pid targets the group created by `process_group(0)`.
+        unsafe {
+            libc::kill(-process_group, libc::SIGKILL);
+        }
+    }
+
+    /// No process groups are created by this engine on non-Unix platforms.
+    #[cfg(not(unix))]
+    pub fn kill_group(_process_group: i32) {}
+
+    /// Kill all active groups and latch teardown.
+    #[cfg(unix)]
+    pub fn kill_all(&self) -> usize {
+        let mut inner = self.inner.lock().expect("process-group registry poisoned");
+        let count = inner.live.len();
+        for process_group in &inner.live {
+            // SAFETY: each id is registered only after spawning a group leader.
+            unsafe {
+                libc::kill(-process_group, libc::SIGKILL);
+            }
+        }
+        inner.live.clear();
+        inner.torn_down = true;
+        count
+    }
+
+    /// Latch teardown on non-Unix platforms.
+    #[cfg(not(unix))]
+    pub fn kill_all(&self) -> usize {
+        let mut inner = self.inner.lock().expect("process-group registry poisoned");
+        inner.live.clear();
+        inner.torn_down = true;
+        0
+    }
+}

--- a/crates/ci-engine/src/process.rs
+++ b/crates/ci-engine/src/process.rs
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic argv execution, bounded capture, and timeout teardown.
+
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    process::{Command, Stdio},
+    time::Duration,
+};
+
+use ci_config::Check;
+use wait_timeout::ChildExt;
+
+use crate::{Disposition, ProcGroupRegistry, strip_ansi};
+
+const MAX_CAPTURE_BYTES: u64 = 16 * 1024 * 1024;
+
+#[derive(Default)]
+pub(crate) struct RunOutput {
+    pub(crate) disposition: Disposition,
+    pub(crate) combined_output: String,
+}
+
+pub(crate) fn run_process(
+    check: &Check,
+    workdir: &std::path::Path,
+    environment: &BTreeMap<String, String>,
+    registry: Option<&ProcGroupRegistry>,
+) -> RunOutput {
+    let Some((program, args)) = check.command.split_first() else {
+        return RunOutput::default();
+    };
+    let mut capture = match tempfile::tempfile() {
+        Ok(file) => file,
+        Err(_) => return RunOutput::default(),
+    };
+    let Ok(stdout) = capture.try_clone() else {
+        return RunOutput::default();
+    };
+    let Ok(stderr) = capture.try_clone() else {
+        return RunOutput::default();
+    };
+
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(workdir)
+        .env_clear()
+        .envs(environment)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(stdout))
+        .stderr(Stdio::from(stderr));
+    set_process_group(&mut command);
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(_) => return RunOutput::default(),
+    };
+    let process_group = child.id() as i32;
+    if registry.is_some_and(|value| !value.register_active(process_group)) {
+        ProcGroupRegistry::kill_group(process_group);
+        let _ = child.wait();
+        return RunOutput::default();
+    }
+
+    let disposition = match child.wait_timeout(Duration::from_secs(check.timeout_secs)) {
+        Ok(Some(status)) if status.success() => Disposition::Success,
+        Ok(Some(status)) => Disposition::Exited(status.code().unwrap_or(-1)),
+        Ok(None) => {
+            kill_process_tree(&mut child);
+            Disposition::TimedOut
+        }
+        Err(_) => {
+            kill_process_tree(&mut child);
+            Disposition::InfraError
+        }
+    };
+    if let Some(value) = registry {
+        value.unregister(process_group);
+    }
+    RunOutput {
+        disposition,
+        combined_output: strip_ansi(&read_capture(&mut capture)),
+    }
+}
+
+#[cfg(unix)]
+fn set_process_group(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    command.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn set_process_group(_command: &mut Command) {}
+
+#[cfg(unix)]
+fn kill_process_tree(child: &mut std::process::Child) {
+    ProcGroupRegistry::kill_group(child.id() as i32);
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(not(unix))]
+fn kill_process_tree(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+fn read_capture(file: &mut File) -> String {
+    let length = file.seek(SeekFrom::End(0)).unwrap_or(0);
+    let truncated = length > MAX_CAPTURE_BYTES;
+    let start = length.saturating_sub(MAX_CAPTURE_BYTES);
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return String::new();
+    }
+    let mut bytes = Vec::new();
+    if file
+        .take(MAX_CAPTURE_BYTES)
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        return String::new();
+    }
+    let mut output = String::from_utf8_lossy(&bytes).into_owned();
+    if truncated {
+        output.insert_str(0, "… [output truncated; showing tail]\n");
+    }
+    output
+}

--- a/crates/ci-engine/src/result.rs
+++ b/crates/ci-engine/src/result.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Verdict result assembly for completed, skipped, and infrastructure runs.
+
+use std::{collections::BTreeMap, time::Duration};
+
+use ci_config::Check;
+use crypto::{Conclusion, FailureClass, FailureDetail};
+
+use crate::{
+    body::{BodyInputs, build_body},
+    classify::{EXCERPT_CAP_BYTES, cap_bytes, classify, extract_excerpt},
+    exec::ResolvedRun,
+    model::{AttemptRecord, CheckResult, ExecutionContext},
+    process::RunOutput,
+    service::ServiceError,
+    strip_ansi,
+};
+
+pub(crate) struct CompletedRun {
+    pub(crate) output: RunOutput,
+    pub(crate) attempts: Vec<AttemptRecord>,
+    pub(crate) environment: BTreeMap<String, String>,
+    pub(crate) started_at: String,
+    pub(crate) finished_at: String,
+    pub(crate) duration: Duration,
+}
+
+pub(crate) fn finalize(
+    check: &Check,
+    context: &ExecutionContext,
+    run: CompletedRun,
+) -> CheckResult {
+    let (conclusion, failure) = failure_from_run(check, &run.output);
+    let body = build_body(
+        check,
+        context,
+        BodyInputs {
+            conclusion,
+            failure,
+            environment: &run.environment,
+            ran_suites: vec![check.name.clone()],
+            skipped_suites: Vec::new(),
+            started_at: run.started_at,
+            finished_at: run.finished_at,
+            duration: run.duration,
+        },
+    );
+    CheckResult {
+        body,
+        combined_output: run.output.combined_output,
+        attempts: run.attempts.len() as u32,
+        attempt_records: run.attempts,
+    }
+}
+
+fn failure_from_run(check: &Check, run: &RunOutput) -> (Conclusion, Option<FailureDetail>) {
+    let Some(class) = classify(run.disposition, &run.combined_output) else {
+        return (Conclusion::Success, None);
+    };
+    let conclusion = match class {
+        FailureClass::Timeout => Conclusion::TimedOut,
+        FailureClass::Infra => Conclusion::InfraError,
+        _ => Conclusion::Failure,
+    };
+    let failure = FailureDetail {
+        class,
+        subclass: None,
+        failing_step: Some(check.name.clone()),
+        excerpt: extract_excerpt(&run.combined_output, class),
+        excerpt_encoding: "utf8".to_string(),
+    };
+    (conclusion, Some(failure))
+}
+
+pub(crate) fn skipped_result(
+    check: &Check,
+    context: &ExecutionContext,
+    run: &ResolvedRun<'_>,
+) -> CheckResult {
+    let at = (run.options.now_rfc3339)();
+    let environment = run
+        .environment
+        .build(&check.env, &BTreeMap::new(), &BTreeMap::new());
+    CheckResult {
+        body: build_body(
+            check,
+            context,
+            BodyInputs {
+                conclusion: Conclusion::Skipped,
+                failure: None,
+                environment: &environment,
+                ran_suites: Vec::new(),
+                skipped_suites: vec![check.name.clone()],
+                started_at: at.clone(),
+                finished_at: at,
+                duration: Duration::ZERO,
+            },
+        ),
+        combined_output: String::new(),
+        attempts: 0,
+        attempt_records: Vec::new(),
+    }
+}
+
+pub(crate) fn infra_result(
+    check: &Check,
+    context: &ExecutionContext,
+    run: &ResolvedRun<'_>,
+    started_at: String,
+    duration: Duration,
+    error: &ServiceError,
+) -> CheckResult {
+    let detail = format!("service provisioning failed: {error}");
+    let excerpt = cap_bytes(&strip_ansi(&detail), EXCERPT_CAP_BYTES);
+    let environment = BTreeMap::new();
+    CheckResult {
+        body: build_body(
+            check,
+            context,
+            BodyInputs {
+                conclusion: Conclusion::InfraError,
+                failure: Some(FailureDetail {
+                    class: FailureClass::Infra,
+                    subclass: Some("service_provisioning".to_string()),
+                    failing_step: Some(check.name.clone()),
+                    excerpt,
+                    excerpt_encoding: "utf8".to_string(),
+                }),
+                environment: &environment,
+                ran_suites: Vec::new(),
+                skipped_suites: Vec::new(),
+                started_at,
+                finished_at: (run.options.now_rfc3339)(),
+                duration,
+            },
+        ),
+        combined_output: detail,
+        attempts: 0,
+        attempt_records: Vec::new(),
+    }
+}

--- a/crates/ci-engine/src/service.rs
+++ b/crates/ci-engine/src/service.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Service-container provisioning boundary harvested from treadle.
+
+mod docker;
+mod fake;
+
+use std::process::Command;
+
+use ci_config::Service;
+pub use docker::DockerProvider;
+pub use fake::FakeProvider;
+use thiserror::Error;
+
+/// Provider handles for services started for one check.
+#[derive(Debug, Default)]
+pub struct RunningServices {
+    /// Provider-specific handles in authored order.
+    pub handles: Vec<String>,
+}
+
+/// Service provisioning failure.
+#[derive(Debug, Error)]
+pub enum ServiceError {
+    /// The selected provider cannot run the requested service.
+    #[error(
+        "service container {name:?} ({image}) requested, but this provider cannot run services"
+    )]
+    Unsupported {
+        /// Authored service name.
+        name: String,
+        /// Authored image.
+        image: String,
+    },
+    /// Container startup failed.
+    #[error("service provisioning failed: {0}")]
+    Provision(String),
+    /// Readiness deadline expired.
+    #[error("service {name:?} ({image}) did not become ready within {timeout_secs}s")]
+    NotReady {
+        /// Authored service name.
+        name: String,
+        /// Authored image.
+        image: String,
+        /// Elapsed readiness deadline.
+        timeout_secs: u64,
+    },
+}
+
+/// Service lifecycle provider used by the executor.
+pub trait ServiceProvider {
+    /// Start all requested services.
+    fn up(&self, services: &[Service]) -> Result<RunningServices, ServiceError>;
+    /// Stop services from one successful `up` call.
+    fn down(&self, running: RunningServices) -> Result<(), ServiceError>;
+}
+
+/// Provider for local mode: no implicit container runtime.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct NoopProvider;
+
+impl ServiceProvider for NoopProvider {
+    fn up(&self, services: &[Service]) -> Result<RunningServices, ServiceError> {
+        match services.first() {
+            Some(service) => Err(ServiceError::Unsupported {
+                name: service.name.clone(),
+                image: service.image.clone(),
+            }),
+            None => Ok(RunningServices::default()),
+        }
+    }
+
+    fn down(&self, _running: RunningServices) -> Result<(), ServiceError> {
+        Ok(())
+    }
+}
+
+/// Captured outcome of one external runtime command.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandOutcome {
+    /// Whether the command exited successfully.
+    pub success: bool,
+    /// Combined diagnostic text.
+    pub output: String,
+}
+
+/// Boundary around external container-runtime commands.
+pub trait CommandRunner: Send + Sync {
+    /// Run one argv.
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome, ServiceError>;
+}
+
+/// Real external-command boundary used by [`DockerProvider`].
+#[derive(Debug, Clone, Copy, Default)]
+pub struct RealCommandRunner;
+
+impl CommandRunner for RealCommandRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome, ServiceError> {
+        let output = Command::new(program)
+            .args(args)
+            .output()
+            .map_err(|error| ServiceError::Provision(format!("spawn {program}: {error}")))?;
+        let mut text = String::from_utf8_lossy(&output.stdout).into_owned();
+        text.push_str(&String::from_utf8_lossy(&output.stderr));
+        Ok(CommandOutcome {
+            success: output.status.success(),
+            output: text,
+        })
+    }
+}

--- a/crates/ci-engine/src/service/docker.rs
+++ b/crates/ci-engine/src/service/docker.rs
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Docker CLI implementation of the treadle service boundary.
+
+use std::{
+    net::{SocketAddr, TcpStream},
+    time::{Duration, Instant},
+};
+
+use ci_config::Service;
+
+use super::{CommandRunner, RealCommandRunner, RunningServices, ServiceError, ServiceProvider};
+
+const DEFAULT_HEALTH_TIMEOUT_SECS: u64 = 60;
+const READINESS_POLL: Duration = Duration::from_millis(500);
+const TCP_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Docker-CLI provider. Local CLI does not select this automatically.
+pub struct DockerProvider {
+    job: String,
+    runner: Box<dyn CommandRunner>,
+    health_timeout_secs: u64,
+    skip_readiness: bool,
+}
+
+impl std::fmt::Debug for DockerProvider {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("DockerProvider")
+            .field("job", &self.job)
+            .field("health_timeout_secs", &self.health_timeout_secs)
+            .field("skip_readiness", &self.skip_readiness)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DockerProvider {
+    /// Construct a Docker provider for one job namespace.
+    #[must_use]
+    pub fn new(job: impl Into<String>) -> Self {
+        Self {
+            job: job.into(),
+            runner: Box::new(RealCommandRunner),
+            health_timeout_secs: DEFAULT_HEALTH_TIMEOUT_SECS,
+            skip_readiness: false,
+        }
+    }
+
+    /// Inject the external-command boundary and skip real-clock readiness.
+    #[must_use]
+    pub fn with_runner(job: impl Into<String>, runner: Box<dyn CommandRunner>) -> Self {
+        Self {
+            job: job.into(),
+            runner,
+            health_timeout_secs: DEFAULT_HEALTH_TIMEOUT_SECS,
+            skip_readiness: true,
+        }
+    }
+
+    /// Override the per-service readiness timeout.
+    #[must_use]
+    pub fn health_timeout_secs(mut self, seconds: u64) -> Self {
+        self.health_timeout_secs = seconds;
+        self
+    }
+
+    fn container_name(&self, service: &Service) -> String {
+        format!("hci-{}-{}", self.job, service.name)
+    }
+
+    fn run_args(&self, service: &Service) -> Vec<String> {
+        let mut args = vec![
+            "run".to_string(),
+            "-d".to_string(),
+            "--name".to_string(),
+            self.container_name(service),
+        ];
+        for port in &service.ports {
+            args.extend(["-p".to_string(), format!("{port}:{port}")]);
+        }
+        for (key, value) in &service.env {
+            args.extend(["-e".to_string(), format!("{key}={value}")]);
+        }
+        args.push(service.image.clone());
+        args
+    }
+
+    fn await_ready(&self, service: &Service) -> Result<(), ServiceError> {
+        if self.skip_readiness {
+            return Ok(());
+        }
+        let deadline = Instant::now() + Duration::from_secs(self.health_timeout_secs);
+        loop {
+            if self.probe_ready(service) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(ServiceError::NotReady {
+                    name: service.name.clone(),
+                    image: service.image.clone(),
+                    timeout_secs: self.health_timeout_secs,
+                });
+            }
+            std::thread::sleep(READINESS_POLL);
+        }
+    }
+
+    fn probe_ready(&self, service: &Service) -> bool {
+        match &service.ready_cmd {
+            Some(command) if !command.is_empty() => {
+                let mut args = vec!["exec".to_string(), self.container_name(service)];
+                args.extend(command.iter().cloned());
+                self.runner
+                    .run("docker", &args)
+                    .map(|outcome| outcome.success)
+                    .unwrap_or(false)
+            }
+            _ => service.ports.first().is_none_or(|port| tcp_probe(*port)),
+        }
+    }
+
+    fn teardown(&self, names: &[String]) {
+        for name in names {
+            let _ = self.runner.run(
+                "docker",
+                &["rm".to_string(), "-f".to_string(), name.clone()],
+            );
+        }
+    }
+}
+
+fn tcp_probe(port: u16) -> bool {
+    let address = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&address, TCP_PROBE_TIMEOUT).is_ok()
+}
+
+impl ServiceProvider for DockerProvider {
+    fn up(&self, services: &[Service]) -> Result<RunningServices, ServiceError> {
+        let mut started = Vec::new();
+        for service in services {
+            let name = self.container_name(service);
+            let outcome = self.runner.run("docker", &self.run_args(service))?;
+            if !outcome.success {
+                self.teardown(&started);
+                return Err(ServiceError::Provision(format!(
+                    "`docker run` for service {:?} failed: {}",
+                    service.name,
+                    outcome.output.trim()
+                )));
+            }
+            started.push(name);
+            if let Err(error) = self.await_ready(service) {
+                self.teardown(&started);
+                return Err(error);
+            }
+        }
+        Ok(RunningServices { handles: started })
+    }
+
+    fn down(&self, running: RunningServices) -> Result<(), ServiceError> {
+        self.teardown(&running.handles);
+        Ok(())
+    }
+}

--- a/crates/ci-engine/src/service/fake.rs
+++ b/crates/ci-engine/src/service/fake.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Recording command boundary for service-provider tests.
+
+use std::sync::Mutex;
+
+use super::{CommandOutcome, CommandRunner, ServiceError};
+
+/// A recording command runner with configurable `docker run` failure.
+#[derive(Debug)]
+pub struct FakeProvider {
+    calls: Mutex<Vec<Vec<String>>>,
+    fail_run_at: Option<usize>,
+    run_count: Mutex<usize>,
+}
+
+impl FakeProvider {
+    /// Construct a recorder whose calls all succeed.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            fail_run_at: None,
+            run_count: Mutex::new(0),
+        }
+    }
+
+    /// Construct a recorder whose first `docker run` fails.
+    #[must_use]
+    pub fn failing() -> Self {
+        Self::failing_run_at(1)
+    }
+
+    /// Construct a recorder whose one-based `docker run` number fails.
+    #[must_use]
+    pub fn failing_run_at(number: usize) -> Self {
+        Self {
+            calls: Mutex::new(Vec::new()),
+            fail_run_at: Some(number),
+            run_count: Mutex::new(0),
+        }
+    }
+
+    /// Snapshot every recorded full argv.
+    #[must_use]
+    pub fn calls(&self) -> Vec<Vec<String>> {
+        self.calls.lock().expect("calls mutex poisoned").clone()
+    }
+}
+
+impl Default for FakeProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CommandRunner for FakeProvider {
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome, ServiceError> {
+        let mut call = Vec::with_capacity(args.len() + 1);
+        call.push(program.to_string());
+        call.extend(args.iter().cloned());
+        let success = if args.first().map(String::as_str) == Some("run") {
+            let mut count = self.run_count.lock().expect("run-count mutex poisoned");
+            *count += 1;
+            self.fail_run_at != Some(*count)
+        } else {
+            true
+        };
+        self.calls.lock().expect("calls mutex poisoned").push(call);
+        Ok(CommandOutcome {
+            success,
+            output: if success {
+                String::new()
+            } else {
+                "fake failure".to_string()
+            },
+        })
+    }
+}

--- a/crates/ci-engine/tests/executor.rs
+++ b/crates/ci-engine/tests/executor.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+
+use ci_engine::{
+    ExecutionContext, HermeticEnv, NoopProvider, RunControls, RunOptions, run_checks,
+    run_checks_with,
+};
+use crypto::{Basis, BasisKind, Conclusion, FailureClass, StateRef};
+
+fn context() -> ExecutionContext {
+    ExecutionContext {
+        repo: "test/repo".to_string(),
+        state: StateRef {
+            content_hash: "state-content".to_string(),
+            change_id: "change".to_string(),
+            logical_change_id: None,
+        },
+        basis: Basis {
+            kind: BasisKind::Branch,
+            evaluated_tree_digest: "tree".to_string(),
+        },
+        definition_digest: "definition".to_string(),
+        toolchain: None,
+        pick_id: None,
+        attempt: 1,
+        runner: None,
+        image_digest: None,
+    }
+}
+
+fn fixed_clock() -> String {
+    "2026-08-14T12:00:00Z".to_string()
+}
+
+fn run(raw: &str, workdir: &std::path::Path) -> Vec<ci_engine::CheckResult> {
+    let config = ci_config::parse(raw).expect("config");
+    let provider = NoopProvider;
+    run_checks(
+        &config,
+        &context(),
+        &RunOptions {
+            workdir,
+            services: &provider,
+            now_rfc3339: &fixed_clock,
+        },
+    )
+}
+
+#[test]
+fn executes_argv_and_classifies_treadle_failure_shapes() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let results = run(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "ok"
+command = ['/bin/sh', '-c', 'printf "\033[32mok\033[0m"']
+[[check]]
+name = "compile"
+command = ["/bin/sh", "-c", "echo 'error[E0432]: unresolved import'; exit 101"]
+"#,
+        workdir.path(),
+    );
+    assert_eq!(results[0].conclusion(), Conclusion::Success);
+    assert_eq!(results[0].combined_output, "ok");
+    assert_eq!(results[1].conclusion(), Conclusion::Failure);
+    assert_eq!(
+        results[1]
+            .body
+            .outcome
+            .failure
+            .as_ref()
+            .map(|failure| failure.class),
+        Some(FailureClass::Build)
+    );
+}
+
+#[test]
+fn retries_only_when_output_matches_a_flake_signature() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let config = ci_config::parse(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "flaky"
+command = ["/bin/sh", "-c", "if test -e retry-marker; then exit 0; else : > retry-marker; echo FLAKE; exit 1; fi"]
+[check.retry]
+max = 1
+flake_signatures = ["FLAKE"]
+"#,
+    )
+    .expect("config");
+    let provider = NoopProvider;
+    let environment = HermeticEnv::with_host(BTreeMap::new());
+    let controls = RunControls {
+        hermetic_env: Some(&environment),
+        ..RunControls::default()
+    };
+    let results = run_checks_with(
+        &config,
+        &context(),
+        &RunOptions {
+            workdir: workdir.path(),
+            services: &provider,
+            now_rfc3339: &fixed_clock,
+        },
+        &controls,
+    );
+    assert_eq!(results[0].conclusion(), Conclusion::Success);
+    assert_eq!(results[0].attempts, 2);
+    assert!(results[0].recovered_after_flake());
+}
+
+#[test]
+fn unsupported_local_service_is_an_honest_infra_verdict() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let results = run(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "database"
+command = ["/bin/true"]
+[[check.services]]
+name = "postgres"
+image = "postgres:17"
+"#,
+        workdir.path(),
+    );
+    assert_eq!(results[0].conclusion(), Conclusion::InfraError);
+    let failure = results[0].body.outcome.failure.as_ref().expect("failure");
+    assert_eq!(failure.class, FailureClass::Infra);
+    assert_eq!(failure.subclass.as_deref(), Some("service_provisioning"));
+}
+
+#[test]
+fn cache_environment_points_outside_the_source_tree() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = tempfile::tempdir().expect("cache");
+    let config = ci_config::parse(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "cache"
+command = ["/usr/bin/env"]
+cache_paths = ["cargo"]
+"#,
+    )
+    .expect("config");
+    let expected = cache.path().join("CARGO").display().to_string();
+    let environment = HermeticEnv::with_host(BTreeMap::from([("EXPECTED".to_string(), expected)]));
+    let provider = NoopProvider;
+    let controls = RunControls {
+        cache_root: Some(cache.path()),
+        hermetic_env: Some(&environment),
+        ..RunControls::default()
+    };
+    let results = run_checks_with(
+        &config,
+        &context(),
+        &RunOptions {
+            workdir: workdir.path(),
+            services: &provider,
+            now_rfc3339: &fixed_clock,
+        },
+        &controls,
+    );
+    assert_eq!(results[0].conclusion(), Conclusion::Success);
+    assert!(
+        results[0]
+            .combined_output
+            .lines()
+            .any(|line| line == format!("HCI_CACHE_CARGO={}", cache.path().join("CARGO").display()))
+    );
+}
+
+#[test]
+fn failure_excerpt_is_utf8_safe_and_capped() {
+    let output = "error[E0001]: ".to_string() + &"é".repeat(3_000);
+    let excerpt = ci_engine::extract_excerpt(&output, FailureClass::Build);
+    assert!(excerpt.len() <= ci_engine::EXCERPT_CAP_BYTES);
+    assert!(excerpt.is_char_boundary(excerpt.len()));
+    assert!(excerpt.ends_with("[excerpt truncated]"));
+}
+
+#[cfg(unix)]
+#[test]
+fn timeout_kills_the_entire_process_group() {
+    use std::time::Duration;
+
+    let workdir = tempfile::tempdir().expect("workdir");
+    let pidfile = workdir.path().join("grandchild.pid");
+    let config = format!(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "timeout"
+command = ["/bin/sh", "-c", "/bin/sleep 120 & echo $! > '{}'; /bin/sleep 120"]
+timeout_secs = 1
+"#,
+        pidfile.display()
+    );
+    let results = run(&config, workdir.path());
+    assert_eq!(results[0].conclusion(), Conclusion::TimedOut);
+    let pid: i32 = std::fs::read_to_string(&pidfile)
+        .expect("grandchild pid")
+        .trim()
+        .parse()
+        .expect("numeric pid");
+    std::thread::sleep(Duration::from_millis(300));
+    // SAFETY: signal zero only checks whether the recorded process still exists.
+    let alive = unsafe { libc::kill(pid, 0) } == 0;
+    if alive {
+        // SAFETY: cleanup is limited to the exact child pid recorded by the test.
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+        panic!("grandchild {pid} survived the timeout process-group kill");
+    }
+}

--- a/crates/ci-engine/tests/service.rs
+++ b/crates/ci-engine/tests/service.rs
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use ci_config::Service;
+use ci_engine::{
+    CommandOutcome, CommandRunner, DockerProvider, FakeProvider, ServiceError, ServiceProvider,
+};
+
+struct SharedRunner(Arc<FakeProvider>);
+
+impl CommandRunner for SharedRunner {
+    fn run(&self, program: &str, args: &[String]) -> Result<CommandOutcome, ServiceError> {
+        self.0.run(program, args)
+    }
+}
+
+fn postgres() -> Service {
+    Service {
+        name: "db".to_string(),
+        image: "postgres:17".to_string(),
+        ports: vec![5432],
+        env: BTreeMap::from([
+            ("POSTGRES_DB".to_string(), "heddle".to_string()),
+            ("POSTGRES_PASSWORD".to_string(), "postgres".to_string()),
+        ]),
+        ready_cmd: Some(vec!["pg_isready".to_string()]),
+    }
+}
+
+#[test]
+fn docker_boundary_preserves_treadle_run_and_teardown_argv() {
+    let recorder = Arc::new(FakeProvider::new());
+    let provider = DockerProvider::with_runner("local", Box::new(SharedRunner(recorder.clone())));
+    let running = provider.up(&[postgres()]).expect("service starts");
+    assert_eq!(running.handles, ["hci-local-db"]);
+
+    provider.down(running).expect("service stops");
+    let calls = recorder.calls();
+    assert_eq!(
+        calls[0],
+        [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            "hci-local-db",
+            "-p",
+            "5432:5432",
+            "-e",
+            "POSTGRES_DB=heddle",
+            "-e",
+            "POSTGRES_PASSWORD=postgres",
+            "postgres:17",
+        ]
+    );
+    assert_eq!(
+        calls[1],
+        ["docker", "rm", "-f", "hci-local-db"],
+        "teardown is best effort but must issue docker rm -f"
+    );
+}
+
+#[test]
+fn docker_boundary_rolls_back_started_services() {
+    let mut redis = postgres();
+    redis.name = "cache".to_string();
+    redis.image = "redis:8".to_string();
+    redis.ports = vec![6379];
+    redis.env.clear();
+
+    let recorder = Arc::new(FakeProvider::failing_run_at(2));
+    let provider = DockerProvider::with_runner("local", Box::new(SharedRunner(recorder.clone())));
+    let error = provider
+        .up(&[postgres(), redis])
+        .expect_err("second service fails");
+    assert!(matches!(error, ServiceError::Provision(_)));
+    assert!(
+        recorder
+            .calls()
+            .iter()
+            .any(|call| call == &["docker", "rm", "-f", "hci-local-db"])
+    );
+}

--- a/crates/cli-args/src/cli/cli_args/commands_ci.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_ci.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Local CI executor arguments.
+
+use std::path::PathBuf;
+
+use clap::{Args, Subcommand};
+
+/// CI executor subcommands.
+#[derive(Clone, Debug, Subcommand)]
+pub enum CiCommands {
+    /// Run the configured checks against a local working tree or state.
+    Run(CiRunArgs),
+}
+
+/// Arguments for `heddle ci run`.
+#[derive(Clone, Debug, Args)]
+pub struct CiRunArgs {
+    /// Select the local, device-signed executor.
+    #[arg(long, required = true)]
+    pub local: bool,
+
+    /// Evaluate an immutable state instead of the current working tree.
+    #[arg(long, value_name = "STATE")]
+    pub state: Option<String>,
+
+    /// Read a CI definition from this path instead of `.heddle/ci.toml`.
+    #[arg(long, value_name = "PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Run only this named check; may be repeated.
+    #[arg(long = "check", value_name = "NAME")]
+    pub checks: Vec<String>,
+}

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -8,7 +8,7 @@ use super::AuthCommands;
 #[cfg(feature = "semantic")]
 use super::SemanticCommands;
 use super::{
-    AgentCommands, CompletionSubject, ContextCommands, DiscussCommands, HookCommands,
+    AgentCommands, CiCommands, CompletionSubject, ContextCommands, DiscussCommands, HookCommands,
     IntegrationCommands, OplogCommands, QueryArgs, RedactCommands, RemoteCommands, ReviewCommands,
     ShellCommands, ThreadCommands, VisibilityCommands,
     commands_args::{
@@ -214,6 +214,12 @@ Heddle options must appear before `--`. Everything after `--` is passed unchange
     /// for `run` when you already have a thread and just need to exec
     /// inside it.
     Run(RunArgs),
+
+    /// Run Heddle CI checks.
+    Ci {
+        #[command(subcommand)]
+        command: CiCommands,
+    },
 
     /// Automation/workflow command: refresh the current thread onto its target when safe.
     Sync(SyncArgs),

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -4,6 +4,7 @@
 mod cli_base;
 mod commands_agent;
 mod commands_args;
+mod commands_ci;
 #[cfg(feature = "client")]
 mod commands_client;
 mod commands_context;
@@ -48,6 +49,7 @@ pub use commands_args::{
     TimelineRecordToolArgs, TimelineRecoverArgs, TimelineResetArgs, TimelineStatusArgs,
     TimelineTargetArgs, TryArgs, UndoArgs, WatchArgs, WorkspaceModeArg,
 };
+pub use commands_ci::{CiCommands, CiRunArgs};
 #[cfg(feature = "client")]
 pub use commands_client::{AgentTemplateArg, AuthCommands, AuthTrustCommands};
 pub use commands_context::ContextCommands;

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -908,6 +908,12 @@ const EXTERNAL_WORKTREE_COMMAND: CommandContract = CommandContract {
     ..EXTERNAL_COMMAND_MUTATION
 };
 
+const CI_RUN: CommandContract = CommandContract {
+    supports_json: true,
+    json_kind: "json",
+    ..EXTERNAL_WORKTREE_COMMAND
+};
+
 const EXTERNAL_WORKTREE_MUTATION: CommandContract = CommandContract {
     external_command: true,
     ..WORKTREE_MUTATION
@@ -1166,6 +1172,11 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ),
             210,
         ),
+    ),
+    entry(&["ci"], surface(GROUP, "automation")),
+    entry(
+        &["ci", "run"],
+        surface(opaque_schemas(CI_RUN, &["ci run"]), "automation"),
     ),
     entry(&["agent"], surface(GROUP, "automation")),
     entry(
@@ -4521,6 +4532,9 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         Commands::Start(_) => vec!["start"],
         Commands::Try(_) => vec!["try"],
         Commands::Run(_) => vec!["run"],
+        Commands::Ci { command } => match command {
+            heddle_cli_args::CiCommands::Run(_) => vec!["ci", "run"],
+        },
         Commands::Sync(args) => {
             #[cfg(feature = "git-overlay")]
             {

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -26,6 +26,7 @@ struct RuntimeContractParseSample {
 const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["abort"], &["abort"]),
     sample(&["adopt"], &["adopt"]),
+    sample(&["ci", "run"], &["ci", "run", "--local"]),
     sample(
         &["agent", "presence", "list"],
         &["agent", "presence", "list"],

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,6 +24,8 @@ biscuit-auth = { workspace = true, optional = true }
 blake3.workspace = true
 bytes = { workspace = true, optional = true }
 chrono.workspace = true
+ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.12" }
+ci-engine = { path = "../ci-engine", package = "heddle-ci-engine", version = "0.12" }
 clap.workspace = true
 clap_complete.workspace = true
 futures.workspace = true

--- a/crates/cli/src/cli/commands/ci/mod.rs
+++ b/crates/cli/src/cli/commands/ci/mod.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+//! `heddle ci` local executor.
+
+mod render;
+mod run;
+mod target;
+
+use anyhow::Result;
+use heddle_cli_args::{CiCommands, Cli};
+
+/// Dispatch a CI subcommand.
+pub fn cmd_ci(cli: &Cli, command: &CiCommands) -> Result<()> {
+    match command {
+        CiCommands::Run(args) => run::run_local(cli, args),
+    }
+}

--- a/crates/cli/src/cli/commands/ci/render.rs
+++ b/crates/cli/src/cli/commands/ci/render.rs
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Machine and operator rendering for signed local verdicts.
+
+use std::fmt::Write as _;
+
+use anyhow::Result;
+use crypto::{CheckClass, Conclusion, SignedVerdict};
+
+use crate::cli::{
+    Cli,
+    render::{write_json_stdout, write_stdout},
+    should_output_json,
+};
+
+pub(crate) fn render(cli: &Cli, verdicts: &[SignedVerdict]) -> Result<()> {
+    if should_output_json(cli, None) {
+        write_json_stdout(&verdicts)
+    } else {
+        write_stdout(&render_table(verdicts))
+    }
+}
+
+pub(crate) fn non_passing_advisory(verdicts: &[SignedVerdict]) -> Vec<&str> {
+    verdicts
+        .iter()
+        .filter(|verdict| {
+            verdict.body.check.class != CheckClass::Required
+                && is_failing(verdict.body.outcome.conclusion)
+        })
+        .map(|verdict| verdict.body.check.name.as_str())
+        .collect()
+}
+
+pub(crate) fn has_required_failure(verdicts: &[SignedVerdict]) -> bool {
+    verdicts.iter().any(|verdict| {
+        verdict.body.check.class == CheckClass::Required
+            && is_failing(verdict.body.outcome.conclusion)
+    })
+}
+
+fn is_failing(conclusion: Conclusion) -> bool {
+    matches!(
+        conclusion,
+        Conclusion::Failure | Conclusion::TimedOut | Conclusion::InfraError
+    )
+}
+
+fn render_table(verdicts: &[SignedVerdict]) -> String {
+    let rows: Vec<_> = verdicts.iter().map(Row::new).collect();
+    let headers = ["CHECK", "CLASS", "CONCLUSION", "DURATION", "FAILING STEP"];
+    let mut widths = headers.map(str::len);
+    for row in &rows {
+        for (index, value) in row.values().iter().enumerate() {
+            widths[index] = widths[index].max(value.len());
+        }
+    }
+    let mut output = String::new();
+    write_row(&mut output, &widths, headers);
+    for row in &rows {
+        let values = row.values();
+        write_row(&mut output, &widths, values.map(|value| value.as_str()));
+    }
+    output
+}
+
+fn write_row(output: &mut String, widths: &[usize; 5], values: [&str; 5]) {
+    for (index, value) in values.iter().enumerate() {
+        if index + 1 == values.len() {
+            let _ = write!(output, "{value}");
+        } else {
+            let _ = write!(output, "{value:<width$}  ", width = widths[index]);
+        }
+    }
+    output.push('\n');
+}
+
+struct Row {
+    check: String,
+    class: String,
+    conclusion: String,
+    duration: String,
+    failing_step: String,
+}
+
+impl Row {
+    fn new(verdict: &SignedVerdict) -> Self {
+        let body = &verdict.body;
+        Self {
+            check: body.check.name.clone(),
+            class: class_name(body.check.class).to_string(),
+            conclusion: conclusion_name(body.outcome.conclusion).to_string(),
+            duration: format_duration(body.execution.duration_ms),
+            failing_step: body
+                .outcome
+                .failure
+                .as_ref()
+                .and_then(|failure| failure.failing_step.clone())
+                .unwrap_or_default(),
+        }
+    }
+
+    fn values(&self) -> [&String; 5] {
+        [
+            &self.check,
+            &self.class,
+            &self.conclusion,
+            &self.duration,
+            &self.failing_step,
+        ]
+    }
+}
+
+fn class_name(class: CheckClass) -> &'static str {
+    match class {
+        CheckClass::Required => "required",
+        CheckClass::Advisory => "advisory",
+        CheckClass::Informational => "informational",
+    }
+}
+
+fn conclusion_name(conclusion: Conclusion) -> &'static str {
+    match conclusion {
+        Conclusion::Success => "success",
+        Conclusion::Failure => "failure",
+        Conclusion::Cancelled => "cancelled",
+        Conclusion::Skipped => "skipped",
+        Conclusion::TimedOut => "timed_out",
+        Conclusion::InfraError => "infra_error",
+    }
+}
+
+fn format_duration(milliseconds: u64) -> String {
+    if milliseconds < 1_000 {
+        return format!("{milliseconds}ms");
+    }
+    let seconds = milliseconds / 1_000;
+    if seconds < 60 {
+        return format!("{}.{:01}s", seconds, (milliseconds % 1_000) / 100);
+    }
+    format!("{}m{:02}s", seconds / 60, seconds % 60)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duration_formats_match_treadle_surface() {
+        assert_eq!(format_duration(850), "850ms");
+        assert_eq!(format_duration(3_400), "3.4s");
+        assert_eq!(format_duration(125_000), "2m05s");
+    }
+}

--- a/crates/cli/src/cli/commands/ci/run.rs
+++ b/crates/cli/src/cli/commands/ci/run.rs
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: Apache-2.0
+//! End-to-end local CI execution and verdict signing.
+
+use std::process::Command;
+
+use anyhow::{Context, Result, ensure};
+use chrono::{SecondsFormat, Utc};
+use ci_config::CiConfig;
+use ci_engine::{
+    BASE_ALLOWLIST, ExecutionContext, NoopProvider, RunControls, RunOptions, run_checks_with,
+};
+use crypto::{
+    Basis, BasisKind, Ed25519Signer, SignedVerdict, Signer, SignerKind, StateRef,
+    signed_verdict_from_signer,
+};
+use heddle_cli_args::{CiRunArgs, Cli};
+use repo::Repository;
+
+use super::{
+    render,
+    target::{EvaluationTarget, config_path},
+};
+use crate::exit::OutcomeExit;
+
+pub(crate) fn run_local(cli: &Cli, args: &CiRunArgs) -> Result<()> {
+    ensure!(args.local, "`heddle ci run` currently requires `--local`");
+    let repo = cli.open_repo()?;
+    let path = config_path(&repo, args.config.as_deref());
+    let raw =
+        std::fs::read(&path).with_context(|| format!("read CI definition {}", path.display()))?;
+    let text = std::str::from_utf8(&raw)
+        .with_context(|| format!("CI definition {} is not UTF-8", path.display()))?;
+    let definition_digest = ci_config::definition_digest(&raw);
+    let mut config = ci_config::parse(text)
+        .with_context(|| format!("parse CI definition {}", path.display()))?;
+    apply_check_filter(&mut config, &args.checks)?;
+    let signer = load_device_signer()?;
+    let mut target = EvaluationTarget::prepare(&repo, args.state.as_deref())?;
+
+    let context = execution_context(&repo, &target, definition_digest);
+    let provider = NoopProvider;
+    let now = now_rfc3339;
+    let options = RunOptions {
+        workdir: &target.workdir,
+        services: &provider,
+        now_rfc3339: &now,
+    };
+    let cache_root = repo.heddle_dir().join("cache/ci");
+    let controls = RunControls {
+        cache_root: Some(&cache_root),
+        ..RunControls::default()
+    };
+    let results = run_checks_with(&config, &context, &options, &controls);
+    target.ensure_unchanged(&repo)?;
+    target.cleanup(&repo)?;
+
+    let verdicts = sign_results(results, &target, &signer)?;
+    for warning in &config.warnings {
+        eprintln!("heddle ci: warning: {warning}");
+    }
+    render::render(cli, &verdicts)?;
+    eprintln!("heddle ci: ran {}", path.display());
+    let advisory = render::non_passing_advisory(&verdicts);
+    if !advisory.is_empty() {
+        eprintln!(
+            "heddle ci: warning: {} advisory check(s) did not pass (not gating): {}",
+            advisory.len(),
+            advisory.join(", ")
+        );
+    }
+    if render::has_required_failure(&verdicts) {
+        return Err(OutcomeExit::data_err().into());
+    }
+    Ok(())
+}
+
+fn apply_check_filter(config: &mut CiConfig, filter: &[String]) -> Result<()> {
+    if filter.is_empty() {
+        return Ok(());
+    }
+    let available: Vec<_> = config
+        .checks
+        .iter()
+        .map(|check| check.name.clone())
+        .collect();
+    for name in filter {
+        ensure!(
+            available.contains(name),
+            "no check named {name:?}; available checks: {}",
+            available.join(", ")
+        );
+    }
+    config.checks.retain(|check| filter.contains(&check.name));
+    Ok(())
+}
+
+fn load_device_signer() -> Result<Ed25519Signer> {
+    let path = repo::identity::device_identity_path();
+    let device = repo::identity::load_device(&path)
+        .with_context(|| format!("load device identity {}", path.display()))?
+        .with_context(|| {
+            format!(
+                "no linked device identity at {}; run `heddle auth login` first",
+                path.display()
+            )
+        })?;
+    let signer = Ed25519Signer::from_pem(&device.private_key_pem)
+        .context("parse linked device signing key")?;
+    ensure!(
+        hex::encode(signer.public_key()) == device.public_key,
+        "linked device identity public key does not match its private key"
+    );
+    Ok(signer)
+}
+
+fn execution_context(
+    repo: &Repository,
+    target: &EvaluationTarget,
+    definition_digest: String,
+) -> ExecutionContext {
+    ExecutionContext {
+        repo: repository_name(repo),
+        state: StateRef {
+            content_hash: target.state.id().to_string_full(),
+            change_id: target.state.change_id.to_string_full(),
+            logical_change_id: None,
+        },
+        basis: Basis {
+            kind: BasisKind::Branch,
+            evaluated_tree_digest: target.tree_digest.to_hex(),
+        },
+        definition_digest,
+        toolchain: detect_toolchain(),
+        pick_id: None,
+        attempt: 1,
+        runner: None,
+        image_digest: None,
+    }
+}
+
+fn repository_name(repo: &Repository) -> String {
+    repo.config().hosted.namespace.clone().unwrap_or_else(|| {
+        repo.root()
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("local")
+            .to_string()
+    })
+}
+
+fn detect_toolchain() -> Option<String> {
+    let mut command = Command::new("rustc");
+    command.arg("--version").env_clear();
+    for name in BASE_ALLOWLIST {
+        if let Some(value) = std::env::var_os(name) {
+            command.env(name, value);
+        }
+    }
+    let output = command.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!version.is_empty()).then_some(version)
+}
+
+fn sign_results(
+    results: Vec<ci_engine::CheckResult>,
+    target: &EvaluationTarget,
+    signer: &dyn Signer,
+) -> Result<Vec<SignedVerdict>> {
+    results
+        .into_iter()
+        .map(|result| {
+            let signed_at = result.body.execution.finished_at.clone();
+            let verdict = signed_verdict_from_signer(
+                result.body,
+                &target.state.change_id,
+                &target.tree_digest,
+                SignerKind::Device,
+                signed_at,
+                signer,
+            )?;
+            verdict.verify()?;
+            Ok(verdict)
+        })
+        .collect()
+}
+
+fn now_rfc3339() -> String {
+    Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
+}

--- a/crates/cli/src/cli/commands/ci/target.rs
+++ b/crates/cli/src/cli/commands/ci/target.rs
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Exact working-tree and named-state evaluation targets.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use objects::{
+    object::{ContentHash, State},
+    store::ObjectStore,
+};
+use repo::{AudienceTier, CheckoutMaterialization, Repository};
+
+pub(crate) struct EvaluationTarget {
+    pub(crate) workdir: PathBuf,
+    pub(crate) state: State,
+    pub(crate) tree_digest: ContentHash,
+    kind: TargetKind,
+    checkout: Option<tempfile::TempDir>,
+}
+
+#[derive(Clone, Copy)]
+enum TargetKind {
+    Worktree,
+    State,
+}
+
+impl EvaluationTarget {
+    pub(crate) fn prepare(repo: &Repository, state: Option<&str>) -> Result<Self> {
+        match state {
+            Some(spec) => Self::from_state(repo, spec),
+            None => Self::from_worktree(repo),
+        }
+    }
+
+    fn from_worktree(repo: &Repository) -> Result<Self> {
+        let mut state = repo
+            .current_state()?
+            .context("local CI needs a current state; capture the working tree first")?;
+        let tree_digest = repo.build_tree(repo.root())?.hash();
+        state.tree = tree_digest;
+        Ok(Self {
+            workdir: repo.root().to_path_buf(),
+            state,
+            tree_digest,
+            kind: TargetKind::Worktree,
+            checkout: None,
+        })
+    }
+
+    fn from_state(repo: &Repository, spec: &str) -> Result<Self> {
+        let state_id = repo
+            .resolve_state(spec)?
+            .with_context(|| format!("state {spec:?} was not found"))?;
+        let state = repo
+            .store()
+            .get_state(&state_id)?
+            .with_context(|| format!("state object {state_id} was not found"))?;
+        let checkout = tempfile::Builder::new()
+            .prefix("heddle-ci-state-")
+            .tempdir()
+            .context("create local CI state checkout")?;
+        let materialized =
+            repo.checkout_state_gated(&state_id, &state, checkout.path(), &AudienceTier::Internal)?;
+        let tree = match materialized {
+            CheckoutMaterialization::Materialized { tree } => tree,
+            CheckoutMaterialization::Withheld { tier } => {
+                repo.clear_materialized_root_records(checkout.path())?;
+                bail!("state {spec:?} is withheld at visibility tier {tier:?}");
+            }
+        };
+        if tree.hash() != state.tree {
+            repo.clear_materialized_root_records(checkout.path())?;
+            bail!("materialized tree for state {spec:?} does not match its recorded digest");
+        }
+        Ok(Self {
+            workdir: checkout.path().to_path_buf(),
+            tree_digest: state.tree,
+            state,
+            kind: TargetKind::State,
+            checkout: Some(checkout),
+        })
+    }
+
+    pub(crate) fn ensure_unchanged(&self, repo: &Repository) -> Result<()> {
+        if matches!(self.kind, TargetKind::Worktree) {
+            let after = repo.build_tree(repo.root())?.hash();
+            if after != self.tree_digest {
+                bail!(
+                    "working tree changed while CI checks ran; refusing to sign a stale tree digest"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn cleanup(&mut self, repo: &Repository) -> Result<()> {
+        if let Some(checkout) = self.checkout.take() {
+            repo.clear_materialized_root_records(checkout.path())?;
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn config_path(repo: &Repository, explicit: Option<&Path>) -> PathBuf {
+    explicit
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| repo.heddle_dir().join("ci.toml"))
+}

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -11,6 +11,7 @@ mod auto_capture;
 mod blame;
 mod checkpoint;
 mod child_env;
+mod ci;
 mod clone;
 mod collapse;
 mod commit;
@@ -91,6 +92,7 @@ pub use agent_cmd::{
     agent_api_schema, cmd_agent_capture, cmd_agent_heartbeat, cmd_agent_list, cmd_agent_ready,
     cmd_agent_release, cmd_agent_reserve,
 };
+pub use ci::cmd_ci;
 #[cfg(feature = "client")]
 pub use clone::recover_interrupted_clone;
 pub use clone::{

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -27,7 +27,7 @@ use cli::{
         cli_args::LandArgs,
         commands::{
             LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
-            cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_clone, cmd_collapse,
+            cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_ci, cmd_clone, cmd_collapse,
             cmd_commit, cmd_complete, cmd_context_audit, cmd_context_check, cmd_context_edit,
             cmd_context_get, cmd_context_history, cmd_context_list, cmd_context_rm,
             cmd_context_set, cmd_context_suggest, cmd_context_supersede, cmd_continue,
@@ -387,6 +387,8 @@ async fn async_main() -> Result<()> {
         Commands::Run(RunArgs { thread, command }) => {
             cmd_run(&cli, thread.clone(), command.clone())
         }
+
+        Commands::Ci { command } => cmd_ci(&cli, command),
 
         Commands::Try(args) => cmd_try(&cli, args.clone()),
 

--- a/crates/cli/tests/ci_run_local.rs
+++ b/crates/cli/tests/ci_run_local.rs
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use crypto::{Conclusion, Ed25519Signer, SignedVerdict, Signer, SignerKind};
+use repo::{Repository, identity::DeviceIdentity};
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    _home: tempfile::TempDir,
+    repo: Repository,
+    home: PathBuf,
+}
+
+impl Fixture {
+    fn new(config: &str) -> Self {
+        let root = tempfile::tempdir().expect("repo root");
+        let home = tempfile::tempdir().expect("heddle home");
+        let repo = Repository::init_default(root.path()).expect("init repo");
+        std::fs::write(repo.heddle_dir().join("ci.toml"), config).expect("write CI config");
+        write_device(home.path());
+        Self {
+            repo,
+            home: home.path().to_path_buf(),
+            _root: root,
+            _home: home,
+        }
+    }
+
+    fn run(&self, args: &[&str]) -> Output {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+        command
+            .args(["--repo", self.repo.root().to_str().expect("UTF-8 root")])
+            .args(args)
+            .env("HEDDLE_HOME", &self.home)
+            .env("HEDDLE_FSMONITOR", "off")
+            .env("HEDDLE_PRINCIPAL_NAME", "CI Test")
+            .env("HEDDLE_PRINCIPAL_EMAIL", "ci@example.invalid");
+        command.output().expect("run heddle")
+    }
+}
+
+fn write_device(home: &Path) {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let device = DeviceIdentity {
+        public_key: hex::encode(signer.public_key()),
+        private_key_pem: signer.to_pem().expect("PEM"),
+        server: "https://test.invalid".to_string(),
+        linked_at: "2026-08-14T12:00:00Z".to_string(),
+    };
+    let path = home.join(repo::identity::DEVICE_IDENTITY_FILE);
+    std::fs::write(&path, toml::to_string(&device).expect("device TOML")).expect("write device");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+            .expect("protect device");
+    }
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+#[test]
+fn json_verdicts_are_device_signed_and_verify() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "build"
+class = "required"
+command = ["/bin/sh", "-c", "echo ok"]
+[[check]]
+name = "advice"
+class = "advisory"
+command = ["/bin/sh", "-c", "echo 'test result: FAILED'; exit 1"]
+"#,
+    );
+    let output = fixture.run(&["--output", "json", "ci", "run", "--local"]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let verdicts: Vec<SignedVerdict> =
+        serde_json::from_slice(&output.stdout).expect("signed verdict JSON");
+    assert_eq!(verdicts.len(), 2);
+    for verdict in &verdicts {
+        verdict.verify().expect("verdict verifies");
+        assert_eq!(verdict.signer_kind, SignerKind::Device);
+        assert!(verdict.is_advisory_only());
+        assert_eq!(
+            verdict.body.basis.evaluated_tree_digest,
+            verdict.tree_digest.to_hex()
+        );
+    }
+    assert_eq!(verdicts[0].body.outcome.conclusion, Conclusion::Success);
+    assert_eq!(verdicts[1].body.outcome.conclusion, Conclusion::Failure);
+    assert!(stderr(&output).contains("advisory"));
+}
+
+#[test]
+fn required_failure_renders_once_and_exits_nonzero() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "build"
+class = "required"
+command = ["/bin/false"]
+"#,
+    );
+    let output = fixture.run(&["--output", "json", "ci", "run", "--local"]);
+    assert_eq!(
+        output.status.code(),
+        Some(65),
+        "stderr: {}",
+        stderr(&output)
+    );
+    let verdicts: Vec<SignedVerdict> =
+        serde_json::from_slice(&output.stdout).expect("single JSON report");
+    assert_eq!(verdicts[0].body.outcome.conclusion, Conclusion::Failure);
+    assert!(!stderr(&output).contains("\"error\""));
+}
+
+#[test]
+fn named_state_runs_in_an_exact_isolated_checkout() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "clean-state"
+class = "required"
+command = ["/bin/sh", "-c", "test ! -e dirty.txt"]
+"#,
+    );
+    std::fs::write(fixture.repo.root().join("dirty.txt"), "working tree only")
+        .expect("write dirty file");
+    let output = fixture.run(&[
+        "--output", "json", "ci", "run", "--local", "--state", "HEAD",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let verdicts: Vec<SignedVerdict> =
+        serde_json::from_slice(&output.stdout).expect("signed verdict JSON");
+    assert_eq!(verdicts[0].body.outcome.conclusion, Conclusion::Success);
+    let head = fixture.repo.current_state().unwrap().unwrap();
+    assert_eq!(verdicts[0].tree_digest, head.tree);
+}
+
+#[test]
+fn refuses_to_sign_when_a_check_mutates_the_working_tree() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "mutating"
+class = "required"
+command = ["/bin/sh", "-c", "echo changed > tracked.txt"]
+"#,
+    );
+    let output = fixture.run(&["--output", "json", "ci", "run", "--local"]);
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty(), "no stale verdict may be emitted");
+    assert!(stderr(&output).contains("refusing to sign a stale tree digest"));
+}
+
+#[test]
+fn missing_device_identity_fails_before_running_checks() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "would-run"
+command = ["/bin/sh", "-c", "touch ran.txt"]
+"#,
+    );
+    std::fs::remove_file(fixture.home.join(repo::identity::DEVICE_IDENTITY_FILE))
+        .expect("remove identity");
+    let output = fixture.run(&["ci", "run", "--local"]);
+    assert!(!output.status.success());
+    assert!(!fixture.repo.root().join("ran.txt").exists());
+    assert!(stderr(&output).contains("heddle auth login"));
+}
+
+#[test]
+fn check_filter_is_exact_and_a_typo_is_an_error() {
+    let fixture = Fixture::new(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "selected"
+command = ["/bin/true"]
+[[check]]
+name = "not-selected"
+command = ["/bin/false"]
+"#,
+    );
+    let output = fixture.run(&[
+        "--output", "json", "ci", "run", "--local", "--check", "selected",
+    ]);
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let verdicts: Vec<SignedVerdict> =
+        serde_json::from_slice(&output.stdout).expect("filtered verdict JSON");
+    assert_eq!(verdicts.len(), 1);
+    assert_eq!(verdicts[0].body.check.name, "selected");
+
+    let typo = fixture.run(&["ci", "run", "--local", "--check", "missing"]);
+    assert!(!typo.status.success());
+    assert!(stderr(&typo).contains("available checks: selected, not-selected"));
+}
+
+#[test]
+fn local_mode_must_be_selected_explicitly() {
+    let fixture = Fixture::new("[meta]\nschema = 1\n");
+    let output = fixture.run(&["ci", "run"]);
+    assert_eq!(output.status.code(), Some(64));
+    assert!(stderr(&output).contains("--local"));
+}


### PR DESCRIPTION
## Summary

- harvest treadle's schema-v1 CI definition parser and local execution engine into lean `heddle-ci-config` and `heddle-ci-engine` crates
- add `heddle ci run --local` for the working tree or an exact `--state`, with repeatable check selection and Heddle's existing output contract
- bind every result to the evaluated Heddle state/tree and emit a verified `heddle-ci-verdict-v2` envelope signed by the linked device identity (therefore advisory-only)
- refuse to sign when a local check changes the evaluated working tree

## Harvest and adaptation

The harvested engine keeps treadle's argv execution, hermetic environment, external caches, process-group timeout teardown, bounded/ANSI-stripped output, classifier, retry behavior, result assembly, and service-provider boundary. The check CLI orchestration is adapted to Heddle's repository/state materialization, linked device identity, canonical typed-object hashes, CLI command contract, and merged verdict-v2 signing path. There is no weft dependency or parallel verdict/signing scheme.

`PLAN.md` records the complete HARVEST + WIRE decisions and explicit deferrals.

## Local-mode behavior

- `heddle ci run --local`
- `heddle ci run --local --state <STATE>`
- optional `--config <PATH>` and repeatable `--check <NAME>`
- JSON emits the complete signed-verdict array; text uses treadle's summary table
- local service declarations produce an honest infra verdict via `NoopProvider`; Docker remains an engine boundary and is never enabled implicitly

## Deferred

Weft scheduling/leasing/upload/trust policy, automatic container isolation, merge-basis execution, protected-policy CheckSet compilation, log upload, and classifier categories treadle does not actually infer (Bench, MergeConflict, default_features).

## Verification

- `cargo build --locked --workspace --all-targets`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- 160 focused config, engine, CLI, and CLI-contract tests
- nightly rustfmt on touched Rust files

Closes HeddleCo/treadle#14
