### PR TITLE
feat(ci): content-addressed result cache for treadle checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,10 +2204,13 @@ dependencies = [
 name = "heddle-ci-engine"
 version = "0.12.0"
 dependencies = [
+ "blake3",
  "heddle-ci-config",
  "heddle-crypto",
  "libc",
  "regex",
+ "serde",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "wait-timeout",

--- a/crates/ci-engine/Cargo.toml
+++ b/crates/ci-engine/Cargo.toml
@@ -8,9 +8,12 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+blake3.workspace = true
 ci-config = { path = "../ci-config", package = "heddle-ci-config", version = "0.12" }
 crypto = { path = "../crypto", package = "heddle-crypto", version = "0.12" }
 regex.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 wait-timeout.workspace = true

--- a/crates/ci-engine/src/exec.rs
+++ b/crates/ci-engine/src/exec.rs
@@ -14,26 +14,25 @@ use crate::{
     proc_group::ProcGroupRegistry,
     process::{RunOutput, run_process},
     result::{CompletedRun, finalize, infra_result, skipped_result},
+    result_cache::{ResultCache, ResultCacheError, SpotCheck, with_cache},
 };
 
 /// Run every check with default controls.
-#[must_use]
 pub fn run_checks(
     config: &CiConfig,
     context: &ExecutionContext,
     options: &RunOptions<'_>,
-) -> Vec<CheckResult> {
+) -> Result<Vec<CheckResult>, ResultCacheError> {
     run_checks_with(config, context, options, &RunControls::default())
 }
 
 /// Run checks with explicit trigger/cache/environment controls.
-#[must_use]
 pub fn run_checks_with(
     config: &CiConfig,
     context: &ExecutionContext,
     options: &RunOptions<'_>,
     controls: &RunControls<'_>,
-) -> Vec<CheckResult> {
+) -> Result<Vec<CheckResult>, ResultCacheError> {
     let default_environment = HermeticEnv::new();
     let environment = controls.hermetic_env.unwrap_or(&default_environment);
     let default_cache_root = options.workdir.join(".hci-cache");
@@ -43,13 +42,15 @@ pub fn run_checks_with(
         environment,
         cache_root,
         proc_groups: controls.proc_groups.as_ref(),
+        result_cache: controls.result_cache,
+        spot_check: controls.spot_check,
     };
     config
         .checks
         .iter()
         .map(|check| match &controls.trigger {
             Some(trigger) if !check_runs_for_trigger(&check.triggers, trigger) => {
-                skipped_result(check, context, &resolved)
+                Ok(skipped_result(check, context, &resolved))
             }
             _ => run_one_check(check, context, &resolved),
         })
@@ -61,9 +62,43 @@ pub(crate) struct ResolvedRun<'a> {
     pub(crate) environment: &'a HermeticEnv,
     pub(crate) cache_root: &'a Path,
     pub(crate) proc_groups: Option<&'a ProcGroupRegistry>,
+    pub(crate) result_cache: Option<&'a dyn ResultCache>,
+    pub(crate) spot_check: SpotCheck,
 }
 
-fn run_one_check(check: &Check, context: &ExecutionContext, run: &ResolvedRun<'_>) -> CheckResult {
+fn run_one_check(
+    check: &Check,
+    context: &ExecutionContext,
+    run: &ResolvedRun<'_>,
+) -> Result<CheckResult, ResultCacheError> {
+    let service_environment = declared_service_env(check);
+    let key_environment = run
+        .environment
+        .build(&check.env, &service_environment, &BTreeMap::new());
+    with_cache(check, context, run, &key_environment, || {
+        run_one_check_uncached(check, context, run, &service_environment)
+    })
+}
+
+fn declared_service_env(check: &Check) -> BTreeMap<String, String> {
+    check
+        .services
+        .iter()
+        .flat_map(|service| {
+            service
+                .env
+                .iter()
+                .map(|entry| (entry.0.clone(), entry.1.clone()))
+        })
+        .collect()
+}
+
+fn run_one_check_uncached(
+    check: &Check,
+    context: &ExecutionContext,
+    run: &ResolvedRun<'_>,
+    service_environment: &BTreeMap<String, String>,
+) -> CheckResult {
     let started_at = (run.options.now_rfc3339)();
     let started = Instant::now();
     let caches = prepare_caches(&check.cache_paths, run.cache_root);
@@ -73,19 +108,9 @@ fn run_one_check(check: &Check, context: &ExecutionContext, run: &ResolvedRun<'_
             return infra_result(check, context, run, started_at, started.elapsed(), &error);
         }
     };
-    let service_environment = check
-        .services
-        .iter()
-        .flat_map(|service| {
-            service
-                .env
-                .iter()
-                .map(|entry| (entry.0.clone(), entry.1.clone()))
-        })
-        .collect();
     let environment = run
         .environment
-        .build(&check.env, &service_environment, &caches.env);
+        .build(&check.env, service_environment, &caches.env);
     let (last, attempts) = run_attempts(check, run, &environment);
     let _ = run.options.services.down(services);
     finalize(

--- a/crates/ci-engine/src/lib.rs
+++ b/crates/ci-engine/src/lib.rs
@@ -11,6 +11,7 @@ mod model;
 mod proc_group;
 mod process;
 mod result;
+mod result_cache;
 mod service;
 
 pub use ansi::strip_ansi;
@@ -20,6 +21,10 @@ pub use env::{BASE_ALLOWLIST, GIT_IDENTITY_EMAIL, GIT_IDENTITY_NAME, HermeticEnv
 pub use exec::{run_checks, run_checks_with};
 pub use model::{AttemptRecord, CheckResult, ExecutionContext, RunControls, RunOptions};
 pub use proc_group::ProcGroupRegistry;
+pub use result_cache::{
+    CacheKey, FsResultCache, MemoryResultCache, RESULT_CACHE_SCHEMA_VERSION, ResultCache,
+    ResultCacheEntry, ResultCacheError, SpotCheck, SpotCheckDivergence, evidence_digest,
+};
 pub use service::{
     CommandOutcome, CommandRunner, DockerProvider, FakeProvider, NoopProvider, RealCommandRunner,
     RunningServices, ServiceError, ServiceProvider,

--- a/crates/ci-engine/src/model.rs
+++ b/crates/ci-engine/src/model.rs
@@ -5,8 +5,12 @@ use std::path::Path;
 
 use ci_config::Trigger;
 use crypto::{Basis, CiVerdictBody, Conclusion, StateRef};
+use serde::{Deserialize, Serialize};
 
-use crate::{HermeticEnv, ProcGroupRegistry, ServiceProvider};
+use crate::{
+    HermeticEnv, ProcGroupRegistry, ServiceProvider,
+    result_cache::{ResultCache, SpotCheck},
+};
 
 /// Facts about the exact state/tree being evaluated.
 #[derive(Debug, Clone)]
@@ -52,10 +56,14 @@ pub struct RunControls<'a> {
     pub hermetic_env: Option<&'a HermeticEnv>,
     /// Optional group registry for runner drain.
     pub proc_groups: Option<ProcGroupRegistry>,
+    /// Optional content-addressed result cache.
+    pub result_cache: Option<&'a dyn ResultCache>,
+    /// Spot-check policy applied to cache hits. Ignored when no cache is set.
+    pub spot_check: SpotCheck,
 }
 
 /// Operational record for one flake-retry attempt.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AttemptRecord {
     /// One-based attempt index.
     pub attempt: u32,

--- a/crates/ci-engine/src/result_cache/entry.rs
+++ b/crates/ci-engine/src/result_cache/entry.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Portable, serializable cache entry and fail-closed comparison.
+
+use crypto::{CiVerdictBody, Conclusion};
+use serde::{Deserialize, Serialize};
+
+use super::key::CacheKey;
+use crate::model::{AttemptRecord, CheckResult};
+
+/// Schema version of [`ResultCacheEntry`]. Bump when the bytes change.
+pub const RESULT_CACHE_SCHEMA_VERSION: u32 = 1;
+
+/// A portable cached check result, keyed only on the content-addressed triple.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResultCacheEntry {
+    /// Entry schema version.
+    pub schema_version: u32,
+    /// Digest of the content-addressed environment `E`.
+    pub env_digest: String,
+    /// Content-addresses of the evaluated inputs.
+    pub input_digests: Vec<String>,
+    /// Digest of the authored definition.
+    pub definition_digest: String,
+    /// Check name within that definition.
+    pub check_name: String,
+    /// BLAKE3 of the captured output (logs are not the cache key).
+    pub evidence_digest: String,
+    /// Reusable verdict body (a cache hit *is* a verdict).
+    pub body: CiVerdictBody,
+    /// ANSI-stripped combined output reused on a hit.
+    pub combined_output: String,
+    /// Attempt count from the original run.
+    pub attempts: u32,
+    /// Operational attempt records; not part of the signed body.
+    pub attempt_records: Vec<AttemptRecord>,
+}
+
+/// Details of a fail-closed spot-check disagreement.
+#[derive(Debug)]
+pub struct SpotCheckDivergence {
+    /// Check that disagreed.
+    pub check_name: String,
+    /// Conclusion stored in the cache entry.
+    pub cached_conclusion: String,
+    /// Evidence digest stored in the cache entry.
+    pub cached_evidence: String,
+    /// Conclusion produced by the fresh run.
+    pub fresh_conclusion: String,
+    /// Evidence digest of the fresh run.
+    pub fresh_evidence: String,
+    /// Environment digest from the lookup key.
+    pub env_digest: String,
+    /// Input digests from the lookup key.
+    pub input_digests: Vec<String>,
+    /// Definition digest from the lookup key.
+    pub definition_digest: String,
+}
+
+impl std::fmt::Display for SpotCheckDivergence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ci result cache spot-check failed for check `{}`: \
+             cached (conclusion={}, evidence={}) \
+             disagrees with fresh (conclusion={}, evidence={}); \
+             refusing to trust the cache entry \
+             [env={} inputs={:?} definition={}]",
+            self.check_name,
+            self.cached_conclusion,
+            self.cached_evidence,
+            self.fresh_conclusion,
+            self.fresh_evidence,
+            self.env_digest,
+            self.input_digests,
+            self.definition_digest
+        )
+    }
+}
+
+impl std::error::Error for SpotCheckDivergence {}
+
+/// Errors from cache I/O or a fail-closed spot-check disagreement.
+#[derive(Debug, thiserror::Error)]
+pub enum ResultCacheError {
+    /// Filesystem or encoding failure while reading or writing an entry.
+    #[error("ci result cache I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    /// A sampled cache hit disagreed with a fresh run. Never trusted.
+    #[error(transparent)]
+    SpotCheckDivergence(Box<SpotCheckDivergence>),
+}
+
+impl ResultCacheEntry {
+    /// Build a portable entry from a completed check result.
+    #[must_use]
+    pub fn from_result(key: &CacheKey, check_name: &str, result: &CheckResult) -> Self {
+        Self {
+            schema_version: RESULT_CACHE_SCHEMA_VERSION,
+            env_digest: key.env_digest.clone(),
+            input_digests: key.input_digests.clone(),
+            definition_digest: key.definition_digest.clone(),
+            check_name: check_name.to_string(),
+            evidence_digest: evidence_digest(&result.combined_output),
+            body: result.body.clone(),
+            combined_output: result.combined_output.clone(),
+            attempts: result.attempts,
+            attempt_records: result.attempt_records.clone(),
+        }
+    }
+
+    /// Reconstruct the executor result reused on a cache hit.
+    #[must_use]
+    pub fn into_check_result(self) -> CheckResult {
+        CheckResult {
+            body: self.body,
+            combined_output: self.combined_output,
+            attempts: self.attempts,
+            attempt_records: self.attempt_records,
+        }
+    }
+
+    pub(super) fn is_valid_for(&self, key: &CacheKey, check_name: &str) -> bool {
+        self.schema_version == RESULT_CACHE_SCHEMA_VERSION
+            && self.env_digest == key.env_digest
+            && self.input_digests == key.input_digests
+            && self.definition_digest == key.definition_digest
+            && self.check_name == check_name
+            && self.evidence_digest == evidence_digest(&self.combined_output)
+    }
+
+    /// Fail-closed comparison of a cached entry against a fresh run.
+    pub fn verify_fresh(&self, fresh: &CheckResult) -> Result<(), ResultCacheError> {
+        let fresh_evidence = evidence_digest(&fresh.combined_output);
+        if self.body.outcome == fresh.body.outcome && self.evidence_digest == fresh_evidence {
+            return Ok(());
+        }
+        Err(ResultCacheError::SpotCheckDivergence(Box::new(
+            SpotCheckDivergence {
+                check_name: self.check_name.clone(),
+                cached_conclusion: conclusion_label(self.body.outcome.conclusion).to_string(),
+                cached_evidence: self.evidence_digest.clone(),
+                fresh_conclusion: conclusion_label(fresh.conclusion()).to_string(),
+                fresh_evidence,
+                env_digest: self.env_digest.clone(),
+                input_digests: self.input_digests.clone(),
+                definition_digest: self.definition_digest.clone(),
+            },
+        )))
+    }
+}
+
+/// Domain-separated BLAKE3 of captured check output.
+#[must_use]
+pub fn evidence_digest(combined_output: &str) -> String {
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"heddle-ci-evidence-v1\0");
+    hasher.update(&(combined_output.len() as u64).to_le_bytes());
+    hasher.update(combined_output.as_bytes());
+    hasher.finalize().to_hex().to_string()
+}
+
+fn conclusion_label(conclusion: Conclusion) -> &'static str {
+    match conclusion {
+        Conclusion::Success => "success",
+        Conclusion::Failure => "failure",
+        Conclusion::Cancelled => "cancelled",
+        Conclusion::Skipped => "skipped",
+        Conclusion::TimedOut => "timed_out",
+        Conclusion::InfraError => "infra_error",
+    }
+}

