### PR TITLE
perf(git-lane): reuse local pack entries on hosted push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Git-lane push reuses local pack entries.** Hosted git-overlay push no
+  longer rebuilds a transfer pack from every decoded object. Existing
+  self-contained pack bytes are copied when they already are the selected
+  closure, so a first push of a packed repo stays near the source pack size
+  instead of a multi-minute, larger tempfile (heddle#1234).
+
 - **Land resolves the target checkout from isolated threads.** A clean
   fast-forward now lands when invoked inside the source thread checkout, while
   genuine readiness-policy blockers retain their concrete recovery guidance.

--- a/crates/cli/src/hosted_runtime/hosted/git_lane_pack_plan_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/git_lane_pack_plan_tests.rs
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{HashMap, HashSet},
+    time::Instant,
+};
+
+use sley::{
+    CommitObject, EntryKind, GitObjectType, ObjectFormat, ObjectId as GitObjectId,
+    Repository as SleyRepository,
+    plumbing::{sley_object::EncodedObject, sley_odb, sley_pack::PackFile},
+};
+use tempfile::TempDir;
+
+use super::{build_git_lane_multi_root_pack_plan, write_git_lane_reachable_pack};
+
+const TEST_IDENT: &[u8] = b"Heddle Test <heddle@test> 0 +0000";
+
+struct PackedFixture {
+    _temp: TempDir,
+    repo: SleyRepository,
+    first: GitObjectId,
+    second: GitObjectId,
+    first_blob: GitObjectId,
+    second_blob: GitObjectId,
+}
+
+fn write_commit(
+    repo: &SleyRepository,
+    name: &str,
+    data: &[u8],
+    parents: &[GitObjectId],
+) -> (GitObjectId, GitObjectId) {
+    let blob = repo.write_blob(data.to_vec()).expect("write blob");
+    let empty = GitObjectId::empty_tree(repo.object_format());
+    let mut tree = repo.edit_tree(&empty).expect("edit tree");
+    tree.upsert(name, EntryKind::Blob, blob);
+    let tree_oid = repo.write_tree(tree).expect("write tree");
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: parents.to_vec(),
+        author: TEST_IDENT.to_vec(),
+        committer: TEST_IDENT.to_vec(),
+        encoding: None,
+        message: format!("commit {name}\n").into_bytes(),
+    };
+    let oid = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+        .expect("write commit");
+    (oid, blob)
+}
+
+fn install_reachable_pack(repo: &SleyRepository, roots: &[GitObjectId]) {
+    let objects = repo.objects();
+    let pack = sley_odb::build_reachable_pack(
+        objects.as_ref(),
+        repo.object_format(),
+        roots.iter().copied(),
+        &HashSet::new(),
+    )
+    .expect("build source pack")
+    .expect("non-empty source pack");
+    objects.install_pack(&pack).expect("install source pack");
+    repo.refresh_objects();
+}
+
+fn packed_history() -> PackedFixture {
+    let temp = TempDir::new().expect("temp git repo");
+    let repo = SleyRepository::init(temp.path()).expect("init git repo");
+    let (first, first_blob) = write_commit(&repo, "a.bin", &vec![b'a'; 16_384], &[]);
+    let mut second_body = vec![b'a'; 16_384];
+    second_body[100..200].fill(b'b');
+    let (second, second_blob) = write_commit(&repo, "a.bin", &second_body, &[first]);
+    install_reachable_pack(&repo, &[second]);
+    PackedFixture {
+        _temp: temp,
+        repo,
+        first,
+        second,
+        first_blob,
+        second_blob,
+    }
+}
+
+fn rebuild_without_reuse(
+    repo: &SleyRepository,
+    roots: &[GitObjectId],
+    excluded: &[GitObjectId],
+) -> Option<Vec<u8>> {
+    let plan = repo
+        .reachable_pack_plan()
+        .roots(roots.iter().copied())
+        .exclusions(excluded.iter().copied())
+        .build()
+        .expect("plan old reachable pack")?;
+    Some(plan.prepare_to_memory().expect("rebuild old pack").pack)
+}
+
+fn parse_objects(bytes: &[u8], format: ObjectFormat) -> HashMap<GitObjectId, EncodedObject> {
+    PackFile::parse(bytes, format)
+        .expect("parse pack")
+        .entries
+        .into_iter()
+        .map(|entry| (entry.entry.oid, entry.object))
+        .collect()
+}
+
+fn write_reuse_pack(
+    repo: &SleyRepository,
+    roots: &[GitObjectId],
+    excluded: &[GitObjectId],
+) -> Option<(Vec<u8>, sley_odb::ReachablePackReuseWrite)> {
+    let mut bytes = Vec::new();
+    let written =
+        write_git_lane_reachable_pack(repo, roots, excluded, &mut bytes).expect("reuse write")?;
+    Some((bytes, written))
+}
+
+#[test]
+fn reuse_pack_contains_the_same_objects_as_the_old_rebuild() {
+    let fixture = packed_history();
+    let old = rebuild_without_reuse(&fixture.repo, &[fixture.second], &[]).expect("old pack");
+    let (reused, stats) =
+        write_reuse_pack(&fixture.repo, &[fixture.second], &[]).expect("reuse pack");
+
+    assert!(
+        stats.reuse.whole_pack || stats.reuse.verbatim_entries > 0,
+        "packed fixture must engage reuse, got {:?}",
+        stats.reuse
+    );
+
+    let format = fixture.repo.object_format();
+    let old_objects = parse_objects(&old, format);
+    let reused_objects = parse_objects(&reused, format);
+    assert_eq!(
+        reused_objects.keys().copied().collect::<HashSet<_>>(),
+        old_objects.keys().copied().collect::<HashSet<_>>(),
+        "reuse must ship the same object ids as the old rebuild"
+    );
+    for (oid, object) in &old_objects {
+        assert_eq!(
+            reused_objects.get(oid),
+            Some(object),
+            "decoded object {oid} must be identical after reuse"
+        );
+    }
+
+    let planned = build_git_lane_multi_root_pack_plan(
+        &fixture.repo,
+        vec![fixture.second],
+        Vec::new(),
+        64 * 1024,
+    )
+    .expect("plan git-lane pack")
+    .expect("non-empty git-lane pack");
+    assert_eq!(planned.pack_size, reused.len() as u64);
+    assert_eq!(planned.pack_id, stats.summary.checksum.as_bytes());
+}
+
+#[test]
+fn have_boundary_excludes_ancestor_objects_from_reused_pack() {
+    let fixture = packed_history();
+    let old = rebuild_without_reuse(&fixture.repo, &[fixture.second], &[fixture.first])
+        .expect("old want-only pack");
+    let (reused, stats) = write_reuse_pack(&fixture.repo, &[fixture.second], &[fixture.first])
+        .expect("reuse want-only pack");
+
+    assert!(
+        !stats.reuse.whole_pack,
+        "a have-boundary must not copy the entire source pack"
+    );
+
+    let format = fixture.repo.object_format();
+    let old_objects = parse_objects(&old, format);
+    let reused_objects = parse_objects(&reused, format);
+    assert_eq!(
+        reused_objects.keys().copied().collect::<HashSet<_>>(),
+        old_objects.keys().copied().collect::<HashSet<_>>(),
+        "want-only reuse must match the old object set"
+    );
+    assert!(
+        reused_objects.contains_key(&fixture.second),
+        "new tip must be packed"
+    );
+    assert!(
+        reused_objects.contains_key(&fixture.second_blob),
+        "new blob must be packed"
+    );
+    assert!(
+        !reused_objects.contains_key(&fixture.first),
+        "excluded ancestor commit must not appear"
+    );
+    assert!(
+        !reused_objects.contains_key(&fixture.first_blob),
+        "objects only reachable from the have-boundary must not appear"
+    );
+
+    PackFile::parse(&reused, format).expect("have-boundary pack must be self-contained");
+}
+
+#[test]
+fn excluded_delta_base_is_not_emitted_as_a_thin_dependency() {
+    let fixture = packed_history();
+    let (reused, _) =
+        write_reuse_pack(&fixture.repo, &[fixture.second_blob], &[fixture.first_blob])
+            .expect("pack only the child blob");
+
+    let objects = parse_objects(&reused, fixture.repo.object_format());
+    assert_eq!(objects.len(), 1);
+    assert!(objects.contains_key(&fixture.second_blob));
+    assert!(
+        !objects.contains_key(&fixture.first_blob),
+        "excluded delta base must not leak into the transfer pack"
+    );
+    PackFile::parse(&reused, fixture.repo.object_format())
+        .expect("pack with an excluded delta base must not be thin");
+}
+
+#[test]
+fn fully_covered_have_boundary_returns_no_pack() {
+    let fixture = packed_history();
+    assert!(
+        write_reuse_pack(&fixture.repo, &[fixture.first], &[fixture.first]).is_none(),
+        "excluding the only root must short-circuit to no pack"
+    );
+    assert!(
+        build_git_lane_multi_root_pack_plan(
+            &fixture.repo,
+            vec![fixture.first],
+            vec![fixture.first],
+            64 * 1024,
+        )
+        .expect("plan empty want-only pack")
+        .is_none()
+    );
+}
+
+#[test]
+fn reuse_beats_full_repack_on_an_already_packed_closure() {
+    let temp = TempDir::new().expect("temp git repo");
+    let repo = SleyRepository::init(temp.path()).expect("init git repo");
+    let mut tree = repo
+        .edit_tree(&GitObjectId::empty_tree(repo.object_format()))
+        .expect("edit tree");
+    for index in 0..48 {
+        let mut body = vec![b'x'; 32_768];
+        body[index * 16] = index as u8;
+        let blob = repo.write_blob(body).expect("write blob");
+        tree.upsert(
+            format!("blob-{index:02}.bin").as_str(),
+            EntryKind::Blob,
+            blob,
+        );
+    }
+    let tree_oid = repo.write_tree(tree).expect("write tree");
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: Vec::new(),
+        author: TEST_IDENT.to_vec(),
+        committer: TEST_IDENT.to_vec(),
+        encoding: None,
+        message: b"packed corpus\n".to_vec(),
+    };
+    let root = repo
+        .write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+        .expect("write commit");
+    install_reachable_pack(&repo, &[root]);
+
+    let rebuild_started = Instant::now();
+    let old = rebuild_without_reuse(&repo, &[root], &[]).expect("old rebuild");
+    let rebuild_elapsed = rebuild_started.elapsed();
+
+    let reuse_started = Instant::now();
+    let (reused, stats) = write_reuse_pack(&repo, &[root], &[]).expect("reuse write");
+    let reuse_elapsed = reuse_started.elapsed();
+
+    eprintln!(
+        "git-lane pack reuse: old={}B/{rebuild_elapsed:?} reuse={}B/{reuse_elapsed:?} stats={:?}",
+        old.len(),
+        reused.len(),
+        stats.reuse
+    );
+    assert!(
+        stats.reuse.whole_pack || stats.reuse.verbatim_entries > 0,
+        "already-packed closure must reuse local pack entries"
+    );
+    assert!(
+        reused.len() <= old.len(),
+        "reuse must not grow past the old rebuild ({} > {})",
+        reused.len(),
+        old.len()
+    );
+    assert!(
+        reuse_elapsed <= rebuild_elapsed || stats.reuse.whole_pack,
+        "reuse ({reuse_elapsed:?}) should not be slower than rebuild ({rebuild_elapsed:?}) unless the sample is too small"
+    );
+}

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -3814,6 +3814,11 @@ fn proto_git_ref_kind(kind: ClassifiedGitRefKind) -> ProtoGitRefKind {
 /// boundary). Returns `Ok(None)` when the exclusions cover the entire reachable
 /// set, i.e. the server already holds every pushed object: a pure ref-move that
 /// needs no pack, only the ref updates (heddle#968 want-only short-circuit).
+///
+/// The write copies already-validated local pack entries when their delta bases
+/// are also in the selected set (sley reachable-pack reuse). That is the
+/// git-lane path that used to rebuild every object from decoded bodies and
+/// produce a slower, larger tempfile than the source pack (heddle#1234).
 fn build_git_lane_multi_root_pack_plan(
     git_repo: &SleyRepository,
     roots: Vec<GitObjectId>,
@@ -3825,26 +3830,21 @@ fn build_git_lane_multi_root_pack_plan(
             "cannot plan a Git pack with no roots".to_string(),
         ));
     }
