### PR TITLE
feat(storage): S3 compact-frame reader (Part of #1323)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **Compact-frame reader extracts one tree or state by typed hash.** SoA
+  columns reconstruct the canonical object, BLAKE3 typed-hash is checked
+  on extraction, and a single corrupt frame byte fails every contained
+  object. The hosted S3 hot-tier is out of scope for this native path.
+
 - **CI-runner trust-set resolver.** Valid, unrevoked, in-window
   `KeyRole::CiRunner` bindings from an authorized registry are collected into
   the trust set a verdict verifier checks `heddle-ci-verdict-v1` signatures

--- a/crates/object-model/src/compact/extract.rs
+++ b/crates/object-model/src/compact/extract.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{CompactError, Result, decode_state_frame};
+use crate::object::{State, StateId};
+
+/// Reconstruct one state and verify its BLAKE3 typed identity.
+///
+/// The whole-frame checksum is verified, every fidelity column is decoded, and
+/// the state's id is recomputed from the reconstructed fields before it is
+/// compared with `expected`.
+pub fn extract_state(bytes: &[u8], expected: StateId) -> Result<State> {
+    decode_state_frame(bytes)?
+        .into_iter()
+        .find(|state| state.id() == expected)
+        .ok_or(CompactError::Missing)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Instant;
+
+    use super::super::{decode_tree_frame, encode_tree_frame, extract_tree};
+    use crate::object::{ContentHash, Tree, TreeEntry};
+
+    #[test]
+    fn extract_tree_point_read_beats_decode_all_and_serialize() {
+        let trees = (0..64)
+            .map(|index| {
+                Tree::from_entries(vec![
+                    TreeEntry::file(
+                        format!("file-{index}.txt"),
+                        ContentHash::from_bytes([index as u8; 32]),
+                        false,
+                    )
+                    .unwrap(),
+                ])
+            })
+            .collect::<Vec<_>>();
+        let encoded = encode_tree_frame(&trees).unwrap();
+        let first = trees[0].hash();
+        let last = trees[trees.len() - 1].hash();
+        let _ = extract_tree(&encoded, first).unwrap();
+        let _ = decode_tree_frame(&encoded).unwrap();
+
+        const ITERATIONS: u32 = 200;
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            let decoded = decode_tree_frame(&encoded).unwrap();
+            let _ = decoded
+                .into_iter()
+                .map(|tree| rmp_serde::to_vec_named(&tree).unwrap())
+                .collect::<Vec<_>>();
+        }
+        let decode_all = start.elapsed();
+
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            let tree = extract_tree(&encoded, first).unwrap();
+            let _ = rmp_serde::to_vec_named(&tree).unwrap();
+        }
+        let extract_first = start.elapsed();
+
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            let tree = extract_tree(&encoded, last).unwrap();
+            let _ = rmp_serde::to_vec_named(&tree).unwrap();
+        }
+        let extract_last = start.elapsed();
+
+        eprintln!(
+            "compact tree frame (64 trees, {ITERATIONS} iters): decode-all+serialize-all {decode_all:?}; extract-first {extract_first:?}; extract-last {extract_last:?}"
+        );
+        assert!(
+            extract_first < decode_all && extract_last < decode_all,
+            "single-object extract should beat decode-all, first={extract_first:?} last={extract_last:?} decode_all={decode_all:?}"
+        );
+    }
+}

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -3,16 +3,20 @@
 
 mod blob;
 mod dictionary;
+mod extract;
 mod io;
 mod state;
 mod state_decode;
 mod tree;
 
 pub use blob::{decode_blob_frame, encode_blob_frame, is_blob_frame};
+pub use extract::extract_state;
 pub use state::{encode_state_frame, is_state_frame};
 pub use state_decode::decode_state_frame;
 use thiserror::Error;
-pub use tree::{decode_tree_frame, encode_tree_frame, encoded_tree_size, is_tree_frame};
+pub use tree::{
+    decode_tree_frame, encode_tree_frame, encoded_tree_size, extract_tree, is_tree_frame,
+};
 
 /// Compact metadata encoding failure.
 #[derive(Debug, Error)]