--- a/crates/ci-engine/src/result_cache/key.rs
+++ b/crates/ci-engine/src/result_cache/key.rs
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Content-addressed cache key: `(env-digest, input-digests, definition-digest)`.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use crate::{cache::CACHE_ENV_PREFIX, model::ExecutionContext};
+
+/// The portable triple that addresses a cached check result.
+///
+/// The key contains no machine-local state (paths, host identity, cache-slot
+/// directories). Changing any component yields a different [`CacheKey::id`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct CacheKey {
+    /// Digest of the content-addressed execution environment `E`.
+    pub env_digest: String,
+    /// Sorted, tagged content-addresses of the evaluated inputs.
+    pub input_digests: Vec<String>,
+    /// Digest of the authored definition (`ci.toml` typed-blob hash).
+    pub definition_digest: String,
+}
+
+#[derive(Serialize)]
+struct EnvMaterial<'a> {
+    os: &'a str,
+    arch: &'a str,
+    image_digest: Option<&'a str>,
+    toolchain: Option<&'a str>,
+    env: BTreeMap<&'a str, &'a str>,
+}
+
+#[derive(Serialize)]
+struct EntryMaterial<'a> {
+    env_digest: &'a str,
+    input_digests: &'a [String],
+    definition_digest: &'a str,
+    check_name: &'a str,
+}
+
+impl CacheKey {
+    /// Derive the triple from the portable projection of `environment` plus
+    /// the execution context's image, toolchain, tree, state, and definition.
+    #[must_use]
+    pub fn derive(environment: &BTreeMap<String, String>, context: &ExecutionContext) -> Self {
+        Self {
+            env_digest: env_digest(environment, context),
+            input_digests: input_digests(context),
+            definition_digest: context.definition_digest.clone(),
+        }
+    }
+
+    /// Domain-separated digest of the triple alone (no check name).
+    #[must_use]
+    pub fn id(&self) -> String {
+        digest_json(b"key", self)
+    }
+}
+
+pub(super) fn entry_id(key: &CacheKey, check_name: &str) -> String {
+    digest_json(
+        b"entry",
+        &EntryMaterial {
+            env_digest: &key.env_digest,
+            input_digests: &key.input_digests,
+            definition_digest: &key.definition_digest,
+            check_name,
+        },
+    )
+}
+
+pub(super) fn entry_id_bytes(key: &CacheKey, check_name: &str) -> [u8; 32] {
+    hash_json(
+        b"entry",
+        &EntryMaterial {
+            env_digest: &key.env_digest,
+            input_digests: &key.input_digests,
+            definition_digest: &key.definition_digest,
+            check_name,
+        },
+    )
+}
+
+fn env_digest(environment: &BTreeMap<String, String>, context: &ExecutionContext) -> String {
+    let env = portable_env(environment);
+    digest_json(
+        b"env",
+        &EnvMaterial {
+            os: std::env::consts::OS,
+            arch: std::env::consts::ARCH,
+            image_digest: context.image_digest.as_deref(),
+            toolchain: context.toolchain.as_deref(),
+            env,
+        },
+    )
+}
+
+fn input_digests(context: &ExecutionContext) -> Vec<String> {
+    let mut inputs = vec![
+        format!("state:{}", context.state.content_hash),
+        format!("tree:{}", context.basis.evaluated_tree_digest),
+    ];
+    inputs.sort();
+    inputs
+}
+
+fn portable_env(environment: &BTreeMap<String, String>) -> BTreeMap<&str, &str> {
+    environment
+        .iter()
+        .filter(|(name, _)| !is_machine_local_key(name))
+        .map(|(name, value)| (name.as_str(), value.as_str()))
+        .collect()
+}
+
+fn is_machine_local_key(name: &str) -> bool {
+    name.starts_with(CACHE_ENV_PREFIX)
+        || matches!(
+            name,
+            "PATH"
+                | "HOME"
+                | "USER"
+                | "SHELL"
+                | "TERM"
+                | "CARGO_HOME"
+                | "RUSTUP_HOME"
+                | "TMPDIR"
+                | "TEMP"
+                | "TMP"
+                | "PWD"
+                | "HOSTNAME"
+                | "HOST"
+                | "LOGNAME"
+        )
+}
+
+fn digest_json(label: &[u8], value: &impl Serialize) -> String {
+    blake3::Hash::from_bytes(hash_json(label, value))
+        .to_hex()
+        .to_string()
+}
+
+fn hash_json(label: &[u8], value: &impl Serialize) -> [u8; 32] {
+    let payload = serde_json::to_vec(value).expect("cache key material is always serializable");
+    let mut hasher = blake3::Hasher::new();
+    hasher.update(b"heddle-ci-result-cache-v1\0");
+    hasher.update(&(label.len() as u64).to_le_bytes());
+    hasher.update(label);
+    hasher.update(&(payload.len() as u64).to_le_bytes());
+    hasher.update(&payload);
+    *hasher.finalize().as_bytes()
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::{Basis, BasisKind, StateRef};
+
+    use super::*;
+    use crate::model::ExecutionContext;
+
+    fn context() -> ExecutionContext {
+        ExecutionContext {
+            repo: "test/repo".to_string(),
+            state: StateRef {
+                content_hash: "state-content".to_string(),
+                change_id: "change".to_string(),
+                logical_change_id: None,
+            },
+            basis: Basis {
+                kind: BasisKind::Branch,
+                evaluated_tree_digest: "tree".to_string(),
+            },
+            definition_digest: "definition".to_string(),
+            toolchain: Some("rustc 1.97.0".to_string()),
+            pick_id: None,
+            attempt: 1,
+            runner: None,
+            image_digest: Some("sha256:image".to_string()),
+        }
+    }
+
+    fn env(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn each_triple_component_changes_the_key() {
+        let base = CacheKey::derive(&env(&[("FOO", "1")]), &context());
+        let mut changed_env = context();
+        let env_miss = CacheKey::derive(&env(&[("FOO", "2")]), &changed_env);
+        assert_ne!(base.env_digest, env_miss.env_digest);
+        assert_ne!(base.id(), env_miss.id());
+
+        changed_env.basis.evaluated_tree_digest = "tree-2".to_string();
+        let input_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_env);
+        assert_ne!(base.input_digests, input_miss.input_digests);
+        assert_ne!(base.id(), input_miss.id());
+
+        let mut changed_definition = context();
+        changed_definition.definition_digest = "definition-2".to_string();
+        let definition_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_definition);
+        assert_ne!(base.definition_digest, definition_miss.definition_digest);
+        assert_ne!(base.id(), definition_miss.id());
+    }
+
+    #[test]
+    fn machine_local_env_is_not_in_the_key() {
+        let portable = CacheKey::derive(&env(&[("FOO", "1"), ("LANG", "C")]), &context());
+        let local = CacheKey::derive(
+            &env(&[
+                ("FOO", "1"),
+                ("LANG", "C"),
+                ("PATH", "/other/bin"),
+                ("HOME", "/other/home"),
+                ("HCI_CACHE_CARGO", "/tmp/machine-a/CARGO"),
+            ]),
+            &context(),
+        );
+        assert_eq!(portable.env_digest, local.env_digest);
+        assert_eq!(portable.id(), local.id());
+    }
+
+    #[test]
+    fn image_and_toolchain_are_part_of_env_digest() {
+        let base = CacheKey::derive(&env(&[]), &context());
+        let mut changed = context();
+        changed.image_digest = Some("sha256:other".to_string());
+        assert_ne!(
+            base.env_digest,
+            CacheKey::derive(&env(&[]), &changed).env_digest
+        );
+        changed = context();
+        changed.toolchain = Some("rustc 1.88.0".to_string());
+        assert_ne!(
+            base.env_digest,
+            CacheKey::derive(&env(&[]), &changed).env_digest
+        );
+    }
+}

