### PR TITLE
security: resolve ci-runner KeyBindings into a verdict trust set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **CI-runner trust-set resolver.** Valid, unrevoked, in-window
+  `KeyRole::CiRunner` bindings from an authorized registry are collected into
+  the trust set a verdict verifier checks `heddle-ci-verdict-v1` signatures
+  against. Revoked, out-of-window, and other-role bindings fail closed to
+  exclusion; an empty registry yields an empty set.
+
 - **CI rejects unreachable Rust modules and blanket dead-code suppression.**
   Every `crates/*/src/**/*.rs` file must be reachable from a Cargo crate root,
   and workspace clippy lanes deny dead code explicitly.

--- a/crates/repo/src/ci_runner_trust.rs
+++ b/crates/repo/src/ci_runner_trust.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Fail-closed ci-runner trust-set resolution for CI verdict verification.
+
+use objects::object::{KeyBindingRegistry, KeyRole};
+
+use crate::{AuthorshipVerification, Repository, TrustedKey};
+
+/// One key the verifier may accept on a `heddle-ci-verdict-v1` signature.
+///
+/// Entries exist only for bindings that already passed
+/// [`Repository::verify_known_actor_key`] with [`KeyRole::CiRunner`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CiRunnerTrustEntry {
+    pub algorithm: String,
+    pub public_key: String,
+    pub identity_ref: String,
+}
+
+/// Keys trusted to sign CI verdicts for a repository at resolution time.
+///
+/// An empty set is the fail-closed outcome: no runner key is trusted.
+/// Callers must treat a missing membership check as reject, never as
+/// "unsigned is fine."
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CiRunnerTrustSet {
+    entries: Vec<CiRunnerTrustEntry>,
+}
+
+impl CiRunnerTrustSet {
+    /// No trusted ci-runner keys. Verdict signatures fail closed.
+    #[must_use]
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    #[must_use]
+    pub fn entries(&self) -> &[CiRunnerTrustEntry] {
+        &self.entries
+    }
+
+    /// Whether `(algorithm, public_key)` is in this set.
+    ///
+    /// Comparison is case-insensitive to match
+    /// [`Repository::verify_known_actor_key`] key identity.
+    #[must_use]
+    pub fn contains(&self, algorithm: &str, public_key: &str) -> bool {
+        self.entries.iter().any(|entry| {
+            entry.algorithm.eq_ignore_ascii_case(algorithm)
+                && entry.public_key.eq_ignore_ascii_case(public_key)
+        })
+    }
+}
+
+impl Repository {
+    /// Collect currently valid `ci-runner` bindings into a verdict trust set.
+    ///
+    /// A binding is included only when [`Self::verify_known_actor_key`]
+    /// returns [`AuthorshipVerification::Verified`] for [`KeyRole::CiRunner`].
+    /// That is the same authorization, revocation, and validity-window
+    /// decision used for other KeyBinding roles:
+    ///
+    /// - an unauthorized registry yields an empty set
+    /// - a recorded `revoked_at` excludes the binding
+    /// - `valid_from` after the verifier clock excludes the binding
+    /// - a non-`ci-runner` role cannot leak into the set
+    ///
+    /// Signer-asserted verdict timestamps are not consulted. A revoked
+    /// binding stays out of the set even if a verdict claims to predate
+    /// revocation. The verifier clock only rejects a future-dated
+    /// authority-issued `valid_from`.
+    #[must_use]
+    pub fn resolve_ci_runner_trust_set(
+        &self,
+        registry: &KeyBindingRegistry,
+        trusted_authority: &TrustedKey,
+    ) -> CiRunnerTrustSet {
+        let entries = registry
+            .bindings
+            .iter()
+            .filter_map(|binding| {
+                match self.verify_known_actor_key(
+                    &binding.algorithm,
+                    &binding.public_key,
+                    KeyRole::CiRunner,
+                    registry,
+                    trusted_authority,
+                ) {
+                    AuthorshipVerification::Verified(identity_ref) => Some(CiRunnerTrustEntry {
+                        algorithm: binding.algorithm.clone(),
+                        public_key: binding.public_key.clone(),
+                        identity_ref,
+                    }),
+                    _ => None,
+                }
+            })
+            .collect();
+        CiRunnerTrustSet { entries }
+    }
+}
+
+#[cfg(test)]
+#[path = "ci_runner_trust_tests.rs"]
+mod tests;