@@ -20,6 +24,9 @@ pub enum CompactError {
     /// The frame is malformed, truncated, or internally inconsistent.
     #[error("invalid compact frame: {0}")]
     Invalid(String),
+    /// The requested object is not present after a verified reconstruction.
+    #[error("compact frame does not contain the requested object")]
+    Missing,
     /// A decoded tree violates the native tree invariants.
     #[error(transparent)]
     Tree(#[from] crate::object::TreeError),

--- a/crates/object-model/src/compact/tests.rs
+++ b/crates/object-model/src/compact/tests.rs
@@ -6,8 +6,8 @@ use chrono::{TimeZone, Utc};
 use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::{
-    decode_blob_frame, decode_state_frame, decode_tree_frame, encode_blob_frame,
-    encode_state_frame, encode_tree_frame,
+    CompactError, decode_blob_frame, decode_state_frame, decode_tree_frame, encode_blob_frame,
+    encode_state_frame, encode_tree_frame, extract_state, extract_tree,
 };
 use crate::object::{
     Agent, Attribution, ChangeId, ChangeLineage, ChangeLineageKind, ContentHash, Principal,
@@ -140,6 +140,90 @@ fn corrupt_frame_byte_rejects_every_contained_object() {
     for _ in &trees {
         let error = decode_tree_frame(&encoded).unwrap_err();
         assert!(error.to_string().contains("checksum mismatch"));
+    }
+}
+
+#[test]
+fn extract_matches_decode_all_canonical_bytes() {
+    let content = ContentHash::from_bytes([31; 32]);
+    let trees = vec![
+        Tree::from_entries(vec![TreeEntry::file("first", content, false).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::file("second", content, true).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::directory("nested", content).unwrap()]),
+    ];
+    let encoded = encode_tree_frame(&trees).unwrap();
+    let decoded = decode_tree_frame(&encoded).unwrap();
+
+    for (expected, decoded) in trees.iter().zip(&decoded) {
+        let extracted = extract_tree(&encoded, expected.hash()).unwrap();
+        assert_eq!(extracted, *decoded);
+        assert_eq!(extracted.hash(), expected.hash());
+        assert_eq!(
+            rmp_serde::to_vec_named(&extracted).unwrap(),
+            rmp_serde::to_vec_named(expected).unwrap()
+        );
+    }
+}
+
+#[test]
+fn extract_state_matches_decode_all_canonical_bytes() {
+    let mut first = State::new(
+        ContentHash::from_bytes([41; 32]),
+        Vec::new(),
+        Attribution::human(Principal::new("Author", "author@example.com")),
+    );
+    first.intent = Some("first".to_string());
+    first.state_id = first.id();
+    let mut second = State::new(
+        ContentHash::from_bytes([42; 32]),
+        vec![first.state_id],
+        Attribution::human(Principal::new("Author", "author@example.com")),
+    );
+    second.intent = Some("second".to_string());
+    second.state_id = second.id();
+    let states = vec![first, second];
+    let encoded = encode_state_frame(&states).unwrap();
+    let decoded = decode_state_frame(&encoded).unwrap();
+
+    for (expected, decoded) in states.iter().zip(&decoded) {
+        let extracted = extract_state(&encoded, expected.id()).unwrap();
+        assert_eq!(extracted.id(), decoded.id());
+        assert_eq!(
+            rmp_serde::to_vec_named(&extracted).unwrap(),
+            rmp_serde::to_vec_named(expected).unwrap()
+        );
+    }
+}
+
+#[test]
+fn extract_rejects_a_forged_typed_hash() {
+    let content = ContentHash::from_bytes([51; 32]);
+    let tree = Tree::from_entries(vec![TreeEntry::file("only", content, false).unwrap()]);
+    let encoded = encode_tree_frame(std::slice::from_ref(&tree)).unwrap();
+    let forged = ContentHash::compute_typed("tree", b"not this tree");
+
+    let error = extract_tree(&encoded, forged).unwrap_err();
+    assert!(matches!(error, CompactError::Missing));
+    assert_ne!(forged, tree.hash());
+}
+
+#[test]
+fn extract_rejects_every_object_after_one_corrupt_frame_byte() {
+    let hash = ContentHash::from_bytes([61; 32]);
+    let trees = vec![
+        Tree::from_entries(vec![TreeEntry::file("a", hash, false).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::file("b", hash, true).unwrap()]),
+    ];
+    let mut encoded = encode_tree_frame(&trees).unwrap();
+    let corrupt_at = encoded.len() / 2;
+    encoded[corrupt_at] ^= 0x01;
+
+    for tree in &trees {
+        let error = extract_tree(&encoded, tree.hash()).unwrap_err();
+        assert!(
+            error.to_string().contains("checksum mismatch"),
+            "corrupt frame must fail typed extraction, got {error}"
+        );
     }
 }
 

--- a/crates/object-model/src/compact/tree.rs
+++ b/crates/object-model/src/compact/tree.rs
@@ -61,6 +61,22 @@ pub fn decode_tree_frame(bytes: &[u8]) -> Result<Vec<Tree>> {
     Ok(trees)
 }
 
+/// Reconstruct one tree and verify its BLAKE3 typed hash.
+///
+/// The whole-frame checksum is verified first. Each tree is rebuilt from its
+/// SoA columns until `expected` matches the reconstructed typed hash.
+pub fn extract_tree(bytes: &[u8], expected: ContentHash) -> Result<Tree> {
+    let mut input = Reader::verified(bytes, TREE_MAGIC)?;
+    let tree_count = input.get_count("tree frame")?;
+    for _ in 0..tree_count {
+        let tree = decode_tree(&mut input)?;
+        if tree.hash() == expected {
+            return Ok(tree);
+        }
+    }
+    Err(super::CompactError::Missing)
+}
+
 fn decode_tree(input: &mut Reader<'_>) -> Result<Tree> {
     let count = input.get_count("tree entry")?;
     let modes = (0..count)

--- a/crates/objects/src/store/fs/repack/tests/frame_reader.rs
+++ b/crates/objects/src/store/fs/repack/tests/frame_reader.rs
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Cursor;
+
+use heddle_format::compression::CompressionConfig;
+use heddle_object_model::compact::{encode_state_frame, encode_tree_frame, extract_state};
+use tempfile::TempDir;
+
+use super::create_store;
+use crate::{
+    object::{Attribution, ContentHash, Principal, State, Tree, TreeEntry},
+    store::{
+        ObjectStore,
+        pack::{ObjectType, PackObjectId, StreamingPackBuilder},
+    },
+};
+
+fn sample_trees() -> Vec<Tree> {
+    let blob = ContentHash::compute_typed("blob", b"frame-reader-blob");
+    vec![
+        Tree::from_entries(vec![
+            TreeEntry::file("readme.md", blob, false).unwrap(),
+            TreeEntry::file("build.sh", blob, true).unwrap(),
+        ]),
+        Tree::from_entries(vec![TreeEntry::directory("src", blob).unwrap()]),
+        Tree::from_entries(vec![TreeEntry::symlink("link", blob).unwrap()]),
+    ]
+}
+
+fn sample_states(trees: &[Tree]) -> Vec<State> {
+    let author = Attribution::human(Principal::new("Reader", "reader@example.com"));
+    let first = State::new(trees[0].hash(), Vec::new(), author.clone()).with_intent("first");
+    let second =
+        State::new(trees[1].hash(), vec![first.id()], author.clone()).with_intent("second");
+    let third = State::new(trees[2].hash(), vec![second.id()], author).with_intent("third");
+    vec![first, second, third]
+}
+
+fn write_compact_pack(trees: &[Tree], states: &[State]) -> (Vec<u8>, Vec<u8>) {
+    let tmp = TempDir::new().unwrap();
+    let index_path = tmp.path().join("compact.idx");
+    let mut builder = StreamingPackBuilder::new(
+        Cursor::new(Vec::new()),
+        index_path.clone(),
+        CompressionConfig::disabled(),
+        tmp.path().join("buckets"),
+    )
+    .unwrap();
+
+    let tree_ids = trees
+        .iter()
+        .map(|tree| PackObjectId::Hash(tree.hash()))
+        .collect::<Vec<_>>();
+    let tree_frame = encode_tree_frame(trees).unwrap();
+    builder
+        .add_shared_frame(&tree_ids, ObjectType::Tree, tree_frame.len(), &tree_frame)
+        .unwrap();
+
+    let state_ids = states
+        .iter()
+        .map(|state| PackObjectId::StateId(state.id()))
+        .collect::<Vec<_>>();
+    let state_frame = encode_state_frame(states).unwrap();
+    builder
+        .add_shared_frame(
+            &state_ids,
+            ObjectType::State,
+            state_frame.len(),
+            &state_frame,
+        )
+        .unwrap();
+
+    let (cursor, _) = builder.finalize().unwrap();
+    (cursor.into_inner(), std::fs::read(index_path).unwrap())
+}
+
+#[test]
+fn compact_reader_matches_pre_frame_canonical_bytes() {
+    let trees = sample_trees();
+    let states = sample_states(&trees);
+    let old_trees = trees
+        .iter()
+        .map(|tree| rmp_serde::to_vec_named(tree).unwrap())
+        .collect::<Vec<_>>();
+    let old_states = states
+        .iter()
+        .map(|state| rmp_serde::to_vec_named(state).unwrap())
+        .collect::<Vec<_>>();
+
+    let (pack, index) = write_compact_pack(&trees, &states);
+    let (_temp, store) = create_store();
+    store.install_pack(&pack, &index).unwrap();
+    store.clear_recent_object_caches();
+
+    for (tree, expected) in trees.iter().zip(&old_trees) {
+        let loaded = store.get_tree(&tree.hash()).unwrap().unwrap();
+        assert_eq!(loaded.hash(), tree.hash());
+        assert_eq!(rmp_serde::to_vec_named(&loaded).unwrap(), *expected);
+    }
+    for (state, expected) in states.iter().zip(&old_states) {
+        let loaded = store.get_state(&state.id()).unwrap().unwrap();
+        assert_eq!(loaded.id(), state.id());
+        assert_eq!(rmp_serde::to_vec_named(&loaded).unwrap(), *expected);
+    }
+}
+
+#[test]
+fn compact_reader_rejects_every_object_after_one_corrupt_frame_byte() {
+    let trees = sample_trees();
+    let states = sample_states(&trees);
+    let mut tree_frame = encode_tree_frame(&trees).unwrap();
+    let tree_corrupt_at = tree_frame.len() / 2;
+    tree_frame[tree_corrupt_at] ^= 0x01;
+    let mut state_frame = encode_state_frame(&states).unwrap();
+    let state_corrupt_at = state_frame.len() / 2;
+    state_frame[state_corrupt_at] ^= 0x01;
+
+    let tmp = TempDir::new().unwrap();
+    let index_path = tmp.path().join("corrupt.idx");
+    let mut builder = StreamingPackBuilder::new(
+        Cursor::new(Vec::new()),
+        index_path.clone(),
+        CompressionConfig::disabled(),
+        tmp.path().join("buckets"),
+    )
+    .unwrap();
+    let tree_ids = trees
+        .iter()
+        .map(|tree| PackObjectId::Hash(tree.hash()))
+        .collect::<Vec<_>>();
+    builder
+        .add_shared_frame(&tree_ids, ObjectType::Tree, tree_frame.len(), &tree_frame)
+        .unwrap();
+    let (cursor, _) = builder.finalize().unwrap();
+
+    let (_temp, store) = create_store();
+    let error = store
+        .install_pack(&cursor.into_inner(), &std::fs::read(index_path).unwrap())
+        .unwrap_err();
+    assert!(
+        error.to_string().contains("checksum mismatch"),
+        "a corrupt compact pack must not install, got {error}"
+    );
+    for tree in &trees {
+        assert!(
+            store.get_tree(&tree.hash()).unwrap().is_none(),
+            "rejected pack must not publish tree {}",
+            tree.hash()
+        );
+    }
+    for state in &states {
+        let error = extract_state(&state_frame, state.id()).unwrap_err();
+        assert!(
+            error.to_string().contains("checksum mismatch"),
+            "every contained state must fail extraction, got {error}"
+        );
+    }
+}

--- a/crates/objects/src/store/fs/repack/tests/mod.rs
+++ b/crates/objects/src/store/fs/repack/tests/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod concurrency;
+mod frame_reader;
 mod hot_tier;
 mod integrity;
 

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -896,14 +896,47 @@ fn decode_compact_object(
     data: &[u8],
     require_blob_frame: bool,
 ) -> Result<Option<Vec<u8>>> {
-    let Some(objects) = decode_compact_objects(obj_type, data, require_blob_frame)? else {
-        return Ok(None);
-    };
-    objects
-        .into_iter()
-        .find_map(|(id, _, bytes)| (id == *requested_id).then_some(bytes))
-        .map(Some)
-        .ok_or_else(|| compact_index_miss(requested_id))
+    match (obj_type, requested_id) {
+        (ObjectType::Tree, PackObjectId::Hash(hash))
+            if heddle_object_model::compact::is_tree_frame(data) =>
+        {
+            let tree = heddle_object_model::compact::extract_tree(data, *hash)
+                .map_err(|error| compact_extract_error(requested_id, error))?;
+            rmp_serde::to_vec_named(&tree)
+                .map(Some)
+                .map_err(|error| StoreError::InvalidObject(error.to_string()))
+        }
+        (ObjectType::State, PackObjectId::StateId(id))
+            if heddle_object_model::compact::is_state_frame(data) =>
+        {
+            let state = heddle_object_model::compact::extract_state(data, *id)
+                .map_err(|error| compact_extract_error(requested_id, error))?;
+            rmp_serde::to_vec_named(&state)
+                .map(Some)
+                .map_err(|error| StoreError::InvalidObject(error.to_string()))
+        }
+        _ => {
+            let Some(objects) = decode_compact_objects(obj_type, data, require_blob_frame)? else {
+                return Ok(None);
+            };
+            objects
+                .into_iter()
+                .find_map(|(id, _, bytes)| (id == *requested_id).then_some(bytes))
+                .map(Some)
+                .ok_or_else(|| compact_index_miss(requested_id))
+        }
+    }
+}
+
+fn compact_extract_error(
+    id: &PackObjectId,
+    error: heddle_object_model::compact::CompactError,
+) -> StoreError {
+    if matches!(error, heddle_object_model::compact::CompactError::Missing) {
+        compact_index_miss(id)
+    } else {
+        StoreError::InvalidObject(error.to_string())
+    }
 }
 
 fn decode_compact_objects(


### PR DESCRIPTION
## Summary

- Add `extract_tree` / `extract_state` for the compact columnar frames the S2 encoder writes. SoA columns reconstruct the object, then BLAKE3 typed-hash (tree hash / recomputed state id) is checked on extraction.
- Point reads through `PackReader` now extract only the requested tree or state and serialize that one object, instead of decoding and MessagePack-encoding every object in the frame.
- Native `FsStore` reads of compact packs remain byte-identical to the pre-frame canonical path. Git reconstruction (#566) is unchanged because fidelity fields are still reconstructed losslessly.

**Out of scope:** the hosted S3 hot-tier (loosely-compressed random-access tier for recent objects). That is a weft hosted-storage concern and should be filed separately. This PR is the native reader only.

## Closes

Part of #1323
Part of #1339 (native compact-frame reader only)

## Test evidence

Correctness: `extract_*` and `FsStore` compact reads return the same named-MessagePack bytes as the objects before they were packed into a frame.

Negative: a forged typed hash is rejected; flipping one compact-frame byte fails every contained extract; a corrupt compact pack is refused at `install_pack` and publishes nothing.

Release measurement, 64-tree frame, 200 iterations:

| Path | Wall | vs decode-all |
| --- | ---: | ---: |
| decode-all + serialize-all (old point-read) | 15.79 ms | 1.00× |
| extract first tree + serialize one | 0.477 ms | **33.1× faster** |
| extract last tree + serialize one | 9.33 ms | **1.69× faster** |

Debug: 55.89 ms vs 1.43 ms extract-first.

Gates (`TMPDIR=/home/scratch`, `CARGO_TARGET_DIR=/home/scratch/perf-1339-frame-reader/target`):

- `cargo test -p heddle-object-model compact`
- `cargo test -p heddle-pack --features zstd --lib` (94 tests)
- `cargo test -p heddle-objects --features zstd frame_reader`
- `cargo test -p heddle-objects --features zstd integrity`
- `cargo build --locked --workspace`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `rustfmt +nightly --edition 2024` on touched Rust files
- `git diff --check`

Ready; no merge.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1390"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789397188&installation_model_id=21489&pr_number=1390&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1390&signature=7da7ae8cc317edb77e40e030a62236495ef4c2f215fec155a02037dfae7386a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->