--- a/crates/ci-engine/src/result_cache/mod.rs
+++ b/crates/ci-engine/src/result_cache/mod.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Content-addressed check-result cache keyed on `(env, inputs, definition)`.
+
+mod entry;
+mod key;
+mod spot_check;
+mod store;
+
+use std::collections::BTreeMap;
+
+use ci_config::Check;
+use crypto::Conclusion;
+pub use entry::{
+    RESULT_CACHE_SCHEMA_VERSION, ResultCacheEntry, ResultCacheError, SpotCheckDivergence,
+    evidence_digest,
+};
+pub use key::CacheKey;
+pub use spot_check::SpotCheck;
+pub use store::{FsResultCache, MemoryResultCache, ResultCache};
+
+use crate::{
+    exec::ResolvedRun,
+    model::{CheckResult, ExecutionContext},
+};
+
+pub(crate) fn with_cache(
+    check: &Check,
+    context: &ExecutionContext,
+    run: &ResolvedRun<'_>,
+    key_environment: &BTreeMap<String, String>,
+    run_fresh: impl FnOnce() -> CheckResult,
+) -> Result<CheckResult, ResultCacheError> {
+    let Some(cache) = run.result_cache else {
+        return Ok(run_fresh());
+    };
+    let key = CacheKey::derive(key_environment, context);
+    if let Some(entry) = cache.get(&key, &check.name)? {
+        if run.spot_check.should_sample(&key, &check.name) {
+            let fresh = run_fresh();
+            entry.verify_fresh(&fresh)?;
+        }
+        return Ok(entry.into_check_result());
+    }
+    let fresh = run_fresh();
+    if is_cacheable(&fresh) {
+        cache.put(&ResultCacheEntry::from_result(&key, &check.name, &fresh))?;
+    }
+    Ok(fresh)
+}
+
+fn is_cacheable(result: &CheckResult) -> bool {
+    !matches!(
+        result.conclusion(),
+        Conclusion::Skipped | Conclusion::Cancelled | Conclusion::InfraError
+    )
+}

