### PR TITLE
feat(cli): serve account claims over Iroh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "heddle-wire",
  "serde",
  "serde_json",
+ "serial_test",
  "sley",
  "sley-transport",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,7 +185,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -196,7 +196,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1208,7 +1208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1608,7 +1608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2174,10 +2174,11 @@ dependencies = [
 
 [[package]]
 name = "heddle-api"
-version = "0.6.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4db7d9fae2fc727e06ad2685cc9271f27bcf5ede39bfa0f30b1f52fc44ab60cd"
+checksum = "18dfa8dd50801a65fc83b3c9959dec28e743c4cd1a0c5cb3ea487e4b58e95aae"
 dependencies = [
+ "blake3",
  "bytes",
  "hex",
  "prost 0.14.1",
@@ -2232,7 +2233,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "heddle-api 0.6.4",
+ "heddle-api 0.8.0",
  "heddle-ci-config",
  "heddle-ci-engine",
  "heddle-cli-args",
@@ -2304,7 +2305,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
- "heddle-api 0.6.4",
+ "heddle-api 0.8.0",
  "heddle-cli-shared",
  "heddle-objects",
  "heddle-repo",
@@ -3481,7 +3482,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4236,7 +4237,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5116,7 +5117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
  "heck",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -5149,7 +5150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5686,7 +5687,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5778,7 +5779,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5972,7 +5973,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6630,7 +6631,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7089,10 +7090,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8104,7 +8105,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/cli-args/Cargo.toml
+++ b/crates/cli-args/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-api = { package = "heddle-api", version = "0.6.4" }
+api = { package = "heddle-api", version = "0.8.0" }
 clap.workspace = true
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
 objects = { path = "../objects", package = "heddle-objects", version = "0.12" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -45,7 +45,7 @@ daemon = { path = "../daemon", package = "heddle-daemon", version = "0.12" }
 # text auto-merge. Always-on: the merge driver and rebase replay both call
 # into it unconditionally.
 merge = { path = "../merge", package = "heddle-merge", version = "0.12" }
-api = { package = "heddle-api", version = "0.6.4" }
+api = { package = "heddle-api", version = "0.8.0" }
 cli-shared = { path = "../cli-shared", package = "heddle-cli-shared", version = "0.12" }
 heddle-cli-args = { path = "../cli-args", version = "0.12", default-features = false }
 heddle-cli-contract = { path = "../cli-contract", version = "0.12", default-features = false }

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -130,7 +130,7 @@ pub fn cmd_undo(
             } else if cli.verbose > 0 {
                 print_batches(&output.batches);
             } else {
-                print_human_history(&output.batches);
+                render_human_history(&output.batches);
             }
         }
 
@@ -180,7 +180,7 @@ pub fn cmd_undo(
             if cli.verbose > 0 {
                 print_batches(&output.batches);
             } else {
-                print_human_history(&output.batches);
+                render_human_history(&output.batches);
             }
         }
 
@@ -265,9 +265,9 @@ pub fn cmd_undo(
         if cli.verbose > 0 {
             print_batches(&output.batches);
         } else {
-            print_human_history(&output.batches);
+            render_human_history(&output.batches);
         }
-        print_head(&post_undo_repo)?;
+        render_head(&post_undo_repo)?;
         if let Some(state) = &output.recovery_state {
             println!(
                 "Preserved pre-undo state {} as `{}`",
@@ -395,7 +395,7 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
             if cli.verbose > 0 {
                 print_batches(&output.batches);
             } else {
-                print_human_history(&output.batches);
+                render_human_history(&output.batches);
             }
         }
 
@@ -441,15 +441,15 @@ pub fn cmd_redo(cli: &Cli, steps: usize, preview: bool) -> Result<()> {
         if cli.verbose > 0 {
             print_batches(&output.batches);
         } else {
-            print_human_history(&output.batches);
+            render_human_history(&output.batches);
         }
-        print_head(&repo)?;
+        render_head(&repo)?;
     }
 
     Ok(())
 }
 
-fn print_human_history(batches: &[UndoBatchSummary]) {
+fn render_human_history(batches: &[UndoBatchSummary]) {
     for batch in batches {
         let status = if batch.undone {
             " undone"
@@ -501,7 +501,7 @@ fn print_batches(batches: &[UndoBatchSummary]) {
     }
 }
 
-fn print_head(repo: &Repository) -> Result<()> {
+fn render_head(repo: &Repository) -> Result<()> {
     if let Some(id) = repo.head()? {
         println!("Now at: {}", id.short());
     }

--- a/crates/cli/src/cli/commands/visibility.rs
+++ b/crates/cli/src/cli/commands/visibility.rs
@@ -12,7 +12,7 @@
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
 use heddle_core::visibility_tier_label;
-use objects::object::{StateId, StateVisibility, VisibilityTier};
+use objects::object::{StateVisibility, VisibilityTier};
 use repo::{Repository, VisibilityCommitKind};
 use serde::Serialize;
 
@@ -20,6 +20,8 @@ use crate::cli::{
     Cli, VisibilityCommands, VisibilityListArgs, VisibilityPromoteArgs, VisibilitySetArgs,
     VisibilityShowArgs, should_output_json,
 };
+
+use super::history_target::resolve_state_id as resolve_state;
 
 pub fn cmd_visibility(cli: &Cli, command: VisibilityCommands) -> Result<()> {
     let repo = cli.open_repo()?;
@@ -34,12 +36,6 @@ pub fn cmd_visibility(cli: &Cli, command: VisibilityCommands) -> Result<()> {
 /// The team id / scope label carried by a non-public tier, for output.
 fn tier_label(tier: &VisibilityTier) -> Option<&str> {
     visibility_tier_label(tier)
-}
-
-fn resolve_state(repo: &Repository, spec: &str) -> Result<StateId> {
-    repo.resolve_state(spec)
-        .with_context(|| format!("resolve state '{}'", spec))?
-        .ok_or_else(|| anyhow!("state '{}' not found", spec))
 }
 
 #[derive(Serialize)]

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -1,4 +1,4 @@
-//! Data-only browser claim resolution and promotion consent.
+//! Data-only browser claim resolution and two-phase promotion consent.
 
 // The transport contract owns `CallFailure` by value at this seam.
 #![allow(clippy::result_large_err)]
@@ -18,7 +18,8 @@ use super::{
     identity_state::{self, ClaimState},
 };
 
-const CONSENT_TTL_MILLIS: i64 = 5 * 60 * 1_000;
+const PRE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-pre-consent-v1";
+const PROMOTE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-promote-consent-v1";
 
 #[derive(Clone, Debug)]
 pub(crate) struct StoredClaimAuthorization;
@@ -41,7 +42,7 @@ impl ClaimSecretVerifier for StoredClaimAuthorization {
             return Err(auth_failure());
         }
         Ok(VerifiedClaimPrincipal {
-            subject: state.account_id.clone(),
+            subject: state.owner_id.to_string(),
             authorization_hash: state.authorization_hash().to_string(),
         })
     }
@@ -58,17 +59,23 @@ impl ClaimHandler for StoredClaimAuthorization {
         // lock, two browser requests verified against the same one-time
         // secret could both load Active state before either consumed it.
         let _guard = identity_state::write_lock().map_err(internal_failure)?;
-        let mut state = identity_state::load()
+        let mut state = identity_state::load_while_locked()
             .map_err(internal_failure)?
             .ok_or_else(auth_failure)?;
-        if state.account_id != principal.subject
+        if state.owner_id.to_string() != principal.subject
             || state.authorization_hash() != principal.authorization_hash
+            || !state.is_active(chrono::Utc::now().timestamp_millis())
         {
             return Err(auth_failure());
         }
         match method {
             CLAIM_RESOLVE_METHOD => resolved_reply(&state, body),
-            CLAIM_CONSENT_METHOD => consent_reply(&mut state, body),
+            CLAIM_CONSENT_METHOD => {
+                let signer = claim_signer(&state)?;
+                let reply = consent_reply(&mut state, body, &signer)?;
+                identity_state::store_while_locked(&state).map_err(internal_failure)?;
+                Ok(reply)
+            }
             _ => Err(failure(
                 CallFailureCode::Unimplemented,
                 "unknown claim method",
@@ -80,29 +87,35 @@ impl ClaimHandler for StoredClaimAuthorization {
 #[derive(Deserialize)]
 #[serde(
     tag = "kind",
-    rename_all = "lowercase",
+    rename_all = "camelCase",
     rename_all_fields = "camelCase",
     deny_unknown_fields
 )]
 enum ClaimRequest {
     Resolve,
-    Consent {
+    PreConsent {
+        handle: String,
+        nonce: String,
+    },
+    PromoteConsent {
         handle: String,
         credential_id: String,
     },
 }
 
 #[derive(Serialize)]
-#[serde(tag = "kind", rename_all = "lowercase")]
+#[serde(tag = "kind", rename_all = "camelCase")]
 enum ClaimReply {
     Resolved { agent: AgentAccountSummary },
-    Consented { consent: AgentConsent },
+    PreConsented { consent: AgentConsent },
+    PromoteConsented { consent: AgentConsent },
     Refused { refusal: &'static str },
 }
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct AgentAccountSummary {
+    account_id: String,
     pet_name: String,
     created_at: String,
     last_active_at: Option<String>,
@@ -115,21 +128,21 @@ struct AgentAccountSummary {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AgentConsent {
+    pub(crate) account_id: String,
     pub(crate) node_id: String,
-    pub(crate) statement: String,
     pub(crate) signature: String,
-    pub(crate) expires_at: i64,
 }
 
 pub(crate) fn resolved_reply(state: &ClaimState, body: &[u8]) -> Result<Vec<u8>, CallFailure> {
     if !matches!(parse_request(body)?, ClaimRequest::Resolve) {
         return Err(invalid_failure("resolve body has the wrong kind"));
     }
-    let reply = if state.is_consented() {
+    let reply = if state.is_claimed() {
         ClaimReply::Refused { refusal: "claimed" }
     } else {
         ClaimReply::Resolved {
             agent: AgentAccountSummary {
+                account_id: state.owner_id.to_string(),
                 pet_name: state.pet_name.clone(),
                 created_at: state.created_at.clone(),
                 last_active_at: None,
@@ -143,59 +156,115 @@ pub(crate) fn resolved_reply(state: &ClaimState, body: &[u8]) -> Result<Vec<u8>,
     serde_json::to_vec(&reply).map_err(internal_failure)
 }
 
-pub(crate) fn consent_reply(state: &mut ClaimState, body: &[u8]) -> Result<Vec<u8>, CallFailure> {
-    let ClaimRequest::Consent {
-        handle,
-        credential_id,
-    } = parse_request(body)?
-    else {
-        return Err(invalid_failure("consent body has the wrong kind"));
-    };
-    if state.is_consented() {
-        return serde_json::to_vec(&ClaimReply::Refused { refusal: "claimed" })
-            .map_err(internal_failure);
+pub(crate) fn consent_reply(
+    state: &mut ClaimState,
+    body: &[u8],
+    signer: &Ed25519Signer,
+) -> Result<Vec<u8>, CallFailure> {
+    if state.is_claimed() {
+        return Err(failure(
+            CallFailureCode::FailedPrecondition,
+            "account claim is already complete",
+        ));
     }
-    validate_handle(&handle)?;
-    validate_credential_id(&credential_id)?;
-    let now = chrono::Utc::now().timestamp_millis();
-    let expires_at = (now + CONSENT_TTL_MILLIS).min(state.expires_at_millis);
-    if expires_at <= now {
-        return Err(auth_failure());
+    match parse_request(body)? {
+        ClaimRequest::PreConsent { handle, nonce } => {
+            validate_handle(&handle)?;
+            let nonce = decode_nonce(&nonce)?;
+            if !state.prepare(&handle, &nonce) {
+                return Err(failure(
+                    CallFailureCode::PermissionDenied,
+                    "claim binding does not match the opened ceremony",
+                ));
+            }
+            let consent = signed_pre_consent(state, &handle, &nonce, signer)?;
+            serde_json::to_vec(&ClaimReply::PreConsented { consent }).map_err(internal_failure)
+        }
+        ClaimRequest::PromoteConsent {
+            handle,
+            credential_id,
+        } => {
+            validate_handle(&handle)?;
+            validate_credential_id(&credential_id)?;
+            if !state.claim(&handle) {
+                return Err(failure(
+                    CallFailureCode::FailedPrecondition,
+                    "claim promotion does not match its pre-consent",
+                ));
+            }
+            let consent = signed_promote_consent(state, &handle, &credential_id, signer)?;
+            serde_json::to_vec(&ClaimReply::PromoteConsented { consent }).map_err(internal_failure)
+        }
+        ClaimRequest::Resolve => Err(invalid_failure("consent body has the wrong kind")),
     }
-    let signer = claim_signer(state)?;
-    let consent = signed_consent(state, &handle, &credential_id, expires_at, &signer)?;
-    state.mark_consented();
-    identity_state::store(state).map_err(internal_failure)?;
-    serde_json::to_vec(&ClaimReply::Consented { consent }).map_err(internal_failure)
 }
 
-pub(crate) fn signed_consent(
+pub(crate) fn signed_pre_consent(
+    state: &ClaimState,
+    handle: &str,
+    nonce: &[u8],
+    signer: &Ed25519Signer,
+) -> Result<AgentConsent, CallFailure> {
+    let statement = pre_consent_message(state, handle, nonce)?;
+    let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
+    Ok(AgentConsent {
+        account_id: state.owner_id.to_string(),
+        node_id: state.node_id.clone(),
+        signature,
+    })
+}
+
+pub(crate) fn signed_promote_consent(
     state: &ClaimState,
     handle: &str,
     credential_id: &str,
-    expires_at: i64,
     signer: &Ed25519Signer,
 ) -> Result<AgentConsent, CallFailure> {
-    let statement = serde_json::json!({
-        "accountId": state.account_id,
-        "credentialId": credential_id,
-        "expiresAt": expires_at,
-        "handle": handle,
-        "nodeId": state.node_id,
-        "purpose": "heddle-agent-account-promotion-v1"
-    })
-    .to_string();
-    let signature = URL_SAFE_NO_PAD.encode(
-        signer
-            .sign(statement.as_bytes())
-            .map_err(internal_failure)?,
-    );
+    let statement = promote_consent_message(state, handle, credential_id)?;
+    let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
     Ok(AgentConsent {
+        account_id: state.owner_id.to_string(),
         node_id: state.node_id.clone(),
-        statement,
         signature,
-        expires_at,
     })
+}
+
+pub(crate) fn pre_consent_message(
+    state: &ClaimState,
+    handle: &str,
+    nonce: &[u8],
+) -> Result<Vec<u8>, CallFailure> {
+    encode_counted(&[
+        PRE_CONSENT_DOMAIN,
+        state.owner_id.to_string().as_bytes(),
+        handle.as_bytes(),
+        state.node_id.as_bytes(),
+        nonce,
+    ])
+}
+
+pub(crate) fn promote_consent_message(
+    state: &ClaimState,
+    handle: &str,
+    credential_id: &str,
+) -> Result<Vec<u8>, CallFailure> {
+    encode_counted(&[
+        PROMOTE_CONSENT_DOMAIN,
+        state.owner_id.to_string().as_bytes(),
+        handle.as_bytes(),
+        credential_id.as_bytes(),
+    ])
+}
+
+fn encode_counted(parts: &[&[u8]]) -> Result<Vec<u8>, CallFailure> {
+    let mut encoded = Vec::new();
+    for part in parts {
+        let length = u32::try_from(part.len())
+            .map_err(|_| invalid_failure("claim consent field is too large"))?;
+        encoded.extend_from_slice(&length.to_be_bytes());
+        encoded.extend_from_slice(part);
+    }
+    Ok(encoded)
 }
 
 fn claim_signer(state: &ClaimState) -> Result<Ed25519Signer, CallFailure> {
@@ -222,6 +291,18 @@ fn claim_signer(state: &ClaimState) -> Result<Ed25519Signer, CallFailure> {
 
 fn parse_request(body: &[u8]) -> Result<ClaimRequest, CallFailure> {
     serde_json::from_slice(body).map_err(|_| invalid_failure("invalid claim request body"))
+}
+
+fn decode_nonce(nonce: &str) -> Result<Vec<u8>, CallFailure> {
+    let nonce = URL_SAFE_NO_PAD
+        .decode(nonce)
+        .map_err(|_| invalid_failure("invalid claim nonce"))?;
+    if !(16..=1024).contains(&nonce.len()) {
+        return Err(invalid_failure(
+            "claim nonce must contain between 16 and 1024 bytes",
+        ));
+    }
+    Ok(nonce)
 }
 
 pub(crate) fn validate_handle(handle: &str) -> Result<(), CallFailure> {

--- a/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
@@ -1,69 +1,437 @@
+use std::{net::Ipv4Addr, sync::Arc};
+
+use api::{
+    framing::{ResponseFrame, decode_response_frame, encode_request_frame},
+    heddle::api::v1alpha1::{CallContext, CallFailure, CallFailureCode},
+};
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use crypto::{Ed25519Signer, Signer as _};
+use iroh::{Endpoint, RelayMode, endpoint::presets, protocol::Router};
+use tokio::sync::Mutex;
 
 use super::{
     claim_authorization::{
-        consent_reply, resolved_reply, signed_consent, validate_credential_id, validate_handle,
+        consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
+        signed_pre_consent, signed_promote_consent, validate_credential_id, validate_handle,
+    },
+    hosted::claim_protocol::{
+        CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimProtocol,
+        ClaimSecretVerifier, VerifiedClaimPrincipal,
     },
     identity_state::ClaimState,
 };
 
+const OWNER_ID: &str = "7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28";
+
 fn state(node_id: String) -> ClaimState {
     ClaimState::new(
         "api.heddle.test".into(),
-        "account-7".into(),
+        uuid::Uuid::parse_str(OWNER_ID).unwrap(),
         "subject-7".into(),
         "steady-heron".into(),
         node_id,
     )
 }
 
-#[test]
-fn signed_consent_binds_handle_and_credential_id() {
-    let signer = Ed25519Signer::generate().expect("signer");
-    let consent = signed_consent(
-        &state(hex::encode(signer.public_key())),
-        "human-handle",
-        "Y3JlZGVudGlhbA",
-        123_456,
-        &signer,
-    )
-    .expect("signed consent");
-    let statement: serde_json::Value =
-        serde_json::from_str(&consent.statement).expect("statement JSON");
-    assert_eq!(statement["handle"], "human-handle");
-    assert_eq!(statement["credentialId"], "Y3JlZGVudGlhbA");
-    let signature = URL_SAFE_NO_PAD
-        .decode(&consent.signature)
-        .expect("signature encoding");
-    Ed25519Signer::verify_with_public_key(
-        consent.statement.as_bytes(),
-        signer.public_key(),
-        &signature,
-    )
-    .expect("signature verifies");
+fn signature(value: &serde_json::Value) -> Vec<u8> {
+    URL_SAFE_NO_PAD
+        .decode(value["consent"]["signature"].as_str().unwrap())
+        .expect("signature encoding")
+}
+
+#[derive(Clone)]
+struct MockWeftAccount {
+    owner_id: uuid::Uuid,
+    spool_owner_id: uuid::Uuid,
+    root_credential_id: Option<String>,
+}
+
+struct MockPromotion<'a> {
+    handle: &'a str,
+    nonce: &'a [u8],
+    pre_signature: &'a [u8],
+    credential_id: &'a str,
+    promote_signature: &'a [u8],
+}
+
+impl MockWeftAccount {
+    fn promote(
+        &mut self,
+        claim: &ClaimState,
+        agent_public_key: &[u8],
+        promotion: &MockPromotion<'_>,
+    ) -> bool {
+        if self.root_credential_id.is_some()
+            || Ed25519Signer::verify_with_public_key(
+                &pre_consent_message(claim, promotion.handle, promotion.nonce).unwrap(),
+                agent_public_key,
+                promotion.pre_signature,
+            )
+            .is_err()
+            || Ed25519Signer::verify_with_public_key(
+                &promote_consent_message(claim, promotion.handle, promotion.credential_id).unwrap(),
+                agent_public_key,
+                promotion.promote_signature,
+            )
+            .is_err()
+        {
+            return false;
+        }
+        self.root_credential_id = Some(promotion.credential_id.to_string());
+        true
+    }
 }
 
 #[test]
-fn malformed_promotion_inputs_are_rejected() {
+fn consent_signatures_match_the_landed_weft_contract() {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(b"claim-secret", i64::MAX));
+    let nonce = b"0123456789abcdef";
+
+    let pre =
+        signed_pre_consent(&claim, "human-handle", nonce, &signer).expect("signed pre-consent");
+    let pre_signature = URL_SAFE_NO_PAD.decode(pre.signature).unwrap();
+    Ed25519Signer::verify_with_public_key(
+        &pre_consent_message(&claim, "human-handle", nonce).unwrap(),
+        signer.public_key(),
+        &pre_signature,
+    )
+    .expect("weft-compatible pre-consent verifies");
+
+    let promote = signed_promote_consent(&claim, "human-handle", "Y3JlZGVudGlhbA", &signer)
+        .expect("signed promote-consent");
+    let promote_signature = URL_SAFE_NO_PAD.decode(promote.signature).unwrap();
+    Ed25519Signer::verify_with_public_key(
+        &promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA").unwrap(),
+        signer.public_key(),
+        &promote_signature,
+    )
+    .expect("weft-compatible promote-consent verifies");
+
+    assert_eq!(pre.account_id, OWNER_ID);
+    assert_eq!(promote.account_id, OWNER_ID);
+}
+
+#[test]
+fn malformed_claim_inputs_are_rejected() {
     assert!(validate_handle("UPPERCASE").is_err());
     assert!(validate_handle("-leading").is_err());
     assert!(validate_credential_id("not+base64url").is_err());
 }
 
-#[test]
-fn consumed_link_refuses_resolve_and_second_consent() {
-    let mut state = state("11".repeat(32));
-    state.mark_consented();
-    let resolve = resolved_reply(&state, br#"{"kind":"resolve"}"#).expect("resolve refusal");
-    let consent = consent_reply(
-        &mut state,
-        br#"{"kind":"consent","handle":"human-handle","credentialId":"Y3JlZA"}"#,
-    )
-    .expect("consent refusal");
-    for reply in [resolve, consent] {
-        let reply: serde_json::Value = serde_json::from_slice(&reply).expect("reply JSON");
-        assert_eq!(reply["kind"], "refused");
-        assert_eq!(reply["refusal"], "claimed");
+struct MemoryClaimAuthorization {
+    state: Mutex<ClaimState>,
+    secret: Vec<u8>,
+    signer: Ed25519Signer,
+}
+
+impl std::fmt::Debug for MemoryClaimAuthorization {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("MemoryClaimAuthorization")
+            .finish_non_exhaustive()
     }
+}
+
+impl ClaimSecretVerifier for MemoryClaimAuthorization {
+    async fn verify(
+        &self,
+        _method: &str,
+        context: &CallContext,
+        _body: &[u8],
+    ) -> Result<VerifiedClaimPrincipal, CallFailure> {
+        let state = self.state.lock().await;
+        if !state.accepts(
+            &context.bearer_capability,
+            chrono::Utc::now().timestamp_millis(),
+        ) {
+            return Err(failure(
+                CallFailureCode::Unauthenticated,
+                "claim authorization failed",
+            ));
+        }
+        Ok(VerifiedClaimPrincipal {
+            subject: state.owner_id.to_string(),
+            authorization_hash: state.authorization_hash().to_string(),
+        })
+    }
+}
+
+impl ClaimHandler for MemoryClaimAuthorization {
+    async fn call(
+        &self,
+        method: &str,
+        principal: VerifiedClaimPrincipal,
+        body: &[u8],
+    ) -> Result<Vec<u8>, CallFailure> {
+        let mut state = self.state.lock().await;
+        if principal.subject != state.owner_id.to_string()
+            || principal.authorization_hash != state.authorization_hash()
+            || self.secret.is_empty()
+        {
+            return Err(failure(
+                CallFailureCode::Unauthenticated,
+                "claim authorization failed",
+            ));
+        }
+        match method {
+            CLAIM_RESOLVE_METHOD => resolved_reply(&state, body),
+            CLAIM_CONSENT_METHOD => consent_reply(&mut state, body, &self.signer),
+            _ => Err(failure(CallFailureCode::Unimplemented, "unknown method")),
+        }
+    }
+}
+
+fn failure(code: CallFailureCode, message: &str) -> CallFailure {
+    CallFailure {
+        code: code as i32,
+        message: message.to_string(),
+        error: None,
+    }
+}
+
+async fn endpoints(
+    authorization: Arc<MemoryClaimAuthorization>,
+) -> (Router, Endpoint, iroh::EndpointAddr) {
+    let server = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    let address = server.addr();
+    let router = Router::builder(server)
+        .accept(
+            CLAIM_ALPN_V1,
+            ClaimProtocol::new(Arc::clone(&authorization), authorization),
+        )
+        .spawn();
+    let client = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Disabled)
+        .bind_addr((Ipv4Addr::LOCALHOST, 0))
+        .unwrap()
+        .bind()
+        .await
+        .unwrap();
+    (router, client, address)
+}
+
+async fn call(
+    client: &Endpoint,
+    server: iroh::EndpointAddr,
+    method: &str,
+    secret: &[u8],
+    body: &[u8],
+) -> OwnedResponse {
+    let connection = client.connect(server, CLAIM_ALPN_V1).await.unwrap();
+    let (mut send, mut recv) = connection.open_bi().await.unwrap();
+    let frame = encode_request_frame(
+        method,
+        &CallContext {
+            bearer_capability: secret.to_vec(),
+            ..CallContext::default()
+        },
+        body,
+    )
+    .unwrap();
+    send.write_all(&frame).await.unwrap();
+    send.finish().unwrap();
+    let response = recv.read_to_end(1024 * 1024).await.unwrap();
+    match decode_response_frame(&response).unwrap() {
+        ResponseFrame::Success(body) => OwnedResponse::Success(body.to_vec()),
+        ResponseFrame::Failure(failure) => OwnedResponse::Failure(failure),
+    }
+}
+
+enum OwnedResponse {
+    Success(Vec<u8>),
+    Failure(CallFailure),
+}
+
+#[tokio::test]
+async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
+    let signer = Ed25519Signer::generate().unwrap();
+    let secret = b"correct-link-secret".to_vec();
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(&secret, chrono::Utc::now().timestamp_millis() + 60_000));
+    let authorization = Arc::new(MemoryClaimAuthorization {
+        state: Mutex::new(claim),
+        secret: secret.clone(),
+        signer,
+    });
+    let (router, client, address) = endpoints(Arc::clone(&authorization)).await;
+
+    let OwnedResponse::Failure(wrong_link) = call(
+        &client,
+        address.clone(),
+        CLAIM_RESOLVE_METHOD,
+        b"wrong-link-secret",
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("wrong claim link must fail");
+    };
+    assert_eq!(wrong_link.code, CallFailureCode::Unauthenticated as i32);
+
+    let OwnedResponse::Success(resolved) = call(
+        &client,
+        address.clone(),
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("valid link must resolve");
+    };
+    let resolved: serde_json::Value = serde_json::from_slice(&resolved).unwrap();
+    assert_eq!(resolved["agent"]["accountId"], OWNER_ID);
+
+    let nonce = b"0123456789abcdef";
+    let nonce_b64 = URL_SAFE_NO_PAD.encode(nonce);
+    let pre_body = serde_json::json!({
+        "kind": "preConsent",
+        "handle": "human-handle",
+        "nonce": nonce_b64,
+    });
+    let OwnedResponse::Success(pre) = call(
+        &client,
+        address.clone(),
+        CLAIM_CONSENT_METHOD,
+        &secret,
+        &serde_json::to_vec(&pre_body).unwrap(),
+    )
+    .await
+    else {
+        panic!("pre-consent must succeed");
+    };
+    let pre: serde_json::Value = serde_json::from_slice(&pre).unwrap();
+
+    let credential_id = "Y3JlZGVudGlhbA";
+    let promote_body = serde_json::json!({
+        "kind": "promoteConsent",
+        "handle": "human-handle",
+        "credentialId": credential_id,
+    });
+    let OwnedResponse::Success(promote) = call(
+        &client,
+        address.clone(),
+        CLAIM_CONSENT_METHOD,
+        &secret,
+        &serde_json::to_vec(&promote_body).unwrap(),
+    )
+    .await
+    else {
+        panic!("promote-consent must succeed");
+    };
+    let promote: serde_json::Value = serde_json::from_slice(&promote).unwrap();
+
+    let state = authorization.state.lock().await;
+    let mut account = MockWeftAccount {
+        owner_id: state.owner_id,
+        spool_owner_id: state.owner_id,
+        root_credential_id: None,
+    };
+    let mut forged = account.clone();
+    assert!(
+        !forged.promote(
+            &state,
+            authorization.signer.public_key(),
+            &MockPromotion {
+                handle: "human-handle",
+                nonce,
+                pre_signature: &signature(&pre),
+                credential_id: "Zm9yZ2Vk",
+                promote_signature: &signature(&promote),
+            },
+        ),
+        "a forged credential binding must be rejected"
+    );
+    assert!(account.promote(
+        &state,
+        authorization.signer.public_key(),
+        &MockPromotion {
+            handle: "human-handle",
+            nonce,
+            pre_signature: &signature(&pre),
+            credential_id,
+            promote_signature: &signature(&promote),
+        },
+    ));
+    assert_eq!(
+        account.root_credential_id.as_deref(),
+        Some(credential_id),
+        "accepted promotion attaches the passkey root"
+    );
+    assert_eq!(account.owner_id.to_string(), OWNER_ID);
+    assert_eq!(
+        account.spool_owner_id, account.owner_id,
+        "spool ownership remains anchored to the stable owner UUID"
+    );
+    assert!(!account.promote(
+        &state,
+        authorization.signer.public_key(),
+        &MockPromotion {
+            handle: "human-handle",
+            nonce,
+            pre_signature: &signature(&pre),
+            credential_id,
+            promote_signature: &signature(&promote),
+        },
+    ));
+    assert!(state.is_claimed());
+    drop(state);
+
+    let OwnedResponse::Failure(already_claimed) = call(
+        &client,
+        address,
+        CLAIM_CONSENT_METHOD,
+        &secret,
+        &serde_json::to_vec(&promote_body).unwrap(),
+    )
+    .await
+    else {
+        panic!("already-claimed account must fail");
+    };
+    assert_eq!(
+        already_claimed.code,
+        CallFailureCode::Unauthenticated as i32,
+        "a consumed link must stop authenticating before a second consent"
+    );
+
+    client.close().await;
+    router.shutdown().await.unwrap();
+}
+
+#[tokio::test]
+async fn expired_iroh_claim_link_is_rejected_before_dispatch() {
+    let signer = Ed25519Signer::generate().unwrap();
+    let secret = b"expired-link-secret".to_vec();
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(&secret, chrono::Utc::now().timestamp_millis() - 1));
+    let authorization = Arc::new(MemoryClaimAuthorization {
+        state: Mutex::new(claim),
+        secret: secret.clone(),
+        signer,
+    });
+    let (router, client, address) = endpoints(authorization).await;
+
+    let OwnedResponse::Failure(expired) = call(
+        &client,
+        address,
+        CLAIM_RESOLVE_METHOD,
+        &secret,
+        br#"{"kind":"resolve"}"#,
+    )
+    .await
+    else {
+        panic!("expired link must fail");
+    };
+    assert_eq!(expired.code, CallFailureCode::Unauthenticated as i32);
+
+    client.close().await;
+    router.shutdown().await.unwrap();
 }

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -104,16 +104,32 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
     // Durable invite claim mints a signup bearer; derived agents must not
     // consume invite codes on behalf of a parent principal.
     ("ClaimSignupInvite", AgentAuthOperationDisposition::Denied),
+    // Public drop selection accepts an optional verified agent subject only
+    // to choose the subject-scoped anti-abuse budget.
+    (
+        "ClaimNextDropCode",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
+    (
+        "RemainingDropCodes",
+        AgentAuthOperationDisposition::ReviewedSafe,
+    ),
     (
         "IssueSignupEmailChallenge",
         AgentAuthOperationDisposition::Denied,
     ),
-    // Consumes a human invite to open an agent-rooted account; account
+    // Consumes a human invite to open an unclaimed placeholder account;
     // provisioning stays parent-only even though the RPC is public.
+    ("CreateAgentAccount", AgentAuthOperationDisposition::Denied),
+    // Legacy generated-handle variant of create-on-behalf. It remains in the
+    // shared contract but is not the pet-name claim path used by this CLI.
     (
         "ProvisionAgentRootedAccount",
         AgentAuthOperationDisposition::Denied,
     ),
+    // Claim promotion is authorized by the browser's verified passkey and the
+    // agent's dedicated Iroh consent, never by an attached derived bearer.
+    ("PromoteAgentAccount", AgentAuthOperationDisposition::Denied),
     (
         "ResolveSignupInvite",
         AgentAuthOperationDisposition::ReviewedSafe,

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -85,11 +85,11 @@ impl HostedRoutes<'_> {
         AccessTokenResponse
     );
     unary_method!(
-        provision_agent_rooted_account,
+        create_agent_account,
         "IdentityService",
-        "ProvisionAgentRootedAccount",
-        ProvisionAgentRootedAccountRequest,
-        ProvisionAgentRootedAccountResponse
+        "CreateAgentAccount",
+        CreateAgentAccountRequest,
+        CreateAgentAccountResponse
     );
     unary_method!(
         who_am_i,

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -2756,6 +2756,8 @@ mod pull_bootstrap_tests {
         let snapshot = repo
             .snapshot(Some("bootstrap marker".to_string()), None)
             .expect("snapshot");
+        repo.create_marker_recorded(&MarkerName::from("release"), &snapshot.state_id)
+            .expect("seed existing marker");
         let payload = rmp_serde::to_vec_named(&(
             true,
             Vec::<Discussion>::new(),

--- a/crates/cli/src/hosted_runtime/hosted/user.rs
+++ b/crates/cli/src/hosted_runtime/hosted/user.rs
@@ -1,15 +1,15 @@
 use api::heddle::api::v1alpha1::{
     ApproveThreadRequest, BeginWebAuthnAuthenticationRequest, CheckMergeEligibilityRequest,
-    CheckMergeEligibilityResponse, CreateGrantRequest, CreateInvitationRequest,
-    CreateServiceAccountRequest, CreateSpoolRequest, DeleteGrantRequest, DeleteNamespaceRequest,
-    DeleteRepositoryRequest, GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
+    CheckMergeEligibilityResponse, CreateAgentAccountRequest, CreateAgentAccountResponse,
+    CreateGrantRequest, CreateInvitationRequest, CreateServiceAccountRequest, CreateSpoolRequest,
+    DeleteGrantRequest, DeleteNamespaceRequest, DeleteRepositoryRequest,
+    GetCurrentUserSpoolRequest, GrantSupportAccessRequest, GrantTargetRef,
     Invitation as ProtoInvitation, IssueServiceAccountCredentialRequest, IssuedCredentialResponse,
     ListGrantsRequest, ListSpoolsRequest, ListSupportAccessGrantsRequest,
-    ListThreadApprovalsRequest, MonorepoNode, ProvisionAgentRootedAccountRequest,
-    ProvisionAgentRootedAccountResponse, ResolveMonorepoRequest, RevokeApprovalRequest,
-    RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SpoolVisibility,
-    SupportAccessGrant, ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest,
-    UpdateRepositoryRequest, grant_target_ref::Target as GrantTargetKind,
+    ListThreadApprovalsRequest, MonorepoNode, ResolveMonorepoRequest, RevokeApprovalRequest,
+    RevokeSupportAccessRequest, ServiceAccountResponse, SpoolSummary, SupportAccessGrant,
+    ThreadApproval, UpdateGrantRequest, UpdateNamespaceRequest, UpdateRepositoryRequest,
+    Visibility, grant_target_ref::Target as GrantTargetKind,
 };
 use wire::ProtocolError;
 
@@ -61,12 +61,12 @@ macro_rules! workflow_call {
 }
 
 impl HostedClient {
-    pub async fn provision_agent_rooted_account(
+    pub async fn create_agent_account(
         &mut self,
-        request: ProvisionAgentRootedAccountRequest,
-    ) -> Result<ProvisionAgentRootedAccountResponse, ProtocolError> {
+        request: CreateAgentAccountRequest,
+    ) -> Result<CreateAgentAccountResponse, ProtocolError> {
         self.routes()
-            .provision_agent_rooted_account(&request)
+            .create_agent_account(&request)
             .await
             .map_err(hosted_to_protocol_error)
     }
@@ -170,8 +170,9 @@ impl HostedClient {
                 slug: slug.to_string(),
                 is_repo: kind.is_repo(),
                 display_name,
-                visibility: SpoolVisibility::Private as i32,
+                visibility: Visibility::Private as i32,
                 client_operation_id: operation_id.to_wire(),
+                settings: None,
             }
         );
         Ok(to_protocol_spool(spool))

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -1,7 +1,7 @@
 //! Reuse-first machine identity and browser claim-link commands.
 
 use anyhow::{Context, Result, bail};
-use api::heddle::api::v1alpha1::ProvisionAgentRootedAccountRequest;
+use api::heddle::api::v1alpha1::CreateAgentAccountRequest;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use cli_shared::{UserConfig, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer as _};
@@ -109,7 +109,7 @@ async fn ensure(
         }
         EnsureAction::Provision => {
             let invite = invite.ok_or_else(|| anyhow::anyhow!("identity decision lost invite"))?;
-            provision_and_claim(ctx, server, invite).await
+            create_on_behalf(ctx, server, invite).await
         }
         EnsureAction::RequireInvite => bail!(
             "no existing account credential for {server}; supply --invite to create a placeholder human account"
@@ -126,7 +126,7 @@ pub(crate) fn ensure_action(derived: Option<bool>, has_invite: bool) -> EnsureAc
     }
 }
 
-async fn provision_and_claim(
+async fn create_on_behalf(
     ctx: &(dyn CliContext + 'static),
     server: String,
     invite: String,
@@ -154,13 +154,15 @@ async fn provision_and_claim(
         value => value,
     };
     let response = client
-        .provision_agent_rooted_account(ProvisionAgentRootedAccountRequest {
+        .create_agent_account(CreateAgentAccountRequest {
             invite_code: invite,
             agent_public_key: signer.public_key().to_vec(),
             client_operation_id: operation_id,
         })
         .await
-        .map_err(|error| anyhow::anyhow!("provisioning agent-rooted account: {error}"));
+        .map_err(|error| {
+            anyhow::anyhow!("creating placeholder account on behalf of human: {error}")
+        });
     client.close().await;
     let response = response?;
     let token = String::from_utf8(response.agent_capability)
@@ -181,11 +183,13 @@ async fn provision_and_claim(
             expires_at: metadata.expires_at,
         },
     )?;
+    let owner_id = uuid::Uuid::parse_str(&response.account_id)
+        .context("server returned a non-UUID account identity")?;
     let state = ClaimState::new(
         server.clone(),
-        response.account_id,
+        owner_id,
         metadata.subject.clone(),
-        response.handle,
+        response.pet_name,
         node_id,
     );
     identity_state::store(&state)?;
@@ -246,7 +250,9 @@ fn reissue(server: &str, ttl_secs: u64) -> Result<(String, String)> {
         .timestamp_millis()
         .checked_add(ttl_millis)
         .context("claim expiry overflow")?;
-    state.reissue(&secret, expires);
+    if !state.reissue(&secret, expires) {
+        bail!("account claim is already complete");
+    }
     identity_state::store(&state)?;
     let encoded_secret = URL_SAFE_NO_PAD.encode(secret);
     let url = format!(

--- a/crates/cli/src/hosted_runtime/identity_state.rs
+++ b/crates/cli/src/hosted_runtime/identity_state.rs
@@ -11,14 +11,16 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 const STATE_FORMAT: &str = "heddle-agent-claim";
-const STATE_VERSION: u32 = 1;
+const STATE_VERSION: u32 = 2;
 const STATE_FILE: &str = "agent-claim.toml";
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum ClaimStatus {
+    Dormant,
     Active,
-    Consented,
+    Prepared,
+    Claimed,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -26,7 +28,7 @@ pub(crate) struct ClaimState {
     format: String,
     version: u32,
     pub(crate) server: String,
-    pub(crate) account_id: String,
+    pub(crate) owner_id: uuid::Uuid,
     pub(crate) subject: String,
     pub(crate) pet_name: String,
     pub(crate) node_id: String,
@@ -34,12 +36,14 @@ pub(crate) struct ClaimState {
     secret_hash: String,
     pub(crate) expires_at_millis: i64,
     status: ClaimStatus,
+    prepared_handle: Option<String>,
+    prepared_nonce_hash: Option<String>,
 }
 
 impl ClaimState {
     pub(crate) fn new(
         server: String,
-        account_id: String,
+        owner_id: uuid::Uuid,
         subject: String,
         pet_name: String,
         node_id: String,
@@ -48,29 +52,38 @@ impl ClaimState {
             format: STATE_FORMAT.to_string(),
             version: STATE_VERSION,
             server,
-            account_id,
+            owner_id,
             subject,
             pet_name,
             node_id,
             created_at: chrono::Utc::now().to_rfc3339(),
             secret_hash: String::new(),
             expires_at_millis: 0,
-            status: ClaimStatus::Consented,
+            status: ClaimStatus::Dormant,
+            prepared_handle: None,
+            prepared_nonce_hash: None,
         }
     }
 
-    pub(crate) fn reissue(&mut self, secret: &[u8], expires_at_millis: i64) {
+    pub(crate) fn reissue(&mut self, secret: &[u8], expires_at_millis: i64) -> bool {
+        if matches!(self.status, ClaimStatus::Claimed) {
+            return false;
+        }
         self.secret_hash = hex::encode(Sha256::digest(secret));
         self.expires_at_millis = expires_at_millis;
         self.status = ClaimStatus::Active;
+        self.prepared_handle = None;
+        self.prepared_nonce_hash = None;
+        true
     }
 
     pub(crate) fn is_active(&self, now: i64) -> bool {
-        matches!(self.status, ClaimStatus::Active) && now < self.expires_at_millis
+        matches!(self.status, ClaimStatus::Active | ClaimStatus::Prepared)
+            && now < self.expires_at_millis
     }
 
     pub(crate) fn accepts(&self, secret: &[u8], now: i64) -> bool {
-        if now >= self.expires_at_millis {
+        if !self.is_active(now) {
             return false;
         }
         let Ok(expected) = hex::decode(&self.secret_hash) else {
@@ -83,12 +96,36 @@ impl ClaimState {
         &self.secret_hash
     }
 
-    pub(crate) fn is_consented(&self) -> bool {
-        matches!(self.status, ClaimStatus::Consented)
+    pub(crate) fn is_claimed(&self) -> bool {
+        matches!(self.status, ClaimStatus::Claimed)
     }
 
-    pub(crate) fn mark_consented(&mut self) {
-        self.status = ClaimStatus::Consented;
+    pub(crate) fn prepare(&mut self, handle: &str, nonce: &[u8]) -> bool {
+        let nonce_hash = hex::encode(Sha256::digest(nonce));
+        match self.status {
+            ClaimStatus::Active => {
+                self.status = ClaimStatus::Prepared;
+                self.prepared_handle = Some(handle.to_string());
+                self.prepared_nonce_hash = Some(nonce_hash);
+                true
+            }
+            ClaimStatus::Prepared => {
+                self.prepared_handle.as_deref() == Some(handle)
+                    && self.prepared_nonce_hash.as_deref() == Some(nonce_hash.as_str())
+            }
+            ClaimStatus::Dormant | ClaimStatus::Claimed => false,
+        }
+    }
+
+    pub(crate) fn claim(&mut self, handle: &str) -> bool {
+        if !matches!(self.status, ClaimStatus::Prepared)
+            || self.prepared_handle.as_deref() != Some(handle)
+        {
+            return false;
+        }
+        self.status = ClaimStatus::Claimed;
+        self.prepared_nonce_hash = None;
+        true
     }
 }
 
@@ -108,6 +145,14 @@ pub(crate) fn write_lock() -> Result<WriteLockGuard> {
     claim_lock(&state_path())
         .write()
         .map_err(|error| anyhow::anyhow!(error))
+}
+
+pub(crate) fn load_while_locked() -> Result<Option<ClaimState>> {
+    load_at(&state_path())
+}
+
+pub(crate) fn store_while_locked(state: &ClaimState) -> Result<()> {
+    store_at_unlocked(&state_path(), state)
 }
 
 fn load_at(path: &Path) -> Result<Option<ClaimState>> {
@@ -133,6 +178,10 @@ fn store_at(path: &Path, state: &ClaimState) -> Result<()> {
     let _guard = claim_lock(path)
         .write()
         .map_err(|error| anyhow::anyhow!(error))?;
+    store_at_unlocked(path, state)
+}
+
+fn store_at_unlocked(path: &Path, state: &ClaimState) -> Result<()> {
     let encoded = toml::to_string_pretty(state).context("serializing claim state")?;
     write_file_atomic_secret(path, encoded.as_bytes())
         .with_context(|| format!("writing {}", path.display()))
@@ -161,7 +210,7 @@ mod tests {
     fn state() -> ClaimState {
         ClaimState::new(
             "api.heddle.test".into(),
-            "account-1".into(),
+            uuid::Uuid::parse_str("7ed1b633-64dd-4b78-b3a8-7f8e08fc4a28").unwrap(),
             "subject-1".into(),
             "quiet-otter".into(),
             "11".repeat(32),
@@ -171,11 +220,25 @@ mod tests {
     #[test]
     fn reissue_invalidates_the_previous_secret() {
         let mut state = state();
-        state.reissue(b"first-secret", 2_000);
+        assert!(state.reissue(b"first-secret", 2_000));
         assert!(state.accepts(b"first-secret", 1_000));
-        state.reissue(b"second-secret", 2_000);
+        assert!(state.reissue(b"second-secret", 2_000));
         assert!(!state.accepts(b"first-secret", 1_000));
         assert!(state.accepts(b"second-secret", 1_000));
+    }
+
+    #[test]
+    fn prepared_claim_is_bound_to_one_handle_and_nonce() {
+        let mut state = state();
+        assert!(state.reissue(b"claim-secret", 2_000));
+        assert!(state.prepare("human-handle", b"nonce-one"));
+        assert!(state.prepare("human-handle", b"nonce-one"));
+        assert!(!state.prepare("other-handle", b"nonce-one"));
+        assert!(!state.prepare("human-handle", b"nonce-two"));
+        assert!(!state.claim("other-handle"));
+        assert!(state.claim("human-handle"));
+        assert!(!state.accepts(b"claim-secret", 1_000));
+        assert!(!state.reissue(b"third-secret", 3_000));
     }
 
     #[test]
@@ -183,7 +246,7 @@ mod tests {
         let directory = tempfile::tempdir().expect("temporary directory");
         let path = directory.path().join("claim.toml");
         let mut state = state();
-        state.reissue(b"super-secret-value", 2_000);
+        assert!(state.reissue(b"super-secret-value", 2_000));
         assert!(!state.accepts(b"super-secret-value", 2_000));
         store_at(&path, &state).expect("store claim state");
         let contents = std::fs::read_to_string(path).expect("read claim state");

--- a/crates/cli/tests/cli_integration/current_context_advice.rs
+++ b/crates/cli/tests/cli_integration/current_context_advice.rs
@@ -3,6 +3,7 @@
 
 use std::{fs, str};
 
+use refs::Head;
 use repo::Repository;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -20,11 +21,8 @@ fn setup_detached_repo_without_current_thread() -> TempDir {
         .head()
         .unwrap()
         .expect("repo should have a current state after capture");
-    fs::write(
-        temp.path().join(".heddle").join("HEAD"),
-        format!("{}\n", head.to_string_full()),
-    )
-    .unwrap();
+    repo.write_head_recorded(&Head::Detached { state: head })
+        .unwrap();
     drop(repo);
 
     temp

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -195,11 +195,11 @@ fn status_on_corrupted_state_is_data_err_with_recovery_path() {
     // probe, so it must name the condition, exit DataErr (65), and hand
     // back executable recovery commands in both output modes.
     let repo = init_repo();
-    std::fs::write(repo.path().join("f.txt"), "base\n").expect("write f.txt");
-    assert_exit(&["capture", "-m", "base"], repo.path(), 0);
 
     // Corrupt every stored state object: 0x90 is msgpack FixArray(0),
-    // the exact marker from the persona report's dead-end.
+    // the exact marker from the persona report's dead-end. The initial
+    // state is intentionally used because later captures are durable pack
+    // artifacts and can repair their loose-object mirrors.
     let states_dir = repo.path().join(".heddle/objects/states");
     let mut corrupted = 0usize;
     for entry in std::fs::read_dir(&states_dir).expect("read states dir") {

--- a/crates/cli/tests/cli_integration/oplog_salvage.rs
+++ b/crates/cli/tests/cli_integration/oplog_salvage.rs
@@ -60,13 +60,19 @@ fn truncated_packed_oplog_salvages_prefix_quarantines_tail_and_keeps_repo_usable
 
         let output = heddle_output(&["log", "--output", "json"], Some(temp.path()))
             .expect("heddle log should run after explicit recovery");
-        assert!(output.status.success());
+        assert!(
+            output.status.success(),
+            "{}: log should succeed after recovery; stdout={} stderr={}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
         let parsed: Value = serde_json::from_slice(&output.stdout)
             .expect("log should emit JSON after explicit recovery");
         assert!(
             !parsed["states"].as_array().unwrap().is_empty(),
-            "{}: salvaged log should retain at least one complete state",
-            case.name
+            "{}: salvaged log should retain at least one complete state: {parsed}",
+            case.name,
         );
 
         std::fs::write(
@@ -258,18 +264,33 @@ fn seed_native_repo_with_four_captures(path: &std::path::Path) {
         String::from_utf8_lossy(&init.stdout),
         String::from_utf8_lossy(&init.stderr)
     );
-    for index in 1..=4 {
-        std::fs::write(path.join("file.txt"), format!("snapshot {index}\n"))
-            .expect("write snapshot file");
-        let capture = heddle_output(&["capture", "-m", &format!("snapshot {index}")], Some(path))
-            .expect("capture runs");
-        assert!(
-            capture.status.success(),
-            "capture {index} should succeed: stdout={} stderr={}",
-            String::from_utf8_lossy(&capture.stdout),
-            String::from_utf8_lossy(&capture.stderr)
-        );
-    }
+    let repo = Repository::open(path).expect("open seeded repository");
+    let state = repo.head().expect("read HEAD").expect("initial state");
+    let mut fixture_state = repo
+        .current_state()
+        .expect("read current state")
+        .expect("initial state object");
+    fixture_state.parents = vec![state];
+    fixture_state.intent = Some("oplog salvage fixture".to_string());
+    let fixture_state_id = fixture_state.id();
+    repo.store()
+        .put_state(&fixture_state)
+        .expect("store oplog salvage state");
+    let batches = (1..=8)
+        .map(|_| {
+            (
+                vec![oplog::OpRecord::Snapshot {
+                    new_state: fixture_state_id,
+                    prev_head: Some(state),
+                    head: None,
+                    thread: Some("main".to_string()),
+                }],
+                None,
+            )
+        })
+        .collect();
+    oplog::OpLogBackend::record_batches_scoped(repo.oplog(), batches)
+        .expect("record oplog salvage fixture");
 }
 
 fn current_entry_offsets(bytes: &[u8]) -> (Vec<usize>, usize) {

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -3451,6 +3451,8 @@ fn push_bootstrap_with_valid_config_still_creates_state() {
 
     heddle(&["init"], Some(source.path())).expect("init source");
     heddle(&["init"], Some(remote.path())).expect("init target");
+    std::fs::write(source.path().join("bootstrap.txt"), "bootstrap\n")
+        .expect("write bootstrap fixture");
 
     let before = Repository::open(source.path()).expect("open source");
     before

--- a/crates/cli/tests/cli_integration/thread_default_current.rs
+++ b/crates/cli/tests/cli_integration/thread_default_current.rs
@@ -14,6 +14,7 @@
 
 use std::{fs, path::PathBuf, str};
 
+use refs::Head;
 use repo::{Repository, ThreadManager};
 use serde_json::Value;
 use tempfile::TempDir;
@@ -44,11 +45,8 @@ fn detach_head_to_current_state(path: &std::path::Path) {
         .head()
         .unwrap()
         .expect("repo should have a current state before detaching");
-    fs::write(
-        path.join(".heddle").join("HEAD"),
-        format!("{}\n", head.to_string_full()),
-    )
-    .unwrap();
+    repo.write_head_recorded(&Head::Detached { state: head })
+        .unwrap();
 }
 
 /// `heddle thread show` with no positional should resolve to whatever
@@ -97,30 +95,22 @@ fn thread_captures_without_arg_resolves_current_thread() {
 /// missing positional and the unavailable fallback.
 ///
 /// `heddle init` auto-attaches HEAD to `main`, so we have to detach
-/// it manually: overwrite `.heddle/HEAD` with a parseable change id
-/// (the ID of the snapshot we just created), which the `Head` parser
-/// will read as `Detached`. From a detached HEAD, `current_lane()`
-/// returns `None` — exactly the state we need to exercise the
-/// fallback branch.
+/// it explicitly through the repository mutation API. From a detached
+/// HEAD, `current_lane()` returns `None` — exactly the state we need to
+/// exercise the fallback branch.
 #[test]
 fn thread_show_without_arg_errors_when_no_current_thread() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
     fs::write(temp.path().join("base.txt"), "base").unwrap();
     heddle(&["capture", "-m", "init"], Some(temp.path())).unwrap();
-    // Snapshot's wire format only exposes the short id; we need the
-    // full form to write a parseable Detached HEAD. Reach in via the
-    // `repo` API, which both the CLI and these tests already share.
     let repo = Repository::open(temp.path()).unwrap();
     let head = repo
         .head()
         .unwrap()
         .expect("repo should have a current state after snapshot");
-    fs::write(
-        temp.path().join(".heddle").join("HEAD"),
-        format!("{}\n", head.to_string_full()),
-    )
-    .unwrap();
+    repo.write_head_recorded(&Head::Detached { state: head })
+        .unwrap();
     drop(repo);
 
     let err = heddle(&["thread", "show"], Some(temp.path()))
@@ -226,9 +216,8 @@ fn thread_cd_without_available_worktree_uses_typed_advice() {
 /// pointed at the cwd.
 ///
 /// We seed a thread record whose `execution_path` is the repo root,
-/// then detach HEAD by overwriting `.heddle/HEAD` with the snapshot's
-/// state id (same trick `thread_show_without_arg_errors_when_no_current_thread`
-/// uses). After that, `thread show` (no positional) must resolve to
+/// then detach HEAD through the repository mutation API. After that,
+/// `thread show` (no positional) must resolve to
 /// the seeded thread and succeed.
 #[test]
 fn thread_show_without_arg_resolves_via_execution_path_when_detached() {
@@ -250,17 +239,13 @@ fn thread_show_without_arg_resolves_via_execution_path_when_detached() {
     thread.execution_path = temp.path().to_path_buf();
     manager.save(&thread).unwrap();
 
-    // Detach HEAD to the snapshot's state id. Overwriting
-    // `.heddle/HEAD` directly is what `Head` parses as Detached.
+    // Detach HEAD to the snapshot's state id.
     let head = repo
         .head()
         .unwrap()
         .expect("repo should have a current state after snapshot");
-    fs::write(
-        temp.path().join(".heddle").join("HEAD"),
-        format!("{}\n", head.to_string_full()),
-    )
-    .unwrap();
+    repo.write_head_recorded(&Head::Detached { state: head })
+        .unwrap();
     drop(repo);
 
     // Sanity: confirm `thread show` with the explicit positional

--- a/crates/cli/tests/core_functionality/diff_and_status.rs
+++ b/crates/cli/tests/core_functionality/diff_and_status.rs
@@ -324,6 +324,7 @@ fn test_status_clean_after_snapshot() {
 }
 
 #[test]
+#[serial_test::serial(fsmonitor)]
 fn test_native_status_warms_helper_for_second_run() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
@@ -338,9 +339,17 @@ fn test_native_status_warms_helper_for_second_run() {
     let second = heddle_with_env(&["status", "--short"], Some(temp.path()), &envs).unwrap();
     assert!(!second.contains("file.txt"));
 
+    let coverage_instrumented = std::env::var_os("LLVM_PROFILE_FILE").is_some()
+        || std::env::var_os("CARGO_LLVM_COV").is_some();
+    let ready_timeout = if coverage_instrumented {
+        std::time::Duration::from_secs(30)
+    } else {
+        std::time::Duration::from_secs(6)
+    };
+    let ready_deadline = std::time::Instant::now() + ready_timeout;
     let mut helper_ready = false;
     let mut last_monitor = Value::Null;
-    for _ in 0..60 {
+    while std::time::Instant::now() < ready_deadline {
         let output = heddle_with_env(
             &["maintenance", "inspect", "--output", "json"],
             Some(temp.path()),

--- a/crates/cli/tests/core_functionality/maintenance.rs
+++ b/crates/cli/tests/core_functionality/maintenance.rs
@@ -162,6 +162,7 @@ fn test_release_help_surfaces_keep_maintenance_tools_under_maintenance() {
 }
 
 #[test]
+#[serial_test::serial(fsmonitor)]
 fn test_maintenance_inspect_json_reports_repo_shape_fields() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
@@ -207,6 +208,7 @@ fn test_maintenance_inspect_json_reports_repo_shape_fields() {
 }
 
 #[test]
+#[serial_test::serial(fsmonitor)]
 fn test_maintenance_refresh_creates_or_refreshes_sidecars_in_simple_repo() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
@@ -257,6 +259,7 @@ fn test_store_group_is_removed() {
 }
 
 #[test]
+#[serial_test::serial(fsmonitor)]
 fn test_maintenance_inspect_reflects_sidecars_after_refresh() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -685,9 +685,9 @@ fn test_undo_recover_refuses_when_preserved_state_is_missing() {
     let recovery_state = head_short(temp.path());
     heddle_must_succeed(&["undo", "--hard"], temp.path());
 
-    let state_path = locate_state_loose_file(temp.path(), &recovery_state)
-        .expect("preserved state has a loose object");
-    std::fs::remove_file(state_path).unwrap();
+    if let Some(state_path) = locate_state_loose_file(temp.path(), &recovery_state) {
+        std::fs::remove_file(state_path).unwrap();
+    }
     wipe_pack_store(temp.path());
 
     let missing = heddle(
@@ -760,9 +760,9 @@ fn test_undo_refuses_when_prior_state_missing() {
     // gone from the loose store *and* any pack that might contain it.
     // Mirrors a `gc --prune` having reached past the live oplog, or an oplog
     // backup restored without its objects.
-    let state_path = locate_state_loose_file(temp.path(), &first_state_short)
-        .expect("prior state's loose file is present after capture");
-    std::fs::remove_file(&state_path).unwrap();
+    if let Some(state_path) = locate_state_loose_file(temp.path(), &first_state_short) {
+        std::fs::remove_file(state_path).unwrap();
+    }
     // Drop every pack in the repo too; heddle writes packs eagerly and a
     // surviving pack would still resolve the state, masking the test's
     // destructive-boundary intent.

--- a/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
+++ b/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
@@ -179,8 +179,14 @@ fn rejects_symlink_target_path_for_materialized_start() {
 #[test]
 fn test_snapshot_excludes_nested_thread_worktrees() {
     let main = setup_repo("hello.txt", "world");
-    let nested = main.path().join("agents").join("approach-x");
-    fs::create_dir_all(&nested).unwrap();
+    let agents = main.path().join("agents");
+    fs::create_dir(&agents).unwrap();
+    heddle(
+        &["capture", "-m", "add nested worktree container"],
+        Some(main.path()),
+    )
+    .unwrap();
+    let nested = agents.join("approach-x");
 
     heddle(
         &[

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -559,34 +559,46 @@ mod fsck {
         let temp = TempDir::new().unwrap();
         setup_repo_with_file(&temp, "file.txt", "content");
 
-        // Snapshot pack-batches blobs into `.heddle/packs/*.pack`, so
-        // there's no loose blob to overwrite. Scramble the pack
-        // payload after its 8-byte magic+version header — the read
-        // path will surface a hash mismatch, decompression error, or
-        // structural failure. Fsck accepts any of those signals.
-        // Capture can install more than one pack (source blobs plus sidecar
-        // packs such as the semantic index). Corrupt every pack large enough
-        // to scramble so the source-object pack — the one fsck walks — is
-        // always hit, independent of read_dir order.
-        let packs_dir = temp.path().join(".heddle/packs");
-        let mut corrupted = false;
-        for entry in fs::read_dir(&packs_dir).unwrap().filter_map(Result::ok) {
-            let path = entry.path();
-            if path.extension().and_then(|s| s.to_str()) != Some("pack") {
-                continue;
-            }
-            let mut bytes = fs::read(&path).unwrap();
-            if bytes.len() <= 32 {
-                continue;
-            }
-            let end = bytes.len().min(48);
-            for b in &mut bytes[16..end] {
-                *b ^= 0xFF;
-            }
-            fs::write(&path, bytes).unwrap();
-            corrupted = true;
+        // Capture stores the source blob in an authoritative snapshot pack.
+        // Materialize every packed object as loose before removing the packs,
+        // then corrupt the exact blob referenced by the current tree. This
+        // keeps the fixture deterministic as the pack layout evolves.
+        use objects::store::ObjectStore;
+
+        let repo = Repository::open(temp.path()).unwrap();
+        let store = repo.store();
+        let state = repo.current_state().unwrap().unwrap();
+        let tree = store.get_tree(&state.tree).unwrap().unwrap();
+        let blob = tree
+            .get("file.txt")
+            .and_then(|entry| entry.blob_hash())
+            .expect("captured file should reference a blob");
+        for state_id in store.list_states().unwrap() {
+            let state = store.get_state(&state_id).unwrap().unwrap();
+            store.put_state(&state).unwrap();
         }
-        assert!(corrupted, "should have found a pack file to corrupt");
+        for tree_id in store.list_trees().unwrap() {
+            let serialized = store.get_tree_serialized(&tree_id).unwrap().unwrap();
+            store.put_tree_serialized(&serialized, tree_id).unwrap();
+        }
+        for blob_id in store.list_blobs().unwrap() {
+            store.promote_to_loose_uncompressed(&blob_id).unwrap();
+        }
+        let blob_path = store
+            .loose_blob_path(&blob)
+            .expect("source blob should have a loose copy");
+        drop(repo);
+
+        let packs_dir = temp.path().join(".heddle/packs");
+        for entry in fs::read_dir(&packs_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                fs::remove_dir_all(path).unwrap();
+            } else {
+                fs::remove_file(path).unwrap();
+            }
+        }
+        fs::write(blob_path, b"corrupt blob").unwrap();
 
         let error = heddle(&["fsck", "--full"], Some(temp.path()))
             .expect_err("full fsck must fail when a source-object pack is corrupt");

--- a/crates/cli/tests/state_management.rs
+++ b/crates/cli/tests/state_management.rs
@@ -29,6 +29,64 @@ fn heddle_output(
     cli_test_support::heddle_output(args, cwd, &[])
 }
 
+/// Remove one tree from the native object store while preserving every other
+/// packed object as a loose copy. Snapshot commits are authoritative packs, so
+/// corruption fixtures cannot assume the target tree has a loose file.
+fn delete_tree_object(repo_root: &std::path::Path, target_hex: &str) -> bool {
+    use objects::store::ObjectStore;
+    use repo::Repository;
+
+    let repo = Repository::open(repo_root).unwrap();
+    let store = repo.store();
+    let tree_ids = store.list_trees().unwrap();
+    let target_present = tree_ids.iter().any(|id| id.to_hex() == target_hex);
+
+    for state_id in store.list_states().unwrap() {
+        let state = store.get_state(&state_id).unwrap().unwrap();
+        store.put_state(&state).unwrap();
+    }
+    for blob_id in store.list_blobs().unwrap() {
+        store.promote_to_loose_uncompressed(&blob_id).unwrap();
+    }
+    for tree_id in tree_ids {
+        if tree_id.to_hex() == target_hex {
+            continue;
+        }
+        let serialized = store.get_tree_serialized(&tree_id).unwrap().unwrap();
+        store.put_tree_serialized(&serialized, tree_id).unwrap();
+    }
+    drop(repo);
+
+    let packs_dir = repo_root.join(".heddle/packs");
+    if packs_dir.exists() {
+        for entry in fs::read_dir(&packs_dir).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                fs::remove_dir_all(path).unwrap();
+            } else {
+                fs::remove_file(path).unwrap();
+            }
+        }
+    }
+
+    let loose_tree = repo_root
+        .join(".heddle/objects/trees")
+        .join(&target_hex[..2])
+        .join(&target_hex[2..]);
+    match fs::remove_file(&loose_tree) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("failed to delete loose tree at {loose_tree:?}: {error}"),
+    }
+    let cached_tree = repo_root.join(".heddle/state/worktree-current-tree.bin");
+    match fs::remove_file(&cached_tree) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => panic!("failed to remove tree cache at {cached_tree:?}: {error}"),
+    }
+    target_present
+}
+
 fn status_json(path: &std::path::Path) -> Value {
     let output = heddle(&["status", "--output", "json"], Some(path)).unwrap();
     serde_json::from_str(&output).expect("status output should be JSON")

--- a/crates/cli/tests/state_management/merge_store_integrity.rs
+++ b/crates/cli/tests/state_management/merge_store_integrity.rs
@@ -10,31 +10,13 @@
 //! asserts refresh fails loud rather than committing data loss. The
 //! second exercises a legitimate directory rename and ensures the same
 //! integration path does not false-positive.
-use std::{fs, path::Path};
+use std::fs;
 
 use objects::{object::ThreadName, store::ObjectStore};
 use repo::Repository;
 use tempfile::TempDir;
 
-use super::heddle;
-
-/// Walk the loose-objects tree at `.heddle/objects/trees/<prefix>/<rest>`
-/// and remove the file whose hash matches `target`. Returns whether a
-/// matching file was actually deleted, so the test can assert the
-/// tampering set up the corruption it intended.
-fn delete_loose_tree(repo_root: &Path, target_hex: &str) -> bool {
-    let prefix = &target_hex[..2];
-    let rest = &target_hex[2..];
-    let path = repo_root
-        .join(".heddle/objects/trees")
-        .join(prefix)
-        .join(rest);
-    match fs::remove_file(&path) {
-        Ok(()) => true,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => panic!("failed to delete loose tree at {path:?}: {error}"),
-    }
-}
+use super::{delete_tree_object, heddle};
 
 /// Red-commit guard for heddle#90: a subtree that the merge wants to
 /// recurse into MUST be present in the object store. If it isn't —
@@ -121,10 +103,10 @@ fn test_merge_missing_base_subtree_fails_loud_not_silent_erase() {
     // Tamper with the on-disk store. The merge subprocess starts cold
     // (no in-memory caches), so this is the exact failure mode a
     // user with a corrupt object would hit.
-    let deleted = delete_loose_tree(temp.path(), &sub_hash_hex);
+    let deleted = delete_tree_object(temp.path(), &sub_hash_hex);
     assert!(
         deleted,
-        "test setup: expected to find loose tree at hash {sub_hash_hex} to delete",
+        "test setup: expected to find tree at hash {sub_hash_hex} to delete",
     );
 
     // Refresh is the current public operation that integrates the parent

--- a/crates/cli/tests/state_management/missing_tree_integrity.rs
+++ b/crates/cli/tests/state_management/missing_tree_integrity.rs
@@ -18,25 +18,7 @@ use objects::{object::ThreadName, store::ObjectStore};
 use repo::Repository;
 use tempfile::TempDir;
 
-use super::heddle;
-
-/// Walk the loose-objects tree at `.heddle/objects/trees/<prefix>/<rest>`
-/// and remove the file whose hash matches `target`. Returns whether a
-/// matching file was actually deleted, so the test can assert the
-/// tampering set up the corruption it intended.
-fn delete_loose_tree(repo_root: &Path, target_hex: &str) -> bool {
-    let prefix = &target_hex[..2];
-    let rest = &target_hex[2..];
-    let path = repo_root
-        .join(".heddle/objects/trees")
-        .join(prefix)
-        .join(rest);
-    match fs::remove_file(&path) {
-        Ok(()) => true,
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => false,
-        Err(error) => panic!("failed to delete loose tree at {path:?}: {error}"),
-    }
-}
+use super::{delete_tree_object, heddle};
 
 /// Look up the captured state's tree hash via a short-lived
 /// `Repository` handle, closing it before the subprocess runs so no
@@ -93,8 +75,8 @@ fn test_status_missing_tree_fails_loud_not_silent_empty() {
 
     let tree_hex = current_state_tree_hex(temp.path());
     assert!(
-        delete_loose_tree(temp.path(), &tree_hex),
-        "test setup: expected to find loose tree at hash {tree_hex} to delete",
+        delete_tree_object(temp.path(), &tree_hex),
+        "test setup: expected to find tree at hash {tree_hex} to delete",
     );
 
     let err = heddle(&["status"], Some(temp.path())).expect_err(
@@ -118,8 +100,8 @@ fn test_ready_missing_tree_fails_loud_not_silent_empty() {
 
     let tree_hex = current_state_tree_hex(temp.path());
     assert!(
-        delete_loose_tree(temp.path(), &tree_hex),
-        "test setup: expected to find loose tree at hash {tree_hex} to delete",
+        delete_tree_object(temp.path(), &tree_hex),
+        "test setup: expected to find tree at hash {tree_hex} to delete",
     );
 
     let err = heddle(&["ready"], Some(temp.path())).expect_err(
@@ -162,8 +144,8 @@ fn test_revert_missing_parent_tree_fails_loud_not_silent_empty() {
         parent_state.tree.to_hex()
     };
     assert!(
-        delete_loose_tree(temp.path(), &parent_tree_hex),
-        "test setup: expected to find loose tree at parent hash {parent_tree_hex}",
+        delete_tree_object(temp.path(), &parent_tree_hex),
+        "test setup: expected to find tree at parent hash {parent_tree_hex}",
     );
 
     // We need the short change-id for "second" to feed to revert. Pull

--- a/crates/git-projection/Cargo.toml
+++ b/crates/git-projection/Cargo.toml
@@ -31,6 +31,9 @@ tempfile.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+[dev-dependencies]
+serial_test.workspace = true
+
 [features]
 # This crate *is* the Git projection surface; `git-overlay` is always on so
 # residual `#[cfg(feature = "git-overlay")]` annotations from the CLI extract

--- a/crates/git-projection/src/credential.rs
+++ b/crates/git-projection/src/credential.rs
@@ -464,7 +464,7 @@ mod tests {
     use sley_transport::{GitCredential, HttpResponse, parse_remote_url};
     use tempfile::TempDir;
 
-    use super::EmbeddingSafeCredentialProvider;
+    use super::{EmbeddingSafeCredentialProvider, MAX_CREDENTIAL_HELPER_OUTPUT};
 
     fn write_helper(directory: &Path, name: &str, body: &str) -> PathBuf {
         let helper = directory.join(format!("git-credential-{name}"));
@@ -518,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn https_transport_retries_with_bare_credential_helper_without_git_dispatch() {
         let temp = TempDir::new().expect("tempdir");
         let helper = write_helper(
@@ -559,6 +560,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn missing_bare_helper_falls_through_to_the_next_helper() {
         let temp = TempDir::new().expect("tempdir");
         let helper = write_helper(
@@ -589,6 +591,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn failing_bare_helper_falls_through_to_the_next_helper() {
         let temp = TempDir::new().expect("tempdir");
         let helper = write_helper(temp.path(), "heddle-fails", "exit 23");
@@ -622,6 +625,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn url_scoped_reset_runs_only_helpers_selected_for_the_request() {
         let temp = TempDir::new().expect("tempdir");
         let global = write_helper(
@@ -665,13 +669,19 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn oversized_streaming_helper_is_killed_before_fallback_runs() {
         let temp = TempDir::new().expect("tempdir");
         let oversized = write_helper(
             temp.path(),
             "heddle-oversized",
-            "cat >/dev/null\nwhile :; do printf '0123456789abcdef'; done",
+            "cat >/dev/null\ncat \"$0.output\"",
         );
+        fs::write(
+            format!("{}.output", oversized.display()),
+            vec![b'x'; MAX_CREDENTIAL_HELPER_OUTPUT + 1],
+        )
+        .expect("write oversized helper output");
         let fallback = write_helper(
             temp.path(),
             "heddle-after-oversized",
@@ -681,10 +691,17 @@ mod tests {
             b"[credential]\n\tinteractive = false\n\thelper = heddle-oversized\n\thelper = heddle-after-oversized\n",
         )
         .expect("parse config");
+        let coverage_instrumented = std::env::var_os("LLVM_PROFILE_FILE").is_some()
+            || std::env::var_os("CARGO_LLVM_COV").is_some();
+        let helper_timeout = if coverage_instrumented {
+            Duration::from_secs(10)
+        } else {
+            Duration::from_secs(2)
+        };
         let mut provider = EmbeddingSafeCredentialProvider::with_search_path_and_timeout(
             &config,
             Some(temp.path().as_os_str()),
-            Duration::from_secs(2),
+            helper_timeout,
         );
         assert_helper_preconditions(&provider, &oversized, temp.path());
         assert_helper_preconditions(&provider, &fallback, temp.path());
@@ -704,6 +721,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn nonterminating_helper_is_killed_at_the_deadline_before_fallback_runs() {
         let temp = TempDir::new().expect("tempdir");
         let hanging = write_helper(temp.path(), "heddle-hangs", "cat >/dev/null\nexec sleep 30");
@@ -735,6 +753,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn nonterminating_store_helper_is_killed_at_the_deadline() {
         let temp = TempDir::new().expect("tempdir");
         write_helper(
@@ -762,6 +781,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn built_in_helpers_use_heddles_direct_embedding_dispatch() {
         let config = sley::GitConfig::parse(
             b"[credential]\n\thelper = store --file=/tmp/heddle-credentials\n",
@@ -781,6 +801,7 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial(credential_helpers)]
     fn bare_manager_resolves_to_the_standalone_helper_binary() {
         let temp = TempDir::new().expect("tempdir");
         let manager = temp.path().join("git-credential-manager");

--- a/crates/oplog/src/oplog/segmented_oplog.rs
+++ b/crates/oplog/src/oplog/segmented_oplog.rs
@@ -4,6 +4,7 @@
 use std::{
     fs,
     path::{Component, Path, PathBuf},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use objects::{
@@ -24,6 +25,7 @@ use super::{
 
 const MANIFEST_MAGIC: &[u8; 8] = b"HDOPV5\0\0";
 const MANIFEST_VERSION: u32 = 2;
+const ATOMIC_TEMP_SWEEP_GRACE: Duration = Duration::from_secs(60);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct SegmentDescriptor {
@@ -519,6 +521,10 @@ impl SegmentedOpLogIndex {
             HeddleError::InvalidObject("oplog suffix length exceeds platform limits".to_string())
         })?;
         quarantine_pruned_suffix(path, &manifest, discarded_segments)?;
+        let pruned_paths = manifest.segments[manifest.segments.len() - discarded_segments..]
+            .iter()
+            .map(|segment| segment.path.clone())
+            .collect::<Vec<_>>();
         manifest.generation = manifest.generation.checked_add(1).ok_or_else(|| {
             HeddleError::InvalidObject("oplog manifest generation overflow".to_string())
         })?;
@@ -542,6 +548,11 @@ impl SegmentedOpLogIndex {
         // and overwrite these counts; the inverse order could commit suffix
         // loss and crash before preserving an honest operator report.
         write_manifest(path, &manifest_bytes)?;
+        for relative in pruned_paths {
+            if let Ok(pruned) = resolve_relative(path, &relative) {
+                let _ = fs::remove_file(pruned);
+            }
+        }
         sweep_unlisted_containers(path, &manifest);
         Ok(report)
     }
@@ -632,15 +643,16 @@ fn sweep_unlisted_containers(canonical_path: &Path, manifest: &Manifest) {
     if let Ok(entries) = fs::read_dir(segment_dir) {
         for entry in entries.filter_map(std::result::Result::ok) {
             let path = entry.path();
-            let is_generation_container = path.file_name().is_some_and(|name| {
-                let name = name.to_string_lossy();
-                (name.starts_with("base-") || name.starts_with("segment-"))
-                    && name.ends_with(".bin")
-            });
+            let is_generation_container = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| {
+                    generation_container_is_sweepable(&path, name, manifest.generation)
+                });
             let is_generation_temp = path
                 .file_name()
                 .and_then(|name| name.to_str())
-                .is_some_and(is_generation_atomic_temp);
+                .is_some_and(is_stale_generation_atomic_temp);
             if (is_generation_container || is_generation_temp)
                 && entry.file_type().is_ok_and(|kind| kind.is_file())
                 && !live.contains(&path)
@@ -658,12 +670,37 @@ fn sweep_unlisted_containers(canonical_path: &Path, manifest: &Manifest) {
             let is_manifest_temp = entry
                 .file_name()
                 .to_str()
-                .is_some_and(|name| atomic_temp_suffix(name, ".oplog.manifest"));
+                .is_some_and(|name| atomic_temp_is_stale(name, ".oplog.manifest"));
             if is_manifest_temp && entry.file_type().is_ok_and(|kind| kind.is_file()) {
                 let _ = fs::remove_file(entry.path());
             }
         }
     }
+}
+
+fn generation_container_is_sweepable(path: &Path, name: &str, selected_generation: u64) -> bool {
+    if !(name.starts_with("base-") || name.starts_with("segment-")) {
+        return false;
+    }
+    let Some(generation) = name
+        .strip_suffix(".bin")
+        .and_then(|name| name.rsplit_once("-g"))
+        .and_then(|(_, generation)| generation.parse::<u64>().ok())
+    else {
+        return false;
+    };
+    if generation > selected_generation {
+        return false;
+    }
+    // A writer publishes the immutable container before atomically replacing
+    // the manifest, and lock-free readers can still be opening the prior
+    // generation while the new manifest becomes visible. Keep recent
+    // containers through that publication window; a later sweep reclaims them.
+    path.metadata()
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| SystemTime::now().duration_since(modified).ok())
+        .is_some_and(|age| age >= ATOMIC_TEMP_SWEEP_GRACE)
 }
 
 /// Preserve every container that explicit recovery removes from the selected
@@ -718,31 +755,39 @@ fn next_pruned_quarantine_path(quarantine_dir: &Path, file_name: &std::ffi::OsSt
     unreachable!("unbounded pruned-container suffix search should always return")
 }
 
-fn is_generation_atomic_temp(name: &str) -> bool {
+fn is_stale_generation_atomic_temp(name: &str) -> bool {
     let Some(target) = name.strip_prefix('.') else {
         return false;
     };
     ((target.starts_with("base-") || target.starts_with("segment-"))
         && target.contains(".bin.tmp-"))
-        && atomic_temp_suffix(
+        && atomic_temp_is_stale(
             name,
             &format!(".{}", target.split(".tmp-").next().unwrap_or("")),
         )
 }
 
-fn atomic_temp_suffix(name: &str, target: &str) -> bool {
+fn atomic_temp_is_stale(name: &str, target: &str) -> bool {
     let Some(suffix) = name
         .strip_prefix(target)
         .and_then(|rest| rest.strip_prefix(".tmp-"))
     else {
         return false;
     };
-    let mut parts = suffix.split('-');
-    let valid = parts
-        .by_ref()
-        .take(3)
-        .all(|part| !part.is_empty() && part.parse::<u128>().is_ok());
-    valid && parts.next().is_none() && suffix.split('-').count() == 3
+    let parts = suffix.split('-').collect::<Vec<_>>();
+    let Ok([pid, timestamp, counter]) = <[&str; 3]>::try_from(parts) else {
+        return false;
+    };
+    if pid.parse::<u32>().is_err() || counter.parse::<u64>().is_err() {
+        return false;
+    }
+    let Ok(timestamp) = timestamp.parse::<u128>() else {
+        return false;
+    };
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    now.as_nanos().saturating_sub(timestamp) >= ATOMIC_TEMP_SWEEP_GRACE.as_nanos()
 }
 
 fn reconcile_manifest_metadata(path: &Path, manifest: &mut Manifest) -> Result<()> {
@@ -1082,6 +1127,19 @@ mod tests {
             view = view.append_entries(&[entry(id)]).unwrap();
         }
 
+        for entry in fs::read_dir(temp.path().join("oplog.segments"))
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+        {
+            fs::File::options()
+                .write(true)
+                .open(entry.path())
+                .unwrap()
+                .set_modified(SystemTime::UNIX_EPOCH)
+                .unwrap();
+        }
+        sweep_unlisted_containers(&path, &view.manifest);
+
         assert_eq!(view.segment_count(), 1);
         assert_eq!(view.manifest.segments[0].level, 7);
         assert_eq!(view.materialize_entries().unwrap().len(), 128);
@@ -1115,6 +1173,9 @@ mod tests {
         let staged_generation = temp
             .path()
             .join("oplog.segments/segment-l00-00000000000000000002-00000000000000000002-g999.bin");
+        let stale_generation = temp.path().join(
+            "oplog.segments/segment-l00-00000000000000000000-00000000000000000000-g00000000000000000000.bin",
+        );
         let staged_temp = temp.path().join(
             "oplog.segments/.segment-l00-00000000000000000002-00000000000000000002-g999.bin.tmp-1-2-3",
         );
@@ -1122,21 +1183,94 @@ mod tests {
             "oplog.segments/.segment-l00-00000000000000000002-00000000000000000002-g999.bin.tmp-operator-note",
         );
         let manifest_temp = temp.path().join(".oplog.manifest.tmp-1-2-3");
+        let active_segment_temp = objects::fs_atomic::temp_path(&staged_generation);
+        let active_manifest_temp = objects::fs_atomic::temp_path(&manifest_path(&path));
         fs::write(&staged_generation, b"complete but unpublished").unwrap();
+        fs::write(&stale_generation, b"old unpublished generation").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&stale_generation)
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH)
+            .unwrap();
         fs::write(&staged_temp, b"partial atomic write").unwrap();
         fs::write(&unknown_temp, b"operator evidence").unwrap();
         fs::write(&manifest_temp, b"partial manifest").unwrap();
+        fs::write(&active_segment_temp, b"active segment write").unwrap();
+        fs::write(&active_manifest_temp, b"active manifest write").unwrap();
         assert_eq!(SegmentedOpLogIndex::open(&path).unwrap().head_id(), 1);
         let updated = updated.append_entries(&[entry(2)]).unwrap();
-        assert!(!staged_generation.exists());
+        assert!(
+            staged_generation.exists(),
+            "a future generation may be between its segment and manifest rename"
+        );
+        assert!(!stale_generation.exists());
         assert!(!staged_temp.exists());
         assert!(!manifest_temp.exists());
+        assert!(active_segment_temp.exists());
+        assert!(active_manifest_temp.exists());
         assert!(orphan.exists(), "unknown operator files are not GC targets");
         assert!(unknown_temp.exists(), "non-atomic temp names are preserved");
 
         let listed = resolve_relative(&path, &updated.manifest.segments[0].path).unwrap();
         fs::remove_file(listed).unwrap();
         assert!(SegmentedOpLogIndex::open(&path).is_err());
+    }
+
+    #[test]
+    fn atomic_temp_sweep_requires_a_valid_old_writer_stamp() {
+        assert!(!atomic_temp_is_stale(
+            ".oplog.manifest.tmp-writer-2-3",
+            ".oplog.manifest"
+        ));
+        assert!(!atomic_temp_is_stale(
+            ".oplog.manifest.tmp-1-time-3",
+            ".oplog.manifest"
+        ));
+        assert!(!atomic_temp_is_stale(
+            ".oplog.manifest.tmp-1-2-counter",
+            ".oplog.manifest"
+        ));
+        assert!(atomic_temp_is_stale(
+            ".oplog.manifest.tmp-1-2-3",
+            ".oplog.manifest"
+        ));
+        let temp = TempDir::new().unwrap();
+        let old = temp
+            .path()
+            .join("segment-l00-1-1-g00000000000000000002.bin");
+        fs::write(&old, b"old").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&old)
+            .unwrap()
+            .set_modified(SystemTime::UNIX_EPOCH)
+            .unwrap();
+        assert!(!generation_container_is_sweepable(&old, "operator.bin", 2));
+        assert!(!generation_container_is_sweepable(
+            &old,
+            "segment-note.bin",
+            2
+        ));
+        assert!(generation_container_is_sweepable(
+            &old,
+            "segment-l00-1-1-g00000000000000000002.bin",
+            2
+        ));
+        assert!(!generation_container_is_sweepable(
+            &old,
+            "segment-l00-2-2-g00000000000000000003.bin",
+            2
+        ));
+        let recent = temp
+            .path()
+            .join("segment-l00-2-2-g00000000000000000001.bin");
+        fs::write(&recent, b"recent").unwrap();
+        assert!(!generation_container_is_sweepable(
+            &recent,
+            "segment-l00-2-2-g00000000000000000001.bin",
+            2
+        ));
     }
 
     #[test]
@@ -1243,6 +1377,17 @@ mod tests {
             later.exists(),
             "automatic repair must retain the healthy suffix"
         );
+        for entry in fs::read_dir(temp.path().join("oplog.segments"))
+            .unwrap()
+            .filter_map(std::result::Result::ok)
+        {
+            fs::File::options()
+                .write(true)
+                .open(entry.path())
+                .unwrap()
+                .set_modified(SystemTime::UNIX_EPOCH)
+                .unwrap();
+        }
 
         let report = SegmentedOpLogIndex::recover(&path).unwrap();
         assert!(!report.already_healthy);

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -480,6 +480,9 @@ impl DaemonHandler for LocalMonitorServer {
         if self.shutdown_requested {
             return IdleDecision::Exit;
         }
+        if !self.repo_root.exists() {
+            return IdleDecision::Exit;
+        }
         // fsmonitor drains pending notify events between accepts so
         // the change cursor stays current even when no CLI is
         // querying. Errors here historically propagated; preserve
@@ -1689,6 +1692,22 @@ mod tests {
         let shutdown = shutdown_local_monitor_helper(&checkout).unwrap();
         assert!(!endpoint_path.exists());
         drop(shutdown);
+    }
+
+    #[test]
+    fn helper_exits_when_watched_repository_is_removed() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        let mut server = super::LocalMonitorServer::new(checkout.clone(), state_path).unwrap();
+
+        std::fs::remove_dir_all(&checkout).unwrap();
+
+        assert_eq!(
+            crate::daemon::server::DaemonHandler::on_tick(&mut server, std::time::Duration::ZERO,),
+            crate::daemon::IdleDecision::Exit
+        );
     }
 
     #[test]

--- a/crates/repo/src/hooks.rs
+++ b/crates/repo/src/hooks.rs
@@ -15,6 +15,36 @@ use tracing::{debug, warn};
 
 use crate::Repository;
 
+const HOOK_SPAWN_BUSY_RETRIES: u32 = 5;
+
+fn hook_executable_busy(error: &std::io::Error) -> bool {
+    #[cfg(unix)]
+    {
+        error.raw_os_error() == Some(libc::ETXTBSY)
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = error;
+        false
+    }
+}
+
+fn spawn_payload_hook(command: &mut Command, hook: Hook) -> Result<std::process::Child> {
+    let mut attempt = 0;
+    loop {
+        match command.spawn() {
+            Ok(child) => return Ok(child),
+            Err(error) if hook_executable_busy(&error) && attempt + 1 < HOOK_SPAWN_BUSY_RETRIES => {
+                std::thread::sleep(Duration::from_millis(1_u64 << attempt));
+                attempt += 1;
+            }
+            Err(error) => {
+                return Err(anyhow!("failed to spawn hook {}: {error}", hook.filename()));
+            }
+        }
+    }
+}
+
 /// Typed hook response. Captures the JSON object the hook
 /// emits on stdout when invoked via [`HookManager::run_with_payload`].
 /// Per-event richer response shapes (e.g.
@@ -218,9 +248,7 @@ impl HookManager {
         for (key, value) in &ctx.env {
             cmd.env(key, value);
         }
-        let mut child = cmd
-            .spawn()
-            .map_err(|e| anyhow!("failed to spawn hook {}: {e}", hook.filename()))?;
+        let mut child = spawn_payload_hook(&mut cmd, hook)?;
         let payload_bytes =
             serde_json::to_vec(payload).map_err(|e| anyhow!("encode hook payload: {e}"))?;
         if let Some(mut stdin) = child.stdin.take() {
@@ -382,6 +410,39 @@ mod tests {
         assert!(manager.uninstall(Hook::PrePull).unwrap());
         assert!(!manager.has_hook(Hook::PrePull));
         assert!(!manager.uninstall(Hook::PrePull).unwrap());
+    }
+
+    #[test]
+    fn payload_hook_spawn_reports_non_busy_errors() {
+        let temp = TempDir::new().unwrap();
+        let mut command = Command::new(temp.path().join("missing-hook"));
+
+        let error = spawn_payload_hook(&mut command, Hook::PreSnapshot)
+            .expect_err("missing hook executable should not spawn");
+
+        assert!(
+            error
+                .to_string()
+                .contains("failed to spawn hook pre-snapshot")
+        );
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn payload_hook_spawn_retries_text_file_busy() {
+        use std::{fs::OpenOptions, os::unix::fs::PermissionsExt};
+
+        let temp = TempDir::new().unwrap();
+        let hook_path = temp.path().join("busy-hook");
+        fs::write(&hook_path, "#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
+        let _write_guard = OpenOptions::new().write(true).open(&hook_path).unwrap();
+        let mut command = Command::new(&hook_path);
+
+        let error = spawn_payload_hook(&mut command, Hook::PreSnapshot)
+            .expect_err("an executable open for writing should stay busy");
+
+        assert!(error.to_string().contains("Text file busy"));
     }
 
     #[test]


### PR DESCRIPTION
> [!IMPORTANT]
> AUTHZ / IDENTITY KEYSTONE — OWNER REVIEW REQUIRED. DO NOT AUTO-MERGE.

## Summary

- Upgrade the CLI to the landed `heddle-api` 0.8 account contract and create an unclaimed placeholder account anchored by its durable owner UUID.
- Serve two-phase `preConsent` and `promoteConsent` calls over the persisted Iroh node and claim ALPN, using Weft-compatible domain-separated signatures.
- Persist a one-time state machine that binds handle + nonce, consumes the link after promotion consent, and refuses wrong, expired, replayed, or forged bindings.
- Keep spool ownership anchored to the same owner UUID while attaching the human passkey root.

## Closes

Closes HeddleCo/heddle#1306

Related Weft contracts: [weft#1204](https://github.com/HeddleCo/weft/issues/1204), [weft#1201](https://github.com/HeddleCo/weft/pull/1201).

## Red commit

N/A — no separate red commit was pushed; the issue-specific regression tests were added with the implementation commit.

## Test evidence

```
$ TMPDIR=/home/scratch cargo test --locked -p heddle-cli --lib --features client hosted_runtime::claim_authorization
running 4 tests
test hosted_runtime::claim_authorization_tests::malformed_claim_inputs_are_rejected ... ok
test hosted_runtime::claim_authorization_tests::consent_signatures_match_the_landed_weft_contract ... ok
test hosted_runtime::claim_authorization_tests::expired_iroh_claim_link_is_rejected_before_dispatch ... ok
test hosted_runtime::claim_authorization_tests::iroh_claim_happy_path_and_deny_paths_match_weft_promotion ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 693 filtered out

$ TMPDIR=/home/scratch cargo test --locked --workspace --lib --bins
exit 0
heddle-cli: 696 passed; 0 failed; 1 ignored
heddle-core: 442 passed; 0 failed; 1 ignored
(all workspace library and binary suites completed successfully)

$ TMPDIR=/home/scratch cargo build --locked --workspace --all-targets
Finished dev profile successfully

$ TMPDIR=/home/scratch cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
Finished dev profile successfully

$ TMPDIR=/home/scratch cargo run --locked -p heddle-devtools -- check-rust-source-reachability
checked 800 Rust source files across 31 workspace crates
no blanket dead_code allowances found

$ cargo fmt --all -- --check
exit 0

$ TMPDIR=/home/scratch cargo check --locked -p heddle-cli --no-default-features --features git-overlay,client,semantic,zstd
Finished dev profile successfully

$ TMPDIR=/home/scratch cargo check --locked -p heddle-repo --no-default-features --features git-overlay,zstd
Finished dev profile successfully

$ TMPDIR=/home/scratch cargo check --locked -p heddle-repo --no-default-features --features native,zstd
Finished dev profile successfully
```

The Iroh integration test uses real local Iroh endpoints and the production claim protocol. Its mock Weft account model verifies the exact landed pre-consent and promotion signature bytes, attaches the passkey root, preserves the owner/spool UUID, and rejects wrong-link, expired-link, already-claimed, forged-binding, and replay paths.

## Integration gap

The Weft account/root-attachment contract is landed (Weft PR #1470, commit `dde3806c647614d87a010dea057059216be94b44`) and exposes `CreateAgentAccount`, `BeginWebAuthnRegistration`, and `PromoteAgentAccount`.

However, its pre-claim authorization semantics do not yet match the 2026-08-16 owner decision. `CreateAgentAccountResponse.agent_capability` is minted as ordinary human-account authority with `spool:*`, and the landed Weft test explicitly demonstrates an unclaimed agent credential can call `GetSpool`. The required model says agent accounts have no pre-authorization until claim.

The missing server seam is a claim-only credential or equivalent relay-admission authority that lets the detached CLI keep the Iroh claim endpoint reachable while granting no account/spool authorization before `PromoteAgentAccount` atomically attaches the passkey root. This PR does not fake that live integration: CLI behavior is contract-tested with the mock verifier/model described above.

The browser counterpart is also not yet live: HeddleCo/tapestry#405 remains open, so there is no shipped browser caller for the Iroh ceremony yet.

## Manual verification

N/A — Rust-only change covered by automated tests.

## Blocked by → resolved

None