-    let Some(plan) = git_repo
-        .reachable_pack_plan()
-        .roots(roots.iter().copied())
-        .exclusions(excluded)
-        .build()
-        .map_err(|err| {
-            ProtocolError::InvalidState(format!("plan reachable Git pack stream: {err}"))
-        })?
+    let mut pack_file = NamedTempFile::new()
+        .map_err(|err| ProtocolError::InvalidState(format!("create Git pack tempfile: {err}")))?;
+    let Some(written) =
+        write_git_lane_reachable_pack(git_repo, &roots, &excluded, pack_file.as_file_mut())?
     else {
         // Empty reachable set: every object the refs reach is already on the
         // server. Skip the pack entirely; only the ref updates ship.
         return Ok(None);
     };
-    let pack_file = NamedTempFile::new()
-        .map_err(|err| ProtocolError::InvalidState(format!("create Git pack tempfile: {err}")))?;
-    let prepared = plan.prepare_to_file(pack_file.path()).map_err(|err| {
-        ProtocolError::InvalidState(format!("write reachable Git pack tempfile: {err}"))
-    })?;
-    let pack_size = prepared.summary.pack_size;
-    let checksum = prepared.summary.checksum;
+    pack_file
+        .as_file()
+        .sync_all()
+        .map_err(|err| ProtocolError::InvalidState(format!("sync Git pack tempfile: {err}")))?;
+    let pack_size = written.summary.pack_size;
+    let checksum = written.summary.checksum;
     if pack_size > wire::MAX_RECEIVED_GIT_PACK_SIZE {
         return Err(ProtocolError::InvalidState(format!(
             "Git pack exceeds maximum transfer size of {} bytes; multi-pack split for repos over this size is a follow-up (plan §B.2)",
@@ -3866,6 +3866,38 @@ fn build_git_lane_multi_root_pack_plan(
         roots,
         pack_file: Arc::new(Mutex::new(pack_file)),
     }))
+}
+
+/// Write the git-lane transfer pack with sley's reuse-aware reachable-pack
+/// writer. Object *set* matches the old `ReachablePackPlan` rebuild; bytes may
+/// be the local pack verbatim when that pack already is the selected closure.
+fn write_git_lane_reachable_pack(
+    git_repo: &SleyRepository,
+    roots: &[GitObjectId],
+    excluded: &[GitObjectId],
+    writer: &mut impl Write,
+) -> Result<Option<sley::plumbing::sley_odb::ReachablePackReuseWrite>, ProtocolError> {
+    let excluded = excluded.iter().copied().collect::<HashSet<_>>();
+    let written = sley::plumbing::sley_odb::write_reachable_pack_with_reuse_stats_to_writer(
+        git_repo.object_database(),
+        git_repo.object_format(),
+        roots.iter().copied(),
+        &excluded,
+        writer,
+    )
+    .map_err(|err| {
+        ProtocolError::InvalidState(format!("write reachable Git pack tempfile: {err}"))
+    })?;
+    if let Some(written) = written.as_ref() {
+        tracing::debug!(
+            verbatim_entries = written.reuse.verbatim_entries,
+            redeltified_entries = written.reuse.redeltified_entries,
+            whole_pack = written.reuse.whole_pack,
+            pack_size = written.summary.pack_size,
+            "git-lane reachable pack reuse"
+        );
+    }
+    Ok(written)
 }
 
 async fn send_git_pack_streaming_messages(
@@ -5264,3 +5296,7 @@ mod pure_helpers_tests {
         let _ = native_pack_required_for_pull(true, &empty_info);
     }
 }
+
+#[cfg(test)]
+#[path = "git_lane_pack_plan_tests.rs"]
+mod git_lane_pack_plan_tests;


### PR DESCRIPTION
Fixes #1234.

## Problem

`heddle push` on the git-lane / git-overlay path rebuilt a transfer pack from every decoded object via `ReachablePackPlan::prepare_to_file`. On git.git (316MB source pack) that local rebuild ran ~493s, grew a tempfile 172 → 607+ MB, and dropped the transport before any bytes were sent.

## Change

`build_git_lane_multi_root_pack_plan` now writes through sley's reuse-aware reachable-pack writer (`write_reachable_pack_with_reuse_stats_to_writer`):

- If the selected closure is exactly one self-contained local pack, copy that pack verbatim (header, deltas, trailer).
- Otherwise copy every selected entry whose delta base is also selected, and only redeltify the rest.
- Want-only / have-boundary packing is unchanged: excluded objects stay out of the pack, and an excluded delta base cannot produce a thin pack.

Object *set* and decoded contents match the old rebuild. Pack *bytes* may be the existing local pack when that pack already is the closure.

## Perf

48 similar 32 KiB blobs, already packed (50 objects, 2718 B):

| Profile | Old rebuild | Reuse (whole pack) |
|---|---|---|
| debug | 1.292 s / 2718 B | 591 µs / 2718 B (~2200×) |
| release | 277 ms / 2718 B | 120 µs / 2718 B (~2300×) |

Reuse engaged `whole_pack=true`, `verbatim_entries=50`. On the reported git.git first-push this is a file copy of the ~316 MB source pack instead of an 8-minute 607 MB rebuild.

## Tests

- **Correctness:** `reuse_pack_contains_the_same_objects_as_the_old_rebuild` — reuse pack object ids and decoded bodies match `ReachablePackPlan::prepare_to_memory`.
- **Negative / regression:**
  - `have_boundary_excludes_ancestor_objects_from_reused_pack` — server-held tips are not copied wholesale; excluded ancestor objects stay out.
  - `excluded_delta_base_is_not_emitted_as_a_thin_dependency` — excluding a delta base does not emit a thin pack.
  - `fully_covered_have_boundary_returns_no_pack` — want-only empty set still short-circuits to `None`.

## Verify

- `cargo build --locked -p heddle-cli`
- `cargo clippy --locked -p heddle-cli --all-targets -- -D warnings -D dead-code`
- `rustfmt +nightly --edition 2024 --check` on touched files
- `cargo test --locked -p heddle-cli --lib git_lane` (9 passed)

Isolated `CARGO_TARGET_DIR=/home/scratch/perf-1234-repack/target`, `TMPDIR=/home/scratch`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1391"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789397530&installation_model_id=21489&pr_number=1391&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1391&signature=2a9f2b8bccbc80f602f092b4e50c1ee3a172685e7a19fb8da36d69a0803db1c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->