--- a/crates/ci-engine/src/result_cache/spot_check.rs
+++ b/crates/ci-engine/src/result_cache/spot_check.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Deterministic sampling of cache hits for fail-closed re-execution.
+
+use super::key::{CacheKey, entry_id_bytes};
+
+/// Policy for re-running a sampled fraction of cache hits.
+///
+/// A disagreement between the cached entry and the fresh run is a hard
+/// error ([`super::ResultCacheError::SpotCheckDivergence`]) — never a
+/// silent fallback to either result.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpotCheck {
+    /// Never re-run a cache hit. Tests use this to prove reuse.
+    Never,
+    /// Re-run every cache hit. Tests use this to prove fail-closed.
+    Always,
+    /// Re-run `numerator / denominator` of hits, chosen from the entry id.
+    Fraction {
+        /// Hits sampled per `denominator` keys.
+        numerator: u32,
+        /// Sampling modulus. Zero is treated as never.
+        denominator: u32,
+    },
+}
+
+impl Default for SpotCheck {
+    fn default() -> Self {
+        Self::Fraction {
+            numerator: 1,
+            denominator: 32,
+        }
+    }
+}
+
+impl SpotCheck {
+    /// Whether this policy samples `key` / `check_name`.
+    #[must_use]
+    pub fn should_sample(&self, key: &CacheKey, check_name: &str) -> bool {
+        match *self {
+            Self::Never => false,
+            Self::Always => true,
+            Self::Fraction {
+                numerator,
+                denominator,
+            } => {
+                if denominator == 0 || numerator == 0 {
+                    return false;
+                }
+                if numerator >= denominator {
+                    return true;
+                }
+                let bytes = entry_id_bytes(key, check_name);
+                let bucket = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                bucket % denominator < numerator
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crypto::{Basis, BasisKind, StateRef};
+
+    use super::*;
+    use crate::model::ExecutionContext;
+
+    fn key() -> CacheKey {
+        CacheKey::derive(
+            &std::collections::BTreeMap::new(),
+            &ExecutionContext {
+                repo: "test/repo".to_string(),
+                state: StateRef {
+                    content_hash: "state".to_string(),
+                    change_id: "change".to_string(),
+                    logical_change_id: None,
+                },
+                basis: Basis {
+                    kind: BasisKind::Branch,
+                    evaluated_tree_digest: "tree".to_string(),
+                },
+                definition_digest: "definition".to_string(),
+                toolchain: None,
+                pick_id: None,
+                attempt: 1,
+                runner: None,
+                image_digest: None,
+            },
+        )
+    }
+
+    #[test]
+    fn fraction_is_deterministic_for_a_key() {
+        let key = key();
+        let policy = SpotCheck::Fraction {
+            numerator: 1,
+            denominator: 2,
+        };
+        let first = policy.should_sample(&key, "build");
+        assert_eq!(first, policy.should_sample(&key, "build"));
+        assert!(SpotCheck::Always.should_sample(&key, "build"));
+        assert!(!SpotCheck::Never.should_sample(&key, "build"));
+    }
+}

--- a/crates/ci-engine/src/result_cache/store.rs
+++ b/crates/ci-engine/src/result_cache/store.rs
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: Apache-2.0
+//! In-memory and filesystem stores for portable result-cache entries.
+
+use std::{
+    collections::BTreeMap,
+    fs::File,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    sync::Mutex,
+};
+
+use super::{
+    entry::{ResultCacheEntry, ResultCacheError},
+    key::{CacheKey, entry_id},
+};
+
+/// Lookup and seed a content-addressed result cache.
+pub trait ResultCache {
+    /// Load the entry for `key` + `check_name`, if a valid one is stored.
+    fn get(
+        &self,
+        key: &CacheKey,
+        check_name: &str,
+    ) -> Result<Option<ResultCacheEntry>, ResultCacheError>;
+
+    /// Persist `entry` under its recorded triple and check name.
+    fn put(&self, entry: &ResultCacheEntry) -> Result<(), ResultCacheError>;
+}
+
+/// Process-local cache used by tests and as a seed/hit fixture.
+#[derive(Debug, Default)]
+pub struct MemoryResultCache {
+    entries: Mutex<BTreeMap<String, ResultCacheEntry>>,
+}
+
+impl MemoryResultCache {
+    /// Empty cache.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Snapshot of every stored entry, for inspection and tampering tests.
+    #[must_use]
+    pub fn entries(&self) -> Vec<ResultCacheEntry> {
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .values()
+            .cloned()
+            .collect()
+    }
+}
+
+impl ResultCache for MemoryResultCache {
+    fn get(
+        &self,
+        key: &CacheKey,
+        check_name: &str,
+    ) -> Result<Option<ResultCacheEntry>, ResultCacheError> {
+        let entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        Ok(entries
+            .get(&entry_id(key, check_name))
+            .filter(|entry| entry.is_valid_for(key, check_name))
+            .cloned())
+    }
+
+    fn put(&self, entry: &ResultCacheEntry) -> Result<(), ResultCacheError> {
+        let key = CacheKey {
+            env_digest: entry.env_digest.clone(),
+            input_digests: entry.input_digests.clone(),
+            definition_digest: entry.definition_digest.clone(),
+        };
+        self.entries
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .insert(entry_id(&key, &entry.check_name), entry.clone());
+        Ok(())
+    }
+}
+
+/// Directory-backed cache. Entries are JSON files named by the entry digest.
+///
+/// The layout is portable: copy the directory (or a single entry file) to
+/// another machine and the same triple hits.
+#[derive(Debug, Clone)]
+pub struct FsResultCache {
+    root: PathBuf,
+}
+
+impl FsResultCache {
+    /// Use `root` as the cache directory. Created on first write.
+    #[must_use]
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Filesystem root this cache reads and writes.
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn path_for(&self, key: &CacheKey, check_name: &str) -> PathBuf {
+        let id = entry_id(key, check_name);
+        self.root.join(&id[..2]).join(format!("{id}.json"))
+    }
+}
+
+impl ResultCache for FsResultCache {
+    fn get(
+        &self,
+        key: &CacheKey,
+        check_name: &str,
+    ) -> Result<Option<ResultCacheEntry>, ResultCacheError> {
+        let path = self.path_for(key, check_name);
+        let mut file = match File::open(&path) {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let mut bytes = Vec::new();
+        file.read_to_end(&mut bytes)?;
+        let Ok(entry) = serde_json::from_slice::<ResultCacheEntry>(&bytes) else {
+            return Ok(None);
+        };
+        if entry.is_valid_for(key, check_name) {
+            Ok(Some(entry))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn put(&self, entry: &ResultCacheEntry) -> Result<(), ResultCacheError> {
+        let key = CacheKey {
+            env_digest: entry.env_digest.clone(),
+            input_digests: entry.input_digests.clone(),
+            definition_digest: entry.definition_digest.clone(),
+        };
+        let path = self.path_for(&key, &entry.check_name);
+        let bytes = serde_json::to_vec(entry).map_err(|error| {
+            std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())
+        })?;
+        write_atomic(&path, &bytes)
+    }
+}
+
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<(), ResultCacheError> {
+    let parent = path.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "result cache entry path has no parent",
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let unique = format!(
+        ".{}.{}-{}.tmp",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("entry"),
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|duration| duration.as_nanos())
+            .unwrap_or(0)
+    );
+    let tmp = parent.join(unique);
+    let written = write_tmp_then_rename(&tmp, path, bytes);
+    if written.is_err() {
+        let _cleanup = std::fs::remove_file(&tmp);
+    }
+    written
+}
+
+fn write_tmp_then_rename(tmp: &Path, dest: &Path, bytes: &[u8]) -> Result<(), ResultCacheError> {
+    let mut file = File::create(tmp)?;
+    file.write_all(bytes)?;
+    file.sync_all()?;
+    std::fs::rename(tmp, dest)?;
+    Ok(())
+}

--- a/crates/ci-engine/tests/executor.rs
+++ b/crates/ci-engine/tests/executor.rs
@@ -45,6 +45,7 @@ fn run(raw: &str, workdir: &std::path::Path) -> Vec<ci_engine::CheckResult> {
             now_rfc3339: &fixed_clock,
         },
     )
+    .expect("run")
 }
 
 #[test]
@@ -108,7 +109,8 @@ flake_signatures = ["FLAKE"]
             now_rfc3339: &fixed_clock,
         },
         &controls,
-    );
+    )
+    .expect("run");
     assert_eq!(results[0].conclusion(), Conclusion::Success);
     assert_eq!(results[0].attempts, 2);
     assert!(results[0].recovered_after_flake());
