### PR TITLE
feat(semantic): reverse-dependency index and invalidation frontier

### DIFF
--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -22,6 +22,7 @@ mod risk_signal;
 mod semantic_change;
 mod semantic_edges;
 mod semantic_index;
+mod semantic_reverse_deps;
 mod session;
 mod source;
 mod spool_id;
@@ -86,6 +87,7 @@ pub use semantic_index::{
     SymbolKindTag, SymbolNamespace, compute_dir_semantic_digest, compute_file_scaffold_hash,
     compute_file_semantic_digest, compute_symbol_semantic_hash,
 };
+pub use semantic_reverse_deps::ReverseDependencyIndex;
 pub use session::{Session, SessionSegment, generate_session_id};
 #[cfg(feature = "async-source")]
 pub use source::AsyncObjectSource;

--- a/crates/object-model/src/object/semantic_index.rs
+++ b/crates/object-model/src/object/semantic_index.rs
@@ -589,6 +589,10 @@ pub struct SemanticIndexRoot {
     /// on repository placement and the first parent's edge set.
     #[serde(default)]
     pub binding_delta: Option<ContentHash>,
+    /// File → importers reverse-dependency index for this state. Capture uses
+    /// the parent copy to re-resolve only the invalidation frontier.
+    #[serde(default)]
+    pub importer_index: Option<ContentHash>,
     /// Heddle-owned resolver policy version used to produce `binding_delta`.
     #[serde(default)]
     pub resolver_version: u32,
@@ -610,6 +614,7 @@ impl SemanticIndexRoot {
             tree,
             semantic_digest,
             binding_delta: None,
+            importer_index: None,
             resolver_version: 0,
         }
     }
