### PR TITLE
refactor(cli): close Phase 5 command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Heddle is an agent-native version control CLI written in Rust. It keeps its own 
 - local captures and Git-compatible commits with explicit human and agent attribution
 - content-addressed immutable history with stable change identifiers that survive rewrites
 - provenance-aware inspection (`heddle query --attribution`, `heddle show`, `heddle diff`)
+- operation-agnostic recovery (`heddle continue` / `heddle abort`) without per-command lifecycle flags
 - separate coordination surfaces for writer leases (`heddle agent`) and acting-worker context (`heddle presence`)
 - explicit maintenance and interoperability namespaces (`heddle maintenance`, `heddle bridge git`)
 
@@ -134,6 +135,11 @@ heddle ready
 # Land locally, then publish with the source authority
 heddle land --thread feature/auth
 heddle push
+
+# Inspect, continue, or abort any in-progress integration
+heddle status
+heddle resolve --list
+heddle continue   # or: heddle abort
 
 # Inspect history and provenance
 heddle log

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -87,7 +87,9 @@ pub enum DoctorCommands {
     /// Walks every `heddle <verb> [<subverb>] [flags]` invocation in
     /// the requested markdown files and reports any drift: missing
     /// verbs, unknown long flags, or invalid literal values for flags
-    /// like `--workspace`, `--scope`, and `--kind`.
+    /// like `--workspace`, `--scope`, and `--kind`. It also enforces the
+    /// accepted closed root surface and centralized `continue`/`abort`
+    /// lifecycle.
     ///
     /// Exits non-zero when any drift is found, so it's safe to run in
     /// CI. Pair with `--output json` for structured output. Run on every PR
@@ -1163,10 +1165,6 @@ pub struct ResolveArgs {
     /// Mark the path resolved even if conflict markers are still present.
     #[arg(long)]
     pub force: bool,
-
-    /// Abort the merge.
-    #[arg(long)]
-    pub abort: bool,
 }
 
 /// The `(remote, thread)` pair shared by remote commands that use an

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -347,7 +347,7 @@ Examples:
     ///
     /// `heddle redact apply` declares a redaction; the blob bytes stay
     /// on disk and reads return the operator-supplied stub. `heddle
-    /// purge` afterward physically removes the bytes. Both are signed,
+    /// redact purge` afterward physically removes the bytes. Both are signed,
     /// attributed, oplog-audited operations. See
     /// `docs/PRINCIPLES.md` (the honesty principle) for context.
     Redact {

--- a/crates/cli-contract/src/cli/commands/doctor_docs.rs
+++ b/crates/cli-contract/src/cli/commands/doctor_docs.rs
@@ -34,6 +34,7 @@ use super::{
         ActionTemplate, CommandCatalogOption, CommandCatalogOutput, build_command_catalog,
         feature_gated_command_roots, recommended_action_template,
     },
+    surface_conformance::command_surface_violations,
 };
 use crate::cli::{Cli, DoctorDocsArgs, should_output_json};
 
@@ -68,6 +69,9 @@ pub enum IssueKind {
     /// The recommendation sends a source operation through Heddle when durable
     /// repository authority requires direct Git or a separate workflow step.
     AuthorityConflict,
+    /// The parser exposes a root or lifecycle flag outside the accepted,
+    /// explicitly reviewed command surface.
+    NonCanonicalSurface,
     /// The file referenced by `--path` (or enumerated by `--all`) could
     /// not be read. We surface this as a real issue, not a silent skip,
     /// so a typoed path or permission error fails CI instead of letting
@@ -97,7 +101,20 @@ pub fn cmd_doctor_docs(cli: &Cli, args: DoctorDocsArgs) -> Result<()> {
 
     let files = resolve_files(&repo_root, &args)?;
     let cli_command = Cli::command();
-    let mut issues = Vec::new();
+    let mut issues: Vec<DocsIssue> = command_surface_violations(&cli_command)
+        .into_iter()
+        .map(|violation| DocsIssue {
+            file: "<command-surface>".to_string(),
+            line: 0,
+            invocation: format!("heddle {}", violation.path.join(" ")),
+            kind: IssueKind::NonCanonicalSurface,
+            detail: violation.detail,
+            suggestion: Some(
+                "remove the surface or amend the accepted CLI design and conformance set"
+                    .to_string(),
+            ),
+        })
+        .collect();
     for file in &files {
         let display = display_path(&repo_root, file);
         let bytes = match std::fs::read_to_string(file) {

--- a/crates/cli-contract/src/cli/commands/mod.rs
+++ b/crates/cli-contract/src/cli/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod command_catalog;
 pub mod doctor_docs;
 pub mod doctor_schemas;
 pub mod schemas;
+pub mod surface_conformance;
 pub mod verification_health;
 
 pub use advice::RecoveryAdvice;
@@ -21,3 +22,8 @@ pub use command_catalog::{
 pub use doctor_docs::cmd_doctor_docs;
 pub use doctor_schemas::{cmd_doctor_schemas, documented_samples_with_bound_verbs};
 pub use schemas::{cmd_schemas, documented_schema_verbs, schema_for_verb, schema_verbs};
+pub use surface_conformance::{
+    APPROVED_NON_EVERYDAY_ROOT_COMMANDS, APPROVED_ROOT_ALIASES, CANONICAL_ROOT_COMMANDS,
+    CommandSurfaceViolation, command_surface_violations, is_approved_root_command,
+    unapproved_root_command_names,
+};

--- a/crates/cli-contract/src/cli/commands/surface_conformance.rs
+++ b/crates/cli-contract/src/cli/commands/surface_conformance.rs
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Closed-world checks for the top-level CLI and operation lifecycle.
+
+use std::collections::BTreeSet;
+
+use clap::Command;
+
+/// Canonical roots from the accepted whole-CLI consolidation decision, with
+/// the maintainer overrides applied.
+///
+/// `switch` and `clean` are reserved here even though the current parser does
+/// not expose them at the root. The Phase 5 gate prevents an unreviewed root
+/// from appearing; it does not silently fold those separately audited surface
+/// regressions into this phase.
+pub const CANONICAL_ROOT_COMMANDS: &[&str] = &[
+    "abort",
+    "adopt",
+    "agent",
+    "auth",
+    "bridge",
+    "clean",
+    "clone",
+    "commit",
+    "context",
+    "continue",
+    "diff",
+    "discuss",
+    "doctor",
+    "help",
+    "init",
+    "integration",
+    "land",
+    "log",
+    "maintenance",
+    "presence",
+    "pull",
+    "push",
+    "query",
+    "ready",
+    "redact",
+    "remote",
+    "resolve",
+    "review",
+    "run",
+    "shell",
+    "show",
+    "start",
+    "status",
+    "switch",
+    "sync",
+    "thread",
+    "try",
+    "undo",
+    "verify",
+    "watch",
+];
+
+/// Explicitly reviewed non-everyday roots that exist in the current product.
+///
+/// This list is intentionally closed. Adding a new root requires updating the
+/// design and this list in the same review; otherwise the source and
+/// `doctor docs` conformance gates fail. `schemas` is retained as the audited
+/// pre-existing Phase 2 regression and must not be mistaken for a canonical
+/// root when that follow-up is handled.
+pub const APPROVED_NON_EVERYDAY_ROOT_COMMANDS: &[&str] = &[
+    "capture",
+    "ci",
+    "collapse",
+    "complete",
+    "daemon",
+    "expand",
+    "hook",
+    "identity",
+    "oplog",
+    "retro",
+    "revert",
+    "schemas",
+    "semantic",
+    "timeline",
+    "visibility",
+    "whoami",
+];
+
+/// Reviewed root aliases. Keeping this set closed prevents a removed verb from
+/// returning as a hidden clap alias and bypassing the root-variant check.
+pub const APPROVED_ROOT_ALIASES: &[&str] = &["__complete", "history", "schema"];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSurfaceViolation {
+    pub path: Vec<String>,
+    pub detail: String,
+}
+
+pub fn is_approved_root_command(command: &str) -> bool {
+    CANONICAL_ROOT_COMMANDS.contains(&command)
+        || APPROVED_NON_EVERYDAY_ROOT_COMMANDS.contains(&command)
+}
+
+/// Return every root that is outside the reviewed closed set.
+pub fn unapproved_root_command_names<'a>(
+    commands: impl IntoIterator<Item = &'a str>,
+) -> Vec<String> {
+    commands
+        .into_iter()
+        .filter(|command| !is_approved_root_command(command))
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+/// Validate both parts of the Phase 5 close-the-class contract against a clap
+/// tree: no unreviewed top-level root, and no command-local `--continue` or
+/// `--abort` lifecycle flag.
+pub fn command_surface_violations(command: &Command) -> Vec<CommandSurfaceViolation> {
+    let mut violations = unapproved_root_command_names(
+        command.get_subcommands().map(Command::get_name),
+    )
+    .into_iter()
+    .map(|root| CommandSurfaceViolation {
+        path: vec![root.clone()],
+        detail: format!(
+            "top-level verb `{root}` is outside the accepted canonical and reviewed advanced surface"
+        ),
+    })
+    .collect::<Vec<_>>();
+
+    for subcommand in command.get_subcommands() {
+        for alias in subcommand.get_all_aliases() {
+            if !APPROVED_ROOT_ALIASES.contains(&alias) {
+                violations.push(CommandSurfaceViolation {
+                    path: vec![alias.to_string()],
+                    detail: format!(
+                        "root alias `{alias}` is outside the explicitly reviewed alias surface"
+                    ),
+                });
+            }
+        }
+    }
+
+    let mut path = Vec::new();
+    collect_lifecycle_flag_violations(command, &mut path, &mut violations);
+    violations
+}
+
+fn collect_lifecycle_flag_violations(
+    command: &Command,
+    path: &mut Vec<String>,
+    violations: &mut Vec<CommandSurfaceViolation>,
+) {
+    for subcommand in command.get_subcommands() {
+        path.push(subcommand.get_name().to_string());
+        for argument in subcommand.get_arguments() {
+            let Some(flag) = argument.get_long() else {
+                continue;
+            };
+            if matches!(flag, "continue" | "abort") {
+                violations.push(CommandSurfaceViolation {
+                    path: path.clone(),
+                    detail: format!(
+                        "`{}` owns a command-local `--{flag}` flag; use the operation-agnostic top-level `{flag}` verb",
+                        path.join(" ")
+                    ),
+                });
+            }
+        }
+        collect_lifecycle_flag_violations(subcommand, path, violations);
+        path.pop();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::{Arg, CommandFactory};
+
+    use super::*;
+    use crate::cli::Cli;
+
+    #[test]
+    fn current_cli_satisfies_closed_surface() {
+        let violations = command_surface_violations(&Cli::command());
+        assert!(
+            violations.is_empty(),
+            "current CLI violates the closed surface: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn reintroduced_noncanonical_root_fails_conformance() {
+        let command = Cli::command().subcommand(Command::new("checkout"));
+        let violations = command_surface_violations(&command);
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.path == ["checkout"]),
+            "reintroduced `checkout` must fail the closed-surface gate: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn command_local_lifecycle_flag_fails_conformance() {
+        let command = Command::new("heddle")
+            .subcommand(Command::new("resolve").arg(Arg::new("abort").long("abort")));
+        let violations = command_surface_violations(&command);
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.detail.contains("command-local `--abort`")),
+            "command-local lifecycle flags must fail the gate: {violations:#?}"
+        );
+    }
+
+    #[test]
+    fn hidden_removed_root_alias_fails_conformance() {
+        let command =
+            Command::new("heddle").subcommand(Command::new("switch").hide(true).alias("checkout"));
+        let violations = command_surface_violations(&command);
+        assert!(
+            violations
+                .iter()
+                .any(|violation| violation.path == ["checkout"]),
+            "a hidden alias must not revive a removed root: {violations:#?}"
+        );
+    }
+}

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -317,9 +317,7 @@ fn typed_recovery_commands(kind: &str) -> Vec<String> {
         // machine envelope, losing the specific recovery path the human
         // hint already documents (HeddleCo/heddle#981 regression). Commands
         // mirror the CLI-side `RecoveryAdvice` versions on `main`.
-        "merge_already_in_progress" => {
-            &["heddle status", "heddle continue", "heddle resolve --abort"]
-        }
+        "merge_already_in_progress" => &["heddle status", "heddle continue", "heddle abort"],
         "thread_not_found" => &["heddle thread list"],
         "merge_no_common_ancestor" => &["heddle status"],
         "dirty_worktree" | "source_thread_uncaptured_work" => {
@@ -952,7 +950,7 @@ mod tests {
         assert_eq!(classified.primary_command, "heddle status");
         assert_eq!(
             classified.recovery_commands,
-            vec!["heddle status", "heddle continue", "heddle resolve --abort"]
+            vec!["heddle status", "heddle continue", "heddle abort"]
         );
 
         let not_found = anyhow!(HeddleError::recovery(RecoveryDetails::safety_refusal(

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -135,7 +135,8 @@ pub use git_projection_io::cmd_context_reason_git;
 #[cfg(feature = "git-overlay")]
 pub use git_projection_io::{cmd_export_git, cmd_import_git, cmd_sync_git};
 pub use heddle_cli_contract::cli::commands::{
-    advice, command_catalog, doctor_docs, doctor_schemas, schemas, verification_health,
+    advice, command_catalog, doctor_docs, doctor_schemas, schemas, surface_conformance,
+    verification_health,
 };
 pub use hook::cmd_hook;
 pub use init::cmd_init;

--- a/crates/cli/src/cli/commands/resolve.rs
+++ b/crates/cli/src/cli/commands/resolve.rs
@@ -30,14 +30,9 @@ pub fn cmd_resolve(
     ours: bool,
     theirs: bool,
     force: bool,
-    abort: bool,
 ) -> Result<()> {
     let repo = cli.open_repo()?;
     let merge_manager = repo.merge_state_manager();
-
-    if abort {
-        return cmd_resolve_abort(&repo, &merge_manager, cli);
-    }
 
     if list {
         return cmd_resolve_list(&repo, &merge_manager, cli);
@@ -48,44 +43,10 @@ pub fn cmd_resolve(
     }
 
     let Some(path) = path else {
-        return Err(anyhow!(
-            "Specify a file to resolve, or use --all, --list, or --abort"
-        ));
+        return Err(anyhow!(missing_resolve_target_advice()));
     };
 
     cmd_resolve_file(&repo, &merge_manager, cli, &path, ours, theirs, force)
-}
-
-fn cmd_resolve_abort(
-    repo: &Repository,
-    merge_manager: &repo::MergeStateManager,
-    cli: &Cli,
-) -> Result<()> {
-    abort_merge_state(repo, merge_manager)?;
-
-    if should_output_json(cli, Some(repo.config())) {
-        println!(
-            "{}",
-            serde_json::to_string(&ResolveReport {
-                output_kind: "resolve".to_string(),
-                message: Some("Merge aborted".to_string()),
-                resolved: vec![],
-                remaining: vec![],
-                conflict_paths: vec![],
-                conflicts: vec![],
-                resolutions: vec![],
-                continued: false,
-                continuation_status: None,
-                continuation_message: None,
-                next_action: None,
-                recommended_action: None,
-            })?
-        );
-    } else {
-        println!("Merge aborted");
-    }
-
-    Ok(())
 }
 
 pub(crate) fn abort_merge_state(
@@ -526,6 +487,19 @@ fn no_merge_in_progress_advice(action: &'static str) -> RecoveryAdvice {
         "repository state was left unchanged",
         "heddle status",
         vec!["heddle status".to_string()],
+    )
+}
+
+fn missing_resolve_target_advice() -> RecoveryAdvice {
+    RecoveryAdvice::safety_refusal(
+        "resolve_target_required",
+        "Specify a file to resolve, or use --all or --list",
+        "Inspect unresolved conflicts with `heddle resolve --list`.",
+        "no conflict path or bulk/list mode was selected",
+        "resolve cannot choose a conflict path on the operator's behalf",
+        "repository state and worktree files were left unchanged",
+        "heddle resolve --list",
+        vec!["heddle resolve --list".to_string()],
     )
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -617,17 +617,7 @@ async fn async_main() -> Result<()> {
             ours,
             theirs,
             force,
-            abort,
-        }) => cmd_resolve(
-            &cli,
-            path.clone(),
-            *all,
-            *list,
-            *ours,
-            *theirs,
-            *force,
-            *abort,
-        ),
+        }) => cmd_resolve(&cli, path.clone(), *all, *list, *ours, *theirs, *force),
 
         Commands::Push(args) => {
             cmd_push(

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -103,6 +103,27 @@ fn verify_exits_zero_when_clean() {
 }
 
 #[test]
+fn removed_resolve_abort_flag_is_a_clean_usage_error() {
+    let temp = TempDir::new().expect("tempdir");
+    let output = heddle_output(&["resolve", "--abort"], Some(temp.path()))
+        .expect("invoke removed resolve flag");
+    assert_eq!(output.status.code(), Some(64));
+    assert!(
+        output.stdout.is_empty(),
+        "parse errors must not write stdout"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unexpected argument '--abort'"),
+        "removed flag should fail through clap: {stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at") && !stderr.contains("thread 'main' panicked"),
+        "removed flag must not panic: {stderr}"
+    );
+}
+
+#[test]
 fn commit_without_git_overlay_is_data_err() {
     let repo = init_repo();
     assert_exit(&["commit", "-m", "again"], repo.path(), 65);

--- a/crates/cli/tests/comprehensive/resolve.rs
+++ b/crates/cli/tests/comprehensive/resolve.rs
@@ -160,7 +160,7 @@ fn test_resolve_all_refuses_conflict_markers_without_force_or_side_selection() {
 }
 
 #[test]
-fn test_resolve_abort_restores_state() {
+fn test_abort_restores_state() {
     let temp = TempDir::new().unwrap();
     create_merge_conflict(&temp);
 
@@ -170,7 +170,7 @@ fn test_resolve_abort_restores_state() {
         "should have conflict markers"
     );
 
-    let result = heddle(&["resolve", "--abort"], Some(temp.path()));
+    let result = heddle(&["abort"], Some(temp.path()));
     assert!(result.is_ok(), "abort failed: {:?}", result.err());
 
     let content_after = fs::read_to_string(temp.path().join("file.txt")).unwrap();

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -1912,7 +1912,7 @@ fn test_undo_pull_local_restores_thread_ref() {
     );
 }
 
-/// Resolve --abort (merge abort): aborting a conflicted 3-way merge
+/// Abort (merge abort): aborting a conflicted 3-way merge
 /// calls `fast_forward_attached(merge_state.ours)` to clean the
 /// worktree back to the pre-merge state. During a 3-way conflict
 /// merge HEAD never moves (only the worktree gets conflict markers),
@@ -1927,7 +1927,7 @@ fn test_undo_pull_local_restores_thread_ref() {
 /// and future-proofs against a partial-apply merge variant that
 /// might move HEAD before abort.
 #[test]
-fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
+fn test_undo_abort_keeps_thread_ref_at_ours() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());
 
@@ -1955,7 +1955,7 @@ fn test_undo_resolve_abort_keeps_thread_ref_at_ours() {
         "refresh should create a durable conflict state: {refresh:?}"
     );
 
-    heddle_must_succeed(&["resolve", "--abort"], temp.path());
+    heddle_must_succeed(&["abort"], temp.path());
     assert_eq!(
         head_short(temp.path()),
         feature_tip_before,

--- a/crates/cli/tests/production_features.rs
+++ b/crates/cli/tests/production_features.rs
@@ -403,12 +403,12 @@ mod resolve {
 
     #[test]
     #[serial(inner_attrs = [timeout(15000)])]
-    fn test_resolve_abort() {
+    fn test_abort() {
         let temp = TempDir::new().unwrap();
         create_conflict(&temp);
 
-        let result = heddle(&["resolve", "--abort"], Some(temp.path()));
-        assert!(result.is_ok(), "resolve --abort failed: {:?}", result.err());
+        let result = heddle(&["abort"], Some(temp.path()));
+        assert!(result.is_ok(), "abort failed: {:?}", result.err());
     }
 
     #[test]

--- a/crates/cli/tests/tier_coverage.rs
+++ b/crates/cli/tests/tier_coverage.rs
@@ -13,7 +13,9 @@
 
 use std::{collections::BTreeSet, path::PathBuf};
 
-use cli::cli::commands::command_contract_root_commands;
+use cli::cli::commands::{
+    command_contract_root_commands, surface_conformance::unapproved_root_command_names,
+};
 
 #[test]
 fn every_commands_variant_has_explicit_root_contract() {
@@ -70,6 +72,33 @@ fn every_commands_variant_has_explicit_root_contract() {
          Add each root verb to CONTRACTS in \
          crates/cli-contract/src/cli/commands/command_catalog/mod.rs.",
         missing.join("\n  ")
+    );
+}
+
+#[test]
+fn every_commands_variant_is_in_the_closed_root_surface() {
+    let commands_rs = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("cli-args")
+        .join("src")
+        .join("cli")
+        .join("cli_args")
+        .join("commands_main.rs");
+    let source = std::fs::read_to_string(&commands_rs)
+        .unwrap_or_else(|e| panic!("read {}: {e}", commands_rs.display()));
+    let variants = enumerate_commands_variants(&source);
+    let verbs = variants
+        .iter()
+        .map(|variant| variant_to_verb(variant))
+        .collect::<Vec<_>>();
+    let violations = unapproved_root_command_names(verbs.iter().map(String::as_str));
+
+    assert!(
+        violations.is_empty(),
+        "top-level Commands contains roots outside the accepted closed surface: {}\n\n\
+         Fold the verb into its canonical owner, or amend the accepted design and \
+         surface-conformance set in the same review.",
+        violations.join(", ")
     );
 }
 

--- a/crates/core/src/fsck/refs.rs
+++ b/crates/core/src/fsck/refs.rs
@@ -51,9 +51,7 @@ pub(crate) fn check_refs(
 pub(crate) fn check_merge_state(repo: &Repository, warnings: &mut Vec<String>) -> Result<()> {
     let merge_manager = repo.merge_state_manager();
     if merge_manager.is_merge_in_progress() {
-        warnings.push(
-            "Merge in progress - resolve conflicts or use 'heddle resolve --abort'".to_string(),
-        );
+        warnings.push("Merge in progress - resolve conflicts or use 'heddle abort'".to_string());
     }
 
     let stash_manager = repo.stash_manager();

--- a/crates/core/src/merge/advice.rs
+++ b/crates/core/src/merge/advice.rs
@@ -42,7 +42,7 @@ pub(crate) fn merge_already_in_progress() -> HeddleError {
     HeddleError::recovery(RecoveryDetails::safety_refusal(
         "merge_already_in_progress",
         "A merge is already in progress",
-        "Inspect the active operation with `heddle status`; resolve it with `heddle continue` or abort it with `heddle resolve --abort`.",
+        "Inspect the active operation with `heddle status`; resolve it with `heddle continue` or abort it with `heddle abort`.",
         "merge state is already present for this repository",
         "starting another merge would overwrite or obscure the in-progress conflict state",
         "existing merge state and worktree were left unchanged",

--- a/docs/design/cross-thread-undo.md
+++ b/docs/design/cross-thread-undo.md
@@ -330,7 +330,7 @@ Today's call sites that emit `FastForward` (via the shared
 | `commands/rebase/rebase_ops.rs:apply_tree_to_worktree` | `heddle sync` (parentless replay) | `"<rebase>"` synthetic | heddle#110; rare parentless-commit replay; same buffering as `apply_commit` |
 | `commands/workflow.rs:adopt_manual_resolution` | `heddle land` (manual-resolution adopt) | landed thread name | heddle#110 |
 | `commands/remote/remote_ops.rs:pull_local` | `heddle pull` (local sync, repeat pull) | remote thread name | heddle#110; first-time pull falls back to `Goto` because there's no pre-target tip to restore |
-| `commands/resolve.rs:abort_merge_state` | `heddle resolve --abort` | `"<abort>"` synthetic | heddle#110; today this is a pre-target = post-target no-op record (HEAD doesn't move during a 3-way conflict merge), kept on the same code path so a future merge variant that does move HEAD before abort gets correct undo semantics for free |
+| `commands/resolve.rs:abort_merge_state` | `heddle abort` | `"<abort>"` synthetic | heddle#110; today this is a pre-target = post-target no-op record (HEAD doesn't move during a 3-way conflict merge), kept on the same code path so a future merge variant that does move HEAD before abort gets correct undo semantics for free |
 
 Any new caller of `fast_forward_attached` should go through
 `record_ff_advance` (or `record_ff_advance_explicit` when the caller


### PR DESCRIPTION
Refs #473.

## Summary

Implements **Phase 5 — close-the-class invariants**, the next unshipped phase after auditing `origin/main`.

- adds a closed-world command-surface contract for root commands and root aliases
- checks both the live clap tree and every source `Commands` variant, including feature-gated variants absent from the current build
- wires live surface and lifecycle violations into `heddle doctor docs`
- rejects command-local `--continue` / `--abort` flags anywhere in the clap tree
- removes `heddle resolve --abort`; the existing operation-agnostic `heddle abort` retains the behavior
- updates recovery guidance and the README verb tour to use canonical `continue` / `abort`

No compatibility alias or shim was added.

## Audit: landed phases and next phase

The audit compared the current root enum, live command catalog, accepted spike, and merged #473 work:

| Phase | Audit result |
| --- | --- |
| 0 — save/land core | Landed in #478 (`commit` / `ready` / `land` / `sync`; `ship` removed). |
| 1 — free deletions | Landed in #488, with residual cleanup in #1318 and #681. |
| 2 — synonym/router collapses | Landed in #681; the later residual cleanup removed the temporary Phase 2 rewrites. |
| 3 — namespace unifications | Landed in #1396. `auth` and `presence` remain separate, and the two daemon responsibilities remain separate. |
| 4 — semantic/redact lifecycle | Already landed out of sequence: semantic-by-default in #669 and physical purge at `redact purge`. |
| 5 — close-the-class invariant | **Next unshipped phase; implemented here.** |

The current live catalog has **54 root commands**. Phase 5 is an enforcement phase, so this PR keeps that count at 54 while preventing an unreviewed root, hidden root alias, or command-local lifecycle flag from increasing/drifting the surface. The accepted spike's headline remains approximately 28 canonical verbs plus explicitly reviewed advanced/admin/help roots.

The audit also found two pre-existing target drifts that this PR records rather than silently sweeping into another phase: canonical `switch` is currently nested at `thread switch`, and `schemas` remains a top-level advanced root. Repairing those landed-Phase-2 regressions belongs in a focused follow-up; the conformance set reserves `switch` and labels `schemas` as an explicit current exception.

## Folded / removed in this phase

- `heddle resolve --abort` → removed
- `heddle abort` → sole merge/rebase abort surface, using the existing abort implementation
- all recovery breadcrumbs that named `resolve --abort` → `abort`

Negative runtime behavior is intentional: `heddle resolve --abort` exits 64 through clap with `unexpected argument '--abort'`, empty stdout, and no panic.

## Maintainer decisions honored

1. `switch` remains reserved as canonical; no `checkout` / `goto` root or alias is allowed.
2. `blame` is absent from the canonical set; attribution remains under `query`.
3. `auth` and `presence` are separate canonical roots.
4. FUSE `daemon` and agent `serve` / `status` / `stop` remain separate.
5. `discuss` remains a distinct canonical root.
6. `marker` is not a root; it remains under `thread`.

## Verification

Copied from the CLI jobs in `.github/workflows/rust-full-suite.yml` and observed to completion:

- `cargo build --locked -p heddle-cli --features telemetry --tests --bin heddle` — passed
- `cargo clippy --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry --lib --bins --tests --examples -- -D warnings` — passed
- `cargo test --locked -p heddle-cli -p heddle-cli-shared --features heddle-cli/telemetry` — passed; main CLI integration target: **922 passed, 0 failed, 20 ignored**, with all remaining targets and doctests green
- `cargo test --locked -p heddle-cli-contract surface_conformance -- --nocapture` — 4 passed
- `cargo test --locked -p heddle-cli-contract doctor_docs` — 25 passed
- `cargo test --locked -p heddle-cli --test tier_coverage` — 2 passed
- `cargo test --locked -p heddle-cli --test cli_integration removed_resolve_abort_flag_is_a_clean_usage_error` — 1 passed
- focused top-level abort tests in `comprehensive`, `core_functionality`, and `production_features` — passed
- `target/debug/heddle doctor docs --path README.md --output json` — verified, 0 issues
- `target/debug/heddle doctor schemas --output json` — verified, 0 issues
- `git diff --check` — passed

Controlled negative proof: temporarily reintroducing a source-only `Checkout` root made `every_commands_variant_is_in_the_closed_root_surface` fail with:

```text
top-level Commands contains roots outside the accepted closed surface: checkout
```

The temporary variant was removed and the test was rerun green before commit.

## #479 follow-up

#479 should generate the versioned CLI reference from the command catalog and expose the canonical/advanced classification enforced here. Its generated recovery examples must use top-level `continue` / `abort`, never `resolve --abort`. This PR does not implement #479.

## Remaining follow-ons

No numbered consolidation phase remains after this PR. Follow-on work is the focused `switch` / `schemas` drift repair noted above, shrinking the explicit exception set as roots are folded, and #479's generated versioned reference.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789534054&installation_model_id=21489&pr_number=1398&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1398&signature=6a7024666b0fa97afb6a300e23e010a8fafc93229493bfb5f3e63b42906cea1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->