### PR TITLE
refactor(cli): consolidate Phase 3 namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   treats a missing residual as a hard error.
 
 - **Offline provenance verification.** `heddle verify --provenance` and
-  `heddle fsck --thorough --provenance` check content integrity,
+  `heddle maintenance fsck --thorough --provenance` check content integrity,
   domain-tagged authorship, registry identity, and review signatures, and
   emit only exact fail-closed statuses.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Heddle is an agent-native version control CLI written in Rust. It keeps its own 
 - local captures and Git-compatible commits with explicit human and agent attribution
 - content-addressed immutable history with stable change identifiers that survive rewrites
 - provenance-aware inspection (`heddle query --attribution`, `heddle show`, `heddle diff`)
+- separate coordination surfaces for writer leases (`heddle agent`) and acting-worker context (`heddle presence`)
+- explicit maintenance and interoperability namespaces (`heddle maintenance`, `heddle bridge git`)
 
 ```bash
 cargo install heddle-cli
@@ -137,9 +139,18 @@ heddle push
 heddle log
 heddle diff HEAD~1 HEAD
 heddle query --attribution path/to/file.rs
+
+# Inspect acting-worker context separately from writer authority
+heddle presence list
+
+# Run advanced integrity and Git projection operations
+heddle maintenance fsck --full
+heddle bridge git export --destination ../project.git
 ```
 
 `heddle status` reports the current branch or thread, what is dirty, whether another operation is in progress, and the recommended next command. The same `recommended_action` field is carried through `heddle doctor`, `heddle thread show`, and `heddle status` for programmatic use.
+
+`heddle presence` reports attribution and active-work context without granting write authority; lease-backed mutations remain under `heddle agent`. Repository integrity checks live under `heddle maintenance fsck`, while explicit Git import/export lives under `heddle bridge git`. These namespaces keep operational plumbing available without expanding the everyday verb surface.
 
 In Git-overlay repositories, `heddle land` projects a landed thread as one atomic Git commit by default. The original per-State captures remain in Heddle history. Use `heddle land --no-squash` for a single invocation that should export one Git commit per State.
 

--- a/clients/npm/README.md
+++ b/clients/npm/README.md
@@ -183,7 +183,7 @@ canonical verbs; the doc column links the field-by-field reference.
 | diff | `diff` | `DiffSchema` | `heddle diff --output json` |
 | pull | `pull` | `PullSchema` | (transport schemas) |
 | push | `push` | `PushSchema` | (transport schemas) |
-| export | `export git` | `BridgeExportSchema` | `heddle export git --output json` |
+| export | `bridge git export` | `BridgeExportSchema` | `heddle bridge git export --output json` |
 
 ## `--op-id` retry convention
 

--- a/clients/npm/generated/heddle-schemas.json
+++ b/clients/npm/generated/heddle-schemas.json
@@ -3677,2626 +3677,6 @@
       "title": "AgentReservationListSchema",
       "type": "object"
     },