@@ -168,7 +170,8 @@ cache_paths = ["cargo"]
             now_rfc3339: &fixed_clock,
         },
         &controls,
-    );
+    )
+    .expect("run");
     assert_eq!(results[0].conclusion(), Conclusion::Success);
     assert!(
         results[0]

--- a/crates/ci-engine/tests/result_cache.rs
+++ b/crates/ci-engine/tests/result_cache.rs
@@ -1,0 +1,260 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, path::Path};
+
+use ci_engine::{
+    CheckResult, ExecutionContext, FsResultCache, HermeticEnv, MemoryResultCache, NoopProvider,
+    ResultCache, ResultCacheEntry, ResultCacheError, RunControls, RunOptions, SpotCheck,
+    SpotCheckDivergence, run_checks_with,
+};
+use crypto::{Basis, BasisKind, Conclusion, StateRef};
+
+const MARKER_CHECK: &str = r#"
+[meta]
+schema = 1
+[[check]]
+name = "marker"
+command = ["/bin/sh", "-c", "echo ran >> marker; echo ok"]
+"#;
+
+fn context() -> ExecutionContext {
+    ExecutionContext {
+        repo: "test/repo".to_string(),
+        state: StateRef {
+            content_hash: "state-content".to_string(),
+            change_id: "change".to_string(),
+            logical_change_id: None,
+        },
+        basis: Basis {
+            kind: BasisKind::Branch,
+            evaluated_tree_digest: "tree".to_string(),
+        },
+        definition_digest: "definition".to_string(),
+        toolchain: None,
+        pick_id: None,
+        attempt: 1,
+        runner: None,
+        image_digest: None,
+    }
+}
+
+fn run_cached(
+    raw: &str,
+    workdir: &Path,
+    context: &ExecutionContext,
+    cache: &dyn ResultCache,
+    spot_check: SpotCheck,
+) -> Result<Vec<CheckResult>, ResultCacheError> {
+    let config = ci_config::parse(raw).expect("config");
+    let provider = NoopProvider;
+    let environment = HermeticEnv::with_host(BTreeMap::new());
+    run_checks_with(
+        &config,
+        context,
+        &RunOptions {
+            workdir,
+            services: &provider,
+            now_rfc3339: &|| "2026-08-14T12:00:00Z".to_string(),
+        },
+        &RunControls {
+            hermetic_env: Some(&environment),
+            result_cache: Some(cache),
+            spot_check,
+            ..RunControls::default()
+        },
+    )
+}
+
+fn marker_runs(workdir: &Path) -> usize {
+    std::fs::read_to_string(workdir.join("marker"))
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.is_empty())
+        .count()
+}
+
+fn seed(raw: &str, workdir: &Path, context: &ExecutionContext, cache: &dyn ResultCache) {
+    run_cached(raw, workdir, context, cache, SpotCheck::Never).expect("seed");
+}
+
+fn env_check(value: &str) -> String {
+    format!(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "marker"
+command = ["/bin/sh", "-c", "echo ran >> marker; echo ok"]
+[check.env]
+FOO = "{value}"
+"#
+    )
+}
+
+#[test]
+fn cache_hit_reuses_result_and_does_not_rerun() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    let first = run_cached(
+        MARKER_CHECK,
+        workdir.path(),
+        &context(),
+        &cache,
+        SpotCheck::Never,
+    )
+    .expect("seed");
+    assert_eq!(first[0].conclusion(), Conclusion::Success);
+    assert_eq!(first[0].combined_output, "ok\n");
+    assert_eq!(marker_runs(workdir.path()), 1);
+
+    let second = run_cached(
+        MARKER_CHECK,
+        workdir.path(),
+        &context(),
+        &cache,
+        SpotCheck::Never,
+    )
+    .expect("hit");
+    assert_eq!(second[0].combined_output, first[0].combined_output);
+    assert_eq!(second[0].body.outcome, first[0].body.outcome);
+    assert_eq!(marker_runs(workdir.path()), 1, "cache hit must not re-run");
+}
+
+#[test]
+fn changed_env_is_a_cache_miss() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    seed(&env_check("one"), workdir.path(), &context(), &cache);
+    seed(&env_check("two"), workdir.path(), &context(), &cache);
+    assert_eq!(
+        marker_runs(workdir.path()),
+        2,
+        "a different declared env must not reuse the cached result"
+    );
+}
+
+#[test]
+fn changed_input_is_a_cache_miss() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    seed(MARKER_CHECK, workdir.path(), &context(), &cache);
+
+    let mut changed = context();
+    changed.basis.evaluated_tree_digest = "tree-changed".to_string();
+    seed(MARKER_CHECK, workdir.path(), &changed, &cache);
+    assert_eq!(
+        marker_runs(workdir.path()),
+        2,
+        "tree digest change is a miss"
+    );
+
+    changed = context();
+    changed.state.content_hash = "state-changed".to_string();
+    seed(MARKER_CHECK, workdir.path(), &changed, &cache);
+    assert_eq!(
+        marker_runs(workdir.path()),
+        3,
+        "state content hash change is a miss"
+    );
+}
+
+#[test]
+fn changed_definition_is_a_cache_miss() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    seed(MARKER_CHECK, workdir.path(), &context(), &cache);
+    let mut changed = context();
+    changed.definition_digest = "definition-changed".to_string();
+    seed(MARKER_CHECK, workdir.path(), &changed, &cache);
+    assert_eq!(
+        marker_runs(workdir.path()),
+        2,
+        "a different definition digest must not reuse the cached result"
+    );
+}
+
+#[test]
+fn serialized_entry_seeds_a_separate_cache_instance() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let seed_cache = MemoryResultCache::new();
+    seed(MARKER_CHECK, workdir.path(), &context(), &seed_cache);
+    assert_eq!(marker_runs(workdir.path()), 1);
+
+    let stored = seed_cache.entries();
+    assert_eq!(stored.len(), 1);
+    let bytes = serde_json::to_vec(&stored[0]).expect("serialize portable entry");
+    let restored: ResultCacheEntry = serde_json::from_slice(&bytes).expect("deserialize");
+    let peer_dir = tempfile::tempdir().expect("peer cache");
+    let peer = FsResultCache::new(peer_dir.path());
+    peer.put(&restored).expect("seed peer");
+
+    let hit = run_cached(
+        MARKER_CHECK,
+        workdir.path(),
+        &context(),
+        &peer,
+        SpotCheck::Never,
+    )
+    .expect("cross-instance hit");
+    assert_eq!(hit[0].conclusion(), Conclusion::Success);
+    assert_eq!(hit[0].combined_output, "ok\n");
+    assert_eq!(marker_runs(workdir.path()), 1, "portable entry must hit");
+}
+
+#[test]
+fn spot_check_fails_closed_on_a_divergent_entry() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    seed(MARKER_CHECK, workdir.path(), &context(), &cache);
+
+    let mut tampered = cache.entries().pop().expect("seeded entry");
+    tampered.body.outcome.conclusion = Conclusion::Failure;
+    cache.put(&tampered).expect("store divergent entry");
+
+    let error = run_cached(
+        MARKER_CHECK,
+        workdir.path(),
+        &context(),
+        &cache,
+        SpotCheck::Always,
+    )
+    .expect_err("divergent spot-check must be a hard error");
+    match &error {
+        ResultCacheError::SpotCheckDivergence(divergence) => {
+            let SpotCheckDivergence {
+                check_name,
+                cached_conclusion,
+                fresh_conclusion,
+                ..
+            } = &**divergence;
+            assert_eq!(check_name, "marker");
+            assert_eq!(cached_conclusion, "failure");
+            assert_eq!(fresh_conclusion, "success");
+        }
+        other => panic!("expected spot-check divergence, got {other}"),
+    }
+    assert_eq!(marker_runs(workdir.path()), 2, "spot-check re-runs fresh");
+    assert!(
+        error
+            .to_string()
+            .contains("refusing to trust the cache entry"),
+        "{error}"
+    );
+}
+
+#[test]
+fn honest_spot_check_accepts_a_matching_entry() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache = MemoryResultCache::new();
+    seed(MARKER_CHECK, workdir.path(), &context(), &cache);
+    let verified = run_cached(
+        MARKER_CHECK,
+        workdir.path(),
+        &context(),
+        &cache,
+        SpotCheck::Always,
+    )
+    .expect("matching spot-check must not fail");
+    assert_eq!(verified[0].conclusion(), Conclusion::Success);
+    assert_eq!(marker_runs(workdir.path()), 2);
+}

