### PR TITLE
perf: enforce instant local-read latency gates

### DIFF
--- a/crates/cli/src/cli/commands/checkpoint.rs
+++ b/crates/cli/src/cli/commands/checkpoint.rs
@@ -92,12 +92,14 @@ pub(crate) fn create_git_checkpoint(
         supplied_tree: None,
         reuse_current_state: true,
         require_clean_worktree: true,
+        require_worktree_change: false,
         worktree_status_options: status_options,
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,
         linearize_git_parent: request.linearize_git_parent,
         precomputed_worktree_status: None,
+        machine_contract_input: None,
     };
 
     let report = execute_save(repo, plan).map_err(|err| {

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -71,7 +71,8 @@ pub fn cmd_diff(
     }
 
     let repo = Repository::open(start)?;
-    let trust = build_repository_verification_state(&repo);
+    let trust = (repo.capability() == RepositoryCapability::GitOverlay)
+        .then(|| build_repository_verification_state(&repo));
     let json = should_output_json(cli, Some(repo.config()));
     let options = diff_options(
         from.clone(),
@@ -85,9 +86,10 @@ pub fn cmd_diff(
         json,
     );
 
-    if to.is_none()
+    if let Some(trust) = trust.as_ref()
+        && to.is_none()
         && from_is_head_or_default
-        && let Some(status) = trust_visible_worktree_status(&repo, &trust)?
+        && let Some(status) = trust_visible_worktree_status(&repo, trust)?
     {
         let report = authority_worktree_diff(&repo, &status, &options)?;
         return render_diff_report(
@@ -100,7 +102,12 @@ pub fn cmd_diff(
             patch,
         );
     }
-    if to.is_none() && from_is_head_or_default && trust.mapping_state == "git_backed" {
+    if to.is_none()
+        && from_is_head_or_default
+        && trust
+            .as_ref()
+            .is_some_and(|trust| trust.mapping_state == "git_backed")
+    {
         let status = repo.git_overlay_worktree_status()?.unwrap_or_default();
         let report = authority_worktree_diff(&repo, &status, &options)?;
         return render_diff_report(

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -5,7 +5,7 @@ use std::time::Instant;
 
 use anyhow::{Result, anyhow};
 use heddle_core::{
-    GitScope, SavePlan, SaveVerb, execute_save, large_capture_requires_force,
+    GitScope, MachineContractInput, SavePlan, SaveVerb, execute_save, large_capture_requires_force,
     principal_lacks_accountable_identity,
 };
 use heddle_git_projection::GitProjection;
@@ -36,8 +36,8 @@ use super::{
     thread_cmd::current_thread,
     verification_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState, action_template,
-        build_repository_verification_state, git_overlay_mutation_preflight_advice,
-        git_overlay_mutation_preflight_advice_with_worktree_status,
+        git_overlay_mutation_preflight_advice,
+        git_overlay_mutation_preflight_advice_with_worktree_status, machine_contract_coverage,
         plain_git_mutation_preflight_advice, unimported_git_history_advice,
     },
 };
@@ -148,7 +148,26 @@ pub struct SnapshotCommandProfile {
     pub blob_write_ms: u128,
     pub tree_write_ms: u128,
     pub state_ref_oplog_ms: u128,
+    pub atomic_execute_ms: u128,
+    pub ref_publish_ms: u128,
+    pub state_create_ms: u128,
+    pub captured_path_count_ms: u128,
+    pub post_verification_ms: u128,
     pub thread_metadata_ms: u128,
+    pub output_build_ms: u128,
+    pub output_task_assignment_ms: u128,
+    pub output_principal_ms: u128,
+    pub preflight_ms: u128,
+    pub attribution_ms: u128,
+    pub execute_save_ms: u128,
+    pub previous_state_ms: u128,
+    pub previous_state_head_ms: u128,
+    pub previous_state_cache_read_ms: u128,
+    pub previous_state_cache_decode_ms: u128,
+    pub previous_state_cache_validate_ms: u128,
+    pub previous_state_store_read_ms: u128,
+    pub previous_state_cache_hit: bool,
+    pub signature_lookup_ms: u128,
 }
 
 #[derive(Clone, Debug)]
@@ -205,7 +224,10 @@ pub async fn cmd_snapshot(
                     .iter()
                     .all(|path| merge_state.resolved.contains(path))
             });
-    if !complete_thread_resolution && !capture_has_worktree_changes(&repo)? {
+    if !complete_thread_resolution
+        && repo.capability() == RepositoryCapability::GitOverlay
+        && !capture_has_worktree_changes(&repo)?
+    {
         return Err(anyhow!(nothing_to_capture_advice()));
     }
     // Compute the git-overlay worktree status ONCE and thread it through both
@@ -235,6 +257,13 @@ pub async fn cmd_snapshot(
     let (mut output, snapshot_profile) = match snapshot_result {
         Ok((output, profile)) => (output, profile),
         Err(err) => {
+            if err.chain().any(|cause| {
+                cause
+                    .downcast_ref::<objects::HeddleError>()
+                    .is_some_and(|error| matches!(error, objects::HeddleError::NoChanges))
+            }) {
+                return Err(anyhow!(nothing_to_capture_advice()));
+            }
             // ENOSPC is the only mid-capture failure where the user's
             // working tree is guaranteed safe (we never touched it) and
             // the recovery is mechanical (free disk, re-run). Surface
@@ -387,8 +416,66 @@ pub async fn cmd_snapshot(
                     snapshot_profile.state_ref_oplog_ms,
                 ),
                 ProfileField::millis(
+                    "snapshot_atomic_execute_ms",
+                    snapshot_profile.atomic_execute_ms,
+                ),
+                ProfileField::millis("snapshot_ref_publish_ms", snapshot_profile.ref_publish_ms),
+                ProfileField::millis("snapshot_state_create_ms", snapshot_profile.state_create_ms),
+                ProfileField::millis(
+                    "snapshot_captured_path_count_ms",
+                    snapshot_profile.captured_path_count_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_post_verification_ms",
+                    snapshot_profile.post_verification_ms,
+                ),
+                ProfileField::millis(
                     "snapshot_thread_metadata_ms",
                     snapshot_profile.thread_metadata_ms,
+                ),
+                ProfileField::millis("snapshot_output_build_ms", snapshot_profile.output_build_ms),
+                ProfileField::millis(
+                    "snapshot_output_task_assignment_ms",
+                    snapshot_profile.output_task_assignment_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_output_principal_ms",
+                    snapshot_profile.output_principal_ms,
+                ),
+                ProfileField::millis("snapshot_preflight_ms", snapshot_profile.preflight_ms),
+                ProfileField::millis("snapshot_attribution_ms", snapshot_profile.attribution_ms),
+                ProfileField::millis("snapshot_execute_save_ms", snapshot_profile.execute_save_ms),
+                ProfileField::millis(
+                    "snapshot_previous_state_ms",
+                    snapshot_profile.previous_state_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_previous_state_head_ms",
+                    snapshot_profile.previous_state_head_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_previous_state_cache_read_ms",
+                    snapshot_profile.previous_state_cache_read_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_previous_state_cache_decode_ms",
+                    snapshot_profile.previous_state_cache_decode_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_previous_state_cache_validate_ms",
+                    snapshot_profile.previous_state_cache_validate_ms,
+                ),
+                ProfileField::millis(
+                    "snapshot_previous_state_store_read_ms",
+                    snapshot_profile.previous_state_store_read_ms,
+                ),
+                ProfileField::boolean(
+                    "snapshot_previous_state_cache_hit",
+                    snapshot_profile.previous_state_cache_hit,
+                ),
+                ProfileField::millis(
+                    "snapshot_signature_lookup_ms",
+                    snapshot_profile.signature_lookup_ms,
                 ),
                 ProfileField::millis("render_ms", render_ms),
             ],
@@ -769,6 +856,7 @@ fn create_snapshot_profiled_inner(
 ) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
     info!("Creating snapshot");
 
+    let preflight_start = Instant::now();
     let preflight_advice = match worktree_status {
         Some(status) => git_overlay_mutation_preflight_advice_with_worktree_status(
             repo,
@@ -785,8 +873,11 @@ fn create_snapshot_profiled_inner(
     if let Some(advice) = preflight_advice {
         return Err(anyhow!(advice));
     }
+    let preflight_ms = preflight_start.elapsed().as_millis();
 
+    let attribution_start = Instant::now();
     let attribution = build_attribution(repo, user_config, &agent)?;
+    let attribution_ms = attribution_start.elapsed().as_millis();
     if let Some(ref agent) = attribution.agent {
         debug!(provider = %agent.provider, model = %agent.model, "Agent attribution");
     }
@@ -801,20 +892,31 @@ fn create_snapshot_profiled_inner(
         supplied_tree: None,
         reuse_current_state: false,
         require_clean_worktree: false,
+        require_worktree_change: repo.capability() == RepositoryCapability::NativeHeddle
+            && repo.merge_state_manager().load()?.is_none(),
         worktree_status_options: worktree_status_options(Some(repo.config())),
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,
         linearize_git_parent: false,
         precomputed_worktree_status: None,
+        machine_contract_input: Some(MachineContractInput::from_coverage(
+            machine_contract_coverage(),
+        )),
     };
     if let Some(status) = worktree_status {
         // Owned copy so SavePlan can take the Result; re-walk is avoided on the
         // success path because execute_save recomputes post-mutation verification.
         plan.precomputed_worktree_status = Some(clone_worktree_status_result(status));
     }
+    let execute_save_start = Instant::now();
     let report = execute_save(repo, plan)?;
-    snapshot_output_from_save_report(repo, user_config, report)
+    let execute_save_ms = execute_save_start.elapsed().as_millis();
+    let (output, mut profile) = snapshot_output_from_save_report(repo, user_config, report)?;
+    profile.preflight_ms = preflight_ms;
+    profile.attribution_ms = attribution_ms;
+    profile.execute_save_ms = execute_save_ms;
+    Ok((output, profile))
 }
 
 #[allow(dead_code)]
@@ -850,12 +952,16 @@ pub(crate) fn create_snapshot_from_tree_profiled(
         supplied_tree: Some(tree),
         reuse_current_state: false,
         require_clean_worktree: false,
+        require_worktree_change: false,
         worktree_status_options: worktree_status_options(Some(repo.config())),
         run_hooks: true,
         commit_safe_post_verify: false,
         coalesce_snapshot_and_checkpoint: false,
         linearize_git_parent: false,
         precomputed_worktree_status: None,
+        machine_contract_input: Some(MachineContractInput::from_coverage(
+            machine_contract_coverage(),
+        )),
     };
     let report = execute_save(repo, plan)?;
     snapshot_output_from_save_report(repo, user_config, report)
@@ -880,21 +986,29 @@ fn snapshot_output_from_save_report(
     user_config: &UserConfig,
     report: heddle_core::SaveReport,
 ) -> Result<(SnapshotOutput, SnapshotCommandProfile)> {
+    let output_build_start = Instant::now();
+    let previous_state_ms = report.previous_state_ms;
+    let previous_state_profile = report.previous_state_profile.clone();
+    let signature_lookup_ms = report.signature_lookup_ms;
     // Public capture JSON still uses the CLI verification adapter so
     // Machine-Contract Proof is injected from the command catalog. Core
     // `execute_save` already computed proof for the embedder path.
-    let trust = build_repository_verification_state(repo);
+    let trust = report.verification.clone();
     let recommended_action =
         (!trust.recommended_action.trim().is_empty()).then(|| trust.recommended_action.clone());
     let recommended_action_template = recommended_action
         .as_deref()
         .and_then(action_template)
         .or_else(|| trust.recommended_action_template.clone());
+    let task_assignment_start = Instant::now();
     let task_assignment_id = active_task_assignment_id(repo)?;
+    let output_task_assignment_ms = task_assignment_start.elapsed().as_millis();
+    let principal_start = Instant::now();
     let principal_source = cli_shared::resolve_principal(repo, user_config)?
         .source
         .unwrap_or("unknown")
         .to_string();
+    let output_principal_ms = principal_start.elapsed().as_millis();
     let warnings = bulk_capture_warning(report.captured_path_count)
         .into_iter()
         .collect();
@@ -922,10 +1036,25 @@ fn snapshot_output_from_save_report(
         recommended_action_template,
         trust,
     };
-    Ok((
-        output,
-        snapshot_command_profile(report.snapshot_profile, report.thread_metadata_ms),
-    ))
+    let mut profile = snapshot_command_profile(
+        report.snapshot_profile,
+        report.state_create_ms,
+        report.captured_path_count_ms,
+        report.post_verification_ms,
+        report.thread_metadata_ms,
+    );
+    profile.output_build_ms = output_build_start.elapsed().as_millis();
+    profile.output_task_assignment_ms = output_task_assignment_ms;
+    profile.output_principal_ms = output_principal_ms;
+    profile.previous_state_ms = previous_state_ms;
+    profile.previous_state_head_ms = previous_state_profile.head_ms;
+    profile.previous_state_cache_read_ms = previous_state_profile.cache_read_ms;
+    profile.previous_state_cache_decode_ms = previous_state_profile.cache_decode_ms;
+    profile.previous_state_cache_validate_ms = previous_state_profile.cache_validate_ms;
+    profile.previous_state_store_read_ms = previous_state_profile.store_read_ms;
+    profile.previous_state_cache_hit = previous_state_profile.cache_hit;
+    profile.signature_lookup_ms = signature_lookup_ms;
+    Ok((output, profile))
 }
 
 const BULK_CAPTURE_WARNING_THRESHOLD: usize = 500;
@@ -954,6 +1083,9 @@ fn default_bootstrap_intent(repo: &Repository) -> String {
 
 fn snapshot_command_profile(
     repo_profile: SnapshotProfile,
+    state_create_ms: u128,
+    captured_path_count_ms: u128,
+    post_verification_ms: u128,
     thread_metadata_ms: u128,
 ) -> SnapshotCommandProfile {
     SnapshotCommandProfile {
@@ -962,7 +1094,26 @@ fn snapshot_command_profile(
         blob_write_ms: repo_profile.blob_write_ms,
         tree_write_ms: repo_profile.tree_write_ms,
         state_ref_oplog_ms: repo_profile.state_ref_oplog_ms,
+        atomic_execute_ms: repo_profile.atomic_execute_ms,
+        ref_publish_ms: repo_profile.ref_publish_ms,
+        state_create_ms,
+        captured_path_count_ms,
+        post_verification_ms,
         thread_metadata_ms,
+        output_build_ms: 0,
+        output_task_assignment_ms: 0,
+        output_principal_ms: 0,
+        preflight_ms: 0,
+        attribution_ms: 0,
+        execute_save_ms: 0,
+        previous_state_ms: 0,
+        previous_state_head_ms: 0,
+        previous_state_cache_read_ms: 0,
+        previous_state_cache_decode_ms: 0,
+        previous_state_cache_validate_ms: 0,
+        previous_state_store_read_ms: 0,
+        previous_state_cache_hit: false,
+        signature_lookup_ms: 0,
     }
 }
 
@@ -1006,6 +1157,9 @@ fn build_attribution_with_env(
     }
 
     let current_session = SessionManager::new(repo.root()).get_current_session()?;
+    let explicit_provider = agent.provider.clone().or(env.provider.clone());
+    let explicit_model = agent.model.clone().or(env.model.clone());
+    let explicit_agent_identity = explicit_provider.is_some() && explicit_model.is_some();
 
     // Pull the thread's declared actor — set when the user ran
     // `heddle start --agent-provider X --agent-model Y` to dedicate this
@@ -1022,10 +1176,14 @@ fn build_attribution_with_env(
     // silently masked by a detected harness actor. The active thread
     // actor remains the zero-config fallback for agent threads when no
     // explicit attribution is present.
-    let thread_actor = current_thread(repo)
-        .ok()
-        .flatten()
-        .and_then(|t| find_active_thread_entry(repo, &t.id).ok().flatten());
+    let thread_actor = (!explicit_agent_identity)
+        .then(|| {
+            current_thread(repo)
+                .ok()
+                .flatten()
+                .and_then(|t| find_active_thread_entry(repo, &t.id).ok().flatten())
+        })
+        .flatten();
     // Harness probing writes the literal "unknown" placeholder into
     // `ActorPresence.model` and `SessionSegment.model` when it can't
     // identify the model from argv/env (see `harness::open_session`
@@ -1058,13 +1216,17 @@ fn build_attribution_with_env(
         .and_then(|session| session.current_segment())
         .and_then(|segment| segment.policy_id.clone())
         .and_then(clean_attribution_value);
-    let harness_probe = crate::harness::probe_current_process_harness(
-        repo,
-        thread_provider.clone().or_else(|| session_provider.clone()),
-        thread_model.clone().or_else(|| session_model.clone()),
-        session_policy.clone(),
-    )
-    .ok();
+    let harness_probe = (!explicit_agent_identity)
+        .then(|| {
+            crate::harness::probe_current_process_harness(
+                repo,
+                thread_provider.clone().or_else(|| session_provider.clone()),
+                thread_model.clone().or_else(|| session_model.clone()),
+                session_policy.clone(),
+            )
+            .ok()
+        })
+        .flatten();
     let harness_provider = harness_probe
         .as_ref()
         .and_then(|probe| probe.provider.clone())
@@ -1078,10 +1240,7 @@ fn build_attribution_with_env(
         .and_then(|probe| probe.policy.clone())
         .and_then(clean_attribution_value);
 
-    let provider = agent
-        .provider
-        .clone()
-        .or(env.provider)
+    let provider = explicit_provider
         .or(thread_provider)
         .or(harness_provider)
         .or(session_provider)
@@ -1099,10 +1258,7 @@ fn build_attribution_with_env(
                 .clone()
                 .and_then(clean_attribution_value)
         });
-    let model = agent
-        .model
-        .clone()
-        .or(env.model)
+    let model = explicit_model
         .or(thread_model)
         .or(harness_model)
         .or(session_model)

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -13,9 +13,10 @@ use heddle_core::{
     ThreadCreateOptions, ThreadListOptions, ThreadPathIsolationError, ThreadPlanError,
     ThreadStartOptions, WorkspaceModeRequest, active_reservation_blocks_start,
     active_reservation_path_matches, check_explicit_path_isolation, list_threads,
-    plan_checkout_path, plan_shared_target_redirect, plan_thread_create, plan_thread_materialize,
-    plan_thread_mode, plan_thread_start, select_thread_base, shared_target_redirect_applies,
-    should_advise_shared_target, should_warn_materialized_without_reflink,
+    list_threads_with_worktree_status, plan_checkout_path, plan_shared_target_redirect,
+    plan_thread_create, plan_thread_materialize, plan_thread_mode, plan_thread_start,
+    select_thread_base, shared_target_redirect_applies, should_advise_shared_target,
+    should_warn_materialized_without_reflink,
     status::next_action::{
         canonical_git_repair_ref_preview_command,
         thread_recovery_action_is_primary as shared_thread_recovery_action_is_primary,
@@ -26,11 +27,12 @@ pub use heddle_core::{
     find_thread_summary, thread_is_available_git_ref, thread_is_imported_git_ref,
 };
 use objects::{
-    object::{State, StateId, ThreadName},
+    object::{State, StateId, ThreadName, Tree},
     store::{
         ActorPresence, ActorPresenceStatus, ActorPresenceStore, ObjectStore, WriterLeaseStatus,
         WriterLeaseStore,
     },
+    worktree::WorktreeStatus,
 };
 use oplog::OpRecord;
 use refs::{Head, RefExpectation, RefUpdate};
@@ -52,8 +54,10 @@ use super::{
     thread_cmd::thread_not_found_advice,
     verification_health::{
         GitOverlayMutationPreflight, RepositoryVerificationState,
-        build_repository_verification_state, git_overlay_mutation_preflight_advice,
-        override_trust_recommended_action, serialize_empty_action_as_null,
+        build_repository_verification_state,
+        build_repository_verification_state_with_worktree_status,
+        git_overlay_mutation_preflight_advice, override_trust_recommended_action,
+        serialize_empty_action_as_null,
     },
     worktree_cmd::{
         helpers::{plan_worktree_target, write_isolated_checkout},
@@ -464,16 +468,34 @@ fn render_repository_context_lines(context: Option<&crate::cli::render::Reposito
 pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs) -> Result<()> {
     let body_start = Instant::now();
     let as_json = should_output_json(cli, Some(repo.config()));
+    let worktree_status_start = Instant::now();
+    let worktree_status: repo::Result<Option<WorktreeStatus>> =
+        if repo.capability() == repo::RepositoryCapability::GitOverlay {
+            repo.git_overlay_worktree_status()
+        } else {
+            let baseline = match repo.current_state_for_worktree_status()? {
+                Some(state) => repo.require_tree_for_worktree_status(&state.tree)?,
+                None => Tree::new(),
+            };
+            repo.compare_worktree_cached_with_options(
+                &baseline,
+                &crate::cli::worktree_status_options(Some(repo.config())),
+            )
+            .map(Some)
+        };
+    let worktree_status_ms = worktree_status_start.elapsed().as_millis();
     let collect_start = Instant::now();
-    let report = list_threads(
-        repo,
-        ThreadListOptions::new()
-            .include_auto(args.include_auto)
-            .include_abandoned(args.include_abandoned),
-    )?;
+    let options = ThreadListOptions::new()
+        .include_auto(args.include_auto)
+        .include_abandoned(args.include_abandoned);
+    let report = match &worktree_status {
+        Ok(Some(status)) => list_threads_with_worktree_status(repo, options, status)?,
+        _ => list_threads(repo, options)?,
+    };
     let collect_summaries_ms = collect_start.elapsed().as_millis();
     let verification_start = Instant::now();
-    let mut trust = build_repository_verification_state(repo);
+    let mut trust =
+        build_repository_verification_state_with_worktree_status(repo, &worktree_status);
     let verification_ms = verification_start.elapsed().as_millis();
     let mut summaries = report.threads;
     let available_git_refs = report.available_git_refs;
@@ -542,6 +564,7 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
         current,
     };
 
+    let render_start = Instant::now();
     if as_json {
         write_full_command_json(
             &output,
@@ -587,15 +610,25 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
         render_thread_sections(&output.threads, cli.verbose > 0);
         render_available_git_refs(&output.available_git_refs, cli.verbose > 0);
     }
+    let render_ms = render_start.elapsed().as_millis();
 
     if instrumentation_enabled() {
         let fields = [
+            ProfileField::millis("worktree_status_ms", worktree_status_ms),
             ProfileField::millis("collect_summaries_ms", collect_summaries_ms),
             ProfileField::millis("verification_ms", verification_ms),
+            ProfileField::millis("render_ms", render_ms),
             ProfileField::duration("command_body_ms", body_start.elapsed()),
         ];
         match profile_mode() {
             ProfileMode::Off | ProfileMode::Jsonl => {
+                emit_profile(
+                    "thread list worktree status",
+                    &[ProfileField::millis(
+                        "worktree_status_ms",
+                        worktree_status_ms,
+                    )],
+                );
                 emit_profile(
                     "thread list collect summaries",
                     &[ProfileField::millis(
@@ -609,10 +642,10 @@ pub(crate) fn cmd_thread_list(cli: &Cli, repo: &Repository, args: ThreadListArgs
                 );
                 emit_profile(
                     "thread list command body",
-                    &[ProfileField::duration(
-                        "command_body_ms",
-                        body_start.elapsed(),
-                    )],
+                    &[
+                        ProfileField::duration("command_body_ms", body_start.elapsed()),
+                        ProfileField::millis("render_ms", render_ms),
+                    ],
                 );
             }
             ProfileMode::Human => emit_profile("thread list phases", &fields),

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -266,10 +266,9 @@ pub(crate) fn current_thread(repo: &Repository) -> Result<Option<Thread>> {
     let Head::Attached { thread } = repo.head_ref()? else {
         return Ok(None);
     };
-    let current_state = repo.refs().get_thread(&thread)?.map(|id| id.short());
-    let base_root = current_state
-        .as_deref()
-        .and_then(|state| repo.resolve_state(state).ok().flatten())
+    let current_state_id = repo.refs().get_thread(&thread)?;
+    let current_state = current_state_id.map(|id| id.short());
+    let base_root = current_state_id
         .and_then(|id| repo.store().get_state(&id).ok().flatten())
         .map(|state| state.tree.short())
         .unwrap_or_default();

--- a/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/fixture.rs
@@ -7,6 +7,11 @@ use std::{
     time::Instant,
 };
 
+use objects::{
+    object::{State, ThreadName},
+    store::{CompressionConfig, ObjectStore, PackBuilder, PackObjectId, pack::ObjectType},
+};
+use refs::PackedRefsModel;
 use repo::{FsMonitorMode, FsMonitorSettings, Repository, WorktreeStatusOptions};
 use tempfile::TempDir;
 
@@ -71,6 +76,69 @@ impl PerfFixture {
         self.dirty_generation += 1;
         let content = format!("captured generation {}\n", self.dirty_generation);
         self.make_dirty(&content);
+    }
+
+    pub(super) fn prepare_history(&self, binary: &Path, depth: usize) {
+        let repo = Repository::open(&self.root).expect("open perf fixture for history setup");
+        let mut parent = repo
+            .head()
+            .expect("read perf fixture head")
+            .expect("seed state");
+        let tree = repo
+            .store()
+            .get_state(&parent)
+            .expect("read seed state")
+            .expect("seed state present")
+            .tree;
+        let attribution = repo.get_attribution().expect("history attribution");
+        let mut pack = PackBuilder::new(CompressionConfig::disabled());
+        for generation in 0..depth {
+            let state = State::new_snapshot(tree, vec![parent], attribution.clone())
+                .with_intent(format!("perf history {generation}"));
+            parent = state.id();
+            pack.add_id(
+                PackObjectId::StateId(parent),
+                ObjectType::State,
+                rmp_serde::to_vec_named(&state).expect("encode perf history state"),
+            );
+        }
+        let (pack_data, index_data, _) = pack.build().expect("build perf history pack");
+        repo.store()
+            .install_pack(&pack_data, &index_data)
+            .expect("install perf history pack");
+        repo.refs()
+            .set_thread(&ThreadName::new("main"), &parent)
+            .expect("advance main to perf history tip");
+        drop(repo);
+        run_setup(
+            binary,
+            &["--output", "json", "log", "--limit", "20"],
+            &self.root,
+        );
+        println!("SETUP history_depth={depth}");
+    }
+
+    pub(super) fn prepare_threads(&self, binary: &Path, count: usize) {
+        let repo = Repository::open(&self.root).expect("open perf fixture for thread setup");
+        let tip = repo
+            .head()
+            .expect("read perf fixture head")
+            .expect("history tip");
+        drop(repo);
+
+        let mut packed = PackedRefsModel::new();
+        for index in 0..count {
+            packed.set_thread(&format!("perf-{index:04}"), tip);
+        }
+        fs::write(self.root.join(".heddle/refs/packed-refs"), packed.to_text())
+            .expect("write packed perf threads");
+        let repo = Repository::open(&self.root).expect("reopen perf fixture for thread setup");
+        repo.refs()
+            .rebuild_ref_summary_index()
+            .expect("rebuild perf thread summary index");
+        drop(repo);
+        run_setup(binary, &["--output", "json", "thread", "list"], &self.root);
+        println!("SETUP additional_threads={count}");
     }
 
     pub(super) fn prepare_full_scan_sample(&self) {

--- a/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/gates.rs
@@ -7,6 +7,9 @@ use serde::Deserialize;
 use super::measurement::{CaseKind, CaseResult, NegativeControl};
 
 const WARM_CLEAN_STATUS_100K_P95_MS: f64 = 50.0;
+const ONE_PATH_STATUS_100K_P95_MS: f64 = 75.0;
+const ONE_PATH_CAPTURE_100K_P95_MS: f64 = 100.0;
+const BOUNDED_LOCAL_READ_P95_MS: f64 = 100.0;
 
 #[derive(Deserialize)]
 struct BaselineFile {
@@ -179,12 +182,58 @@ pub(super) fn enforce_contract(results: &[CaseResult]) {
         }
     }
 
+    enforce_absolute_p95(
+        results,
+        CaseKind::StatusDirty,
+        ONE_PATH_STATUS_100K_P95_MS,
+        &mut failures,
+    );
+    enforce_absolute_p95(
+        results,
+        CaseKind::CaptureOne,
+        ONE_PATH_CAPTURE_100K_P95_MS,
+        &mut failures,
+    );
+    for kind in [
+        CaseKind::DiffOne,
+        CaseKind::LogBounded,
+        CaseKind::ThreadListBounded,
+    ] {
+        enforce_absolute_p95(results, kind, BOUNDED_LOCAL_READ_P95_MS, &mut failures);
+    }
+
     if !failures.is_empty() {
         eprintln!("PERF GATE RED");
         for failure in &failures {
             eprintln!("  - {failure}");
         }
         panic!("{} core-loop performance gate(s) failed", failures.len());
+    }
+}
+
+fn enforce_absolute_p95(
+    results: &[CaseResult],
+    kind: CaseKind,
+    budget_ms: f64,
+    failures: &mut Vec<String>,
+) {
+    let Some(result) = find(results, kind, 100_000) else {
+        failures.push(format!(
+            "absolute latency gate: missing {} @ 100000 paths",
+            kind.name()
+        ));
+        return;
+    };
+    let observed = result.metric(|sample| sample.wall_ms).p95;
+    println!(
+        "TARGET case={} paths=100000 budget_p95_ms={budget_ms:.3} observed_p95_ms={observed:.3}",
+        kind.name()
+    );
+    if observed > budget_ms {
+        failures.push(format!(
+            "absolute latency gate: {} @ 100000 paths p95 {observed:.3} ms > {budget_ms:.3} ms",
+            kind.name()
+        ));
     }
 }
 

--- a/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/measurement.rs
@@ -44,6 +44,9 @@ pub(super) enum CaseKind {
     StatusClean,
     StatusDirty,
     CaptureOne,
+    DiffOne,
+    LogBounded,
+    ThreadListBounded,
 }
 
 impl CaseKind {
@@ -54,6 +57,9 @@ impl CaseKind {
             Self::StatusClean => "status_clean",
             Self::StatusDirty => "status_one_dirty",
             Self::CaptureOne => "capture_one",
+            Self::DiffOne => "diff_one",
+            Self::LogBounded => "log_bounded",
+            Self::ThreadListBounded => "thread_list_bounded",
         }
     }
 
@@ -63,6 +69,9 @@ impl CaseKind {
             Self::Help => &["help"],
             Self::StatusClean | Self::StatusDirty => &["--output", "json", "status"],
             Self::CaptureOne => &["--output", "json", "capture", "-m", "perf sample"],
+            Self::DiffOne => &["--output", "json", "diff"],
+            Self::LogBounded => &["--output", "json", "log", "--limit", "20"],
+            Self::ThreadListBounded => &["--output", "json", "thread", "list"],
         }
     }
 
@@ -71,6 +80,7 @@ impl CaseKind {
             Self::Version | Self::Help => 0,
             Self::StatusClean | Self::StatusDirty => 1,
             Self::CaptureOne => 2,
+            Self::DiffOne | Self::LogBounded | Self::ThreadListBounded => 1,
         }
     }
 }
@@ -85,6 +95,9 @@ pub(super) struct Sample {
     pub current_state_ms: f64,
     pub verification_ms: f64,
     pub worktree_status_ms: f64,
+    pub worktree_index_load_ms: f64,
+    pub worktree_compare_ms: f64,
+    pub worktree_index_save_ms: f64,
     pub thread_summary_ms: f64,
     pub snapshot_ms: f64,
     pub snapshot_tree_walk_ms: f64,
@@ -92,7 +105,23 @@ pub(super) struct Sample {
     pub snapshot_blob_write_ms: f64,
     pub snapshot_tree_write_ms: f64,
     pub snapshot_state_ref_oplog_ms: f64,
+    pub snapshot_atomic_execute_ms: f64,
+    pub snapshot_ref_publish_ms: f64,
+    pub snapshot_state_create_ms: f64,
+    pub snapshot_captured_path_count_ms: f64,
+    pub snapshot_post_verification_ms: f64,
     pub snapshot_thread_metadata_ms: f64,
+    pub snapshot_preflight_ms: f64,
+    pub snapshot_attribution_ms: f64,
+    pub snapshot_execute_save_ms: f64,
+    pub snapshot_previous_state_ms: f64,
+    pub snapshot_previous_state_head_ms: f64,
+    pub snapshot_previous_state_cache_read_ms: f64,
+    pub snapshot_previous_state_cache_decode_ms: f64,
+    pub snapshot_previous_state_cache_validate_ms: f64,
+    pub snapshot_previous_state_store_read_ms: f64,
+    pub snapshot_signature_lookup_ms: f64,
+    pub snapshot_output_build_ms: f64,
     pub monitor_ms: f64,
     pub rendering_ms: f64,
     pub network_ms: f64,
@@ -124,6 +153,9 @@ impl Sample {
         self.current_state_ms += other.current_state_ms;
         self.verification_ms += other.verification_ms;
         self.worktree_status_ms += other.worktree_status_ms;
+        self.worktree_index_load_ms += other.worktree_index_load_ms;
+        self.worktree_compare_ms += other.worktree_compare_ms;
+        self.worktree_index_save_ms += other.worktree_index_save_ms;
         self.thread_summary_ms += other.thread_summary_ms;
         self.snapshot_ms += other.snapshot_ms;
         self.snapshot_tree_walk_ms += other.snapshot_tree_walk_ms;
@@ -131,7 +163,25 @@ impl Sample {
         self.snapshot_blob_write_ms += other.snapshot_blob_write_ms;
         self.snapshot_tree_write_ms += other.snapshot_tree_write_ms;
         self.snapshot_state_ref_oplog_ms += other.snapshot_state_ref_oplog_ms;
+        self.snapshot_atomic_execute_ms += other.snapshot_atomic_execute_ms;
+        self.snapshot_ref_publish_ms += other.snapshot_ref_publish_ms;
+        self.snapshot_state_create_ms += other.snapshot_state_create_ms;
+        self.snapshot_captured_path_count_ms += other.snapshot_captured_path_count_ms;
+        self.snapshot_post_verification_ms += other.snapshot_post_verification_ms;
         self.snapshot_thread_metadata_ms += other.snapshot_thread_metadata_ms;
+        self.snapshot_preflight_ms += other.snapshot_preflight_ms;
+        self.snapshot_attribution_ms += other.snapshot_attribution_ms;
+        self.snapshot_execute_save_ms += other.snapshot_execute_save_ms;
+        self.snapshot_previous_state_ms += other.snapshot_previous_state_ms;
+        self.snapshot_previous_state_head_ms += other.snapshot_previous_state_head_ms;
+        self.snapshot_previous_state_cache_read_ms += other.snapshot_previous_state_cache_read_ms;
+        self.snapshot_previous_state_cache_decode_ms +=
+            other.snapshot_previous_state_cache_decode_ms;
+        self.snapshot_previous_state_cache_validate_ms +=
+            other.snapshot_previous_state_cache_validate_ms;
+        self.snapshot_previous_state_store_read_ms += other.snapshot_previous_state_store_read_ms;
+        self.snapshot_signature_lookup_ms += other.snapshot_signature_lookup_ms;
+        self.snapshot_output_build_ms += other.snapshot_output_build_ms;
         self.monitor_ms += other.monitor_ms;
         self.rendering_ms += other.rendering_ms;
         self.network_ms += other.network_ms;
@@ -179,7 +229,7 @@ impl CaseResult {
     pub(super) fn print(&self) {
         let wall = self.metric(|sample| sample.wall_ms);
         println!(
-            "RESULT case={} mode={} paths={} samples={} wall_ms={} total_ms={} startup_ms={} warm_repo_ms={} repo_open_ms={} current_state_ms={} verification_ms={} worktree_status_ms={} thread_summary_ms={} snapshot_ms={} snapshot_tree_walk_ms={} snapshot_blob_prep_ms={} snapshot_blob_write_ms={} snapshot_tree_write_ms={} snapshot_state_ref_oplog_ms={} snapshot_thread_metadata_ms={} monitor_ms={} render_ms={} network_ms={}",
+            "RESULT case={} mode={} paths={} samples={} wall_ms={} total_ms={} startup_ms={} warm_repo_ms={} repo_open_ms={} current_state_ms={} verification_ms={} worktree_status_ms={} worktree_index_load_ms={} worktree_compare_ms={} worktree_index_save_ms={} thread_summary_ms={} snapshot_ms={} snapshot_tree_walk_ms={} snapshot_blob_prep_ms={} snapshot_blob_write_ms={} snapshot_tree_write_ms={} snapshot_state_ref_oplog_ms={} snapshot_atomic_execute_ms={} snapshot_ref_publish_ms={} snapshot_state_create_ms={} snapshot_captured_path_count_ms={} snapshot_post_verification_ms={} snapshot_thread_metadata_ms={} snapshot_preflight_ms={} snapshot_attribution_ms={} snapshot_execute_save_ms={} snapshot_previous_state_ms={} snapshot_previous_state_head_ms={} snapshot_previous_state_cache_read_ms={} snapshot_previous_state_cache_decode_ms={} snapshot_previous_state_cache_validate_ms={} snapshot_previous_state_store_read_ms={} snapshot_signature_lookup_ms={} snapshot_output_build_ms={} monitor_ms={} render_ms={} network_ms={}",
             self.kind.name(),
             if self.path_count == 0 {
                 "cold_process"
@@ -196,6 +246,9 @@ impl CaseResult {
             self.metric(|sample| sample.current_state_ms),
             self.metric(|sample| sample.verification_ms),
             self.metric(|sample| sample.worktree_status_ms),
+            self.metric(|sample| sample.worktree_index_load_ms),
+            self.metric(|sample| sample.worktree_compare_ms),
+            self.metric(|sample| sample.worktree_index_save_ms),
             self.metric(|sample| sample.thread_summary_ms),
             self.metric(|sample| sample.snapshot_ms),
             self.metric(|sample| sample.snapshot_tree_walk_ms),
@@ -203,7 +256,23 @@ impl CaseResult {
             self.metric(|sample| sample.snapshot_blob_write_ms),
             self.metric(|sample| sample.snapshot_tree_write_ms),
             self.metric(|sample| sample.snapshot_state_ref_oplog_ms),
+            self.metric(|sample| sample.snapshot_atomic_execute_ms),
+            self.metric(|sample| sample.snapshot_ref_publish_ms),
+            self.metric(|sample| sample.snapshot_state_create_ms),
+            self.metric(|sample| sample.snapshot_captured_path_count_ms),
+            self.metric(|sample| sample.snapshot_post_verification_ms),
             self.metric(|sample| sample.snapshot_thread_metadata_ms),
+            self.metric(|sample| sample.snapshot_preflight_ms),
+            self.metric(|sample| sample.snapshot_attribution_ms),
+            self.metric(|sample| sample.snapshot_execute_save_ms),
+            self.metric(|sample| sample.snapshot_previous_state_ms),
+            self.metric(|sample| sample.snapshot_previous_state_head_ms),
+            self.metric(|sample| sample.snapshot_previous_state_cache_read_ms),
+            self.metric(|sample| sample.snapshot_previous_state_cache_decode_ms),
+            self.metric(|sample| sample.snapshot_previous_state_cache_validate_ms),
+            self.metric(|sample| sample.snapshot_previous_state_store_read_ms),
+            self.metric(|sample| sample.snapshot_signature_lookup_ms),
+            self.metric(|sample| sample.snapshot_output_build_ms),
             self.metric(|sample| sample.monitor_ms),
             self.metric(|sample| sample.rendering_ms),
             self.metric(|sample| sample.network_ms),

--- a/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/mod.rs
@@ -68,7 +68,10 @@ fn core_loop_release_contract() {
                 samples,
                 negative,
             ));
-            if negative == NegativeControl::None {
+            if matches!(
+                negative,
+                NegativeControl::None | NegativeControl::SubtreeSkip
+            ) {
                 fixture.make_dirty("dirty status\n");
                 std::thread::sleep(Duration::from_millis(50));
                 results.push(measure_case(
@@ -85,6 +88,33 @@ fn core_loop_release_contract() {
                     samples,
                     negative,
                 ));
+                if negative == NegativeControl::None && path_count == 100_000 {
+                    fixture.make_dirty("dirty diff\n");
+                    std::thread::sleep(Duration::from_millis(50));
+                    results.push(measure_case(
+                        binary,
+                        Some(&mut fixture),
+                        CaseKind::DiffOne,
+                        samples,
+                        negative,
+                    ));
+                    fixture.prepare_history(binary, 1_000);
+                    results.push(measure_case(
+                        binary,
+                        Some(&mut fixture),
+                        CaseKind::LogBounded,
+                        samples,
+                        negative,
+                    ));
+                    fixture.prepare_threads(binary, 1_000);
+                    results.push(measure_case(
+                        binary,
+                        Some(&mut fixture),
+                        CaseKind::ThreadListBounded,
+                        samples,
+                        negative,
+                    ));
+                }
             }
         }
     }
@@ -97,7 +127,7 @@ fn core_loop_release_contract() {
     } else {
         enforce_contract(&results);
         println!(
-            "GATES green: 100k clean status target, latency, scale invariance, repository opens, zero network"
+            "GATES green: absolute p95 targets, scale invariance, structural bounds, repository opens, zero network"
         );
     }
 }

--- a/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
+++ b/crates/cli/tests/cli_integration/perf_core_loop/profile.rs
@@ -18,10 +18,20 @@ pub(super) fn sample_from_trace(wall_ms: f64, trace: &Value) -> Sample {
         warm_repository_ms: status_repo + capture_repo,
         repository_open_ms: phase_metric(trace, "status repo open", "repo_open_ms"),
         current_state_ms: phase_metric(trace, "status current state", "current_state_ms"),
-        verification_ms: phase_metric(trace, "status verification", "verification_ms"),
+        verification_ms: phase_metric(trace, "status verification", "verification_ms")
+            + phase_metric(trace, "thread list verification", "verification_ms"),
         worktree_status_ms: phase_metric(trace, "status worktree status", "worktree_status_ms")
-            + phase_metric(trace, "capture phases", "worktree_status_ms"),
-        thread_summary_ms: phase_metric(trace, "status thread summary", "thread_summary_ms"),
+            + phase_metric(trace, "capture phases", "worktree_status_ms")
+            + phase_metric(trace, "thread list worktree status", "worktree_status_ms"),
+        worktree_index_load_ms: phase_metric(trace, "status worktree detail", "index_load_ms"),
+        worktree_compare_ms: phase_metric(trace, "status worktree detail", "compare_ms"),
+        worktree_index_save_ms: phase_metric(trace, "status worktree detail", "index_save_ms"),
+        thread_summary_ms: phase_metric(trace, "status thread summary", "thread_summary_ms")
+            + phase_metric(
+                trace,
+                "thread list collect summaries",
+                "collect_summaries_ms",
+            ),
         snapshot_ms: phase_metric(trace, "capture phases", "snapshot_ms"),
         snapshot_tree_walk_ms: phase_metric(trace, "capture phases", "snapshot_tree_walk_ms"),
         snapshot_blob_prep_ms: phase_metric(trace, "capture phases", "snapshot_blob_prep_ms"),
@@ -32,14 +42,71 @@ pub(super) fn sample_from_trace(wall_ms: f64, trace: &Value) -> Sample {
             "capture phases",
             "snapshot_state_ref_oplog_ms",
         ),
+        snapshot_atomic_execute_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_atomic_execute_ms",
+        ),
+        snapshot_ref_publish_ms: phase_metric(trace, "capture phases", "snapshot_ref_publish_ms"),
+        snapshot_state_create_ms: phase_metric(trace, "capture phases", "snapshot_state_create_ms"),
+        snapshot_captured_path_count_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_captured_path_count_ms",
+        ),
+        snapshot_post_verification_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_post_verification_ms",
+        ),
         snapshot_thread_metadata_ms: phase_metric(
             trace,
             "capture phases",
             "snapshot_thread_metadata_ms",
         ),
+        snapshot_preflight_ms: phase_metric(trace, "capture phases", "snapshot_preflight_ms"),
+        snapshot_attribution_ms: phase_metric(trace, "capture phases", "snapshot_attribution_ms"),
+        snapshot_execute_save_ms: phase_metric(trace, "capture phases", "snapshot_execute_save_ms"),
+        snapshot_previous_state_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_ms",
+        ),
+        snapshot_previous_state_head_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_head_ms",
+        ),
+        snapshot_previous_state_cache_read_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_cache_read_ms",
+        ),
+        snapshot_previous_state_cache_decode_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_cache_decode_ms",
+        ),
+        snapshot_previous_state_cache_validate_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_cache_validate_ms",
+        ),
+        snapshot_previous_state_store_read_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_previous_state_store_read_ms",
+        ),
+        snapshot_signature_lookup_ms: phase_metric(
+            trace,
+            "capture phases",
+            "snapshot_signature_lookup_ms",
+        ),
+        snapshot_output_build_ms: phase_metric(trace, "capture phases", "snapshot_output_build_ms"),
         monitor_ms: phase_metric(trace, "structural counters", "monitor_startup_ms"),
         rendering_ms: phase_metric(trace, "status render", "render_ms")
-            + phase_metric(trace, "capture phases", "render_ms"),
+            + phase_metric(trace, "capture phases", "render_ms")
+            + phase_metric(trace, "thread list command body", "render_ms"),
         network_ms: 0.0,
         counters,
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -290,8 +290,8 @@ pub use status::{
 pub use thread::{
     AvailableGitRef, ThreadActorInfo, ThreadListEntry, ThreadListOptions, ThreadListReport,
     ThreadSummary, ThreadTaskSummary, collect_thread_summaries, find_thread_summary, list_threads,
-    split_available_git_refs, thread_is_available_git_ref, thread_is_imported_git_ref,
-    visibility_label,
+    list_threads_with_worktree_status, split_available_git_refs, thread_is_available_git_ref,
+    thread_is_imported_git_ref, visibility_label,
 };
 pub use thread_lifecycle::{
     CleanWorktreeGuard, ThreadDropDisposition, ThreadDropOptions, ThreadDropPlan,

--- a/crates/core/src/save.rs
+++ b/crates/core/src/save.rs
@@ -20,14 +20,18 @@ use oplog::{OpLogBackend, OpRecord};
 use refs::Head;
 use repo::{
     GitCheckpointRecord, Hook, HookContext, HookManager, Repository, RepositoryCapability,
-    SnapshotProfile, WorktreeStatusOptions, refresh_active_thread_metadata,
+    SnapshotProfile, WorktreeStateLookupProfile, WorktreeStatusOptions,
+    refresh_active_thread_metadata,
 };
 use serde::Serialize;
 use sley::Repository as SleyRepository;
 
 use crate::{
-    RepositoryVerificationState, build_repository_verification_health_with_worktree_status,
-    build_repository_verification_state, build_repository_verification_state_with_worktree_status,
+    MachineContractInput, RepositoryVerificationState,
+    build_repository_verification_health_with_worktree_status, build_repository_verification_state,
+    build_repository_verification_state_with_machine_contract,
+    build_repository_verification_state_with_worktree_status,
+    build_repository_verification_state_with_worktree_status_and_machine_contract,
 };
 
 /// How far a save should write through into Git (Git-overlay only).
@@ -67,6 +71,10 @@ pub struct SavePlan {
     pub reuse_current_state: bool,
     /// After ensuring state, refuse dirty Heddle worktree before Git write-through.
     pub require_clean_worktree: bool,
+    /// Refuse a worktree snapshot whose tree is identical to the current state.
+    /// The comparison happens during the snapshot tree build, avoiding a
+    /// separate preflight walk.
+    pub require_worktree_change: bool,
     pub worktree_status_options: WorktreeStatusOptions,
     /// Run pre/post snapshot hooks when creating a new Heddle state.
     pub run_hooks: bool,
@@ -81,6 +89,10 @@ pub struct SavePlan {
     /// on the no-new-state path. Post-mutation paths always recompute.
     pub precomputed_worktree_status:
         Option<repo::Result<Option<objects::worktree::WorktreeStatus>>>,
+    /// Optional embedding-surface machine-contract inventory. Passing it into
+    /// core verification lets callers reuse the post-save proof instead of
+    /// rebuilding the entire repository health envelope for presentation.
+    pub machine_contract_input: Option<MachineContractInput>,
 }
 
 impl SavePlan {
@@ -94,12 +106,14 @@ impl SavePlan {
             supplied_tree: None,
             reuse_current_state: false,
             require_clean_worktree: false,
+            require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
             run_hooks: true,
             commit_safe_post_verify: false,
             coalesce_snapshot_and_checkpoint: false,
             linearize_git_parent: false,
             precomputed_worktree_status: None,
+            machine_contract_input: None,
         }
     }
 
@@ -117,6 +131,7 @@ impl SavePlan {
             supplied_tree: None,
             reuse_current_state: false,
             require_clean_worktree: matches!(git_scope, GitScope::WorktreeAll),
+            require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
             run_hooks: true,
             commit_safe_post_verify: true,
@@ -126,6 +141,7 @@ impl SavePlan {
             ),
             linearize_git_parent: false,
             precomputed_worktree_status: None,
+            machine_contract_input: None,
         }
     }
 
@@ -143,12 +159,14 @@ impl SavePlan {
             supplied_tree: None,
             reuse_current_state: true,
             require_clean_worktree: !staged,
+            require_worktree_change: false,
             worktree_status_options: WorktreeStatusOptions::default(),
             run_hooks: true,
             commit_safe_post_verify: false,
             coalesce_snapshot_and_checkpoint: false,
             linearize_git_parent: false,
             precomputed_worktree_status: None,
+            machine_contract_input: None,
         }
     }
 
@@ -199,7 +217,13 @@ pub struct SaveReport {
     pub created_new_state: bool,
     pub git_checkpoint: Option<GitCheckpointRecord>,
     pub snapshot_profile: SnapshotProfile,
+    pub state_create_ms: u128,
+    pub captured_path_count_ms: u128,
+    pub post_verification_ms: u128,
     pub thread_metadata_ms: u128,
+    pub previous_state_ms: u128,
+    pub previous_state_profile: WorktreeStateLookupProfile,
+    pub signature_lookup_ms: u128,
 }
 
 /// Pure routing helper: which Git write-through scope a verb should use.
@@ -415,7 +439,10 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
         )));
     }
 
-    let previous_state = repo.current_state()?;
+    let previous_state_started = Instant::now();
+    let (previous_state, previous_state_profile) =
+        repo.current_state_for_worktree_status_profiled()?;
+    let previous_state_ms = previous_state_started.elapsed().as_millis();
     let has_current = previous_state.is_some();
     let mut created_new_state = false;
     let mut snapshot_profile = SnapshotProfile::default();
@@ -424,10 +451,14 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
     let mut heavy_impact_paths = Vec::new();
     let mut snapshot_state_id: Option<StateId> = None;
     let mut captured_path_count = 0usize;
+    let mut state_create_ms = 0u128;
+    let mut captured_path_count_ms = 0u128;
 
     let mut state = if plan_creates_new_state(&plan, has_current) {
         created_new_state = true;
+        let state_create_started = Instant::now();
         let execution = create_heddle_state(repo, &plan)?;
+        state_create_ms = state_create_started.elapsed().as_millis();
         snapshot_profile = execution.profile;
         thread_metadata_ms = execution.thread_metadata_ms;
         promotion_suggested = execution.promotion_suggested;
@@ -437,9 +468,11 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
             Some(state) => state.tree,
             None => repo.store().put_tree(&Tree::new())?,
         };
+        let captured_path_count_started = Instant::now();
         captured_path_count = repo
             .diff_trees(&previous_tree, &execution.state.tree)?
             .len();
+        captured_path_count_ms = captured_path_count_started.elapsed().as_millis();
         execution.state
     } else {
         repo.current_state()?
@@ -497,17 +530,56 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
     // Post-mutation verification is always fresh when we created state or wrote
     // a Git checkpoint (those mutations flip health classification). Otherwise
     // reuse a caller-supplied worktree status to avoid a redundant walk.
-    let mut verification = if created_new_state || git_checkpoint.is_some() {
-        build_repository_verification_state(repo)?
+    let captured_native_worktree = created_new_state
+        && plan.supplied_tree.is_none()
+        && repo.capability() == RepositoryCapability::NativeHeddle;
+    let captured_worktree_status = Ok(Some(objects::worktree::WorktreeStatus::default()));
+    let verification_started = Instant::now();
+    let mut verification = if captured_native_worktree && git_checkpoint.is_none() {
+        let health = build_repository_verification_health_with_worktree_status(
+            repo,
+            &captured_worktree_status,
+        );
+        if let Some(input) = &plan.machine_contract_input {
+            build_repository_verification_state_with_worktree_status_and_machine_contract(
+                repo,
+                health,
+                &captured_worktree_status,
+                input,
+            )
+        } else {
+            build_repository_verification_state_with_worktree_status(
+                repo,
+                health,
+                &captured_worktree_status,
+            )
+        }
+    } else if created_new_state || git_checkpoint.is_some() {
+        if let Some(input) = &plan.machine_contract_input {
+            build_repository_verification_state_with_machine_contract(repo, input)?
+        } else {
+            build_repository_verification_state(repo)?
+        }
     } else if let Some(status) = &plan.precomputed_worktree_status {
         let health = build_repository_verification_health_with_worktree_status(repo, status);
-        build_repository_verification_state_with_worktree_status(repo, health, status)
+        if let Some(input) = &plan.machine_contract_input {
+            build_repository_verification_state_with_worktree_status_and_machine_contract(
+                repo, health, status, input,
+            )
+        } else {
+            build_repository_verification_state_with_worktree_status(repo, health, status)
+        }
     } else {
-        build_repository_verification_state(repo)?
+        if let Some(input) = &plan.machine_contract_input {
+            build_repository_verification_state_with_machine_contract(repo, input)?
+        } else {
+            build_repository_verification_state(repo)?
+        }
     };
     if plan.commit_safe_post_verify {
         soften_commit_next_action(&mut verification);
     }
+    let post_verification_ms = verification_started.elapsed().as_millis();
 
     let summary = match plan.verb {
         SaveVerb::Capture => format!(
@@ -525,13 +597,16 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
             .unwrap_or_else(|| format!("Checkpoint {}", state.state_id.short())),
     };
 
+    let signature_lookup_started = Instant::now();
+    let signed = repo.get_state_signature(&state.id())?.is_some();
+    let signature_lookup_ms = signature_lookup_started.elapsed().as_millis();
     Ok(SaveReport {
         verb: plan.verb,
         state_id: state.state_id,
         content_hash: state.hash(),
         intent: state.intent.clone(),
         confidence: state.confidence,
-        signed: repo.get_state_signature(&state.id())?.is_some(),
+        signed,
         git_commit,
         git_previous_commit,
         summary,
@@ -544,7 +619,13 @@ pub fn execute_save(repo: &Repository, plan: SavePlan) -> Result<SaveReport> {
         created_new_state,
         git_checkpoint,
         snapshot_profile,
+        state_create_ms,
+        captured_path_count_ms,
+        post_verification_ms,
         thread_metadata_ms,
+        previous_state_ms,
+        previous_state_profile,
+        signature_lookup_ms,
     })
 }
 
@@ -592,6 +673,12 @@ fn create_heddle_state(repo: &Repository, plan: &SavePlan) -> Result<CreatedStat
     let mut execution = if let Some(tree) = plan.supplied_tree.clone() {
         repo.snapshot_tree_with_attribution_profiled(
             tree,
+            plan.intent.clone(),
+            plan.confidence,
+            plan.attribution.clone(),
+        )?
+    } else if plan.require_worktree_change {
+        repo.snapshot_with_attribution_profiled_if_changed(
             plan.intent.clone(),
             plan.confidence,
             plan.attribution.clone(),

--- a/crates/core/src/thread.rs
+++ b/crates/core/src/thread.rs
@@ -11,7 +11,7 @@
 //! report shape.
 
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
 };
 
@@ -19,10 +19,11 @@ use anyhow::Result;
 use chrono::Utc;
 use cli_shared::UserConfig;
 use objects::{
-    object::{ThreadName, Tree},
+    object::Tree,
     store::{
         ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentTaskRecord, AgentTaskStore,
     },
+    worktree::WorktreeStatus,
 };
 use repo::{
     AgentUsageSummary, GitOverlayBranchTip, GitRemoteTrackingStatus, Repository,
@@ -298,7 +299,25 @@ fn display_path_string(path: &Path) -> Option<String> {
 
 /// Collect, filter, and split thread list domain for an opened repository.
 pub fn list_threads(repo: &Repository, options: ThreadListOptions) -> Result<ThreadListReport> {
-    let mut summaries = collect_thread_summaries(repo)?;
+    list_threads_inner(repo, options, None)
+}
+
+/// List threads while reusing a worktree comparison already required by the
+/// caller's verification envelope.
+pub fn list_threads_with_worktree_status(
+    repo: &Repository,
+    options: ThreadListOptions,
+    worktree_status: &WorktreeStatus,
+) -> Result<ThreadListReport> {
+    list_threads_inner(repo, options, Some(worktree_status))
+}
+
+fn list_threads_inner(
+    repo: &Repository,
+    options: ThreadListOptions,
+    worktree_status: Option<&WorktreeStatus>,
+) -> Result<ThreadListReport> {
+    let mut summaries = collect_thread_summaries_inner(repo, worktree_status)?;
     if !options.include_auto {
         // Always keep the current thread visible even if it's auto:
         // hiding it from the user who is *standing in it* would be
@@ -326,7 +345,22 @@ pub fn list_threads(repo: &Repository, options: ThreadListOptions) -> Result<Thr
 
 /// Collect full thread summaries (no auto filter / git-ref split).
 pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry>> {
-    let thread_refs = repo.refs().list_threads()?;
+    collect_thread_summaries_inner(repo, None)
+}
+
+fn collect_thread_summaries_inner(
+    repo: &Repository,
+    worktree_status: Option<&WorktreeStatus>,
+) -> Result<Vec<ThreadListEntry>> {
+    let thread_refs = repo.refs().list_threads_with_states()?;
+    let thread_ref_names = thread_refs
+        .iter()
+        .map(|(name, _)| name.to_string())
+        .collect::<HashSet<_>>();
+    let thread_ref_states = thread_refs
+        .iter()
+        .map(|(name, state)| (name.to_string(), *state))
+        .collect::<HashMap<_, _>>();
     let current = repo.current_lane()?;
     let operation = repo.operation_status()?;
     let remote_tracking = repo.git_remote_tracking_status().unwrap_or(None);
@@ -353,7 +387,7 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
         threads_by_name.insert(thread.thread.clone(), thread);
     }
 
-    let mut names: BTreeSet<String> = thread_refs.iter().map(|t| t.to_string()).collect();
+    let mut names: BTreeSet<String> = thread_ref_names.iter().cloned().collect();
     names.extend(current.iter().cloned());
     names.extend(entries_by_thread.keys().cloned());
     names.extend(threads_by_name.keys().cloned());
@@ -368,6 +402,7 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
             repo,
             current.as_ref() == Some(&name),
             name.clone(),
+            thread_ref_states.get(&name).copied(),
             entries,
             threads_by_name.remove(&name),
             branch_tips.get(&name).cloned(),
@@ -379,49 +414,55 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
             summary.git_branch_tip = Some(branch_tip.git_commit.clone());
             summary.history_imported = branch_tip.history_imported;
         }
-        let has_heddle_tip = thread_refs.iter().any(|thread| thread == &summary.name);
-        let thread = Thread {
-            id: summary.name.clone(),
-            thread: summary.name.clone(),
-            target_thread: summary.target_thread.clone(),
-            parent_thread: summary.parent_thread.clone(),
-            mode: summary
-                .thread_mode
-                .clone()
-                .unwrap_or(ThreadMode::Materialized),
-            state: summary.thread_state.clone().unwrap_or(ThreadState::Active),
-            base_state: summary.base_state.clone().unwrap_or_default(),
-            base_root: summary.base_root.clone().unwrap_or_default(),
-            current_state: summary.current_state.clone(),
-            merged_state: None,
-            task: summary.task.clone(),
-            execution_path: summary
-                .execution_path
-                .as_ref()
-                .map(PathBuf::from)
-                .unwrap_or_else(|| repo.root().to_path_buf()),
-            materialized_path: summary.path.as_ref().map(PathBuf::from),
-            changed_paths: summary.changed_paths.clone(),
-            impact_categories: summary.impact_categories.clone(),
-            heavy_impact_paths: summary.heavy_impact_paths.clone(),
-            promotion_suggested: summary.promotion_suggested,
-            freshness: summary
-                .freshness
-                .clone()
-                .unwrap_or(ThreadFreshness::Unknown),
-            verification_summary: summary.verification_summary.clone(),
-            confidence_summary: summary.confidence_summary.clone(),
-            integration_policy_result: summary.integration_policy_result.clone(),
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-            ephemeral: None,
-            auto: summary.auto,
-            shared_target_dir: summary.shared_target_dir.as_ref().map(PathBuf::from),
-        };
-        let advice = describe_thread_advice(&thread, false, 0, false);
-        summary.thread_health = advice.thread_health;
-        summary.blockers = advice.blockers;
-        summary.recommended_action = advice.recommended_action;
+        let has_heddle_tip = thread_ref_names.contains(&summary.name);
+        let needs_advice = summary.thread_state != Some(ThreadState::Active)
+            || summary.freshness == Some(ThreadFreshness::Stale)
+            || !summary.changed_paths.is_empty()
+            || summary.promotion_suggested;
+        if needs_advice {
+            let thread = Thread {
+                id: summary.name.clone(),
+                thread: summary.name.clone(),
+                target_thread: summary.target_thread.clone(),
+                parent_thread: summary.parent_thread.clone(),
+                mode: summary
+                    .thread_mode
+                    .clone()
+                    .unwrap_or(ThreadMode::Materialized),
+                state: summary.thread_state.clone().unwrap_or(ThreadState::Active),
+                base_state: summary.base_state.clone().unwrap_or_default(),
+                base_root: summary.base_root.clone().unwrap_or_default(),
+                current_state: summary.current_state.clone(),
+                merged_state: None,
+                task: summary.task.clone(),
+                execution_path: summary
+                    .execution_path
+                    .as_ref()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| repo.root().to_path_buf()),
+                materialized_path: summary.path.as_ref().map(PathBuf::from),
+                changed_paths: summary.changed_paths.clone(),
+                impact_categories: summary.impact_categories.clone(),
+                heavy_impact_paths: summary.heavy_impact_paths.clone(),
+                promotion_suggested: summary.promotion_suggested,
+                freshness: summary
+                    .freshness
+                    .clone()
+                    .unwrap_or(ThreadFreshness::Unknown),
+                verification_summary: summary.verification_summary.clone(),
+                confidence_summary: summary.confidence_summary.clone(),
+                integration_policy_result: summary.integration_policy_result.clone(),
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+                ephemeral: None,
+                auto: summary.auto,
+                shared_target_dir: summary.shared_target_dir.as_ref().map(PathBuf::from),
+            };
+            let advice = describe_thread_advice(&thread, false, 0, false);
+            summary.thread_health = advice.thread_health;
+            summary.blockers = advice.blockers;
+            summary.recommended_action = advice.recommended_action;
+        }
         apply_terminal_thread_advice(&mut summary);
         apply_materialized_merge_advice(repo, &mut summary);
         if let Some(branch_tip) = branch_tips.get(&summary.name)
@@ -446,7 +487,8 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
                 };
             }
         }
-        if summary.history_imported
+        if repo.capability() == repo::RepositoryCapability::GitOverlay
+            && summary.history_imported
             && summary.current_state.is_some()
             && remote_tracking_local_ref(repo, &summary.name).is_some()
         {
@@ -457,7 +499,7 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
                 canonical_git_repair_ref_preview_command(None, &summary.name);
         }
         if summary.is_current {
-            enrich_current_summary_with_dirty_paths(repo, &mut summary)?;
+            enrich_current_summary_with_dirty_paths(repo, &mut summary, worktree_status)?;
             summary.operation = operation.clone();
             summary.remote_tracking = remote_tracking.clone();
             summary.recommended_action = effective_next_action(
@@ -490,32 +532,31 @@ pub fn collect_thread_summaries(repo: &Repository) -> Result<Vec<ThreadListEntry
         }
     }
     for summary in &mut summaries {
-        if let Some(children) = children_by_parent.remove(&summary.name) {
-            let mut children = children;
+        if let Some(children) = children_by_parent.get(&summary.name) {
+            let mut children = children.clone();
             children.sort();
             summary.child_threads = children;
         }
     }
 
-    let summaries_by_name = summaries
+    let parents_by_name = summaries
         .iter()
-        .map(|summary| (summary.name.clone(), summary.clone()))
+        .map(|summary| (summary.name.clone(), summary.parent_thread.clone()))
         .collect::<HashMap<_, _>>();
-    let mut siblings_by_thread: HashMap<String, Vec<String>> = HashMap::new();
-    for summary in &summaries {
-        if let Some(parent) = &summary.parent_thread {
-            let siblings = summaries_by_name
-                .values()
-                .filter(|candidate| candidate.parent_thread.as_deref() == Some(parent.as_str()))
-                .filter(|candidate| candidate.name != summary.name)
-                .map(|candidate| candidate.name.clone())
-                .collect::<Vec<_>>();
-            siblings_by_thread.insert(summary.name.clone(), siblings);
-        }
-    }
     for summary in &mut summaries {
-        summary.sibling_threads = siblings_by_thread.remove(&summary.name).unwrap_or_default();
-        summary.stack_depth = stack_depth(&summaries_by_name, &summary.name);
+        summary.sibling_threads = summary
+            .parent_thread
+            .as_ref()
+            .and_then(|parent| children_by_parent.get(parent))
+            .map(|children| {
+                children
+                    .iter()
+                    .filter(|child| *child != &summary.name)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default();
+        summary.stack_depth = stack_depth(&parents_by_name, &summary.name);
         summary.stale_from_parent =
             summary.parent_thread.is_some() && summary.freshness == Some(ThreadFreshness::Stale);
         if summary.last_progress_at.is_some() {
@@ -594,13 +635,19 @@ fn available_git_ref_from_summary(summary: &ThreadListEntry) -> AvailableGitRef 
 fn enrich_current_summary_with_dirty_paths(
     repo: &Repository,
     summary: &mut ThreadListEntry,
+    worktree_status: Option<&WorktreeStatus>,
 ) -> Result<()> {
-    let baseline = match repo.current_state()? {
-        Some(state) => repo.require_tree(&state.tree)?,
-        None => Tree::new(),
+    let status = match worktree_status {
+        Some(status) => status.clone(),
+        None => {
+            let baseline = match repo.current_state_for_worktree_status()? {
+                Some(state) => repo.require_tree_for_worktree_status(&state.tree)?,
+                None => Tree::new(),
+            };
+            let options = UserConfig::default().worktree_status_options(Some(repo.config()));
+            repo.compare_worktree_cached_with_options(&baseline, &options)?
+        }
     };
-    let options = UserConfig::default().worktree_status_options(Some(repo.config()));
-    let status = repo.compare_worktree_cached_with_options(&baseline, &options)?;
     let mut paths = summary
         .changed_paths
         .iter()
@@ -618,16 +665,12 @@ fn enrich_current_summary_with_dirty_paths(
     Ok(())
 }
 
-fn stack_depth(summaries_by_name: &HashMap<String, ThreadListEntry>, thread: &str) -> usize {
+fn stack_depth(parents_by_name: &HashMap<String, Option<String>>, thread: &str) -> usize {
     let mut depth = 0usize;
-    let mut cursor = summaries_by_name
-        .get(thread)
-        .and_then(|summary| summary.parent_thread.clone());
+    let mut cursor = parents_by_name.get(thread).cloned().flatten();
     while let Some(parent) = cursor {
         depth += 1;
-        cursor = summaries_by_name
-            .get(&parent)
-            .and_then(|summary| summary.parent_thread.clone());
+        cursor = parents_by_name.get(&parent).cloned().flatten();
     }
     depth
 }
@@ -661,11 +704,11 @@ fn build_thread_view(
     repo: &Repository,
     is_current: bool,
     name: String,
+    ref_state: Option<objects::object::StateId>,
     entries: Vec<ActorPresence>,
     thread: Option<Thread>,
     branch_tip: Option<GitOverlayBranchTip>,
 ) -> Result<(ThreadView, CoordinationStatus)> {
-    let ref_state = repo.refs().get_thread(&ThreadName::new(&name))?;
     let current_state = ref_state
         .or_else(|| {
             (is_current && repo.capability() == repo::RepositoryCapability::GitOverlay)

--- a/crates/fs-prims/src/fs_atomic.rs
+++ b/crates/fs-prims/src/fs_atomic.rs
@@ -745,6 +745,28 @@ pub fn write_file_atomic(path: &Path, bytes: &[u8]) -> io::Result<()> {
     write_file_atomic_impl(path, bytes, AtomicWriteKind::Normal, |_, _| Ok(()))
 }
 
+/// Atomically publish reconstructible bytes without forcing them to stable
+/// storage. The final path is never observed partially written, but a crash may
+/// lose this write. Callers must have an independent durable source from which
+/// the file can be rebuilt.
+pub fn write_file_atomic_reconstructible(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    fs::create_dir_all(parent).map_err(|error| enrich_fs_error(parent, "creating", error))?;
+    let tmp = temp_path(path);
+    let result = (|| -> io::Result<()> {
+        let mut file = AtomicWriteKind::Normal.open_tmp(&tmp)?;
+        file.write_all(bytes)?;
+        file.flush()?;
+        drop(file);
+        fs::rename(&tmp, path).map_err(|error| enrich_rename_error(&tmp, path, error))
+    })();
+    if let Err(error) = result {
+        let _ = fs::remove_file(&tmp);
+        return Err(enrich_write_error(path, error));
+    }
+    Ok(())
+}
+
 /// Create a directory tree with owner-only permissions on Unix (`0o700`),
 /// making newly created dirents crash-durable (same fsync chain as
 /// [`create_dir_all_durable`]).

--- a/crates/object-model/src/error.rs
+++ b/crates/object-model/src/error.rs
@@ -158,6 +158,8 @@ pub enum HeddleError {
     NotFound(String),
     #[error("No merge in progress")]
     NoMergeInProgress,
+    #[error("no worktree changes to capture")]
+    NoChanges,
     #[error("state not found: {0}")]
     StateNotFound(StateId),
     #[error("invalid object: {0}")]

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -752,6 +752,17 @@ impl FsStore {
 }
 
 impl FsStore {
+    pub(crate) fn snapshot_commit_recovery_descriptors_impl(
+        &self,
+    ) -> Result<Vec<SnapshotCommitDescriptor>> {
+        self.reload_packs_if_stale()?;
+        let manager = self
+            .pack_manager()
+            .read()
+            .map_err(|_| HeddleError::Config("Failed to acquire pack manager lock".to_string()))?;
+        manager.snapshot_commit_recovery_descriptors()
+    }
+
     pub(crate) fn snapshot_commit_descriptors_impl(&self) -> Result<Vec<SnapshotCommitDescriptor>> {
         self.reload_packs_if_stale()?;
         let manager = self
@@ -1530,7 +1541,7 @@ impl ObjectStore for FsStore {
         tree: &Tree,
         state: &State,
     ) -> Result<()> {
-        self.put_snapshot_objects_packed_impl(blobs, tree, state, Vec::new(), None)
+        self.put_snapshot_objects_packed_impl(blobs, Vec::new(), tree, state, Vec::new(), None)
             .map(|_| ())
     }
 
@@ -1541,7 +1552,7 @@ impl ObjectStore for FsStore {
         state: &State,
         attachments: Vec<StateAttachment>,
     ) -> Result<()> {
-        self.put_snapshot_objects_packed_impl(blobs, tree, state, attachments, None)
+        self.put_snapshot_objects_packed_impl(blobs, Vec::new(), tree, state, attachments, None)
             .map(|_| ())
     }
 

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -19,7 +19,7 @@ use crate::{
         FsRepackOperation, HeddleError, ObjectStore, RepackPolicy, RepackResourceLimits,
         RepackSchedule, RepackScheduler, Result, SnapshotCommitArtifact, SnapshotCommitDescriptor,
         codec,
-        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId},
+        pack::{ObjectType as PackObjectType, PackBuilder, PackObjectId, PackReader},
         snapshot_commit::snapshot_commit_marker_path,
     },
 };
@@ -135,17 +135,25 @@ impl FsStore {
     pub(crate) fn put_committed_snapshot_objects_packed_impl(
         &self,
         blobs: Vec<(ContentHash, Vec<u8>)>,
+        trees: Vec<Tree>,
         tree: &Tree,
         state: &State,
         attachments: Vec<StateAttachment>,
         artifact: SnapshotCommitArtifact,
     ) -> Result<SnapshotCommitDescriptor> {
-        self.put_snapshot_objects_packed_impl(blobs, tree, state, attachments, Some(artifact))?
-            .ok_or_else(|| {
-                HeddleError::InvalidObject(
-                    "committed snapshot pack did not expose its artifact descriptor".to_string(),
-                )
-            })
+        self.put_snapshot_objects_packed_impl(
+            blobs,
+            trees,
+            tree,
+            state,
+            attachments,
+            Some(artifact),
+        )?
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(
+                "committed snapshot pack did not expose its artifact descriptor".to_string(),
+            )
+        })
     }
 
     /// Install blobs, root tree, state, and immutable authored attachments
@@ -155,6 +163,7 @@ impl FsStore {
     pub(super) fn put_snapshot_objects_packed_impl(
         &self,
         blobs: Vec<(ContentHash, Vec<u8>)>,
+        trees: Vec<Tree>,
         tree: &Tree,
         state: &State,
         attachments: Vec<StateAttachment>,
@@ -185,12 +194,31 @@ impl FsStore {
         }
 
         let tree_hash = tree.hash();
-        if commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)? {
+        let mut staged_trees = Vec::with_capacity(trees.len() + 1);
+        let mut seen_trees = std::collections::HashSet::with_capacity(trees.len() + 1);
+        for authored_tree in trees {
+            let authored_hash = authored_tree.hash();
+            if seen_trees.insert(authored_hash)
+                && (commit_artifact.is_some()
+                    || !ObjectStore::has_tree_locally(self, &authored_hash)?)
+            {
+                builder.add(
+                    authored_hash,
+                    PackObjectType::Tree,
+                    rmp_serde::to_vec_named(&authored_tree)?,
+                );
+                staged_trees.push((authored_hash, authored_tree));
+            }
+        }
+        if (commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)?)
+            && seen_trees.insert(tree_hash)
+        {
             builder.add(
                 tree_hash,
                 PackObjectType::Tree,
                 rmp_serde::to_vec_named(tree)?,
             );
+            staged_trees.push((tree_hash, tree.clone()));
         }
 
         let state_id = state.id();
@@ -217,12 +245,16 @@ impl FsStore {
             })
             .collect::<Result<Vec<StateAttachmentId>>>()?;
         let artifact_id = commit_artifact.as_ref().map(SnapshotCommitArtifact::id);
+        let artifact_bytes = commit_artifact
+            .as_ref()
+            .map(rmp_serde::to_vec_named)
+            .transpose()?;
         if let Some(artifact) = &commit_artifact {
             artifact.validate()?;
             builder.add(
                 artifact.id(),
                 PackObjectType::SnapshotCommit,
-                rmp_serde::to_vec_named(artifact)?,
+                artifact_bytes.clone().expect("artifact bytes are present"),
             );
         }
 
@@ -234,6 +266,7 @@ impl FsStore {
                 pack_data,
                 index_data,
                 artifact_id.expect("commit artifact id is present"),
+                artifact_bytes.expect("commit artifact bytes are present"),
             )?
         } else {
             super::pack_install_journal::install_snapshot_pack_bytes(&packs, pack_data, index_data)?
@@ -255,21 +288,25 @@ impl FsStore {
             }
         }
         if let Ok(mut cache) = self.recent_trees.write() {
-            cache.insert(tree_hash, tree.clone());
+            for (hash, authored_tree) in staged_trees {
+                cache.insert(hash, authored_tree);
+            }
         }
         if let Ok(mut cache) = self.recent_states.write() {
             let mut cached = state.clone();
             cached.state_id = state_id;
             cache.insert(state_id, cached);
         }
-        let descriptor = if let Some(artifact_id) = artifact_id {
-            self.pack_manager()
-                .read()
-                .map_err(|_| {
-                    HeddleError::Config("Failed to acquire pack manager lock".to_string())
-                })?
-                .snapshot_commit_descriptor_for_state(&state_id)?
-                .filter(|descriptor| descriptor.artifact.id() == artifact_id)
+        let descriptor = if let Some(artifact) = commit_artifact {
+            let pack_path = packs.join(format!("{installed_pack_name}.pack"));
+            let index_path = packs.join(format!("{installed_pack_name}.idx"));
+            let object_ids = PackReader::open(&pack_path, &index_path)?.list_ids()?;
+            Some(SnapshotCommitDescriptor {
+                artifact,
+                pack_name: installed_pack_name,
+                pack_path,
+                object_ids,
+            })
         } else {
             None
         };

--- a/crates/objects/src/store/fs/pack_install_journal.rs
+++ b/crates/objects/src/store/fs/pack_install_journal.rs
@@ -910,8 +910,14 @@ pub(crate) fn install_committed_snapshot_pack_bytes(
     pack_data: Vec<u8>,
     index_data: Vec<u8>,
     artifact_id: ContentHash,
+    artifact_bytes: Vec<u8>,
 ) -> io::Result<String> {
-    install_snapshot_pack_bytes_inner(packs_dir, pack_data, index_data, &[artifact_id])
+    install_snapshot_pack_bytes_inner(
+        packs_dir,
+        pack_data,
+        index_data,
+        &[(artifact_id, artifact_bytes)],
+    )
 }
 
 pub(crate) fn install_snapshot_pack_bytes_with_commit_markers(
@@ -920,14 +926,19 @@ pub(crate) fn install_snapshot_pack_bytes_with_commit_markers(
     index_data: Vec<u8>,
     artifact_ids: &[ContentHash],
 ) -> io::Result<String> {
-    install_snapshot_pack_bytes_inner(packs_dir, pack_data, index_data, artifact_ids)
+    let markers = artifact_ids
+        .iter()
+        .copied()
+        .map(|id| (id, Vec::new()))
+        .collect::<Vec<_>>();
+    install_snapshot_pack_bytes_inner(packs_dir, pack_data, index_data, &markers)
 }
 
 fn install_snapshot_pack_bytes_inner(
     packs_dir: &Path,
     pack_data: Vec<u8>,
     index_data: Vec<u8>,
-    artifact_ids: &[ContentHash],
+    commit_markers: &[(ContentHash, Vec<u8>)],
 ) -> io::Result<String> {
     ensure_journal_layout_safe(packs_dir)?;
     let digest = *blake3::hash(&pack_data).as_bytes();
@@ -936,13 +947,14 @@ fn install_snapshot_pack_bytes_inner(
 
     let pack_path = dst_pack_path(packs_dir, &pack_name);
     if existing_pair_matches_digest(packs_dir, &pack_name, &digest)? {
-        for artifact_id in artifact_ids {
+        for (artifact_id, artifact_bytes) in commit_markers {
             let marker = snapshot_commit_marker_path(&pack_path, artifact_id);
             if !marker.exists() {
-                OpenOptions::new()
+                let mut file = OpenOptions::new()
                     .write(true)
                     .create_new(true)
                     .open(marker)?;
+                file.write_all(artifact_bytes)?;
             }
         }
         sync_directory(packs_dir)?;
@@ -968,12 +980,13 @@ fn install_snapshot_pack_bytes_inner(
         fault_inject::maybe_fail_at("snapshot_pack_after_publish_pack")?;
         fs::rename(&tmp_idx, &dst_idx)?;
         fault_inject::maybe_fail_at("snapshot_pack_after_publish_idx")?;
-        for artifact_id in artifact_ids {
+        for (artifact_id, artifact_bytes) in commit_markers {
             let marker = snapshot_commit_marker_path(&dst_pack, artifact_id);
-            OpenOptions::new()
+            let mut file = OpenOptions::new()
                 .write(true)
                 .create_new(true)
                 .open(marker)?;
+            file.write_all(artifact_bytes)?;
         }
         sync_directory(packs_dir)?;
         Ok(pack_name.clone())
@@ -1726,6 +1739,7 @@ mod tests {
                 pack_bytes.clone(),
                 idx_bytes.clone(),
                 artifact_id,
+                b"snapshot artifact metadata".to_vec(),
             )
         })
         .expect_err("fault should stop publication before the commit marker");
@@ -1733,11 +1747,17 @@ mod tests {
         assert!(existing_pair_matches_pack_name(&packs, &expected_name).unwrap());
         assert!(!marker.exists());
 
-        let repaired =
-            install_committed_snapshot_pack_bytes(&packs, pack_bytes, idx_bytes, artifact_id)
-                .unwrap();
+        let repaired = install_committed_snapshot_pack_bytes(
+            &packs,
+            pack_bytes,
+            idx_bytes,
+            artifact_id,
+            b"snapshot artifact metadata".to_vec(),
+        )
+        .unwrap();
         assert_eq!(repaired, expected_name);
         assert!(marker.exists());
+        assert_eq!(fs::read(marker).unwrap(), b"snapshot artifact metadata");
     }
 
     #[test]

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -308,6 +308,14 @@ impl ObjectStore for AnyStore {
 }
 
 impl AnyStore {
+    /// Lightweight repository-open seam for authoritative snapshot recovery.
+    #[doc(hidden)]
+    pub fn snapshot_commit_recovery_descriptors(&self) -> Result<Vec<SnapshotCommitDescriptor>> {
+        match self {
+            Self::Fs(store) => store.snapshot_commit_recovery_descriptors_impl(),
+        }
+    }
+
     /// Attach a read-only external source to the local filesystem store.
     pub fn set_external_source(&mut self, source: Arc<dyn ExternalObjectSource>) {
         match self {
@@ -344,6 +352,7 @@ impl AnyStore {
     pub fn put_committed_snapshot_objects_packed(
         &self,
         blobs: Vec<(ContentHash, Vec<u8>)>,
+        trees: Vec<Tree>,
         tree: &Tree,
         state: &State,
         attachments: Vec<StateAttachment>,
@@ -352,6 +361,7 @@ impl AnyStore {
         match self {
             Self::Fs(store) => store.put_committed_snapshot_objects_packed_impl(
                 blobs,
+                trees,
                 tree,
                 state,
                 attachments,

--- a/crates/objects/src/store/snapshot_commit.rs
+++ b/crates/objects/src/store/snapshot_commit.rs
@@ -20,6 +20,8 @@ use crate::{
 
 pub const SNAPSHOT_COMMIT_ARTIFACT_SCHEMA: u32 = 1;
 
+type SnapshotCommitMarkersByPack = HashMap<String, Vec<(ContentHash, Vec<u8>)>>;
+
 pub(crate) fn snapshot_commit_marker_path(pack_path: &Path, artifact_id: &ContentHash) -> PathBuf {
     let stem = pack_path
         .file_stem()
@@ -136,6 +138,53 @@ impl SnapshotPackManager {
         Ok(self.snapshot_commit_index()?.descriptors.clone())
     }
 
+    /// Read recovery metadata directly from commit markers. New markers carry
+    /// the canonical artifact bytes, so repository open does not need to parse
+    /// a large pack index merely to decide whether oplog/ref views need repair.
+    /// Empty or damaged legacy markers fall back to the authoritative pack.
+    pub(crate) fn snapshot_commit_recovery_descriptors(
+        &self,
+    ) -> Result<Vec<SnapshotCommitDescriptor>> {
+        let mut descriptors = Vec::new();
+        let markers_by_pack = snapshot_commit_markers_by_pack(self.format.packs_dir())?;
+        for (pack_path, _) in self.format.pack_file_paths() {
+            let pack_name = pack_path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .unwrap_or_default();
+            let markers = markers_by_pack
+                .get(pack_name)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            if markers.is_empty() {
+                continue;
+            }
+            let decoded = markers
+                .iter()
+                .map(|(expected, bytes)| decode_marker_artifact(*expected, bytes))
+                .collect::<Option<Vec<_>>>();
+            let Some(artifacts) = decoded else {
+                descriptors.extend(Self::snapshot_commit_descriptors_for_pack(
+                    &self.format,
+                    pack_path,
+                )?);
+                continue;
+            };
+            let pack_name = pack_name.to_string();
+            descriptors.extend(
+                artifacts
+                    .into_iter()
+                    .map(|artifact| SnapshotCommitDescriptor {
+                        artifact,
+                        pack_name: pack_name.clone(),
+                        pack_path: pack_path.to_path_buf(),
+                        object_ids: Vec::new(),
+                    }),
+            );
+        }
+        Ok(descriptors)
+    }
+
     pub(crate) fn snapshot_commit_descriptor_for_state(
         &self,
         state: &StateId,
@@ -213,7 +262,39 @@ impl SnapshotPackManager {
     }
 }
 
+fn snapshot_commit_markers_by_pack(packs_dir: &Path) -> Result<SnapshotCommitMarkersByPack> {
+    let mut markers = SnapshotCommitMarkersByPack::new();
+    for entry in fs::read_dir(packs_dir)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let Some((pack_name, artifact_hex)) = name
+            .to_str()
+            .and_then(|name| name.split_once(".snapshot-commit-"))
+        else {
+            continue;
+        };
+        let Ok(id) = ContentHash::from_hex(artifact_hex) else {
+            continue;
+        };
+        markers
+            .entry(pack_name.to_string())
+            .or_default()
+            .push((id, fs::read(entry.path())?));
+    }
+    for values in markers.values_mut() {
+        values.sort_unstable_by_key(|(id, _)| *id);
+    }
+    Ok(markers)
+}
+
 fn snapshot_commit_marker_ids(pack_path: &Path) -> Result<Vec<ContentHash>> {
+    Ok(snapshot_commit_markers(pack_path)?
+        .into_iter()
+        .map(|(id, _)| id)
+        .collect())
+}
+
+fn snapshot_commit_markers(pack_path: &Path) -> Result<Vec<(ContentHash, Vec<u8>)>> {
     let Some(parent) = pack_path.parent() else {
         return Ok(Vec::new());
     };
@@ -222,7 +303,7 @@ fn snapshot_commit_marker_ids(pack_path: &Path) -> Result<Vec<ContentHash>> {
         .and_then(|name| name.to_str())
         .unwrap_or_default();
     let prefix = format!("{stem}.snapshot-commit-");
-    let mut ids = Vec::new();
+    let mut markers = Vec::new();
     for entry in fs::read_dir(parent)? {
         let entry = entry?;
         let name = entry.file_name();
@@ -230,11 +311,17 @@ fn snapshot_commit_marker_ids(pack_path: &Path) -> Result<Vec<ContentHash>> {
             continue;
         };
         if let Ok(id) = ContentHash::from_hex(suffix) {
-            ids.push(id);
+            markers.push((id, fs::read(entry.path())?));
         }
     }
-    ids.sort_unstable();
-    Ok(ids)
+    markers.sort_unstable_by_key(|(id, _)| *id);
+    Ok(markers)
+}
+
+fn decode_marker_artifact(expected: ContentHash, bytes: &[u8]) -> Option<SnapshotCommitArtifact> {
+    let artifact = rmp_serde::from_slice::<SnapshotCommitArtifact>(bytes).ok()?;
+    artifact.validate().ok()?;
+    (artifact.id() == expected).then_some(artifact)
 }
 
 impl Deref for SnapshotPackManager {
@@ -290,7 +377,11 @@ mod tests {
         let index_path = root.join(format!("snapshot-{ordinal:03}.idx"));
         fs::write(&pack_path, pack_data).unwrap();
         fs::write(&index_path, index_data).unwrap();
-        fs::write(snapshot_commit_marker_path(&pack_path, &artifact_id), []).unwrap();
+        fs::write(
+            snapshot_commit_marker_path(&pack_path, &artifact_id),
+            rmp_serde::to_vec_named(&artifact).unwrap(),
+        )
+        .unwrap();
         (pack_path, index_path, state)
     }
 
@@ -360,6 +451,17 @@ mod tests {
         }
         assert_eq!(manager.pack_count(), 128);
         assert!(manager.snapshot_commit_index.get().is_none());
+        assert_eq!(
+            manager
+                .snapshot_commit_recovery_descriptors()
+                .unwrap()
+                .len(),
+            128
+        );
+        assert!(
+            manager.snapshot_commit_index.get().is_none(),
+            "marker-backed recovery must not build the full pack index"
+        );
         assert_eq!(manager.snapshot_commit_descriptors().unwrap().len(), 128);
         assert!(manager.snapshot_commit_index.get().is_some());
 

--- a/crates/objects/src/worktree/worktree_types.rs
+++ b/crates/objects/src/worktree/worktree_types.rs
@@ -26,7 +26,7 @@ pub struct WorktreeChange {
 }
 
 /// Worktree status summary.
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct WorktreeStatus {
     /// Files that have been modified.
     pub modified: Vec<PathBuf>,

--- a/crates/oplog/src/oplog/packed_oplog.rs
+++ b/crates/oplog/src/oplog/packed_oplog.rs
@@ -26,7 +26,7 @@ use heddle_schema::op_record::{
 };
 use objects::{
     error::{HeddleError, Result},
-    fs_atomic::{sync_directory, write_file_atomic},
+    fs_atomic::{sync_directory, write_file_atomic, write_file_atomic_reconstructible},
 };
 
 use super::oplog_types::{OpBatch, OpEntry, OpRecord};
@@ -310,13 +310,25 @@ impl PackedOpLog {
     }
 
     pub(crate) fn save(&self) -> Result<()> {
+        self.save_inner(false)
+    }
+
+    pub(crate) fn save_reconstructible(&self) -> Result<()> {
+        self.save_inner(true)
+    }
+
+    fn save_inner(&self, reconstructible: bool) -> Result<()> {
         let data = OplogData {
             entries: self.entries.clone(),
             head_id: self.head_id,
         };
         let mut bytes = Vec::new();
         encode_current_container(&data, &mut bytes)?;
-        write_file_atomic(&self.path, &bytes)?;
+        if reconstructible {
+            write_file_atomic_reconstructible(&self.path, &bytes)?;
+        } else {
+            write_file_atomic(&self.path, &bytes)?;
+        }
         Ok(())
     }
 

--- a/crates/oplog/src/oplog/segmented_oplog.rs
+++ b/crates/oplog/src/oplog/segmented_oplog.rs
@@ -8,7 +8,10 @@ use std::{
 
 use objects::{
     error::{HeddleError, Result},
-    fs_atomic::{create_dir_all_durable, sync_directory, write_file_atomic},
+    fs_atomic::{
+        create_dir_all_durable, sync_directory, write_file_atomic,
+        write_file_atomic_reconstructible,
+    },
 };
 
 use super::{
@@ -380,17 +383,14 @@ impl SegmentedOpLogIndex {
     }
 
     pub(crate) fn append_entries(&self, entries: &[OpEntry]) -> Result<Self> {
-        self.append_entries_inner(entries)
+        self.append_entries_inner(entries, false)
     }
 
     pub(crate) fn append_entries_reconstructible(&self, entries: &[OpEntry]) -> Result<Self> {
-        // The snapshot artifact remains the reconstruction source, but the
-        // manifest must not survive a crash without its selected segment.
-        // This durable ordering runs in the background materialization worker.
-        self.append_entries_inner(entries)
+        self.append_entries_inner(entries, true)
     }
 
-    fn append_entries_inner(&self, entries: &[OpEntry]) -> Result<Self> {
+    fn append_entries_inner(&self, entries: &[OpEntry], reconstructible: bool) -> Result<Self> {
         if entries.is_empty() {
             return Ok(self.clone());
         }
@@ -422,11 +422,20 @@ impl SegmentedOpLogIndex {
             "oplog.segments/segment-l{level:02}-{start:020}-{head:020}-g{generation:020}.bin"
         );
         let path = resolve_relative(&self.canonical_path, &relative)?;
-        create_dir_all_durable(path.parent().unwrap_or_else(|| Path::new(".")))?;
+        let segment_parent = path.parent().unwrap_or_else(|| Path::new("."));
+        if reconstructible {
+            fs::create_dir_all(segment_parent)?;
+        } else {
+            create_dir_all_durable(segment_parent)?;
+        }
         let mut packed = PackedOpLog::new(path.clone());
         packed.entries = carry_entries;
         packed.head_id = head;
-        packed.save()?;
+        if reconstructible {
+            packed.save_reconstructible()?;
+        } else {
+            packed.save()?;
+        }
         let index = PackedOpLogIndex::open(&path)?;
 
         let mut manifest = self.manifest.clone();
@@ -442,7 +451,11 @@ impl SegmentedOpLogIndex {
             .ok_or_else(|| HeddleError::InvalidObject("oplog entry count overflow".to_string()))?;
         manifest.head_id = head;
         let bytes = encode_manifest(&manifest)?;
-        write_manifest(&self.canonical_path, &bytes)?;
+        if reconstructible {
+            write_manifest_reconstructible(&self.canonical_path, &bytes)?;
+        } else {
+            write_manifest(&self.canonical_path, &bytes)?;
+        }
         sweep_unlisted_containers(&self.canonical_path, &manifest);
 
         indexes.push(index);
@@ -593,6 +606,12 @@ impl SegmentedOpLogIndex {
 fn write_manifest(path: &Path, bytes: &[u8]) -> Result<()> {
     let manifest = manifest_path(path);
     write_file_atomic(&manifest, bytes)?;
+    Ok(())
+}
+
+fn write_manifest_reconstructible(path: &Path, bytes: &[u8]) -> Result<()> {
+    let manifest = manifest_path(path);
+    write_file_atomic_reconstructible(&manifest, bytes)?;
     Ok(())
 }
 

--- a/crates/pack/src/store/pack/manager.rs
+++ b/crates/pack/src/store/pack/manager.rs
@@ -6,6 +6,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     sync::{OnceLock, RwLock},
+    time::SystemTime,
 };
 
 use tracing::{debug, instrument, trace};
@@ -127,7 +128,16 @@ impl PackManager {
             }
         }
 
-        packs.sort_by(|left, right| left.0.cmp(&right.0));
+        // Pack names are content hashes, so lexical order says nothing about
+        // recency. Keep the oldest pack first: point lookups walk this vector
+        // backwards and current snapshot trees overwhelmingly live in the
+        // newest incremental pack. The path is a deterministic tie-breaker
+        // for filesystems with coarse timestamp precision.
+        packs.sort_by(|left, right| {
+            pack_modified(&left.0)
+                .cmp(&pack_modified(&right.0))
+                .then_with(|| left.0.cmp(&right.0))
+        });
 
         debug!(count = packs.len(), "Discovered pack files");
         Ok(packs)
@@ -210,6 +220,33 @@ impl PackManager {
         Ok(index.locations.get(id).map(|location| location.pack_index))
     }
 
+    /// Locate one object through each pack's sorted index without building the
+    /// cross-pack map. Newer packs are checked first because incremental
+    /// snapshots usually place the current state/tree chain in the newest pack.
+    fn point_object_location(&self, id: &PackObjectId) -> Result<Option<usize>> {
+        {
+            let index = self
+                .object_locations
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if let Some(location) = index.locations.get(id) {
+                return Ok(Some(location.pack_index));
+            }
+            if index.complete {
+                return Ok(None);
+            }
+        }
+        for (pack_index, pack) in self.packs.iter().enumerate().rev() {
+            let Some(reader) = pack.reader() else {
+                continue;
+            };
+            if reader.contains_object(id)? {
+                return Ok(Some(pack_index));
+            }
+        }
+        Ok(None)
+    }
+
     /// Add a complete pack/index pair to the in-memory format index.
     pub fn add_pack(&mut self, pack_path: PathBuf, index_path: PathBuf) -> Result<()> {
         if self.packs.iter().any(|pack| pack.pack_path == pack_path) {
@@ -268,7 +305,7 @@ impl PackManager {
     }
 
     pub fn get_object(&self, id: &PackObjectId) -> Result<Option<(ObjectType, Vec<u8>)>> {
-        let Some(pack_index) = self.object_location(id)? else {
+        let Some(pack_index) = self.point_object_location(id)? else {
             trace!("Object not found in any pack");
             return Ok(None);
         };
@@ -332,7 +369,7 @@ impl PackManager {
     /// Look up the logical object type without decoding the object payload.
     pub fn get_hashed_object_type(&self, hash: &ContentHash) -> Result<Option<ObjectType>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_location(&id)? else {
+        let Some(pack_index) = self.point_object_location(&id)? else {
             return Ok(None);
         };
         let Some(reader) = self.packs[pack_index].reader() else {
@@ -350,7 +387,7 @@ impl PackManager {
         hash: &ContentHash,
     ) -> Result<Option<(ObjectType, bytes::Bytes)>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_location(&id)? else {
+        let Some(pack_index) = self.point_object_location(&id)? else {
             return Ok(None);
         };
         let Some(reader) = self.packs[pack_index].reader() else {
@@ -360,7 +397,7 @@ impl PackManager {
     }
 
     pub fn has_object(&self, hash: &ContentHash) -> bool {
-        self.object_location(&PackObjectId::Hash(*hash))
+        self.point_object_location(&PackObjectId::Hash(*hash))
             .is_ok_and(|location| location.is_some())
     }
 
@@ -369,7 +406,7 @@ impl PackManager {
     /// when the object isn't in any loaded pack.
     pub fn get_hashed_object_size(&self, hash: &ContentHash) -> Result<Option<u64>> {
         let id = PackObjectId::Hash(*hash);
-        let Some(pack_index) = self.object_location(&id)? else {
+        let Some(pack_index) = self.point_object_location(&id)? else {
             return Ok(None);
         };
         let Some(reader) = self.packs[pack_index].reader() else {
@@ -419,6 +456,12 @@ impl PackManager {
     pub fn packs_dir(&self) -> &Path {
         &self.packs_dir
     }
+}
+
+fn pack_modified(path: &Path) -> SystemTime {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .unwrap_or(SystemTime::UNIX_EPOCH)
 }
 
 fn remember_location(

--- a/crates/pack/src/store/pack/manager_tests.rs
+++ b/crates/pack/src/store/pack/manager_tests.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{fs::OpenOptions, sync::Arc};
+use std::{
+    fs::OpenOptions,
+    sync::Arc,
+    time::{Duration, SystemTime},
+};
 
 use heddle_format::compression::CompressionConfig;
 use tempfile::TempDir;
@@ -32,6 +36,33 @@ fn write_pack(
 
 fn cached_location_count(manager: &PackManager) -> usize {
     manager.object_locations.read().unwrap().locations.len()
+}
+
+#[test]
+fn discovered_packs_are_ordered_oldest_to_newest() {
+    let temp = TempDir::new().unwrap();
+    let (old_pack, _, _) = write_pack(temp.path(), 999);
+    let (new_pack, _, _) = write_pack(temp.path(), 0);
+    std::fs::File::options()
+        .write(true)
+        .open(&old_pack)
+        .unwrap()
+        .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(1))
+        .unwrap();
+    std::fs::File::options()
+        .write(true)
+        .open(&new_pack)
+        .unwrap()
+        .set_modified(SystemTime::UNIX_EPOCH + Duration::from_secs(2))
+        .unwrap();
+
+    let manager = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
+    let discovered = manager
+        .packs
+        .iter()
+        .map(|pack| pack.pack_path.clone())
+        .collect::<Vec<_>>();
+    assert_eq!(discovered, vec![old_pack, new_pack]);
 }
 
 fn write_solid_tree_pack(root: &std::path::Path, name: &str, trees: &[Tree]) {
@@ -90,8 +121,15 @@ fn object_locator_is_lazy_for_incremental_and_reloaded_packs() {
     assert_eq!(ids.len(), 8);
     assert_eq!(cached_location_count(&manager), 0);
     for id in &ids {
-        assert!(manager.has_object_id(id));
         assert!(manager.get_object(id).unwrap().is_some());
+    }
+    assert_eq!(
+        cached_location_count(&manager),
+        0,
+        "point reads must not materialize the global object map"
+    );
+    for id in &ids {
+        assert!(manager.has_object_id(id));
     }
     assert_eq!(cached_location_count(&manager), 8);
 
@@ -111,7 +149,7 @@ fn object_locator_is_lazy_for_incremental_and_reloaded_packs() {
 }
 
 #[test]
-fn adding_a_pack_extends_a_completed_lazy_index() {
+fn adding_a_pack_remains_point_addressable_without_a_global_index() {
     let temp = TempDir::new().unwrap();
     let mut manager = PackManager::new_with_index_mode(temp.path().to_path_buf(), false);
     let (pack_path, index_path, id) = write_pack(temp.path(), 1);
@@ -119,7 +157,7 @@ fn adding_a_pack_extends_a_completed_lazy_index() {
     assert!(!manager.has_object(&id));
     assert_eq!(cached_location_count(&manager), 0);
     manager.add_pack(pack_path, index_path).unwrap();
-    assert_eq!(cached_location_count(&manager), 1);
+    assert_eq!(cached_location_count(&manager), 0);
     assert!(manager.has_object(&id));
     assert!(manager.get_hashed_object(&id).unwrap().is_some());
 }

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -232,6 +232,12 @@ impl<'a> PackReader<'a> {
             .collect())
     }
 
+    /// Point-membership probe backed by the sorted pack index. This avoids
+    /// enumerating every object merely to locate one hot-path tree or state.
+    pub(super) fn contains_object(&self, id: &PackObjectId) -> Result<bool> {
+        Ok(self.index.find(id)?.is_some())
+    }
+
     #[cfg(test)]
     pub(super) fn compact_frame_read_count(&self) -> usize {
         self.compact_frame_reads.load(Ordering::Relaxed)

--- a/crates/refs/src/refs/ref_summary_index.rs
+++ b/crates/refs/src/refs/ref_summary_index.rs
@@ -127,6 +127,13 @@ pub(super) struct RefSummaryIndex {
 }
 
 impl RefSummaryIndex {
+    pub(super) fn thread_states(&self) -> Vec<(ThreadName, StateId)> {
+        self.threads
+            .iter()
+            .map(|entry| (ThreadName::new(&entry.name), entry.state_id))
+            .collect()
+    }
+
     fn parse(contents: &str) -> Result<Self> {
         let mut lines = contents.lines();
         let header = lines

--- a/crates/refs/src/refs/refs_manager.rs
+++ b/crates/refs/src/refs/refs_manager.rs
@@ -47,6 +47,14 @@ const RECONCILE_WATERMARK_LOCAL: &str = "RECONCILE_WATERMARK_LOCAL";
 /// sibling had already processed/published — resurrecting it cross-worktree.
 const RECONCILE_WATERMARK_SHARED: &str = "RECONCILE_WATERMARK_SHARED";
 
+/// Reconstructible, request-scoped proof that the canonical HEAD written by a
+/// committed snapshot already matches the current oplog tip. Unlike a class
+/// watermark this is trusted only when both its tip and raw ref value match.
+const SNAPSHOT_WITNESS_LOCAL: &str = "SNAPSHOT_WITNESS_LOCAL";
+
+/// Shared-thread counterpart to [`SNAPSHOT_WITNESS_LOCAL`].
+const SNAPSHOT_WITNESS_SHARED: &str = "SNAPSHOT_WITNESS_SHARED";
+
 /// Well-known refspec that resolves the heddle-internal pre-undo recovery
 /// pointer used by `heddle undo --recover`. It is UNSHADOWABLE by any user
 /// marker or thread, in BOTH directions (heddle#305 r3):
@@ -72,7 +80,7 @@ pub const UNDO_RECOVERY_HANDLE: &str = ".undo-recovery";
 /// revalidated via `(mtime, len)` when another process rewrites the file.
 struct CachedPackedRefs {
     stamp: Option<(SystemTime, u64)>,
-    packed: PackedRefs,
+    packed: Arc<PackedRefs>,
 }
 
 /// Manager for references (threads, markers, HEAD).
@@ -275,6 +283,14 @@ impl RefManager {
         // Attached snapshots do not change HEAD's identity; this commit has no
         // other local-class effect, so the local view is complete at `tip` too.
         self.cached_local_generation.store(tip, Ordering::Release);
+        let _ = std::fs::write(
+            self.snapshot_witness_local_path(),
+            format!("{tip}\nattached\n{thread}\n"),
+        );
+        let _ = std::fs::write(
+            self.snapshot_witness_shared_path(),
+            format!("{tip}\nthread\n{thread}\n{}\n", state.to_string_full()),
+        );
         Ok(())
     }
 
@@ -295,6 +311,10 @@ impl RefManager {
         self.cached_local_generation.store(tip, Ordering::Release);
         // Detached snapshots do not touch a shared ref.
         self.cached_shared_generation.store(tip, Ordering::Release);
+        let _ = std::fs::write(
+            self.snapshot_witness_local_path(),
+            format!("{tip}\ndetached\n{}\n", state.to_string_full()),
+        );
         Ok(())
     }
 
@@ -409,6 +429,9 @@ impl RefManager {
         let tip = reconciler.generation()?;
         if watermark_covers(watermark.load(Ordering::Acquire), tip) {
             return self.raw_load(&req);
+        }
+        if let Some(loaded) = self.snapshot_witnessed_load(&req, tip)? {
+            return Ok(loaded);
         }
 
         // Lag: the fold AND the lazy re-publish must be atomic w.r.t. a
@@ -542,6 +565,80 @@ impl RefManager {
     /// under the same shared root and whose `LOCK` already serializes writers.
     fn reconcile_watermark_shared_path(&self) -> PathBuf {
         self.root.join(RECONCILE_WATERMARK_SHARED)
+    }
+
+    fn snapshot_witness_local_path(&self) -> PathBuf {
+        self.head_path()
+            .parent()
+            .map(|dir| dir.join(SNAPSHOT_WITNESS_LOCAL))
+            .unwrap_or_else(|| self.root.join(SNAPSHOT_WITNESS_LOCAL))
+    }
+
+    fn snapshot_witness_shared_path(&self) -> PathBuf {
+        self.root.join(SNAPSHOT_WITNESS_SHARED)
+    }
+
+    /// Return the raw point value when a snapshot witness proves this exact
+    /// read is already materialized at `tip`. Missing, torn, stale, and
+    /// mismatched witnesses are cache misses and fall through to reconciliation.
+    fn snapshot_witnessed_load(&self, request: &LoadRequest, tip: u64) -> Result<Option<Loaded>> {
+        let parse_tip = |lines: &mut std::str::Lines<'_>| {
+            lines
+                .next()
+                .and_then(|value| value.parse::<u64>().ok())
+                .filter(|value| *value == tip)
+        };
+        match request {
+            LoadRequest::Head => {
+                let Some(contents) =
+                    self.read_optional_string(&self.snapshot_witness_local_path())?
+                else {
+                    return Ok(None);
+                };
+                let mut lines = contents.lines();
+                if parse_tip(&mut lines).is_none() {
+                    return Ok(None);
+                }
+                let witnessed = match lines.next() {
+                    Some("attached") => lines.next().map(|thread| Head::Attached {
+                        thread: ThreadName::new(thread),
+                    }),
+                    Some("detached") => lines
+                        .next()
+                        .and_then(|state| StateId::parse(state).ok())
+                        .map(|state| Head::Detached { state }),
+                    _ => None,
+                };
+                let Some(witnessed) = witnessed else {
+                    return Ok(None);
+                };
+                let raw = self.read_head_state()?.head;
+                Ok((raw == witnessed).then_some(Loaded::Head(raw)))
+            }
+            LoadRequest::Thread(requested) => {
+                let Some(contents) =
+                    self.read_optional_string(&self.snapshot_witness_shared_path())?
+                else {
+                    return Ok(None);
+                };
+                let mut lines = contents.lines();
+                if parse_tip(&mut lines).is_none() || lines.next() != Some("thread") {
+                    return Ok(None);
+                }
+                let Some(thread) = lines.next() else {
+                    return Ok(None);
+                };
+                let Some(state) = lines.next().and_then(|value| StateId::parse(value).ok()) else {
+                    return Ok(None);
+                };
+                if thread != requested.as_str() {
+                    return Ok(None);
+                }
+                let raw = self.raw_get_thread(requested)?;
+                Ok((raw == Some(state)).then_some(Loaded::Point(raw)))
+            }
+            _ => Ok(None),
+        }
     }
 
     /// Read the persisted `(local, shared)` watermark from their two scope
@@ -710,7 +807,7 @@ impl RefManager {
     /// Load packed-refs with a process-local cache. Safe under concurrent
     /// readers in this process; writers call [`invalidate_packed_refs_cache`]
     /// after mutating the file.
-    pub(super) fn load_packed_refs_cached(&self) -> Result<PackedRefs> {
+    pub(super) fn load_packed_refs_cached(&self) -> Result<Arc<PackedRefs>> {
         let path = self.packed_refs_path();
         let stamp = Self::packed_refs_stamp(&path);
         let mut guard = self.packed_refs_cache.lock().map_err(|_| {
@@ -721,7 +818,7 @@ impl RefManager {
         {
             return Ok(cached.packed.clone());
         }
-        let packed = PackedRefs::load(&path)?;
+        let packed = Arc::new(PackedRefs::load(&path)?);
         *guard = Some(CachedPackedRefs {
             stamp,
             packed: packed.clone(),
@@ -877,6 +974,32 @@ impl RefManager {
             Loaded::ThreadList(names) => Ok(names),
             _ => unreachable!("ThreadList request yields ThreadList"),
         }
+    }
+
+    /// List thread names and targets through one reconciled list read. The
+    /// summary index is updated by reconciliation before it is read here, so
+    /// callers avoid one logical point read per listed thread.
+    pub fn list_threads_with_states(&self) -> Result<Vec<(ThreadName, StateId)>> {
+        let names = self.list_threads()?;
+        if let Some(summary) = self.try_read_ref_summary_index() {
+            let states = summary.thread_states();
+            if states.len() == names.len()
+                && states
+                    .iter()
+                    .zip(&names)
+                    .all(|((state_name, _), name)| state_name == name)
+            {
+                return Ok(states);
+            }
+        }
+        names
+            .into_iter()
+            .filter_map(|name| match self.raw_get_thread(&name) {
+                Ok(Some(state)) => Some(Ok((name, state))),
+                Ok(None) => None,
+                Err(error) => Some(Err(error)),
+            })
+            .collect()
     }
 
     pub fn get_marker(&self, name: &MarkerName) -> Result<Option<StateId>> {
@@ -1120,7 +1243,7 @@ impl RefManager {
     pub fn pack_refs(&self) -> Result<()> {
         let lock = self.lock_refs()?;
         let packed_path = self.packed_refs_path();
-        let mut packed = self.load_packed_refs_cached()?;
+        let mut packed = (*self.load_packed_refs_cached()?).clone();
 
         let threads = self.list_threads_from_storage()?;
         for name in &threads {

--- a/crates/refs/src/refs/refs_tests.rs
+++ b/crates/refs/src/refs/refs_tests.rs
@@ -887,6 +887,7 @@ mod chokepoint {
         });
         let refs = RefManager::new(&dir).with_reconciler(reconciler.clone());
         refs.init().unwrap();
+        refs.init_reconcile_watermark().unwrap();
 
         let thread = ThreadName::new("main");
         let attached_state = crate::refs::fresh_state_id();
@@ -898,6 +899,22 @@ mod chokepoint {
         let summary = refs.inspect_ref_summary_index().unwrap();
         assert!(summary.present && summary.valid);
         assert_eq!(summary.threads, 1);
+
+        reconciler.generation.store(2, Ordering::Release);
+        let reopened = RefManager::new(&dir).with_reconciler(reconciler.clone());
+        reopened.init_reconcile_watermark().unwrap();
+        assert_eq!(
+            reopened.read_head().unwrap(),
+            super::super::Head::Attached {
+                thread: thread.clone()
+            }
+        );
+        assert_eq!(reopened.get_thread(&thread).unwrap(), Some(attached_state));
+        assert_eq!(
+            calls.load(Ordering::Acquire),
+            0,
+            "a fresh reader should validate snapshot witnesses without replay"
+        );
 
         let detached_state = crate::refs::fresh_state_id();
         reconciler.generation.store(3, Ordering::Release);

--- a/crates/refs/src/refs/refs_transactions.rs
+++ b/crates/refs/src/refs/refs_transactions.rs
@@ -646,7 +646,7 @@ impl RefManager {
             return Ok(());
         }
 
-        let mut packed = self.load_packed_refs_cached()?;
+        let mut packed = (*self.load_packed_refs_cached()?).clone();
         for removal in removals {
             match removal {
                 PackedRemove::Thread(name) => packed.remove_track(name),

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -105,6 +105,15 @@ pub(crate) struct ChangeMonitorSession {
     pub(crate) status: MonitorStatus,
 }
 
+/// Opaque identity for the exact change-monitor position used to prepare a
+/// snapshot. Equality means the monitor observed no worktree event between
+/// preparation and the under-lock revalidation check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ChangeMonitorToken {
+    backend: &'static str,
+    cursor: String,
+}
+
 impl ChangeMonitorSession {
     /// Prepare a change-monitor query for a worktree compare run.
     pub(crate) fn prepare(repo_root: &Path, settings: FsMonitorSettings) -> Self {
@@ -141,6 +150,64 @@ impl ChangeMonitorSession {
         self.changed_paths
             .as_ref()
             .map_or(0, |paths| paths.len() as u64)
+    }
+
+    /// Return the sole changed path when the monitor has an authoritative,
+    /// non-policy-changing one-path delta. Snapshot can then update that leaf
+    /// and its ancestor trees directly instead of enumerating every sibling in
+    /// a large root directory.
+    pub(crate) fn single_changed_path(&self) -> Option<&str> {
+        if subtree_skip_disabled() || self.status != MonitorStatus::Usable {
+            return None;
+        }
+        let paths = self.changed_paths.as_ref()?;
+        if paths.len() != 1 || ignore_policy_paths_changed(paths) {
+            return None;
+        }
+        paths.iter().next().map(String::as_str)
+    }
+
+    /// Immediate child names that may have changed below `rel_path`.
+    ///
+    /// `None` means callers must enumerate the directory (the monitor is not
+    /// authoritative, an ignore policy changed, or the directory itself was
+    /// reported). `Some` is an exhaustive set, so tracked/status walkers may
+    /// visit only those children and preserve all other baseline entries.
+    pub(crate) fn changed_child_names(&self, rel_path: &Path) -> Option<BTreeSet<String>> {
+        if subtree_skip_disabled() || self.status != MonitorStatus::Usable {
+            return None;
+        }
+        let paths = self.changed_paths.as_ref()?;
+        if ignore_policy_paths_changed(paths) {
+            return None;
+        }
+        let key = cache_key(rel_path);
+        let mut names = BTreeSet::new();
+        for changed in paths {
+            let suffix = if key.is_empty() {
+                changed.as_str()
+            } else if changed == &key {
+                return None;
+            } else {
+                changed.strip_prefix(&format!("{key}/"))?
+            };
+            let name = suffix.split('/').next()?;
+            if name.is_empty() {
+                return None;
+            }
+            names.insert(name.to_string());
+        }
+        Some(names)
+    }
+
+    pub(crate) fn revalidation_token(&self) -> Option<ChangeMonitorToken> {
+        if self.status != MonitorStatus::Usable {
+            return None;
+        }
+        Some(ChangeMonitorToken {
+            backend: self.backend?,
+            cursor: self.next_cursor.clone()?,
+        })
     }
 
     pub(crate) fn changed_directory_keys(&self) -> BTreeSet<String> {
@@ -194,6 +261,29 @@ impl ChangeMonitorSession {
             && self.status == MonitorStatus::Usable
             && self.changed_paths.is_some()
             && index.get_directory(&cache_key(rel_path)).is_some()
+    }
+
+    /// Returns whether the active monitor cursor proves that `rel_path` did
+    /// not change since the persisted baseline. Unlike
+    /// [`Self::can_reuse_unchanged_child`], this does not require an index
+    /// entry: callers that are validating a tree they just prepared already
+    /// own the relevant tree baseline and only need the cursor proof.
+    pub(crate) fn can_reuse_since_cursor(&self, rel_path: &Path) -> bool {
+        !subtree_skip_disabled()
+            && self.status == MonitorStatus::Usable
+            && self.changed_paths.is_some()
+            && !self.path_may_have_changed(rel_path)
+    }
+
+    /// Returns whether a tracked child can be reused without touching its
+    /// metadata. A validated parent index entry anchors the monitor's clean
+    /// baseline, and the monitor proves that this child has not changed since
+    /// that baseline. Requiring the parent (rather than the child's own hot
+    /// index entry) lets a one-path query load only the changed path and its
+    /// ancestors while safely reusing unchanged sibling trees.
+    pub(crate) fn can_reuse_unchanged_child(&self, rel_path: &Path, index: &WorktreeIndex) -> bool {
+        let parent = rel_path.parent().unwrap_or_else(|| Path::new(""));
+        self.can_filter_directory_children(parent, index) && self.can_reuse_since_cursor(rel_path)
     }
 
     pub(crate) fn can_skip_directory(
@@ -1397,6 +1487,7 @@ fn optional_string(value: &Value, key: &str) -> Option<String> {
 mod tests {
     use std::{
         collections::BTreeSet,
+        path::Path,
         sync::{
             Arc, Barrier,
             atomic::{AtomicUsize, Ordering},
@@ -1408,9 +1499,9 @@ mod tests {
     use tempfile::TempDir;
 
     use super::{
-        HELPER_HOST, HELPER_PROTOCOL_VERSION, helper_endpoint_path,
-        local_helper_binary_for_executable, shutdown_local_monitor_helper, subtree_has_changes,
-        try_spawn_local_helper_with, try_spawn_local_helper_with_probe,
+        ChangeMonitorSession, HELPER_HOST, HELPER_PROTOCOL_VERSION, MonitorStatus,
+        helper_endpoint_path, local_helper_binary_for_executable, shutdown_local_monitor_helper,
+        subtree_has_changes, try_spawn_local_helper_with, try_spawn_local_helper_with_probe,
     };
     use crate::{DirectoryCacheEntry, WorktreeIndex};
 
@@ -1446,6 +1537,34 @@ mod tests {
 
         let cached = index.get_directory("src").unwrap();
         assert_eq!(cached.clean_tree_hash, Some(tree_hash));
+    }
+
+    #[test]
+    fn unchanged_child_reuse_is_anchored_by_its_parent_index_entry() {
+        let mut index = WorktreeIndex::new();
+        index.insert_directory(
+            "src".to_string(),
+            DirectoryCacheEntry {
+                mtime_sec: 0,
+                mtime_nsec: 0,
+                child_count: 2,
+                child_digest: DirectoryCacheEntry::digest_for_child_names(
+                    ["changed", "unchanged"].into_iter(),
+                    2,
+                )
+                .unwrap(),
+                clean_tree_hash: None,
+            },
+        );
+        let monitor = ChangeMonitorSession {
+            changed_paths: Some(BTreeSet::from(["src/changed/file.rs".to_string()])),
+            status: MonitorStatus::Usable,
+            ..ChangeMonitorSession::default()
+        };
+
+        assert!(monitor.can_reuse_unchanged_child(Path::new("src/unchanged"), &index));
+        assert!(!monitor.can_reuse_unchanged_child(Path::new("src/changed"), &index));
+        assert!(!monitor.can_reuse_unchanged_child(Path::new("other/unchanged"), &index));
     }
 
     #[test]

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -159,9 +159,9 @@ pub use repository::{
     RepositoryPerformanceInspectionReport, RepositorySourceAuthority, SUGGESTION_WINDOW,
     SnapshotExecution, SnapshotProfile, SpoolFacet, ThreadCaptureOutcome, TreeBuildProfile,
     TrustedKey, UntrackedSet, UntrackedSubtree, WarmCanonicalStoreStats, WorktreeCompareProfile,
-    WorktreeIndexInspection, WorktreeStatusDetailed, compute_rewrite_pct, discover_heddle_root,
-    find_merge_base, is_heddle_repository_root, is_major_rewrite, is_synthetic_root,
-    open_git_repository_at_root, query_history_from_source,
+    WorktreeIndexInspection, WorktreeStateLookupProfile, WorktreeStatusDetailed,
+    compute_rewrite_pct, discover_heddle_root, find_merge_base, is_heddle_repository_root,
+    is_major_rewrite, is_synthetic_root, open_git_repository_at_root, query_history_from_source,
 };
 #[cfg(feature = "git-overlay")]
 pub use repository::{GitOverlayBranchTip, GitOverlayOutOfBandCommits, GitOverlayShortStatus};

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -101,7 +101,7 @@ pub use repository_materialization::WarmCanonicalStoreStats;
 pub use repository_partial_fetch::MissingBlob;
 pub use repository_snapshot::{SnapshotExecution, SnapshotProfile};
 pub use repository_thread_materialize::{CheckoutMaterialization, ThreadCaptureOutcome};
-pub use repository_tree::{TreeBuildProfile, WorktreeCompareProfile};
+pub use repository_tree::{TreeBuildProfile, WorktreeCompareProfile, WorktreeStateLookupProfile};
 pub use repository_worktree_status::{UntrackedSet, UntrackedSubtree, WorktreeStatusDetailed};
 use rusqlite::{Connection, OpenFlags};
 use serde::{Deserialize, Serialize};
@@ -786,7 +786,7 @@ impl Repository {
     /// Replay authoritative structured-snapshot artifacts whose oplog/ref
     /// materialized views were lost before they reached stable storage.
     fn recover_snapshot_artifact_views(&self) -> Result<()> {
-        let mut pending = self.store.snapshot_commit_descriptors()?;
+        let mut pending = self.store.snapshot_commit_recovery_descriptors()?;
         if pending.is_empty() {
             return Ok(());
         }

--- a/crates/repo/src/repository_recovery.rs
+++ b/crates/repo/src/repository_recovery.rs
@@ -204,7 +204,6 @@ fn recovery_dirty_conflict(paths: Vec<String>) -> HeddleError {
 mod tests {
     use std::fs;
 
-    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use super::*;
@@ -225,17 +224,36 @@ mod tests {
             .heddle_dir()
             .join("objects/states")
             .join(format!("{}.state", current.id().to_string_full()));
-        fs::remove_file(current_path).unwrap();
+        if current_path.exists() {
+            fs::remove_file(current_path).unwrap();
+        }
+        let current_pack = repo
+            .store()
+            .snapshot_commit_descriptors()
+            .unwrap()
+            .into_iter()
+            .find(|descriptor| descriptor.artifact.state == current.id())
+            .unwrap()
+            .pack_path;
+        let current_pack_stem = current_pack
+            .file_stem()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
         let packs = repo.heddle_dir().join("packs");
         for entry in fs::read_dir(packs).unwrap() {
             let path = entry.unwrap().path();
-            if path.is_dir() {
-                fs::remove_dir_all(path).unwrap();
-            } else {
+            let is_current_pack_artifact = path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().starts_with(&current_pack_stem));
+            if is_current_pack_artifact {
                 fs::remove_file(path).unwrap();
             }
         }
-        repo.store().clear_recent_caches();
+        // Snapshot objects are authoritative in packs, so reopen to discard
+        // the live store's immutable pack mappings after deleting those packs.
+        drop(repo);
+        let repo = Repository::open(temp.path()).unwrap();
 
         let error = repo
             .restore_state_tree_to_worktree(&recovery.id())

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -58,6 +58,10 @@ use crate::{
 /// symbols.
 const SEMANTIC_FILE_BUDGET_BYTES: usize = 1 << 20;
 
+type PendingSemanticBlobs = Vec<(ContentHash, Vec<u8>)>;
+type DeferredSemanticRoot = (SemanticIndexRoot, ContentHash, PendingSemanticBlobs);
+type DeferredSemanticIndex = (Option<ContentHash>, PendingSemanticBlobs);
+
 /// What a built subtree resolved to: the storage hash of the node blob (or the
 /// raw source blob, for opaque entries) plus its reformat-stable digest.
 #[derive(Clone, Copy)]
@@ -74,6 +78,7 @@ struct BuiltEntry {
 pub struct SemanticIndexBuilder<'store, S: ObjectStore> {
     store: &'store S,
     source_blobs: Option<&'store HashMap<ContentHash, &'store [u8]>>,
+    source_trees: Option<&'store HashMap<ContentHash, &'store Tree>>,
     extractor_version: u32,
     /// Per-build memo keyed by `(source blob hash, language)` — a blob that
     /// appears at several paths is parsed once, but byte-identical blobs at
@@ -95,6 +100,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         Self {
             store,
             source_blobs: None,
+            source_trees: None,
             extractor_version,
             file_memo: HashMap::new(),
             grammars: BTreeMap::new(),
@@ -103,13 +109,15 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         }
     }
 
-    pub(crate) fn with_source_blobs(
+    pub(crate) fn with_source_objects(
         store: &'store S,
         extractor_version: u32,
         source_blobs: &'store HashMap<ContentHash, &'store [u8]>,
+        source_trees: &'store HashMap<ContentHash, &'store Tree>,
     ) -> Self {
         Self {
             source_blobs: Some(source_blobs),
+            source_trees: Some(source_trees),
             ..Self::new(store, extractor_version)
         }
     }
@@ -122,6 +130,19 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
         tree: &Tree,
         parent: Option<&ParentIndex>,
     ) -> Result<(SemanticIndexRoot, ContentHash)> {
+        let (root, root_hash, pending) = self.build_root_deferred(tree, parent)?;
+        self.store.put_blobs_packed(pending)?;
+        Ok((root, root_hash))
+    }
+
+    /// Build the semantic closure without crossing a durability barrier.
+    /// Worktree snapshots fold these blobs into their authoritative commit
+    /// pack; other callers use [`Self::build_root`] for immediate persistence.
+    pub(crate) fn build_root_deferred(
+        &mut self,
+        tree: &Tree,
+        parent: Option<&ParentIndex>,
+    ) -> Result<DeferredSemanticRoot> {
         // Refuse node reuse across an extractor or grammar bump: reusing stale
         // nodes would mix v1+v2 fingerprints in one index. A non-current parent
         // is dropped entirely, forcing a clean full rebuild.
@@ -138,12 +159,7 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             digest,
         );
         let root_hash = self.put_node(root.encode()?);
-        // Flush every node blob as a single pack — the same hot path the
-        // snapshot uses for source blobs, so capture stays fsync-cheap and
-        // leaves nothing loose behind.
-        self.store
-            .put_blobs_packed(std::mem::take(&mut self.pending))?;
-        Ok((root, root_hash))
+        Ok((root, root_hash, std::mem::take(&mut self.pending)))
     }
 
     /// Whether a parent index may be reused: its extractor version and every
@@ -225,10 +241,16 @@ impl<'store, S: ObjectStore> SemanticIndexBuilder<'store, S> {
             });
         }
 
-        let source_tree = self
-            .store
-            .get_tree(&source_hash)?
-            .ok_or_else(|| crate::HeddleError::NotFound(format!("tree {source_hash}")))?;
+        let source_tree = match self
+            .source_trees
+            .and_then(|trees| trees.get(&source_hash).copied())
+        {
+            Some(tree) => tree.clone(),
+            None => self
+                .store
+                .get_tree(&source_hash)?
+                .ok_or_else(|| crate::HeddleError::NotFound(format!("tree {source_hash}")))?,
+        };
 
         // Descend with the matching parent subtree as the reuse basis, if any.
         let child_parent = self.child_parent_ctx(name, parent)?;
@@ -420,7 +442,7 @@ impl Repository {
                 return Ok(None);
             }
         };
-        self.compute_and_persist_semantic_index_for_tree(prior, &tree, None)
+        self.compute_and_persist_semantic_index_for_tree(prior, &tree, None, None)
     }
 
     pub(crate) fn compute_and_persist_semantic_index_for_tree(
@@ -428,7 +450,23 @@ impl Repository {
         prior: Option<&State>,
         tree: &Tree,
         source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
     ) -> Result<Option<ContentHash>> {
+        let (root, pending) =
+            self.compute_semantic_index_for_tree_deferred(prior, tree, source_blobs, source_trees)?;
+        self.store().put_blobs_packed(pending)?;
+        Ok(root)
+    }
+
+    /// Build and resolve the semantic closure without persisting it. Snapshot
+    /// authoring includes the returned blobs in its single authoritative pack.
+    pub(crate) fn compute_semantic_index_for_tree_deferred(
+        &self,
+        prior: Option<&State>,
+        tree: &Tree,
+        source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&HashMap<ContentHash, &Tree>>,
+    ) -> Result<DeferredSemanticIndex> {
         let parent = match prior.map(|p| self.materialize_parent_index(p)) {
             Some(Ok(Some(parent))) => Some(parent),
             Some(Ok(None)) | None => None,
@@ -437,25 +475,32 @@ impl Repository {
                 None
             }
         };
-        let mut builder = match source_blobs {
-            Some(source_blobs) => SemanticIndexBuilder::with_source_blobs(
+        let mut builder = match (source_blobs, source_trees) {
+            (Some(source_blobs), Some(source_trees)) => SemanticIndexBuilder::with_source_objects(
                 self.store(),
                 EXTRACTOR_VERSION,
                 source_blobs,
+                source_trees,
             ),
-            None => SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION),
+            _ => SemanticIndexBuilder::new(self.store(), EXTRACTOR_VERSION),
         };
-        match builder.build_root(tree, parent.as_ref()) {
-            Ok((root, _)) => match self.persist_resolved_semantic_edges(prior, root) {
-                Ok(root_hash) => Ok(Some(root_hash)),
-                Err(err) => {
-                    warn!(error = %err, "semantic graph: resolution failed; skipping index");
-                    Ok(None)
+        match builder.build_root_deferred(tree, parent.as_ref()) {
+            Ok((root, _, mut pending)) => {
+                let pending_by_hash = pending.iter().cloned().collect::<HashMap<_, _>>();
+                match self.persist_resolved_semantic_edges_deferred(prior, root, &pending_by_hash) {
+                    Ok((root_hash, resolved)) => {
+                        pending.extend(resolved);
+                        Ok((Some(root_hash), pending))
+                    }
+                    Err(err) => {
+                        warn!(error = %err, "semantic graph: resolution failed; skipping index");
+                        Ok((None, Vec::new()))
+                    }
                 }
-            },
+            }
             Err(err) => {
                 warn!(error = %err, "semantic index: build failed; skipping");
-                Ok(None)
+                Ok((None, Vec::new()))
             }
         }
     }

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -15,11 +15,14 @@ use oplog::{IsolationKey, OpRecord};
 use refs::Head;
 use tracing::{debug, instrument};
 
-use super::{HeddleError, Repository, Result, repository_tree::TreeBuildProfile};
+use super::{
+    HeddleError, Repository, Result,
+    repository_tree::{SnapshotTreeBuildOutput, TreeBuildProfile},
+};
 use crate::{
     WorktreeIndex,
     atomic::{AtomicMutation, RewindLedger, StagedCommit, Tx, execute, execute_reconstructible},
-    fsmonitor::{ChangeMonitorSession, MonitorStatus},
+    fsmonitor::{ChangeMonitorSession, ChangeMonitorToken, MonitorStatus},
     thread_manifest::ManifestFile,
     worktree_ignore::WorktreeIgnoreMatcher,
     worktree_walk::{
@@ -109,6 +112,7 @@ pub struct SnapshotExecution {
     pub state: State,
     pub tree: Tree,
     pub profile: SnapshotProfile,
+    worktree_tree_chain: Vec<Tree>,
 }
 
 #[derive(Clone)]
@@ -128,6 +132,7 @@ struct SnapshotDetails {
 
 struct PreparedSnapshotArtifact {
     blobs: Vec<(ContentHash, Vec<u8>)>,
+    trees: Vec<Tree>,
     tree: Tree,
     state: State,
     attachments: Vec<StateAttachment>,
@@ -150,6 +155,8 @@ struct SnapshotMutation<'a> {
     prepared_execution: Option<SnapshotExecution>,
     worktree_revalidation_files: Option<BTreeMap<String, ManifestFile>>,
     worktree_revalidation_cutoff_ns: Option<i64>,
+    worktree_monitor_token: Option<ChangeMonitorToken>,
+    require_worktree_change: bool,
 }
 
 impl<'a> SnapshotMutation<'a> {
@@ -159,6 +166,7 @@ impl<'a> SnapshotMutation<'a> {
         details: SnapshotDetails,
         prev_head: Option<StateId>,
         head: Head,
+        require_worktree_change: bool,
     ) -> Self {
         Self {
             repo,
@@ -172,6 +180,8 @@ impl<'a> SnapshotMutation<'a> {
             prepared_execution: None,
             worktree_revalidation_files: None,
             worktree_revalidation_cutoff_ns: None,
+            worktree_monitor_token: None,
+            require_worktree_change,
         }
     }
 
@@ -316,6 +326,9 @@ impl AtomicMutation for SnapshotMutation<'_> {
         }) else {
             return Ok(this_run);
         };
+        if this_run.state.id() == committed_state {
+            return Ok(this_run);
+        }
         let Some(state) = self.repo.store.get_state(&committed_state)? else {
             return Ok(this_run);
         };
@@ -326,6 +339,7 @@ impl AtomicMutation for SnapshotMutation<'_> {
             state,
             tree,
             profile: SnapshotProfile::default(),
+            worktree_tree_chain: Vec::new(),
         })
     }
 }
@@ -338,6 +352,15 @@ impl SnapshotMutation<'_> {
         let execution = self.prepared_execution.as_ref().ok_or_else(|| {
             HeddleError::Config("snapshot revalidation reached an unprepared mutation".to_string())
         })?;
+        if let Some(prepared_token) = self.worktree_monitor_token.as_ref() {
+            let current = ChangeMonitorSession::prepare(
+                self.repo.root(),
+                crate::FsMonitorSettings::from(self.repo.config.worktree.fsmonitor),
+            );
+            if current.revalidation_token().as_ref() == Some(prepared_token) {
+                return Ok(true);
+            }
+        }
         let files = self.worktree_revalidation_files.as_ref().ok_or_else(|| {
             HeddleError::Config("snapshot preparation omitted its stat cache".to_string())
         })?;
@@ -354,23 +377,42 @@ impl SnapshotMutation<'_> {
         debug!("Building tree from worktree");
         let (tree, tree_profile, supplied_blobs) = match &self.source {
             SnapshotSource::Worktree => {
-                let (tree, profile, revalidation_files) = self.build_worktree_tree()?;
+                let (tree, profile, revalidation_files, blobs, trees, monitor_token) =
+                    self.build_worktree_tree()?;
                 self.worktree_revalidation_files = Some(revalidation_files);
-                (tree, profile, None)
+                self.worktree_monitor_token = monitor_token;
+                (tree, profile, Some((blobs, trees)))
             }
             SnapshotSource::SuppliedTree(tree) => (tree.clone(), TreeBuildProfile::default(), None),
             SnapshotSource::SuppliedTreeWithBlobs { tree, blobs } => (
                 tree.clone(),
                 TreeBuildProfile::default(),
-                Some(
+                Some((
                     blobs
                         .iter()
                         .map(|blob| (blob.hash(), blob.content().to_vec()))
                         .collect(),
-                ),
+                    Vec::new(),
+                )),
             ),
         };
+        #[cfg(feature = "tree-sitter-symbols")]
+        let mut supplied_blobs = supplied_blobs;
         debug!(duration_ms = tree_profile.tree_walk_ms, "Tree built");
+
+        if self.require_worktree_change && matches!(&self.source, SnapshotSource::Worktree) {
+            let previous_tree = match self.prev_head {
+                Some(state_id) => self
+                    .repo
+                    .store
+                    .get_state(&state_id)?
+                    .map(|state| state.tree),
+                None => Some(Tree::new().hash()),
+            };
+            if previous_tree == Some(tree.hash()) {
+                return Err(HeddleError::NoChanges);
+            }
+        }
 
         debug!("Storing tree");
         let root_tree_write_start = std::time::Instant::now();
@@ -417,15 +459,6 @@ impl SnapshotMutation<'_> {
 
         #[cfg(feature = "tree-sitter-symbols")]
         {
-            let source_blobs =
-                supplied_blobs
-                    .as_ref()
-                    .map(|blobs: &Vec<(ContentHash, Vec<u8>)>| {
-                        blobs
-                            .iter()
-                            .map(|(hash, bytes)| (*hash, bytes.as_slice()))
-                            .collect::<std::collections::HashMap<_, _>>()
-                    });
             let prior_state = match self.prev_head {
                 Some(id) => self.repo.store.get_state(&id).ok().flatten(),
                 None => None,
@@ -443,19 +476,51 @@ impl SnapshotMutation<'_> {
 
             // Eager semantic index: parse only changed blobs, reusing the
             // parent index for unchanged subtrees. Never fails the capture.
-            match self.repo.compute_and_persist_semantic_index_for_tree(
-                prior_state.as_ref(),
-                &tree,
-                source_blobs.as_ref(),
-            ) {
-                Ok(Some(hash)) => semantic_index = Some(hash),
-                Ok(None) => {}
+            let semantic_result = if let Some((blobs, trees)) = supplied_blobs.as_ref() {
+                let source_blobs = blobs
+                    .iter()
+                    .map(|(hash, bytes)| (*hash, bytes.as_slice()))
+                    .collect::<std::collections::HashMap<_, _>>();
+                let source_trees = trees
+                    .iter()
+                    .map(|tree| (tree.hash(), tree))
+                    .collect::<std::collections::HashMap<_, _>>();
+                self.repo.compute_semantic_index_for_tree_deferred(
+                    prior_state.as_ref(),
+                    &tree,
+                    Some(&source_blobs),
+                    Some(&source_trees),
+                )
+            } else {
+                self.repo
+                    .compute_and_persist_semantic_index_for_tree(
+                        prior_state.as_ref(),
+                        &tree,
+                        None,
+                        None,
+                    )
+                    .map(|root| (root, Vec::new()))
+            };
+            match semantic_result {
+                Ok((Some(hash), pending)) => {
+                    semantic_index = Some(hash);
+                    if let Some((blobs, _)) = supplied_blobs.as_mut() {
+                        blobs.extend(pending);
+                    }
+                }
+                Ok((None, _)) => {}
                 Err(err) => {
                     tracing::warn!(error = %err, "semantic index computation failed; continuing without index");
                 }
             }
 
             if let Some(parent_state) = prior_state.as_ref() {
+                let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
+                    blobs
+                        .iter()
+                        .map(|(hash, bytes)| (*hash, bytes.as_slice()))
+                        .collect::<std::collections::HashMap<_, _>>()
+                });
                 match self.repo.compute_and_persist_discussion_anchor_travel(
                     parent_state,
                     &tree,
@@ -525,9 +590,15 @@ impl SnapshotMutation<'_> {
                 self.repo.put_state_attachment(&attachment)?;
             }
         }
-        if let Some(blobs) = supplied_blobs {
+        let worktree_tree_chain = supplied_blobs
+            .as_ref()
+            .filter(|(_, trees)| trees.len() <= 32)
+            .map(|(_, trees)| trees.clone())
+            .unwrap_or_default();
+        if let Some((blobs, trees)) = supplied_blobs {
             self.prepared_artifact = Some(PreparedSnapshotArtifact {
                 blobs,
+                trees,
                 tree: tree.clone(),
                 state: state.clone(),
                 attachments,
@@ -541,6 +612,7 @@ impl SnapshotMutation<'_> {
                 root_tree_write_ms,
                 state_ref_oplog_start.elapsed().as_millis(),
             ),
+            worktree_tree_chain,
         })
     }
 
@@ -566,6 +638,7 @@ impl SnapshotMutation<'_> {
         let started = std::time::Instant::now();
         let descriptor = self.repo.store.put_committed_snapshot_objects_packed(
             prepared.blobs,
+            prepared.trees,
             &prepared.tree,
             &prepared.state,
             prepared.attachments,
@@ -578,9 +651,7 @@ impl SnapshotMutation<'_> {
         Ok((descriptor, elapsed_ms))
     }
 
-    fn build_worktree_tree(
-        &self,
-    ) -> Result<(Tree, TreeBuildProfile, BTreeMap<String, ManifestFile>)> {
+    fn build_worktree_tree(&self) -> Result<SnapshotTreeBuildOutput> {
         let baseline_tree = match self.prev_head {
             Some(prev_head) => {
                 let state = self.repo.state_for_worktree_status(&prev_head)?;
@@ -690,19 +761,28 @@ impl WorktreeWalkPolicy for SnapshotFingerprintPolicy<'_> {
         tree_entry: &TreeEntry,
         state: &mut Self::DirectoryState,
     ) -> Result<bool> {
-        let Some(tree_hash) = tree_entry.tree_hash() else {
+        let Some(_) = tree_entry.tree_hash() else {
             return Ok(false);
         };
-        let key = crate::worktree_walk::cache_key(rel_path);
-        let reusable = !self.monitor.path_may_have_changed(rel_path)
-            && self
-                .index
-                .get_directory(&key)
-                .is_some_and(|entry| entry.clean_tree_hash == Some(tree_hash));
+        // This tree was prepared immediately before this revalidation pass.
+        // The monitor cursor alone proves an unreported sibling stayed equal
+        // to that prepared tree; requiring the old worktree-index baseline
+        // here forces a full walk whenever the hot index intentionally omits
+        // unchanged siblings in a one-path capture.
+        let reusable = self.monitor.can_reuse_since_cursor(rel_path);
         if reusable {
             state.entries.push(tree_entry.clone());
         }
         Ok(reusable)
+    }
+
+    fn cached_tree_for_entry(
+        &self,
+        rel_path: &std::path::Path,
+        tree_hash: &ContentHash,
+    ) -> Option<Tree> {
+        let key = crate::worktree_walk::cache_key(rel_path);
+        self.index.clean_tree(&key, tree_hash).cloned()
     }
 
     fn skip_directory_before_enumeration(
@@ -1034,7 +1114,30 @@ impl Repository {
         confidence: Option<f32>,
         attribution: Attribution,
     ) -> Result<SnapshotExecution> {
-        self.snapshot_with_attribution_profiled_locked(intent, confidence, attribution, Vec::new())
+        self.snapshot_with_attribution_profiled_locked(
+            intent,
+            confidence,
+            attribution,
+            Vec::new(),
+            false,
+        )
+    }
+
+    /// Create a worktree snapshot only when its tree differs from the current
+    /// state, using the snapshot build itself as the change check.
+    pub fn snapshot_with_attribution_profiled_if_changed(
+        &self,
+        intent: Option<String>,
+        confidence: Option<f32>,
+        attribution: Attribution,
+    ) -> Result<SnapshotExecution> {
+        self.snapshot_with_attribution_profiled_locked(
+            intent,
+            confidence,
+            attribution,
+            Vec::new(),
+            true,
+        )
     }
 
     pub fn snapshot_with_attribution_and_lineage(
@@ -1044,8 +1147,14 @@ impl Repository {
         attribution: Attribution,
         lineage: Vec<ChangeLineage>,
     ) -> Result<State> {
-        self.snapshot_with_attribution_profiled_locked(intent, confidence, attribution, lineage)
-            .map(|execution| execution.state)
+        self.snapshot_with_attribution_profiled_locked(
+            intent,
+            confidence,
+            attribution,
+            lineage,
+            false,
+        )
+        .map(|execution| execution.state)
     }
 
     #[instrument(skip(self, attribution), fields(intent = ?intent, confidence))]
@@ -1055,6 +1164,7 @@ impl Repository {
         confidence: Option<f32>,
         attribution: Attribution,
         lineage: Vec<ChangeLineage>,
+        require_worktree_change: bool,
     ) -> Result<SnapshotExecution> {
         const MAX_WORKTREE_CHANGE_ATTEMPTS: usize = 4;
         let mut worktree_change_attempts = 0;
@@ -1116,6 +1226,7 @@ impl Repository {
                         state,
                         tree,
                         profile: SnapshotProfile::default(),
+                        worktree_tree_chain: Vec::new(),
                     });
                 }
 
@@ -1133,6 +1244,7 @@ impl Repository {
                 },
                 prev_head,
                 head.clone(),
+                require_worktree_change,
             );
             mutation.prepare()?;
 
@@ -1159,9 +1271,23 @@ impl Repository {
             }
 
             let atomic_execute_started = std::time::Instant::now();
-            let mut execution = execute(self, mutation)?;
+            let committed =
+                execute_reconstructible(self, mutation, |mutation, base_head_id, records| {
+                    mutation.install_prepared_artifact(base_head_id, records)
+                })?;
+            let committed_tip = committed.committed_tip;
+            let mut execution = committed.output;
+            if let Some((descriptor, artifact_write_ms)) = committed.artifact {
+                execution.profile.blob_write_ms = artifact_write_ms;
+                debug!(
+                    pack = %descriptor.pack_name,
+                    path = %descriptor.pack_path.display(),
+                    objects = descriptor.object_ids.len(),
+                    state = %descriptor.artifact.state,
+                    "worktree snapshot committed through authoritative pack artifact"
+                );
+            }
             execution.profile.atomic_execute_ms = atomic_execute_started.elapsed().as_millis();
-            let committed_tip = self.oplog().head_id()?;
 
             objects::fault_inject::maybe_panic_at(
                 "snapshot_after_atomic_commit_before_ref_publish",
@@ -1172,10 +1298,12 @@ impl Repository {
             let ref_publish_started = std::time::Instant::now();
             reconcile_snapshot_ref(self, &head, &execution.state, committed_tip)?;
             execution.profile.ref_publish_ms = ref_publish_started.elapsed().as_millis();
+            self.cache_current_worktree_state(
+                &execution.state,
+                &execution.tree,
+                &execution.worktree_tree_chain,
+            );
             refresh_materialized_thread_manifest(self, &head, &execution.state, &execution.tree);
-            if let Err(error) = self.compare_worktree_cached_detailed(&execution.tree) {
-                tracing::warn!(%error, "Captured state, but could not refresh worktree monitor/index baseline");
-            }
             return Ok(execution);
         }
     }
@@ -1256,6 +1384,7 @@ impl Repository {
                 },
                 prev_head,
                 head.clone(),
+                false,
             );
             mutation.prepare()?;
 

--- a/crates/repo/src/repository_symbol_graph.rs
+++ b/crates/repo/src/repository_symbol_graph.rs
@@ -3,12 +3,12 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 
 use objects::{
     object::{
         BindingDelta, ContentHash, FileBindingDelta, SemanticEntryKind, SemanticFileNode,
-        SemanticIndexRoot, SemanticTreeEntry,
+        SemanticIndexRoot, SemanticTreeEntry, SemanticTreeNode,
     },
     store::ObjectStore,
 };
@@ -18,6 +18,9 @@ use semantic::cross_file_resolution::{
 
 use crate::{HeddleError, Repository, Result};
 
+type PendingSymbolGraphBlobs = Vec<(ContentHash, Vec<u8>)>;
+type DeferredSymbolGraph = (ContentHash, PendingSymbolGraphBlobs);
+
 impl Repository {
     /// Resolve the semantic root and persist a delta over the first parent's
     /// edge set, returning a replacement semantic-root blob hash.
@@ -26,6 +29,20 @@ impl Repository {
         parent_state: Option<&objects::object::State>,
         root: SemanticIndexRoot,
     ) -> Result<ContentHash> {
+        let (root_hash, pending) =
+            self.persist_resolved_semantic_edges_deferred(parent_state, root, &HashMap::new())?;
+        self.store().put_blobs_packed(pending)?;
+        Ok(root_hash)
+    }
+
+    /// Resolve semantic edges while leaving every newly-authored blob in
+    /// memory for a caller-owned durability transaction.
+    pub(crate) fn persist_resolved_semantic_edges_deferred(
+        &self,
+        parent_state: Option<&objects::object::State>,
+        root: SemanticIndexRoot,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<DeferredSymbolGraph> {
         let parent_root = parent_state
             .map(|state| self.attached_semantic_index(&state.id()))
             .transpose()?
@@ -36,12 +53,12 @@ impl Repository {
             .and_then(|root| root.binding_delta);
 
         if let (Some(parent_root), Some(parent_delta)) = (&parent_root, parent_delta)
-            && !self.semantic_file_nodes_changed(parent_root.tree, root.tree)?
+            && !self.semantic_file_nodes_changed(parent_root.tree, root.tree, pending_nodes)?
         {
-            return self.persist_binding_delta(root, Some(parent_delta), Vec::new());
+            return self.prepare_binding_delta(root, Some(parent_delta), Vec::new());
         }
 
-        let current_files = self.semantic_files(&root)?;
+        let current_files = self.semantic_files_with_pending(&root, pending_nodes)?;
         let current_resolution = resolve_repository(&current_files);
 
         let frontier = if parent_delta.is_some() {
@@ -71,30 +88,32 @@ impl Repository {
                 None => FileBindingDelta::new(path, None, Vec::new()),
             })
             .collect();
-        self.persist_binding_delta(root, parent_delta, files)
+        self.prepare_binding_delta(root, parent_delta, files)
     }
 
-    fn persist_binding_delta(
+    fn prepare_binding_delta(
         &self,
         root: SemanticIndexRoot,
         parent_delta: Option<ContentHash>,
         files: Vec<FileBindingDelta>,
-    ) -> Result<ContentHash> {
+    ) -> Result<DeferredSymbolGraph> {
         let delta = BindingDelta::new(parent_delta, files);
         let delta_bytes = delta.encode()?;
         let delta_hash = ContentHash::compute_typed("blob", &delta_bytes);
         let rooted = root.with_binding_delta(delta_hash, RESOLVER_VERSION);
         let root_bytes = rooted.encode()?;
         let root_hash = ContentHash::compute_typed("blob", &root_bytes);
-        self.store()
-            .put_blobs_packed(vec![(delta_hash, delta_bytes), (root_hash, root_bytes)])?;
-        Ok(root_hash)
+        Ok((
+            root_hash,
+            vec![(delta_hash, delta_bytes), (root_hash, root_bytes)],
+        ))
     }
 
     fn semantic_file_nodes_changed(
         &self,
         parent_hash: ContentHash,
         current_hash: ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
     ) -> Result<bool> {
         let mut pairs = vec![(parent_hash, current_hash, 0usize)];
         while let Some((parent_hash, current_hash, depth)) = pairs.pop() {
@@ -106,8 +125,8 @@ impl Repository {
                     "semantic index tree exceeds max depth".to_string(),
                 ));
             }
-            let parent = self.load_semantic_tree(&parent_hash)?;
-            let current = self.load_semantic_tree(&current_hash)?;
+            let parent = self.load_semantic_tree_with_pending(&parent_hash, pending_nodes)?;
+            let current = self.load_semantic_tree_with_pending(&current_hash, pending_nodes)?;
             let parent_by_name = parent
                 .entries
                 .iter()
@@ -137,15 +156,15 @@ impl Repository {
                             pairs.push((parent.node, current.node, depth + 1));
                         }
                         _ => {
-                            if self.semantic_entry_contains_file(parent)?
-                                || self.semantic_entry_contains_file(current)?
+                            if self.semantic_entry_contains_file(parent, pending_nodes)?
+                                || self.semantic_entry_contains_file(current, pending_nodes)?
                             {
                                 return Ok(true);
                             }
                         }
                     },
                     (Some(entry), None) | (None, Some(entry)) => {
-                        if self.semantic_entry_contains_file(entry)? {
+                        if self.semantic_entry_contains_file(entry, pending_nodes)? {
                             return Ok(true);
                         }
                     }
@@ -156,7 +175,11 @@ impl Repository {
         Ok(false)
     }
 
-    fn semantic_entry_contains_file(&self, entry: &SemanticTreeEntry) -> Result<bool> {
+    fn semantic_entry_contains_file(
+        &self,
+        entry: &SemanticTreeEntry,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<bool> {
         match entry.kind {
             SemanticEntryKind::File => Ok(true),
             SemanticEntryKind::Opaque => Ok(false),
@@ -168,7 +191,10 @@ impl Repository {
                             "semantic index tree exceeds max depth".to_string(),
                         ));
                     }
-                    for child in self.load_semantic_tree(&hash)?.entries {
+                    for child in self
+                        .load_semantic_tree_with_pending(&hash, pending_nodes)?
+                        .entries
+                    {
                         match child.kind {
                             SemanticEntryKind::File => return Ok(true),
                             SemanticEntryKind::Dir => stack.push((child.node, depth + 1)),
@@ -185,6 +211,14 @@ impl Repository {
         &self,
         root: &SemanticIndexRoot,
     ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
+        self.semantic_files_with_pending(root, &HashMap::new())
+    }
+
+    fn semantic_files_with_pending(
+        &self,
+        root: &SemanticIndexRoot,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
         let mut files = BTreeMap::new();
         let mut stack = vec![(String::new(), root.tree, 0usize)];
         while let Some((prefix, hash, depth)) = stack.pop() {
@@ -193,7 +227,12 @@ impl Repository {
                     "semantic index tree exceeds max depth".to_string(),
                 ));
             }
-            for entry in self.load_semantic_tree(&hash)?.entries.into_iter().rev() {
+            for entry in self
+                .load_semantic_tree_with_pending(&hash, pending_nodes)?
+                .entries
+                .into_iter()
+                .rev()
+            {
                 let path = if prefix.is_empty() {
                     entry.name
                 } else {
@@ -202,7 +241,11 @@ impl Repository {
                 match entry.kind {
                     SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
                     SemanticEntryKind::File => {
-                        let node: SemanticFileNode = self.load_semantic_file(&entry.node)?;
+                        let node = match pending_nodes.get(&entry.node) {
+                            Some(bytes) => SemanticFileNode::decode(bytes)
+                                .map_err(|err| HeddleError::InvalidObject(err.to_string()))?,
+                            None => self.load_semantic_file(&entry.node)?,
+                        };
                         files.insert(
                             path,
                             RepositorySemanticFile {
@@ -216,6 +259,18 @@ impl Repository {
             }
         }
         Ok(files)
+    }
+
+    fn load_semantic_tree_with_pending(
+        &self,
+        hash: &ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<SemanticTreeNode> {
+        match pending_nodes.get(hash) {
+            Some(bytes) => SemanticTreeNode::decode(bytes)
+                .map_err(|err| HeddleError::InvalidObject(err.to_string())),
+            None => self.load_semantic_tree(hash),
+        }
     }
 }
 

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -951,6 +951,69 @@ fn packed_structured_snapshot_remains_invisible_until_oplog_commit() {
 }
 
 #[test]
+fn durable_worktree_snapshot_artifact_recovers_the_complete_tree_closure() {
+    let (temp_dir, repo) = create_test_repo();
+    let baseline = repo.head().unwrap();
+    let before = repo
+        .store()
+        .list_states()
+        .unwrap()
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    fs::create_dir_all(temp_dir.path().join("nested")).unwrap();
+    fs::write(
+        temp_dir.path().join("nested/artifact.txt"),
+        "authoritative worktree closure",
+    )
+    .unwrap();
+
+    let crashed = with_snapshot_fault(SnapshotFault::ArtifactCommitBeforeOplogView, || {
+        std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _ = repo.snapshot(Some("worktree artifact committed".to_string()), None);
+        }))
+    });
+    assert!(crashed.is_err());
+    assert_eq!(repo.head().unwrap(), baseline);
+
+    let committed = repo
+        .store()
+        .list_states()
+        .unwrap()
+        .into_iter()
+        .find(|state| !before.contains(state))
+        .expect("durable artifact must contain the worktree state");
+    drop(repo);
+
+    let reopened = Repository::open(temp_dir.path()).unwrap();
+    assert_eq!(reopened.head().unwrap(), Some(committed));
+    let state = reopened.store().get_state(&committed).unwrap().unwrap();
+    let root = reopened.store().get_tree(&state.tree).unwrap().unwrap();
+    let nested_hash = root
+        .entries()
+        .iter()
+        .find(|entry| entry.name() == "nested")
+        .and_then(TreeEntry::tree_hash)
+        .expect("root tree must retain the nested tree");
+    let nested = reopened.store().get_tree(&nested_hash).unwrap().unwrap();
+    let blob_hash = nested
+        .entries()
+        .iter()
+        .find(|entry| entry.name() == "artifact.txt")
+        .and_then(TreeEntry::blob_hash)
+        .expect("nested tree must retain the authored blob");
+    let blob = reopened.store().get_blob(&blob_hash).unwrap().unwrap();
+    assert_eq!(blob.content(), b"authoritative worktree closure");
+    #[cfg(feature = "tree-sitter-symbols")]
+    assert!(
+        reopened
+            .attached_semantic_index(&committed)
+            .unwrap()
+            .is_some(),
+        "authoritative artifact must retain the deferred semantic closure"
+    );
+}
+
+#[test]
 fn durable_snapshot_artifact_recovers_missing_oplog_and_ref_views_after_reopen() {
     let (temp_dir, repo) = create_test_repo();
     let baseline = repo.head().unwrap();

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -2,7 +2,7 @@
 //! Tree building and materialization helpers.
 
 use std::{
-    collections::{BTreeMap, HashSet},
+    collections::{BTreeMap, HashMap, HashSet},
     fs,
     path::Path,
     time::Instant,
@@ -16,13 +16,15 @@ use objects::{
 };
 use tracing::{debug, instrument, trace, warn};
 
+use serde::{Deserialize, Serialize};
+
 use super::{
     HeddleError, Repository, Result,
     repository_worktree_status::{WorktreeStatusDetailed, compare_worktree_with_index_detailed},
 };
 use crate::{
     FsMonitorSettings, WorktreeIndex, WorktreeStatusOptions,
-    fsmonitor::{ChangeMonitorSession, MonitorStatus},
+    fsmonitor::{ChangeMonitorSession, ChangeMonitorToken, MonitorStatus},
     thread_manifest::ManifestFile,
     worktree_ignore::WorktreeIgnoreMatcher,
     worktree_index::{WorktreeIndexLoadStats, WorktreeIndexSaveStats},
@@ -76,11 +78,94 @@ pub struct TreeBuildProfile {
     pub dir_count: usize,
 }
 
+pub(crate) type SnapshotTreeBuildOutput = (
+    Tree,
+    TreeBuildProfile,
+    BTreeMap<String, ManifestFile>,
+    Vec<(ContentHash, Vec<u8>)>,
+    Vec<Tree>,
+    Option<ChangeMonitorToken>,
+);
+
+#[derive(Debug, Clone, Default)]
+pub struct WorktreeStateLookupProfile {
+    pub head_ms: u128,
+    pub cache_read_ms: u128,
+    pub cache_decode_ms: u128,
+    pub cache_validate_ms: u128,
+    pub store_read_ms: u128,
+    pub cache_hit: bool,
+}
+
+#[derive(Serialize, Deserialize)]
+struct WorktreeTreeChainCache {
+    root: ContentHash,
+    ignore_fingerprint: ContentHash,
+    trees: Vec<Tree>,
+}
+
 #[derive(Debug, Clone)]
 struct TreeBuildOutput {
     tree: Tree,
     profile: TreeBuildProfile,
     revalidation_files: BTreeMap<String, ManifestFile>,
+    pending_blobs: Vec<(ContentHash, Vec<u8>)>,
+    pending_trees: Vec<Tree>,
+    monitor_token: Option<ChangeMonitorToken>,
+}
+
+fn rewrite_single_tracked_file(
+    repo: &Repository,
+    tree: &Tree,
+    components: &[&str],
+    blob_hash: ContentHash,
+    executable: bool,
+    cached_trees: &HashMap<ContentHash, Tree>,
+    descendant_trees: &mut Vec<Tree>,
+) -> Result<Option<Tree>> {
+    let Some((name, rest)) = components.split_first() else {
+        return Ok(None);
+    };
+    let Some(existing) = tree.get(name) else {
+        return Ok(None);
+    };
+    let replacement = if rest.is_empty() {
+        if existing.blob_hash().is_none() {
+            return Ok(None);
+        }
+        TreeEntry::file((*name).to_string(), blob_hash, executable)?
+    } else {
+        let Some(child_hash) = existing.tree_hash() else {
+            return Ok(None);
+        };
+        let child = match cached_trees.get(&child_hash) {
+            Some(tree) => tree.clone(),
+            None => {
+                let Some(tree) = repo.store().get_tree(&child_hash)? else {
+                    return Ok(None);
+                };
+                tree
+            }
+        };
+        let Some(updated_child) = rewrite_single_tracked_file(
+            repo,
+            &child,
+            rest,
+            blob_hash,
+            executable,
+            cached_trees,
+            descendant_trees,
+        )?
+        else {
+            return Ok(None);
+        };
+        let updated_hash = updated_child.hash();
+        descendant_trees.push(updated_child);
+        TreeEntry::directory((*name).to_string(), updated_hash)?
+    };
+    let mut updated = tree.clone();
+    updated.insert(replacement);
+    Ok(Some(updated))
 }
 
 impl Repository {
@@ -157,7 +242,7 @@ impl Repository {
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
     ) -> Result<(Tree, TreeBuildProfile)> {
-        self.build_tree_profiled_output(dir, baseline_tree, stat_cache)
+        self.build_tree_profiled_output(dir, baseline_tree, stat_cache, false)
             .map(|output| (output.tree, output.profile))
     }
 
@@ -166,9 +251,140 @@ impl Repository {
         dir: &Path,
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
-    ) -> Result<(Tree, TreeBuildProfile, BTreeMap<String, ManifestFile>)> {
-        self.build_tree_profiled_output(dir, baseline_tree, stat_cache)
-            .map(|output| (output.tree, output.profile, output.revalidation_files))
+    ) -> Result<SnapshotTreeBuildOutput> {
+        let fast_start = Instant::now();
+        if let Some(mut output) = self.try_build_single_changed_file_tree(dir, baseline_tree)? {
+            output.profile.tree_walk_ms = fast_start.elapsed().as_millis();
+            return Ok((
+                output.tree,
+                output.profile,
+                output.revalidation_files,
+                output.pending_blobs,
+                output.pending_trees,
+                output.monitor_token,
+            ));
+        }
+        self.build_tree_profiled_output(dir, baseline_tree, stat_cache, true)
+            .map(|output| {
+                (
+                    output.tree,
+                    output.profile,
+                    output.revalidation_files,
+                    output.pending_blobs,
+                    output.pending_trees,
+                    output.monitor_token,
+                )
+            })
+    }
+
+    /// Apply an authoritative one-file monitor delta directly to the baseline
+    /// tree. This is the common capture path and avoids enumerating 1,000 root
+    /// directories plus every sibling in the changed file's directory.
+    /// Unsupported shapes (new/deleted paths, symlinks, policy changes, or a
+    /// non-authoritative monitor) fall back to the general walker.
+    fn try_build_single_changed_file_tree(
+        &self,
+        dir: &Path,
+        baseline_tree: Option<&Tree>,
+    ) -> Result<Option<TreeBuildOutput>> {
+        if dir != self.root() {
+            return Ok(None);
+        }
+        let Some(baseline_tree) = baseline_tree else {
+            return Ok(None);
+        };
+        let monitor = ChangeMonitorSession::prepare(
+            self.root(),
+            self.default_worktree_status_options().fsmonitor,
+        );
+        let Some(changed) = monitor.single_changed_path() else {
+            return Ok(None);
+        };
+        let rel_path = Path::new(changed);
+        let components = rel_path
+            .components()
+            .map(|component| match component {
+                std::path::Component::Normal(name) => name.to_str(),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>();
+        let Some(components) = components.filter(|parts| !parts.is_empty()) else {
+            return Ok(None);
+        };
+
+        let expected_ignore_fingerprint =
+            WorktreeIgnoreMatcher::fingerprint_patterns(&self.ignore_patterns()?);
+        let Some(cached_trees) = self
+            .load_current_worktree_tree_chain(&baseline_tree.hash(), &expected_ignore_fingerprint)
+        else {
+            return Ok(None);
+        };
+        let nested_exclusions = self.nested_thread_worktree_exclusions(dir)?;
+        let mut absolute = self.root().to_path_buf();
+        for component in &components {
+            absolute.push(component);
+        }
+        let canonical_absolute = absolute.canonicalize().unwrap_or_else(|_| absolute.clone());
+        if nested_exclusions
+            .iter()
+            .any(|excluded| canonical_absolute.starts_with(excluded))
+        {
+            return Ok(None);
+        }
+
+        let metadata = match fs::symlink_metadata(&absolute) {
+            Ok(metadata) if metadata.is_file() => metadata,
+            Ok(_) => return Ok(None),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        #[cfg(unix)]
+        let executable = {
+            use std::os::unix::fs::PermissionsExt;
+            metadata.permissions().mode() & 0o111 != 0
+        };
+        #[cfg(not(unix))]
+        let executable = false;
+
+        let (blob, hash) = read_blob_with_hash(&absolute, metadata.len())?;
+        let mut pending_trees = Vec::with_capacity(components.len().saturating_sub(1));
+        let Some(tree) = rewrite_single_tracked_file(
+            self,
+            baseline_tree,
+            &components,
+            hash,
+            executable,
+            &cached_trees,
+            &mut pending_trees,
+        )?
+        else {
+            return Ok(None);
+        };
+        let (size, inode, mtime_ns, ctime_ns, mode) =
+            crate::stat_signature::stat_signature(&absolute, &metadata);
+        let revalidation_files = BTreeMap::from([(
+            cache_key(rel_path),
+            ManifestFile {
+                hash,
+                size,
+                inode,
+                mtime_ns,
+                ctime_ns,
+                mode,
+            },
+        )]);
+        Ok(Some(TreeBuildOutput {
+            tree,
+            profile: TreeBuildProfile {
+                file_count: 1,
+                dir_count: components.len().saturating_sub(1),
+                ..TreeBuildProfile::default()
+            },
+            revalidation_files,
+            pending_blobs: vec![(hash, blob.into_content())],
+            pending_trees,
+            monitor_token: monitor.revalidation_token(),
+        }))
     }
 
     fn build_tree_profiled_output(
@@ -176,13 +392,20 @@ impl Repository {
         dir: &Path,
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
+        defer_object_writes: bool,
     ) -> Result<TreeBuildOutput> {
         let patterns = self.ignore_patterns()?;
         debug!(pattern_count = patterns.len(), "Starting tree build");
         let start = Instant::now();
         let nested_exclusions = self.nested_thread_worktree_exclusions(dir)?;
-        let tree =
-            self.build_tree_walk(dir, &patterns, nested_exclusions, baseline_tree, stat_cache);
+        let tree = self.build_tree_walk(
+            dir,
+            &patterns,
+            nested_exclusions,
+            baseline_tree,
+            stat_cache,
+            defer_object_writes,
+        );
         let elapsed = start.elapsed().as_millis();
         debug!(duration_ms = elapsed, "Tree build complete");
         tree.map(|mut output| {
@@ -201,6 +424,7 @@ impl Repository {
         nested_exclusions: Vec<std::path::PathBuf>,
         baseline_tree: Option<&Tree>,
         stat_cache: Option<&crate::thread_manifest::ThreadManifest>,
+        defer_object_writes: bool,
     ) -> Result<TreeBuildOutput> {
         let ignore_matcher =
             WorktreeIgnoreMatcher::new(patterns).with_nested_worktree_exclusions(nested_exclusions);
@@ -221,15 +445,28 @@ impl Repository {
             .unwrap_or_default();
             (index, monitor)
         });
-        let mut policy = TreeBuildPolicy::new(self, dir, stat_cache, incremental_state);
+        let mut policy = TreeBuildPolicy::new(
+            self,
+            dir,
+            stat_cache,
+            incremental_state,
+            defer_object_writes,
+        );
         let mut output = walk_worktree(self, dir, &ignore_matcher, baseline_tree, &mut policy)?;
+        output.monitor_token = policy
+            .incremental_state
+            .as_ref()
+            .and_then(|(_, monitor)| monitor.revalidation_token());
 
         // Flush every newly-seen blob as a single packfile. Stores
         // that don't override `put_blobs_packed` fall back to per-blob
         // writes (correct, just slower). Time is folded into
         // `blob_write_ms` so the existing perf profile keeps tracking
         // total blob-storage cost.
-        if !policy.pending_blobs.is_empty() {
+        if defer_object_writes {
+            output.pending_blobs = std::mem::take(&mut policy.pending_blobs);
+            output.pending_trees = std::mem::take(&mut policy.pending_trees);
+        } else if !policy.pending_blobs.is_empty() {
             let flush_start = Instant::now();
             let pending = std::mem::take(&mut policy.pending_blobs);
             self.store.put_blobs_packed(pending)?;
@@ -255,7 +492,8 @@ impl Repository {
         }
         let tree = self.require_tree(hash)?;
         if let Ok(bytes) = rmp_serde::to_vec_named(&tree)
-            && let Err(error) = objects::fs_atomic::write_file_atomic(&cache_path, &bytes)
+            && let Err(error) =
+                objects::fs_atomic::write_file_atomic_reconstructible(&cache_path, &bytes)
         {
             warn!(path = %cache_path.display(), %error, "Could not refresh worktree tree cache");
         }
@@ -263,30 +501,145 @@ impl Repository {
     }
 
     pub fn state_for_worktree_status(&self, id: &StateId) -> Result<State> {
+        self.state_for_worktree_status_profiled(id)
+            .map(|(state, _)| state)
+    }
+
+    fn state_for_worktree_status_profiled(
+        &self,
+        id: &StateId,
+    ) -> Result<(State, WorktreeStateLookupProfile)> {
+        let mut profile = WorktreeStateLookupProfile::default();
         let cache_path = self.root().join(".heddle/state/worktree-current-state.bin");
-        if let Ok(bytes) = fs::read(&cache_path)
-            && let Ok(mut state) = rmp_serde::from_slice::<State>(&bytes)
-            && state.id() == *id
-        {
-            state.state_id = *id;
-            return Ok(state);
+        let cache_read_started = Instant::now();
+        let cached = fs::read(&cache_path);
+        profile.cache_read_ms = cache_read_started.elapsed().as_millis();
+        if let Ok(bytes) = cached {
+            let cache_decode_started = Instant::now();
+            let decoded = rmp_serde::from_slice::<State>(&bytes);
+            profile.cache_decode_ms = cache_decode_started.elapsed().as_millis();
+            if let Ok(mut state) = decoded {
+                let cache_validate_started = Instant::now();
+                let matches = state.id() == *id;
+                profile.cache_validate_ms = cache_validate_started.elapsed().as_millis();
+                if matches {
+                    state.state_id = *id;
+                    profile.cache_hit = true;
+                    return Ok((state, profile));
+                }
+            }
         }
+        let store_read_started = Instant::now();
         let state = self
             .store()
             .get_state(id)?
             .ok_or(HeddleError::StateNotFound(*id))?;
+        profile.store_read_ms = store_read_started.elapsed().as_millis();
         if let Ok(bytes) = rmp_serde::to_vec_named(&state)
-            && let Err(error) = objects::fs_atomic::write_file_atomic(&cache_path, &bytes)
+            && let Err(error) =
+                objects::fs_atomic::write_file_atomic_reconstructible(&cache_path, &bytes)
         {
             warn!(path = %cache_path.display(), %error, "Could not refresh worktree state cache");
         }
-        Ok(state)
+        Ok((state, profile))
     }
 
     pub fn current_state_for_worktree_status(&self) -> Result<Option<State>> {
-        self.head()?
-            .map(|id| self.state_for_worktree_status(&id))
-            .transpose()
+        self.current_state_for_worktree_status_profiled()
+            .map(|(state, _)| state)
+    }
+
+    pub fn current_state_for_worktree_status_profiled(
+        &self,
+    ) -> Result<(Option<State>, WorktreeStateLookupProfile)> {
+        let head_started = Instant::now();
+        let head = self.head()?;
+        let head_ms = head_started.elapsed().as_millis();
+        let Some(id) = head else {
+            return Ok((
+                None,
+                WorktreeStateLookupProfile {
+                    head_ms,
+                    ..WorktreeStateLookupProfile::default()
+                },
+            ));
+        };
+        let (state, mut profile) = self.state_for_worktree_status_profiled(&id)?;
+        profile.head_ms = head_ms;
+        Ok((Some(state), profile))
+    }
+
+    /// Refresh the rebuildable current-state/tree materialized views from a
+    /// snapshot that has already committed and published its authoritative
+    /// state. A later process can resolve HEAD without searching pack indexes;
+    /// torn/missing views are harmless because the readers validate hashes and
+    /// fall back to the object store.
+    pub(crate) fn cache_current_worktree_state(
+        &self,
+        state: &State,
+        tree: &Tree,
+        tree_chain: &[Tree],
+    ) {
+        let state_path = self.root().join(".heddle/state/worktree-current-state.bin");
+        if let Ok(bytes) = rmp_serde::to_vec_named(state)
+            && let Err(error) = fs::write(&state_path, &bytes)
+        {
+            warn!(path = %state_path.display(), %error, "Could not refresh worktree state cache");
+        }
+        let tree_path = self.root().join(".heddle/state/worktree-current-tree.bin");
+        if let Ok(bytes) = rmp_serde::to_vec_named(tree)
+            && let Err(error) = fs::write(&tree_path, &bytes)
+        {
+            warn!(path = %tree_path.display(), %error, "Could not refresh worktree tree cache");
+        }
+        self.cache_current_worktree_tree_chain(tree, tree_chain);
+    }
+
+    fn cache_current_worktree_tree_chain(&self, root: &Tree, trees: &[Tree]) {
+        let path = self
+            .root()
+            .join(".heddle/state/worktree-current-tree-chain.bin");
+        let Ok(patterns) = self.ignore_patterns() else {
+            return;
+        };
+        let cache = WorktreeTreeChainCache {
+            root: root.hash(),
+            ignore_fingerprint: WorktreeIgnoreMatcher::fingerprint_patterns(&patterns),
+            trees: trees.to_vec(),
+        };
+        if let Ok(bytes) = rmp_serde::to_vec_named(&cache)
+            && let Err(error) = fs::write(&path, &bytes)
+        {
+            warn!(path = %path.display(), %error, "Could not refresh worktree tree-chain cache");
+        }
+    }
+
+    fn load_current_worktree_tree_chain(
+        &self,
+        expected_root: &ContentHash,
+        expected_ignore_fingerprint: &ContentHash,
+    ) -> Option<HashMap<ContentHash, Tree>> {
+        let path = self
+            .root()
+            .join(".heddle/state/worktree-current-tree-chain.bin");
+        let Ok(bytes) = fs::read(path) else {
+            return None;
+        };
+        let Ok(cache) = rmp_serde::from_slice::<WorktreeTreeChainCache>(&bytes) else {
+            return None;
+        };
+        if cache.root != *expected_root || cache.ignore_fingerprint != *expected_ignore_fingerprint
+        {
+            return None;
+        }
+        let mut trees = HashMap::with_capacity(cache.trees.len());
+        for tree in cache.trees {
+            if tree.validate().is_err() {
+                return None;
+            }
+            trees.insert(tree.hash(), tree);
+        }
+        Some(trees)
     }
 
     /// Return the complete gitlink summary cached for `tree`, when the hot
@@ -574,6 +927,8 @@ struct TreeBuildPolicy<'a> {
     /// Hashes already queued in `pending_blobs` so we don't double-add
     /// content-equal files (which is common: README.md, .gitkeep, etc).
     seen: HashSet<ContentHash>,
+    pending_trees: Vec<Tree>,
+    defer_object_writes: bool,
 }
 
 impl<'a> TreeBuildPolicy<'a> {
@@ -582,6 +937,7 @@ impl<'a> TreeBuildPolicy<'a> {
         walk_root: &'a Path,
         stat_cache: Option<&'a crate::thread_manifest::ThreadManifest>,
         incremental_state: Option<(WorktreeIndex, ChangeMonitorSession)>,
+        defer_object_writes: bool,
     ) -> Self {
         Self {
             repo,
@@ -591,6 +947,8 @@ impl<'a> TreeBuildPolicy<'a> {
             stat_cache_hits: 0,
             pending_blobs: Vec::new(),
             seen: HashSet::new(),
+            pending_trees: Vec::new(),
+            defer_object_writes,
         }
     }
 
@@ -639,13 +997,10 @@ impl<'a> TreeBuildPolicy<'a> {
         let Some((index, monitor)) = &self.incremental_state else {
             return false;
         };
-        entry.path.strip_prefix(self.walk_root).is_ok_and(|path| {
-            let parent = path.parent().unwrap_or_else(|| Path::new(""));
-            index
-                .get_directory(&crate::worktree_walk::cache_key(parent))
-                .is_some()
-                && !monitor.path_may_have_changed(path)
-        })
+        entry
+            .path
+            .strip_prefix(self.walk_root)
+            .is_ok_and(|path| monitor.can_reuse_unchanged_child(path, index))
     }
 
     fn changed_path_mode(&self) -> bool {
@@ -713,22 +1068,26 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         tree_entry: &TreeEntry,
         state: &mut Self::DirectoryState,
     ) -> Result<bool> {
-        let Some(tree_hash) = tree_entry.tree_hash() else {
+        let Some(_) = tree_entry.tree_hash() else {
             return Ok(false);
         };
         let Some((index, monitor)) = &self.incremental_state else {
             return Ok(false);
         };
-        let key = crate::worktree_walk::cache_key(rel_path);
-        let reusable = !monitor.path_may_have_changed(rel_path)
-            && index
-                .get_directory(&key)
-                .is_some_and(|entry| entry.clean_tree_hash == Some(tree_hash));
+        let reusable = monitor.can_reuse_unchanged_child(rel_path, index);
         if reusable {
             state.entries.push(tree_entry.clone());
             state.profile.dir_count += 1;
         }
         Ok(reusable)
+    }
+
+    fn cached_tree_for_entry(&self, rel_path: &Path, tree_hash: &ContentHash) -> Option<Tree> {
+        let key = crate::worktree_walk::cache_key(rel_path);
+        self.incremental_state
+            .as_ref()
+            .and_then(|(index, _)| index.clean_tree(&key, tree_hash))
+            .cloned()
     }
 
     fn skip_directory_before_enumeration(
@@ -749,6 +1108,9 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
                 tree: tree.clone(),
                 profile: TreeBuildProfile::default(),
                 revalidation_files: BTreeMap::new(),
+                pending_blobs: Vec::new(),
+                pending_trees: Vec::new(),
+                monitor_token: None,
             }))
     }
 
@@ -917,9 +1279,14 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
         state.profile.file_count += subtree.profile.file_count;
         state.profile.dir_count += subtree.profile.dir_count + 1;
         state.revalidation_files.extend(subtree.revalidation_files);
-        let store_start = Instant::now();
-        let hash = self.repo.store.put_tree(&subtree.tree)?;
-        state.profile.tree_write_ms += store_start.elapsed().as_millis();
+        let hash = subtree.tree.hash();
+        if self.defer_object_writes {
+            self.pending_trees.push(subtree.tree);
+        } else {
+            let store_start = Instant::now();
+            self.repo.store.put_tree(&subtree.tree)?;
+            state.profile.tree_write_ms += store_start.elapsed().as_millis();
+        }
         state
             .entries
             .push(TreeEntry::directory(entry.name.to_string(), hash)?);
@@ -951,16 +1318,72 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
             tree: Tree::from_entries(state.entries),
             profile: state.profile,
             revalidation_files: state.revalidation_files,
+            pending_blobs: Vec::new(),
+            pending_trees: Vec::new(),
+            monitor_token: None,
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use objects::object::ContentHash;
+    use objects::object::{ContentHash, Tree, TreeEntry};
     use tempfile::TempDir;
 
-    use crate::worktree_walk::{read_blob_with_hash, read_file_hash};
+    use crate::{
+        Repository,
+        worktree_ignore::WorktreeIgnoreMatcher,
+        worktree_walk::{read_blob_with_hash, read_file_hash},
+    };
+
+    #[test]
+    fn current_tree_chain_cache_is_hash_validated_and_root_scoped() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+        let blob = ContentHash::compute_typed("blob", b"cached");
+        let child = Tree::from_entries(vec![TreeEntry::file("file", blob, false).unwrap()]);
+        let root = Tree::from_entries(vec![TreeEntry::directory("dir", child.hash()).unwrap()]);
+        let ignore_fingerprint =
+            WorktreeIgnoreMatcher::fingerprint_patterns(&repo.ignore_patterns().unwrap());
+
+        repo.cache_current_worktree_tree_chain(&root, &[]);
+        assert!(
+            repo.load_current_worktree_tree_chain(&root.hash(), &ignore_fingerprint)
+                .unwrap()
+                .is_empty()
+        );
+        repo.cache_current_worktree_tree_chain(&root, std::slice::from_ref(&child));
+        let loaded = repo
+            .load_current_worktree_tree_chain(&root.hash(), &ignore_fingerprint)
+            .unwrap();
+        assert_eq!(loaded.get(&child.hash()), Some(&child));
+        assert!(
+            repo.load_current_worktree_tree_chain(
+                &ContentHash::compute_typed("tree", b"other"),
+                &ignore_fingerprint,
+            )
+            .is_none()
+        );
+        assert!(
+            repo.load_current_worktree_tree_chain(
+                &root.hash(),
+                &ContentHash::compute_typed("heddle.ignore", b"changed"),
+            )
+            .is_none()
+        );
+
+        std::fs::write(
+            temp_dir
+                .path()
+                .join(".heddle/state/worktree-current-tree-chain.bin"),
+            b"torn",
+        )
+        .unwrap();
+        assert!(
+            repo.load_current_worktree_tree_chain(&root.hash(), &ignore_fingerprint)
+                .is_none()
+        );
+    }
 
     #[test]
     fn read_blob_with_hash_uses_bytes_read_when_file_grows() {

--- a/crates/repo/src/status_tracked_refresh.rs
+++ b/crates/repo/src/status_tracked_refresh.rs
@@ -58,8 +58,10 @@ fn refresh_tracked_directory(
     dir_key: &str,
     tree: &Tree,
 ) -> Result<bool> {
-    ctx.index
-        .insert_clean_tree(dir_key.to_string(), tree.clone());
+    if ctx.index.clean_tree(dir_key, &tree.hash()).is_none() {
+        ctx.index
+            .insert_clean_tree(dir_key.to_string(), tree.clone());
+    }
     let dir_path = if dir_key.is_empty() {
         ctx.repo.root().to_path_buf()
     } else {
@@ -91,8 +93,18 @@ fn refresh_tracked_directory(
     // contents are edited in place, so they are not sufficient to skip tracked
     // subtree refresh safely. Only fsmonitor-backed skip decisions are sound here.
 
+    let changed_child_names = ctx
+        .monitor
+        .can_filter_directory_children(rel_path, ctx.index)
+        .then(|| ctx.monitor.changed_child_names(rel_path))
+        .flatten();
+    let entries = match changed_child_names.as_ref() {
+        Some(names) => names.iter().filter_map(|name| tree.get(name)).collect(),
+        None => tree.entries().iter().collect::<Vec<_>>(),
+    };
+
     let mut subtree_clean = true;
-    for entry in tree.entries() {
+    for entry in entries {
         let child_rel_path = join_relative_path(rel_path, entry.name());
         if ctx
             .monitor

--- a/crates/repo/src/status_untracked_scan.rs
+++ b/crates/repo/src/status_untracked_scan.rs
@@ -68,8 +68,6 @@ fn scan_directory(
         return Ok(true);
     }
 
-    ctx.index.remove_untracked_directory(dir_key);
-
     let metadata = match fs::symlink_metadata(dir) {
         Ok(metadata) if metadata.is_dir() => metadata,
         Ok(_) | Err(_) => {
@@ -77,6 +75,76 @@ fn scan_directory(
             return Ok(false);
         }
     };
+    if ctx
+        .monitor
+        .can_filter_directory_children(rel_path, ctx.index)
+        && let Some(changed_children) = ctx.monitor.changed_child_names(rel_path)
+    {
+        ctx.stats.directories_scanned += 1;
+        let tree = tree.expect("tracked-tree scan requires a tree");
+        let mut subtree_has_untracked = false;
+        for name in changed_children {
+            if ctx
+                .ignore_matcher
+                .should_prune_directory_child(rel_path, &name)
+            {
+                continue;
+            }
+            let child_rel_path = join_relative_path(rel_path, &name);
+            let child_path = dir.join(&name);
+            if ctx.ignore_matcher.should_prune_absolute_path(&child_path) {
+                continue;
+            }
+            let child_key = cache_key(&child_rel_path);
+            let tree_entry = tree.get(&name);
+            let child_metadata = match fs::symlink_metadata(&child_path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(error.into()),
+            };
+            if child_metadata.is_dir() {
+                ctx.index.remove(&child_key);
+                let child_tree = match tree_entry {
+                    Some(tree_entry) if tree_entry.entry_type() == EntryType::Tree => {
+                        let tree_hash = tree_entry.require_content_hash();
+                        Some(
+                            if let Some(tree) = ctx.index.clean_tree(&child_key, &tree_hash) {
+                                tree.clone()
+                            } else {
+                                ctx.repo.store().get_tree(&tree_hash)?.ok_or_else(|| {
+                                    objects::error::HeddleError::NotFound(format!(
+                                        "tree {tree_hash}"
+                                    ))
+                                })?
+                            },
+                        )
+                    }
+                    _ => None,
+                };
+                if child_tree.is_some() {
+                    ctx.index.remove_untracked_directory_descendants(&child_key);
+                } else {
+                    ctx.index.remove_path_and_descendants(&child_key);
+                    subtree_has_untracked = true;
+                }
+                subtree_has_untracked |= scan_directory(
+                    ctx,
+                    &child_rel_path,
+                    &child_path,
+                    &child_key,
+                    child_tree.as_ref(),
+                )?;
+            } else if (child_metadata.is_file() || child_metadata.file_type().is_symlink())
+                && tree_entry.is_none()
+            {
+                ctx.index.remove_path_and_descendants(&child_key);
+                ctx.untracked.files.push(child_rel_path);
+                subtree_has_untracked = true;
+            }
+        }
+        return Ok(subtree_has_untracked);
+    }
+    ctx.index.remove_untracked_directory(dir_key);
     let entries = list_directory(dir, false)?;
     ctx.stats.directories_scanned += 1;
 

--- a/crates/repo/src/worktree_ignore.rs
+++ b/crates/repo/src/worktree_ignore.rs
@@ -106,6 +106,10 @@ impl WorktreeIgnoreMatcher {
     }
 
     pub(crate) fn fingerprint(&self) -> ContentHash {
+        Self::fingerprint_patterns(&self.raw_patterns)
+    }
+
+    pub(crate) fn fingerprint_patterns(patterns: &[String]) -> ContentHash {
         // Hash patterns in declaration order — gitignore semantics are
         // *order-sensitive*. `*.log` followed by `!keep.log` ignores
         // every log file except `keep.log`; the same rules in reverse
@@ -114,7 +118,7 @@ impl WorktreeIgnoreMatcher {
         // files with identical rule sets but different orders produce
         // different ignore semantics, and the untracked-cache layer
         // needs cache keys to reflect that.
-        ContentHash::compute_typed("heddle.ignore", self.raw_patterns.join("\0").as_bytes())
+        ContentHash::compute_typed("heddle.ignore", patterns.join("\0").as_bytes())
     }
 }
 

--- a/crates/repo/src/worktree_index_storage.rs
+++ b/crates/repo/src/worktree_index_storage.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use objects::{
-    fs_atomic::{sync_directory, sync_file, sync_file_data},
+    fs_atomic::{sync_directory, sync_file},
     object::ContentHash,
 };
 use tracing::{debug, warn};
@@ -1163,21 +1163,11 @@ fn hot_gitlinks_path(snapshot_path: &Path) -> std::path::PathBuf {
 fn write_reconstructible_atomic(path: &Path, bytes: &[u8]) -> Result<(), IndexError> {
     let parent = path.parent().unwrap_or(Path::new("."));
     fs::create_dir_all(parent)?;
-    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
-    temporary.write_all(bytes)?;
-    temporary.flush()?;
-    let (_file, temporary_path) = temporary
-        .keep()
-        .map_err(|error| IndexError::Io(error.error))?;
-    match fs::rename(&temporary_path, path) {
-        Ok(()) => Ok(()),
-        Err(_error) if path.exists() => {
-            fs::remove_file(path)?;
-            fs::rename(temporary_path, path)?;
-            Ok(())
-        }
-        Err(error) => Err(IndexError::Io(error)),
-    }
+    // Hot records are rebuildable and checksum-framed. A concurrent or
+    // post-crash reader that observes a short write rejects it and safely
+    // falls back to the canonical index, so temp-file creation plus rename for
+    // every changed ancestor only adds latency without strengthening history.
+    fs::write(path, bytes).map_err(IndexError::Io)
 }
 
 fn frame_hot_record(mut body: Vec<u8>) -> Vec<u8> {
@@ -1464,7 +1454,6 @@ fn append_journal(index: &WorktreeIndex, journal_path: &Path) -> Result<(), Inde
         fs::create_dir_all(parent)?;
     }
 
-    let journal_existed = journal_path.exists();
     let mut file = OpenOptions::new()
         .create(true)
         .append(true)
@@ -1481,10 +1470,10 @@ fn append_journal(index: &WorktreeIndex, journal_path: &Path) -> Result<(), Inde
     file.write_all(&crc32(&payload).to_be_bytes())?;
     file.write_all(&payload)?;
     file.flush()?;
-    sync_file_data(&file, journal_path)?;
-    if !journal_existed && let Some(parent) = journal_path.parent() {
-        sync_directory(parent)?;
-    }
+    // The index journal is a rebuildable acceleration sidecar, never an
+    // authoritative history record. A torn tail is already ignored/rejected
+    // by framed checksums and forces a safe full scan, so fsyncing this file
+    // and its parent directory only adds latency without improving correctness.
     Ok(())
 }
 

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -90,6 +90,10 @@ pub(crate) trait WorktreeWalkPolicy {
         Ok(false)
     }
 
+    fn cached_tree_for_entry(&self, _rel_path: &Path, _tree_hash: &ContentHash) -> Option<Tree> {
+        None
+    }
+
     fn visit_file(
         &mut self,
         entry: WalkEntry<'_>,
@@ -274,6 +278,18 @@ fn walk_directory<P: WorktreeWalkPolicy>(
                     &mut state,
                 ),
                 ListedDirEntryKind::Directory => {
+                    let child_rel_path = directory.rel_path.join(name);
+                    let subtree = tree_entry
+                        .filter(|entry| entry.is_tree())
+                        .and_then(TreeEntry::tree_hash)
+                        .map(
+                            |hash| match policy.cached_tree_for_entry(&child_rel_path, &hash) {
+                                Some(tree) => Ok(Some(tree)),
+                                None => repo.store().get_tree(&hash),
+                            },
+                        )
+                        .transpose()?
+                        .flatten();
                     let output = walk_directory(
                         repo,
                         base,
@@ -283,13 +299,7 @@ fn walk_directory<P: WorktreeWalkPolicy>(
                         },
                         Some(metadata.clone()),
                         ignore_matcher,
-                        tree_entry
-                            .filter(|entry| entry.is_tree())
-                            .and_then(|entry| entry.tree_hash())
-                            .map(|hash| repo.store().get_tree(&hash))
-                            .transpose()?
-                            .flatten()
-                            .as_ref(),
+                        subtree.as_ref(),
                         policy,
                     )?;
                     policy.visit_directory_output(

--- a/docs/perf/cli-core-loop-baseline.json
+++ b/docs/perf/cli-core-loop-baseline.json
@@ -1,6 +1,6 @@
 {
   "schema": "heddle-cli-core-loop-baseline/v2",
-  "recorded_at": "2026-08-09",
+  "recorded_at": "2026-08-15",
   "sample_count": 20,
   "profiles": [
     {
@@ -30,22 +30,6 @@
           "measured_p95_ms": 337.419,
           "gate_p95_ms": 50.0,
           "disposition": "target; clean hot status does not replay the full worktree journal"
-        },
-        {
-          "case": "status_one_dirty",
-          "paths": 100000,
-          "target_p95_ms": 75.0,
-          "measured_p95_ms": 537.327,
-          "gate_p95_ms": 592.0,
-          "disposition": "controlled-runner baseline + 10% noise; 462.327 ms above target"
-        },
-        {
-          "case": "capture_one",
-          "paths": 100000,
-          "target_p95_ms": 100.0,
-          "measured_p95_ms": 2000.495,
-          "gate_p95_ms": 2201.0,
-          "disposition": "controlled-runner baseline + 10% noise; 1900.495 ms above target"
         }
       ],
       "scale_cases": [
@@ -69,13 +53,13 @@
     },
     {
       "name": "local-calibration",
-      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 57338320 bytes",
+      "runner_fingerprint": "linux/x86_64; Linux 7.0.0-22-generic; AMD Ryzen 7 7700 8-Core Processor; 16 logical cores; rustc 1.97.0 (2d8144b78 2026-07-07); release binary 59765776 bytes",
       "cases": [
         {
           "case": "version",
           "paths": 0,
           "target_p95_ms": 20.0,
-          "measured_p95_ms": 1.498,
+          "measured_p95_ms": 1.475,
           "gate_p95_ms": 20.0,
           "disposition": "target"
         },
@@ -83,7 +67,7 @@
           "case": "help",
           "paths": 0,
           "target_p95_ms": 20.0,
-          "measured_p95_ms": 4.903,
+          "measured_p95_ms": 5.378,
           "gate_p95_ms": 20.0,
           "disposition": "target"
         },
@@ -91,31 +75,15 @@
           "case": "status_clean",
           "paths": 100000,
           "target_p95_ms": 50.0,
-          "measured_p95_ms": 11.703,
+          "measured_p95_ms": 11.617,
           "gate_p95_ms": 50.0,
           "disposition": "target; clean hot status does not replay the full worktree journal"
-        },
-        {
-          "case": "status_one_dirty",
-          "paths": 100000,
-          "target_p95_ms": 75.0,
-          "measured_p95_ms": 78.619,
-          "gate_p95_ms": 87.0,
-          "disposition": "local lazy-pack baseline + 10% noise; 3.619 ms above target"
-        },
-        {
-          "case": "capture_one",
-          "paths": 100000,
-          "target_p95_ms": 100.0,
-          "measured_p95_ms": 971.053,
-          "gate_p95_ms": 1069.0,
-          "disposition": "local lazy-pack baseline + 10% noise; 871.053 ms above target"
         }
       ],
       "scale_cases": [
         {
           "case": "status_clean",
-          "measured_wall_ratio": 6.976,
+          "measured_wall_ratio": 1.088,
           "gate_wall_ratio": 7.4,
           "measured_directory_ratio": 1.0,
           "gate_directory_ratio": 3.0,
@@ -123,7 +91,7 @@
         },
         {
           "case": "status_one_dirty",
-          "measured_wall_ratio": 7.096,
+          "measured_wall_ratio": 3.847,
           "gate_wall_ratio": 8.0,
           "measured_directory_ratio": 1.0,
           "gate_directory_ratio": 3.0,

--- a/docs/perf/cli-core-loop-todo.md
+++ b/docs/perf/cli-core-loop-todo.md
@@ -34,6 +34,9 @@ toward these bands:
   one-dirty-path, and one-path-capture fixtures, including percentile phase
   totals, structural counters, a runner fingerprint, baseline ratchets, and
   repeatable red negative controls.
+- Replace the one-path status/capture ratchets with absolute 75/100 ms p95
+  gates, add 100 ms gates for bounded diff/log/thread-list, and optimize the
+  durable capture and local-read paths until all gates pass at 100k paths.
 
 ## Next
 
@@ -43,5 +46,5 @@ toward these bands:
   only needs sorted path lists.
 - Reduce repo-open work by skipping migration/hydrator probes when a repo has a
   clean schema ledger and no lazy-hydrator file.
-- Close the recorded Wave 0 target and scale-ratchet gaps in
-  `docs/perf/cli-core-loop-baseline.json`.
+- Recalibrate the historical controlled-runner scale ratios after the next
+  dedicated Blacksmith run; absolute latency gates do not depend on them.

--- a/docs/perf/cli-core-loop.md
+++ b/docs/perf/cli-core-loop.md
@@ -60,19 +60,22 @@ profile total, process startup, warm repository work, repository open,
 verification, worktree status, snapshot subphases, monitor startup, rendering,
 and network work. Structural counters use the same percentiles.
 
-Wave 0 covers `--version`, `help`, clean status, one-dirty-path status, and a
-one-path capture. Repository fixtures contain 10k and 100k paths. Version and
+Wave 0 covers `--version`, `help`, clean status, one-dirty-path status, a
+one-path capture, one-path diff, a 20-entry log over 1,000 ancestors, and a
+1,000-thread list. Repository fixtures contain 10k and 100k paths. Version and
 help enforce the cold-process band; repository commands run after two explicit
-native-monitor warmups. The versioned, runner-scoped baselines and target gaps
-live in `docs/perf/cli-core-loop-baseline.json`. CI selects the controlled
-Blacksmith profile with `HEDDLE_PERF_BASELINE`; local runs use the recorded
-local calibration profile.
+native-monitor warmups. The versioned, runner-scoped cold-process and scale
+baselines live in `docs/perf/cli-core-loop-baseline.json`. CI selects the
+controlled Blacksmith profile with `HEDDLE_PERF_BASELINE`; local runs use the
+recorded local calibration profile.
 
 The ignored marker keeps the harness out of debug and ordinary unit-test runs;
-the dedicated release workflow runs it on a controlled runner. Warm clean
-status at 100k paths has an explicit 50 ms p95 assertion independent of the
-runner baseline. Other absolute bands already met use the product target;
-missed bands use a baseline ratchet and keep the target gap explicit.
+the dedicated release workflow runs it on a controlled runner. Every bounded
+100k local command has a fail-loud absolute p95 gate independent of the runner
+baseline: clean status is 50 ms, one-path status is 75 ms, and one-path durable
+capture, diff, bounded log, and bounded thread-list are each 100 ms. Structural
+directory, hash, object-decode, history-walk, repository-open, and zero-network
+gates remain in force alongside the latency contract.
 
 The repeatable negative controls are:
 
@@ -92,21 +95,26 @@ repository open inside each sample. Each invocation must fail with `PERF GATE
 RED`. The eager-index control is pinned by the warm repository-open p95 gate
 (2 ms), not only by the aggregate wall-time band.
 
-## 2026-08-09 local calibration
+## 2026-08-15 local calibration
 
-The 100k clean-status path now consumes its root hot sidecar without replaying
-the full file journal. Changed-path operations still replay the file entries
-they need. The release contract pins clean status p95 directly to the product
-target; one-path status and capture retain their existing ratchets.
+The before column is a fresh-main five-sample calibration on the same host.
+The after column is the final 20-sample release contract. Status consumes hot
+directory proofs; capture applies an authoritative one-file monitor delta to a
+cached, hash-validated tree chain and commits the complete snapshot closure in
+one durable pack.
 
-| Case | Previous p95 | Recorded p95 | Gate | Product target |
-|---|---:|---:|---:|---:|
-| Clean status | 73.271 ms | 11.703 ms | 50 ms | 50 ms |
-| One-path status | 415.569 ms | 78.619 ms | 87 ms | 75 ms |
-| One-path capture | 2436.937 ms | 971.053 ms | 1069 ms | 100 ms |
+| Case (100k paths) | Before p95 | After p95 | Absolute gate |
+|---|---:|---:|---:|
+| Clean status | 12.815 ms | 11.617 ms | 50 ms |
+| One-path status | 164.556 ms | 61.843 ms | 75 ms |
+| One-path durable capture | 1045.373 ms | 49.674 ms | 100 ms |
+| One-path diff | 354.053 ms | 62.965 ms | 100 ms |
+| Bounded log (20 of 1,000) | 20.724 ms | 10.316 ms | 100 ms |
+| Bounded thread-list (1,000) | 332.113 ms | 72.622 ms | 100 ms |
 
-Repository open measured 0 ms at both 10k and 100k. At 100k the clean,
-one-path status, and one-path capture cases scanned 2, 6, and 16 directories
-respectively and hashed 0, at most 1, and 1 files. The local 10k-to-100k
-wall-ratio gates are 7.4x (clean, unchanged) and 8.0x (one path, tightened
-from 8.55x); both retain a 3x directory-ratio ceiling.
+Repository open measured 0 ms throughout, and no measured command initialized
+a network client. Clean and one-path status scanned 2 and 6 directories;
+capture used the direct tree rewrite and hashed only the changed file. Disabling
+subtree and unchanged-child reuse is a repeatable red control: at 100k paths its
+five-sample p95 was 501.425 ms for status and 1557.785 ms for capture, exceeding
+the 75/100 ms gates while scanning 2,004 directories.


### PR DESCRIPTION
## Summary

- replace the 100k one-path status ratchet with a fail-loud absolute p95 gate of 75 ms
- optimize durable one-path capture and enforce a fail-loud absolute p95 gate of 100 ms
- add absolute 100 ms p95 gates for diff, log, and thread-list
- retain structural, repository-open, scale-invariance, and zero-network assertions
- add phase-level profiling and repeatable negative controls

## Calibrated results

Same host, release build, 100k-path repository. Before is the fresh-main five-sample baseline; after is the final rebased twenty-sample gate run.

| Path | Before p95 | After p95 | Gate |
|---|---:|---:|---:|
| clean status | 12.815 ms | 11.617 ms | 50 ms |
| one-path dirty status | 164.556 ms | 61.843 ms | 75 ms |
| durable one-path capture | 1,045.373 ms | 49.674 ms | 100 ms |
| diff | 354.053 ms | 62.965 ms | 100 ms |
| log | 20.724 ms | 10.316 ms | 100 ms |
| thread-list | 332.113 ms | 72.622 ms | 100 ms |

The final positive run passed all six absolute gates, scale invariance, structural bounds, repository-open bounds, and zero-network checks.

## Red-control proof

With subtree and unchanged-child reuse deliberately disabled, the five-sample p95 rose to 501.425 ms for dirty status and 1,557.785 ms for capture while scanning 2,004 directories. The harness emitted PERF GATE RED and failed as expected against the 75/100 ms gates.

## Verification

- cargo fmt --all -- --check
- cargo run --locked -p heddle-devtools -- check-rust-source-reachability
- cargo build --locked --workspace --all-targets
- cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
- heddle-pack: 87 passed
- heddle-objects: 192 passed, plus fault-injection integration test
- heddle-refs: 72 passed, 1 ignored
- heddle-repository: 648 passed, 3 ignored
- heddle-core: 441 passed, 1 ignored
- twenty-sample release performance contract: green
- five-sample subtree-skip negative control: red as expected

Closes #1218
Refs #1219
Refs #1220
Refs #1263

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789361371&installation_model_id=21489&pr_number=1387&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1387&signature=2c198230c230851198056a7f63f2ac998ff370fe80412a27de6b96fc143a2f55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->