### PR TITLE
fix(storage): reclaim loose metadata after compact repack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Compact repack reclaims loose metadata copies.** Loose trees and states are
+  now included in repack inventory, solidified with typed-hash verification,
+  and removed only after the durable replacement reconstructs the same object
+  and typed identity.
+  The pinned physical-store benchmark now measures pack/index framing and loose
+  objects before and after repack; native storage falls from 3.675× to 0.914×
+  Git pack on semver and from 12.430× to 0.857× on ripgrep.
+
 - **Git-lane push reuses local pack entries.** Hosted git-overlay push no
   longer rebuilds a transfer pack from every decoded object. Existing
   self-contained pack bytes are copied when they already are the selected

--- a/crates/cli/examples/native_lineage_solid.rs
+++ b/crates/cli/examples/native_lineage_solid.rs
@@ -71,8 +71,12 @@ struct RegatedTotal {
     total_bytes: u64,
     git_pack_bytes: u64,
     git_pack_and_idx_bytes: u64,
+    physical_native_before_bytes: u64,
+    physical_native_after_bytes: u64,
     total_to_git_pack: f64,
     total_to_git_pack_and_idx: f64,
+    physical_before_to_git_pack: f64,
+    physical_after_to_git_pack: f64,
 }
 
 fn main() -> Result<()> {
@@ -169,8 +173,12 @@ fn regate(
         total_bytes,
         git_pack_bytes: git.pack_bytes,
         git_pack_and_idx_bytes,
+        physical_native_before_bytes: compact.storage_before.total_bytes,
+        physical_native_after_bytes: compact.storage_after.total_bytes,
         total_to_git_pack: ratio(total_bytes, git.pack_bytes),
         total_to_git_pack_and_idx: ratio(total_bytes, git_pack_and_idx_bytes),
+        physical_before_to_git_pack: ratio(compact.storage_before.total_bytes, git.pack_bytes),
+        physical_after_to_git_pack: ratio(compact.storage_after.total_bytes, git.pack_bytes),
     }
 }
 