@@ -618,6 +623,12 @@ impl SemanticIndexRoot {
     pub fn with_binding_delta(mut self, binding_delta: ContentHash, resolver_version: u32) -> Self {
         self.binding_delta = Some(binding_delta);
         self.resolver_version = resolver_version;
+        self
+    }
+
+    /// Attach the file → importers index used for frontier-bounded re-resolution.
+    pub fn with_importer_index(mut self, importer_index: ContentHash) -> Self {
+        self.importer_index = Some(importer_index);
         self
     }
 

--- a/crates/object-model/src/object/semantic_reverse_deps.rs
+++ b/crates/object-model/src/object/semantic_reverse_deps.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+//! File → importers reverse-dependency index for incremental re-resolution.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::SemanticIndexError;
+
+/// Content-addressed file → importers map for one state.
+///
+/// `importers[target]` lists every source file whose resolved dependencies
+/// include `target`. Capture walks this map from changed files to obtain the
+/// invalidation frontier without re-resolving the rest of the repository.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ReverseDependencyIndex {
+    pub format_version: u8,
+    /// Imported file → sorted importer paths.
+    pub importers: BTreeMap<String, Vec<String>>,
+}
+
+impl ReverseDependencyIndex {
+    pub const FORMAT_VERSION: u8 = 1;
+
+    /// Construct a canonical index from an importer map.
+    pub fn new(importers: BTreeMap<String, BTreeSet<String>>) -> Self {
+        let importers = importers
+            .into_iter()
+            .filter_map(|(target, sources)| {
+                if sources.is_empty() {
+                    None
+                } else {
+                    Some((target, sources.into_iter().collect()))
+                }
+            })
+            .collect();
+        Self {
+            format_version: Self::FORMAT_VERSION,
+            importers,
+        }
+    }
+
+    /// Invert source → dependencies into a file → importers index.
+    pub fn from_dependencies(dependencies: &BTreeMap<String, BTreeSet<String>>) -> Self {
+        let mut importers = BTreeMap::<String, BTreeSet<String>>::new();
+        for (source, deps) in dependencies {
+            for dep in deps {
+                importers
+                    .entry(dep.clone())
+                    .or_default()
+                    .insert(source.clone());
+            }
+        }
+        Self::new(importers)
+    }
+
+    /// Look up the files that import `path`.
+    pub fn importers_of(&self, path: &str) -> &[String] {
+        self.importers
+            .get(path)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Encode this index as named MessagePack.
+    pub fn encode(&self) -> Result<Vec<u8>, SemanticIndexError> {
+        rmp_serde::to_vec_named(self).map_err(|err| SemanticIndexError::Encoding(err.to_string()))
+    }
+
+    /// Decode and version-check a reverse-dependency index.
+    pub fn decode(bytes: &[u8]) -> Result<Self, SemanticIndexError> {
+        let index: Self = rmp_serde::from_slice(bytes)
+            .map_err(|err| SemanticIndexError::Encoding(err.to_string()))?;
+        if index.format_version != Self::FORMAT_VERSION {
+            return Err(SemanticIndexError::UnsupportedVersion(index.format_version));
+        }
+        Ok(index)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_roundtrips_and_drops_empty_importer_sets() {
+        let index = ReverseDependencyIndex::from_dependencies(&BTreeMap::from([
+            (
+                "b.rs".to_string(),
+                BTreeSet::from(["a.rs".to_string(), "a.rs".to_string()]),
+            ),
+            ("c.rs".to_string(), BTreeSet::from(["b.rs".to_string()])),
+            ("d.rs".to_string(), BTreeSet::new()),
+        ]));
+
+        assert_eq!(index.importers_of("a.rs"), ["b.rs"]);
+        assert_eq!(index.importers_of("b.rs"), ["c.rs"]);
+        assert!(index.importers_of("d.rs").is_empty());
+        assert_eq!(
+            ReverseDependencyIndex::decode(&index.encode().unwrap()).unwrap(),
+            index
+        );
+    }
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -63,6 +63,10 @@ pub use repository_semantic_recovery::{
 };
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_symbol_graph;
+#[cfg(feature = "tree-sitter-symbols")]
+mod repository_symbol_graph_frontier;
+#[cfg(feature = "tree-sitter-symbols")]
+mod repository_symbol_graph_load;
 mod repository_symbol_graph_query;
 pub use repository_symbol_graph_query::ResolvedSemanticEdgeSet;
 #[cfg(feature = "tree-sitter-symbols")]
@@ -70,6 +74,8 @@ mod repository_signals;
 mod repository_state_visibility;
 #[cfg(all(test, feature = "tree-sitter-symbols"))]
 mod repository_symbol_graph_tests;
+#[cfg(all(test, feature = "tree-sitter-symbols"))]
+pub(crate) use repository_symbol_graph::SemanticGraphBind;
 mod revision_address;
 pub use repository_state_visibility::{
     DefaultVisibilityBinding, PutVisibilityOutcome, VisibilityCommitKind, VisibilityCommitOutcome,

--- a/crates/repo/src/repository_semantic_index.rs
+++ b/crates/repo/src/repository_semantic_index.rs
@@ -21,6 +21,8 @@
 //! parent index's node wholesale wherever the source subtree hash is unchanged
 //! (assembly is O(changed-path)), and memoizes per source-blob so a blob shared
 //! across paths — or across the reformat of a sibling — is parsed at most once.
+//! Cross-file resolution mirrors that: capture walks the persisted file→importers
+//! index and re-resolves only the transitive invalidation frontier.
 //!
 //! ## Never-fail capture
 //!
@@ -510,6 +512,7 @@ impl Repository {
     /// bump recomputes.
     fn index_is_current(&self, root: &SemanticIndexRoot) -> bool {
         root.binding_delta.is_some()
+            && root.importer_index.is_some()
             && root.resolver_version == semantic::cross_file_resolution::RESOLVER_VERSION
             && root.extractor_version == EXTRACTOR_VERSION
             && root

--- a/crates/repo/src/repository_symbol_graph.rs
+++ b/crates/repo/src/repository_symbol_graph.rs
@@ -3,23 +3,31 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeSet, HashMap};
 
 use objects::{
     object::{
-        BindingDelta, ContentHash, FileBindingDelta, SemanticEntryKind, SemanticFileNode,
-        SemanticIndexRoot, SemanticTreeEntry, SemanticTreeNode,
+        BindingDelta, ContentHash, FileBindingDelta, ReverseDependencyIndex, SemanticIndexRoot,
     },
     store::ObjectStore,
 };
-use semantic::cross_file_resolution::{
-    RESOLVER_VERSION, RepositorySemanticFile, resolve_repository,
-};
+use semantic::cross_file_resolution::{RESOLVER_VERSION, resolve_paths};
 
-use crate::{HeddleError, Repository, Result};
+use crate::{
+    HeddleError, Repository, Result,
+    repository_symbol_graph_frontier::{invalidation_frontier, patch_importer_index},
+};
 
 type PendingSymbolGraphBlobs = Vec<(ContentHash, Vec<u8>)>;
 type DeferredSymbolGraph = (ContentHash, PendingSymbolGraphBlobs);
+
+/// Outcome of binding one semantic root, including how many files re-resolved.
+pub(crate) struct SemanticGraphBind {
+    pub root_hash: ContentHash,
+    pub pending: PendingSymbolGraphBlobs,
+    pub resolve_count: usize,
+    pub frontier: BTreeSet<String>,
+}
 
 impl Repository {
     /// Resolve the semantic root and persist a delta over the first parent's
@@ -29,10 +37,10 @@ impl Repository {
         parent_state: Option<&objects::object::State>,
         root: SemanticIndexRoot,
     ) -> Result<ContentHash> {
-        let (root_hash, pending) =
+        let bound =
             self.persist_resolved_semantic_edges_deferred(parent_state, root, &HashMap::new())?;
-        self.store().put_blobs_packed(pending)?;
-        Ok(root_hash)
+        self.store().put_blobs_packed(bound.1)?;
+        Ok(bound.0)
     }
 
     /// Resolve semantic edges while leaving every newly-authored blob in
@@ -43,282 +51,140 @@ impl Repository {
         root: SemanticIndexRoot,
         pending_nodes: &HashMap<ContentHash, Vec<u8>>,
     ) -> Result<DeferredSymbolGraph> {
+        let bound = self.bind_semantic_graph(parent_state, root, pending_nodes)?;
+        Ok((bound.root_hash, bound.pending))
+    }
+
+    pub(crate) fn bind_semantic_graph(
+        &self,
+        parent_state: Option<&objects::object::State>,
+        root: SemanticIndexRoot,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<SemanticGraphBind> {
         let parent_root = parent_state
             .map(|state| self.attached_semantic_index(&state.id()))
             .transpose()?
             .flatten();
-        let parent_delta = parent_root
-            .as_ref()
-            .filter(|root| root.resolver_version == RESOLVER_VERSION)
-            .and_then(|root| root.binding_delta);
-
-        if let (Some(parent_root), Some(parent_delta)) = (&parent_root, parent_delta)
-            && !self.semantic_file_nodes_changed(parent_root.tree, root.tree, pending_nodes)?
-        {
-            return self.prepare_binding_delta(root, Some(parent_delta), Vec::new());
-        }
-
-        let current_files = self.semantic_files_with_pending(&root, pending_nodes)?;
-        let current_resolution = resolve_repository(&current_files);
-
-        let frontier = if parent_delta.is_some() {
-            let parent_files = self.semantic_files(parent_root.as_ref().expect("checked above"))?;
-            let parent_resolution = resolve_repository(&parent_files);
-            invalidation_frontier(
-                &parent_files,
-                &current_files,
-                &parent_resolution,
-                &current_resolution,
-            )
-        } else {
-            current_files.keys().cloned().collect()
+        let parent_root = parent_root.filter(|root| {
+            root.resolver_version == RESOLVER_VERSION
+                && root.binding_delta.is_some()
+                && root.importer_index.is_some()
+        });
+        let parent_delta = parent_root.as_ref().and_then(|root| root.binding_delta);
+        let parent_index = match parent_root.as_ref().and_then(|root| root.importer_index) {
+            Some(hash) => Some(self.load_reverse_dependency_index(&hash)?),
+            None => None,
         };
 
+        if let (Some(parent_root), Some(parent_delta), Some(parent_index_hash)) = (
+            &parent_root,
+            parent_delta,
+            parent_root.as_ref().and_then(|root| root.importer_index),
+        ) {
+            let changed =
+                self.changed_semantic_file_paths(parent_root.tree, root.tree, pending_nodes)?;
+            if changed.is_empty() {
+                return self.finish_bind(
+                    root,
+                    Some(parent_delta),
+                    Vec::new(),
+                    Some(parent_index_hash),
+                    None,
+                );
+            }
+            return self.bind_frontier(
+                root,
+                Some(parent_delta),
+                parent_index.as_ref(),
+                changed,
+                pending_nodes,
+            );
+        }
+
+        self.bind_frontier(
+            root,
+            parent_delta,
+            parent_index.as_ref(),
+            BTreeSet::new(),
+            pending_nodes,
+        )
+    }
+
+    fn bind_frontier(
+        &self,
+        root: SemanticIndexRoot,
+        parent_delta: Option<ContentHash>,
+        parent_index: Option<&ReverseDependencyIndex>,
+        changed: BTreeSet<String>,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<SemanticGraphBind> {
+        let current_files = self.semantic_files_with_pending(&root, pending_nodes)?;
+        let frontier = match parent_index {
+            Some(index) if !changed.is_empty() || parent_delta.is_some() => {
+                invalidation_frontier(&changed, index)
+            }
+            _ => current_files.keys().cloned().collect(),
+        };
+        let resolutions = resolve_paths(&current_files, frontier.iter().map(String::as_str));
+        let resolve_count = resolutions.len();
         let files = frontier
-            .into_iter()
-            .map(|path| match current_files.get(&path) {
+            .iter()
+            .map(|path| match current_files.get(path) {
                 Some(file) => FileBindingDelta::new(
                     path.clone(),
                     Some(file.node_hash),
-                    current_resolution
-                        .get(&path)
+                    resolutions
+                        .get(path)
                         .map(|resolution| resolution.edges.clone())
                         .unwrap_or_default(),
                 ),
                 None => FileBindingDelta::new(path, None, Vec::new()),
             })
             .collect();
-        self.prepare_binding_delta(root, parent_delta, files)
+        let index = patch_importer_index(parent_index, &frontier, &resolutions, &current_files);
+        let mut bound = self.finish_bind(root, parent_delta, files, None, Some(index))?;
+        bound.resolve_count = resolve_count;
+        bound.frontier = frontier;
+        Ok(bound)
     }
 
-    fn prepare_binding_delta(
+    fn finish_bind(
         &self,
         root: SemanticIndexRoot,
         parent_delta: Option<ContentHash>,
         files: Vec<FileBindingDelta>,
-    ) -> Result<DeferredSymbolGraph> {
+        reuse_index: Option<ContentHash>,
+        index: Option<ReverseDependencyIndex>,
+    ) -> Result<SemanticGraphBind> {
         let delta = BindingDelta::new(parent_delta, files);
         let delta_bytes = delta.encode()?;
         let delta_hash = ContentHash::compute_typed("blob", &delta_bytes);
-        let rooted = root.with_binding_delta(delta_hash, RESOLVER_VERSION);
+        let (index_hash, index_bytes) = match (reuse_index, index) {
+            (Some(hash), _) => (hash, None),
+            (None, Some(index)) => {
+                let bytes = index.encode()?;
+                (ContentHash::compute_typed("blob", &bytes), Some(bytes))
+            }
+            (None, None) => {
+                return Err(HeddleError::InvalidObject(
+                    "semantic graph bind missing reverse-dependency index".to_string(),
+                ));
+            }
+        };
+        let rooted = root
+            .with_binding_delta(delta_hash, RESOLVER_VERSION)
+            .with_importer_index(index_hash);
         let root_bytes = rooted.encode()?;
         let root_hash = ContentHash::compute_typed("blob", &root_bytes);
-        Ok((
+        let mut pending = vec![(delta_hash, delta_bytes), (root_hash, root_bytes)];
+        if let Some(index_bytes) = index_bytes {
+            pending.push((index_hash, index_bytes));
+        }
+        Ok(SemanticGraphBind {
             root_hash,
-            vec![(delta_hash, delta_bytes), (root_hash, root_bytes)],
-        ))
-    }
-
-    fn semantic_file_nodes_changed(
-        &self,
-        parent_hash: ContentHash,
-        current_hash: ContentHash,
-        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
-    ) -> Result<bool> {
-        let mut pairs = vec![(parent_hash, current_hash, 0usize)];
-        while let Some((parent_hash, current_hash, depth)) = pairs.pop() {
-            if parent_hash == current_hash {
-                continue;
-            }
-            if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
-                return Err(HeddleError::InvalidObject(
-                    "semantic index tree exceeds max depth".to_string(),
-                ));
-            }
-            let parent = self.load_semantic_tree_with_pending(&parent_hash, pending_nodes)?;
-            let current = self.load_semantic_tree_with_pending(&current_hash, pending_nodes)?;
-            let parent_by_name = parent
-                .entries
-                .iter()
-                .map(|entry| (entry.name.as_str(), entry))
-                .collect::<BTreeMap<_, _>>();
-            let current_by_name = current
-                .entries
-                .iter()
-                .map(|entry| (entry.name.as_str(), entry))
-                .collect::<BTreeMap<_, _>>();
-            let names = parent_by_name
-                .keys()
-                .chain(current_by_name.keys())
-                .copied()
-                .collect::<BTreeSet<_>>();
-
-            for name in names {
-                match (parent_by_name.get(name), current_by_name.get(name)) {
-                    (Some(parent), Some(current)) => match (parent.kind, current.kind) {
-                        (SemanticEntryKind::Opaque, SemanticEntryKind::Opaque) => {}
-                        (SemanticEntryKind::File, SemanticEntryKind::File) => {
-                            if parent.node != current.node {
-                                return Ok(true);
-                            }
-                        }
-                        (SemanticEntryKind::Dir, SemanticEntryKind::Dir) => {
-                            pairs.push((parent.node, current.node, depth + 1));
-                        }
-                        _ => {
-                            if self.semantic_entry_contains_file(parent, pending_nodes)?
-                                || self.semantic_entry_contains_file(current, pending_nodes)?
-                            {
-                                return Ok(true);
-                            }
-                        }
-                    },
-                    (Some(entry), None) | (None, Some(entry)) => {
-                        if self.semantic_entry_contains_file(entry, pending_nodes)? {
-                            return Ok(true);
-                        }
-                    }
-                    (None, None) => unreachable!("name came from one of the two trees"),
-                }
-            }
-        }
-        Ok(false)
-    }
-
-    fn semantic_entry_contains_file(
-        &self,
-        entry: &SemanticTreeEntry,
-        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
-    ) -> Result<bool> {
-        match entry.kind {
-            SemanticEntryKind::File => Ok(true),
-            SemanticEntryKind::Opaque => Ok(false),
-            SemanticEntryKind::Dir => {
-                let mut stack = vec![(entry.node, 0usize)];
-                while let Some((hash, depth)) = stack.pop() {
-                    if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
-                        return Err(HeddleError::InvalidObject(
-                            "semantic index tree exceeds max depth".to_string(),
-                        ));
-                    }
-                    for child in self
-                        .load_semantic_tree_with_pending(&hash, pending_nodes)?
-                        .entries
-                    {
-                        match child.kind {
-                            SemanticEntryKind::File => return Ok(true),
-                            SemanticEntryKind::Dir => stack.push((child.node, depth + 1)),
-                            SemanticEntryKind::Opaque => {}
-                        }
-                    }
-                }
-                Ok(false)
-            }
-        }
-    }
-
-    pub(crate) fn semantic_files(
-        &self,
-        root: &SemanticIndexRoot,
-    ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
-        self.semantic_files_with_pending(root, &HashMap::new())
-    }
-
-    fn semantic_files_with_pending(
-        &self,
-        root: &SemanticIndexRoot,
-        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
-    ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
-        let mut files = BTreeMap::new();
-        let mut stack = vec![(String::new(), root.tree, 0usize)];
-        while let Some((prefix, hash, depth)) = stack.pop() {
-            if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
-                return Err(HeddleError::InvalidObject(
-                    "semantic index tree exceeds max depth".to_string(),
-                ));
-            }
-            for entry in self
-                .load_semantic_tree_with_pending(&hash, pending_nodes)?
-                .entries
-                .into_iter()
-                .rev()
-            {
-                let path = if prefix.is_empty() {
-                    entry.name
-                } else {
-                    format!("{prefix}/{}", entry.name)
-                };
-                match entry.kind {
-                    SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
-                    SemanticEntryKind::File => {
-                        let node = match pending_nodes.get(&entry.node) {
-                            Some(bytes) => SemanticFileNode::decode(bytes)
-                                .map_err(|err| HeddleError::InvalidObject(err.to_string()))?,
-                            None => self.load_semantic_file(&entry.node)?,
-                        };
-                        files.insert(
-                            path,
-                            RepositorySemanticFile {
-                                node_hash: entry.node,
-                                node,
-                            },
-                        );
-                    }
-                    SemanticEntryKind::Opaque => {}
-                }
-            }
-        }
-        Ok(files)
-    }
-
-    fn load_semantic_tree_with_pending(
-        &self,
-        hash: &ContentHash,
-        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
-    ) -> Result<SemanticTreeNode> {
-        match pending_nodes.get(hash) {
-            Some(bytes) => SemanticTreeNode::decode(bytes)
-                .map_err(|err| HeddleError::InvalidObject(err.to_string())),
-            None => self.load_semantic_tree(hash),
-        }
-    }
-}
-
-fn invalidation_frontier(
-    parent_files: &BTreeMap<String, RepositorySemanticFile>,
-    current_files: &BTreeMap<String, RepositorySemanticFile>,
-    parent: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
-    current: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
-) -> BTreeSet<String> {
-    let all_paths = parent_files
-        .keys()
-        .chain(current_files.keys())
-        .cloned()
-        .collect::<BTreeSet<_>>();
-    let changed = all_paths
-        .into_iter()
-        .filter(|path| {
-            parent_files.get(path).map(|file| file.node_hash)
-                != current_files.get(path).map(|file| file.node_hash)
+            pending,
+            resolve_count: 0,
+            frontier: BTreeSet::new(),
         })
-        .collect::<BTreeSet<_>>();
-    let reverse = reverse_dependencies(parent, current);
-    let mut frontier = changed.clone();
-    let mut queue = VecDeque::from_iter(changed);
-    while let Some(path) = queue.pop_front() {
-        if let Some(importers) = reverse.get(&path) {
-            for importer in importers {
-                if frontier.insert(importer.clone()) {
-                    queue.push_back(importer.clone());
-                }
-            }
-        }
     }
-    frontier
-}
-
-fn reverse_dependencies(
-    parent: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
-    current: &BTreeMap<String, semantic::cross_file_resolution::FileResolution>,
-) -> BTreeMap<String, BTreeSet<String>> {
-    let mut reverse = BTreeMap::<String, BTreeSet<String>>::new();
-    for (importer, resolution) in parent.iter().chain(current) {
-        for dependency in &resolution.dependencies {
-            reverse
-                .entry(dependency.clone())
-                .or_default()
-                .insert(importer.clone());
-        }
-    }
-    reverse
 }

--- a/crates/repo/src/repository_symbol_graph_frontier.rs
+++ b/crates/repo/src/repository_symbol_graph_frontier.rs
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Reverse-dependency frontier: which files must re-resolve after a change.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use objects::object::{ContentHash, ReverseDependencyIndex};
+use semantic::cross_file_resolution::{FileResolution, RepositorySemanticFile};
+
+/// Paths whose semantic file node appeared, disappeared, or changed hash.
+pub(crate) fn changed_file_paths(
+    parent: &BTreeMap<String, ContentHash>,
+    current: &BTreeMap<String, ContentHash>,
+) -> BTreeSet<String> {
+    parent
+        .keys()
+        .chain(current.keys())
+        .filter(|path| parent.get(*path) != current.get(*path))
+        .cloned()
+        .collect()
+}
+
+/// Walk file → importers from `changed` to the transitive invalidation frontier.
+pub(crate) fn invalidation_frontier(
+    changed: &BTreeSet<String>,
+    index: &ReverseDependencyIndex,
+) -> BTreeSet<String> {
+    let mut frontier = changed.clone();
+    let mut queue = VecDeque::from_iter(changed.iter().cloned());
+    while let Some(path) = queue.pop_front() {
+        for importer in index.importers_of(&path) {
+            if frontier.insert(importer.clone()) {
+                queue.push_back(importer.clone());
+            }
+        }
+    }
+    frontier
+}
+
+/// Replace frontier files' outgoing edges in the reverse-dependency index.
+pub(crate) fn patch_importer_index(
+    parent: Option<&ReverseDependencyIndex>,
+    frontier: &BTreeSet<String>,
+    resolutions: &BTreeMap<String, FileResolution>,
+    current_files: &BTreeMap<String, RepositorySemanticFile>,
+) -> ReverseDependencyIndex {
+    let mut importers = parent
+        .map(|index| {
+            index
+                .importers
+                .iter()
+                .map(|(target, sources)| (target.clone(), sources.iter().cloned().collect()))
+                .collect::<BTreeMap<String, BTreeSet<String>>>()
+        })
+        .unwrap_or_default();
+
+    for sources in importers.values_mut() {
+        for path in frontier {
+            sources.remove(path);
+        }
+    }
+    for path in frontier {
+        if !current_files.contains_key(path) {
+            importers.remove(path);
+        }
+    }
+    for (source, resolution) in resolutions {
+        for dep in &resolution.dependencies {
+            importers
+                .entry(dep.clone())
+                .or_default()
+                .insert(source.clone());
+        }
+    }
+    ReverseDependencyIndex::new(importers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frontier_is_changed_files_plus_transitive_importers() {
+        let index = ReverseDependencyIndex::from_dependencies(&BTreeMap::from([
+            ("b.rs".to_string(), BTreeSet::from(["a.rs".to_string()])),
+            ("c.rs".to_string(), BTreeSet::from(["b.rs".to_string()])),
+            ("e.rs".to_string(), BTreeSet::from(["d.rs".to_string()])),
+        ]));
+        let changed = BTreeSet::from(["a.rs".to_string()]);
+        assert_eq!(
+            invalidation_frontier(&changed, &index),
+            BTreeSet::from(["a.rs".to_string(), "b.rs".to_string(), "c.rs".to_string()])
+        );
+    }
+}

--- a/crates/repo/src/repository_symbol_graph_load.rs
+++ b/crates/repo/src/repository_symbol_graph_load.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Load semantic file facts and node hashes for graph binding.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+
+use objects::object::{
+    ContentHash, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot, SemanticTreeNode,
+};
+use semantic::cross_file_resolution::RepositorySemanticFile;
+
+use crate::{
+    HeddleError, Repository, Result, repository_symbol_graph_frontier::changed_file_paths,
+};
+
+impl Repository {
+    pub(crate) fn changed_semantic_file_paths(
+        &self,
+        parent_hash: ContentHash,
+        current_hash: ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<BTreeSet<String>> {
+        let parent = self.semantic_file_node_hashes(parent_hash, pending_nodes)?;
+        let current = self.semantic_file_node_hashes(current_hash, pending_nodes)?;
+        Ok(changed_file_paths(&parent, &current))
+    }
+
+    pub(crate) fn semantic_files_with_pending(
+        &self,
+        root: &SemanticIndexRoot,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<BTreeMap<String, RepositorySemanticFile>> {
+        let mut files = BTreeMap::new();
+        self.walk_semantic_files(root.tree, pending_nodes, |path, entry| {
+            if entry.kind == SemanticEntryKind::File {
+                files.insert(path, self.load_repository_file(&entry.node, pending_nodes)?);
+            }
+            Ok(())
+        })?;
+        Ok(files)
+    }
+
+    fn semantic_file_node_hashes(
+        &self,
+        root_hash: ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<BTreeMap<String, ContentHash>> {
+        let mut files = BTreeMap::new();
+        self.walk_semantic_files(root_hash, pending_nodes, |path, entry| {
+            if entry.kind == SemanticEntryKind::File {
+                files.insert(path, entry.node);
+            }
+            Ok(())
+        })?;
+        Ok(files)
+    }
+
+    fn walk_semantic_files(
+        &self,
+        root_hash: ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+        mut visit: impl FnMut(String, objects::object::SemanticTreeEntry) -> Result<()>,
+    ) -> Result<()> {
+        let mut stack = vec![(String::new(), root_hash, 0usize)];
+        while let Some((prefix, hash, depth)) = stack.pop() {
+            if depth > crate::repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH {
+                return Err(HeddleError::InvalidObject(
+                    "semantic index tree exceeds max depth".to_string(),
+                ));
+            }
+            for entry in self
+                .load_semantic_tree_with_pending(&hash, pending_nodes)?
+                .entries
+                .into_iter()
+                .rev()
+            {
+                let path = join_semantic_path(&prefix, &entry.name);
+                match entry.kind {
+                    SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
+                    SemanticEntryKind::File | SemanticEntryKind::Opaque => visit(path, entry)?,
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn load_repository_file(
+        &self,
+        node: &ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<RepositorySemanticFile> {
+        let decoded = match pending_nodes.get(node) {
+            Some(bytes) => SemanticFileNode::decode(bytes)
+                .map_err(|err| HeddleError::InvalidObject(err.to_string()))?,
+            None => self.load_semantic_file(node)?,
+        };
+        Ok(RepositorySemanticFile {
+            node_hash: *node,
+            node: decoded,
+        })
+    }
+
+    fn load_semantic_tree_with_pending(
+        &self,
+        hash: &ContentHash,
+        pending_nodes: &HashMap<ContentHash, Vec<u8>>,
+    ) -> Result<SemanticTreeNode> {
+        match pending_nodes.get(hash) {
+            Some(bytes) => SemanticTreeNode::decode(bytes)
+                .map_err(|err| HeddleError::InvalidObject(err.to_string())),
+            None => self.load_semantic_tree(hash),
+        }
+    }
+}
+
+fn join_semantic_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}

--- a/crates/repo/src/repository_symbol_graph_query.rs
+++ b/crates/repo/src/repository_symbol_graph_query.rs
@@ -3,6 +3,8 @@
 
 use std::collections::{BTreeMap, HashSet};
 
+#[cfg(feature = "tree-sitter-symbols")]
+use objects::object::ReverseDependencyIndex;
 use objects::{
     object::{BindingDelta, ContentHash, ResolvedSemanticEdge, StateId},
     store::ObjectStore,
@@ -54,6 +56,18 @@ impl Repository {
                     .into_iter()
                     .find(|edge| edge.source_occurrence == source_occurrence)
             }))
+    }
+
+    #[cfg(feature = "tree-sitter-symbols")]
+    pub(crate) fn load_reverse_dependency_index(
+        &self,
+        hash: &ContentHash,
+    ) -> Result<ReverseDependencyIndex> {
+        let blob = self.store().get_blob(hash)?.ok_or_else(|| {
+            HeddleError::NotFound(format!("semantic reverse-dependency index {hash}"))
+        })?;
+        ReverseDependencyIndex::decode(blob.content())
+            .map_err(|err| HeddleError::InvalidObject(err.to_string()))
     }
 
     pub(crate) fn load_binding_delta(&self, hash: &ContentHash) -> Result<BindingDelta> {

--- a/crates/repo/src/repository_symbol_graph_tests.rs
+++ b/crates/repo/src/repository_symbol_graph_tests.rs
@@ -2,12 +2,14 @@
 
 #![cfg(feature = "tree-sitter-symbols")]
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
 
 use objects::{
-    object::{Attribution, OccurrenceRole, Principal, StateId},
+    object::{Attribution, OccurrenceRole, Principal, SemanticIndexRoot, StateId},
     store::ObjectStore,
 };
+
+use crate::SemanticGraphBind;
 use tempfile::TempDir;
 
 use crate::{Repository, ResolvedSemanticEdgeSet};
@@ -135,6 +137,13 @@ fn rust_cross_file_roundtrip_and_frontier_delta_are_exact() {
             .unwrap(),
         "the attached delta is a content-addressed blob"
     );
+    let first_index = repo
+        .load_reverse_dependency_index(&first_root.importer_index.unwrap())
+        .unwrap();
+    assert_eq!(
+        first_index.importers_of("src/api.rs"),
+        ["src/client.rs", "src/qualified.rs"]
+    );
 }
 
 #[test]
@@ -162,6 +171,10 @@ fn opaque_only_change_inherits_bindings_without_a_repository_wide_resolve() {
     assert!(
         second_delta.files.is_empty(),
         "opaque files cannot change cross-file symbol bindings"
+    );
+    assert_eq!(
+        first_root.importer_index, second_root.importer_index,
+        "opaque-only capture content-address reuses the parent importer index"
     );
 }
 
@@ -193,4 +206,118 @@ fn typescript_named_import_resolves_across_files() {
             .unwrap()
             .is_none()
     );
+}
+
+fn unbound_root(repo: &Repository, state: &StateId) -> SemanticIndexRoot {
+    let root = repo.attached_semantic_index(state).unwrap().unwrap();
+    SemanticIndexRoot::new(
+        root.extractor_version,
+        root.grammars,
+        root.tree,
+        root.semantic_digest,
+    )
+}
+
+fn rebind(repo: &Repository, parent: &StateId, current: &StateId) -> SemanticGraphBind {
+    let parent_state = repo.store().get_state(parent).unwrap().unwrap();
+    repo.bind_semantic_graph(
+        Some(&parent_state),
+        unbound_root(repo, current),
+        &HashMap::new(),
+    )
+    .unwrap()
+}
+
+/// GOLDEN (heddle#1275): editing A's exports re-resolves exactly A and A's
+/// transitive importers — not the unrelated import lane.
+#[test]
+fn export_edit_reresolves_exactly_the_transitive_importer_frontier() {
+    let (temp, repo) = repo();
+    let first = snapshot(
+        &repo,
+        &temp,
+        &[
+            ("src/a.rs", "pub fn export_a() -> u8 { 1 }\n"),
+            (
+                "src/b.rs",
+                "use crate::a::export_a;\npub fn export_b() -> u8 { export_a() }\n",
+            ),
+            (
+                "src/c.rs",
+                "use crate::b::export_b;\npub fn run() { export_b(); }\n",
+            ),
+            ("src/d.rs", "pub fn unrelated() {}\n"),
+            (
+                "src/e.rs",
+                "use crate::d::unrelated;\npub fn use_d() { unrelated(); }\n",
+            ),
+        ],
+    );
+    let first_root = repo.attached_semantic_index(&first).unwrap().unwrap();
+    let first_index = repo
+        .load_reverse_dependency_index(&first_root.importer_index.unwrap())
+        .unwrap();
+    assert_eq!(first_index.importers_of("src/a.rs"), ["src/b.rs"]);
+    assert_eq!(first_index.importers_of("src/b.rs"), ["src/c.rs"]);
+    assert_eq!(first_index.importers_of("src/d.rs"), ["src/e.rs"]);
+
+    let second = snapshot(
+        &repo,
+        &temp,
+        &[("src/a.rs", "pub fn export_a() -> u8 { 2 }\n")],
+    );
+    let bound = rebind(&repo, &first, &second);
+    assert_eq!(
+        bound.frontier,
+        BTreeSet::from([
+            "src/a.rs".to_string(),
+            "src/b.rs".to_string(),
+            "src/c.rs".to_string()
+        ]),
+        "edit A's exports must invalidate exactly A's transitive importers"
+    );
+    assert_eq!(
+        bound.resolve_count, 3,
+        "only the frontier may re-resolve: {:?}",
+        bound.frontier
+    );
+
+    let delta = repo.semantic_edge_delta(&second).unwrap().unwrap();
+    let delta_paths = delta
+        .files
+        .iter()
+        .map(|file| file.path.as_str())
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        delta_paths,
+        BTreeSet::from(["src/a.rs", "src/b.rs", "src/c.rs"])
+    );
+}
+
+#[test]
+fn unrelated_export_lane_does_not_reresolve_a_importers() {
+    let (temp, repo) = repo();
+    let first = snapshot(
+        &repo,
+        &temp,
+        &[
+            ("src/a.rs", "pub fn export_a() -> u8 { 1 }\n"),
+            (
+                "src/b.rs",
+                "use crate::a::export_a;\npub fn export_b() -> u8 { export_a() }\n",
+            ),
+            ("src/d.rs", "pub fn unrelated() {}\n"),
+            (
+                "src/e.rs",
+                "use crate::d::unrelated;\npub fn use_d() { unrelated(); }\n",
+            ),
+        ],
+    );
+    let second = snapshot(&repo, &temp, &[("src/d.rs", "pub fn unrelated() { 1; }\n")]);
+    let bound = rebind(&repo, &first, &second);
+    assert_eq!(
+        bound.frontier,
+        BTreeSet::from(["src/d.rs".to_string(), "src/e.rs".to_string()])
+    );
+    assert_eq!(bound.resolve_count, 2);
 }

--- a/crates/semantic/src/cross_file_resolution/mod.rs
+++ b/crates/semantic/src/cross_file_resolution/mod.rs
@@ -38,34 +38,49 @@ pub struct FileResolution {
 pub fn resolve_repository(
     files: &BTreeMap<String, RepositorySemanticFile>,
 ) -> BTreeMap<String, FileResolution> {
-    files
-        .iter()
-        .map(|(path, file)| {
-            let mut dependencies = dependencies_for(path, &file.node, files);
-            let mut edges = file
-                .node
-                .occurrences
-                .iter()
-                .filter(|occurrence| occurrence.role != OccurrenceRole::Definition)
-                .filter_map(|occurrence| resolve_occurrence(path, file, occurrence, files))
-                .collect::<Vec<_>>();
-            edges.sort();
-            edges.dedup();
-            dependencies.extend(
-                edges
-                    .iter()
-                    .filter(|edge| edge.target_path != *path)
-                    .map(|edge| edge.target_path.clone()),
-            );
-            (
-                path.clone(),
-                FileResolution {
-                    dependencies,
-                    edges,
-                },
-            )
+    resolve_paths(files, files.keys().map(String::as_str))
+}
+
+/// Resolve only `paths`. `files` remains the full repository map so module and
+/// definition lookup can see files outside the invalidation frontier.
+pub fn resolve_paths<'a>(
+    files: &BTreeMap<String, RepositorySemanticFile>,
+    paths: impl IntoIterator<Item = &'a str>,
+) -> BTreeMap<String, FileResolution> {
+    paths
+        .into_iter()
+        .filter_map(|path| {
+            let file = files.get(path)?;
+            Some((path.to_string(), resolve_file(path, file, files)))
         })
         .collect()
+}
+
+fn resolve_file(
+    path: &str,
+    file: &RepositorySemanticFile,
+    files: &BTreeMap<String, RepositorySemanticFile>,
+) -> FileResolution {
+    let mut dependencies = dependencies_for(path, &file.node, files);
+    let mut edges = file
+        .node
+        .occurrences
+        .iter()
+        .filter(|occurrence| occurrence.role != OccurrenceRole::Definition)
+        .filter_map(|occurrence| resolve_occurrence(path, file, occurrence, files))
+        .collect::<Vec<_>>();
+    edges.sort();
+    edges.dedup();
+    dependencies.extend(
+        edges
+            .iter()
+            .filter(|edge| edge.target_path != *path)
+            .map(|edge| edge.target_path.clone()),
+    );
+    FileResolution {
+        dependencies,
+        edges,
+    }
 }
 
 fn dependencies_for(

--- a/crates/semantic/src/cross_file_resolution/tests.rs
+++ b/crates/semantic/src/cross_file_resolution/tests.rs
@@ -44,6 +44,13 @@ fn rust_imported_call_resolves_and_missing_name_stays_unresolved() {
     );
 
     let resolution = resolve_repository(&files);
+    let only_client = resolve_paths(&files, ["src/client.rs"]);
+    assert_eq!(
+        only_client.len(),
+        1,
+        "resolve_paths must not visit other files"
+    );
+    assert_eq!(only_client["src/client.rs"], resolution["src/client.rs"]);
     let client = &resolution["src/client.rs"];
     assert_eq!(
         client.dependencies,

--- a/crates/wire/src/object_graph.rs
+++ b/crates/wire/src/object_graph.rs
@@ -3,9 +3,9 @@ use std::collections::{HashSet, VecDeque};
 
 use objects::{
     object::{
-        AnnotatedTag, BindingDelta, ContentHash, RedactionsBlob, SemanticEntryKind,
-        SemanticIndexRoot, SemanticTreeNode, State, StateAttachment, StateAttachmentBody,
-        StateAttachmentId, StateAttachmentKind, StateId, TreeEntryTarget,
+        AnnotatedTag, BindingDelta, ContentHash, RedactionsBlob, ReverseDependencyIndex,
+        SemanticEntryKind, SemanticIndexRoot, SemanticTreeNode, State, StateAttachment,
+        StateAttachmentBody, StateAttachmentId, StateAttachmentKind, StateId, TreeEntryTarget,
     },
     store::{ObjectStore, pack::ObjectType as PackObjectType},
 };
@@ -663,6 +663,9 @@ fn walk_semantic_index_closure(
                     // shallow-clone boundary.
                     emit_binding_delta(store, hash, excluded, seen, visit)?;
                 }
+                SemanticChild::ImporterIndex(hash) => {
+                    emit_importer_index(store, hash, excluded, seen, visit)?;
+                }
             }
         }
     }
@@ -674,6 +677,7 @@ enum SemanticChild {
     Interior(ContentHash),
     Leaf(ContentHash),
     BindingDelta(ContentHash),
+    ImporterIndex(ContentHash),
 }
 
 /// Decode a semantic-closure node — the root (which points at a tree node) or a
@@ -689,6 +693,9 @@ fn decode_semantic_container(
         let mut children = vec![SemanticChild::Interior(root.tree)];
         if let Some(binding_delta) = root.binding_delta {
             children.push(SemanticChild::BindingDelta(binding_delta));
+        }
+        if let Some(importer_index) = root.importer_index {
+            children.push(SemanticChild::ImporterIndex(importer_index));
         }
         return Ok(children);
     }
@@ -721,6 +728,25 @@ fn emit_binding_delta(
         .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
     BindingDelta::decode(blob.content()).map_err(|err| {
         ProtocolError::Serialization(format!("semantic binding delta {hash}: {err}"))
+    })?;
+    Ok(())
+}
+
+fn emit_importer_index(
+    store: &impl ObjectStore,
+    hash: ContentHash,
+    excluded: &HashSet<ContentHash>,
+    seen: &mut HashSet<ContentHash>,
+    visit: &mut impl for<'event> FnMut(StateClosureEvent<'event>) -> Result<()>,
+) -> Result<()> {
+    if !emit_semantic_blob(store, hash, excluded, seen, visit)? {
+        return Ok(());
+    }
+    let blob = store
+        .get_blob(&hash)?
+        .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
+    ReverseDependencyIndex::decode(blob.content()).map_err(|err| {
+        ProtocolError::Serialization(format!("semantic reverse-dependency index {hash}: {err}"))
     })?;
     Ok(())
 }
@@ -777,7 +803,7 @@ fn collect_semantic_hashes(
                 SemanticChild::Leaf(hash) => {
                     excluded.insert(hash);
                 }
-                SemanticChild::BindingDelta(hash) => {
+                SemanticChild::BindingDelta(hash) | SemanticChild::ImporterIndex(hash) => {
                     excluded.insert(hash);
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Persist a content-addressed **file → importers** reverse-dependency index on each `SemanticIndexRoot` (`importer_index`).
- Capture walks the parent index from changed files and **re-resolves only the transitive invalidation frontier**, mirroring the builder's O(changed-path) reuse. Unchanged unrelated files are not re-resolved.
- Opaque-only edits content-address reuse the parent importer index (no graph work). Binding-delta membership stays frontier-exact.
- In-tree Rust goldens (no external corpus): edit A's exports → exactly A's transitive importers re-resolve.

## Closes

Closes HeddleCo/heddle#1275

## Residual — what #1276 still owes

This PR is the **index + invalidation frontier only**. It does **not** implement the parse-free graph query API.

#1276 still owes:

- `refs_of(state, anchor)` / `importers_of(state, path)` on the always-compiled, tree-sitter-free query module (`repository_semantic_query` / `repository_symbol_graph_query`)
- `heddle semantic refs` CLI
- the wire surface weft#451 Tier-2 consumes
- Salsa-style memoization remains deferred; this PR only measures the content-address short-circuit that falls out of the persisted index (opaque-only capture reuses the parent `importer_index` hash)

weft#451 should consume #1276, not this PR.

## Red commit

`e41cc8c4` — goldens were authored against the new bind path in the same commit. Pre-change `main` resolved the whole repository, then trimmed the delta; the new `resolve_count` assertion did not exist yet.

## Test evidence

```
cargo test -p heddle-repo --features tree-sitter-symbols --lib repository_symbol_graph -- --test-threads=1

running 6 tests
test repository_symbol_graph_frontier::tests::frontier_is_changed_files_plus_transitive_importers ... ok
test repository_symbol_graph_tests::export_edit_reresolves_exactly_the_transitive_importer_frontier ... ok
test repository_symbol_graph_tests::opaque_only_change_inherits_bindings_without_a_repository_wide_resolve ... ok
test repository_symbol_graph_tests::rust_cross_file_roundtrip_and_frontier_delta_are_exact ... ok
test repository_symbol_graph_tests::typescript_named_import_resolves_across_files ... ok
test repository_symbol_graph_tests::unrelated_export_lane_does_not_reresolve_a_importers ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 691 filtered out

Also green:
- heddle-object-model semantic tests (14)
- heddle-semantic cross_file_resolution tests (5)
- heddle-repo repository_semantic tests (17)
- heddle-wire object_graph tests (17)
- clippy -D warnings on object-model / semantic / repo / wire
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

#1276 remains blocked on this landing if it needed the persisted index; this PR does not close #1276.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-40d9076a-a18e-48d7-9f29-7c8414f03ee9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40d9076a-a18e-48d7-9f29-7c8414f03ee9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789690159&installation_model_id=21489&pr_number=1416&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1416&signature=e4b477f843f33a5cd0db3b62afcc8b1322966da6e6a95c9dca8a80f95b164001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->