### PR TITLE
test(cli): stop leaking heddle-cli-test-* temp homes

### DIFF
--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -723,20 +723,70 @@ fn seed_default_test_user_config(
     .map_err(|err| err.to_string())
 }
 
+#[derive(PartialEq, Eq)]
+enum TestTempPath {
+    Directory(std::path::PathBuf),
+    File(std::path::PathBuf),
+}
+
+#[derive(Default)]
+struct TestTempPaths(Vec<TestTempPath>);
+
+impl Drop for TestTempPaths {
+    fn drop(&mut self) {
+        for path in self.0.drain(..).rev() {
+            let result = match &path {
+                TestTempPath::Directory(path) => std::fs::remove_dir_all(path),
+                TestTempPath::File(path) => std::fs::remove_file(path),
+            };
+            if let Err(err) = result
+                && err.kind() != std::io::ErrorKind::NotFound
+            {
+                let path = match path {
+                    TestTempPath::Directory(path) | TestTempPath::File(path) => path,
+                };
+                eprintln!("failed to remove test temp path {}: {err}", path.display());
+            }
+        }
+    }
+}
+
+thread_local! {
+    static TEST_TEMP_PATHS: std::cell::RefCell<TestTempPaths> =
+        std::cell::RefCell::new(TestTempPaths::default());
+}
+
+fn track_test_temp_path(path: std::path::PathBuf, directory: bool) -> std::path::PathBuf {
+    TEST_TEMP_PATHS.with(|paths| {
+        let tracked = if directory {
+            TestTempPath::Directory(path.clone())
+        } else {
+            TestTempPath::File(path.clone())
+        };
+        let mut paths = paths.borrow_mut();
+        if !paths.0.contains(&tracked) {
+            paths.0.push(tracked);
+        }
+    });
+    path
+}
+
 fn default_test_user_config_path(cwd: &std::path::Path) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
+    let path = std::env::temp_dir().join(format!(
         "heddle-cli-test-user-{}-{:016x}.toml",
         std::process::id(),
         test_path_hash(cwd)
-    ))
+    ));
+    track_test_temp_path(path, false)
 }
 
 fn default_test_home_path(cwd: &std::path::Path) -> std::path::PathBuf {
-    std::env::temp_dir().join(format!(
+    let path = std::env::temp_dir().join(format!(
         "heddle-cli-test-home-{}-{:016x}",
         std::process::id(),
         test_path_hash(cwd)
-    ))
+    ));
+    track_test_temp_path(path, true)
 }
 
 fn test_path_hash(path: &std::path::Path) -> u64 {


### PR DESCRIPTION
## Summary

- Register each deterministic per-`cwd` CLI test home and user-config path with a thread-local RAII guard.
- Remove the owned home directory and config file when the test execution thread exits, including during panic unwinding, while preserving stable-path reuse within a test.
- Keep the change harness-only and disjoint from the CLI consolidation phases.

## Sharing model

Each test uses an independent temporary `cwd`, so its hash produces an independent home/config pair. Multiple CLI subprocesses within that test intentionally reuse the same deterministic paths. The cleanup guard therefore lives for the test execution thread rather than one subprocess invocation.

## Closes

Part of HeddleCo/heddle#1047
Part of HeddleCo/heddle#1125

## Red commit

N/A — mechanical test-cleanup PR; assertions and production behavior are unchanged. The leak itself was verified with before/after residue counting around the full suite.

## Test evidence

```text
$ TMPDIR=<fresh-dir> cargo test --locked -p heddle-cli --test cli_integration --features heddle-cli/telemetry
running 941 tests
test result: ok. 921 passed; 0 failed; 20 ignored; 0 measured; 0 filtered out

heddle-cli-test-* entries before: 0
heddle-cli-test-* entries after:  0

$ cargo clippy --locked -p heddle-cli --features telemetry --test cli_integration -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 45.13s
```

## Manual verification

N/A — covered by the full CLI integration suite and negative residue count.

## Blocked by → resolved

None

Class: `test-cleanup` (mechanical)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789532921&installation_model_id=21489&pr_number=1397&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1397&signature=3a9a3b03b707a50205d81d68bb26ddab2e8cf11eb47e061185f5a7cc8d92d5c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->