--- a/crates/cli/examples/native_lineage_solid/real_compact.rs
+++ b/crates/cli/examples/native_lineage_solid/real_compact.rs
@@ -17,6 +17,8 @@ use crate::{
 
 #[derive(Serialize)]
 pub struct RealCompactMeasurement {
+    pub storage_before: StorageFootprint,
+    pub storage_after: StorageFootprint,
     pub source_blob_bytes: u64,
     pub source_tree_bytes: u64,
     pub source_state_bytes: u64,
@@ -31,10 +33,22 @@ pub struct RealCompactMeasurement {
     pub byte_identical: bool,
 }
 
+/// Physical bytes occupied by retention-equalized native objects.
+#[derive(Debug, Serialize)]
+pub struct StorageFootprint {
+    pub loose_blob_bytes: u64,
+    pub loose_tree_bytes: u64,
+    pub loose_state_bytes: u64,
+    pub pack_bytes: u64,
+    pub index_bytes: u64,
+    pub total_bytes: u64,
+}
+
 pub fn measure_real_compact_repack(
     store: &FsStore,
     objects: &ObjectSet,
 ) -> Result<RealCompactMeasurement> {
+    let storage_before = measure_store_footprint(store.root())?;
     let (source_blob_bytes, source_tree_bytes, source_state_bytes) =
         source_object_bytes(store, objects)?;
     let (source_fingerprint, _) = fingerprint_objects(store, objects)?;
@@ -51,7 +65,10 @@ pub fn measure_real_compact_repack(
         index_bytes,
         replacement_pack_bytes,
     ) = physical_object_bytes(store)?;
+    let storage_after = measure_store_footprint(store.root())?;
     Ok(RealCompactMeasurement {
+        storage_before,
+        storage_after,
         source_blob_bytes,
         source_tree_bytes,
         source_state_bytes,
@@ -64,6 +81,71 @@ pub fn measure_real_compact_repack(
         source_fingerprint: source_fingerprint.to_hex().to_string(),
         reconstructed_fingerprint: reconstructed_fingerprint.to_hex().to_string(),
         byte_identical: true,
+    })
+}
+
+fn measure_store_footprint(root: &std::path::Path) -> Result<StorageFootprint> {
+    let objects = root.join("objects");
+    let loose_blob_bytes = regular_file_bytes(&objects.join("blobs"))?;
+    let loose_tree_bytes = regular_file_bytes(&objects.join("trees"))?;
+    let loose_state_bytes = regular_file_bytes(&objects.join("states"))?;
+    let packs = root.join("packs");
+    let pack_bytes = extension_bytes(&packs, "pack")?;
+    let index_bytes = extension_bytes(&packs, "idx")?;
+    let total_bytes = loose_blob_bytes
+        .saturating_add(loose_tree_bytes)
+        .saturating_add(loose_state_bytes)
+        .saturating_add(pack_bytes)
+        .saturating_add(index_bytes);
+    Ok(StorageFootprint {
+        loose_blob_bytes,
+        loose_tree_bytes,
+        loose_state_bytes,
+        pack_bytes,
+        index_bytes,
+        total_bytes,
+    })
+}
+
+fn regular_file_bytes(root: &std::path::Path) -> Result<u64> {
+    if !root.try_exists()? {
+        return Ok(0);
+    }
+    let mut total = 0u64;
+    for entry in fs::read_dir(root)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            bail!(
+                "object-store footprint refuses symlink {}",
+                entry.path().display()
+            );
+        }
+        if file_type.is_dir() {
+            total = total.saturating_add(regular_file_bytes(&entry.path())?);
+        } else if file_type.is_file() {
+            total = total.saturating_add(entry.metadata()?.len());
+        }
+    }
+    Ok(total)
+}
+
+fn extension_bytes(directory: &std::path::Path, extension: &str) -> Result<u64> {
+    if !directory.try_exists()? {
+        return Ok(0);
+    }
+    fs::read_dir(directory)?.try_fold(0u64, |total, entry| {
+        let entry = entry?;
+        if entry.file_type()?.is_file()
+            && entry
+                .path()
+                .extension()
+                .is_some_and(|value| value == extension)
+        {
+            Ok(total.saturating_add(entry.metadata()?.len()))
+        } else {
+            Ok(total)
+        }
     })
 }
 
@@ -121,4 +203,33 @@ fn physical_object_bytes(store: &FsStore) -> Result<(u64, u64, u64, u64, u64)> {
         pack_bytes += fs::metadata(&pack)?.len();
     }
     Ok((blob_bytes, tree_bytes, state_bytes, index_bytes, pack_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn footprint_counts_only_native_object_payloads_and_indexes() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("objects/blobs/ab")).unwrap();
+        fs::create_dir_all(root.join("objects/trees/cd")).unwrap();
+        fs::create_dir_all(root.join("objects/states")).unwrap();
+        fs::create_dir_all(root.join("packs")).unwrap();
+        fs::write(root.join("objects/blobs/ab/blob"), b"blob").unwrap();
+        fs::write(root.join("objects/trees/cd/tree"), b"tree!!").unwrap();
+        fs::write(root.join("objects/states/state"), b"state").unwrap();
+        fs::write(root.join("packs/one.pack"), b"packpack").unwrap();
+        fs::write(root.join("packs/one.idx"), b"index").unwrap();
+        fs::write(root.join("config.toml"), vec![0; 100]).unwrap();
+
+        let measured = measure_store_footprint(root).unwrap();
+        assert_eq!(measured.loose_blob_bytes, 4);
+        assert_eq!(measured.loose_tree_bytes, 6);
+        assert_eq!(measured.loose_state_bytes, 5);
+        assert_eq!(measured.pack_bytes, 8);
+        assert_eq!(measured.index_bytes, 5);
+        assert_eq!(measured.total_bytes, 28);
+    }
 }

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -97,7 +97,7 @@ fn validate_loaded_state(requested_id: &StateId, mut state: State) -> Result<Sta
     Ok(state)
 }
 
