### PR TITLE
fix(object-model): cap compact-frame counts before prealloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Compact frames reject attacker-declared object counts before prealloc.**
+  `get_count` now caps declarations against the 12 MiB writer frame object
+  ceiling and a real per-entry encoded floor, so a hostile pack cannot force
+  `Vec::with_capacity` or `blank_state()` from a count near the 1 GiB
+  decompress cap (heddle#1408).
+
 - **Compact repack reclaims loose metadata copies.** Loose trees and states are
   now included in repack inventory, solidified with typed-hash verification,
   and removed only after the durable replacement reconstructs the same object

--- a/crates/object-model/src/compact/blob.rs
+++ b/crates/object-model/src/compact/blob.rs
@@ -3,6 +3,7 @@
 use super::{
     Result,
     io::{Reader, Writer},
+    limits::{MAX_COMPACT_COUNT, MIN_BLOB_ITEM_BYTES},
 };
 use crate::object::ContentHash;
 
@@ -21,6 +22,12 @@ pub fn is_blob_frame(bytes: &[u8]) -> bool {
 /// Lengths precede the concatenated bodies, giving the frame reader an exact
 /// `(offset, len)` for every object while zstd sees one continuous lineage.
 pub fn encode_blob_frame(blobs: &[&[u8]]) -> Result<Vec<u8>> {
+    if blobs.len() > MAX_COMPACT_COUNT {
+        return Err(super::invalid(format!(
+            "blob frame count {} exceeds maximum {MAX_COMPACT_COUNT}",
+            blobs.len()
+        )));
+    }
     let mut output = Writer::new(BLOB_MAGIC);
     output.put_u64(blobs.len() as u64);
     if let Some((first, rest)) = blobs.split_first() {
@@ -43,7 +50,7 @@ pub fn encode_blob_frame(blobs: &[&[u8]]) -> Result<Vec<u8>> {
 /// Decode and whole-frame-verify every indexed blob slice.
 pub fn decode_blob_frame(bytes: &[u8]) -> Result<Vec<DecodedBlob<'_>>> {
     let mut input = Reader::verified(bytes, BLOB_MAGIC)?;
-    let count = input.get_count("blob frame")?;
+    let count = input.get_count("blob frame", MIN_BLOB_ITEM_BYTES)?;
     let mut lengths = Vec::with_capacity(count);
     if count > 0 {
         let first = input.get_u64()?;

--- a/crates/object-model/src/compact/hostile.rs
+++ b/crates/object-model/src/compact/hostile.rs
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{decode_blob_frame, decode_state_frame, decode_tree_frame};
-
-/// Matches the packer writer split (`FRAME_LIMIT` in `objects`).
-const MAX_COMPACT_COUNT: usize = 12 * 1024 * 1024;
+use super::{
+    decode_blob_frame, decode_state_frame, decode_tree_frame, encode_state_frame,
+    limits::MAX_COMPACT_COUNT,
+};
+use crate::object::{Attribution, ContentHash, Principal, State};
 
 #[test]
 fn blob_frame_rejects_declared_count_above_object_cap() {
@@ -39,6 +40,17 @@ fn state_frame_count_that_fits_remaining_bytes_still_fails_column_floor() {
         error.to_string().contains("bytes per item"),
         "state count that only fits a 1-byte remaining() check must fail before blank_state materialization, got {error}"
     );
+}
+
+#[test]
+fn minimal_state_frame_survives_column_floor() {
+    let mut state = State::new(
+        ContentHash::from_bytes([1; 32]),
+        Vec::new(),
+        Attribution::human(Principal::new("A", "a@b.c")),
+    );
+    state.state_id = state.id();
+    decode_state_frame(&encode_state_frame(&[state]).unwrap()).unwrap();
 }
 
 fn frame(magic: &[u8; 4], after_magic: &[u8]) -> Vec<u8> {

--- a/crates/object-model/src/compact/hostile.rs
+++ b/crates/object-model/src/compact/hostile.rs
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{decode_blob_frame, decode_state_frame, decode_tree_frame};
+
+/// Matches the packer writer split (`FRAME_LIMIT` in `objects`).
+const MAX_COMPACT_COUNT: usize = 12 * 1024 * 1024;
+
+#[test]
+fn blob_frame_rejects_declared_count_above_object_cap() {
+    let mut payload = Vec::new();
+    put_u64(&mut payload, (MAX_COMPACT_COUNT + 1) as u64);
+    let error = decode_blob_frame(&frame(b"HCB2", &payload)).unwrap_err();
+    assert!(
+        error.to_string().contains("exceeds maximum"),
+        "hostile blob count must fail at the count gate before with_capacity, got {error}"
+    );
+}
+
+#[test]
+fn tree_entry_count_that_fits_remaining_bytes_still_fails_encoded_floor() {
+    let mut payload = Vec::new();
+    put_u64(&mut payload, 1);
+    put_u64(&mut payload, 100);
+    payload.resize(payload.len() + 100, 0);
+    let error = decode_tree_frame(&frame(b"HCT1", &payload)).unwrap_err();
+    assert!(
+        error.to_string().contains("bytes per item"),
+        "tree entry count that only fits a 1-byte remaining() check must fail before with_capacity, got {error}"
+    );
+}
+
+#[test]
+fn state_frame_count_that_fits_remaining_bytes_still_fails_column_floor() {
+    let mut payload = Vec::new();
+    put_u64(&mut payload, 200);
+    payload.resize(payload.len() + 200, 0);
+    let error = decode_state_frame(&frame(b"HCS1", &payload)).unwrap_err();
+    assert!(
+        error.to_string().contains("bytes per item"),
+        "state count that only fits a 1-byte remaining() check must fail before blank_state materialization, got {error}"
+    );
+}
+
+fn frame(magic: &[u8; 4], after_magic: &[u8]) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(4 + after_magic.len() + 32);
+    bytes.extend_from_slice(magic);
+    bytes.extend_from_slice(after_magic);
+    let digest = blake3::hash(&bytes);
+    bytes.extend_from_slice(digest.as_bytes());
+    bytes
+}
+
+fn put_u64(out: &mut Vec<u8>, mut value: u64) {
+    while value >= 0x80 {
+        out.push((value as u8) | 0x80);
+        value >>= 7;
+    }
+    out.push(value as u8);
+}

--- a/crates/object-model/src/compact/io.rs
+++ b/crates/object-model/src/compact/io.rs
@@ -139,15 +139,19 @@ impl<'a> Reader<'a> {
         Ok(((value >> 1) as i64) ^ (-((value & 1) as i64)))
     }
 
-    pub(super) fn get_count(&mut self, field: &str) -> Result<usize> {
+    pub(super) fn get_count(&mut self, field: &str, min_item_bytes: usize) -> Result<usize> {
+        self.get_count_at_most(field, min_item_bytes, super::limits::MAX_COMPACT_COUNT)
+    }
+
+    pub(super) fn get_count_at_most(
+        &mut self,
+        field: &str,
+        min_item_bytes: usize,
+        max_count: usize,
+    ) -> Result<usize> {
         let count = usize::try_from(self.get_u64()?)
             .map_err(|_| invalid(format!("{field} count exceeds platform limits")))?;
-        if count > self.remaining() {
-            return Err(invalid(format!(
-                "{field} count {count} exceeds remaining frame bytes {}",
-                self.remaining()
-            )));
-        }
+        super::limits::admit_count(field, count, self.remaining(), min_item_bytes, max_count)?;
         Ok(count)
     }
 

--- a/crates/object-model/src/compact/limits.rs
+++ b/crates/object-model/src/compact/limits.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Result, invalid};
+
+/// Matches the packer writer split (`FRAME_LIMIT` in `objects`).
+///
+/// A legitimate compact frame is at most 12 MiB, so a 1-byte item cannot
+/// exceed this many declarations. Combined with [`admit_count`], a hostile
+/// 1 GiB pack object cannot force a `Vec` reservation from an attacker
+/// count near the decompress cap.
+pub(super) const MAX_COMPACT_COUNT: usize = 12 * 1024 * 1024;
+
+/// In-memory `State` values are much larger than their compact columns.
+/// Cap declared state-frame counts so `blank_state()` cannot approach
+/// process-aborting allocation. The writer batches states by 12 MiB of
+/// messagepack, well below this many objects.
+pub(super) const MAX_COMPACT_STATE_COUNT: usize = 1024 * 1024;
+
+/// Empty blob bodies are valid; each length is at least a 1-byte varint.
+pub(super) const MIN_BLOB_ITEM_BYTES: usize = 1;
+
+/// An empty tree is a single zero entry-count varint.
+pub(super) const MIN_TREE_ITEM_BYTES: usize = 1;
+
+/// Smallest valid tree entry: mode + kind + 1-byte name + SHA-1 gitlink.
+pub(super) const MIN_TREE_ENTRY_BYTES: usize = 1 + 1 + 2 + 21;
+
+/// Columnar floor after dictionaries: change_id, tree, and the per-state
+/// tags/varints a minimal state always writes.
+pub(super) const MIN_STATE_COLUMN_BYTES: usize = 16 + 32 + 18;
+
+pub(super) const MIN_STATE_PARENT_BYTES: usize = 32;
+pub(super) const MIN_EXTRA_HEADER_BYTES: usize = 2;
+pub(super) const MIN_LINEAGE_BYTES: usize = 1 + 16 + 32;
+pub(super) const MIN_VERIFICATION_CUSTOM_BYTES: usize = 2;
+pub(super) const MIN_PRINCIPAL_BYTES: usize = 2;
+pub(super) const MIN_AGENT_BYTES: usize = 5;
+
+/// Reject a declared count before any `Vec::with_capacity` or `blank_state`.
+pub(super) fn admit_count(
+    field: &str,
+    count: usize,
+    remaining: usize,
+    min_item_bytes: usize,
+    max_count: usize,
+) -> Result<()> {
+    if count > max_count {
+        return Err(invalid(format!(
+            "{field} count {count} exceeds maximum {max_count}"
+        )));
+    }
+    let min_item_bytes = min_item_bytes.max(1);
+    match count.checked_mul(min_item_bytes) {
+        Some(needed) if needed <= remaining => Ok(()),
+        _ => Err(invalid(format!(
+            "{field} count {count} exceeds remaining frame bytes {remaining} at {min_item_bytes} bytes per item"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_output_cap_declaration_fails_before_any_alloc() {
+        let remaining = 1024 * 1024 * 1024;
+        let error = admit_count("blob frame", remaining, remaining, 1, MAX_COMPACT_COUNT)
+            .expect_err("1 GiB declared count must not be admitted");
+        assert!(
+            error.to_string().contains("exceeds maximum"),
+            "count gate must fire before with_capacity, got {error}"
+        );
+    }
+
+    #[test]
+    fn encoded_floor_rejects_count_that_fits_remaining_bytes() {
+        let error = admit_count(
+            "tree entry",
+            5,
+            100,
+            MIN_TREE_ENTRY_BYTES,
+            MAX_COMPACT_COUNT,
+        )
+        .expect_err("1-byte remaining() floor is not enough");
+        assert!(error.to_string().contains("bytes per item"), "got {error}");
+    }
+
+    #[test]
+    fn encoded_floor_accepts_count_that_fits() {
+        admit_count(
+            "tree entry",
+            4,
+            4 * MIN_TREE_ENTRY_BYTES,
+            MIN_TREE_ENTRY_BYTES,
+            MAX_COMPACT_COUNT,
+        )
+        .expect("exact floor must be admitted");
+    }
+}

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -52,3 +52,5 @@ pub(crate) fn invalid(message: impl Into<String>) -> CompactError {
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod hostile;

--- a/crates/object-model/src/compact/mod.rs
+++ b/crates/object-model/src/compact/mod.rs
@@ -5,6 +5,7 @@ mod blob;
 mod dictionary;
 mod extract;
 mod io;
+mod limits;
 mod state;
 mod state_decode;
 mod tree;
@@ -51,6 +52,6 @@ pub(crate) fn invalid(message: impl Into<String>) -> CompactError {
 }
 
 #[cfg(test)]
-mod tests;
-#[cfg(test)]
 mod hostile;
+#[cfg(test)]
+mod tests;

--- a/crates/object-model/src/compact/state.rs
+++ b/crates/object-model/src/compact/state.rs
@@ -3,7 +3,9 @@
 use super::{
     Result,
     dictionary::{PrincipalKey, StateDictionaries},
+    invalid,
     io::Writer,
+    limits::MAX_COMPACT_STATE_COUNT,
 };
 use crate::object::{ChangeLineageKind, State};
 
@@ -16,6 +18,12 @@ pub fn is_state_frame(bytes: &[u8]) -> bool {
 
 /// Encode states as lossless columns, omitting only the derivable state id.
 pub fn encode_state_frame(states: &[State]) -> Result<Vec<u8>> {
+    if states.len() > MAX_COMPACT_STATE_COUNT {
+        return Err(invalid(format!(
+            "state frame count {} exceeds maximum {MAX_COMPACT_STATE_COUNT}",
+            states.len()
+        )));
+    }
     let dictionaries = StateDictionaries::from_states(states);
     let mut output = Writer::new(STATE_MAGIC);
     output.put_u64(states.len() as u64);

--- a/crates/object-model/src/compact/state_decode.rs
+++ b/crates/object-model/src/compact/state_decode.rs
@@ -9,6 +9,11 @@ use super::{
     dictionary::{AgentKey, PrincipalKey},
     invalid,
     io::Reader,
+    limits::{
+        MAX_COMPACT_STATE_COUNT, MIN_AGENT_BYTES, MIN_EXTRA_HEADER_BYTES, MIN_LINEAGE_BYTES,
+        MIN_PRINCIPAL_BYTES, MIN_STATE_COLUMN_BYTES, MIN_STATE_PARENT_BYTES,
+        MIN_VERIFICATION_CUSTOM_BYTES, admit_count,
+    },
     state::STATE_MAGIC,
 };
 use crate::object::{
@@ -19,8 +24,15 @@ use crate::object::{
 /// Decode and whole-frame-verify every state, recomputing each state id.
 pub fn decode_state_frame(bytes: &[u8]) -> Result<Vec<State>> {
     let mut input = Reader::verified(bytes, STATE_MAGIC)?;
-    let count = input.get_count("state frame")?;
+    let count = input.get_count_at_most("state frame", 1, MAX_COMPACT_STATE_COUNT)?;
     let (principals, agents) = decode_dictionaries(&mut input)?;
+    admit_count(
+        "state frame",
+        count,
+        input.remaining(),
+        MIN_STATE_COLUMN_BYTES,
+        MAX_COMPACT_STATE_COUNT,
+    )?;
     let mut states = (0..count).map(|_| blank_state()).collect::<Vec<_>>();
     decode_structure(&mut input, &mut states)?;
     decode_attribution(&mut input, &mut states, &principals, &agents)?;
@@ -43,7 +55,7 @@ fn decode_structure(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> 
         state.tree = ContentHash::from_bytes(input.get_fixed()?);
     }
     for state in states {
-        let count = input.get_count("state parent")?;
+        let count = input.get_count("state parent", MIN_STATE_PARENT_BYTES)?;
         state.parents = (0..count)
             .map(|_| Ok(StateId::from_bytes(input.get_fixed()?)))
             .collect::<Result<Vec<_>>>()?;
@@ -144,7 +156,7 @@ fn decode_fidelity(
         state.raw_message = input.get_optional_bytes()?;
     }
     for state in &mut *states {
-        let count = input.get_count("extra header")?;
+        let count = input.get_count("extra header", MIN_EXTRA_HEADER_BYTES)?;
         state.extra_headers = (0..count)
             .map(|_| Ok((input.get_bytes()?, input.get_bytes()?)))
             .collect::<Result<Vec<_>>>()?;
@@ -157,7 +169,7 @@ fn decode_fidelity(
 
 fn decode_lineage(input: &mut Reader<'_>, states: &mut [State]) -> Result<()> {
     for state in states {
-        let count = input.get_count("state lineage")?;
+        let count = input.get_count("state lineage", MIN_LINEAGE_BYTES)?;
         state.lineage = (0..count)
             .map(|_| {
                 Ok(ChangeLineage {
@@ -180,7 +192,7 @@ fn decode_verification(input: &mut Reader<'_>) -> Result<Option<Verification>> {
             let coverage_pct = get_optional_f32(input)?;
             let coverage_delta = get_optional_f32(input)?;
             let lint_warnings = get_optional_u32(input)?;
-            let count = input.get_count("verification custom")?;
+            let count = input.get_count("verification custom", MIN_VERIFICATION_CUSTOM_BYTES)?;
             let mut custom = BTreeMap::new();
             for _ in 0..count {
                 let key = String::from_utf8(input.get_bytes()?)
@@ -201,10 +213,10 @@ fn decode_verification(input: &mut Reader<'_>) -> Result<Option<Verification>> {
 }
 
 fn decode_dictionaries(input: &mut Reader<'_>) -> Result<(Vec<Principal>, Vec<Agent>)> {
-    let principals = (0..input.get_count("principal dictionary")?)
+    let principals = (0..input.get_count("principal dictionary", MIN_PRINCIPAL_BYTES)?)
         .map(|_| principal_from_key(PrincipalKey(input.get_bytes()?, input.get_bytes()?)))
         .collect::<Result<Vec<_>>>()?;
-    let agents = (0..input.get_count("agent dictionary")?)
+    let agents = (0..input.get_count("agent dictionary", MIN_AGENT_BYTES)?)
         .map(|_| {
             agent_from_key(AgentKey {
                 provider: input.get_bytes()?,

--- a/crates/object-model/src/compact/tree.rs
+++ b/crates/object-model/src/compact/tree.rs
@@ -5,6 +5,7 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 use super::{
     Result, invalid,
     io::{Reader, Writer, varint_len},
+    limits::{MAX_COMPACT_COUNT, MIN_TREE_ENTRY_BYTES, MIN_TREE_ITEM_BYTES},
 };
 use crate::object::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry};
 
@@ -28,6 +29,21 @@ pub fn encoded_tree_size(tree: &Tree) -> usize {
 
 /// Encode name-sorted trees as columnar mode/kind/name/target payloads.
 pub fn encode_tree_frame(trees: &[Tree]) -> Result<Vec<u8>> {
+    if trees.len() > MAX_COMPACT_COUNT {
+        return Err(invalid(format!(
+            "tree frame count {} exceeds maximum {MAX_COMPACT_COUNT}",
+            trees.len()
+        )));
+    }
+    if let Some(count) = trees
+        .iter()
+        .map(Tree::len)
+        .find(|len| *len > MAX_COMPACT_COUNT)
+    {
+        return Err(invalid(format!(
+            "tree entry count {count} exceeds maximum {MAX_COMPACT_COUNT}"
+        )));
+    }
     let mut output = Writer::new(TREE_MAGIC);
     output.put_u64(trees.len() as u64);
     for tree in trees {
@@ -52,7 +68,7 @@ pub fn encode_tree_frame(trees: &[Tree]) -> Result<Vec<u8>> {
 /// Decode and whole-frame-verify every tree in a compact frame.
 pub fn decode_tree_frame(bytes: &[u8]) -> Result<Vec<Tree>> {
     let mut input = Reader::verified(bytes, TREE_MAGIC)?;
-    let tree_count = input.get_count("tree frame")?;
+    let tree_count = input.get_count("tree frame", MIN_TREE_ITEM_BYTES)?;
     let mut trees = Vec::with_capacity(tree_count);
     for _ in 0..tree_count {
         trees.push(decode_tree(&mut input)?);
@@ -67,7 +83,7 @@ pub fn decode_tree_frame(bytes: &[u8]) -> Result<Vec<Tree>> {
 /// SoA columns until `expected` matches the reconstructed typed hash.
 pub fn extract_tree(bytes: &[u8], expected: ContentHash) -> Result<Tree> {
     let mut input = Reader::verified(bytes, TREE_MAGIC)?;
-    let tree_count = input.get_count("tree frame")?;
+    let tree_count = input.get_count("tree frame", MIN_TREE_ITEM_BYTES)?;
     for _ in 0..tree_count {
         let tree = decode_tree(&mut input)?;
         if tree.hash() == expected {
@@ -78,7 +94,7 @@ pub fn extract_tree(bytes: &[u8], expected: ContentHash) -> Result<Tree> {
 }
 
 fn decode_tree(input: &mut Reader<'_>) -> Result<Tree> {
-    let count = input.get_count("tree entry")?;
+    let count = input.get_count("tree entry", MIN_TREE_ENTRY_BYTES)?;
     let modes = (0..count)
         .map(|_| decode_mode(input.get_u8()?))
         .collect::<Result<Vec<_>>>()?;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Compact-frame `get_count` used to admit any declared count that fit in remaining frame bytes. Empty blob bodies and 1-byte length deltas could therefore declare a count near the 1 GiB pack-object decompress cap, and `decode_blob_frame` / `decode_tree_frame` / `decode_state_frame` would `Vec::with_capacity` or `blank_state()` that many slots before the object set was rejected.
- Admission now happens in `admit_count` before any prealloc: a 12 MiB writer-frame object ceiling (`MAX_COMPACT_COUNT`, matching packer `FRAME_LIMIT`) plus a real per-entry encoded floor. State frames use a tighter 1M cap and re-check the columnar floor after dictionaries, so `blank_state()` cannot run on a remaining()-only count.
- Hostile checksum-valid frames that pass the old 1-byte `remaining()` check now fail at the count gate. Legitimate encode/decode round-trips are unchanged.

## Closes

Closes HeddleCo/heddle#1408

## Red commit
`cd2814ec`

The red commit added decode tests that required `exceeds maximum` / `bytes per item` at the count gate. On main they failed with `remaining frame bytes` or `truncated compact payload` after the old `get_count` had already accepted the declaration.

## Test evidence
```
$ cargo test -p heddle-object-model --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.27s
     Running unittests src/lib.rs (target/debug/deps/heddle_object_model-dbffae9332fc3a8e)

running 207 tests
test compact::hostile::blob_frame_rejects_declared_count_above_object_cap ... ok
test compact::hostile::minimal_state_frame_survives_column_floor ... ok
test compact::hostile::state_frame_count_that_fits_remaining_bytes_still_fails_column_floor ... ok
test compact::hostile::tree_entry_count_that_fits_remaining_bytes_still_fails_encoded_floor ... ok
test compact::limits::tests::encoded_floor_accepts_count_that_fits ... ok
test compact::limits::tests::pack_output_cap_declaration_fails_before_any_alloc ... ok
test compact::limits::tests::encoded_floor_rejects_count_that_fits_remaining_bytes ... ok
test compact::tests::blob_frame_round_trips_offsets_lengths_and_typed_hashes ... ok
test compact::tests::corrupt_blob_frame_byte_rejects_every_contained_object ... ok
test compact::tests::corrupt_frame_byte_rejects_every_contained_object ... ok
test compact::tests::extract_rejects_a_forged_typed_hash ... ok
test compact::tests::extract_matches_decode_all_canonical_bytes ... ok
test compact::tests::extract_rejects_every_object_after_one_corrupt_frame_byte ... ok
test compact::tests::extract_state_matches_decode_all_canonical_bytes ... ok
test compact::tests::state_frame_round_trips_every_fidelity_field_and_recomputes_id ... ok
test compact::tests::tree_frame_round_trips_every_entry_kind_and_native_bytes ... ok
...
test result: ok. 207 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.15s
```

Also green:

- `cargo clippy -p heddle-object-model --all-targets -- -D warnings`
- `cargo test -p heddle-objects compact --lib` — 3 passed
- `cargo test -p heddle-pack compact --lib` — 3 passed

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0daff9b7-2ace-487e-a95a-1028d0b2ebf0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0daff9b7-2ace-487e-a95a-1028d0b2ebf0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1418"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789703297&installation_model_id=21489&pr_number=1418&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1418&signature=3f8484eb74f70b9918e210f385f1fc55866398e1653d73ee74b8a9d057d5c447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->