--- a/crates/repo/src/ci_runner_trust_tests.rs
+++ b/crates/repo/src/ci_runner_trust_tests.rs
@@ -1,0 +1,307 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use chrono::{Duration, TimeZone, Utc};
+use crypto::{Ed25519Signer, Signer};
+use objects::object::{KeyBinding, KeyBindingRegistry, KeyRole, StateSignature};
+use tempfile::TempDir;
+
+use super::{CiRunnerTrustSet, Repository};
+use crate::{AuthorshipVerification, TrustedKey};
+
+fn setup() -> (TempDir, Repository) {
+    let temp = TempDir::new().expect("temp dir");
+    let repo = Repository::init_default(temp.path()).expect("init repo");
+    (temp, repo)
+}
+
+fn trusted_key(signer: &Ed25519Signer) -> TrustedKey {
+    TrustedKey {
+        algorithm: signer.algorithm().to_string(),
+        public_key: hex::encode(signer.public_key()),
+        label: None,
+    }
+}
+
+fn sign_binding(signer: &Ed25519Signer, mut binding: KeyBinding) -> KeyBinding {
+    binding.added_by_sig.signature = hex::encode(
+        signer
+            .sign(&binding.canonical_signing_payload())
+            .expect("sign binding"),
+    );
+    binding
+}
+
+fn binding_with(
+    signer: &Ed25519Signer,
+    role: KeyRole,
+    identity: &str,
+    valid_from: chrono::DateTime<Utc>,
+    revoked_at: Option<chrono::DateTime<Utc>>,
+) -> KeyBinding {
+    let public_key = hex::encode(signer.public_key());
+    sign_binding(
+        signer,
+        KeyBinding {
+            algorithm: signer.algorithm().to_string(),
+            public_key: public_key.clone(),
+            identity_ref: identity.to_string(),
+            role,
+            added_by_sig: StateSignature {
+                algorithm: signer.algorithm().to_string(),
+                public_key,
+                signature: String::new(),
+            },
+            valid_from,
+            revoked_at,
+            delegated_from: None,
+        },
+    )
+}
+
+fn past() -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(1_000, 0).unwrap()
+}
+
+fn in_window_ci_runner(signer: &Ed25519Signer, identity: &str) -> KeyBinding {
+    binding_with(signer, KeyRole::CiRunner, identity, past(), None)
+}
+
+fn signed_registry(authority: &Ed25519Signer, bindings: Vec<KeyBinding>) -> KeyBindingRegistry {
+    let mut registry = KeyBindingRegistry::new(
+        0,
+        None,
+        StateSignature {
+            algorithm: authority.algorithm().to_string(),
+            public_key: hex::encode(authority.public_key()),
+            signature: String::new(),
+        },
+        bindings,
+    );
+    registry.authority_signature.signature = hex::encode(
+        authority
+            .sign(
+                &registry
+                    .canonical_checkpoint_signing_payload()
+                    .expect("registry payload"),
+            )
+            .expect("sign registry"),
+    );
+    registry
+}
+
+fn resolve(
+    repo: &Repository,
+    authority: &Ed25519Signer,
+    bindings: Vec<KeyBinding>,
+) -> CiRunnerTrustSet {
+    let registry = signed_registry(authority, bindings);
+    repo.resolve_ci_runner_trust_set(&registry, &trusted_key(authority))
+}
+
+fn hex_key(signer: &Ed25519Signer) -> String {
+    hex::encode(signer.public_key())
+}
+
+#[test]
+fn unrevoked_in_window_ci_runner_is_included() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let runner = Ed25519Signer::generate().expect("runner");
+    let binding = in_window_ci_runner(&runner, "identity:runner");
+
+    let set = resolve(&repo, &authority, vec![binding]);
+
+    assert_eq!(set.len(), 1);
+    assert!(set.contains(runner.algorithm(), &hex_key(&runner)));
+    assert_eq!(set.entries()[0].identity_ref, "identity:runner");
+}
+
+#[test]
+fn revoked_ci_runner_is_excluded() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let runner = Ed25519Signer::generate().expect("runner");
+    let revoked = binding_with(
+        &runner,
+        KeyRole::CiRunner,
+        "identity:revoked",
+        past(),
+        Some(Utc.timestamp_opt(1_500, 0).unwrap()),
+    );
+
+    let set = resolve(&repo, &authority, vec![revoked]);
+
+    assert!(
+        set.is_empty(),
+        "revoked ci-runner must fail closed to an empty trust set, got {set:?}"
+    );
+    assert!(
+        !set.contains(runner.algorithm(), &hex_key(&runner)),
+        "revoked ci-runner key must not be a trusted verdict signer"
+    );
+}
+
+#[test]
+fn out_of_window_ci_runner_is_excluded() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let not_yet_valid = Ed25519Signer::generate().expect("future runner");
+    let future = binding_with(
+        &not_yet_valid,
+        KeyRole::CiRunner,
+        "identity:future",
+        Utc::now() + Duration::days(1),
+        None,
+    );
+
+    let set = resolve(&repo, &authority, vec![future]);
+
+    assert!(
+        set.is_empty(),
+        "not-yet-valid ci-runner must fail closed to an empty trust set, got {set:?}"
+    );
+    assert!(
+        !set.contains(not_yet_valid.algorithm(), &hex_key(&not_yet_valid)),
+        "out-of-window ci-runner key must not be a trusted verdict signer"
+    );
+}
+
+#[test]
+fn wrong_role_binding_is_excluded() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let author = Ed25519Signer::generate().expect("author");
+    let reviewer = Ed25519Signer::generate().expect("reviewer");
+    let author_binding = binding_with(&author, KeyRole::Author, "identity:author", past(), None);
+    let reviewer_binding = binding_with(
+        &reviewer,
+        KeyRole::Reviewer,
+        "identity:reviewer",
+        past(),
+        None,
+    );
+
+    let set = resolve(&repo, &authority, vec![author_binding, reviewer_binding]);
+
+    assert!(
+        set.is_empty(),
+        "author/reviewer bindings must not leak into the ci-runner trust set, got {set:?}"
+    );
+    assert!(!set.contains(author.algorithm(), &hex_key(&author)));
+    assert!(!set.contains(reviewer.algorithm(), &hex_key(&reviewer)));
+}
+
+#[test]
+fn empty_registry_yields_empty_trust_set() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+
+    let set = resolve(&repo, &authority, Vec::new());
+
+    assert!(set.is_empty());
+    assert_eq!(set, CiRunnerTrustSet::empty());
+}
+
+#[test]
+fn mixed_registry_includes_only_the_valid_ci_runner() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let valid = Ed25519Signer::generate().expect("valid runner");
+    let revoked = Ed25519Signer::generate().expect("revoked runner");
+    let future = Ed25519Signer::generate().expect("future runner");
+    let author = Ed25519Signer::generate().expect("author");
+    let bindings = vec![
+        in_window_ci_runner(&valid, "identity:valid"),
+        binding_with(
+            &revoked,
+            KeyRole::CiRunner,
+            "identity:revoked",
+            past(),
+            Some(Utc.timestamp_opt(1_500, 0).unwrap()),
+        ),
+        binding_with(
+            &future,
+            KeyRole::CiRunner,
+            "identity:future",
+            Utc::now() + Duration::days(1),
+            None,
+        ),
+        binding_with(&author, KeyRole::Author, "identity:author", past(), None),
+    ];
+
+    let set = resolve(&repo, &authority, bindings);
+
+    assert_eq!(
+        set.len(),
+        1,
+        "only the unrevoked in-window ci-runner belongs"
+    );
+    assert!(set.contains(valid.algorithm(), &hex_key(&valid)));
+    assert!(!set.contains(revoked.algorithm(), &hex_key(&revoked)));
+    assert!(!set.contains(future.algorithm(), &hex_key(&future)));
+    assert!(!set.contains(author.algorithm(), &hex_key(&author)));
+    assert_eq!(set.entries()[0].identity_ref, "identity:valid");
+}
+
+#[test]
+fn unauthorized_registry_fails_closed_to_empty() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let other = Ed25519Signer::generate().expect("other authority");
+    let runner = Ed25519Signer::generate().expect("runner");
+    let registry = signed_registry(
+        &authority,
+        vec![in_window_ci_runner(&runner, "identity:runner")],
+    );
+
+    let set = repo.resolve_ci_runner_trust_set(&registry, &trusted_key(&other));
+
+    assert!(
+        set.is_empty(),
+        "a registry not signed by the trusted authority must not yield runner keys, got {set:?}"
+    );
+}
+
+#[test]
+fn membership_agrees_with_known_actor_resolution() {
+    let (_temp, repo) = setup();
+    let authority = Ed25519Signer::generate().expect("authority");
+    let valid = Ed25519Signer::generate().expect("valid runner");
+    let revoked = Ed25519Signer::generate().expect("revoked runner");
+    let bindings = vec![
+        in_window_ci_runner(&valid, "identity:valid"),
+        binding_with(
+            &revoked,
+            KeyRole::CiRunner,
+            "identity:revoked",
+            past(),
+            Some(Utc.timestamp_opt(1_500, 0).unwrap()),
+        ),
+    ];
+    let registry = signed_registry(&authority, bindings);
+    let trusted = trusted_key(&authority);
+    let set = repo.resolve_ci_runner_trust_set(&registry, &trusted);
+
+    for binding in &registry.bindings {
+        let resolved = repo.verify_known_actor_key(
+            &binding.algorithm,
+            &binding.public_key,
+            KeyRole::CiRunner,
+            &registry,
+            &trusted,
+        );
+        let in_set = set.contains(&binding.algorithm, &binding.public_key);
+        match resolved {
+            AuthorshipVerification::Verified(_) => assert!(
+                in_set,
+                "Verified ci-runner {} must be in the trust set",
+                binding.identity_ref
+            ),
+            other => assert!(
+                !in_set,
+                "{} resolved as {other:?} must not be in the trust set",
+                binding.identity_ref
+            ),
+        }
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) fn test_state_id() -> objects::object::StateId {
 }
 
 pub mod atomic;
+mod ci_runner_trust;
 pub mod clone_intent;
 mod collaboration_migration;
 mod collaboration_store;
@@ -107,6 +108,7 @@ mod worktree_status_options;
 pub mod worktree_walk;
 
 // Re-export commonly used types from underlying crates.
+pub use ci_runner_trust::{CiRunnerTrustEntry, CiRunnerTrustSet};
 pub use collaboration_migration::{
     LegacyDiscussionMigrationBlocker, LegacyDiscussionMigrationItem, LegacyDiscussionMigrationPlan,
     LegacyDiscussionMigrationReport, apply_legacy_discussion_migration,


### PR DESCRIPTION
Closes #1369.

This also closes the **CI half of #1008 item 1** (treadle runner key ↔ repo trust set). The remaining identity-registry work in that item is authorship / device / owner binding, not this CI-runner slice. weft#1348 is the consumer that will check `SignedVerdict::verify` against the set this PR produces.

## Resolver design

`Repository::resolve_ci_runner_trust_set` walks an already-loaded `KeyBindingRegistry` and keeps only bindings for which `verify_known_actor_key(..., KeyRole::CiRunner)` returns `Verified`. That is the existing role resolver used for authorship (`Author`) and review evidence (`Reviewer` / `CiRunner` on `AgentPreview`). The trust set therefore cannot drift from the revocation, window, authorization, and role checks already in `crates/repo/src/repository_key_binding.rs`.

Returned type is `CiRunnerTrustSet`: an opaque collection of `(algorithm, public_key, identity_ref)` entries with case-insensitive `contains()`, matching the existing key-identity comparison. Construction is resolver-only; an empty set is the fail-closed outcome.

`SignedVerdict::verify` stays an integrity check. Membership is a separate policy step for the weft consumer:

```text
verdict.verify()?;
if !trust_set.contains(&verdict.algorithm, &verdict.public_key) { reject }
```

## Trust-boundary decisions

These follow the existing resolver exactly. They are not new, looser window rules.

| Decision | Rule | Why |
|---|---|---|
| Authorization | Unauthorized registry → empty set | Same as `verify_known_actor_key` returning `Invalid` for every key |
| Revocation | Any recorded `revoked_at` excludes the binding | Signer-asserted verdict timestamps are not trusted to move a signature behind a revocation boundary |
| Window | `valid_from` after the verifier clock excludes the binding | The verifier clock only bounds a future-dated authority-issued binding |
| Role isolation | Only `KeyRole::CiRunner` can enter the set | Author/Reviewer keys must not satisfy a CI verdict |
| Empty | No bindings / none valid → empty set | Fail closed: no trusted runner, not “unsigned is fine” |
| Time source | Verifier `Utc::now()`, never `signed_at` | Matches the existing “signer-claimed time does not control validity” rule |

End-of-window is `revoked_at` in this model (there is no separate expiry field). A past `revoked_at` is therefore both “revoked” and “expired.”

## Tests (all 8 passed)

Required cases:

- `unrevoked_in_window_ci_runner_is_included` — included
- `revoked_ci_runner_is_excluded` — empty set; `contains()` is false
- `out_of_window_ci_runner_is_excluded` — future `valid_from`; empty set; `contains()` is false
- `wrong_role_binding_is_excluded` — Author + Reviewer only; empty set; neither key is a member
- `empty_registry_yields_empty_trust_set` — empty ≡ `CiRunnerTrustSet::empty()`

Additional fail-closed proofs:

- `mixed_registry_includes_only_the_valid_ci_runner` — valid key kept; revoked / future / author excluded from the same snapshot
- `unauthorized_registry_fails_closed_to_empty` — wrong authority yields no keys
- `membership_agrees_with_known_actor_resolution` — set membership ≡ `verify_known_actor_key` for every binding

Verified locally with `CARGO_TARGET_DIR=/home/scratch/heddle-1369/target` and `TMPDIR=/home/scratch`:

- `cargo fmt --all -- --check`
- `cargo build --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked -p heddle-object-model`
- `cargo test --locked -p heddle-repo --lib` (656 passed, including the 8 new cases)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789390677&installation_model_id=21489&pr_number=1388&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1388&signature=af862909af057708652ba79a5087d893485a836e1a03c529e69688dfc42a880f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->