-    "agent presence complete": {
-      "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "MachineContractCoverageSchema": {
-          "properties": {
-            "accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "accepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope": {
-              "type": "string"
-            },
-            "advanced_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "advanced_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "documented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "jsonl_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "missing_mutating_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "supports_op_id_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "unaccepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "unaccepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "undocumented_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "undocumented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope": {
-              "type": "string"
-            },
-            "verified_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "status",
-            "verified_scope",
-            "advanced_scope",
-            "summary",
-            "catalog_commands_total",
-            "catalog_mutating_commands_total",
-            "json_commands_total",
-            "json_mutating_commands_total",
-            "json_commands_with_schema",
-            "json_commands_with_accepted_opaque_schema",
-            "json_commands_without_schema",
-            "verified_scope_json_commands_total",
-            "verified_scope_json_commands_with_schema",
-            "verified_scope_json_commands_with_accepted_opaque_schema",
-            "verified_scope_json_commands_without_schema",
-            "advanced_scope_json_commands_total",
-            "advanced_scope_json_commands_with_accepted_opaque_schema",
-            "mutating_commands_total",
-            "mutating_commands_with_schema",
-            "mutating_commands_with_accepted_opaque_schema",
-            "mutating_commands_without_schema",
-            "verified_scope_mutating_commands_total",
-            "verified_scope_mutating_commands_with_schema",
-            "verified_scope_mutating_commands_with_accepted_opaque_schema",
-            "verified_scope_mutating_commands_without_schema",
-            "advanced_scope_mutating_commands_total",
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-            "schema_verbs_total",
-            "documented_schema_verbs_total",
-            "undocumented_schema_verbs_total",
-            "opaque_schema_verbs_total",
-            "accepted_opaque_schema_verbs_total",
-            "unaccepted_opaque_schema_verbs_total",
-            "supports_op_id_total",
-            "jsonl_commands_total",
-            "missing_schema_examples",
-            "missing_mutating_schema_examples",
-            "verified_scope_missing_schema_examples",
-            "verified_scope_accepted_opaque_schema_examples",
-            "advanced_scope_accepted_opaque_schema_examples",
-            "accepted_opaque_schema_examples",
-            "unaccepted_opaque_schema_examples",
-            "undocumented_schema_examples"
-          ],
-          "type": "object"
-        },
-        "RepositoryVerificationStateSchema": {
-          "properties": {
-            "active_operation": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "checks": {
-              "items": {
-                "$ref": "#/$defs/VerificationCheckSchema"
-              },
-              "type": "array"
-            },
-            "clone_verification": {
-              "type": "string"
-            },
-            "default_remote": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git_branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_initialized": {
-              "type": "boolean"
-            },
-            "heddle_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "import_state": {
-              "type": "string"
-            },
-            "machine_contract": {
-              "type": "string"
-            },
-            "machine_contract_coverage": {
-              "$ref": "#/$defs/MachineContractCoverageSchema"
-            },
-            "mapping_state": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_drift": {
-              "type": "string"
-            },
-            "repository_mode": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "verified": {
-              "type": "boolean"
-            },
-            "workflow_status": {
-              "type": "string"
-            },
-            "workflow_summary": {
-              "type": "string"
-            },
-            "worktree_dirty": {
-              "type": "boolean"
-            },
-            "worktree_state": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "verified",
-            "status",
-            "repository_mode",
-            "heddle_initialized",
-            "worktree_dirty",
-            "worktree_state",
-            "import_state",
-            "mapping_state",
-            "remote_drift",
-            "clone_verification",
-            "machine_contract",
-            "machine_contract_coverage",
-            "workflow_status",
-            "workflow_summary",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "checks"
-          ],
-          "type": "object"
-        },
-        "VerificationCheckSchema": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "details": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "status",
-            "clean",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "details"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "coordination_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "idempotency_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "op_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "operation_record": {
-          "anyOf": [
-            {
-              "properties": {
-                "command": {
-                  "type": "string"
-                },
-                "idempotency_status": {
-                  "type": "string"
-                },
-                "op_id": {
-                  "type": "string"
-                },
-                "replayed": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "command",
-                "idempotency_status",
-                "op_id",
-                "replayed"
-              ],
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "output_kind": {
-          "enum": [
-            "agent_presence_complete"
-          ],
-          "type": "string"
-        },
-        "recommended_action": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recommended_action_template": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActionTemplateSchema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "replayed": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "session_id": {
-          "type": "string"
-        },
-        "status": {
-          "type": "string"
-        },
-        "thread": {
-          "type": "string"
-        },
-        "verification": {
-          "$ref": "#/$defs/RepositoryVerificationStateSchema"
-        }
-      },
-      "required": [
-        "output_kind",
-        "session_id",
-        "status",
-        "thread",
-        "verification"
-      ],
-      "title": "AgentPresenceCompleteSchema",
-      "type": "object"
-    },
-    "agent presence explain": {
-      "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "MachineContractCoverageSchema": {
-          "properties": {
-            "accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "accepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope": {
-              "type": "string"
-            },
-            "advanced_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "advanced_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "documented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "jsonl_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "missing_mutating_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "supports_op_id_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "unaccepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "unaccepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "undocumented_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "undocumented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope": {
-              "type": "string"
-            },
-            "verified_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "status",
-            "verified_scope",
-            "advanced_scope",
-            "summary",
-            "catalog_commands_total",
-            "catalog_mutating_commands_total",
-            "json_commands_total",
-            "json_mutating_commands_total",
-            "json_commands_with_schema",
-            "json_commands_with_accepted_opaque_schema",
-            "json_commands_without_schema",
-            "verified_scope_json_commands_total",
-            "verified_scope_json_commands_with_schema",
-            "verified_scope_json_commands_with_accepted_opaque_schema",
-            "verified_scope_json_commands_without_schema",
-            "advanced_scope_json_commands_total",
-            "advanced_scope_json_commands_with_accepted_opaque_schema",
-            "mutating_commands_total",
-            "mutating_commands_with_schema",
-            "mutating_commands_with_accepted_opaque_schema",
-            "mutating_commands_without_schema",
-            "verified_scope_mutating_commands_total",
-            "verified_scope_mutating_commands_with_schema",
-            "verified_scope_mutating_commands_with_accepted_opaque_schema",
-            "verified_scope_mutating_commands_without_schema",
-            "advanced_scope_mutating_commands_total",
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-            "schema_verbs_total",
-            "documented_schema_verbs_total",
-            "undocumented_schema_verbs_total",
-            "opaque_schema_verbs_total",
-            "accepted_opaque_schema_verbs_total",
-            "unaccepted_opaque_schema_verbs_total",
-            "supports_op_id_total",
-            "jsonl_commands_total",
-            "missing_schema_examples",
-            "missing_mutating_schema_examples",
-            "verified_scope_missing_schema_examples",
-            "verified_scope_accepted_opaque_schema_examples",
-            "advanced_scope_accepted_opaque_schema_examples",
-            "accepted_opaque_schema_examples",
-            "unaccepted_opaque_schema_examples",
-            "undocumented_schema_examples"
-          ],
-          "type": "object"
-        },
-        "RepositoryVerificationStateSchema": {
-          "properties": {
-            "active_operation": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "checks": {
-              "items": {
-                "$ref": "#/$defs/VerificationCheckSchema"
-              },
-              "type": "array"
-            },
-            "clone_verification": {
-              "type": "string"
-            },
-            "default_remote": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git_branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_initialized": {
-              "type": "boolean"
-            },
-            "heddle_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "import_state": {
-              "type": "string"
-            },
-            "machine_contract": {
-              "type": "string"
-            },
-            "machine_contract_coverage": {
-              "$ref": "#/$defs/MachineContractCoverageSchema"
-            },
-            "mapping_state": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_drift": {
-              "type": "string"
-            },
-            "repository_mode": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "verified": {
-              "type": "boolean"
-            },
-            "workflow_status": {
-              "type": "string"
-            },
-            "workflow_summary": {
-              "type": "string"
-            },
-            "worktree_dirty": {
-              "type": "boolean"
-            },
-            "worktree_state": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "verified",
-            "status",
-            "repository_mode",
-            "heddle_initialized",
-            "worktree_dirty",
-            "worktree_state",
-            "import_state",
-            "mapping_state",
-            "remote_drift",
-            "clone_verification",
-            "machine_contract",
-            "machine_contract_coverage",
-            "workflow_status",
-            "workflow_summary",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "checks"
-          ],
-          "type": "object"
-        },
-        "VerificationCheckSchema": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "details": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "status",
-            "clean",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "details"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "active_presence": true,
-        "attach_precedence": {
-          "items": {
-            "type": "string"
-          },
-          "type": [
-            "array",
-            "null"
-          ]
-        },
-        "attach_reason": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "attached": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "client_instance_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "detected": true,
-        "environment": true,
-        "heddle_session_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "native_actor_key": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "native_instance_key": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "native_parent_actor_key": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "output_kind": {
-          "enum": [
-            "agent_presence_explain"
-          ],
-          "type": "string"
-        },
-        "probe_confidence": {
-          "format": "float",
-          "type": [
-            "number",
-            "null"
-          ]
-        },
-        "probe_source": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "reason": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recommended_action": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recommended_action_template": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActionTemplateSchema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "repository": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "session_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "thread": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "verification": {
-          "$ref": "#/$defs/RepositoryVerificationStateSchema"
-        },
-        "winning_rule": {
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "output_kind",
-        "verification"
-      ],
-      "title": "AgentPresenceExplainSchema",
-      "type": "object"
-    },
-    "agent presence list": {
-      "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "ActorChainEntrySchema": {
-          "properties": {
-            "harness": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "model": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_parent_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "provider": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "session_id": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "thread": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "session_id",
-            "thread",
-            "status"
-          ],
-          "type": "object"
-        },
-        "ActorEntrySchema": {
-          "properties": {
-            "actor_chain": {
-              "items": {
-                "$ref": "#/$defs/ActorChainEntrySchema"
-              },
-              "type": "array"
-            },
-            "attach_precedence": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "attach_reason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "base_state": {
-              "type": "string"
-            },
-            "client_instance_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "harness": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_session_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "last_progress_at": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "model": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_instance_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_parent_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "path": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "probe_confidence": {
-              "format": "float",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "probe_source": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "provider": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "report_flush_state": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "session_id": {
-              "type": "string"
-            },
-            "started_at": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "thinking_level": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "thread": {
-              "type": "string"
-            },
-            "thread_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "usage_summary": true,
-            "winning_attach_rule": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "session_id",
-            "thread",
-            "base_state",
-            "usage_summary",
-            "attach_precedence",
-            "status",
-            "started_at",
-            "actor_chain"
-          ],
-          "type": "object"
-        },
-        "MachineContractCoverageSchema": {
-          "properties": {
-            "accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "accepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope": {
-              "type": "string"
-            },
-            "advanced_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "advanced_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "documented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "jsonl_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "missing_mutating_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "supports_op_id_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "unaccepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "unaccepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "undocumented_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "undocumented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope": {
-              "type": "string"
-            },
-            "verified_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "status",
-            "verified_scope",
-            "advanced_scope",
-            "summary",
-            "catalog_commands_total",
-            "catalog_mutating_commands_total",
-            "json_commands_total",
-            "json_mutating_commands_total",
-            "json_commands_with_schema",
-            "json_commands_with_accepted_opaque_schema",
-            "json_commands_without_schema",
-            "verified_scope_json_commands_total",
-            "verified_scope_json_commands_with_schema",
-            "verified_scope_json_commands_with_accepted_opaque_schema",
-            "verified_scope_json_commands_without_schema",
-            "advanced_scope_json_commands_total",
-            "advanced_scope_json_commands_with_accepted_opaque_schema",
-            "mutating_commands_total",
-            "mutating_commands_with_schema",
-            "mutating_commands_with_accepted_opaque_schema",
-            "mutating_commands_without_schema",
-            "verified_scope_mutating_commands_total",
-            "verified_scope_mutating_commands_with_schema",
-            "verified_scope_mutating_commands_with_accepted_opaque_schema",
-            "verified_scope_mutating_commands_without_schema",
-            "advanced_scope_mutating_commands_total",
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-            "schema_verbs_total",
-            "documented_schema_verbs_total",
-            "undocumented_schema_verbs_total",
-            "opaque_schema_verbs_total",
-            "accepted_opaque_schema_verbs_total",
-            "unaccepted_opaque_schema_verbs_total",
-            "supports_op_id_total",
-            "jsonl_commands_total",
-            "missing_schema_examples",
-            "missing_mutating_schema_examples",
-            "verified_scope_missing_schema_examples",
-            "verified_scope_accepted_opaque_schema_examples",
-            "advanced_scope_accepted_opaque_schema_examples",
-            "accepted_opaque_schema_examples",
-            "unaccepted_opaque_schema_examples",
-            "undocumented_schema_examples"
-          ],
-          "type": "object"
-        },
-        "RepositoryVerificationStateSchema": {
-          "properties": {
-            "active_operation": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "checks": {
-              "items": {
-                "$ref": "#/$defs/VerificationCheckSchema"
-              },
-              "type": "array"
-            },
-            "clone_verification": {
-              "type": "string"
-            },
-            "default_remote": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git_branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_initialized": {
-              "type": "boolean"
-            },
-            "heddle_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "import_state": {
-              "type": "string"
-            },
-            "machine_contract": {
-              "type": "string"
-            },
-            "machine_contract_coverage": {
-              "$ref": "#/$defs/MachineContractCoverageSchema"
-            },
-            "mapping_state": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_drift": {
-              "type": "string"
-            },
-            "repository_mode": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "verified": {
-              "type": "boolean"
-            },
-            "workflow_status": {
-              "type": "string"
-            },
-            "workflow_summary": {
-              "type": "string"
-            },
-            "worktree_dirty": {
-              "type": "boolean"
-            },
-            "worktree_state": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "verified",
-            "status",
-            "repository_mode",
-            "heddle_initialized",
-            "worktree_dirty",
-            "worktree_state",
-            "import_state",
-            "mapping_state",
-            "remote_drift",
-            "clone_verification",
-            "machine_contract",
-            "machine_contract_coverage",
-            "workflow_status",
-            "workflow_summary",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "checks"
-          ],
-          "type": "object"
-        },
-        "VerificationCheckSchema": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "details": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "status",
-            "clean",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "details"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "active_only": {
-          "type": "boolean"
-        },
-        "output_kind": {
-          "enum": [
-            "agent_presence_list"
-          ],
-          "type": "string"
-        },
-        "presence": {
-          "items": {
-            "$ref": "#/$defs/ActorEntrySchema"
-          },
-          "type": "array"
-        },
-        "verification": {
-          "$ref": "#/$defs/RepositoryVerificationStateSchema"
-        }
-      },
-      "required": [
-        "output_kind",
-        "presence",
-        "active_only",
-        "verification"
-      ],
-      "title": "AgentPresenceListSchema",
-      "type": "object"
-    },
-    "agent presence show": {
-      "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "ActorChainEntrySchema": {
-          "properties": {
-            "harness": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "model": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_parent_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "provider": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "session_id": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "thread": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "session_id",
-            "thread",
-            "status"
-          ],
-          "type": "object"
-        },
-        "ActorEntrySchema": {
-          "properties": {
-            "actor_chain": {
-              "items": {
-                "$ref": "#/$defs/ActorChainEntrySchema"
-              },
-              "type": "array"
-            },
-            "attach_precedence": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "attach_reason": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "base_state": {
-              "type": "string"
-            },
-            "client_instance_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "harness": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_session_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "last_progress_at": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "model": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_instance_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "native_parent_actor_key": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "path": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "probe_confidence": {
-              "format": "float",
-              "type": [
-                "number",
-                "null"
-              ]
-            },
-            "probe_source": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "provider": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "report_flush_state": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "session_id": {
-              "type": "string"
-            },
-            "started_at": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "thinking_level": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "thread": {
-              "type": "string"
-            },
-            "thread_id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "usage_summary": true,
-            "winning_attach_rule": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "session_id",
-            "thread",
-            "base_state",
-            "usage_summary",
-            "attach_precedence",
-            "status",
-            "started_at",
-            "actor_chain"
-          ],
-          "type": "object"
-        },
-        "MachineContractCoverageSchema": {
-          "properties": {
-            "accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "accepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope": {
-              "type": "string"
-            },
-            "advanced_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "advanced_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "catalog_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "documented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "json_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "jsonl_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "missing_mutating_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "supports_op_id_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "unaccepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "unaccepted_opaque_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "undocumented_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "undocumented_schema_verbs_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope": {
-              "type": "string"
-            },
-            "verified_scope_accepted_opaque_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_json_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_json_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_missing_schema_examples": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "verified_scope_mutating_commands_total": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_with_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "verified_scope_mutating_commands_without_schema": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "status",
-            "verified_scope",
-            "advanced_scope",
-            "summary",
-            "catalog_commands_total",
-            "catalog_mutating_commands_total",
-            "json_commands_total",
-            "json_mutating_commands_total",
-            "json_commands_with_schema",
-            "json_commands_with_accepted_opaque_schema",
-            "json_commands_without_schema",
-            "verified_scope_json_commands_total",
-            "verified_scope_json_commands_with_schema",
-            "verified_scope_json_commands_with_accepted_opaque_schema",
-            "verified_scope_json_commands_without_schema",
-            "advanced_scope_json_commands_total",
-            "advanced_scope_json_commands_with_accepted_opaque_schema",
-            "mutating_commands_total",
-            "mutating_commands_with_schema",
-            "mutating_commands_with_accepted_opaque_schema",
-            "mutating_commands_without_schema",
-            "verified_scope_mutating_commands_total",
-            "verified_scope_mutating_commands_with_schema",
-            "verified_scope_mutating_commands_with_accepted_opaque_schema",
-            "verified_scope_mutating_commands_without_schema",
-            "advanced_scope_mutating_commands_total",
-            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
-            "schema_verbs_total",
-            "documented_schema_verbs_total",
-            "undocumented_schema_verbs_total",
-            "opaque_schema_verbs_total",
-            "accepted_opaque_schema_verbs_total",
-            "unaccepted_opaque_schema_verbs_total",
-            "supports_op_id_total",
-            "jsonl_commands_total",
-            "missing_schema_examples",
-            "missing_mutating_schema_examples",
-            "verified_scope_missing_schema_examples",
-            "verified_scope_accepted_opaque_schema_examples",
-            "advanced_scope_accepted_opaque_schema_examples",
-            "accepted_opaque_schema_examples",
-            "unaccepted_opaque_schema_examples",
-            "undocumented_schema_examples"
-          ],
-          "type": "object"
-        },
-        "RepositoryVerificationStateSchema": {
-          "properties": {
-            "active_operation": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "checks": {
-              "items": {
-                "$ref": "#/$defs/VerificationCheckSchema"
-              },
-              "type": "array"
-            },
-            "clone_verification": {
-              "type": "string"
-            },
-            "default_remote": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "git_branch": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "heddle_initialized": {
-              "type": "boolean"
-            },
-            "heddle_thread": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "import_state": {
-              "type": "string"
-            },
-            "machine_contract": {
-              "type": "string"
-            },
-            "machine_contract_coverage": {
-              "$ref": "#/$defs/MachineContractCoverageSchema"
-            },
-            "mapping_state": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "remote_drift": {
-              "type": "string"
-            },
-            "repository_mode": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            },
-            "verified": {
-              "type": "boolean"
-            },
-            "workflow_status": {
-              "type": "string"
-            },
-            "workflow_summary": {
-              "type": "string"
-            },
-            "worktree_dirty": {
-              "type": "boolean"
-            },
-            "worktree_state": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "verified",
-            "status",
-            "repository_mode",
-            "heddle_initialized",
-            "worktree_dirty",
-            "worktree_state",
-            "import_state",
-            "mapping_state",
-            "remote_drift",
-            "clone_verification",
-            "machine_contract",
-            "machine_contract_coverage",
-            "workflow_status",
-            "workflow_summary",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "checks"
-          ],
-          "type": "object"
-        },
-        "VerificationCheckSchema": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "details": {
-              "additionalProperties": {
-                "type": "string"
-              },
-              "type": "object"
-            },
-            "name": {
-              "type": "string"
-            },
-            "recommended_action": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "recommended_action_template": {
-              "anyOf": [
-                {
-                  "$ref": "#/$defs/ActionTemplateSchema"
-                },
-                {
-                  "type": "null"
-                }
-              ]
-            },
-            "recovery_action_templates": {
-              "items": {
-                "$ref": "#/$defs/ActionTemplateSchema"
-              },
-              "type": "array"
-            },
-            "recovery_commands": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "status": {
-              "type": "string"
-            },
-            "summary": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "status",
-            "clean",
-            "summary",
-            "recovery_commands",
-            "recovery_action_templates",
-            "details"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "output_kind": {
-          "enum": [
-            "agent_presence_show"
-          ],
-          "type": "string"
-        },
-        "presence": {
-          "$ref": "#/$defs/ActorEntrySchema"
-        },
-        "verification": {
-          "$ref": "#/$defs/RepositoryVerificationStateSchema"
-        }
-      },
-      "required": [
-        "output_kind",
-        "presence",
-        "verification"
-      ],
-      "title": "AgentPresenceSingleSchema",
-      "type": "object"
-    },
     "agent provenance begin": {
       "$defs": {
         "SessionEntrySchema": {
@@ -11946,6 +9326,328 @@
       "title": "AuthTrustSchema",
       "type": "object"
     },
+    "bridge git export": {
+      "$defs": {
+        "ExportedRefSchema": {
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "tip": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "tip"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "branches": {
+          "items": {
+            "$ref": "#/$defs/ExportedRefSchema"
+          },
+          "type": "array"
+        },
+        "commits_total": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "destination": {
+          "type": "string"
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "markers_synced": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "bridge_git_export"
+          ],
+          "type": "string"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "states_exported": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "tags": {
+          "items": {
+            "$ref": "#/$defs/ExportedRefSchema"
+          },
+          "type": "array"
+        },
+        "threads_synced": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "states_exported",
+        "commits_total",
+        "threads_synced",
+        "markers_synced",
+        "branches",
+        "tags",
+        "destination",
+        "output_kind"
+      ],
+      "title": "ExportGitSchema",
+      "type": "object"
+    },
+    "bridge git import": {
+      "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "LossyImportEntrySchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "git_object": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": "string"
+            },
+            "reason": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "path",
+            "action",
+            "reason"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "already_in_sync": {
+          "type": "boolean"
+        },
+        "branches_synced": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "commits_imported": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "lossy_entries": {
+          "items": {
+            "$ref": "#/$defs/LossyImportEntrySchema"
+          },
+          "type": "array"
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "bridge_git_import"
+          ],
+          "type": "string"
+        },
+        "recommended_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recommended_action_template": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActionTemplateSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "recovery_commands": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "skipped_non_commit_refs": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "states_created": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "status": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "tags_synced": {
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "status",
+        "summary",
+        "commits_imported",
+        "states_created",
+        "branches_synced",
+        "tags_synced",
+        "skipped_non_commit_refs",
+        "lossy_entries",
+        "already_in_sync",
+        "recovery_commands",
+        "output_kind"
+      ],
+      "title": "ImportGitSchema",
+      "type": "object"
+    },
     "capture": {
       "$defs": {
         "ActionTemplateSchema": {
@@ -17097,545 +14799,6 @@
       "title": "ExpandSchema",
       "type": "object"
     },
-    "export git": {
-      "$defs": {
-        "ExportedRefSchema": {
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "tip": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "name",
-            "tip"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "branches": {
-          "items": {
-            "$ref": "#/$defs/ExportedRefSchema"
-          },
-          "type": "array"
-        },
-        "commits_total": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "destination": {
-          "type": "string"
-        },
-        "idempotency_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "markers_synced": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "op_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "operation_record": {
-          "anyOf": [
-            {
-              "properties": {
-                "command": {
-                  "type": "string"
-                },
-                "idempotency_status": {
-                  "type": "string"
-                },
-                "op_id": {
-                  "type": "string"
-                },
-                "replayed": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "command",
-                "idempotency_status",
-                "op_id",
-                "replayed"
-              ],
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "output_kind": {
-          "enum": [
-            "export_git"
-          ],
-          "type": "string"
-        },
-        "replayed": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "states_exported": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "tags": {
-          "items": {
-            "$ref": "#/$defs/ExportedRefSchema"
-          },
-          "type": "array"
-        },
-        "threads_synced": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        }
-      },
-      "required": [
-        "states_exported",
-        "commits_total",
-        "threads_synced",
-        "markers_synced",
-        "branches",
-        "tags",
-        "destination",
-        "output_kind"
-      ],
-      "title": "ExportGitSchema",
-      "type": "object"
-    },
-    "fsck": {
-      "$defs": {
-        "FsckError": {
-          "properties": {
-            "kind": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "object": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "kind",
-            "message"
-          ],
-          "type": "object"
-        },
-        "FsckRepair": {
-          "properties": {
-            "count": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "detail": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "repaired": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "repaired",
-            "detail",
-            "count"
-          ],
-          "type": "object"
-        },
-        "ProvenanceReport": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "registry_hash": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "registry_status": {
-              "type": "string"
-            },
-            "states": {
-              "items": {
-                "$ref": "#/$defs/StateProvenanceVerification"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "clean",
-            "registry_status",
-            "states"
-          ],
-          "type": "object"
-        },
-        "StateProvenanceVerification": {
-          "properties": {
-            "detail": {
-              "type": "string"
-            },
-            "failed_link": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "identity": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "reviewer_identities": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "reviews_verified": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "state_id": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "state_id",
-            "status",
-            "detail",
-            "reviews_verified",
-            "reviewer_identities"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "errors": {
-          "items": {
-            "$ref": "#/$defs/FsckError"
-          },
-          "type": "array"
-        },
-        "git_projection_checked": {
-          "type": "boolean"
-        },
-        "objects_checked": {
-          "format": "uint",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "provenance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ProvenanceReport"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "repair_target": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "repaired": {
-          "type": "boolean"
-        },
-        "repairs": {
-          "items": {
-            "$ref": "#/$defs/FsckRepair"
-          },
-          "type": "array"
-        },
-        "valid": {
-          "type": "boolean"
-        },
-        "warnings": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "valid",
-        "errors",
-        "warnings",
-        "objects_checked",
-        "git_projection_checked",
-        "repaired",
-        "repairs"
-      ],
-      "title": "FsckReport",
-      "type": "object"
-    },
-    "fsck repair git": {
-      "$defs": {
-        "FsckError": {
-          "properties": {
-            "kind": {
-              "type": "string"
-            },
-            "message": {
-              "type": "string"
-            },
-            "object": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
-          },
-          "required": [
-            "kind",
-            "message"
-          ],
-          "type": "object"
-        },
-        "FsckRepair": {
-          "properties": {
-            "count": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "detail": {
-              "type": "string"
-            },
-            "name": {
-              "type": "string"
-            },
-            "repaired": {
-              "type": "boolean"
-            }
-          },
-          "required": [
-            "name",
-            "repaired",
-            "detail",
-            "count"
-          ],
-          "type": "object"
-        },
-        "ProvenanceReport": {
-          "properties": {
-            "clean": {
-              "type": "boolean"
-            },
-            "registry_hash": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "registry_status": {
-              "type": "string"
-            },
-            "states": {
-              "items": {
-                "$ref": "#/$defs/StateProvenanceVerification"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "clean",
-            "registry_status",
-            "states"
-          ],
-          "type": "object"
-        },
-        "StateProvenanceVerification": {
-          "properties": {
-            "detail": {
-              "type": "string"
-            },
-            "failed_link": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "identity": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "reviewer_identities": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "reviews_verified": {
-              "format": "uint",
-              "minimum": 0,
-              "type": "integer"
-            },
-            "state_id": {
-              "type": "string"
-            },
-            "status": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "state_id",
-            "status",
-            "detail",
-            "reviews_verified",
-            "reviewer_identities"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "errors": {
-          "items": {
-            "$ref": "#/$defs/FsckError"
-          },
-          "type": "array"
-        },
-        "git_projection_checked": {
-          "type": "boolean"
-        },
-        "idempotency_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "objects_checked": {
-          "format": "uint",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "op_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "operation_record": {
-          "anyOf": [
-            {
-              "properties": {
-                "command": {
-                  "type": "string"
-                },
-                "idempotency_status": {
-                  "type": "string"
-                },
-                "op_id": {
-                  "type": "string"
-                },
-                "replayed": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "command",
-                "idempotency_status",
-                "op_id",
-                "replayed"
-              ],
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "provenance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ProvenanceReport"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "repair_target": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "repaired": {
-          "type": "boolean"
-        },
-        "repairs": {
-          "items": {
-            "$ref": "#/$defs/FsckRepair"
-          },
-          "type": "array"
-        },
-        "replayed": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "valid": {
-          "type": "boolean"
-        },
-        "warnings": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "valid",
-        "errors",
-        "warnings",
-        "objects_checked",
-        "git_projection_checked",
-        "repaired",
-        "repairs"
-      ],
-      "title": "FsckReport",
-      "type": "object"
-    },
     "help": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
@@ -17909,205 +15072,6 @@
         "subject"
       ],
       "title": "IdentityOutputSchema",
-      "type": "object"
-    },
-    "import git": {
-      "$defs": {
-        "ActionTemplateSchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "agent_may_fill": {
-              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
-              "type": "boolean"
-            },
-            "argv_template": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            "required_inputs": {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            }
-          },
-          "required": [
-            "action",
-            "argv_template",
-            "required_inputs",
-            "agent_may_fill"
-          ],
-          "type": "object"
-        },
-        "LossyImportEntrySchema": {
-          "properties": {
-            "action": {
-              "type": "string"
-            },
-            "git_object": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "path": {
-              "type": "string"
-            },
-            "reason": {
-              "type": "string"
-            }
-          },
-          "required": [
-            "path",
-            "action",
-            "reason"
-          ],
-          "type": "object"
-        }
-      },
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "action": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "already_in_sync": {
-          "type": "boolean"
-        },
-        "branches_synced": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "commits_imported": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "idempotency_status": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "lossy_entries": {
-          "items": {
-            "$ref": "#/$defs/LossyImportEntrySchema"
-          },
-          "type": "array"
-        },
-        "op_id": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "operation_record": {
-          "anyOf": [
-            {
-              "properties": {
-                "command": {
-                  "type": "string"
-                },
-                "idempotency_status": {
-                  "type": "string"
-                },
-                "op_id": {
-                  "type": "string"
-                },
-                "replayed": {
-                  "type": "boolean"
-                }
-              },
-              "required": [
-                "command",
-                "idempotency_status",
-                "op_id",
-                "replayed"
-              ],
-              "type": "object"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "output_kind": {
-          "enum": [
-            "import_git"
-          ],
-          "type": "string"
-        },
-        "recommended_action": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "recommended_action_template": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActionTemplateSchema"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "recovery_commands": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "replayed": {
-          "type": [
-            "boolean",
-            "null"
-          ]
-        },
-        "skipped_non_commit_refs": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "states_created": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "status": {
-          "type": "string"
-        },
-        "summary": {
-          "type": "string"
-        },
-        "tags_synced": {
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        }
-      },
-      "required": [
-        "status",
-        "summary",
-        "commits_imported",
-        "states_created",
-        "branches_synced",
-        "tags_synced",
-        "skipped_non_commit_refs",
-        "lossy_entries",
-        "already_in_sync",
-        "recovery_commands",
-        "output_kind"
-      ],
-      "title": "ImportGitSchema",
       "type": "object"
     },
     "init": {
@@ -20406,6 +17370,422 @@
       "title": "TimelineLogSchema",
       "type": "object"
     },
+    "maintenance fsck": {
+      "$defs": {
+        "FsckError": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "object": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "message"
+          ],
+          "type": "object"
+        },
+        "FsckRepair": {
+          "properties": {
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "repaired": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "repaired",
+            "detail",
+            "count"
+          ],
+          "type": "object"
+        },
+        "ProvenanceReport": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "registry_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "registry_status": {
+              "type": "string"
+            },
+            "states": {
+              "items": {
+                "$ref": "#/$defs/StateProvenanceVerification"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "clean",
+            "registry_status",
+            "states"
+          ],
+          "type": "object"
+        },
+        "StateProvenanceVerification": {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "failed_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewer_identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reviews_verified": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "state_id",
+            "status",
+            "detail",
+            "reviews_verified",
+            "reviewer_identities"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/FsckError"
+          },
+          "type": "array"
+        },
+        "git_projection_checked": {
+          "type": "boolean"
+        },
+        "objects_checked": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "repair_target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repaired": {
+          "type": "boolean"
+        },
+        "repairs": {
+          "items": {
+            "$ref": "#/$defs/FsckRepair"
+          },
+          "type": "array"
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "valid",
+        "errors",
+        "warnings",
+        "objects_checked",
+        "git_projection_checked",
+        "repaired",
+        "repairs"
+      ],
+      "title": "FsckReport",
+      "type": "object"
+    },
+    "maintenance fsck repair git": {
+      "$defs": {
+        "FsckError": {
+          "properties": {
+            "kind": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "object": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "message"
+          ],
+          "type": "object"
+        },
+        "FsckRepair": {
+          "properties": {
+            "count": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "detail": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "repaired": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "name",
+            "repaired",
+            "detail",
+            "count"
+          ],
+          "type": "object"
+        },
+        "ProvenanceReport": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "registry_hash": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "registry_status": {
+              "type": "string"
+            },
+            "states": {
+              "items": {
+                "$ref": "#/$defs/StateProvenanceVerification"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "clean",
+            "registry_status",
+            "states"
+          ],
+          "type": "object"
+        },
+        "StateProvenanceVerification": {
+          "properties": {
+            "detail": {
+              "type": "string"
+            },
+            "failed_link": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "identity": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "reviewer_identities": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "reviews_verified": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "state_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "state_id",
+            "status",
+            "detail",
+            "reviews_verified",
+            "reviewer_identities"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "errors": {
+          "items": {
+            "$ref": "#/$defs/FsckError"
+          },
+          "type": "array"
+        },
+        "git_projection_checked": {
+          "type": "boolean"
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "objects_checked": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProvenanceReport"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "repair_target": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "repaired": {
+          "type": "boolean"
+        },
+        "repairs": {
+          "items": {
+            "$ref": "#/$defs/FsckRepair"
+          },
+          "type": "array"
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "valid": {
+          "type": "boolean"
+        },
+        "warnings": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "valid",
+        "errors",
+        "warnings",
+        "objects_checked",
+        "git_projection_checked",
+        "repaired",
+        "repairs"
+      ],
+      "title": "FsckReport",
+      "type": "object"
+    },
     "maintenance gc": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "additionalProperties": true,
@@ -21470,6 +18850,2626 @@
         "output_kind"
       ],
       "title": "GenericJsonObjectSchema",
+      "type": "object"
+    },
+    "presence complete": {
+      "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "$ref": "#/$defs/MachineContractCoverageSchema"
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "machine_contract_coverage",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "coordination_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "idempotency_status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "op_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "operation_record": {
+          "anyOf": [
+            {
+              "properties": {
+                "command": {
+                  "type": "string"
+                },
+                "idempotency_status": {
+                  "type": "string"
+                },
+                "op_id": {
+                  "type": "string"
+                },
+                "replayed": {
+                  "type": "boolean"
+                }
+              },
+              "required": [
+                "command",
+                "idempotency_status",
+                "op_id",
+                "replayed"
+              ],
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "presence_complete"
+          ],
+          "type": "string"
+        },
+        "recommended_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recommended_action_template": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActionTemplateSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "replayed": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "session_id": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "thread": {
+          "type": "string"
+        },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        }
+      },
+      "required": [
+        "output_kind",
+        "session_id",
+        "status",
+        "thread",
+        "verification"
+      ],
+      "title": "AgentPresenceCompleteSchema",
+      "type": "object"
+    },
+    "presence explain": {
+      "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "$ref": "#/$defs/MachineContractCoverageSchema"
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "machine_contract_coverage",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "active_presence": true,
+        "attach_precedence": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "attach_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "attached": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "client_instance_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "detected": true,
+        "environment": true,
+        "heddle_session_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "native_actor_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "native_instance_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "native_parent_actor_key": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "output_kind": {
+          "enum": [
+            "presence_explain"
+          ],
+          "type": "string"
+        },
+        "probe_confidence": {
+          "format": "float",
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "probe_source": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recommended_action": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "recommended_action_template": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActionTemplateSchema"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "repository": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "session_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "thread": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        },
+        "winning_rule": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "output_kind",
+        "verification"
+      ],
+      "title": "AgentPresenceExplainSchema",
+      "type": "object"
+    },
+    "presence list": {
+      "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "ActorChainEntrySchema": {
+          "properties": {
+            "harness": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_parent_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "thread": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "session_id",
+            "thread",
+            "status"
+          ],
+          "type": "object"
+        },
+        "ActorEntrySchema": {
+          "properties": {
+            "actor_chain": {
+              "items": {
+                "$ref": "#/$defs/ActorChainEntrySchema"
+              },
+              "type": "array"
+            },
+            "attach_precedence": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "attach_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "base_state": {
+              "type": "string"
+            },
+            "client_instance_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "harness": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "last_progress_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_instance_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_parent_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "probe_confidence": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "probe_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "report_flush_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session_id": {
+              "type": "string"
+            },
+            "started_at": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "thinking_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "thread": {
+              "type": "string"
+            },
+            "thread_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "usage_summary": true,
+            "winning_attach_rule": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "session_id",
+            "thread",
+            "base_state",
+            "usage_summary",
+            "attach_precedence",
+            "status",
+            "started_at",
+            "actor_chain"
+          ],
+          "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "$ref": "#/$defs/MachineContractCoverageSchema"
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "machine_contract_coverage",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "active_only": {
+          "type": "boolean"
+        },
+        "output_kind": {
+          "enum": [
+            "presence_list"
+          ],
+          "type": "string"
+        },
+        "presence": {
+          "items": {
+            "$ref": "#/$defs/ActorEntrySchema"
+          },
+          "type": "array"
+        },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        }
+      },
+      "required": [
+        "output_kind",
+        "presence",
+        "active_only",
+        "verification"
+      ],
+      "title": "AgentPresenceListSchema",
+      "type": "object"
+    },
+    "presence show": {
+      "$defs": {
+        "ActionTemplateSchema": {
+          "properties": {
+            "action": {
+              "type": "string"
+            },
+            "agent_may_fill": {
+              "description": "Whether an agent may replace placeholders in `argv_template`.\n\nWhen `agent_may_fill` is false, treat `action` and `argv_template` as\ndisplay-only: do not substitute `<name>`/`<url>` placeholders. Surface\nthe template to a human or discard it. Substituting and running it will\npass literal `<name>` to Heddle and fail.",
+              "type": "boolean"
+            },
+            "argv_template": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "required_inputs": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "action",
+            "argv_template",
+            "required_inputs",
+            "agent_may_fill"
+          ],
+          "type": "object"
+        },
+        "ActorChainEntrySchema": {
+          "properties": {
+            "harness": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_parent_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session_id": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "thread": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "session_id",
+            "thread",
+            "status"
+          ],
+          "type": "object"
+        },
+        "ActorEntrySchema": {
+          "properties": {
+            "actor_chain": {
+              "items": {
+                "$ref": "#/$defs/ActorChainEntrySchema"
+              },
+              "type": "array"
+            },
+            "attach_precedence": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "attach_reason": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "base_state": {
+              "type": "string"
+            },
+            "client_instance_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "harness": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_session_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "last_progress_at": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "model": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_instance_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "native_parent_actor_key": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "path": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "probe_confidence": {
+              "format": "float",
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "probe_source": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "provider": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "report_flush_state": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "session_id": {
+              "type": "string"
+            },
+            "started_at": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "thinking_level": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "thread": {
+              "type": "string"
+            },
+            "thread_id": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "usage_summary": true,
+            "winning_attach_rule": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "session_id",
+            "thread",
+            "base_state",
+            "usage_summary",
+            "attach_precedence",
+            "status",
+            "started_at",
+            "actor_chain"
+          ],
+          "type": "object"
+        },
+        "MachineContractCoverageSchema": {
+          "properties": {
+            "accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "accepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope": {
+              "type": "string"
+            },
+            "advanced_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "advanced_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "catalog_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "documented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "json_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "jsonl_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "missing_mutating_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "supports_op_id_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "unaccepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "unaccepted_opaque_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "undocumented_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "undocumented_schema_verbs_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope": {
+              "type": "string"
+            },
+            "verified_scope_accepted_opaque_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_json_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_json_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_missing_schema_examples": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "verified_scope_mutating_commands_total": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_accepted_opaque_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_with_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "verified_scope_mutating_commands_without_schema": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "verified_scope",
+            "advanced_scope",
+            "summary",
+            "catalog_commands_total",
+            "catalog_mutating_commands_total",
+            "json_commands_total",
+            "json_mutating_commands_total",
+            "json_commands_with_schema",
+            "json_commands_with_accepted_opaque_schema",
+            "json_commands_without_schema",
+            "verified_scope_json_commands_total",
+            "verified_scope_json_commands_with_schema",
+            "verified_scope_json_commands_with_accepted_opaque_schema",
+            "verified_scope_json_commands_without_schema",
+            "advanced_scope_json_commands_total",
+            "advanced_scope_json_commands_with_accepted_opaque_schema",
+            "mutating_commands_total",
+            "mutating_commands_with_schema",
+            "mutating_commands_with_accepted_opaque_schema",
+            "mutating_commands_without_schema",
+            "verified_scope_mutating_commands_total",
+            "verified_scope_mutating_commands_with_schema",
+            "verified_scope_mutating_commands_with_accepted_opaque_schema",
+            "verified_scope_mutating_commands_without_schema",
+            "advanced_scope_mutating_commands_total",
+            "advanced_scope_mutating_commands_with_accepted_opaque_schema",
+            "schema_verbs_total",
+            "documented_schema_verbs_total",
+            "undocumented_schema_verbs_total",
+            "opaque_schema_verbs_total",
+            "accepted_opaque_schema_verbs_total",
+            "unaccepted_opaque_schema_verbs_total",
+            "supports_op_id_total",
+            "jsonl_commands_total",
+            "missing_schema_examples",
+            "missing_mutating_schema_examples",
+            "verified_scope_missing_schema_examples",
+            "verified_scope_accepted_opaque_schema_examples",
+            "advanced_scope_accepted_opaque_schema_examples",
+            "accepted_opaque_schema_examples",
+            "unaccepted_opaque_schema_examples",
+            "undocumented_schema_examples"
+          ],
+          "type": "object"
+        },
+        "RepositoryVerificationStateSchema": {
+          "properties": {
+            "active_operation": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "checks": {
+              "items": {
+                "$ref": "#/$defs/VerificationCheckSchema"
+              },
+              "type": "array"
+            },
+            "clone_verification": {
+              "type": "string"
+            },
+            "default_remote": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "git_branch": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "heddle_initialized": {
+              "type": "boolean"
+            },
+            "heddle_thread": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "import_state": {
+              "type": "string"
+            },
+            "machine_contract": {
+              "type": "string"
+            },
+            "machine_contract_coverage": {
+              "$ref": "#/$defs/MachineContractCoverageSchema"
+            },
+            "mapping_state": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "remote_drift": {
+              "type": "string"
+            },
+            "repository_mode": {
+              "type": "string"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "verified": {
+              "type": "boolean"
+            },
+            "workflow_status": {
+              "type": "string"
+            },
+            "workflow_summary": {
+              "type": "string"
+            },
+            "worktree_dirty": {
+              "type": "boolean"
+            },
+            "worktree_state": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "verified",
+            "status",
+            "repository_mode",
+            "heddle_initialized",
+            "worktree_dirty",
+            "worktree_state",
+            "import_state",
+            "mapping_state",
+            "remote_drift",
+            "clone_verification",
+            "machine_contract",
+            "machine_contract_coverage",
+            "workflow_status",
+            "workflow_summary",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "checks"
+          ],
+          "type": "object"
+        },
+        "VerificationCheckSchema": {
+          "properties": {
+            "clean": {
+              "type": "boolean"
+            },
+            "details": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "name": {
+              "type": "string"
+            },
+            "recommended_action": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "recommended_action_template": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ActionTemplateSchema"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "recovery_action_templates": {
+              "items": {
+                "$ref": "#/$defs/ActionTemplateSchema"
+              },
+              "type": "array"
+            },
+            "recovery_commands": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "status": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "status",
+            "clean",
+            "summary",
+            "recovery_commands",
+            "recovery_action_templates",
+            "details"
+          ],
+          "type": "object"
+        }
+      },
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "output_kind": {
+          "enum": [
+            "presence_show"
+          ],
+          "type": "string"
+        },
+        "presence": {
+          "$ref": "#/$defs/ActorEntrySchema"
+        },
+        "verification": {
+          "$ref": "#/$defs/RepositoryVerificationStateSchema"
+        }
+      },
+      "required": [
+        "output_kind",
+        "presence",
+        "verification"
+      ],
+      "title": "AgentPresenceSingleSchema",
       "type": "object"
     },
     "pull": {

--- a/clients/npm/generated/heddle-schemas.ts
+++ b/clients/npm/generated/heddle-schemas.ts
@@ -198,7 +198,7 @@ export interface AgentPresenceCompleteSchema {
   idempotency_status?: string | null;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "agent_presence_complete";
+  output_kind: "presence_complete";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   replayed?: boolean | null;
@@ -220,7 +220,7 @@ export interface AgentPresenceExplainSchema {
   native_actor_key?: string | null;
   native_instance_key?: string | null;
   native_parent_actor_key?: string | null;
-  output_kind: "agent_presence_explain";
+  output_kind: "presence_explain";
   probe_confidence?: number | null;
   probe_source?: string | null;
   reason?: string | null;
@@ -235,13 +235,13 @@ export interface AgentPresenceExplainSchema {
 
 export interface AgentPresenceListSchema {
   active_only: boolean;
-  output_kind: "agent_presence_list";
+  output_kind: "presence_list";
   presence: ActorEntrySchema[];
   verification: RepositoryVerificationStateSchema;
 }
 
 export interface AgentPresenceSingleSchema {
-  output_kind: "agent_presence_show";
+  output_kind: "presence_show";
   presence: ActorEntrySchema;
   verification: RepositoryVerificationStateSchema;
 }
@@ -1064,7 +1064,7 @@ export interface ExportGitSchema {
   markers_synced: number;
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "export_git";
+  output_kind: "bridge_git_export";
   replayed?: boolean | null;
   states_exported: number;
   tags: ExportedRefSchema[];
@@ -1108,34 +1108,6 @@ export interface FsckRepair {
   detail: string;
   name: string;
   repaired: boolean;
-}
-
-export interface FsckRepairGitSchema {
-  errors: FsckError[];
-  git_projection_checked: boolean;
-  idempotency_status?: string | null;
-  objects_checked: number;
-  op_id?: string | null;
-  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  provenance?: ProvenanceReport | null;
-  repair_target?: string | null;
-  repaired: boolean;
-  repairs: FsckRepair[];
-  replayed?: boolean | null;
-  valid: boolean;
-  warnings: string[];
-}
-
-export interface FsckSchema {
-  errors: FsckError[];
-  git_projection_checked: boolean;
-  objects_checked: number;
-  provenance?: ProvenanceReport | null;
-  repair_target?: string | null;
-  repaired: boolean;
-  repairs: FsckRepair[];
-  valid: boolean;
-  warnings: string[];
 }
 
 export interface GitCheckpointInfo {
@@ -1229,7 +1201,7 @@ export interface ImportGitSchema {
   lossy_entries: LossyImportEntrySchema[];
   op_id?: string | null;
   operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
-  output_kind: "import_git";
+  output_kind: "bridge_git_import";
   recommended_action?: string | null;
   recommended_action_template?: ActionTemplateSchema | null;
   recovery_commands: string[];
@@ -1530,6 +1502,34 @@ export interface MachineContractCoverageSchema {
   verified_scope_mutating_commands_with_accepted_opaque_schema: number;
   verified_scope_mutating_commands_with_schema: number;
   verified_scope_mutating_commands_without_schema: number;
+}
+
+export interface MaintenanceFsckRepairGitSchema {
+  errors: FsckError[];
+  git_projection_checked: boolean;
+  idempotency_status?: string | null;
+  objects_checked: number;
+  op_id?: string | null;
+  operation_record?: { command: string; idempotency_status: string; op_id: string; replayed: boolean; } | null;
+  provenance?: ProvenanceReport | null;
+  repair_target?: string | null;
+  repaired: boolean;
+  repairs: FsckRepair[];
+  replayed?: boolean | null;
+  valid: boolean;
+  warnings: string[];
+}
+
+export interface MaintenanceFsckSchema {
+  errors: FsckError[];
+  git_projection_checked: boolean;
+  objects_checked: number;
+  provenance?: ProvenanceReport | null;
+  repair_target?: string | null;
+  repaired: boolean;
+  repairs: FsckRepair[];
+  valid: boolean;
+  warnings: string[];
 }
 
 export interface MaintenanceGcSchema {
@@ -3434,10 +3434,6 @@ export interface HeddleVerbOutputs {
   "agent fanout start": AgentFanoutStartSchema;
   "agent heartbeat": AgentHeartbeatSchema;
   "agent list": AgentReservationListSchema;
-  "agent presence complete": AgentPresenceCompleteSchema;
-  "agent presence explain": AgentPresenceExplainSchema;
-  "agent presence list": AgentPresenceListSchema;
-  "agent presence show": AgentPresenceSingleSchema;
   "agent provenance begin": AgentProvenanceBeginSchema;
   "agent provenance end": AgentProvenanceEndSchema;
   "agent provenance list": AgentProvenanceListSchema;
@@ -3455,6 +3451,8 @@ export interface HeddleVerbOutputs {
   "auth status": AuthStatusSchema;
   "auth trust replace": AuthTrustReplaceSchema;
   "auth trust show": AuthTrustShowSchema;
+  "bridge git export": ExportGitSchema;
+  "bridge git import": ImportGitSchema;
   capture: CaptureSchema;
   "ci run": CiRunSchema;
   clone: CloneSchema;
@@ -3487,9 +3485,6 @@ export interface HeddleVerbOutputs {
   "doctor schemas": DoctorSchemasSchema;
   error: ErrorEnvelopeSchema;
   expand: ExpandSchema;
-  "export git": ExportGitSchema;
-  fsck: FsckSchema;
-  "fsck repair git": FsckRepairGitSchema;
   help: HelpSchema;
   "hook events": HookEventsSchema;
   "hook install": HookInstallSchema;
@@ -3497,7 +3492,6 @@ export interface HeddleVerbOutputs {
   "hook uninstall": HookUninstallSchema;
   "identity claim-link": IdentityClaimLinkSchema;
   "identity ensure": IdentityEnsureSchema;
-  "import git": ImportGitSchema;
   init: InitSchema;
   "integration doctor": IntegrationDoctorSchema;
   "integration install": IntegrationInstallSchema;
@@ -3510,11 +3504,17 @@ export interface HeddleVerbOutputs {
   log: LogSchema;
   "log --reflog": LogReflogSchema;
   "log --timeline": TimelineLogSchema;
+  "maintenance fsck": MaintenanceFsckSchema;
+  "maintenance fsck repair git": MaintenanceFsckRepairGitSchema;
   "maintenance gc": MaintenanceGcSchema;
   "maintenance inspect": MaintenanceInspectSchema;
   "maintenance refresh": MaintenanceRefreshSchema;
   "maintenance repack": MaintenanceRepackSchema;
   "oplog recover": OplogRecoverSchema;
+  "presence complete": AgentPresenceCompleteSchema;
+  "presence explain": AgentPresenceExplainSchema;
+  "presence list": AgentPresenceListSchema;
+  "presence show": AgentPresenceSingleSchema;
   pull: PullSchema;
   push: PushSchema;
   query: QueryReport;
@@ -3604,10 +3604,6 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "agent fanout start",
   "agent heartbeat",
   "agent list",
-  "agent presence complete",
-  "agent presence explain",
-  "agent presence list",
-  "agent presence show",
   "agent provenance begin",
   "agent provenance end",
   "agent provenance list",
@@ -3625,6 +3621,8 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "auth status",
   "auth trust replace",
   "auth trust show",
+  "bridge git export",
+  "bridge git import",
   "capture",
   "ci run",
   "clone",
@@ -3657,9 +3655,6 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "doctor schemas",
   "error",
   "expand",
-  "export git",
-  "fsck",
-  "fsck repair git",
   "help",
   "hook events",
   "hook install",
@@ -3667,7 +3662,6 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "hook uninstall",
   "identity claim-link",
   "identity ensure",
-  "import git",
   "init",
   "integration doctor",
   "integration install",
@@ -3680,11 +3674,17 @@ export const HEDDLE_SCHEMA_VERBS: readonly HeddleSchemaVerb[] = [
   "log",
   "log --reflog",
   "log --timeline",
+  "maintenance fsck",
+  "maintenance fsck repair git",
   "maintenance gc",
   "maintenance inspect",
   "maintenance refresh",
   "maintenance repack",
   "oplog recover",
+  "presence complete",
+  "presence explain",
+  "presence list",
+  "presence show",
   "pull",
   "push",
   "query",

--- a/clients/npm/src/heddle.ts
+++ b/clients/npm/src/heddle.ts
@@ -372,9 +372,9 @@ export class Heddle {
     return this.run("push", args, options);
   }
 
-  /** `heddle export git` — export to a git repo. Mutating. */
+  /** `heddle bridge git export` — export to a git repo. Mutating. */
   export(args: readonly string[] = [], options: RunOptions = {}) {
-    return this.run("export git", args, options);
+    return this.run("bridge git export", args, options);
   }
 
   /** `heddle watch` — stream live oplog activity (JSONL). Read-only. */

--- a/crates/cli-args/src/cli/cli_args/commands_agent.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_agent.rs
@@ -49,17 +49,13 @@ pub enum AgentCommands {
     #[command(subcommand)]
     Fanout(AgentFanoutCommands),
 
-    /// Inspect attribution and work context for local agents.
-    #[command(subcommand)]
-    Presence(AgentPresenceCommands),
-
     /// Record provider, model, and policy provenance across an agent run.
     #[command(subcommand)]
     Provenance(AgentProvenanceCommands),
 }
 
 #[derive(Clone, Debug, Subcommand)]
-pub enum AgentPresenceCommands {
+pub enum PresenceCommands {
     /// List agent presence records known to this repository.
     List(AgentPresenceListArgs),
 

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -1402,7 +1402,7 @@ pub struct WorktreeRemoveArgs {
     pub delete_thread: bool,
 }
 
-/// Arguments for `agent presence list`.
+/// Arguments for `presence list`.
 #[derive(Clone, Debug, clap::Args)]
 pub struct AgentPresenceListArgs {
     /// Show only active actors.
@@ -1410,21 +1410,21 @@ pub struct AgentPresenceListArgs {
     pub active: bool,
 }
 
-/// Arguments for `agent presence show`.
+/// Arguments for `presence show`.
 #[derive(Clone, Debug, clap::Args)]
 pub struct AgentPresenceShowArgs {
     /// Session ID to show (default: current thread actor).
     pub session: Option<String>,
 }
 
-/// Arguments for `agent presence explain`.
+/// Arguments for `presence explain`.
 #[derive(Clone, Debug, clap::Args)]
 pub struct AgentPresenceExplainArgs {
     /// Session ID to explain (default: current thread actor).
     pub session: Option<String>,
 }
 
-/// Arguments for `agent presence complete`.
+/// Arguments for `presence complete`.
 #[derive(Clone, Debug, clap::Args)]
 pub struct AgentPresenceCompleteArgs {
     /// Session ID to mark as complete (default: current thread actor).

--- a/crates/cli-args/src/cli/cli_args/commands_git_projection.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_git_projection.rs
@@ -41,12 +41,21 @@ pub(crate) fn parse_git_source(s: &str) -> Result<GitSource, String> {
 }
 
 #[derive(Subcommand, Clone)]
-pub enum ImportCommands {
-    /// Import Git commits to Heddle.
+pub enum BridgeCommands {
+    /// Explicit Git projection operations.
+    Git {
+        #[command(subcommand)]
+        command: BridgeGitCommands,
+    },
+}
+
+#[derive(Subcommand, Clone)]
+pub enum BridgeGitCommands {
+    /// Import Git commits to Heddle without changing source authority.
     ///
     /// Walks local branches and tags by default. To import remote-tracking
     /// refs (`refs/remotes/*`), name them explicitly with `--ref`.
-    Git {
+    Import {
         /// Local path or git URL to import from.
         #[arg(short, long, value_parser = parse_git_source)]
         path: Option<GitSource>,
@@ -61,16 +70,12 @@ pub enum ImportCommands {
         #[arg(long)]
         lossy: bool,
     },
-}
-
-#[derive(Subcommand, Clone)]
-pub enum ExportCommands {
     /// Export Heddle states to Git.
     ///
     /// Writes a complete bare Git repository at `--destination` containing
     /// every reachable Heddle state as a Git commit, with branches and tags
     /// mirroring Heddle's threads and markers.
-    Git {
+    Export {
         /// Destination path for the exported Git repository. Must be writable;
         /// will be initialized as a bare repo if it does not already exist.
         #[arg(short, long)]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -3,12 +3,14 @@
 
 use clap::{Args, Subcommand};
 
+#[cfg(feature = "git-overlay")]
+use super::BridgeCommands;
 #[cfg(feature = "semantic")]
 use super::SemanticCommands;
 use super::{
     AgentCommands, CiCommands, CompletionSubject, ContextCommands, DiscussCommands, HookCommands,
-    IntegrationCommands, OplogCommands, QueryArgs, RedactCommands, RemoteCommands, ReviewCommands,
-    ShellCommands, ThreadCommands, VisibilityCommands,
+    IntegrationCommands, OplogCommands, PresenceCommands, QueryArgs, RedactCommands,
+    RemoteCommands, ReviewCommands, ShellCommands, ThreadCommands, VisibilityCommands,
     commands_args::{
         AdoptArgs, CloneArgs, CollapseArgs, CommitArgs, DiffArgs, DoctorArgs, ExpandArgs, InitArgs,
         LandArgs, LogArgs, PullArgs, PushArgs, ReadyArgs, ResolveArgs, RetroArgs, RevertArgs,
@@ -18,8 +20,6 @@ use super::{
 };
 #[cfg(feature = "client")]
 use super::{AuthCommands, IdentityCommands};
-#[cfg(feature = "git-overlay")]
-use super::{ExportCommands, ImportCommands};
 
 #[derive(Clone, Debug, Args)]
 pub struct FsckArgs {
@@ -402,9 +402,6 @@ Examples:
     /// Resolve merge conflicts.
     Resolve(ResolveArgs),
 
-    /// Verify repository integrity or explicitly repair one surface.
-    Fsck(FsckArgs),
-
     /// Inspect and repair the operation log.
     ///
     /// `heddle oplog recover` explicitly salvages a truncated or torn oplog,
@@ -415,18 +412,11 @@ Examples:
         command: OplogCommands,
     },
 
-    /// Import from another version control system.
+    /// Explicit interoperability with other version-control formats.
     #[cfg(feature = "git-overlay")]
-    Import {
+    Bridge {
         #[command(subcommand)]
-        command: ImportCommands,
-    },
-
-    /// Export to another version control system.
-    #[cfg(feature = "git-overlay")]
-    Export {
-        #[command(subcommand)]
-        command: ExportCommands,
+        command: BridgeCommands,
     },
 
     /// Push the source-authoritative history to a remote.
@@ -531,6 +521,15 @@ Examples:
         command: AgentCommands,
     },
 
+    /// Inspect attribution and work context for local agents.
+    ///
+    /// Presence is intentionally separate from `agent`: presence records
+    /// explain who is acting, while `agent reserve` grants writer authority.
+    Presence {
+        #[command(subcommand)]
+        command: PresenceCommands,
+    },
+
     /// Inspect and refresh rebuildable performance sidecars.
     Maintenance {
         #[command(subcommand)]
@@ -550,6 +549,9 @@ Examples:
 /// Maintenance subcommands.
 #[derive(Clone, Debug, clap::Subcommand)]
 pub enum MaintenanceCommands {
+    /// Verify repository integrity or explicitly repair one surface.
+    Fsck(FsckArgs),
+
     /// Inspect repository performance sidecars and repo shape.
     Inspect,
 

--- a/crates/cli-args/src/cli/cli_args/mod.rs
+++ b/crates/cli-args/src/cli/cli_args/mod.rs
@@ -29,8 +29,8 @@ mod output_mode;
 pub use cli_base::{Cli, should_output_json};
 pub use cli_shared::OutputMode;
 pub use commands_agent::{
-    AgentCommands, AgentFanoutCommands, AgentPresenceCommands, AgentProvenanceCommands,
-    AgentTaskCommands,
+    AgentCommands, AgentFanoutCommands, AgentProvenanceCommands, AgentTaskCommands,
+    PresenceCommands,
 };
 pub use commands_args::{
     AdoptArgs, AgentApiListArgs, AgentCaptureArgs, AgentFanoutPlanArgs, AgentFanoutStartArgs,
@@ -60,7 +60,7 @@ pub use commands_discuss::{
     DiscussResolveArgs, DiscussShowArgs, ResolveModeArg,
 };
 #[cfg(feature = "git-overlay")]
-pub use commands_git_projection::{ExportCommands, GitSource, ImportCommands, SyncCommands};
+pub use commands_git_projection::{BridgeCommands, BridgeGitCommands, GitSource, SyncCommands};
 pub use commands_hook::{HookCommands, HookInstallSource};
 pub use commands_integration::{
     IntegrationCommands, IntegrationInstallArgs, IntegrationRelayArgs, IntegrationTargetArgs,

--- a/crates/cli-contract/src/cli/commands/advice.rs
+++ b/crates/cli-contract/src/cli/commands/advice.rs
@@ -352,7 +352,7 @@ impl RecoveryAdvice {
     }
 
     pub fn git_import_metadata_required(map_path: &str, git_path: &str) -> Self {
-        let command = format!("heddle import git --path {git_path}");
+        let command = format!("heddle bridge git import --path {git_path}");
         Self::safety_refusal(
             "git_import_metadata_required",
             format!("No Git SHA map exists at {map_path}"),
@@ -984,7 +984,7 @@ impl RecoveryAdvice {
     /// commit. Keep this distinct from a remote push rejection so recovery is
     /// executable in the current checkout.
     pub(crate) fn git_overlay_local_non_fast_forward(branch: &str) -> Self {
-        let import_command = format!("heddle import git --ref {branch}");
+        let import_command = format!("heddle bridge git import --ref {branch}");
         Self::safety_refusal(
             "git_overlay_local_non_fast_forward",
             format!("Local Git branch '{branch}' does not fast-forward from the Heddle tip"),
@@ -1392,7 +1392,7 @@ mod tests {
 
     #[test]
     fn git_projection_shallow_clone_returns_typed_advice() {
-        let retry_command = "heddle import git --ref main";
+        let retry_command = "heddle bridge git import --ref main";
         let error = GitProjectionError::ShallowClone {
             repository: std::path::PathBuf::from("/tmp/shallow"),
             retry_command: retry_command.to_string(),

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -22,15 +22,15 @@ use crate::cli::{
     RedactTrustCommands, RemoteCommands, ShellCommands, ThreadCommands, ThreadMarkerCommands,
     TimelineCommands, VisibilityCommands,
     cli_args::{
-        AgentFanoutCommands, AgentPresenceCommands, AgentProvenanceCommands, AgentTaskCommands,
-        DiscussCommands, ReviewCommands,
+        AgentFanoutCommands, AgentProvenanceCommands, AgentTaskCommands, DiscussCommands,
+        PresenceCommands, ReviewCommands,
     },
     render::shell_quote,
 };
 #[cfg(feature = "client")]
 use crate::cli::{AuthCommands, IdentityCommands};
 #[cfg(feature = "git-overlay")]
-use crate::cli::{ExportCommands, ImportCommands};
+use crate::cli::{BridgeCommands, BridgeGitCommands};
 
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct CommandCatalogOutput {
@@ -410,7 +410,7 @@ const RECOMMENDED_ACTION_PLACEHOLDERS: &[&str] = &[
     "heddle agent provenance begin",
     "heddle start <name> --path <empty-path>",
     "heddle start <name> --path ../<name>",
-    "heddle agent presence show <session>",
+    "heddle presence show <session>",
     "heddle thread show <THREAD>",
     // Remote setup requires filling in a real name and URL after
     // inspecting current configuration.
@@ -424,8 +424,8 @@ const RECOMMENDED_ACTION_PLACEHOLDERS: &[&str] = &[
     "heddle clone <remote> <fresh-path>",
     "heddle clone <remote> <path> --thread <thread>",
     // Shallow Git import recovery requires choosing a complete checkout.
-    "heddle import git --path <full-git-repo>",
-    "heddle import git --path <full-git-repo> --ref <ref>",
+    "heddle bridge git import --path <full-git-repo>",
+    "heddle bridge git import --path <full-git-repo> --ref <ref>",
     "heddle thread switch <branch>",
     "heddle ready --thread <thread>",
     "heddle land --thread <thread>",
@@ -526,8 +526,8 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
         true,
     ),
     (
-        "heddle agent presence show <session>",
-        &["heddle", "agent", "presence", "show", "<session>"],
+        "heddle presence show <session>",
+        &["heddle", "presence", "show", "<session>"],
         &["session"],
         true,
     ),
@@ -646,17 +646,25 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
         false,
     ),
     (
-        "heddle import git --path <full-git-repo>",
-        &["heddle", "import", "git", "--path", "<full-git-repo>"],
+        "heddle bridge git import --path <full-git-repo>",
+        &[
+            "heddle",
+            "bridge",
+            "git",
+            "import",
+            "--path",
+            "<full-git-repo>",
+        ],
         &["path"],
         false,
     ),
     (
-        "heddle import git --path <full-git-repo> --ref <ref>",
+        "heddle bridge git import --path <full-git-repo> --ref <ref>",
         &[
             "heddle",
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             "<full-git-repo>",
             "--ref",
@@ -1328,58 +1336,58 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "automation",
         ),
     ),
-    entry(&["agent", "presence"], surface(GROUP, "automation")),
+    entry(&["presence"], surface(GROUP, "automation")),
     entry(
-        &["agent", "presence", "list"],
+        &["presence", "list"],
         surface(
             json_discriminators(
-                documented_schemas(READ_JSON, &["agent presence list"]),
+                documented_schemas(READ_JSON, &["presence list"]),
                 &[json_discriminator(
-                    Some("agent presence list"),
+                    Some("presence list"),
                     "output_kind",
-                    "agent_presence_list",
+                    "presence_list",
                 )],
             ),
             "automation",
         ),
     ),
     entry(
-        &["agent", "presence", "show"],
+        &["presence", "show"],
         surface(
             json_discriminators(
-                documented_schemas(READ_JSON, &["agent presence show"]),
+                documented_schemas(READ_JSON, &["presence show"]),
                 &[json_discriminator(
-                    Some("agent presence show"),
+                    Some("presence show"),
                     "output_kind",
-                    "agent_presence_show",
+                    "presence_show",
                 )],
             ),
             "automation",
         ),
     ),
     entry(
-        &["agent", "presence", "explain"],
+        &["presence", "explain"],
         surface(
             json_discriminators(
-                documented_schemas(READ_JSON, &["agent presence explain"]),
+                documented_schemas(READ_JSON, &["presence explain"]),
                 &[json_discriminator(
-                    Some("agent presence explain"),
+                    Some("presence explain"),
                     "output_kind",
-                    "agent_presence_explain",
+                    "presence_explain",
                 )],
             ),
             "automation",
         ),
     ),
     entry(
-        &["agent", "presence", "complete"],
+        &["presence", "complete"],
         surface(
             json_discriminators(
-                documented_schemas(METADATA_MUTATION, &["agent presence complete"]),
+                documented_schemas(METADATA_MUTATION, &["presence complete"]),
                 &[json_discriminator(
-                    Some("agent presence complete"),
+                    Some("presence complete"),
                     "output_kind",
-                    "agent_presence_complete",
+                    "presence_complete",
                 )],
             ),
             "automation",
@@ -1567,16 +1575,17 @@ const CONTRACTS: &[CommandContractEntry] = &[
             "repo",
         ),
     ),
-    entry(&["import"], surface(GROUP, "git_projection")),
+    entry(&["bridge"], surface(GROUP, "git_projection")),
+    entry(&["bridge", "git"], surface(GROUP, "git_projection")),
     entry(
-        &["import", "git"],
+        &["bridge", "git", "import"],
         exits(
             json_discriminators(
-                documented_schemas(IMPORTING_MUTATION, &["import git"]),
+                documented_schemas(IMPORTING_MUTATION, &["bridge git import"]),
                 &[json_discriminator(
-                    Some("import git"),
+                    Some("bridge git import"),
                     "output_kind",
-                    "import_git",
+                    "bridge_git_import",
                 )],
             ),
             &[
@@ -1586,21 +1595,20 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ],
         ),
     ),
-    entry(&["export"], surface(GROUP, "git_projection")),
     entry(
-        &["export", "git"],
+        &["bridge", "git", "export"],
         json_discriminators(
             documented_schemas(
                 CommandContract {
                     writes_git_refs: true,
                     ..REF_MUTATION
                 },
-                &["export git"],
+                &["bridge git export"],
             ),
             &[json_discriminator(
-                Some("export git"),
+                Some("bridge git export"),
                 "output_kind",
-                "export_git",
+                "bridge_git_export",
             )],
         ),
     ),
@@ -2013,19 +2021,22 @@ const CONTRACTS: &[CommandContractEntry] = &[
         ),
     ),
     entry(
-        &["fsck"],
+        &["maintenance", "fsck"],
         category(
             documented_core_report_schema(READ_JSON, FsckReport::CONTRACT),
             "recovery",
         ),
     ),
-    entry(&["fsck", "repair"], category(GROUP, "recovery")),
     entry(
-        &["fsck", "repair", "git"],
+        &["maintenance", "fsck", "repair"],
+        category(GROUP, "recovery"),
+    ),
+    entry(
+        &["maintenance", "fsck", "repair", "git"],
         category(
             documented_schemas(
                 documented_core_report_schema(FSCK_GIT_REPAIR, FsckReport::CONTRACT),
-                &["fsck repair git"],
+                &["maintenance fsck repair git"],
             ),
             "recovery",
         ),
@@ -3159,7 +3170,7 @@ fn walk_commands(
 
 /// Append catalog entries for `feature_gated` contracts whose clap
 /// subcommand is compiled out of THIS build (e.g. the `client`-gated
-/// `auth`/`support`/`presence` surfaces in a default `cargo install`).
+/// `auth`/`identity`/`whoami` surfaces in a default `cargo install`).
 ///
 /// `walk_commands` only sees the live clap tree, so without this the
 /// hosted verbs would be missing from the catalog `commands` list even
@@ -3831,7 +3842,7 @@ fn active_command_contract_entries() -> &'static [&'static CommandContractEntry]
 /// The contracts advertised to agents: every [`active_command_contract_entries`]
 /// entry (present in the compiled clap tree) PLUS any `feature_gated` contract
 /// whose clap subcommand is compiled out of this build. The hosted surfaces
-/// (`auth`, `support`, `presence`) are `client`-gated, so a default
+/// (`auth`, `identity`, `whoami`) are `client`-gated, so a default
 /// `cargo install heddle-cli` omits their clap nodes — but their schema verbs
 /// and `output_kind` discriminators are a wire-format-stable promise that must
 /// stay advertised in the catalog regardless of build features. Distinct from
@@ -4697,19 +4708,12 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
         },
         Commands::Complete { .. } => vec!["complete"],
         Commands::Resolve(_) => vec!["resolve"],
-        Commands::Fsck(args) => match &args.command {
-            None => vec!["fsck"],
-            Some(crate::cli::FsckCommands::Repair { target }) => match target {
-                crate::cli::FsckRepairCommands::Git(_) => vec!["fsck", "repair", "git"],
+        #[cfg(feature = "git-overlay")]
+        Commands::Bridge { command } => match command {
+            BridgeCommands::Git { command } => match command {
+                BridgeGitCommands::Import { .. } => vec!["bridge", "git", "import"],
+                BridgeGitCommands::Export { .. } => vec!["bridge", "git", "export"],
             },
-        },
-        #[cfg(feature = "git-overlay")]
-        Commands::Import { command } => match command {
-            ImportCommands::Git { .. } => vec!["import", "git"],
-        },
-        #[cfg(feature = "git-overlay")]
-        Commands::Export { command } => match command {
-            ExportCommands::Git { .. } => vec!["export", "git"],
         },
         Commands::Oplog { command } => match command {
             OplogCommands::Recover => vec!["oplog", "recover"],
@@ -4797,12 +4801,6 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
                 AgentFanoutCommands::Plan(_) => vec!["agent", "fanout", "plan"],
                 AgentFanoutCommands::Start(_) => vec!["agent", "fanout", "start"],
             },
-            AgentCommands::Presence(command) => match command {
-                AgentPresenceCommands::List(_) => vec!["agent", "presence", "list"],
-                AgentPresenceCommands::Show(_) => vec!["agent", "presence", "show"],
-                AgentPresenceCommands::Explain(_) => vec!["agent", "presence", "explain"],
-                AgentPresenceCommands::Complete(_) => vec!["agent", "presence", "complete"],
-            },
             AgentCommands::Provenance(command) => match command {
                 AgentProvenanceCommands::Begin(_) => vec!["agent", "provenance", "begin"],
                 AgentProvenanceCommands::Segment(_) => vec!["agent", "provenance", "segment"],
@@ -4811,7 +4809,21 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
                 AgentProvenanceCommands::List(_) => vec!["agent", "provenance", "list"],
             },
         },
+        Commands::Presence { command } => match command {
+            PresenceCommands::List(_) => vec!["presence", "list"],
+            PresenceCommands::Show(_) => vec!["presence", "show"],
+            PresenceCommands::Explain(_) => vec!["presence", "explain"],
+            PresenceCommands::Complete(_) => vec!["presence", "complete"],
+        },
         Commands::Maintenance { command } => match command {
+            MaintenanceCommands::Fsck(args) => match &args.command {
+                None => vec!["maintenance", "fsck"],
+                Some(crate::cli::FsckCommands::Repair { target }) => match target {
+                    crate::cli::FsckRepairCommands::Git(_) => {
+                        vec!["maintenance", "fsck", "repair", "git"]
+                    }
+                },
+            },
             MaintenanceCommands::Inspect => vec!["maintenance", "inspect"],
             MaintenanceCommands::Refresh => vec!["maintenance", "refresh"],
             MaintenanceCommands::Repack => vec!["maintenance", "repack"],

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -27,22 +27,10 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["abort"], &["abort"]),
     sample(&["adopt"], &["adopt"]),
     sample(&["ci", "run"], &["ci", "run", "--local"]),
-    sample(
-        &["agent", "presence", "list"],
-        &["agent", "presence", "list"],
-    ),
-    sample(
-        &["agent", "presence", "show"],
-        &["agent", "presence", "show"],
-    ),
-    sample(
-        &["agent", "presence", "explain"],
-        &["agent", "presence", "explain"],
-    ),
-    sample(
-        &["agent", "presence", "complete"],
-        &["agent", "presence", "complete"],
-    ),
+    sample(&["presence", "list"], &["presence", "list"]),
+    sample(&["presence", "show"], &["presence", "show"]),
+    sample(&["presence", "explain"], &["presence", "explain"]),
+    sample(&["presence", "complete"], &["presence", "complete"]),
     sample(
         &["agent", "reserve"],
         &["agent", "reserve", "--thread", "main"],
@@ -181,11 +169,11 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     #[cfg(feature = "client")]
     sample(&["whoami"], &["whoami"]),
     #[cfg(feature = "git-overlay")]
-    sample(&["import", "git"], &["import", "git"]),
+    sample(&["bridge", "git", "import"], &["bridge", "git", "import"]),
     #[cfg(feature = "git-overlay")]
     sample(
-        &["export", "git"],
-        &["export", "git", "--destination", "out.git"],
+        &["bridge", "git", "export"],
+        &["bridge", "git", "export", "--destination", "out.git"],
     ),
     #[cfg(feature = "git-overlay")]
     sample(&["sync", "git"], &["sync", "git"]),
@@ -256,10 +244,18 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["doctor"], &["doctor"]),
     sample(&["doctor", "docs"], &["doctor", "docs"]),
     sample(&["doctor", "schemas"], &["doctor", "schemas"]),
-    sample(&["fsck"], &["fsck"]),
+    sample(&["maintenance", "fsck"], &["maintenance", "fsck"]),
     sample(
-        &["fsck", "repair", "git"],
-        &["fsck", "repair", "git", "--ref", "main", "--preview"],
+        &["maintenance", "fsck", "repair", "git"],
+        &[
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--ref",
+            "main",
+            "--preview",
+        ],
     ),
     sample(&["oplog", "recover"], &["oplog", "recover"]),
     sample(&["help"], &["help"]),
@@ -547,7 +543,7 @@ fn recommended_actions_parse_through_clap_or_registered_placeholders() {
         "heddle clone <remote> <fresh-path>",
         "heddle clone <local-path> <path>",
         "heddle clone /tmp/source <path> --thread main",
-        "heddle import git --path <full-git-repo> --ref <ref>",
+        "heddle bridge git import --path <full-git-repo> --ref <ref>",
         "heddle thread promote main",
         "heddle thread resolve main",
     ] {
@@ -557,11 +553,11 @@ fn recommended_actions_parse_through_clap_or_registered_placeholders() {
     #[cfg(feature = "git-overlay")]
     {
         for action in [
-            "heddle import git --ref main",
-            "heddle import git --ref origin/main",
+            "heddle bridge git import --ref main",
+            "heddle bridge git import --ref origin/main",
             "heddle ready --thread origin/main",
-            "heddle fsck repair git --ref main --preview",
-            "heddle fsck repair git --prefer heddle --ref main --preview",
+            "heddle maintenance fsck repair git --ref main --preview",
+            "heddle maintenance fsck repair git --prefer heddle --ref main --preview",
         ] {
             validate_recommended_action(action)
                 .unwrap_or_else(|err| panic!("expected `{action}` to validate: {err}"));
@@ -676,14 +672,15 @@ fn recommended_action_templates_describe_display_only_placeholders() {
     assert!(!dynamic_clone.agent_may_fill);
 
     let import =
-        recommended_action_template("heddle import git --path <full-git-repo> --ref <ref>")
+        recommended_action_template("heddle bridge git import --path <full-git-repo> --ref <ref>")
             .expect("shallow import recovery placeholder should resolve");
     assert_eq!(
         import.argv_template,
         vec![
             "heddle",
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             "<full-git-repo>",
             "--ref",
@@ -771,7 +768,6 @@ fn contracted_commands_are_not_parseable() {
         "fetch",
         "git-overlay",
         "merge",
-        "presence",
         "prove",
         "rebase",
         "spool",
@@ -782,6 +778,22 @@ fn contracted_commands_are_not_parseable() {
         assert!(
             Cli::try_parse_from(["heddle", command]).is_err(),
             "removed command `{command}` must not return to the public CLI"
+        );
+    }
+}
+
+#[test]
+fn phase_3_old_command_paths_are_not_parseable() {
+    for argv in [
+        &["heddle", "agent", "presence", "list"][..],
+        &["heddle", "fsck"],
+        &["heddle", "import", "git"],
+        &["heddle", "export", "git"],
+    ] {
+        assert!(
+            Cli::try_parse_from(argv).is_err(),
+            "removed Phase 3 command path `{}` must be rejected",
+            argv[1..].join(" ")
         );
     }
 }
@@ -1359,7 +1371,7 @@ fn assert_command_effects(path: &[&str], expected: &[CommandSideEffect]) {
 #[test]
 fn sidecar_only_effect_sets_exclude_refs() {
     for path in [
-        &["agent", "presence", "complete"][..],
+        &["presence", "complete"][..],
         &["agent", "heartbeat"],
         &["agent", "release"],
         &["agent", "task", "create"],
@@ -1475,8 +1487,8 @@ fn auth_commands_are_user_scoped() {
 
 #[test]
 fn fsck_observation_has_no_side_effects() {
-    assert_command_effects(&["fsck"], &[CommandSideEffect::ObserveOnly]);
-    let contract = raw_command_contract_for_path(["fsck"]).expect("fsck contract");
+    assert_command_effects(&["maintenance", "fsck"], &[CommandSideEffect::ObserveOnly]);
+    let contract = raw_command_contract_for_path(["maintenance", "fsck"]).expect("fsck contract");
     assert!(contract.observe_only);
     assert!(!contract.supports_op_id);
 }
@@ -1484,7 +1496,7 @@ fn fsck_observation_has_no_side_effects() {
 #[test]
 fn fsck_repair_git_has_explicit_mutation_effects() {
     assert_command_effects(
-        &["fsck", "repair", "git"],
+        &["maintenance", "fsck", "repair", "git"],
         &[
             CommandSideEffect::ImportGit,
             CommandSideEffect::WritesHeddleRefs,
@@ -1493,8 +1505,8 @@ fn fsck_repair_git_has_explicit_mutation_effects() {
             CommandSideEffect::WritesMetadata,
         ],
     );
-    let contract =
-        raw_command_contract_for_path(["fsck", "repair", "git"]).expect("fsck repair git contract");
+    let contract = raw_command_contract_for_path(["maintenance", "fsck", "repair", "git"])
+        .expect("fsck repair git contract");
     assert!(contract.supports_op_id);
     assert!(!contract.persists_op_id);
 }
@@ -1664,10 +1676,10 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             "agent task update",
             "agent fanout plan",
             "agent fanout start",
-            "agent presence list",
-            "agent presence show",
-            "agent presence explain",
-            "agent presence complete",
+            "presence list",
+            "presence show",
+            "presence explain",
+            "presence complete",
             "auth logout",
             "auth status",
             // heddle#1130: descriptor-trust inspection and explicit
@@ -1682,8 +1694,8 @@ fn json_discriminator_table_starts_with_bounded_command_slice() {
             // advertises its discriminator here alongside the other
             // client-gated hosted verbs.
             "whoami",
-            "import git",
-            "export git",
+            "bridge git import",
+            "bridge git export",
             "sync git",
             "capture",
             "clone",
@@ -2116,7 +2128,7 @@ fn catalog_option_lookup_includes_globals_and_finite_values() {
     );
 
     let fsck_options = catalog
-        .options_for_display("fsck")
+        .options_for_display("maintenance fsck")
         .expect("fsck should be cataloged");
     for mutation_option in ["ref", "prefer", "preview"] {
         assert!(
@@ -2127,7 +2139,7 @@ fn catalog_option_lookup_includes_globals_and_finite_values() {
         );
     }
     let repair_options = catalog
-        .options_for_display("fsck repair git")
+        .options_for_display("maintenance fsck repair git")
         .expect("fsck repair git should be cataloged");
     let prefer = repair_options
         .iter()

--- a/crates/cli-contract/src/cli/commands/doctor_docs.rs
+++ b/crates/cli-contract/src/cli/commands/doctor_docs.rs
@@ -420,7 +420,6 @@ fn scan_forbidden_prose(file: &str, text: &str, out: &mut Vec<DocsIssue>) {
             "support",
             "spool",
             "prove",
-            "presence",
             "actor",
             "session",
             "switch",
@@ -475,7 +474,6 @@ fn forbidden_invocation_issue(file: &str, inv: &DocsInvocation) -> Option<DocsIs
             | "support"
             | "spool"
             | "prove"
-            | "presence"
             | "actor"
             | "session"
     );

--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -69,7 +69,7 @@ fn report_contract_schema_verbs() -> &'static [&'static str] {
 }
 
 schema_registry! {
-    (&["fsck repair git"], FsckReport),
+    (&["maintenance fsck repair git"], FsckReport),
     (&["init"], InitSchema),
     (&["adopt"], AdoptSchema),
     (&["capture"], CaptureSchema),
@@ -123,17 +123,17 @@ schema_registry! {
     (&["discuss show"], DiscussionShowSchema),
     (&["discuss list"], DiscussionListSchema),
     (&["query --attribution"], BlameSchema),
-    (&["export git"], ExportGitSchema),
-    (&["import git"], ImportGitSchema),
+    (&["bridge git export"], ExportGitSchema),
+    (&["bridge git import"], ImportGitSchema),
     (&["sync git"], SyncGitSchema),
     (&["revert"], RevertSchema),
     (&["doctor"], DoctorSchema),
     (&["doctor docs"], DoctorDocsSchema),
     (&["doctor schemas"], DoctorSchemasSchema),
-    (&["agent presence show"], AgentPresenceSingleSchema),
-    (&["agent presence list"], AgentPresenceListSchema),
-    (&["agent presence complete"], AgentPresenceCompleteSchema),
-    (&["agent presence explain"], AgentPresenceExplainSchema),
+    (&["presence show"], AgentPresenceSingleSchema),
+    (&["presence list"], AgentPresenceListSchema),
+    (&["presence complete"], AgentPresenceCompleteSchema),
+    (&["presence explain"], AgentPresenceExplainSchema),
     (&["agent reserve", "agent heartbeat", "agent release"], AgentReservationEnvelopeSchema),
     (&["agent capture"], CaptureSchema),
     (&["agent ready"], ReadySchema),
@@ -3459,8 +3459,8 @@ mod tests {
     fn native_only_schema_registry_excludes_git_overlay_verbs() {
         let catalog = command_catalog::build_command_catalog();
         for verb in [
-            "import git",
-            "export git",
+            "bridge git import",
+            "bridge git export",
             "sync git",
             "context reason git",
             "git-overlay",
@@ -3928,7 +3928,7 @@ mod tests {
     #[test]
     fn oss_recovery_surfaces_do_not_use_opaque_generic_schema() {
         for verb in [
-            "fsck",
+            "maintenance fsck",
             "resolve",
             "retro",
             "discuss open",

--- a/crates/cli-contract/src/cli/commands/verification_health/tests.rs
+++ b/crates/cli-contract/src/cli/commands/verification_health/tests.rs
@@ -92,7 +92,7 @@ fn canonical_git_overlay_ref_commands_quote_parseable_refs() {
         action_template(&import)
             .expect("import command should expose a template")
             .argv_template[1..],
-        ["import", "git", "--ref", "feature with spaces"]
+        ["bridge", "git", "import", "--ref", "feature with spaces"]
     );
 
     let reconcile = canonical_git_repair_ref_preview_command(Some("heddle"), "feature 'quoted'");
@@ -101,6 +101,7 @@ fn canonical_git_overlay_ref_commands_quote_parseable_refs() {
             .expect("reconcile command should expose a template")
             .argv_template[1..],
         [
+            "maintenance",
             "fsck",
             "repair",
             "git",
@@ -139,9 +140,9 @@ fn repository_verification_blocked_advice_uses_verify_when_no_action_exists() {
 #[test]
 fn repository_verification_blocked_advice_preserves_trust_recovery_commands() {
     let trust = verification_state(
-        "heddle fsck repair git --ref main --preview",
+        "heddle maintenance fsck repair git --ref main --preview",
         vec![
-            "heddle fsck repair git --ref main --preview".to_string(),
+            "heddle maintenance fsck repair git --ref main --preview".to_string(),
             "heddle verify".to_string(),
         ],
     );
@@ -159,7 +160,7 @@ fn repository_verification_blocked_advice_preserves_trust_recovery_commands() {
 
     assert_eq!(
         advice.primary_command,
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
     assert_eq!(advice.recovery_commands, trust.recovery_commands);
 }
@@ -167,8 +168,8 @@ fn repository_verification_blocked_advice_preserves_trust_recovery_commands() {
 #[test]
 fn repository_verification_blocked_advice_keeps_primary_override_first() {
     let trust = verification_state(
-        "heddle import git --ref origin/main",
-        vec!["heddle import git --ref origin/main".to_string()],
+        "heddle bridge git import --ref origin/main",
+        vec!["heddle bridge git import --ref origin/main".to_string()],
     );
 
     let advice = repository_verification_blocked_advice(
@@ -201,7 +202,7 @@ fn remote_tracking_next_action_covers_basic_git_states_without_repo_context() {
     );
     assert_eq!(
         remote_tracking_next_action(&remote("main", "origin/main", 1, 1, "heddle pull")).as_deref(),
-        Some("heddle import git --ref origin/main")
+        Some("heddle bridge git import --ref origin/main")
     );
     assert_eq!(
         remote_tracking_next_action(&remote("main", "", 1, 0, "heddle push")).as_deref(),
@@ -218,13 +219,13 @@ fn remote_drift_decision_prefers_import_until_upstream_thread_matches_git_tip() 
     assert_eq!(unimported.status, "remote_diverged");
     assert_eq!(
         unimported.primary_action.as_deref(),
-        Some("heddle import git --ref origin/main")
+        Some("heddle bridge git import --ref origin/main")
     );
     assert_eq!(
         unimported.recovery_commands,
         vec![
-            "heddle import git --ref origin/main",
-            "heddle fsck repair git --ref origin/main --preview"
+            "heddle bridge git import --ref origin/main",
+            "heddle maintenance fsck repair git --ref origin/main --preview"
         ]
     );
 
@@ -235,13 +236,13 @@ fn remote_drift_decision_prefers_import_until_upstream_thread_matches_git_tip() 
     let stale_thread = remote_drift_decision(&repo, &diverged);
     assert_eq!(
         stale_thread.primary_action.as_deref(),
-        Some("heddle import git --ref origin/main")
+        Some("heddle bridge git import --ref origin/main")
     );
     assert_eq!(
         stale_thread.recovery_commands,
         vec![
-            "heddle import git --ref origin/main",
-            "heddle fsck repair git --ref origin/main --preview"
+            "heddle bridge git import --ref origin/main",
+            "heddle maintenance fsck repair git --ref origin/main --preview"
         ]
     );
 }

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -463,7 +463,7 @@ pub fn render_for_args(args: &[&str]) -> Option<String> {
     }
 
     // `heddle <path> --help` pre-parse direct help (e.g. `clone --help`,
-    // `import git --help`).
+    // `bridge git import --help`).
     if let Some(rendered) = render_direct_help_for_raw(&command, &raw) {
         return Some(rendered);
     }
@@ -706,8 +706,8 @@ Common mappings:
 
 Heddle intentionally does not reproduce the full Git command surface. An
 optional Git-compatible client can perform unsupported Git operations against
-the same `.git`; it is not a Heddle dependency. Explicit `import git`, `export
-git`, and `sync git` translate data between authorities. After `heddle adopt`,
+the same `.git`; it is not a Heddle dependency. Explicit `bridge git import`,
+`bridge git export`, and `sync git` translate data between authorities. After `heddle adopt`,
 the retained `.git` is an explicit Git Projection adapter; it no longer selects
 repository source authority.
 "#;
@@ -862,7 +862,7 @@ Git-compatible client, but that client is optional and is never invoked by
 Heddle. Unsupported capabilities fail closed.
 
 Run `heddle help --output json` to inspect the public command surface, and
-`heddle doctor` / `heddle fsck --full` when a repository reports integrity
+`heddle doctor` / `heddle maintenance fsck --full` when a repository reports integrity
 or Git Projection state problems.
 "#;
 
@@ -968,12 +968,12 @@ Move an existing Git repository to Native Heddle atomically:
 
 Translate explicitly without changing source authority:
 
-    heddle import git --path <git-repository> --ref <branch>
-    heddle export git --destination <bare-git-repository>
+    heddle bridge git import --path <git-repository> --ref <branch>
+    heddle bridge git export --destination <bare-git-repository>
     heddle sync git --path <git-repository>
 
-`import git` and `sync git` accept a local path or Git URL. Omit `--ref` to
-import all local branches and tags. `export git` writes a bare Git repository.
+`bridge git import` and `sync git` accept a local path or Git URL. Omit `--ref` to
+import all local branches and tags. `bridge git export` writes a bare Git repository.
 Legacy migration and repair may still read an existing Bridge Mirror at
 `.heddle/git` while ADR 0042's retirement work remains incomplete.
 
@@ -1164,7 +1164,7 @@ mod tests {
         let projection = topic_text("git-projection").expect("git-projection topic should exist");
         assert!(projection.contains("It is not Git Overlay"));
         assert!(projection.contains("heddle adopt --ref <branch>"));
-        assert!(projection.contains("heddle export git --destination"));
+        assert!(projection.contains("heddle bridge git export --destination"));
         assert!(projection.contains("Bridge Mirror"));
     }
 

--- a/crates/cli/src/cli/commands/agent.rs
+++ b/crates/cli/src/cli/commands/agent.rs
@@ -4,9 +4,9 @@
 use anyhow::Result;
 
 use crate::cli::cli_args::{
-    AgentCommands, AgentPresenceCommands, AgentProvenanceBeginArgs, AgentProvenanceCommands,
-    AgentProvenanceEndArgs, AgentProvenanceListArgs, AgentProvenanceSegmentArgs,
-    AgentProvenanceShowArgs, Cli,
+    AgentCommands, AgentProvenanceBeginArgs, AgentProvenanceCommands, AgentProvenanceEndArgs,
+    AgentProvenanceListArgs, AgentProvenanceSegmentArgs, AgentProvenanceShowArgs, Cli,
+    PresenceCommands,
 };
 
 pub async fn run(cli: &Cli, command: &AgentCommands) -> Result<()> {
@@ -21,21 +21,20 @@ pub async fn run(cli: &Cli, command: &AgentCommands) -> Result<()> {
         AgentCommands::List(args) => super::agent_cmd::cmd_agent_list(cli, args.clone()),
         AgentCommands::Task(command) => super::agent_cmd::cmd_agent_task(cli, command.clone()),
         AgentCommands::Fanout(command) => super::agent_cmd::cmd_agent_fanout(cli, command.clone()),
-        AgentCommands::Presence(command) => run_presence(cli, command).await,
         AgentCommands::Provenance(command) => run_provenance(cli, command).await,
     }
 }
 
-async fn run_presence(cli: &Cli, command: &AgentPresenceCommands) -> Result<()> {
+pub async fn run_presence(cli: &Cli, command: &PresenceCommands) -> Result<()> {
     match command {
-        AgentPresenceCommands::List(args) => super::agent_presence::list(cli, args.active).await,
-        AgentPresenceCommands::Show(args) => {
+        PresenceCommands::List(args) => super::agent_presence::list(cli, args.active).await,
+        PresenceCommands::Show(args) => {
             super::agent_presence::show(cli, args.session.clone()).await
         }
-        AgentPresenceCommands::Explain(args) => {
+        PresenceCommands::Explain(args) => {
             super::agent_presence::explain(cli, args.session.clone()).await
         }
-        AgentPresenceCommands::Complete(args) => {
+        PresenceCommands::Complete(args) => {
             super::agent_presence::complete(cli, args.session.clone()).await
         }
     }

--- a/crates/cli/src/cli/commands/agent_presence.rs
+++ b/crates/cli/src/cli/commands/agent_presence.rs
@@ -154,7 +154,7 @@ pub async fn list(cli: &Cli, active_only: bool) -> Result<()> {
 
     if should_output_json(cli, None) {
         let output = ActorListOutput {
-            output_kind: "agent_presence_list",
+            output_kind: "presence_list",
             presence: report.actors,
             active_only: report.active_only,
             trust: build_repository_verification_state(&repo),
@@ -174,13 +174,13 @@ pub async fn show(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle agent presence show <SESSION>",
+        "heddle presence show <SESSION>",
     )?;
     let show = show_actor_from_entry(&registry, &entry)?;
 
     if should_output_json(cli, None) {
         let output = ActorSingleOutput {
-            output_kind: "agent_presence_show",
+            output_kind: "presence_show",
             presence: show.actor,
             trust: build_repository_verification_state(&repo),
         };
@@ -281,7 +281,7 @@ pub async fn complete(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle agent presence complete --session <SESSION>",
+        "heddle presence complete --session <SESSION>",
     )?;
     let plan = plan_actor_done(&entry);
     mark_actor_done(&registry, &plan.session_id)?;
@@ -293,7 +293,7 @@ pub async fn complete(cli: &Cli, session_id: Option<String>) -> Result<()> {
 
     if should_output_json(cli, None) {
         let output = ActorDoneOutput {
-            output_kind: "agent_presence_complete",
+            output_kind: "presence_complete",
             session_id: plan.session_id.clone(),
             status: "complete",
             thread: plan.thread.clone(),
@@ -333,7 +333,7 @@ pub async fn explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle agent presence explain <SESSION>",
+        "heddle presence explain <SESSION>",
     ) {
         Ok(entry) => entry,
         Err(err) if session_id.is_none() && is_no_active_actor_error(&err) => {
@@ -348,7 +348,7 @@ pub async fn explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
 
     if should_output_json(cli, None) {
         let output = ActorExplainOutput {
-            output_kind: "agent_presence_explain",
+            output_kind: "presence_explain",
             session_id: entry.session_id,
             thread: entry.thread,
             heddle_session_id: entry.heddle_session_id,
@@ -425,7 +425,7 @@ fn explain_detected_actor_identity(cli: &Cli, repo: &Repository) -> Result<()> {
 
     if should_output_json(cli, None) {
         let output = ActorExplainDetectedOutput {
-            output_kind: "agent_presence_explain",
+            output_kind: "presence_explain",
             attached: false,
             active_presence: None,
             reason: "No active actor is registered for this checkout.",
@@ -637,11 +637,11 @@ fn no_active_actor_advice() -> RecoveryAdvice {
         "no active actor registry entry matches the current thread or checkout path",
         "choosing a completed actor implicitly could show the wrong session",
         "no actor registry entries, refs, repository objects, or worktree files were changed",
-        "heddle agent presence list",
+        "heddle presence list",
         vec![
-            "heddle agent presence list".to_string(),
-            "heddle agent presence explain".to_string(),
-            "heddle agent presence show <session>".to_string(),
+            "heddle presence list".to_string(),
+            "heddle presence explain".to_string(),
+            "heddle presence show <session>".to_string(),
         ],
     )
 }

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -307,8 +307,8 @@ impl ErrorClassification {
 
 fn typed_recovery_commands(kind: &str) -> Vec<String> {
     let commands: &[&str] = match kind {
-        "state_corrupted" => &["heddle verify", "heddle fsck --full"],
-        "repository_integrity_error" => &["heddle fsck --full"],
+        "state_corrupted" => &["heddle verify", "heddle maintenance fsck --full"],
+        "repository_integrity_error" => &["heddle maintenance fsck --full"],
         "repository_not_found" => &["heddle init"],
         "state_not_found" => &["heddle log"],
         // Merge-orchestration refusals raised from core as typed
@@ -611,11 +611,11 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
                 | HeddleError::InvalidTreeEntry(_) => {
                     return ErrorClassification::known(
                         "repository_integrity_error",
-                        "Inspect repository integrity with `heddle fsck --full`, then restore or repair the reported object/ref.",
+                        "Inspect repository integrity with `heddle maintenance fsck --full`, then restore or repair the reported object/ref.",
                         "repository object or ref integrity did not pass validation",
                         "continuing could compound corruption or hide the missing object",
                         "the command stopped before applying the requested mutation",
-                        "heddle fsck --full",
+                        "heddle maintenance fsck --full",
                     );
                 }
                 HeddleError::NoMergeInProgress => {
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(classified.primary_command, "heddle verify");
         assert_eq!(
             classified.recovery_commands,
-            vec!["heddle verify", "heddle fsck --full"]
+            vec!["heddle verify", "heddle maintenance fsck --full"]
         );
         assert!(classified.extra_json_fields.is_empty());
     }

--- a/crates/cli/src/cli/commands/fsck.rs
+++ b/crates/cli/src/cli/commands/fsck.rs
@@ -241,12 +241,12 @@ fn git_repair_ref_required_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "git_repair_ref_required",
         "Git ref repair needs a ref name",
-        "Run `heddle fsck repair git --ref <branch> --preview` to inspect the authority-valid repair.",
+        "Run `heddle maintenance fsck repair git --ref <branch> --preview` to inspect the authority-valid repair.",
         "--preview was supplied without --ref",
         "repairing a Git projection ref without a ref name could mutate the wrong branch",
         "Git refs, Heddle refs, index, remotes, and worktree files were left unchanged",
-        "heddle fsck repair git --ref <branch> --preview",
-        vec!["heddle fsck repair git --ref <branch> --preview".to_string()],
+        "heddle maintenance fsck repair git --ref <branch> --preview",
+        vec!["heddle maintenance fsck repair git --ref <branch> --preview".to_string()],
     )
 }
 
@@ -254,12 +254,12 @@ fn git_repair_native_ref_required_advice() -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "git_repair_native_ref_required",
         "Native Git projection repair needs a ref name",
-        "Run `heddle fsck repair git --ref <branch> --preview` to inspect the Heddle-to-Git projection repair.",
+        "Run `heddle maintenance fsck repair git --ref <branch> --preview` to inspect the Heddle-to-Git projection repair.",
         "the native repository has no projection ref target",
         "repairing every retained Git ref could overwrite unrelated adapter state",
         "Git refs, Heddle refs, index, remotes, and worktree files were left unchanged",
-        "heddle fsck repair git --ref <branch> --preview",
-        vec!["heddle fsck repair git --ref <branch> --preview".to_string()],
+        "heddle maintenance fsck repair git --ref <branch> --preview",
+        vec!["heddle maintenance fsck repair git --ref <branch> --preview".to_string()],
     )
 }
 
@@ -281,7 +281,7 @@ fn git_repair_authority_mismatch_advice(
         ),
         RepositorySourceAuthority::Native => {
             let import = ref_name.map_or_else(
-                || "heddle import git".to_string(),
+                || "heddle bridge git import".to_string(),
                 heddle_core::status::next_action::canonical_git_import_ref_command,
             );
             RecoveryAdvice::safety_refusal(
@@ -342,7 +342,7 @@ fn repair_git(
 
 fn git_repair_ref_command(prefer: &str, ref_name: &str, preview: bool) -> String {
     let mut command = format!(
-        "heddle fsck repair git --prefer {} --ref {}",
+        "heddle maintenance fsck repair git --prefer {} --ref {}",
         repo::shell_quote(prefer),
         repo::shell_quote(ref_name)
     );
@@ -356,12 +356,12 @@ fn fsck_integrity_error_advice(error_count: usize) -> RecoveryAdvice {
     RecoveryAdvice::safety_refusal(
         "repository_integrity_error",
         "Repository has integrity errors",
-        "Inspect repository integrity with `heddle fsck --full`, then restore or repair the reported object/ref.",
+        "Inspect repository integrity with `heddle maintenance fsck --full`, then restore or repair the reported object/ref.",
         format!("{error_count} integrity error(s) remain after fsck"),
         "treating this repository as verified could hide missing or corrupt objects/refs",
         "no repository objects, refs, or worktree files were changed",
-        "heddle fsck --full",
-        vec!["heddle fsck --full".to_string()],
+        "heddle maintenance fsck --full",
+        vec!["heddle maintenance fsck --full".to_string()],
     )
 }
 

--- a/crates/cli/src/cli/commands/git_projection_io.rs
+++ b/crates/cli/src/cli/commands/git_projection_io.rs
@@ -349,7 +349,7 @@ pub fn cmd_export_git(cli: &Cli, destination: Option<PathBuf>) -> Result<()> {
         &repo,
         &mut bridge,
         destination,
-        "no destination specified. Use `export git --destination PATH` to write a bare Git repository, or `push <remote>` to push to a configured remote.",
+        "no destination specified. Use `bridge git export --destination PATH` to write a bare Git repository, or `push <remote>` to push to a configured remote.",
     )
 }
 
@@ -368,9 +368,9 @@ pub fn cmd_import_git(
         path,
         &refs,
         lossy,
-        "import_git",
-        "import git",
-        &["import", "git"],
+        "bridge_git_import",
+        "bridge git import",
+        &["bridge", "git", "import"],
     )
 }
 
@@ -405,7 +405,7 @@ fn run_git_export(
         // could not publish every ref.
         if failure.is_none() {
             let out = serde_json::json!({
-                "output_kind": "export_git",
+                "output_kind": "bridge_git_export",
                 "states_exported": stats.states_exported,
                 "commits_total": stats.commits_total,
                 "threads_synced": stats.threads_synced,

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -915,7 +915,7 @@ fn write_reflog_full<W: std::io::Write>(out: &mut W, output: &ReflogOutput) -> s
     writeln!(out, "Reflog: {} entrie(s)", output.entries.len())?;
     if output.entries.is_empty() {
         if let Some(line) = format_next_step_dim(
-            "run `heddle commit` after capturing work, `heddle pull`, or `heddle import git`",
+            "run `heddle commit` after capturing work, `heddle pull`, or `heddle bridge git import`",
             0,
         ) {
             writeln!(out, "{line}")?;

--- a/crates/cli/src/cli/commands/maintenance.rs
+++ b/crates/cli/src/cli/commands/maintenance.rs
@@ -10,7 +10,9 @@ use objects::store::{
 use serde::Serialize;
 
 use crate::cli::{
-    Cli, MaintenanceCommands, commands::cmd_gc, should_output_json, worktree_status_options,
+    Cli, FsckCommands, FsckRepairCommands, MaintenanceCommands,
+    commands::{cmd_fsck, cmd_fsck_repair_git, cmd_gc},
+    should_output_json, worktree_status_options,
 };
 
 #[derive(Serialize)]
@@ -49,6 +51,16 @@ pub fn cmd_maintenance(cli: &Cli, command: MaintenanceCommands) -> Result<()> {
     let options = worktree_status_options(Some(repo.config()));
 
     match command {
+        MaintenanceCommands::Fsck(args) => {
+            return match args.command {
+                None => cmd_fsck(cli, args.full, args.thorough, args.provenance, args.git),
+                Some(FsckCommands::Repair { target }) => match target {
+                    FsckRepairCommands::Git(args) => {
+                        cmd_fsck_repair_git(cli, args.ref_name, args.prefer, args.preview)
+                    }
+                },
+            };
+        }
         MaintenanceCommands::Inspect => {
             let report = repo.inspect_performance_with_options(&options)?;
             if should_output_json(cli, Some(repo.config())) {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -88,6 +88,7 @@ mod worktree_safety;
 pub use adopt::cmd_adopt;
 pub use advice::RecoveryAdvice;
 pub use agent::run as cmd_agent;
+pub use agent::run_presence as cmd_presence;
 pub use agent_cmd::{
     agent_api_schema, cmd_agent_capture, cmd_agent_heartbeat, cmd_agent_list, cmd_agent_ready,
     cmd_agent_release, cmd_agent_reserve,

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -359,7 +359,7 @@ pub(crate) fn suppress_thread_actions_while_trust_blocked(
         if trust.status == "needs_import"
             && summary
                 .recommended_action
-                .starts_with("heddle import git --ref ")
+                .starts_with("heddle bridge git import --ref ")
         {
             summary.recommended_action_template =
                 recommended_action_template(&summary.recommended_action);
@@ -2867,7 +2867,7 @@ mod tests {
         assert!(advice.unsafe_condition.contains("dirty Git index"));
         assert_eq!(
             advice.primary_command,
-            "heddle fsck repair git --prefer heddle --ref feature/git --preview"
+            "heddle maintenance fsck repair git --prefer heddle --ref feature/git --preview"
         );
         assert!(advice.preserved.contains("Git checkout was left unchanged"));
     }

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -661,12 +661,13 @@ mod tests {
                 "active Git branch has not been imported"
             }
             .to_string(),
-            recommended_action: (!verified).then(|| "heddle import git --ref main".to_string()),
+            recommended_action: (!verified)
+                .then(|| "heddle bridge git import --ref main".to_string()),
             recommended_action_template: None,
             recovery_commands: if verified {
                 Vec::new()
             } else {
-                vec!["heddle import git --ref main".to_string()]
+                vec!["heddle bridge git import --ref main".to_string()]
             },
             recovery_action_templates: Vec::new(),
             details: std::collections::BTreeMap::new(),
@@ -724,7 +725,7 @@ mod tests {
         );
         assert_eq!(
             blocked.recommended_action.as_deref(),
-            Some("heddle import git --ref main")
+            Some("heddle bridge git import --ref main")
         );
         assert!(
             blocked

--- a/crates/cli/src/cli/commands/undo.rs
+++ b/crates/cli/src/cli/commands/undo.rs
@@ -312,8 +312,8 @@ pub fn cmd_undo_recover(cli: &Cli) -> Result<()> {
             "the checkout-local recovery ref points to an unavailable state",
             "recovery cannot materialize a state whose object is missing",
             "HEAD and worktree files were left unchanged",
-            "heddle fsck",
-            vec!["heddle fsck".to_string()],
+            "heddle maintenance fsck",
+            vec!["heddle maintenance fsck".to_string()],
         )));
     }
 

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn fsck_authority_refusal_is_data_err() {
-        // An authority-conflicting `heddle fsck repair git --prefer ...`
+        // An authority-conflicting `heddle maintenance fsck repair git --prefer ...`
         // request is a semantic refusal, not an IO failure.
         let advice = crate::cli::commands::RecoveryAdvice::safety_refusal(
             "git_repair_requires_adoption",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,15 +15,15 @@ use cli::cli::commands::cmd_context_reason_git;
 use cli::cli::commands::cmd_semantic;
 #[cfg(feature = "git-overlay")]
 use cli::cli::{
-    ExportCommands, ImportCommands,
+    BridgeCommands, BridgeGitCommands,
     cli_args::{SyncArgs, SyncCommands},
     commands::{cmd_export_git, cmd_import_git, cmd_sync_git},
 };
 use cli::{
     cli::{
         Cli, CloneArgs, CollapseArgs, Commands, ContextCommands, DaemonCommands, DiffArgs,
-        ExpandArgs, FsckCommands, FsckRepairCommands, IntegrationCommands, LogArgs,
-        MaintenanceCommands, ResolveArgs, RetroArgs, RevertArgs, RunArgs, ThreadCommands, UndoArgs,
+        ExpandArgs, IntegrationCommands, LogArgs, MaintenanceCommands, ResolveArgs, RetroArgs,
+        RevertArgs, RunArgs, ThreadCommands, UndoArgs,
         cli_args::LandArgs,
         commands::{
             LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
@@ -32,14 +32,14 @@ use cli::{
             cmd_context_get, cmd_context_history, cmd_context_list, cmd_context_rm,
             cmd_context_set, cmd_context_suggest, cmd_context_supersede, cmd_continue,
             cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff, cmd_discuss,
-            cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_fsck,
-            cmd_fsck_repair_git, cmd_hook, cmd_init, cmd_integration, cmd_land, cmd_log,
-            cmd_maintenance, cmd_oplog, cmd_pull, cmd_push, cmd_query, cmd_ready, cmd_redo,
-            cmd_remote, cmd_resolve, cmd_retro, cmd_revert, cmd_review, cmd_run, cmd_schemas,
-            cmd_shell, cmd_show, cmd_snapshot, cmd_start, cmd_status, cmd_sync_smart, cmd_thread,
-            cmd_timeline, cmd_try, cmd_undo, cmd_undo_recover, cmd_verify, cmd_watch,
-            command_runtime_contract_for_command, print_error_with_hint,
-            print_parse_error_json_envelope, recover_incomplete_land_if_present,
+            cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_hook, cmd_init,
+            cmd_integration, cmd_land, cmd_log, cmd_maintenance, cmd_oplog, cmd_presence, cmd_pull,
+            cmd_push, cmd_query, cmd_ready, cmd_redo, cmd_remote, cmd_resolve, cmd_retro,
+            cmd_revert, cmd_review, cmd_run, cmd_schemas, cmd_shell, cmd_show, cmd_snapshot,
+            cmd_start, cmd_status, cmd_sync_smart, cmd_thread, cmd_timeline, cmd_try, cmd_undo,
+            cmd_undo_recover, cmd_verify, cmd_watch, command_runtime_contract_for_command,
+            print_error_with_hint, print_parse_error_json_envelope,
+            recover_incomplete_land_if_present,
         },
         render::write_json_stdout,
     },
@@ -84,7 +84,7 @@ async fn async_main() -> Result<()> {
     }
 
     // Install the ring crypto provider as the rustls default. Without this,
-    // any rustls TLS handshake (hosted API, GitHub REST, `import git
+    // any rustls TLS handshake (hosted API, GitHub REST, `bridge git import
     // https://…`) panics in 0.23.x. We pin ring instead of aws-lc-rs to
     // keep the 80s aws-lc-sys C build out of release builds. Measured
     // ~0ms on macOS — defensive ordering rather than a perf hot spot.
@@ -583,26 +583,14 @@ async fn async_main() -> Result<()> {
         }
 
         #[cfg(feature = "git-overlay")]
-        Commands::Import { command } => match command {
-            ImportCommands::Git { path, refs, lossy } => {
-                cmd_import_git(&cli, path.clone(), refs.clone(), *lossy)
-            }
-        },
-
-        #[cfg(feature = "git-overlay")]
-        Commands::Export { command } => match command {
-            ExportCommands::Git { destination } => cmd_export_git(&cli, destination.clone()),
-        },
-
-        Commands::Fsck(args) => match &args.command {
-            None => cmd_fsck(&cli, args.full, args.thorough, args.provenance, args.git),
-            Some(cli::cli::FsckCommands::Repair { target }) => match target {
-                cli::cli::FsckRepairCommands::Git(args) => cmd_fsck_repair_git(
-                    &cli,
-                    args.ref_name.clone(),
-                    args.prefer.clone(),
-                    args.preview,
-                ),
+        Commands::Bridge { command } => match command {
+            BridgeCommands::Git { command } => match command {
+                BridgeGitCommands::Import { path, refs, lossy } => {
+                    cmd_import_git(&cli, path.clone(), refs.clone(), *lossy)
+                }
+                BridgeGitCommands::Export { destination } => {
+                    cmd_export_git(&cli, destination.clone())
+                }
             },
         },
 
@@ -802,6 +790,8 @@ async fn async_main() -> Result<()> {
         },
 
         Commands::Agent { command } => cmd_agent(&cli, command).await,
+
+        Commands::Presence { command } => cmd_presence(&cli, command).await,
 
         Commands::Discuss { command } => cmd_discuss(&cli, command).await,
 
@@ -1161,10 +1151,12 @@ fn invocation_is_observe_only(command: &Commands) -> bool {
     match command {
         Commands::Undo(args) => args.list || args.preview,
         Commands::Resolve(args) => args.list,
-        Commands::Fsck(args) => matches!(
+        Commands::Maintenance {
+            command: MaintenanceCommands::Fsck(args),
+        } => matches!(
             &args.command,
-            Some(FsckCommands::Repair {
-                target: FsckRepairCommands::Git(args)
+            Some(cli::cli::FsckCommands::Repair {
+                target: cli::cli::FsckRepairCommands::Git(args)
             }) if args.preview
         ),
         Commands::Thread {
@@ -1242,9 +1234,27 @@ mod tests {
             (&["heddle", "undo", "--redo"], false),
             (&["heddle", "resolve", "--list"], true),
             (&["heddle", "resolve", "--all"], false),
-            (&["heddle", "fsck", "repair", "git", "--preview"], true),
             (
-                &["heddle", "fsck", "repair", "git", "--prefer", "git"],
+                &[
+                    "heddle",
+                    "maintenance",
+                    "fsck",
+                    "repair",
+                    "git",
+                    "--preview",
+                ],
+                true,
+            ),
+            (
+                &[
+                    "heddle",
+                    "maintenance",
+                    "fsck",
+                    "repair",
+                    "git",
+                    "--prefer",
+                    "git",
+                ],
                 false,
             ),
             (&["heddle", "thread", "absorb", "child", "--preview"], true),

--- a/crates/cli/tests/advice_lint.rs
+++ b/crates/cli/tests/advice_lint.rs
@@ -230,7 +230,7 @@ fn next_action_priority_lives_in_shared_selector() {
         for (line_index, line) in source.lines().enumerate() {
             for fragment in [
                 "remote_tracking.behind > 0",
-                "heddle import git --ref {}",
+                "heddle bridge git import --ref {}",
                 "thread_action.filter(|action| !action.trim().is_empty())",
             ] {
                 if line.contains(fragment) {

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -358,11 +358,11 @@ fn test_cli_adopt_partial_divergence_failure_preserves_state_and_one_recovery() 
     );
     assert_eq!(
         envelope["primary_command"],
-        "heddle fsck repair git --ref feature/drop-in --preview"
+        "heddle maintenance fsck repair git --ref feature/drop-in --preview"
     );
     assert_eq!(
         envelope["recovery_commands"],
-        serde_json::json!(["heddle fsck repair git --ref feature/drop-in --preview"])
+        serde_json::json!(["heddle maintenance fsck repair git --ref feature/drop-in --preview"])
     );
 }
 
@@ -1406,7 +1406,11 @@ fn test_cli_import_git_clears_import_hint_for_existing_branches() {
             .unwrap();
     assert_no_legacy_verification_sidecars(&before);
 
-    let import_output = heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    let import_output = heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
     let parsed_import: serde_json::Value =
         serde_json::from_str(&import_output).unwrap_or(serde_json::Value::Null);
     let synced = parsed_import["branches_synced"].as_u64().unwrap_or(0);
@@ -1447,8 +1451,9 @@ fn test_cli_import_git_ref_imports_only_selected_branch() {
         &[
             "--output",
             "json",
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             ".",
             "--ref",
@@ -1538,7 +1543,7 @@ fn test_cli_diff_mapped_git_branch_alias_resolves_without_import_loop() {
     git(&["branch", "support/git-only"], temp.path());
     heddle(&["init"], Some(temp.path())).unwrap();
     heddle(
-        &["import", "git", "--ref", "support/git-only"],
+        &["bridge", "git", "import", "--ref", "support/git-only"],
         Some(temp.path()),
     )
     .unwrap();
@@ -1568,7 +1573,11 @@ fn test_cli_compare_mapped_git_tag_resolves_without_import_loop() {
     git_commit_all(temp.path(), "seed branch");
     git(&["tag", "v1.0.0"], temp.path());
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "v1.0.0"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "v1.0.0"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let output = heddle(
         &["diff", "HEAD", "v1.0.0", "--output", "json"],
@@ -1639,7 +1648,7 @@ fn test_cli_import_git_ref_imports_only_selected_tag() {
 
     let import_output = heddle(
         &[
-            "--output", "json", "import", "git", "--path", ".", "--ref", "v1.0.0",
+            "--output", "json", "bridge", "git", "import", "--path", ".", "--ref", "v1.0.0",
         ],
         Some(temp.path()),
     )
@@ -1670,11 +1679,15 @@ fn test_cli_import_git_defaults_to_current_repo_even_after_mirror_exists() {
     std::fs::write(temp.path().join("tracked.txt"), "tracked").unwrap();
     git_commit_all(temp.path(), "seed branch");
 
-    heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     git(&["branch", "support/import-latest"], temp.path());
 
-    let import_output = heddle(&["import", "git"], Some(temp.path())).unwrap();
+    let import_output = heddle(&["bridge", "git", "import"], Some(temp.path())).unwrap();
     let parsed_import: Value = serde_json::from_str(&import_output).unwrap_or(Value::Null);
     let synced = parsed_import["branches_synced"].as_u64().unwrap_or(0);
     assert!(

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -23,9 +23,7 @@ fn help_render_matches_spawned_binary() {
         vec!["capture", "--help-agent"],
         vec!["push", "--help"],
         vec!["log", "--help"],
-        vec!["import", "git", "--help"],
-        // Alias resolution: `import` is an alias that resolves to `adopt`.
-        vec!["import", "--help"],
+        vec!["bridge", "git", "import", "--help"],
         // Curated topic page + `heddle help <verb>` clap fall-through.
         vec!["help"],
         vec!["help", "advanced"],
@@ -309,9 +307,9 @@ fn git_concepts_topic_explains_authority_and_current_surface() {
     assert!(
         help.contains("optional Git-compatible client")
             && help.contains("it is not a Heddle dependency")
-            && help.contains("`import git`")
-            && help.contains("`export")
-            && help.contains("git`, and `sync git`")
+            && help.contains("`bridge git import`")
+            && help.contains("`bridge git export`")
+            && help.contains("`sync git`")
             && help.contains("translate data between authorities"),
         "git-concepts topic should explain unsupported Git operations and authority translation: {help}"
     );

--- a/crates/cli/tests/cli_integration/current_context_advice.rs
+++ b/crates/cli/tests/cli_integration/current_context_advice.rs
@@ -119,6 +119,29 @@ fn removed_phase_2_roots_are_unknown_commands() {
     }
 }
 
+#[test]
+fn removed_phase_3_paths_are_clean_parse_errors() {
+    let temp = setup_detached_repo_without_current_thread();
+    for args in [
+        &["--output", "json", "agent", "presence", "list"][..],
+        &["--output", "json", "fsck"],
+        &["--output", "json", "import", "git"],
+        &["--output", "json", "export", "git"],
+    ] {
+        let output = heddle_output(args, Some(temp.path())).expect("invoke removed Phase 3 path");
+        assert_eq!(output.status.code(), Some(64), "args={args:?}");
+        assert!(output.stdout.is_empty(), "args={args:?}");
+
+        let stderr = str::from_utf8(&output.stderr).expect("stderr should be utf8");
+        let envelope: Value = serde_json::from_str(stderr.trim()).expect("stderr should be JSON");
+        assert_eq!(envelope["kind"], "parse_error", "args={args:?}");
+        assert!(
+            !stderr.to_ascii_lowercase().contains("panicked"),
+            "removed path must fail without a panic: {stderr}"
+        );
+    }
+}
+
 fn assert_action_template(
     template: &Value,
     action: &str,

--- a/crates/cli/tests/cli_integration/error_envelope_lint.rs
+++ b/crates/cli/tests/cli_integration/error_envelope_lint.rs
@@ -40,9 +40,9 @@ const SWEPT_COVERAGE: &[&str] = &[
     "commit",
     "push",
     "pull",
-    "import git",
+    "bridge git import",
     "sync git",
-    "fsck repair git",
+    "maintenance fsck repair git",
 ];
 
 /// One representative error case: the swept command it covers, the argv
@@ -97,11 +97,12 @@ fn adopted_git_overlay() -> TempDir {
     git(&["add", "a.txt"], dir);
     git(&["commit", "-qm", "init"], dir);
     heddle_output(&["adopt"], Some(dir)).expect("heddle adopt");
-    heddle_output(&["import", "git", "--ref", "main"], Some(dir)).expect("heddle import git");
+    heddle_output(&["bridge", "git", "import", "--ref", "main"], Some(dir))
+        .expect("heddle bridge git import");
     temp
 }
 
-/// `init` / `status` / `verify` / `import git|sync` exit
+/// `init` / `status` / `verify` / `bridge git import|sync` exit
 /// `0` on their documented happy paths, so this lint covers them through
 /// adjacent error conditions: an unparseable invocation (`init`), a
 /// missing-state lookup (`status`/`verify` share the
@@ -140,9 +141,9 @@ fn cases() -> Vec<ErrorCase> {
             fixture: init_repo,
         },
         ErrorCase {
-            covers: &["import git"],
-            label: "import git of a missing ref",
-            argv: &["import", "git", "--ref", "no-such-branch"],
+            covers: &["bridge git import"],
+            label: "bridge git import of a missing ref",
+            argv: &["bridge", "git", "import", "--ref", "no-such-branch"],
             fixture: adopted_git_overlay,
         },
         ErrorCase {
@@ -156,9 +157,18 @@ fn cases() -> Vec<ErrorCase> {
             fixture: adopted_git_overlay,
         },
         ErrorCase {
-            covers: &["fsck repair git"],
+            covers: &["maintenance fsck repair git"],
             label: "fsck repair git against native source authority",
-            argv: &["fsck", "repair", "git", "--prefer", "git", "--ref", "main"],
+            argv: &[
+                "maintenance",
+                "fsck",
+                "repair",
+                "git",
+                "--prefer",
+                "git",
+                "--ref",
+                "main",
+            ],
             fixture: adopted_git_overlay,
         },
     ]

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -126,14 +126,22 @@ fn pull_without_remote_is_config() {
 fn import_git_exits_zero() {
     // Documented: `0 ok`.
     let repo = adopted_git_overlay();
-    assert_exit(&["import", "git", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
 }
 
 #[test]
 fn sync_git_exits_zero() {
     // Documented: `0 ok`.
     let repo = adopted_git_overlay();
-    assert_exit(&["import", "git", "--ref", "main"], repo.path(), 0);
+    assert_exit(
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
     assert_exit(&["sync", "git"], repo.path(), 0);
 }
 
@@ -142,9 +150,22 @@ fn fsck_git_repair_against_native_authority_is_data_err() {
     // Documented: `65 DataErr` — the retained Git adapter cannot become
     // authoritative through a repair command in a native repository.
     let repo = adopted_git_overlay();
-    assert_exit(&["import", "git", "--ref", "main"], repo.path(), 0);
     assert_exit(
-        &["fsck", "repair", "git", "--prefer", "git", "--ref", "main"],
+        &["bridge", "git", "import", "--ref", "main"],
+        repo.path(),
+        0,
+    );
+    assert_exit(
+        &[
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--prefer",
+            "git",
+            "--ref",
+            "main",
+        ],
         repo.path(),
         65,
     );

--- a/crates/cli/tests/cli_integration/fault_injection.rs
+++ b/crates/cli/tests/cli_integration/fault_injection.rs
@@ -21,7 +21,7 @@ use super::*;
 
 /// R9: Git Projection Mapping persistence.
 ///
-/// `export git` writes the served heddle↔git mapping to disk via a
+/// `bridge git export` writes the served heddle↔git mapping to disk via a
 /// tmp-rename-rename pattern (`git-projection-mapping.json.tmp` →
 /// `git-projection-mapping.json`). The fault checkpoint
 /// `mapping_after_tmp_before_commit` panics in the gap between those
@@ -69,7 +69,13 @@ fn bridge_recovers_from_crash_after_tmp_before_commit() {
     // panic message so a regression that silently no-ops the
     // checkpoint surfaces here, not three commits downstream.
     let crashed = Command::new(env!("CARGO_BIN_EXE_heddle"))
-        .args(["export", "git", "--destination", export.to_str().unwrap()])
+        .args([
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            export.to_str().unwrap(),
+        ])
         .current_dir(&work)
         .env("HEDDLE_FAULT_INJECT", "mapping_after_tmp_before_commit")
         .env("HEDDLE_CONFIG", work.join(".heddle-user/config.toml"))
@@ -115,7 +121,13 @@ fn bridge_recovers_from_crash_after_tmp_before_commit() {
     // export. Final assertion: the canonical mapping file exists,
     // is non-empty, and parses as the expected shape.
     let recovered = heddle_output_with_env(
-        &["export", "git", "--destination", export.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            export.to_str().unwrap(),
+        ],
         Some(&work),
         &[],
     )

--- a/crates/cli/tests/cli_integration/git_overlay_fixtures.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_fixtures.rs
@@ -25,7 +25,7 @@ impl GitOverlayFixture {
         git_hermetic(&["add", "README.md"], &work);
         git_hermetic(&["commit", "-m", "base"], &work);
         heddle(&["init"], Some(&work)).expect("initialize Git Overlay");
-        heddle(&["import", "git", "--ref", "main"], Some(&work)).expect("import main");
+        heddle(&["bridge", "git", "import", "--ref", "main"], Some(&work)).expect("import main");
         Self {
             temp,
             work,

--- a/crates/cli/tests/cli_integration/git_overlay_interop_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_interop_matrix.rs
@@ -49,7 +49,9 @@ fn git_overlay_interop_import_git_imports_current_branch() {
     assert!(parsed["current_state"].is_null());
 
     let import = heddle(
-        &["--output", "json", "import", "git", "--ref", "main"],
+        &[
+            "--output", "json", "bridge", "git", "import", "--ref", "main",
+        ],
         Some(temp.path()),
     )
     .unwrap();
@@ -57,7 +59,7 @@ fn git_overlay_interop_import_git_imports_current_branch() {
     assert!(
         parsed_import["branches_synced"].as_u64() == Some(1)
             || import.contains("Synced 1 branches to threads"),
-        "import git should import branch: {import}"
+        "bridge git import should import branch: {import}"
     );
 
     let status = status_json(temp.path());
@@ -73,7 +75,11 @@ fn git_overlay_interop_native_git_commit_stays_direct_backed_until_import() {
     init_git(temp.path());
     let first_tip = commit_file(temp.path(), "story.txt", "one\n", "seed");
     heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     let first_state = status_json(temp.path())["current_state"]
         .as_str()
         .unwrap()
@@ -89,7 +95,11 @@ fn git_overlay_interop_native_git_commit_stays_direct_backed_until_import() {
     );
     assert_eq!(before_import["verification"]["status"], "clean");
 
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     let after_import = status_json(temp.path());
     assert_ne!(after_import["current_state"], first_state);
     assert_eq!(
@@ -127,7 +137,7 @@ fn git_overlay_interop_fetch_sync_then_heddle_status_stays_clean() {
     configure_git(&work);
     git(&work, &["switch", "main"]);
     heddle(&["status", "--output", "json"], Some(&work)).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(&work)).unwrap();
+    heddle(&["bridge", "git", "import", "--ref", "main"], Some(&work)).unwrap();
 
     git(
         temp.path(),
@@ -166,7 +176,11 @@ fn git_overlay_interop_git_conflict_routes_to_no_git_handoff() {
     init_git(temp.path());
     commit_file(temp.path(), "clash.txt", "base\n", "seed");
     heddle(&["status", "--output", "json"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     git(temp.path(), &["switch", "-c", "side"]);
     commit_file(temp.path(), "clash.txt", "side\n", "side change");

--- a/crates/cli/tests/cli_integration/git_overlay_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_matrix.rs
@@ -546,7 +546,7 @@ fn git_overlay_matrix_undo_reconciles_checkout_without_persistent_mirror() {
     );
 
     initialize_git_overlay(&work);
-    json(&work, &["import", "git", "--ref", "main"]);
+    json(&work, &["bridge", "git", "import", "--ref", "main"]);
     std::fs::write(work.join("first.txt"), "first\n").unwrap();
     json(&work, &["capture", "-m", "first"]);
     json(&work, &["commit", "-m", "first"]);
@@ -1487,7 +1487,11 @@ fn git_overlay_matrix_ready_thread_action_not_overridden_by_remote_push() {
     git(&["remote", "add", "origin", origin_arg], temp.path());
     git(&["push", "-u", "origin", "main"], temp.path());
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let started = json(
         temp.path(),
@@ -1673,7 +1677,7 @@ fn git_overlay_matrix_native_git_import_materializes_current_thread_when_clean()
     let import = json(
         dest.path(),
         &[
-            "--output", "json", "import", "git", "--path", source_arg, "--ref", "main",
+            "--output", "json", "bridge", "git", "import", "--path", source_arg, "--ref", "main",
         ],
     );
     assert_eq!(import["states_created"], 1);
@@ -1791,7 +1795,16 @@ fn git_overlay_matrix_reconcile_apply_imports_current_git_branch() {
 
     let reconcile = json(
         temp.path(),
-        &["fsck", "repair", "git", "--prefer", "git", "--ref", "main"],
+        &[
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--prefer",
+            "git",
+            "--ref",
+            "main",
+        ],
     );
     assert_eq!(reconcile["repair_target"], "git");
     assert_eq!(reconcile["valid"], true);
@@ -1815,7 +1828,16 @@ fn git_overlay_matrix_reconcile_prefer_heddle_requires_adoption() {
 
     let output = heddle_output(
         &[
-            "--output", "json", "fsck", "repair", "git", "--prefer", "heddle", "--ref", "main",
+            "--output",
+            "json",
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--prefer",
+            "heddle",
+            "--ref",
+            "main",
         ],
         Some(temp.path()),
     )
@@ -1855,7 +1877,11 @@ fn git_overlay_matrix_commit_ignores_gitignored_noise_and_refuses_noop() {
     std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
     git_commit_all(temp.path(), "seed");
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     std::fs::create_dir(temp.path().join("__pycache__")).unwrap();
     std::fs::write(temp.path().join("__pycache__/tracked.pyc"), "cache").unwrap();
@@ -1885,7 +1911,11 @@ fn git_overlay_matrix_commit_requires_explicit_ignore_for_python_generated_noise
     std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
     git_commit_all(temp.path(), "seed");
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     std::fs::create_dir_all(temp.path().join("src/__pycache__")).unwrap();
     std::fs::write(
@@ -1940,7 +1970,11 @@ fn git_overlay_matrix_commit_noop_fails_closed_when_verification_blocked() {
     std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
     git_commit_all(temp.path(), "seed");
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let head = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
     std::fs::write(
@@ -1995,7 +2029,11 @@ fn git_overlay_matrix_top_level_push_closes_remote_verification_loop() {
     git(&["push", "-u", "origin", "main"], temp.path());
 
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     std::fs::write(temp.path().join("tracked.txt"), "two\n").unwrap();
     json(
         temp.path(),
@@ -2101,7 +2139,11 @@ fn git_overlay_matrix_commit_refuses_remote_divergence_before_capture() {
     git(&["remote", "add", "origin", origin_arg], temp.path());
     git(&["push", "-u", "origin", "main"], temp.path());
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let peer_arg = peer.path().to_str().expect("peer path should be utf8");
     git(&["clone", origin_arg, peer_arg], temp.path());
@@ -2150,7 +2192,7 @@ fn git_overlay_matrix_commit_refuses_remote_divergence_before_capture() {
     let envelope: Value = serde_json::from_str(stderr).expect("commit refusal JSON parses");
     assert_eq!(envelope["kind"], "git_checkpoint_preflight_blocked");
     assert_eq!(
-        envelope["primary_command"], "heddle import git --ref origin/main",
+        envelope["primary_command"], "heddle bridge git import --ref origin/main",
         "{envelope}"
     );
     assert!(
@@ -2195,7 +2237,11 @@ fn git_overlay_matrix_push_defaults_to_branch_upstream_remote() {
     git(&["push", "-u", "upstream", "main"], temp.path());
 
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     std::fs::write(temp.path().join("tracked.txt"), "two\n").unwrap();
     json(
         temp.path(),
@@ -2239,7 +2285,11 @@ fn git_overlay_matrix_local_only_branch_is_clean_until_push_sets_tracking() {
     git(&["push", "upstream", "main"], temp.path());
 
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     std::fs::write(temp.path().join("tracked.txt"), "two\n").unwrap();
     json(
         temp.path(),
@@ -2295,7 +2345,11 @@ fn git_overlay_matrix_remote_add_configures_default_push_remote() {
     git_commit_all(temp.path(), "seed");
 
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     let audit_arg = audit.path().to_str().expect("audit path should be utf8");
     let added = json(
         temp.path(),
@@ -2567,7 +2621,7 @@ fn git_overlay_matrix_manual_git_commit_after_bootstrap_commands() {
 
     initialize_git_overlay(temp.path());
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(temp.path()),
     )
     .unwrap();
@@ -2762,7 +2816,11 @@ fn git_overlay_matrix_raw_git_reset_reports_reconcile_not_unsaved_work() {
     std::fs::write(temp.path().join("tracked.txt"), "base\n").unwrap();
     git_commit_all(temp.path(), "seed");
     initialize_git_overlay(temp.path());
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     std::fs::write(temp.path().join("tracked.txt"), "heddle change\n").unwrap();
     json(
@@ -2791,11 +2849,19 @@ fn git_overlay_matrix_raw_git_reset_reports_reconcile_not_unsaved_work() {
     assert!(status["changes"]["deleted"].as_array().unwrap().is_empty());
     assert_eq!(
         status["recommended_action"],
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
     assert_eq!(
         status["recommended_action_template"]["argv_template"],
-        heddle_argv_json(["fsck", "repair", "git", "--ref", "main", "--preview"])
+        heddle_argv_json([
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--ref",
+            "main",
+            "--preview"
+        ])
     );
     assert!(
         status["blockers"]
@@ -2826,14 +2892,14 @@ fn git_overlay_matrix_raw_git_reset_reports_reconcile_not_unsaved_work() {
     assert_eq!(verify["status"], "needs_reconcile");
     assert_eq!(
         verify["recommended_action"],
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
 
     let bridge = json(temp.path(), &["status", "--output", "json"]);
     assert_eq!(bridge["verification"]["status"], "needs_reconcile");
     assert_eq!(
         bridge["recommended_action"],
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
 
     let refused = heddle_output(
@@ -2863,7 +2929,7 @@ fn git_overlay_matrix_raw_git_reset_reports_reconcile_not_unsaved_work() {
     );
     assert_eq!(
         envelope["primary_command"],
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
     assert_eq!(
         git_stdout(temp.path(), &["rev-parse", "HEAD"]),
@@ -3051,7 +3117,11 @@ fn git_overlay_matrix_import_marks_branch_tip_history_as_imported() {
     );
     assert_eq!(before["history_imported"], false);
 
-    heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let after = json(
         temp.path(),
@@ -3091,7 +3161,7 @@ fn git_overlay_matrix_detached_head_sequence_commands() {
     git_commit_all(temp.path(), "seed branch");
     heddle(&["init"], Some(temp.path())).unwrap();
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(temp.path()),
     )
     .unwrap();
@@ -3153,7 +3223,11 @@ fn git_overlay_matrix_commit_refuses_detached_head_without_advancing_branch() {
     std::fs::write(temp.path().join("tracked.txt"), "tracked").unwrap();
     git_commit_all(temp.path(), "seed branch");
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     let before_head = git_stdout(temp.path(), &["rev-parse", "HEAD"]);
     let before_main = git_stdout(temp.path(), &["rev-parse", "refs/heads/main"]);
@@ -3334,7 +3408,11 @@ fn git_overlay_matrix_imported_branch_evolution_after_git_import() {
     assert_no_legacy_verification_sidecars(&before);
     assert_eq!(before["verification"]["status"], "needs_init");
 
-    let import_output = heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    let import_output = heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
     assert!(
         import_output.contains("branches") || import_output.contains("\"branches_synced\""),
         "Git import should report branch sync activity: {import_output}"
@@ -3397,7 +3475,7 @@ fn git_overlay_matrix_reopen_from_different_cwds_preserves_state_and_git_only_al
     git_commit_all(temp.path(), "seed branch");
     initialize_git_overlay(temp.path());
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(temp.path()),
     )
     .unwrap();
@@ -3462,7 +3540,7 @@ fn git_overlay_matrix_binary_file_commands_remain_coherent() {
     git_commit_all(temp.path(), "seed binary");
     initialize_git_overlay(temp.path());
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(temp.path()),
     )
     .unwrap();
@@ -4600,7 +4678,11 @@ fn git_overlay_matrix_multi_peer_land_fast_forwards_git_tip() {
     std::fs::write(temp.path().join("README.md"), "base\n").unwrap();
     git_commit_all(temp.path(), "base");
     heddle(&["init"], Some(temp.path())).expect("initialize Git Overlay");
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).expect("import main");
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .expect("import main");
 
     let alpha = temp.path().with_extension("alpha");
     let beta = temp.path().with_extension("beta");
@@ -4664,7 +4746,11 @@ fn git_overlay_matrix_land_threads_flag_lands_peers_in_order() {
     std::fs::write(temp.path().join("README.md"), "base\n").unwrap();
     git_commit_all(temp.path(), "base");
     heddle(&["init"], Some(temp.path())).expect("initialize Git Overlay");
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).expect("import main");
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .expect("import main");
 
     let alpha = temp.path().with_extension("alpha-mt");
     let beta = temp.path().with_extension("beta-mt");
@@ -4827,7 +4913,7 @@ fn git_overlay_matrix_manual_git_merge_commit_after_bootstrap_commands() {
     git_commit_all(temp.path(), "seed branch");
     heddle(&["init"], Some(temp.path())).unwrap();
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(temp.path()),
     )
     .unwrap();
@@ -4889,7 +4975,11 @@ fn git_overlay_matrix_imported_branch_git_only_advance_reappears_in_import_hint(
     git_commit_all(temp.path(), "alpha one");
     git(&["checkout", "feature/drop-in"], temp.path());
 
-    let import_output = heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    let import_output = heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
     assert!(
         import_output.contains("branches") || import_output.contains("\"branches_synced\""),
         "Git import should report branch sync activity: {import_output}"
@@ -4929,7 +5019,11 @@ fn git_overlay_matrix_imported_branch_delete_and_recreate_same_name_reappears_in
     git_commit_all(temp.path(), "first reborn");
     git(&["checkout", "feature/drop-in"], temp.path());
 
-    let _ = heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    let _ = heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     git(&["branch", "-D", "support/reborn"], temp.path());
     git(&["checkout", "-b", "support/reborn"], temp.path());
@@ -5060,7 +5154,7 @@ fn git_overlay_matrix_rebase_and_cherry_pick_sequences_remain_coherent() {
     std::fs::write(cherry_repo.path().join("conflict.txt"), "main cherry\n").unwrap();
     git_commit_all(cherry_repo.path(), "main cherry");
     heddle(
-        &["import", "git", "--ref", "feature/drop-in"],
+        &["bridge", "git", "import", "--ref", "feature/drop-in"],
         Some(cherry_repo.path()),
     )
     .unwrap();
@@ -5220,7 +5314,11 @@ fn git_overlay_matrix_imported_branch_merge_commit_drift_reappears_in_hint() {
     git_commit_all(temp.path(), "support base");
     git(&["checkout", "feature/drop-in"], temp.path());
 
-    let _ = heddle(&["import", "git", "--path", "."], Some(temp.path())).unwrap();
+    let _ = heddle(
+        &["bridge", "git", "import", "--path", "."],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     git(&["checkout", "support/merge-drift"], temp.path());
     git(&["checkout", "-b", "support/merge-drift-side"], temp.path());

--- a/crates/cli/tests/cli_integration/git_overlay_remote_ref_import.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_remote_ref_import.rs
@@ -63,8 +63,9 @@ fn git_overlay_imports_explicit_remote_tracking_branch_ref() {
         &[
             "--output",
             "json",
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             ".",
             "--ref",
@@ -98,8 +99,9 @@ fn git_overlay_import_missing_local_branch_suggests_remote_tracking_ref() {
 
     let err = heddle(
         &[
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             ".",
             "--ref",

--- a/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
+++ b/crates/cli/tests/cli_integration/git_overlay_sync_adoption.rs
@@ -206,7 +206,7 @@ fn git_overlay_sync_adopts_fast_forward_upstream_tip() {
     configure_git_identity(&work);
 
     heddle(&["status", "--output", "json"], Some(&work)).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(&work)).unwrap();
+    heddle(&["bridge", "git", "import", "--ref", "main"], Some(&work)).unwrap();
     let before = status_json(&work);
     let before_state = before["current_state"]
         .as_str()

--- a/crates/cli/tests/cli_integration/git_projection_commands.rs
+++ b/crates/cli/tests/cli_integration/git_projection_commands.rs
@@ -197,7 +197,13 @@ fn import_git_refuses_unrepresentable_tree_name_by_default_and_lossy_summarizes(
     let default_target = TempDir::new().unwrap();
     heddle(&["init"], Some(default_target.path())).expect("init default target");
     let default_output = heddle_output(
-        &["import", "git", "--path", source.path().to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "import",
+            "--path",
+            source.path().to_str().unwrap(),
+        ],
         Some(default_target.path()),
     )
     .expect("run default import");
@@ -219,8 +225,9 @@ fn import_git_refuses_unrepresentable_tree_name_by_default_and_lossy_summarizes(
     heddle(&["init"], Some(lossy_target.path())).expect("init lossy target");
     let lossy = heddle(
         &[
-            "import",
+            "bridge",
             "git",
+            "import",
             "--lossy",
             "--path",
             source.path().to_str().unwrap(),
@@ -242,7 +249,7 @@ fn import_git_refuses_unrepresentable_tree_name_by_default_and_lossy_summarizes(
 
 #[test]
 fn import_git_help_documents_lossy_flag() {
-    let output = heddle_help(&["import", "git", "--help"]);
+    let output = heddle_help(&["bridge", "git", "import", "--help"]);
 
     assert!(output.contains("--lossy"), "help should document --lossy");
 }
@@ -542,14 +549,24 @@ fn test_cli_export_git_and_clone_roundtrip() {
     )
     .unwrap();
 
-    // Phase A: `export git` requires `--destination`. Pre-Phase-A
+    // Phase A: `bridge git export` requires `--destination`. Pre-Phase-A
     // it silently no-op'd if no flag was given (writing only the sidecar
     // mapping, not actually exporting any git objects). Now it errors.
     let export = heddle(
-        &["export", "git", "--destination", dest.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            dest.to_str().unwrap(),
+        ],
         Some(source.path()),
     );
-    assert!(export.is_ok(), "export git failed: {:?}", export.err());
+    assert!(
+        export.is_ok(),
+        "bridge git export failed: {:?}",
+        export.err()
+    );
 
     let dest_repo = open_git(&dest).unwrap();
     assert!(find_reference(&dest_repo, "refs/heads/main").is_ok());
@@ -577,14 +594,24 @@ fn test_cli_export_git_writes_bare_repo() {
     let dest = dest_holder.path().join("export");
 
     heddle(&["init"], Some(source.path())).unwrap();
-    std::fs::write(source.path().join("file.txt"), "export git").unwrap();
+    std::fs::write(source.path().join("file.txt"), "bridge git export").unwrap();
     heddle(&["capture", "-m", "Export git source"], Some(source.path())).unwrap();
 
     let export = heddle(
-        &["export", "git", "--destination", dest.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            dest.to_str().unwrap(),
+        ],
         Some(source.path()),
     );
-    assert!(export.is_ok(), "export git failed: {:?}", export.err());
+    assert!(
+        export.is_ok(),
+        "bridge git export failed: {:?}",
+        export.err()
+    );
 
     let dest_repo = open_git(&dest).unwrap();
     assert!(find_reference(&dest_repo, "refs/heads/main").is_ok());
@@ -609,7 +636,13 @@ fn test_cli_export_git_preserves_foreign_destination_push_and_reports_divergence
     .expect("capture projection tip");
 
     let first = heddle_output(
-        &["export", "git", "--destination", dest.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            dest.to_str().unwrap(),
+        ],
         Some(source.path()),
     )
     .expect("first export");
@@ -639,7 +672,13 @@ fn test_cli_export_git_preserves_foreign_destination_push_and_reports_divergence
     );
 
     let second = heddle_output(
-        &["export", "git", "--destination", dest.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            dest.to_str().unwrap(),
+        ],
         Some(source.path()),
     )
     .expect("second export");
@@ -699,14 +738,19 @@ fn test_cli_import_git_from_external_repo() {
     heddle(&["init"], Some(heddle_repo_dir.path())).unwrap();
     let result = heddle(
         &[
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             git_repo_dir.path().to_str().unwrap(),
         ],
         Some(heddle_repo_dir.path()),
     );
-    assert!(result.is_ok(), "import git failed: {:?}", result.err());
+    assert!(
+        result.is_ok(),
+        "bridge git import failed: {:?}",
+        result.err()
+    );
 
     let repo = Repository::open(heddle_repo_dir.path()).unwrap();
     assert!(

--- a/crates/cli/tests/cli_integration/git_replacement_matrix.rs
+++ b/crates/cli/tests/cli_integration/git_replacement_matrix.rs
@@ -63,7 +63,9 @@ fn assert_clean_json_without_git(args: &[&str], cwd: &std::path::Path) -> Value 
 fn init_and_import_git_overlay_without_git(cwd: &std::path::Path, ref_name: &str) -> Value {
     assert_clean_json_without_git(&["--output", "json", "init"], cwd);
     assert_clean_json_without_git(
-        &["--output", "json", "import", "git", "--ref", ref_name],
+        &[
+            "--output", "json", "bridge", "git", "import", "--ref", ref_name,
+        ],
         cwd,
     )
 }
@@ -302,7 +304,9 @@ fn git_replacement_matrix_shallow_import_refuses_without_raw_git_advice() {
     assert_clean_json_without_git(&["--output", "json", "init"], temp.path());
 
     let output = heddle_output_without_git(
-        &["--output", "json", "import", "git", "--ref", "main"],
+        &[
+            "--output", "json", "bridge", "git", "import", "--ref", "main",
+        ],
         temp.path(),
     );
     let stdout = str::from_utf8(&output.stdout).unwrap_or("");
@@ -326,7 +330,7 @@ fn git_replacement_matrix_shallow_import_refuses_without_raw_git_advice() {
         envelope["recovery_commands"],
         serde_json::json!([
             "heddle clone <remote> <fresh-path>",
-            "heddle import git --path <full-git-repo> --ref <ref>"
+            "heddle bridge git import --path <full-git-repo> --ref <ref>"
         ])
     );
     assert_eq!(
@@ -335,7 +339,7 @@ fn git_replacement_matrix_shallow_import_refuses_without_raw_git_advice() {
     );
     assert_eq!(
         envelope["recovery_action_templates"][1]["action"],
-        "heddle import git --path <full-git-repo> --ref <ref>"
+        "heddle bridge git import --path <full-git-repo> --ref <ref>"
     );
 }
 
@@ -729,8 +733,9 @@ fn git_replacement_matrix_file_url_clone_and_import_without_git_on_path() {
         &[
             "--output",
             "json",
-            "import",
+            "bridge",
             "git",
+            "import",
             "--path",
             &origin_url,
             "--ref",
@@ -770,7 +775,7 @@ fn git_replacement_matrix_git_import_export_sync_reconcile_without_git_on_path()
     let origin_arg = origin.to_str().expect("origin path should be utf8");
     let import = assert_clean_json_without_git(
         &[
-            "--output", "json", "import", "git", "--path", origin_arg, "--ref", "main",
+            "--output", "json", "bridge", "git", "import", "--path", origin_arg, "--ref", "main",
         ],
         &work,
     );
@@ -778,7 +783,7 @@ fn git_replacement_matrix_git_import_export_sync_reconcile_without_git_on_path()
         import["commits_imported"].as_u64().unwrap_or(0) >= 1,
         "explicit Git import should walk Git commits natively: {import}"
     );
-    assert_eq!(import["output_kind"], "import_git");
+    assert_eq!(import["output_kind"], "bridge_git_import");
     assert_eq!(
         import["verification"]["verified"], true,
         "Git import should embed post-operation verification: {import}"
@@ -789,8 +794,9 @@ fn git_replacement_matrix_git_import_export_sync_reconcile_without_git_on_path()
         &[
             "--output",
             "json",
-            "export",
+            "bridge",
             "git",
+            "export",
             "--destination",
             export_path.to_str().expect("export path should be utf8"),
         ],
@@ -814,6 +820,7 @@ fn git_replacement_matrix_git_import_export_sync_reconcile_without_git_on_path()
         &[
             "--output",
             "json",
+            "maintenance",
             "fsck",
             "repair",
             "git",
@@ -1141,7 +1148,8 @@ fn git_replacement_matrix_fsck_git_projection_validates_mapping_notes_and_checko
     heddle_without_git(&["capture", "-m", "git projection fsck"], &work).unwrap();
     heddle_without_git(&["commit", "-m", "git projection fsck"], &work).unwrap();
 
-    let fsck = heddle_without_git(&["fsck", "--git", "--output", "json"], &work).unwrap();
+    let fsck =
+        heddle_without_git(&["maintenance", "fsck", "--git", "--output", "json"], &work).unwrap();
     let parsed: Value = serde_json::from_str(&fsck).expect("fsck output should parse");
     assert_eq!(
         parsed["valid"], true,

--- a/crates/cli/tests/cli_integration/interactive_selection.rs
+++ b/crates/cli/tests/cli_integration/interactive_selection.rs
@@ -127,7 +127,7 @@ fn piped_actor_ambiguity_never_prompts_or_consumes_a_selection() {
         .unwrap();
 
     let output = heddle_output_with_stdin(
-        &["--output", "json", "agent", "presence", "show"],
+        &["--output", "json", "presence", "show"],
         temp.path(),
         "1\n",
     )
@@ -135,7 +135,7 @@ fn piped_actor_ambiguity_never_prompts_or_consumes_a_selection() {
     assert_non_tty_ambiguity(
         output,
         "ambiguous_actor_selection",
-        "heddle agent presence show <SESSION>",
+        "heddle presence show <SESSION>",
     );
 }
 
@@ -153,7 +153,7 @@ fn piped_actor_completion_never_picks_a_destructive_target() {
         .unwrap();
 
     let output = heddle_output_with_stdin(
-        &["--output", "json", "agent", "presence", "complete"],
+        &["--output", "json", "presence", "complete"],
         temp.path(),
         "1\n",
     )
@@ -161,7 +161,7 @@ fn piped_actor_completion_never_picks_a_destructive_target() {
     assert_non_tty_ambiguity(
         output,
         "ambiguous_actor_selection",
-        "heddle agent presence complete --session <SESSION>",
+        "heddle presence complete --session <SESSION>",
     );
     assert!(matches!(
         actors.load("agent-alpha").unwrap().unwrap().status,

--- a/crates/cli/tests/cli_integration/native_scope_boundary.rs
+++ b/crates/cli/tests/cli_integration/native_scope_boundary.rs
@@ -371,7 +371,7 @@ fn overlay_records_leave_no_git_residue() {
     );
 
     let fsck = std::process::Command::new("git")
-        .args(["fsck", "--no-progress"])
+        .args(["maintenance", "fsck", "--no-progress"])
         .current_dir(dir)
         .output()
         .expect("git fsck");

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -1406,8 +1406,8 @@ fn verify_cold_flow_scripts_assert_required_proof_steps() {
                 script.display()
             );
             assert!(
-                source.contains("\"heddle bridge git\"") && source.contains("\"reconcile\""),
-                "{} should keep old bridge ceremony out of the human cold path by linting it from transcripts",
+                source.contains("bridge git import") && source.contains("\"reconcile\""),
+                "{} should exercise the canonical Git import and keep stale reconcile wording out of human transcripts",
                 script.display()
             );
             assert!(

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -81,8 +81,8 @@ fn git_projection_help_topic_distinguishes_native_projection_from_overlay() {
     );
     for needle in [
         "heddle adopt --ref <branch>",
-        "heddle import git --path <git-repository> --ref <branch>",
-        "heddle export git --destination <bare-git-repository>",
+        "heddle bridge git import --path <git-repository> --ref <branch>",
+        "heddle bridge git export --destination <bare-git-repository>",
         "heddle sync git --path <git-repository>",
         "Export metadata for Git readers",
         "refs/notes/heddle",
@@ -103,12 +103,11 @@ fn git_projection_help_topic_distinguishes_native_projection_from_overlay() {
 }
 
 #[test]
-fn import_alias_leads_to_adopt_instead_of_clap_guesswork() {
-    let help = heddle_help(&["import", "--help"]);
+fn bridge_git_import_help_names_the_explicit_git_importer() {
+    let help = heddle_help(&["bridge", "git", "import", "--help"]);
     assert!(
-        help.contains("Import from another version control system")
-            && help.contains("git   Import Git commits to Heddle"),
-        "`heddle import --help` should route import intent to the explicit git importer: {help}"
+        help.contains("Import Git commits to Heddle") && help.contains("--ref <REF>"),
+        "`heddle bridge git import --help` should describe the explicit git importer: {help}"
     );
 }
 
@@ -1347,7 +1346,7 @@ fn verify_cold_flow_scripts_assert_required_proof_steps() {
         }
         assert!(
             source.contains("adopt")
-                || source.contains("import git")
+                || source.contains("bridge git import")
                 || source.contains("run_verify_recommended_action"),
             "{} should run one-command adoption, explicit import, or verify's recommended action",
             script.display()
@@ -1864,8 +1863,9 @@ fn op_id_replays_export_git() {
             "json",
             "--op-id",
             &export_op_id,
-            "export",
+            "bridge",
             "git",
+            "export",
             "--destination",
             &export_dest_arg,
         ],
@@ -1879,8 +1879,9 @@ fn op_id_replays_export_git() {
             "json",
             "--op-id",
             &export_op_id,
-            "export",
+            "bridge",
             "git",
+            "export",
             "--destination",
             &export_dest_arg,
         ],
@@ -2408,10 +2409,10 @@ fn core_loop_schemas_are_discoverable() {
         "doctor docs",
         "doctor schemas",
         "diff",
-        "agent presence list",
-        "agent presence show",
-        "agent presence explain",
-        "agent presence complete",
+        "presence list",
+        "presence show",
+        "presence explain",
+        "presence complete",
         "agent provenance begin",
         "agent provenance segment",
         "agent provenance end",
@@ -2424,7 +2425,7 @@ fn core_loop_schemas_are_discoverable() {
         "agent release",
         "agent list",
         "thread list",
-        "fsck repair git",
+        "maintenance fsck repair git",
         "remote list",
         "remote show",
         "remote add",
@@ -6560,7 +6561,14 @@ fn narrow_no_color_text_outputs_cover_everyday_read_surfaces() {
     );
     assert_text_surface(
         temp.path(),
-        vec!["--quiet", "--output", "text", "fsck", "--git"],
+        vec![
+            "--quiet",
+            "--output",
+            "text",
+            "maintenance",
+            "fsck",
+            "--git",
+        ],
         &["repository is valid", "Git projection:"],
     );
 
@@ -7289,8 +7297,8 @@ fn command_catalog_exposes_public_surface_for_agents() {
     );
     let import_git = commands
         .iter()
-        .find(|entry| entry["display"] == "import git")
-        .expect("import git command should be cataloged");
+        .find(|entry| entry["display"] == "bridge git import")
+        .expect("bridge git import command should be cataloged");
     assert!(
         import_git["summary"]
             .as_str()
@@ -7403,8 +7411,8 @@ fn command_catalog_exposes_public_surface_for_agents() {
     );
     let bridge_import = commands
         .iter()
-        .find(|entry| entry["display"] == "import git")
-        .expect("import git should be cataloged");
+        .find(|entry| entry["display"] == "bridge git import")
+        .expect("bridge git import should be cataloged");
     assert_eq!(bridge_import["canonical_action"], Value::Null);
     assert_eq!(bridge_import["canonical_command"], Value::Null);
     for removed in ["stash pop", "stash push"] {
@@ -8640,7 +8648,7 @@ fn agent_presence_explain_json_detects_harness_without_active_presence() {
     heddle(&["init"], Some(temp.path())).unwrap();
 
     let output = heddle_output_with_env_removed(
-        &["agent", "presence", "explain", "--output", "json"],
+        &["presence", "explain", "--output", "json"],
         Some(temp.path()),
         &[
             ("CODEX_THREAD_ID", "thread-cold-agent"),
@@ -8665,7 +8673,7 @@ fn agent_presence_explain_json_detects_harness_without_active_presence() {
     let stdout = String::from_utf8_lossy(&output.stdout);
     let parsed: Value = serde_json::from_str(&stdout)
         .unwrap_or_else(|err| panic!("actor explain JSON should parse: {err}: {stdout}"));
-    assert_eq!(parsed["output_kind"], "agent_presence_explain", "{parsed}");
+    assert_eq!(parsed["output_kind"], "presence_explain", "{parsed}");
     assert_eq!(parsed["attached"], false);
     assert!(parsed.get("active_presence").is_none());
     assert_eq!(parsed["detected"]["harness"], "codex");
@@ -8702,7 +8710,7 @@ fn agent_presence_explain_json_detects_harness_without_active_presence() {
         heddle_argv_json(["agent", "reserve", "--thread", "main"]),
         "presence explain should expose replayable argv for reservation: {parsed}"
     );
-    assert_schema_declares_runtime_top_level(&["agent", "presence", "explain"], &parsed);
+    assert_schema_declares_runtime_top_level(&["presence", "explain"], &parsed);
     assert!(
         parsed.get("verification").is_some(),
         "actor explain should prove repository verify for agents: {parsed}"
@@ -8724,15 +8732,9 @@ fn agent_presence_and_provenance_outputs_match_registered_schemas() {
         .as_str()
         .expect("reserve should attach presence");
 
-    let actor_list = json_value(
-        temp.path(),
-        &["agent", "presence", "list", "--output", "json"],
-    );
-    assert_schema_declares_runtime_top_level(&["agent", "presence", "list"], &actor_list);
-    assert_eq!(
-        actor_list["output_kind"], "agent_presence_list",
-        "{actor_list}"
-    );
+    let actor_list = json_value(temp.path(), &["presence", "list", "--output", "json"]);
+    assert_schema_declares_runtime_top_level(&["presence", "list"], &actor_list);
+    assert_eq!(actor_list["output_kind"], "presence_list", "{actor_list}");
     assert!(
         actor_list["presence"].as_array().is_some(),
         "presence list should emit an envelope: {actor_list}"
@@ -8741,19 +8743,15 @@ fn agent_presence_and_provenance_outputs_match_registered_schemas() {
 
     let actor_show = json_value(
         temp.path(),
-        &["agent", "presence", "show", presence_id, "--output", "json"],
+        &["presence", "show", presence_id, "--output", "json"],
     );
-    assert_schema_declares_runtime_top_level(&["agent", "presence", "show"], &actor_show);
-    assert_eq!(
-        actor_show["output_kind"], "agent_presence_show",
-        "{actor_show}"
-    );
+    assert_schema_declares_runtime_top_level(&["presence", "show"], &actor_show);
+    assert_eq!(actor_show["output_kind"], "presence_show", "{actor_show}");
     assert_eq!(actor_show["presence"]["session_id"], presence_id);
 
     let actor_done = json_value(
         temp.path(),
         &[
-            "agent",
             "presence",
             "complete",
             "--session",
@@ -8762,9 +8760,9 @@ fn agent_presence_and_provenance_outputs_match_registered_schemas() {
             "json",
         ],
     );
-    assert_schema_declares_runtime_top_level(&["agent", "presence", "complete"], &actor_done);
+    assert_schema_declares_runtime_top_level(&["presence", "complete"], &actor_done);
     assert_eq!(
-        actor_done["output_kind"], "agent_presence_complete",
+        actor_done["output_kind"], "presence_complete",
         "{actor_done}"
     );
     assert_eq!(actor_done["status"], "complete");
@@ -9067,8 +9065,11 @@ fn fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json() {
     )
     .unwrap();
 
-    let json = heddle_output(&["--output", "json", "fsck"], Some(temp.path()))
-        .expect("invoke corrupt fsck json");
+    let json = heddle_output(
+        &["--output", "json", "maintenance", "fsck"],
+        Some(temp.path()),
+    )
+    .expect("invoke corrupt fsck json");
     assert!(
         !json.status.success(),
         "corrupt fsck JSON should exit non-zero"
@@ -9093,12 +9094,15 @@ fn fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json() {
         envelope["hint"]
             .as_str()
             .unwrap_or("")
-            .contains("heddle fsck --full"),
+            .contains("heddle maintenance fsck --full"),
         "corrupt ref should point at fsck recovery: {envelope}"
     );
 
-    let text = heddle_output(&["--output", "text", "fsck"], Some(temp.path()))
-        .expect("invoke corrupt fsck text");
+    let text = heddle_output(
+        &["--output", "text", "maintenance", "fsck"],
+        Some(temp.path()),
+    )
+    .expect("invoke corrupt fsck text");
     assert!(
         !text.status.success(),
         "corrupt fsck text should exit non-zero"
@@ -9111,8 +9115,8 @@ fn fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json() {
     let text_stderr = String::from_utf8_lossy(&text.stderr);
     assert!(
         text_stderr.contains("Error: invalid object")
-            && text_stderr.contains("Next: heddle fsck --full")
-            && text_stderr.contains("heddle fsck --full"),
+            && text_stderr.contains("Next: heddle maintenance fsck --full")
+            && text_stderr.contains("heddle maintenance fsck --full"),
         "corrupt ref text recovery should include original error and fsck hint: {text_stderr}"
     );
 }
@@ -9401,13 +9405,13 @@ fn doctor_schemas_reports_runtime_and_documented_coverage() {
     }
     for verb in [
         "thread list",
-        "fsck repair git",
+        "maintenance fsck repair git",
         "capture",
         "commit",
-        "agent presence list",
-        "agent presence show",
-        "agent presence explain",
-        "agent presence complete",
+        "presence list",
+        "presence show",
+        "presence explain",
+        "presence complete",
         "agent provenance begin",
         "agent provenance segment",
         "agent provenance end",
@@ -9451,7 +9455,7 @@ fn doctor_schemas_reports_runtime_and_documented_coverage() {
         "watch",
         "try",
         "query --attribution",
-        "fsck",
+        "maintenance fsck",
         "resolve",
     ] {
         assert!(
@@ -10062,7 +10066,7 @@ fn make_local_master_git_repo(parent: &std::path::Path, commits: usize) -> std::
 
 #[test]
 fn import_git_after_clone_reports_commits_not_zero() {
-    // heddle#147: rerunning `import git --ref master --path .`
+    // heddle#147: rerunning `bridge git import --ref master --path .`
     // after `heddle clone` used to land at `commits_imported: 0` even
     // though every commit on master had been imported during clone —
     // visually indistinguishable from "your import did nothing".
@@ -10086,7 +10090,7 @@ fn import_git_after_clone_reports_commits_not_zero() {
 
     let json = heddle(
         &[
-            "--output", "json", "import", "git", "--ref", "master", "--path", ".",
+            "--output", "json", "bridge", "git", "import", "--ref", "master", "--path", ".",
         ],
         Some(&work),
     )
@@ -10108,7 +10112,7 @@ fn import_git_after_clone_reports_commits_not_zero() {
 
     let text = heddle(
         &[
-            "--output", "text", "import", "git", "--ref", "master", "--path", ".",
+            "--output", "text", "bridge", "git", "import", "--ref", "master", "--path", ".",
         ],
         Some(&work),
     )
@@ -10329,7 +10333,9 @@ fn bridge_git_divergence_error_uses_structured_recovery_envelope() {
     git_commit_all_for_json_contract(temp.path(), "git side");
 
     let output = heddle_output(
-        &["--output", "json", "import", "git", "--ref", "main"],
+        &[
+            "--output", "json", "bridge", "git", "import", "--ref", "main",
+        ],
         Some(temp.path()),
     )
     .expect("invoke import git");
@@ -10349,11 +10355,11 @@ fn bridge_git_divergence_error_uses_structured_recovery_envelope() {
     assert_eq!(envelope["kind"], "git_heddle_thread_diverged");
     assert_eq!(
         envelope["primary_command"],
-        "heddle fsck repair git --ref main --preview"
+        "heddle maintenance fsck repair git --ref main --preview"
     );
     assert_eq!(
         envelope["recovery_commands"],
-        serde_json::json!(["heddle fsck repair git --ref main --preview"])
+        serde_json::json!(["heddle maintenance fsck repair git --ref main --preview"])
     );
     assert!(
         envelope["preserved"]
@@ -10364,18 +10370,27 @@ fn bridge_git_divergence_error_uses_structured_recovery_envelope() {
     );
     assert_eq!(
         envelope["primary_command_template"]["argv_template"],
-        heddle_argv_json(["fsck", "repair", "git", "--ref", "main", "--preview",])
+        heddle_argv_json([
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--ref",
+            "main",
+            "--preview",
+        ])
     );
 }
 
 #[test]
 fn import_git_schema_declares_already_in_sync() {
     // heddle#147 added `already_in_sync: bool` to the JSON output of
-    // `import git`. The schema contract surfaced via
-    // `heddle schemas "import git"` must list the field, or
+    // `bridge git import`. The schema contract surfaced via
+    // `heddle schemas "bridge git import"` must list the field, or
     // automation that validates against the schema will reject the
     // new payload shape.
-    let schema = heddle(&["schemas", "import git"], None).expect("heddle schemas \"import git\"");
+    let schema = heddle(&["schemas", "bridge git import"], None)
+        .expect("heddle schemas \"bridge git import\"");
     let parsed: Value = serde_json::from_str(&schema).expect("schema parses");
     let props = parsed["properties"]
         .as_object()
@@ -10496,11 +10511,11 @@ fn exit_codes_surface_in_json_catalog() {
     let bridge_import = catalog
         .commands
         .iter()
-        .find(|c| c.display == "import git")
-        .expect("import git command in catalog");
+        .find(|c| c.display == "bridge git import")
+        .expect("bridge git import command in catalog");
     assert!(
         bridge_import.exit_codes.iter().any(|c| c.code == 65),
-        "import git must surface DataErr (65) for malformed repos"
+        "bridge git import must surface DataErr (65) for malformed repos"
     );
 }
 
@@ -10515,7 +10530,11 @@ fn read_commands_gate_repository_preamble_on_verbose() {
     std::fs::write(temp.path().join("tracked.txt"), "tracked\n").unwrap();
     git_commit_all_for_json_contract(temp.path(), "seed");
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
     std::fs::write(temp.path().join("tracked.txt"), "tracked changed\n").unwrap();
     heddle(&["capture", "-m", "checkpoint"], Some(temp.path())).unwrap();
     heddle(&["commit", "-m", "checkpoint"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/cli_integration/output_kind_invariant.rs
+++ b/crates/cli/tests/cli_integration/output_kind_invariant.rs
@@ -58,18 +58,18 @@ const SWEPT: &[&str] = &[
     "doctor docs",
     "doctor schemas",
     "schemas",
-    "import git",
-    "export git",
+    "bridge git import",
+    "bridge git export",
     "sync git",
     "status",
     // heddle#1057 — whoami emits `output_kind: "whoami"` (matches its verb path,
     // no override needed).
     "whoami",
     // heddle#272 — output_kind sweep on the named-by-persona verbs.
-    "agent presence list",
-    "agent presence show",
-    "agent presence explain",
-    "agent presence complete",
+    "presence list",
+    "presence show",
+    "presence explain",
+    "presence complete",
     "auth logout",
     "auth status",
     "auth trust show",
@@ -202,8 +202,8 @@ const UNSWEPT_TODO: &[&str] = &[
     "collapse",
     "daemon serve",
     "daemon status",
-    "fsck",
-    "fsck repair git",
+    "maintenance fsck",
+    "maintenance fsck repair git",
     "git-overlay",
     "hook events",
     "hook install",
@@ -1047,7 +1047,7 @@ fn runtime_doc_case(output_kind: &str) -> Option<RuntimeDocCase> {
         git_hermetic(&["add", "README.md"], &work);
         git_hermetic(&["commit", "-m", "base"], &work);
         heddle(&["init"], Some(&work)).expect("initialize Git Overlay");
-        heddle(&["import", "git", "--ref", "main"], Some(&work)).expect("import main");
+        heddle(&["bridge", "git", "import", "--ref", "main"], Some(&work)).expect("import main");
         for (thread, path, file) in [
             ("alpha", alpha.as_path(), "alpha.txt"),
             ("beta", beta.as_path(), "beta.txt"),

--- a/crates/cli/tests/cli_integration/realworld_git.rs
+++ b/crates/cli/tests/cli_integration/realworld_git.rs
@@ -206,11 +206,12 @@ fn realworld_git_complex_fixture_round_trips_overlay_inventory_without_git_on_pa
         temp.path(),
     )
     .unwrap();
-    // `import git` imports every ref by default; the legacy `--all`
+    // `bridge git import` imports every ref by default; the legacy `--all`
     // flag was retired once the default flow was the all-refs path.
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
 
-    let fsck = heddle_without_git(&["fsck", "--git", "--output", "json"], &work).unwrap();
+    let fsck =
+        heddle_without_git(&["maintenance", "fsck", "--git", "--output", "json"], &work).unwrap();
     let parsed: Value = serde_json::from_str(&fsck).expect("fsck output should parse");
     assert_eq!(parsed["valid"], true, "complex fixture should fsck: {fsck}");
 
@@ -263,7 +264,8 @@ fn realworld_git_large_binary_blob_stress_without_git_on_path() {
         metadata.len() > 0,
         "large checkout should materialize a blob or a safety pointer"
     );
-    let fsck = heddle_without_git(&["fsck", "--git", "--output", "json"], &work).unwrap();
+    let fsck =
+        heddle_without_git(&["maintenance", "fsck", "--git", "--output", "json"], &work).unwrap();
     let parsed: Value = serde_json::from_str(&fsck).expect("fsck output should parse");
     assert_eq!(parsed["valid"], true, "large fixture should fsck: {fsck}");
 }
@@ -281,7 +283,7 @@ fn realworld_git_large_binary_blob_stress_without_git_on_path() {
 // -----------------------------------------------------------------
 
 /// R1: a five-commit linear chain rebased onto a new base must
-/// round-trip every commit through `heddle import git` and surface
+/// round-trip every commit through `heddle bridge git import` and surface
 /// the rebased tip as the active branch. Verifies the import path
 /// preserves rewritten history rather than collapsing it.
 #[test]
@@ -354,7 +356,7 @@ fn realworld_git_rebase_chain_round_trips_overlay() {
         temp.path(),
     )
     .unwrap();
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
 
     let threads = serde_json::from_str::<Value>(
         &heddle_without_git(&["thread", "list", "--output", "json"], &work).unwrap(),
@@ -395,7 +397,7 @@ fn realworld_git_rebase_chain_round_trips_overlay() {
 /// R3: divergent origin + upstream remotes both expose `main` at
 /// different tips. Heddle Git import and remote listing must
 /// surface both remotes and treat them as distinct sources. The
-/// `heddle import git --ref origin/main` form picks origin
+/// `heddle bridge git import --ref origin/main` form picks origin
 /// explicitly; the upstream tip remains imported but not the active
 /// thread.
 #[test]
@@ -446,7 +448,7 @@ fn realworld_git_multi_remote_divergent_main_resolves_origin_first() {
 }
 
 /// R4: an annotated tag retargeted to a new commit and re-annotated
-/// must round-trip through `heddle import git` without losing the
+/// must round-trip through `heddle bridge git import` without losing the
 /// tag message or moving the original commit.
 #[test]
 #[ignore = "nightly real-world matrix: annotated tag rename + re-annotate"]
@@ -493,7 +495,7 @@ fn realworld_git_annotated_tag_rename_round_trips() {
         temp.path(),
     )
     .unwrap();
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
 
     // The legacy Bridge Mirror should expose the retargeted tag at the new
     // tag oid; both A and B remain reachable.
@@ -584,7 +586,7 @@ fn realworld_git_cherry_pick_assigns_distinct_state_ids() {
         temp.path(),
     )
     .unwrap();
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
 
     let log_a: Value = serde_json::from_str(
         &heddle_with_host_git(&["--output", "json", "log", "feature/a", "-n", "1"], &work).unwrap(),
@@ -630,10 +632,16 @@ fn realworld_git_gc_prunes_unreachable_mapping_entries() {
         temp.path(),
     )
     .unwrap();
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
     let export = temp.path().join("export.git");
     heddle_without_git(
-        &["export", "git", "--destination", export.to_str().unwrap()],
+        &[
+            "bridge",
+            "git",
+            "export",
+            "--destination",
+            export.to_str().unwrap(),
+        ],
         &work,
     )
     .unwrap();
@@ -690,7 +698,7 @@ fn realworld_git_gc_prunes_unreachable_mapping_entries() {
 // -----------------------------------------------------------------
 
 /// Clone each of the four vendored fixtures via `heddle clone`, run
-/// `import git` to materialize the git refs as overlay threads, and
+/// `bridge git import` to materialize the git refs as overlay threads, and
 /// assert the heddle workspace lines up with the bare repo it came from.
 /// Heavier than a unit test (untars ~28 MB across four extracts), so it
 /// is gated `#[ignore]` for the nightly realworld matrix run.
@@ -711,13 +719,13 @@ fn realworld_fixtures_clone_and_import_round_trip() {
         )
         .unwrap_or_else(|err| panic!("heddle clone failed for {}: {err}", entry.name));
 
-        // The default `import git` walks every ref; the synthetic
+        // The default `bridge git import` walks every ref; the synthetic
         // tests above use the same form. We do not need the legacy
         // `--all` flag.
-        heddle_without_git(&["import", "git"], &work)
+        heddle_without_git(&["bridge", "git", "import"], &work)
             .unwrap_or_else(|err| panic!("Git import failed for {}: {err}", entry.name));
 
-        let fsck = heddle_without_git(&["fsck", "--git", "--output", "json"], &work)
+        let fsck = heddle_without_git(&["maintenance", "fsck", "--git", "--output", "json"], &work)
             .unwrap_or_else(|err| panic!("fsck --git failed for {}: {err}", entry.name));
         let parsed: Value = serde_json::from_str(&fsck)
             .unwrap_or_else(|_| panic!("fsck output should parse for {}: {fsck}", entry.name));
@@ -803,7 +811,7 @@ fn marketing_moments_walkthrough_against_real_fixture() {
         .head_commit()
         .expect("cloned repo should have a HEAD commit");
     git_set_reference(&cloned, "refs/heads/raw-side-branch", head.id());
-    heddle_without_git(&["import", "git"], &work).unwrap();
+    heddle_without_git(&["bridge", "git", "import"], &work).unwrap();
     let threads_json = heddle_without_git(&["thread", "list", "--output", "json"], &work).unwrap();
     let threads: Value = serde_json::from_str(&threads_json).unwrap();
     let names: Vec<String> = threads["threads"]

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -92,7 +92,11 @@ fn setup_git_overlay_repo_with_secret() -> (TempDir, String) {
     git_overlay_fixture_cmd(temp.path(), &["add", "."]);
     git_overlay_fixture_cmd(temp.path(), &["commit", "-m", "seed"]);
     heddle(&["init"], Some(temp.path())).unwrap();
-    heddle(&["import", "git", "--ref", "main"], Some(temp.path())).unwrap();
+    heddle(
+        &["bridge", "git", "import", "--ref", "main"],
+        Some(temp.path()),
+    )
+    .unwrap();
 
     fs::create_dir_all(temp.path().join("config")).unwrap();
     fs::write(

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -8,7 +8,8 @@ use super::{git_overlay_fixtures::GitOverlayFixture, *};
 
 fn initialize_direct_git_overlay(path: &std::path::Path) {
     heddle(&["init"], Some(path)).expect("initialize direct Git overlay");
-    heddle(&["import", "git"], Some(path)).expect("import Git history into Heddle metadata");
+    heddle(&["bridge", "git", "import"], Some(path))
+        .expect("import Git history into Heddle metadata");
 }
 
 #[test]
@@ -1527,7 +1528,7 @@ fn setup_git_overlay_push_fixture() -> (TempDir, TempDir, SleyRepository) {
     .unwrap();
 
     heddle(&["init"], Some(work.path())).unwrap();
-    heddle(&["import", "git"], Some(work.path())).unwrap();
+    heddle(&["bridge", "git", "import"], Some(work.path())).unwrap();
     heddle_git_projection::git_notes::write_note(
         &git_repo,
         main,
@@ -2693,7 +2694,7 @@ fn test_cli_raw_git_clone_pull_fetches_notes_before_import() {
     git_ok(&["commit", "-m", "seed"], &work);
 
     heddle(&["init"], Some(&work)).expect("initialize direct Git overlay");
-    heddle(&["import", "git"], Some(&work)).expect("import initial Git mapping");
+    heddle(&["bridge", "git", "import"], Some(&work)).expect("import initial Git mapping");
     std::fs::write(work.join("README.md"), "seed\npublished by heddle\n").unwrap();
     heddle(&["capture", "-m", "Publish Heddle identity"], Some(&work))
         .expect("first Heddle capture succeeds");

--- a/crates/cli/tests/comprehensive/fsck.rs
+++ b/crates/cli/tests/comprehensive/fsck.rs
@@ -10,7 +10,7 @@ fn test_fsck_dangling_ref() {
     let thread_path = temp.path().join(".heddle/refs/threads/orphan");
     fs::write(&thread_path, "hs-deadbeef12345678901234567890").unwrap();
 
-    let result = heddle(&["fsck"], Some(temp.path()));
+    let result = heddle(&["maintenance", "fsck"], Some(temp.path()));
     assert!(result.is_err(), "fsck should fail with dangling ref");
     let err = result.unwrap_err();
     assert!(
@@ -36,7 +36,7 @@ fn test_fsck_orphaned_objects() {
     )
     .unwrap();
 
-    let result = heddle(&["fsck", "--full"], Some(temp.path()));
+    let result = heddle(&["maintenance", "fsck", "--full"], Some(temp.path()));
     assert!(result.is_ok(), "fsck should complete: {:?}", result.err());
 }
 
@@ -45,7 +45,7 @@ fn test_fsck_empty_repository() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
 
-    let result = heddle(&["fsck", "--full"], Some(temp.path()));
+    let result = heddle(&["maintenance", "fsck", "--full"], Some(temp.path()));
     assert!(
         result.is_ok(),
         "fsck on empty repo should succeed: {:?}",
@@ -65,6 +65,6 @@ fn test_fsck_basic_vs_full() {
     let temp = TempDir::new().unwrap();
     setup_repo_with_file(&temp, "file.txt", "content");
 
-    assert!(heddle(&["fsck"], Some(temp.path())).is_ok());
-    assert!(heddle(&["fsck", "--full"], Some(temp.path())).is_ok());
+    assert!(heddle(&["maintenance", "fsck"], Some(temp.path())).is_ok());
+    assert!(heddle(&["maintenance", "fsck", "--full"], Some(temp.path())).is_ok());
 }

--- a/crates/cli/tests/multi_agent_worktrees/actor_presence.rs
+++ b/crates/cli/tests/multi_agent_worktrees/actor_presence.rs
@@ -113,11 +113,7 @@ fn start_path_inherits_codex_probe_identity_into_actor_metadata() {
     assert_eq!(started["name"].as_str(), Some("feature/codex-probed"));
 
     let actor: Value = serde_json::from_str(
-        &heddle(
-            &["--output", "json", "agent", "presence", "show"],
-            Some(main.path()),
-        )
-        .unwrap(),
+        &heddle(&["--output", "json", "presence", "show"], Some(main.path())).unwrap(),
     )
     .unwrap();
     let actor_entry = &actor["presence"];
@@ -163,11 +159,7 @@ fn actor_show_defaults_to_current_thread_actor() {
     let actor: Value = inject_post_verification_at(
         main.path(),
         serde_json::from_str(
-            &heddle(
-                &["--output", "json", "agent", "presence", "show"],
-                Some(main.path()),
-            )
-            .unwrap(),
+            &heddle(&["--output", "json", "presence", "show"], Some(main.path())).unwrap(),
         )
         .unwrap(),
     );
@@ -204,7 +196,7 @@ fn actor_explain_reports_attach_reason_for_current_actor() {
 
     let explained: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "agent", "presence", "explain"],
+            &["--output", "json", "presence", "explain"],
             Some(main.path()),
         )
         .unwrap(),

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -549,11 +549,8 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
         Some("heddle land --thread feature/native-cli")
     );
 
-    let actor_list_json = heddle(
-        &["--output", "json", "agent", "presence", "list"],
-        Some(main.path()),
-    )
-    .expect("actor list should succeed");
+    let actor_list_json = heddle(&["--output", "json", "presence", "list"], Some(main.path()))
+        .expect("actor list should succeed");
     let actor_list: Value = serde_json::from_str(&actor_list_json).unwrap();
     let actor_session = actor_list["presence"]
         .as_array()
@@ -566,7 +563,6 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
         &[
             "--output",
             "json",
-            "agent",
             "presence",
             "complete",
             "--session",
@@ -849,11 +845,8 @@ fn land_auto_captures_and_merges_clean_thread() {
         "auto_integrated"
     );
 
-    let actor_show = heddle_output(
-        &["--output", "json", "agent", "presence", "show"],
-        Some(main.path()),
-    )
-    .expect("invoke actor show after land");
+    let actor_show = heddle_output(&["--output", "json", "presence", "show"], Some(main.path()))
+        .expect("invoke actor show after land");
     assert!(
         !actor_show.status.success(),
         "actor show should not select the merged actor implicitly after land"
@@ -862,7 +855,7 @@ fn land_auto_captures_and_merges_clean_thread() {
     let envelope: Value = serde_json::from_str(stderr.trim())
         .unwrap_or_else(|err| panic!("actor show failure should be JSON: {err}: {stderr}"));
     assert_eq!(envelope["kind"], "no_active_actor");
-    assert_eq!(envelope["primary_command"], "heddle agent presence list");
+    assert_eq!(envelope["primary_command"], "heddle presence list");
     assert!(
         envelope["hint"]
             .as_str()

--- a/crates/cli/tests/onboarding_contract.rs
+++ b/crates/cli/tests/onboarding_contract.rs
@@ -291,9 +291,11 @@ fn adopt_moves_authority_to_native_and_retains_git_projection() {
     let imported = json(&heddle(
         repo.path(),
         &config,
-        &["import", "git", "--ref", "main", "--output", "json"],
+        &[
+            "bridge", "git", "import", "--ref", "main", "--output", "json",
+        ],
     ));
-    assert_eq!(imported["output_kind"], "import_git");
+    assert_eq!(imported["output_kind"], "bridge_git_import");
 }
 
 #[cfg(unix)]

--- a/crates/cli/tests/op_id_coverage.rs
+++ b/crates/cli/tests/op_id_coverage.rs
@@ -157,8 +157,8 @@ fn command_contract_table_drives_op_id_and_read_only_classification() {
         "clone",
         "thread switch",
         "thread drop",
-        "export git",
-        "import git",
+        "bridge git export",
+        "bridge git import",
         "context set",
         "review sign",
         "agent capture",
@@ -235,7 +235,7 @@ fn extract_command_arms(source: &str) -> Vec<Arm> {
         }
 
         // Word-boundary check: skip when preceded by an identifier char
-        // (e.g. `ContextCommands::`, `AgentPresenceCommands::`).
+        // (e.g. `ContextCommands::`, `PresenceCommands::`).
         if start > 0 {
             let prev = bytes[start - 1];
             if prev.is_ascii_alphanumeric() || prev == b'_' {

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -546,7 +546,7 @@ mod fsck {
         let temp = TempDir::new().unwrap();
         setup_repo_with_file(&temp, "file.txt", "content");
 
-        let result = heddle(&["fsck"], Some(temp.path()));
+        let result = heddle(&["maintenance", "fsck"], Some(temp.path()));
         assert!(
             result.is_ok(),
             "fsck on clean repo should succeed: {:?}",
@@ -600,7 +600,7 @@ mod fsck {
         }
         fs::write(blob_path, b"corrupt blob").unwrap();
 
-        let error = heddle(&["fsck", "--full"], Some(temp.path()))
+        let error = heddle(&["maintenance", "fsck", "--full"], Some(temp.path()))
             .expect_err("full fsck must fail when a source-object pack is corrupt");
         assert!(
             ["error", "mismatch", "invalid", "corrupt"]
@@ -615,7 +615,10 @@ mod fsck {
         let temp = TempDir::new().unwrap();
         setup_repo_with_file(&temp, "file.txt", "content");
 
-        let result = heddle(&["fsck", "--output", "json"], Some(temp.path()));
+        let result = heddle(
+            &["maintenance", "fsck", "--output", "json"],
+            Some(temp.path()),
+        );
         assert!(
             result.is_ok(),
             "fsck --output json failed: {:?}",
@@ -631,14 +634,14 @@ mod fsck {
         let temp = TempDir::new().unwrap();
         setup_repo_with_file(&temp, "file.txt", "content");
 
-        let result = heddle(&["fsck", "repair"], Some(temp.path()));
+        let result = heddle(&["maintenance", "fsck", "repair"], Some(temp.path()));
         assert!(
             result.is_err(),
             "fsck repair should require an explicit repair target"
         );
         let err = result.unwrap_err();
         assert!(
-            err.contains("Usage: heddle fsck repair") && err.contains("Commands:"),
+            err.contains("Usage: heddle maintenance fsck repair") && err.contains("Commands:"),
             "bare repair command should fail at CLI parsing, got: {err}"
         );
     }
@@ -650,6 +653,7 @@ mod fsck {
 
         let result = heddle(
             &[
+                "maintenance",
                 "fsck",
                 "repair",
                 "git",
@@ -663,7 +667,7 @@ mod fsck {
         );
         assert!(
             result.is_ok(),
-            "fsck repair git --output json failed: {:?}",
+            "maintenance fsck repair git --output json failed: {:?}",
             result.err()
         );
 
@@ -683,7 +687,7 @@ mod fsck {
         let temp = TempDir::new().unwrap();
         setup_repo_with_file(&temp, "file.txt", "content");
 
-        let result = heddle(&["fsck", "--full"], Some(temp.path()));
+        let result = heddle(&["maintenance", "fsck", "--full"], Some(temp.path()));
         assert!(result.is_ok(), "fsck --full failed: {:?}", result.err());
     }
 
@@ -707,7 +711,10 @@ mod fsck {
         refresh_thread_for_land(temp.path(), "feature");
         land_thread(temp.path(), "feature");
 
-        let result = heddle(&["fsck", "--full", "--thorough"], Some(temp.path()));
+        let result = heddle(
+            &["maintenance", "fsck", "--full", "--thorough"],
+            Some(temp.path()),
+        );
         assert!(
             result.is_ok(),
             "fsck after merge should pass: {:?}",
@@ -984,7 +991,7 @@ mod gc {
 
         heddle(&["maintenance", "gc", "--aggressive"], Some(temp.path())).unwrap();
 
-        let result = heddle(&["fsck", "--full"], Some(temp.path()));
+        let result = heddle(&["maintenance", "fsck", "--full"], Some(temp.path()));
         assert!(
             result.is_ok(),
             "fsck after gc should pass: {:?}",

--- a/crates/cli/tests/provenance_verify.rs
+++ b/crates/cli/tests/provenance_verify.rs
@@ -129,7 +129,14 @@ fn verify_and_fsck_render_verified_registry_identity_end_to_end() {
 
     let fsck = run_json(
         &repo,
-        &["--output", "json", "fsck", "--thorough", "--provenance"],
+        &[
+            "--output",
+            "json",
+            "maintenance",
+            "fsck",
+            "--thorough",
+            "--provenance",
+        ],
     );
     assert_eq!(fsck["valid"], true, "{fsck}");
     assert_eq!(

--- a/crates/cli/tests/state_management/merge_store_integrity.rs
+++ b/crates/cli/tests/state_management/merge_store_integrity.rs
@@ -129,10 +129,10 @@ fn test_merge_missing_base_subtree_fails_loud_not_silent_erase() {
     assert!(
         err.contains(&sub_hash_hex),
         "refresh error must include the missing subtree's hash so the \
-         operator can correlate with `heddle fsck` output; got: {err}"
+         operator can correlate with `heddle maintenance fsck` output; got: {err}"
     );
     assert!(
-        err.contains("heddle fsck"),
+        err.contains("heddle maintenance fsck"),
         "refresh error must point at the recovery command so the operator \
          has a next step instead of just a stack trace; got: {err}"
     );

--- a/crates/cli/tests/state_management/missing_tree_integrity.rs
+++ b/crates/cli/tests/state_management/missing_tree_integrity.rs
@@ -9,7 +9,7 @@
 //! engine). Each test introduces targeted corruption (deletes the loose
 //! tree object backing a captured state) and asserts the CLI command
 //! fails loud with a diagnostic naming the missing hash and pointing at
-//! `heddle fsck` — pre-fix the same scenario produced silent, plausible-
+//! `heddle maintenance fsck` — pre-fix the same scenario produced silent, plausible-
 //! looking output that masked store corruption.
 
 use std::{fs, path::Path};
@@ -39,7 +39,7 @@ fn current_state_tree_hex(repo_root: &Path) -> String {
 }
 
 /// Assert the CLI error names the missing-tree diagnostic, includes the
-/// missing hash so the operator can correlate with `heddle fsck` output,
+/// missing hash so the operator can correlate with `heddle maintenance fsck` output,
 /// and points at the recovery command so they have a next step instead
 /// of just a stack trace. Used by every test in this module — the
 /// contract is the same regardless of which command surfaced the error.
@@ -52,10 +52,10 @@ fn assert_missing_tree_error(err: &str, tree_hex: &str) {
     assert!(
         err.contains(tree_hex),
         "error must include the missing tree's hash so the operator can correlate \
-         with `heddle fsck` output; got: {err}"
+         with `heddle maintenance fsck` output; got: {err}"
     );
     assert!(
-        err.contains("heddle fsck"),
+        err.contains("heddle maintenance fsck"),
         "error must point at the recovery command so the operator has a next step \
          instead of just a stack trace; got: {err}"
     );

--- a/crates/cli/tests/tier_coverage.rs
+++ b/crates/cli/tests/tier_coverage.rs
@@ -51,7 +51,7 @@ fn every_commands_variant_has_explicit_root_contract() {
                 // `command_contract_root_commands()` omits them in a no-client
                 // build even though the enum source (read as text) still lists
                 // the variant.
-                "Auth" | "Whoami" | "Support" | "Presence" | "Prove" | "Spool"
+                "Auth" | "Whoami" | "Support" | "Prove" | "Spool"
             )
         {
             continue;

--- a/crates/core/src/actor.rs
+++ b/crates/core/src/actor.rs
@@ -6,7 +6,7 @@
 //! - pure active-only (and related) filters over [`ActorPresence`] slices
 //! - assembling a single actor entry plus ancestry chain for presence JSON
 //! - pure [`complete_actor_entry`] / [`plan_actor_done`] and thin
-//!   [`mark_actor_done`] for `agent presence complete`
+//!   [`mark_actor_done`] for `presence complete`
 //!
 //! Human/JSON rendering and implicit session resolution (current-lane / path /
 //! any-active fallbacks) stay CLI-owned because they couple to recovery advice
@@ -20,7 +20,7 @@ use objects::store::{
 use repo::Repository;
 use serde::Serialize;
 
-/// Machine JSON for `heddle agent presence list` domain fields (stable field names).
+/// Machine JSON for `heddle presence list` domain fields (stable field names).
 ///
 /// CLI may wrap this with a `verification` envelope; domain fields here match
 /// the public `actor_list` contract (`output_kind`, `actors`, `active_only`).
@@ -210,7 +210,7 @@ pub fn list_actors_from_registry(
 
 /// Assemble a single actor entry plus ancestry chain (pure relative to I/O).
 ///
-/// Used by `agent presence show` machine JSON after the caller has resolved
+/// Used by `presence show` machine JSON after the caller has resolved
 /// which registry entry to surface.
 pub fn assemble_actor_entry(
     registry: &ActorPresenceStore,

--- a/crates/core/src/fsck/mod.rs
+++ b/crates/core/src/fsck/mod.rs
@@ -39,7 +39,7 @@ pub struct FsckReport {
 
 impl FsckReport {
     pub const CONTRACT: ReportContract = ReportContract {
-        schema_name: "fsck",
+        schema_name: "maintenance fsck",
         machine_output_kind: MachineOutputKind::Json,
         output_discriminator: None,
         schema: schema_for_report::<FsckReport>,

--- a/crates/core/src/git_projection_io_plan.rs
+++ b/crates/core/src/git_projection_io_plan.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Pure Git projection import/export/sync summary strings (no Git I/O).
 //!
-//! Owns plain-text commit and ref listing summaries for `export git` /
+//! Owns plain-text commit and ref listing summaries for `bridge git export` /
 //! `sync git` human output. Styling, destination I/O, and RecoveryAdvice
 //! stay CLI-owned.
 

--- a/crates/core/src/merge/advice.rs
+++ b/crates/core/src/merge/advice.rs
@@ -12,7 +12,7 @@ pub(crate) fn merge_integrity_refusal(
     HeddleError::recovery(RecoveryDetails::safety_refusal(
         "repository_integrity_error",
         error,
-        "Inspect repository integrity with `heddle fsck --full`, then restore or repair the reported object/ref.",
+        "Inspect repository integrity with `heddle maintenance fsck --full`, then restore or repair the reported object/ref.",
         unsafe_condition,
         would_change,
         preserved,

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -909,7 +909,7 @@ fn tag_mapping_recovery_commands(check: &RepositoryVerificationCheck) -> Vec<Str
     if tags.len() == 1 {
         vec![canonical_git_import_ref_command(&tags[0])]
     } else {
-        vec!["heddle import git".to_string()]
+        vec!["heddle bridge git import".to_string()]
     }
 }
 

--- a/crates/core/src/status/next_action.rs
+++ b/crates/core/src/status/next_action.rs
@@ -212,12 +212,13 @@ pub fn canonical_adopt_ref_command(ref_name: &str) -> String {
 }
 
 pub fn canonical_git_import_ref_command(ref_name: &str) -> String {
-    heddle_action(["import", "git", "--ref", ref_name])
+    heddle_action(["bridge", "git", "import", "--ref", ref_name])
 }
 
 pub fn canonical_git_repair_ref_preview_command(prefer: Option<&str>, ref_name: &str) -> String {
     match prefer {
         Some(prefer) => heddle_action([
+            "maintenance",
             "fsck",
             "repair",
             "git",
@@ -227,13 +228,28 @@ pub fn canonical_git_repair_ref_preview_command(prefer: Option<&str>, ref_name: 
             ref_name,
             "--preview",
         ]),
-        None => heddle_action(["fsck", "repair", "git", "--ref", ref_name, "--preview"]),
+        None => heddle_action([
+            "maintenance",
+            "fsck",
+            "repair",
+            "git",
+            "--ref",
+            ref_name,
+            "--preview",
+        ]),
     }
 }
 
 pub fn canonical_git_repair_ref_command(prefer: &str, ref_name: &str) -> String {
     heddle_action([
-        "fsck", "repair", "git", "--prefer", prefer, "--ref", ref_name,
+        "maintenance",
+        "fsck",
+        "repair",
+        "git",
+        "--prefer",
+        prefer,
+        "--ref",
+        ref_name,
     ])
 }
 
@@ -409,7 +425,7 @@ mod tests {
         assert_eq!(
             remote_tracking_next_action(&remote("main", "origin/main", 1, 1, "heddle pull"))
                 .as_deref(),
-            Some("heddle import git --ref origin/main")
+            Some("heddle bridge git import --ref origin/main")
         );
         assert_eq!(
             remote_tracking_next_action(&remote("main", "", 1, 0, "heddle push")).as_deref(),

--- a/crates/core/src/verify.rs
+++ b/crates/core/src/verify.rs
@@ -1624,7 +1624,7 @@ pub fn repository_setup_action_kind(action: &str) -> RepositorySetupActionKind {
         RepositorySetupActionKind::Init
     } else if action.starts_with("heddle adopt") {
         RepositorySetupActionKind::Adopt
-    } else if action.starts_with("heddle import git") {
+    } else if action.starts_with("heddle bridge git import") {
         RepositorySetupActionKind::GitImport
     } else {
         RepositorySetupActionKind::Other

--- a/crates/devtools/src/check_no_silent_default_tree_load.rs
+++ b/crates/devtools/src/check_no_silent_default_tree_load.rs
@@ -69,7 +69,7 @@ pub fn run(args: Vec<String>) -> Result<()> {
 site(s) in production code. This pattern silently substitutes \
 `Tree::default()` for a missing subtree (heddle#90 merge / heddle#93 \
 non-merge). Replace with `repo.require_tree(&hash)?` so missing trees \
-surface with a `heddle fsck --full` recovery hint.\n\
+surface with a `heddle maintenance fsck --full` recovery hint.\n\
 \n\
 If a site is a legitimate empty-tree sentinel (no-parent-commit marker, \
 etc.) add a `path:line` entry to HEDDLE_ASSERTER_ALLOWLIST with a \

--- a/crates/devtools/src/fuse_dispatch_bench.rs
+++ b/crates/devtools/src/fuse_dispatch_bench.rs
@@ -576,7 +576,7 @@ fn prepare_sources(args: &Args) -> Result<Sources> {
     let heddle_source = if need_heddle {
         let hs = args.out_dir.join("heddle-source");
         if !hs.exists() {
-            // `heddle import git` adopts a git branch as a heddle
+            // `heddle bridge git import` adopts a git branch as a heddle
             // lane. We import from git_source.
             sh(
                 &args.heddle_bin,

--- a/crates/git-projection/src/git_ingest.rs
+++ b/crates/git-projection/src/git_ingest.rs
@@ -123,8 +123,8 @@ fn reject_shallow_source(source: &Path, refs: &[String]) -> GitProjectionResult<
 
 fn shallow_import_retry_command(wanted_refs: Option<&HashSet<String>>) -> String {
     match wanted_refs.and_then(|refs| refs.iter().next()) {
-        Some(_) => "heddle import git --path <full-git-repo> --ref <ref>".to_string(),
-        None => "heddle import git --path <full-git-repo>".to_string(),
+        Some(_) => "heddle bridge git import --path <full-git-repo> --ref <ref>".to_string(),
+        None => "heddle bridge git import --path <full-git-repo>".to_string(),
     }
 }
 

--- a/crates/merge/src/tree_merge/executor.rs
+++ b/crates/merge/src/tree_merge/executor.rs
@@ -1331,7 +1331,7 @@ mod tests {
              can locate the corrupt entry; got: {msg}"
         );
         assert!(
-            msg.contains("heddle fsck"),
+            msg.contains("heddle maintenance fsck"),
             "error must point at the recovery command so operators have a \
              next step instead of just a stack trace; got: {msg}"
         );

--- a/crates/merge/src/tree_merge/mod.rs
+++ b/crates/merge/src/tree_merge/mod.rs
@@ -90,7 +90,7 @@ impl fmt::Display for MergeError {
                 preserved,
             } => write!(
                 formatter,
-                "{error}\nUnsafe condition: {unsafe_condition}\nWould change: {would_change}\nPreserved: {preserved}\nNext: heddle fsck --full"
+                "{error}\nUnsafe condition: {unsafe_condition}\nWould change: {would_change}\nPreserved: {preserved}\nNext: heddle maintenance fsck --full"
             ),
         }
     }

--- a/crates/object-model/src/error.rs
+++ b/crates/object-model/src/error.rs
@@ -253,7 +253,7 @@ pub enum HeddleError {
         found: ContentHash,
     },
     #[error(
-        "missing {object_type} object: {id} (run `heddle fsck --full` to inspect store integrity)"
+        "missing {object_type} object: {id} (run `heddle maintenance fsck --full` to inspect store integrity)"
     )]
     MissingObject { object_type: String, id: String },
     #[error("invalid tree entry: {0}")]
@@ -337,6 +337,6 @@ mod tests {
         let err = HeddleError::recovery(RecoveryDetails::serialization_error("bad marker"));
 
         assert!(err.to_string().contains("Repository state is corrupted"));
-        assert!(!err.to_string().contains("heddle fsck --full"));
+        assert!(!err.to_string().contains("heddle maintenance fsck --full"));
     }
 }

--- a/crates/repo/src/atomic/tx.rs
+++ b/crates/repo/src/atomic/tx.rs
@@ -478,7 +478,7 @@ impl Drop for Tx<'_> {
             tracing::error!(
                 error = %e,
                 "Tx Drop rewind failed; staged effects may persist as orphans \
-                 (gc-collectable); run heddle fsck"
+                 (gc-collectable); run heddle maintenance fsck"
             );
         }
     }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -358,7 +358,7 @@ pub struct GitOverlayTagTip {
 
 /// How many Git commits reachable from a branch tip have no Heddle mapping
 /// (neither imported/projection-mapped nor checkpointed). Used to report
-/// how far a Git branch moved out-of-band before `heddle import git --ref`
+/// how far a Git branch moved out-of-band before `heddle bridge git import --ref`
 /// reconciles it.
 #[cfg(feature = "git-overlay")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -3258,7 +3258,7 @@ impl Repository {
     /// Returns [`HeddleError::MissingObject`] with `object_type =
     /// "tree"` so callers and the top-level error printer can
     /// recognize the bug class. The `Display` impl on `MissingObject`
-    /// includes the `heddle fsck --full` recovery hint, so call sites
+    /// includes the `heddle maintenance fsck --full` recovery hint, so call sites
     /// don't need to wrap with anyhow context to give the operator a
     /// next step.
     ///

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -2636,7 +2636,7 @@ mod require_tree_callback {
     //! `require_tree` has no hydrator dance — partial-fetch only ever
     //! lazy-fetches blobs, not trees — so the contract is the simpler
     //! shape: present trees round-trip; absent trees surface
-    //! `MissingObject { object_type: "tree" }` with the `heddle fsck`
+    //! `MissingObject { object_type: "tree" }` with the `heddle maintenance fsck`
     //! hint baked into the display.
     //!
     //! These tests pin the contract at the API boundary; the
@@ -2711,7 +2711,7 @@ mod require_tree_callback {
         };
         let msg = err.to_string();
         assert!(
-            msg.contains("heddle fsck"),
+            msg.contains("heddle maintenance fsck"),
             "missing-object display must include the fsck recovery hint; got: {msg}",
         );
         assert!(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -197,7 +197,7 @@ This matters for harness integration work:
 - Heddle should follow supported harnesses ambiently rather than requiring users to run tools through Heddle
 - presence records are stored separately from writer leases
 - harness-native identities are tracked separately from Heddle-local reconnect identifiers
-- `heddle agent presence ...` inspects attribution without granting write authority
+- `heddle presence ...` inspects attribution without granting write authority
 - `heddle agent reserve|heartbeat|capture|ready|release` is the writer hot loop
 - `heddle agent provenance ...` records provider, model, and policy epochs
 

--- a/docs/CLI_WORLD_CLASS_AUDIT_2026-05-21.md
+++ b/docs/CLI_WORLD_CLASS_AUDIT_2026-05-21.md
@@ -59,7 +59,7 @@ extract time.
 | `start` / `merge` / `undo` JSON workflow | `start_merge_undo_json_workflow_keeps_machine_streams_clean` | Pass after strengthening | Isolated solid checkout, feature capture, merge preview/apply, undo list/preview all emit parseable JSON with empty stderr; merge and undo preview paths do not mutate current state or worktree content; repeat merge is a successful `Already up to date` text no-op. |
 | `version --repo <path> --verbose --output json` | `version_verbose_honors_explicit_repo_path` | Pass after fix | Verbose bug-context JSON reports the explicitly requested repository root, not the process cwd. |
 | `resolve` outside a merge | `resolve_without_merge_emits_actionable_json_error` | Pass after fix | JSON and text failures use `kind=no_merge_in_progress` / `Error: No merge in progress`, hint at `heddle status`, keep stdout empty, and avoid the old `object not found` wrapper. |
-| corrupt repository ref recovery | `fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json` | Pass after fix | Corrupt thread ref fails non-zero with stdout clean; JSON stderr has `kind=repository_integrity_error`, preserves the invalid-object error, and hints `heddle fsck --full`; text mode mirrors the recovery hint. |
+| corrupt repository ref recovery | `fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json` | Pass after fix | Corrupt thread ref fails non-zero with stdout clean; JSON stderr has `kind=repository_integrity_error`, preserves the invalid-object error, and hints `heddle maintenance fsck --full`; text mode mirrors the recovery hint. |
 | global quiet/color/narrow text behavior | `quiet_no_color_and_narrow_text_outputs_preserve_global_contract`; `narrow_no_color_text_outputs_cover_everyday_read_surfaces` | Pass after fix | `--quiet` suppresses capture/log tips; `NO_COLOR=1` wins over forced color; `COLUMNS=28/30` text succeeds across status, diagnose, doctor, diff, log, show, thread list, status, bridge status, fsck, and ready with primary labels intact. |
 | default auto-output contract | `default_auto_output_is_json_when_stdout_is_piped_and_text_when_forced`; `tty_auto_mode_renders_text_and_explicit_json_stays_json` | Pass | Confirms piped stdout uses parseable JSON in `auto` mode; TTY stdout uses human text for `status` and rich guidance for `start`; `--output text` and `--output json` override auto regardless of stream. |
 | exit-code and failure-stream taxonomy | `global_exit_codes_and_failure_streams_are_predictable` | Pass | Help exits 0 on stdout; clap parse errors exit 2 on stderr with suggestions; environment failures exit 1 with clean stdout and JSON error envelope when requested. |
@@ -123,7 +123,7 @@ extract time.
 - Added ready text/no-op coverage and broadened missing-state recovery checks
   across `goto`, `show`, and `diff`.
 - Classified invalid, corrupt, or missing object failures as
-  `repository_integrity_error`, with an actionable `heddle fsck --full` hint in
+  `repository_integrity_error`, with an actionable `heddle maintenance fsck --full` hint in
   both JSON and text modes.
 - Fixed the help-router regression test to match the current unknown-topic
   wording: unknown help names now say `no topic or command`, then point back to

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -1190,14 +1190,14 @@ verification.
 }
 ```
 
-## `heddle agent presence show --output json`
+## `heddle presence show --output json`
 
 Presence inspection emits an envelope with post-command verification. Lists are
 also enveloped so agents never have to special-case a raw array.
 
 ```json
 {
-  "output_kind": "agent_presence_show",
+  "output_kind": "presence_show",
   "presence": {
     "session_id": "agent-4dvta2dd6as3uzjrszmq",
     "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
@@ -1219,11 +1219,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence list --output json`
+## `heddle presence list --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_list",
+  "output_kind": "presence_list",
   "presence": [],
   "active_only": false,
   "verification": {
@@ -1251,11 +1251,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence complete --output json`
+## `heddle presence complete --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_complete",
+  "output_kind": "presence_complete",
   "session_id": "agent-4dvta2dd6as3uzjrszmq",
   "status": "complete",
   "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
@@ -1265,11 +1265,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence explain --output json`
+## `heddle presence explain --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_explain",
+  "output_kind": "presence_explain",
   "attached": false,
   "reason": "No active actor is registered for this checkout.",
   "repository": "/work/project",
@@ -2187,7 +2187,7 @@ native Heddle, and returns the post-adoption verification proof. The existing
 
 Canonical surface for Git Overlay and native Heddle state. Plain Git first-run
 flows recommend `heddle init`; Git Overlay reconciliation uses explicit
-`heddle import git ...`; `heddle adopt` is the explicit authority transition.
+`heddle bridge git import ...`; `heddle adopt` is the explicit authority transition.
 
 `verification` is the public proof block. Legacy `git_overlay_import_hint`
 and `git_overlay_health` sidecars are internal render data, not public JSON
@@ -2207,11 +2207,11 @@ contract fields.
     "mapping_state": "needs_import",
     "summary": "1 Git branch tip(s) still need Heddle import",
     "checks": [],
-    "recommended_action": "heddle import git --ref support/import-me",
-    "recovery_commands": ["heddle import git --ref support/import-me"]
+    "recommended_action": "heddle bridge git import --ref support/import-me",
+    "recovery_commands": ["heddle bridge git import --ref support/import-me"]
   },
-  "recommended_action": "heddle import git --ref support/import-me",
-  "recovery_commands": ["heddle import git --ref support/import-me"]
+  "recommended_action": "heddle bridge git import --ref support/import-me",
+  "recovery_commands": ["heddle bridge git import --ref support/import-me"]
 }
 ```
 
@@ -2965,22 +2965,22 @@ objects installed after the repack snapshot are preserved separately.
 | `duration_ms` | integer | Wall-clock duration of the completed repack. |
 | `bytes_reclaimed` | integer | Physical bytes removed by retiring superseded storage. |
 
-## `heddle export git --output json`
+## `heddle bridge git export --output json`
 
 Export emits:
 
 ```json
-{"output_kind": "export_git", "states_exported": 3, "commits_total": 3, "threads_synced": 1, "markers_synced": 2, "branches": [{"name": "main", "tip": "0123456789abcdef0123456789abcdef01234567"}], "tags": [{"name": "v1.0.0", "tip": "89abcdef0123456789abcdef0123456789abcdef"}], "destination": "/work/project.git"}
+{"output_kind": "bridge_git_export", "states_exported": 3, "commits_total": 3, "threads_synced": 1, "markers_synced": 2, "branches": [{"name": "main", "tip": "0123456789abcdef0123456789abcdef01234567"}], "tags": [{"name": "v1.0.0", "tip": "89abcdef0123456789abcdef0123456789abcdef"}], "destination": "/work/project.git"}
 ```
 
 Export requires an explicit destination and does not default to `.heddle/git`.
 
-## `heddle import git --output json`
+## `heddle bridge git import --output json`
 
 Import emits:
 
 ```json
-{"output_kind": "import_git", "status": "completed", "action": "import git", "summary": "Imported Git history from /work/project; repository verification is clean", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false, "recommended_action": null, "recommended_action_template": null, "recovery_commands": []}
+{"output_kind": "bridge_git_import", "status": "completed", "action": "import git", "summary": "Imported Git history from /work/project; repository verification is clean", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false, "recommended_action": null, "recommended_action_template": null, "recovery_commands": []}
 ```
 
 ### Import Git Fields
@@ -2998,26 +2998,26 @@ key naming:
 
 | Verb | Shape |
 |------|-------|
-| `export` | `{"output_kind": "export_git", "states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
-| `import` | `{"output_kind": "import_git", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "lossy_entries": [], "already_in_sync": false}` |
+| `export` | `{"output_kind": "bridge_git_export", "states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
+| `import` | `{"output_kind": "bridge_git_import", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "lossy_entries": [], "already_in_sync": false}` |
 | `sync` | `{"output_kind": "sync_git", "states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
 
-## `heddle export git --output json`
+## `heddle bridge git export --output json`
 
 Export emits:
 
 ```json
-{"output_kind": "export_git", "states_exported": 3, "threads_synced": 1, "markers_synced": 2, "destination": "/work/project.git"}
+{"output_kind": "bridge_git_export", "states_exported": 3, "threads_synced": 1, "markers_synced": 2, "destination": "/work/project.git"}
 ```
 
 Export requires an explicit destination and does not default to `.heddle/git`.
 
-## `heddle import git --output json`
+## `heddle bridge git import --output json`
 
 Import emits:
 
 ```json
-{"output_kind": "import_git", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false}
+{"output_kind": "bridge_git_import", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false}
 ```
 
 ## `heddle sync git --output json`
@@ -3150,9 +3150,9 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
       "redact trust list",
       "redact trust remove"
     ],
-    "advanced_scope_json_commands_total": 116,
+    "advanced_scope_json_commands_total": 120,
     "advanced_scope_json_commands_with_accepted_opaque_schema": 44,
-    "advanced_scope_mutating_commands_total": 68,
+    "advanced_scope_mutating_commands_total": 69,
     "advanced_scope_mutating_commands_with_accepted_opaque_schema": 25,
     "catalog_commands_total": 198,
     "catalog_mutating_commands_total": 97,
@@ -3169,21 +3169,21 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "mutating_commands_without_schema": 0,
     "opaque_schema_verbs_total": 44,
     "status": "available",
-    "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
+    "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
     "undocumented_schema_verbs_total": 0,
     "verified_scope": "everyday_and_agent",
     "verified_scope_accepted_opaque_schema_examples": [],
-    "verified_scope_json_commands_total": 40,
+    "verified_scope_json_commands_total": 36,
     "verified_scope_json_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_json_commands_with_schema": 40,
+    "verified_scope_json_commands_with_schema": 36,
     "verified_scope_json_commands_without_schema": 0,
     "verified_scope_missing_schema_examples": [],
-    "verified_scope_mutating_commands_total": 24,
+    "verified_scope_mutating_commands_total": 23,
     "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_mutating_commands_with_schema": 24,
+    "verified_scope_mutating_commands_with_schema": 23,
     "verified_scope_mutating_commands_without_schema": 0
   },
   "doc_path": "/repo/docs/json-schemas.md",
@@ -3207,7 +3207,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
+  "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -3300,7 +3300,7 @@ Refresh the active or named thread, or report the verification/action blocker.
 }
 ```
 
-## `heddle fsck repair git --output json`
+## `heddle maintenance fsck repair git --output json`
 
 Preview or apply the repair direction allowed by durable source authority.
 Git Overlay repairs Git into Heddle metadata; native repositories repair a
@@ -3320,7 +3320,7 @@ named Heddle ref into the retained Git projection. Supplying the opposite
     {
       "name": "git_projection_ref_reconcile_preview",
       "repaired": false,
-      "detail": "heddle fsck repair git --prefer git --ref main",
+      "detail": "heddle maintenance fsck repair git --prefer git --ref main",
       "count": 0
     }
   ]
@@ -3431,7 +3431,7 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_list","discussions":[]}
 ```
 
-`heddle fsck --output json` emits:
+`heddle maintenance fsck --output json` emits:
 
 ```json
 {"valid": true, "errors": [], "warnings": [], "objects_checked": 42, "git_projection_checked": false, "repair_target": null, "repaired": false, "repairs": []}
@@ -3609,7 +3609,7 @@ discipline; see the corresponding handler in `crates/cli/src/cli/commands/`:
 `heddle clone`, `heddle collapse`,
 `heddle context get/set`, `heddle diff`, `heddle expand`,
 `heddle discuss`, `heddle doctor docs`,
-`heddle fsck`, `heddle init`, `heddle integration`,
+`heddle maintenance fsck`, `heddle init`, `heddle integration`,
 `heddle maintenance`, `heddle ready`,
 `heddle remote`, `heddle resolve`, `heddle retro`,
 `heddle agent provenance`, `heddle capture`,

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -205,7 +205,7 @@ This matters for harness integration work:
 - Heddle should follow supported harnesses ambiently rather than requiring users to run tools through Heddle
 - presence records are stored separately from writer leases
 - harness-native identities are tracked separately from Heddle-local reconnect identifiers
-- `heddle agent presence ...` inspects attribution without granting write authority
+- `heddle presence ...` inspects attribution without granting write authority
 - `heddle agent reserve|heartbeat|capture|ready|release` is the writer hot loop
 - `heddle agent provenance ...` records provider, model, and policy epochs
 
@@ -674,7 +674,7 @@ extract time.
 | `start` / `merge` / `undo` JSON workflow | `start_merge_undo_json_workflow_keeps_machine_streams_clean` | Pass after strengthening | Isolated solid checkout, feature capture, merge preview/apply, undo list/preview all emit parseable JSON with empty stderr; merge and undo preview paths do not mutate current state or worktree content; repeat merge is a successful `Already up to date` text no-op. |
 | `version --repo <path> --verbose --output json` | `version_verbose_honors_explicit_repo_path` | Pass after fix | Verbose bug-context JSON reports the explicitly requested repository root, not the process cwd. |
 | `resolve` outside a merge | `resolve_without_merge_emits_actionable_json_error` | Pass after fix | JSON and text failures use `kind=no_merge_in_progress` / `Error: No merge in progress`, hint at `heddle status`, keep stdout empty, and avoid the old `object not found` wrapper. |
-| corrupt repository ref recovery | `fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json` | Pass after fix | Corrupt thread ref fails non-zero with stdout clean; JSON stderr has `kind=repository_integrity_error`, preserves the invalid-object error, and hints `heddle fsck --full`; text mode mirrors the recovery hint. |
+| corrupt repository ref recovery | `fsck_on_corrupt_ref_emits_integrity_hint_in_text_and_json` | Pass after fix | Corrupt thread ref fails non-zero with stdout clean; JSON stderr has `kind=repository_integrity_error`, preserves the invalid-object error, and hints `heddle maintenance fsck --full`; text mode mirrors the recovery hint. |
 | global quiet/color/narrow text behavior | `quiet_no_color_and_narrow_text_outputs_preserve_global_contract`; `narrow_no_color_text_outputs_cover_everyday_read_surfaces` | Pass after fix | `--quiet` suppresses capture/log tips; `NO_COLOR=1` wins over forced color; `COLUMNS=28/30` text succeeds across status, diagnose, doctor, diff, log, show, thread list, status, bridge status, fsck, and ready with primary labels intact. |
 | default auto-output contract | `default_auto_output_is_json_when_stdout_is_piped_and_text_when_forced`; `tty_auto_mode_renders_text_and_explicit_json_stays_json` | Pass | Confirms piped stdout uses parseable JSON in `auto` mode; TTY stdout uses human text for `status` and rich guidance for `start`; `--output text` and `--output json` override auto regardless of stream. |
 | exit-code and failure-stream taxonomy | `global_exit_codes_and_failure_streams_are_predictable` | Pass | Help exits 0 on stdout; clap parse errors exit 2 on stderr with suggestions; environment failures exit 1 with clean stdout and JSON error envelope when requested. |
@@ -738,7 +738,7 @@ extract time.
 - Added ready text/no-op coverage and broadened missing-state recovery checks
   across `goto`, `show`, and `diff`.
 - Classified invalid, corrupt, or missing object failures as
-  `repository_integrity_error`, with an actionable `heddle fsck --full` hint in
+  `repository_integrity_error`, with an actionable `heddle maintenance fsck --full` hint in
   both JSON and text modes.
 - Fixed the help-router regression test to match the current unknown-topic
   wording: unknown help names now say `no topic or command`, then point back to
@@ -5222,14 +5222,14 @@ verification.
 }
 ```
 
-## `heddle agent presence show --output json`
+## `heddle presence show --output json`
 
 Presence inspection emits an envelope with post-command verification. Lists are
 also enveloped so agents never have to special-case a raw array.
 
 ```json
 {
-  "output_kind": "agent_presence_show",
+  "output_kind": "presence_show",
   "presence": {
     "session_id": "agent-4dvta2dd6as3uzjrszmq",
     "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
@@ -5251,11 +5251,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence list --output json`
+## `heddle presence list --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_list",
+  "output_kind": "presence_list",
   "presence": [],
   "active_only": false,
   "verification": {
@@ -5283,11 +5283,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence complete --output json`
+## `heddle presence complete --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_complete",
+  "output_kind": "presence_complete",
   "session_id": "agent-4dvta2dd6as3uzjrszmq",
   "status": "complete",
   "thread": "actor/agent-4dvta2dd6as3uzjrszmq",
@@ -5297,11 +5297,11 @@ also enveloped so agents never have to special-case a raw array.
 
 ---
 
-## `heddle agent presence explain --output json`
+## `heddle presence explain --output json`
 
 ```json
 {
-  "output_kind": "agent_presence_explain",
+  "output_kind": "presence_explain",
   "attached": false,
   "reason": "No active actor is registered for this checkout.",
   "repository": "/work/project",
@@ -5935,6 +5935,48 @@ the same ready envelope.
 
 ---
 
+## `heddle ci run --output json`
+
+Local device-signed check verdicts. The payload is an array of signed
+verdict envelopes; the machine contract keeps this verb opaque while
+the verdict schema is still settling.
+
+```json
+[]
+```
+
+---
+
+## `heddle identity ensure --output json`
+
+```json
+{
+  "output_kind": "identity_ensure",
+  "outcome": "created_on_behalf",
+  "server": "api.heddle.sh",
+  "subject": "account-01K2N",
+  "node_id": "b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121",
+  "claim_url": "https://heddle.sh/claim/hcl1.b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121.c2hvcnQtbGl2ZWQtY2xhaW0tc2VjcmV0"
+}
+```
+
+---
+
+## `heddle identity claim-link --output json`
+
+```json
+{
+  "output_kind": "identity_claim_link",
+  "outcome": "claim_link_reissued",
+  "server": "api.heddle.sh",
+  "subject": "account-01K2N",
+  "node_id": "b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121",
+  "claim_url": "https://heddle.sh/claim/hcl1.b1a1cb0e0644173d6dc75f787fd203fdfd8f5ec116a0f70a854f12f54a67c121.bmV3LXNob3J0LWxpdmVkLWNsYWltLXNlY3JldA"
+}
+```
+
+---
+
 ## `heddle whoami --output json`
 
 ```json
@@ -6177,7 +6219,7 @@ native Heddle, and returns the post-adoption verification proof. The existing
 
 Canonical surface for Git Overlay and native Heddle state. Plain Git first-run
 flows recommend `heddle init`; Git Overlay reconciliation uses explicit
-`heddle import git ...`; `heddle adopt` is the explicit authority transition.
+`heddle bridge git import ...`; `heddle adopt` is the explicit authority transition.
 
 `verification` is the public proof block. Legacy `git_overlay_import_hint`
 and `git_overlay_health` sidecars are internal render data, not public JSON
@@ -6197,11 +6239,11 @@ contract fields.
     "mapping_state": "needs_import",
     "summary": "1 Git branch tip(s) still need Heddle import",
     "checks": [],
-    "recommended_action": "heddle import git --ref support/import-me",
-    "recovery_commands": ["heddle import git --ref support/import-me"]
+    "recommended_action": "heddle bridge git import --ref support/import-me",
+    "recovery_commands": ["heddle bridge git import --ref support/import-me"]
   },
-  "recommended_action": "heddle import git --ref support/import-me",
-  "recovery_commands": ["heddle import git --ref support/import-me"]
+  "recommended_action": "heddle bridge git import --ref support/import-me",
+  "recovery_commands": ["heddle bridge git import --ref support/import-me"]
 }
 ```
 
@@ -6955,22 +6997,22 @@ objects installed after the repack snapshot are preserved separately.
 | `duration_ms` | integer | Wall-clock duration of the completed repack. |
 | `bytes_reclaimed` | integer | Physical bytes removed by retiring superseded storage. |
 
-## `heddle export git --output json`
+## `heddle bridge git export --output json`
 
 Export emits:
 
 ```json
-{"output_kind": "export_git", "states_exported": 3, "commits_total": 3, "threads_synced": 1, "markers_synced": 2, "branches": [{"name": "main", "tip": "0123456789abcdef0123456789abcdef01234567"}], "tags": [{"name": "v1.0.0", "tip": "89abcdef0123456789abcdef0123456789abcdef"}], "destination": "/work/project.git"}
+{"output_kind": "bridge_git_export", "states_exported": 3, "commits_total": 3, "threads_synced": 1, "markers_synced": 2, "branches": [{"name": "main", "tip": "0123456789abcdef0123456789abcdef01234567"}], "tags": [{"name": "v1.0.0", "tip": "89abcdef0123456789abcdef0123456789abcdef"}], "destination": "/work/project.git"}
 ```
 
 Export requires an explicit destination and does not default to `.heddle/git`.
 
-## `heddle import git --output json`
+## `heddle bridge git import --output json`
 
 Import emits:
 
 ```json
-{"output_kind": "import_git", "status": "completed", "action": "import git", "summary": "Imported Git history from /work/project; repository verification is clean", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false, "recommended_action": null, "recommended_action_template": null, "recovery_commands": []}
+{"output_kind": "bridge_git_import", "status": "completed", "action": "import git", "summary": "Imported Git history from /work/project; repository verification is clean", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false, "recommended_action": null, "recommended_action_template": null, "recovery_commands": []}
 ```
 
 ### Import Git Fields
@@ -6988,26 +7030,26 @@ key naming:
 
 | Verb | Shape |
 |------|-------|
-| `export` | `{"output_kind": "export_git", "states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
-| `import` | `{"output_kind": "import_git", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "lossy_entries": [], "already_in_sync": false}` |
+| `export` | `{"output_kind": "bridge_git_export", "states_exported": N, "threads_synced": N, "markers_synced": N, "destination": "..."}` |
+| `import` | `{"output_kind": "bridge_git_import", "commits_imported": N, "states_created": N, "branches_synced": N, "tags_synced": N, "skipped_non_commit_refs": N, "lossy_entries": [], "already_in_sync": false}` |
 | `sync` | `{"output_kind": "sync_git", "states_exported": N, "commits_imported": N, "threads_synced": N, "markers_synced": N}` |
 
-## `heddle export git --output json`
+## `heddle bridge git export --output json`
 
 Export emits:
 
 ```json
-{"output_kind": "export_git", "states_exported": 3, "threads_synced": 1, "markers_synced": 2, "destination": "/work/project.git"}
+{"output_kind": "bridge_git_export", "states_exported": 3, "threads_synced": 1, "markers_synced": 2, "destination": "/work/project.git"}
 ```
 
 Export requires an explicit destination and does not default to `.heddle/git`.
 
-## `heddle import git --output json`
+## `heddle bridge git import --output json`
 
 Import emits:
 
 ```json
-{"output_kind": "import_git", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false}
+{"output_kind": "bridge_git_import", "commits_imported": 4, "states_created": 4, "branches_synced": 2, "tags_synced": 1, "skipped_non_commit_refs": 0, "lossy_entries": [], "already_in_sync": false}
 ```
 
 ## `heddle sync git --output json`
@@ -7120,60 +7162,60 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
   "command_contract_schema_coverage": {
     "accepted_opaque_schema_examples": [
       "help",
+      "ci run",
       "redact apply",
       "redact list",
       "redact show",
       "redact trust add",
       "redact trust list",
-      "redact trust remove",
-      "redact purge apply"
+      "redact trust remove"
     ],
-    "accepted_opaque_schema_verbs_total": 43,
+    "accepted_opaque_schema_verbs_total": 44,
     "advanced_scope": "advanced_internal_admin",
     "advanced_scope_accepted_opaque_schema_examples": [
       "help",
+      "ci run",
       "redact apply",
       "redact list",
       "redact show",
       "redact trust add",
       "redact trust list",
-      "redact trust remove",
-      "redact purge apply"
+      "redact trust remove"
     ],
-    "advanced_scope_json_commands_total": 113,
-    "advanced_scope_json_commands_with_accepted_opaque_schema": 43,
-    "advanced_scope_mutating_commands_total": 65,
-    "advanced_scope_mutating_commands_with_accepted_opaque_schema": 24,
-    "catalog_commands_total": 192,
-    "catalog_mutating_commands_total": 93,
-    "json_commands_total": 153,
-    "json_commands_with_accepted_opaque_schema": 43,
-    "json_commands_with_schema": 110,
+    "advanced_scope_json_commands_total": 120,
+    "advanced_scope_json_commands_with_accepted_opaque_schema": 44,
+    "advanced_scope_mutating_commands_total": 69,
+    "advanced_scope_mutating_commands_with_accepted_opaque_schema": 25,
+    "catalog_commands_total": 198,
+    "catalog_mutating_commands_total": 97,
+    "json_commands_total": 156,
+    "json_commands_with_accepted_opaque_schema": 44,
+    "json_commands_with_schema": 112,
     "json_commands_without_schema": 0,
-    "json_mutating_commands_total": 89,
+    "json_mutating_commands_total": 92,
     "missing_mutating_schema_examples": [],
     "missing_schema_examples": [],
-    "mutating_commands_total": 89,
-    "mutating_commands_with_accepted_opaque_schema": 24,
-    "mutating_commands_with_schema": 65,
+    "mutating_commands_total": 92,
+    "mutating_commands_with_accepted_opaque_schema": 25,
+    "mutating_commands_with_schema": 67,
     "mutating_commands_without_schema": 0,
-    "opaque_schema_verbs_total": 43,
+    "opaque_schema_verbs_total": 44,
     "status": "available",
-    "summary": "192 command(s), 153 JSON command(s), 93 mutating command(s), 89 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
+    "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
     "unaccepted_opaque_schema_examples": [],
     "unaccepted_opaque_schema_verbs_total": 0,
     "undocumented_schema_examples": [],
     "undocumented_schema_verbs_total": 0,
     "verified_scope": "everyday_and_agent",
     "verified_scope_accepted_opaque_schema_examples": [],
-    "verified_scope_json_commands_total": 40,
+    "verified_scope_json_commands_total": 36,
     "verified_scope_json_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_json_commands_with_schema": 40,
+    "verified_scope_json_commands_with_schema": 36,
     "verified_scope_json_commands_without_schema": 0,
     "verified_scope_missing_schema_examples": [],
-    "verified_scope_mutating_commands_total": 24,
+    "verified_scope_mutating_commands_total": 23,
     "verified_scope_mutating_commands_with_accepted_opaque_schema": 0,
-    "verified_scope_mutating_commands_with_schema": 24,
+    "verified_scope_mutating_commands_with_schema": 23,
     "verified_scope_mutating_commands_without_schema": 0
   },
   "doc_path": "/repo/docs/json-schemas.md",
@@ -7197,7 +7239,7 @@ runtime facts. Refresh it with `heddle doctor schemas --update-docs`.
     "try"
   ],
   "status": "available",
-  "summary": "192 command(s), 153 JSON command(s), 93 mutating command(s), 89 mutating JSON command(s); verified everyday/agent machine surface has 40 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 43 accepted opaque schema(s) outside clean verification",
+  "summary": "198 command(s), 156 JSON command(s), 97 mutating command(s), 92 mutating JSON command(s); verified everyday/agent machine surface has 36 concrete schema-backed JSON command(s); advanced/internal/admin surfaces carry 44 accepted opaque schema(s) outside clean verification",
   "undocumented_verbs": [],
   "unmatched_verbs": [],
   "verified": true
@@ -7290,7 +7332,7 @@ Refresh the active or named thread, or report the verification/action blocker.
 }
 ```
 
-## `heddle fsck repair git --output json`
+## `heddle maintenance fsck repair git --output json`
 
 Preview or apply the repair direction allowed by durable source authority.
 Git Overlay repairs Git into Heddle metadata; native repositories repair a
@@ -7310,7 +7352,7 @@ named Heddle ref into the retained Git projection. Supplying the opposite
     {
       "name": "git_projection_ref_reconcile_preview",
       "repaired": false,
-      "detail": "heddle fsck repair git --prefer git --ref main",
+      "detail": "heddle maintenance fsck repair git --prefer git --ref main",
       "count": 0
     }
   ]
@@ -7421,7 +7463,7 @@ the `discuss_show` discriminator:
 {"output_kind":"discuss_list","discussions":[]}
 ```
 
-`heddle fsck --output json` emits:
+`heddle maintenance fsck --output json` emits:
 
 ```json
 {"valid": true, "errors": [], "warnings": [], "objects_checked": 42, "git_projection_checked": false, "repair_target": null, "repaired": false, "repairs": []}
@@ -7599,7 +7641,7 @@ discipline; see the corresponding handler in `crates/cli/src/cli/commands/`:
 `heddle clone`, `heddle collapse`,
 `heddle context get/set`, `heddle diff`, `heddle expand`,
 `heddle discuss`, `heddle doctor docs`,
-`heddle fsck`, `heddle init`, `heddle integration`,
+`heddle maintenance fsck`, `heddle init`, `heddle integration`,
 `heddle maintenance`, `heddle ready`,
 `heddle remote`, `heddle resolve`, `heddle retro`,
 `heddle agent provenance`, `heddle capture`,

--- a/scripts/verify-cold-flow-agent.sh
+++ b/scripts/verify-cold-flow-agent.sh
@@ -871,7 +871,7 @@ PYJSON
 
   run_json "$transcript" "$repo" "$shape.03.init-overlay" init
   assert_source_authority "$repo" git-overlay
-  run_json "$transcript" "$repo" "$shape.03.import-overlay-main" import git --ref main
+  run_json "$transcript" "$repo" "$shape.03.import-overlay-main" bridge git import --ref main
   assert_source_authority "$repo" git-overlay
   assert_git_commit_mapped "$repo" "$overlay_base"
   assert_clean_git_status "$repo"

--- a/scripts/verify-cold-flow-human.sh
+++ b/scripts/verify-cold-flow-human.sh
@@ -416,6 +416,7 @@ assert_transcript_claims() {
     "pull" \
     "push" \
     "clone" \
+    "bridge git import" \
     "start" \
     "ready" \
     "Git repo detected" \
@@ -448,7 +449,6 @@ assert_transcript_claims() {
     "Last 5 captures" \
     "Captures on" \
     "materialized" \
-    "heddle bridge git" \
     "reconcile" \
     "performed:" \
     "skipped:" \
@@ -700,7 +700,7 @@ run_shape() {
 
   run_text "$transcript" "$repo" init --output text
   assert_source_authority "$repo" git-overlay
-  run_text "$transcript" "$repo" import git --ref main --output text
+  run_text "$transcript" "$repo" bridge git import --ref main --output text
   assert_source_authority "$repo" git-overlay
   assert_git_commit_mapped "$repo" "$overlay_base"
   assert_clean_git_status "$repo"


### PR DESCRIPTION
## Summary

Implements the next incomplete CLI consolidation slice from #473: **Phase 3 — namespace unification**.

- hard-moves acting-worker context from `agent presence ...` to the separate canonical `presence ...` root
- hard-moves `fsck` and `fsck repair git` under `maintenance fsck ...`
- hard-moves explicit Git projection I/O from `import git` / `export git` to `bridge git import` / `bridge git export`
- updates dispatch, command catalog entries, output-kind discriminators, schemas, generated TypeScript contracts, recovery advice, tests, and the README verb tour
- leaves no hidden aliases or compatibility shims for the removed spellings

Refs #473.

## Audit

The audit compared `crates/cli-args/src/cli/cli_args/commands_main.rs`, the runtime command catalog, and the current handlers against `docs/spikes/whole-cli-consolidation.md` plus the six maintainer decisions on #473.

- **Phase 0 landed:** save/land core in #478 / #464 (`cd7a49b1`).
- **Phase 1 landed:** free deletions in #488, with the residual in #1318 (`513c5638`, `db45688a`).
- **Phase 2 landed:** synonym/router removals in #681 (`60bef3d7`).
- **Phase 4 landed out of sequence:** semantic-by-default in #669 (`24893b1d`); the redact purge lifecycle is already under `redact purge`.
- **Phase 3 was the next incomplete phase:** actor/session responsibilities had already migrated into `agent`, but presence was incorrectly nested there, while integrity and explicit Git projection operations still occupied redundant roots. This PR completes that independently shippable namespace slice.
- **Phase 5 is unshipped:** there is no canonical-root conformance gate that rejects future root drift.

The audit also found current-main drift from already-landed decisions: canonical top-level `switch` is currently nested as `thread switch`, and top-level `schemas` remains. Those are intentionally not mixed into this Phase 3 PR; they need a focused regression follow-up before Phase 5 locks the class.

## Maintainer decisions

- `auth` and `presence` are separate canonical roots; presence is no longer under `agent`.
- `blame` stays absent; per-line attribution remains `query --attribution`.
- the FUSE `daemon` namespace is untouched and is not merged with agent control.
- `discuss` remains distinct from `context`.
- markers remain under `thread marker`.
- this phase does not alter the `switch` decision; the audit calls out current-main's `thread switch` regression for its own correction.

## Surface change

| Removed path | Canonical path |
|---|---|
| `agent presence {list,show,explain,complete}` | `presence {list,show,explain,complete}` |
| `fsck [repair git]` | `maintenance fsck [repair git]` |
| `import git` | `bridge git import` |
| `export git` | `bridge git export` |

The runtime catalog now reports approximately **54 root commands, down from 55** on `origin/main` (the source count includes feature-gated/internal roots), continuing toward the design target of ~28.

## Verification

Exact CLI CI invocations completed successfully on the final tree:

- `cargo build --locked -p heddle-cli --features telemetry --tests --bin heddle`
- `cargo clippy --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry --lib --bins --tests --examples -- -D warnings`
- `cargo test --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry`
  - main CLI integration binary: 921 passed, 0 failed, 20 ignored
  - generated TypeScript schema sync, doctor integration, tier coverage, and remaining CLI/CLI-shared suites passed
- `cargo test --locked -p heddle-object-model -p heddle-repo -p heddle-merge` passed
- `cargo fmt --all --check` passed
- live `heddle doctor schemas --output json`: verified, 0 issues
- catalog check contains `presence list`, `maintenance fsck`, `bridge git import`, and `bridge git export`
- negative runtime checks for `agent presence list`, `fsck`, `import git`, and `export git` each return exit 64 with `kind=parse_error`, never panic

The standalone npm test command could not start because this checkout does not have `tsc` installed; the Rust `ts_types_in_sync` tests did pass against the regenerated artifacts.

A live repository-wide `doctor docs` scan still reports 17 drift findings. Eight are newly stale invocations in read-only/off-limits `.agents` operating docs; the other nine are pre-existing current-main findings (including unimplemented agent-daemon docs). The doctor integration tests and live schema gate pass. This is recorded rather than expanding this PR into orchestrator-file or unrelated daemon cleanup.

## #479 follow-up

#479 should consume the current `heddle help --output json` command catalog for each released version, regenerate reference pages for the new canonical paths and output kinds, and ensure the removed Phase 3 spellings do not appear. It should not copy the stale `heddle commands --output json` invocation from the issue body.

## Remaining follow-ons

- repair the audited `switch` and `schemas` regressions without reopening the landed Phase 2 scope
- finish any remaining Phase 4 lifecycle/flag work not represented by the already-landed semantic and redact changes
- implement Phase 5's canonical-root conformance gate, including a proved failing negative case
- complete #479 after the canonical surface is locked

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789524123&installation_model_id=21489&pr_number=1396&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1396&signature=552611e83646b69290e06ca135741c5be5d5203fc65be184be839a6aff498ba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->