-fn validate_state_serialized(data: &[u8], id: StateId) -> Result<State> {
+pub(super) fn validate_state_serialized(data: &[u8], id: StateId) -> Result<State> {
     let state: State = rmp_serde::from_slice(data)?;
     validate_loaded_state(&id, state)
 }

--- a/crates/objects/src/store/fs/fs_io.rs
+++ b/crates/objects/src/store/fs/fs_io.rs
@@ -17,6 +17,7 @@ use crate::{
         create_dir_all_durable, enrich_fs_error, enrich_rename_error, sync_directory, sync_file,
         temp_path,
     },
+    object::StateId,
     store::Result,
 };
 
@@ -255,4 +256,30 @@ pub(super) fn list_hashes_from_dir(
     }
     debug!(count = hashes.len(), "Listed hashes");
     Ok(hashes)
+}
+
+/// List state ids from the flat `<state-id>.state` loose-object directory.
+pub(super) fn list_state_ids_from_dir(dir: &Path) -> Result<Vec<StateId>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut ids = Vec::new();
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_file() {
+            continue;
+        }
+        let path = entry.path();
+        if path.extension().and_then(|value| value.to_str()) != Some("state") {
+            continue;
+        }
+        if let Some(stem) = path.file_stem().and_then(|value| value.to_str())
+            && let Ok(id) = StateId::parse(stem)
+        {
+            ids.push(id);
+        }
+    }
+    ids.sort();
+    ids.dedup();
+    Ok(ids)
 }

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -10,8 +10,9 @@ use std::{
 
 use super::{
     FsStore,
-    fs_io::{list_hashes_from_dir, read_file_bytes},
-    fs_paths::{blobs_dir, hash_path, packs_dir, trees_dir},
+    fs_impl::validate_state_serialized,
+    fs_io::{list_hashes_from_dir, list_state_ids_from_dir, read_file_bytes},
+    fs_paths::{blobs_dir, hash_path, packs_dir, state_path, states_dir, trees_dir},
 };
 use crate::{
     object::{ContentHash, State, StateAttachment, StateAttachmentId, Tree},
@@ -76,6 +77,19 @@ fn remove_file_ignore_missing(path: &std::path::Path) -> Result<()> {
         Ok(()) => Ok(()),
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(HeddleError::from(e)),
+    }
+}
+
+fn remove_file_counted(path: &Path) -> Result<Option<u64>> {
+    let metadata = match fs::metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(HeddleError::from(error)),
+    };
+    match fs::remove_file(path) {
+        Ok(()) => Ok(Some(metadata.len())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(HeddleError::from(error)),
     }
 }
 
@@ -633,6 +647,7 @@ impl FsStore {
 
         let blobs = list_hashes_from_dir(&blobs_dir(&self.root))?;
         let trees = list_hashes_from_dir(&trees_dir(&self.root))?;
+        let states = list_state_ids_from_dir(&states_dir(&self.root))?;
 
         let pack_manager = self
             .pack_manager()
@@ -642,17 +657,9 @@ impl FsStore {
         for hash in &blobs {
             if pack_manager.get_hashed_object(hash)?.is_some() {
                 let path = hash_path(&blobs_dir(&self.root), hash);
-                match fs::metadata(&path) {
-                    Ok(metadata) => match fs::remove_file(&path) {
-                        Ok(()) => {
-                            bytes_freed += metadata.len();
-                            removed += 1;
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                        Err(e) => return Err(HeddleError::from(e)),
-                    },
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(HeddleError::from(e)),
+                if let Some(bytes) = remove_file_counted(&path)? {
+                    bytes_freed = bytes_freed.saturating_add(bytes);
+                    removed += 1;
                 }
             }
         }
@@ -668,20 +675,61 @@ impl FsStore {
             let Some(loose_data) = read_file_bytes(&path)? else {
                 continue;
             };
-            let loose_data = codec::decode_tree_body(loose_data.as_slice())?;
-            if packed_data == loose_data {
-                match fs::metadata(&path) {
-                    Ok(metadata) => match fs::remove_file(&path) {
-                        Ok(()) => {
-                            bytes_freed += metadata.len();
-                            removed += 1;
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                        Err(e) => return Err(HeddleError::from(e)),
-                    },
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-                    Err(e) => return Err(HeddleError::from(e)),
-                }
+            let loose_tree = codec::decode_tree(loose_data.as_slice())?;
+            let found = loose_tree.hash();
+            if found != *hash {
+                return Err(HeddleError::Corruption {
+                    expected: *hash,
+                    found,
+                });
+            }
+            // A loose current tree can intentionally shadow an older packed
+            // schema at the same semantic hash. Preserve that migration copy
+            // until consolidation replaces the legacy body.
+            let Ok(packed_tree) = codec::decode_tree_serialized(&packed_data) else {
+                continue;
+            };
+            let packed_found = packed_tree.hash();
+            if packed_found != *hash {
+                return Err(HeddleError::Corruption {
+                    expected: *hash,
+                    found: packed_found,
+                });
+            }
+            if packed_tree == loose_tree
+                && let Some(bytes) = remove_file_counted(&path)?
+            {
+                bytes_freed = bytes_freed.saturating_add(bytes);
+                removed += 1;
+            }
+        }
+
+        for id in &states {
+            let Some((obj_type, packed_data)) =
+                pack_manager.get_object(&PackObjectId::StateId(*id))?
+            else {
+                continue;
+            };
+            if obj_type != PackObjectType::State {
+                continue;
+            }
+            let path = state_path(&self.root, id);
+            let Some(loose_data) = read_file_bytes(&path)? else {
+                continue;
+            };
+            let loose_state = codec::decode_state(loose_data.as_slice())?;
+            let packed_state = validate_state_serialized(&packed_data, *id)?;
+            if loose_state.id() != *id {
+                return Err(HeddleError::InvalidObject(format!(
+                    "loose state id mismatch while pruning: expected {id}, computed {}",
+                    loose_state.id()
+                )));
+            }
+            if packed_state == loose_state
+                && let Some(bytes) = remove_file_counted(&path)?
+            {
+                bytes_freed = bytes_freed.saturating_add(bytes);
+                removed += 1;
             }
         }
 

--- a/crates/objects/src/store/fs/repack/operation.rs
+++ b/crates/objects/src/store/fs/repack/operation.rs
@@ -5,8 +5,8 @@ use std::{collections::HashSet, fs, fs::OpenOptions};
 use super::{
     super::{
         FsStore,
-        fs_io::list_hashes_from_dir,
-        fs_paths::{blobs_dir, packs_dir, trees_dir},
+        fs_io::{list_hashes_from_dir, list_state_ids_from_dir},
+        fs_paths::{blobs_dir, packs_dir, state_path, states_dir, trees_dir},
     },
     compact::add_compact_metadata,
     cutover::{
@@ -65,6 +65,7 @@ impl FsRepackOperation {
     fn inventory(&self) -> Result<RepackInventory> {
         let loose_blobs = list_hashes_from_dir(&blobs_dir(self.store.root()))?;
         let loose_trees = list_hashes_from_dir(&trees_dir(self.store.root()))?;
+        let loose_states = list_state_ids_from_dir(&states_dir(self.store.root()))?;
         let loose_bytes = loose_blobs
             .iter()
             .map(|hash| object_file_len(&blobs_dir(self.store.root()), hash))
@@ -72,6 +73,11 @@ impl FsRepackOperation {
                 loose_trees
                     .iter()
                     .map(|hash| object_file_len(&trees_dir(self.store.root()), hash)),
+            )
+            .chain(
+                loose_states
+                    .iter()
+                    .map(|id| file_len(&state_path(self.store.root(), id))),
             )
             .sum();
         let manager =
@@ -87,7 +93,7 @@ impl FsRepackOperation {
         let ids = manager.list_all_ids()?;
         let unique = ids.iter().copied().collect::<HashSet<_>>().len() as u64;
         Ok(RepackInventory {
-            loose_objects: (loose_blobs.len() + loose_trees.len()) as u64,
+            loose_objects: (loose_blobs.len() + loose_trees.len() + loose_states.len()) as u64,
             loose_bytes,
             pack_count: paths.len() as u64,
             pack_bytes,
@@ -106,6 +112,7 @@ impl FsRepackOperation {
         if snapshot.ids.is_empty()
             && snapshot.loose_blobs.is_empty()
             && snapshot.loose_trees.is_empty()
+            && snapshot.loose_states.is_empty()
         {
             return Ok(RepackOutcome::default());
         }
@@ -242,6 +249,12 @@ impl FsRepackOperation {
             let id = PackObjectId::Hash(*hash);
             if expected.insert(id) {
                 tree_hashes.push(*hash);
+            }
+        }
+        for id in &snapshot.loose_states {
+            let object_id = PackObjectId::StateId(*id);
+            if expected.insert(object_id) {
+                state_ids.push(*id);
             }
         }
         logical_bytes = logical_bytes.saturating_add(add_compact_metadata(

--- a/crates/objects/src/store/fs/repack/staging.rs
+++ b/crates/objects/src/store/fs/repack/staging.rs
@@ -4,11 +4,11 @@ use std::{collections::HashSet, fs, path::PathBuf};
 
 use super::super::{
     FsStore,
-    fs_io::list_hashes_from_dir,
-    fs_paths::{blobs_dir, trees_dir},
+    fs_io::{list_hashes_from_dir, list_state_ids_from_dir},
+    fs_paths::{blobs_dir, states_dir, trees_dir},
 };
 use crate::{
-    object::ContentHash,
+    object::{ContentHash, StateId},
     store::{
         HeddleError, Result,
         fs::fs_impl::validate_pack_entry,
@@ -20,6 +20,7 @@ pub(super) struct RepackSnapshot {
     pub(super) ids: Vec<PackObjectId>,
     pub(super) loose_blobs: Vec<ContentHash>,
     pub(super) loose_trees: Vec<ContentHash>,
+    pub(super) loose_states: Vec<StateId>,
     pub(super) old_pack_files: Vec<(PathBuf, PathBuf)>,
     pub(super) commit_artifact_ids: Vec<ContentHash>,
 }
@@ -28,6 +29,7 @@ impl RepackSnapshot {
     pub(super) fn capture(store: &FsStore) -> Result<Self> {
         let loose_blobs = list_hashes_from_dir(&blobs_dir(store.root()))?;
         let loose_trees = list_hashes_from_dir(&trees_dir(store.root()))?;
+        let loose_states = list_state_ids_from_dir(&states_dir(store.root()))?;
         let manager = store
             .pack_manager()
             .read()
@@ -47,6 +49,7 @@ impl RepackSnapshot {
             ids,
             loose_blobs,
             loose_trees,
+            loose_states,
             old_pack_files,
             commit_artifact_ids,
         })

--- a/crates/objects/src/store/fs/repack/tests/integrity.rs
+++ b/crates/objects/src/store/fs/repack/tests/integrity.rs
@@ -167,6 +167,47 @@ fn loose_object_trigger_consolidates_and_reclaims_the_loose_copy() {
 }
 
 #[test]
+fn loose_state_is_solidified_and_reclaimed() {
+    let (_temp, store) = create_store();
+    let tree = Tree::from_entries(Vec::new());
+    let tree_hash = store.put_tree(&tree).unwrap();
+    let state = State::new(
+        tree_hash,
+        Vec::new(),
+        Attribution::human(Principal::new("Loose State", "loose-state@example.com")),
+    );
+    let state_id = state.id();
+    store.put_state(&state).unwrap();
+    let state_path = store
+        .root()
+        .join("objects/states")
+        .join(format!("{}.state", state_id.to_string_full()));
+    assert!(state_path.is_file());
+
+    let operation = Arc::new(FsRepackOperation::new(store.clone()));
+    assert_eq!(operation.inspect().unwrap().loose_objects, 2);
+    started_handle(scheduler(None).repack_now(operation).unwrap())
+        .wait()
+        .unwrap();
+
+    assert!(!state_path.exists());
+    assert_eq!(
+        FsRepackOperation::new(store.clone())
+            .inspect()
+            .unwrap()
+            .loose_objects,
+        0
+    );
+    store.clear_recent_object_caches();
+    let loaded = store.get_state(&state_id).unwrap().unwrap();
+    assert_eq!(loaded.id(), state_id);
+    assert_eq!(
+        rmp_serde::to_vec_named(&loaded).unwrap(),
+        rmp_serde::to_vec_named(&state).unwrap()
+    );
+}
+
+#[test]
 fn deliberately_corrupted_repack_output_is_rejected_before_cutover() {
     let (_temp, store) = create_store();
     let blob = Blob::from("authoritative bytes must survive rejection");

--- a/scripts/run-storage-vs-git.sh
+++ b/scripts/run-storage-vs-git.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <fresh-work-dir> [semver|ripgrep|curl ...]" >&2
+  echo "default corpora: semver ripgrep" >&2
+}
+
+if (( $# < 1 )); then
+  usage
+  exit 64
+fi
+
+run_root=$1
+shift
+if (( $# == 0 )); then
+  set -- semver ripgrep
+fi
+
+if [[ -e "$run_root" ]]; then
+  echo "benchmark work directory must not exist: $run_root" >&2
+  exit 73
+fi
+
+for command in cargo git jq /usr/bin/zstd; do
+  if ! command -v "$command" >/dev/null 2>&1; then
+    echo "required command is unavailable: $command" >&2
+    exit 69
+  fi
+done
+
+source_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+mkdir -p "$run_root"
+run_root=$(cd "$run_root" && pwd)
+benchmark_tmp="$run_root/tmp"
+benchmark_target=${CARGO_TARGET_DIR:-"$run_root/target"}
+if [[ "$benchmark_target" != /* ]]; then
+  echo "CARGO_TARGET_DIR must be absolute when supplied: $benchmark_target" >&2
+  exit 64
+fi
+mkdir -p "$benchmark_tmp" "$benchmark_target"
+
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_CONFIG_GLOBAL=/dev/null
+
+TMPDIR="$benchmark_tmp" CARGO_TARGET_DIR="$benchmark_target" \
+  cargo build \
+    --manifest-path "$source_root/Cargo.toml" \
+    --locked \
+    --release \
+    -p heddle-cli \
+    --bin heddle \
+    --example native_lineage_solid \
+    --features semantic,zstd
+
+heddle_bin="$benchmark_target/release/heddle"
+benchmark_bin="$benchmark_target/release/examples/native_lineage_solid"
+
+corpus_details() {
+  case "$1" in
+    semver)
+      printf '%s\t%s\n' \
+        'https://github.com/maykonlf/semver-cli.git' \
+        '4fea7f0d5a1c9fca85f764c02953643d7fd45b27'
+      ;;
+    ripgrep)
+      printf '%s\t%s\n' \
+        'https://github.com/BurntSushi/ripgrep.git' \
+        '3fce3b5bb0236da2df6d99672afb8a719642eca7'
+      ;;
+    curl)
+      printf '%s\t%s\n' \
+        'https://github.com/curl/curl.git' \
+        'f5378b88a974e565f767f2a041972aa942a69c5d'
+      ;;
+    *)
+      echo "unknown corpus: $1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+}
+
+run_corpus() {
+  local corpus=$1
+  local details url revision git_dir checkout output
+  details=$(corpus_details "$corpus")
+  IFS=$'\t' read -r url revision <<<"$details"
+  git_dir="$run_root/$corpus.git"
+  checkout="$run_root/$corpus"
+  output="$run_root/$corpus-results"
+
+  git init --bare --quiet "$git_dir"
+  git --git-dir="$git_dir" fetch --quiet --no-tags "$url" \
+    "$revision:refs/heads/storage-bench"
+  git --git-dir="$git_dir" symbolic-ref HEAD refs/heads/storage-bench
+  git --git-dir="$git_dir" reflog expire --expire=now --all
+  git --git-dir="$git_dir" repack -adf --window=250 --depth=50
+  git --git-dir="$git_dir" prune-packed
+  git clone --quiet --no-local "$git_dir" "$checkout"
+
+  "$heddle_bin" --output json adopt "$checkout" --ref storage-bench \
+    >"$run_root/$corpus-adopt.json"
+
+  TMPDIR="$benchmark_tmp" "$benchmark_bin" "$checkout" "$git_dir" "$output"
+}
+
+declare -A selected=()
+for corpus in "$@"; do
+  if [[ -n "${selected[$corpus]:-}" ]]; then
+    echo "duplicate corpus: $corpus" >&2
+    exit 64
+  fi
+  selected[$corpus]=1
+  run_corpus "$corpus"
+done
+
+echo
+echo -e 'corpus\tobjects\tbefore/git\tafter/git\tbyte-identical'
+for corpus in "$@"; do
+  jq -r --arg corpus "$corpus" '
+    [
+      $corpus,
+      .object_counts.total,
+      .regated_total.physical_before_to_git_pack,
+      .regated_total.physical_after_to_git_pack,
+      .compact.byte_identical
+    ] | @tsv
+  ' "$run_root/$corpus-results/results.json"
+done


### PR DESCRIPTION
## Summary

- make compact repack inventory and solidify loose states, then reclaim semantically equivalent loose state/tree copies while preserving legacy V1 tree migration shadows
- report the actual installed native footprint (loose objects + pack + index) before and after repack
- add a pinned, retention-equalized semver/ripgrep benchmark runner for reproducible native-versus-Git measurements

## Closes

Closes #1323

## Test evidence

The production benchmark adopted the exact same reachable revisions into Heddle and a single-ref bare Git repository. Git's denominator is the optimized pack bytes (excluding its index); Heddle's numerator is conservatively the full physical object footprint, including loose objects, pack, and index.

| Corpus | Pinned revision | Objects | Git pack | Native before | Before/Git | Native after | After/Git | Mismatches |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| semver | `4fea7f0d5a1c9fca85f764c02953643d7fd45b27` | 343 | 112,045 B | 411,792 B | 3.675× | 102,377 B | **0.914×** | 0 |
| ripgrep | `3fce3b5bb0236da2df6d99672afb8a719642eca7` | 13,591 | 3,212,116 B | 39,927,023 B | 12.430× | 2,753,958 B | **0.857×** | 0 |

BLAKE3 byte-exact proof across all 13,934 tree/state/blob objects:

- semver source/reconstructed: `61e11d7465420b6f01aaeec7ea4909db8d17ca57ca3dbafcca796c5f6c2fa684`
- ripgrep source/reconstructed: `5e3baa1fd2a6155da9e5992c0ebcd7ceba8dfddb195414d32da775cb6e998f37`
- every reconstructed object also passed its typed state/tree/blob identity validation; zero mismatches
- lineage walk assigned 5,021/5,021 ripgrep blobs with zero leftovers; all produced zstd frames passed integrity checks

Benchmark command:

```bash
CARGO_HOME=/home/scratch/.cargo \
CARGO_TARGET_DIR=/home/scratch/heddle-1323-storage-proof/target \
scripts/run-storage-vs-git.sh \
  /home/scratch/heddle-1323-storage-proof-final \
  semver ripgrep
```

Validation:

- `cargo build --locked --workspace`
- `cargo test --locked --workspace --quiet`
- `cargo clippy --locked --workspace --all-targets -- -D warnings`
- `cargo test --locked -p heddle-cli --example native_lineage_solid --features semantic,zstd`
- `cargo test --locked -p heddle-object-model -p heddle-pack -p heddle-objects --features zstd`
- focused repack, corruption-rejection, compact-reader corruption, migration-shadow, and production packfile tests
- `cargo fmt --all -- --check`, `git diff --check`, `bash -n scripts/run-storage-vs-git.sh`, and ShellCheck

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789671281&installation_model_id=21489&pr_number=1403&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1403&signature=973198d70e757b45332c666f8e4fb89861d8de2d29c6412cb6c6868cc10ad0e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->