--- a/crates/cli/src/cli/commands/ci/run.rs
+++ b/crates/cli/src/cli/commands/ci/run.rs
@@ -7,7 +7,8 @@ use anyhow::{Context, Result, ensure};
 use chrono::{SecondsFormat, Utc};
 use ci_config::CiConfig;
 use ci_engine::{
-    BASE_ALLOWLIST, ExecutionContext, NoopProvider, RunControls, RunOptions, run_checks_with,
+    BASE_ALLOWLIST, ExecutionContext, FsResultCache, NoopProvider, RunControls, RunOptions,
+    run_checks_with,
 };
 use crypto::{
     Basis, BasisKind, Ed25519Signer, SignedVerdict, Signer, SignerKind, StateRef,
@@ -46,11 +47,15 @@ pub(crate) fn run_local(cli: &Cli, args: &CiRunArgs) -> Result<()> {
         now_rfc3339: &now,
     };
     let cache_root = repo.heddle_dir().join("cache/ci");
+    let result_cache_root = repo.heddle_dir().join("cache/ci-results");
+    let result_cache = FsResultCache::new(&result_cache_root);
     let controls = RunControls {
         cache_root: Some(&cache_root),
+        result_cache: Some(&result_cache),
         ..RunControls::default()
     };
-    let results = run_checks_with(&config, &context, &options, &controls);
+    let results = run_checks_with(&config, &context, &options, &controls)
+        .context("run checks (including result-cache spot-check)")?;
     target.ensure_unchanged(&repo)?;
     target.cleanup(&repo)?;
 


### PR DESCRIPTION
Closes #1374

Part of the treadle epic (#1365). Adds a portable, content-addressed result cache so a hermetic check whose `(env, inputs, definition)` triple is already stored is not re-run — and so a local run can seed a cache the CI box / peers reuse.

## Cache design + key derivation

The cache is keyed on the **full triple** only. No machine-local state (paths, `HCI_CACHE_*` slots, `PATH`/`HOME`/`USER`, host identity) enters the key.

| Component | Derived from | Digest |
|---|---|---|
| **env-digest** | portable projection of the hermetic env recorded for `repro` (declared check/service env, locale, git-hermetic vars) plus `os`/`arch`, `image_digest`, and `toolchain` | domain-separated BLAKE3 over canonical JSON (`heddle-ci-result-cache-v1`) |
| **input-digests** | tagged `state:<content_hash>` and `tree:<evaluated_tree_digest>` | sorted list, part of the triple |
| **definition-digest** | `ExecutionContext.definition_digest` (the `ci-config` typed-blob hash of `ci.toml`) | as provided by the caller |

Lookup identity is `hash(triple ∥ check_name)` so two checks in the same definition do not collide. The stored **entry** is JSON (`RESULT_CACHE_SCHEMA_VERSION = 1`): the triple, check name, reusable `CiVerdictBody`, captured output, and an `evidence_digest` (BLAKE3 of the output). Writes are temp → `fsync` → `rename`.

Stores:
- `MemoryResultCache` — process-local, used by tests
- `FsResultCache` — directory of `{id[0..2]}/{id}.json` files; copy the directory (or a single JSON file) to another machine and the same triple hits

`heddle ci run --local` seeds/reads `.heddle/cache/ci-results`. Infra / skipped / cancelled results are not stored.

## Spot-check / fail-closed

Default policy is `SpotCheck::Fraction { 1, 32 }`, sampled **deterministically** from the entry id (same key always makes the same decision). Tests use `Never` (prove reuse) and `Always` (prove fail-closed).

On a sampled hit the check is re-run fresh. The cached `outcome` + `evidence_digest` are compared to the fresh run. **Any disagreement is a hard `ResultCacheError::SpotCheckDivergence`** — the executor returns `Err`, the CLI fails, and neither the cached nor the fresh result is trusted. The error names the check, both conclusions, both evidence digests, and the full triple.

## Tests (required cases, all passing)

| Test | Proves |
|---|---|
| `cache_hit_reuses_result_and_does_not_rerun` | second run reuses the verdict; marker file is written once |
| `changed_env_is_a_cache_miss` | declared env change re-runs |
| `changed_input_is_a_cache_miss` | tree digest **or** state content hash change re-runs |
| `changed_definition_is_a_cache_miss` | definition-digest change re-runs |
| `serialized_entry_seeds_a_separate_cache_instance` | JSON entry from `MemoryResultCache` hits on a new `FsResultCache` |
| `spot_check_fails_closed_on_a_divergent_entry` | tampered Success→Failure entry + `Always` is a hard error |
| `honest_spot_check_accepts_a_matching_entry` | matching re-run is not an error |
| unit: `each_triple_component_changes_the_key` | every triple field moves the key |
| unit: `machine_local_env_is_not_in_the_key` | `PATH`/`HOME`/`HCI_CACHE_*` do not |

`heddle-ci-engine` + `heddle-ci-config` tests: all pass.

## Verification

- `cargo +nightly fmt --all -- --check`
- `cargo build --locked --workspace`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked -p heddle-ci-engine -p heddle-ci-config`
- `rustfmt +nightly --edition 2024` on touched files
- Isolated `CARGO_TARGET_DIR=/home/scratch/heddle-1374/target`, `TMPDIR=/home/scratch`

The cache API is new (tests would not compile against `main`), so this lands as a single commit rather than a red-then-green pair.

Built on the existing `ci-engine` executor (`run_checks` / `run_checks_with` / `run_one_check`), `CiVerdictBody` / `definition_digest`, and `HermeticEnv`. Did not touch `crates/object-model` KeyBinding files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789391575&installation_model_id=21489&pr_number=1389&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1389&signature=edcf5b63d665a51d1115e2ddcff9519b82c6f3e98983a9ee2da187d8d6110173"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->