### PR TITLE
fix(hosted): hydrate the requested blob, not the whole tip

### DIFF
--- a/crates/cli/src/hosted_runtime/hosted/hydration.rs
+++ b/crates/cli/src/hosted_runtime/hosted/hydration.rs
@@ -26,8 +26,9 @@ const DEFAULT_HOSTED_HYDRATION_TIMEOUT: Duration = Duration::from_secs(30);
 /// [`Repository::require_blob`] hits a missing-blob marker left behind by a
 /// lazy hosted clone (`heddle clone --lazy <hosted-url>` /
 /// `--filter blob:none`), the read path delegates here, this hydrator re-runs
-/// the pull with full materialization for the *current* tip of `local_thread`,
-/// and the read is retried against the freshly populated store.
+/// a single-object fetch for the requested hash (path-resolved `GetBlob`,
+/// or a scoped pull that wants only that hash), and the read is retried
+/// against the freshly populated store.
 ///
 /// ## Runtime bridge
 ///
@@ -113,12 +114,11 @@ impl LazyHostedHydrator {
 }
 
 impl BlobHydrator for LazyHostedHydrator {
-    fn hydrate(&self, repo: &Repository, _hash: &ContentHash) -> objects::error::Result<()> {
-        // `_hash` is ignored: `hydrate_pulled_state` refetches every
-        // missing blob reachable from `target_state`, not just one. This
-        // matches the hosted-side strategy that already exists
-        // (sync.rs:541) and is the cheapest correct behaviour given the
-        // partial-fetch metadata records the blake3 only.
+    fn hydrate(&self, repo: &Repository, hash: &ContentHash) -> objects::error::Result<()> {
+        // Honor `hash`: fetch that object (plus whatever decode needs),
+        // not every missing blob on the current tip. Partial-fetch
+        // metadata records blake3 only, so the hosted client resolves a
+        // tip-tree path when one exists and otherwise wants this hash.
 
         // Re-resolve the target state from the repo on EVERY call. If a
         // `pull --lazy` advanced the local thread between clone and now,
@@ -146,7 +146,13 @@ impl BlobHydrator for LazyHostedHydrator {
 
         let bridge = self.ensure_bridge()?;
         bridge
-            .hydrate(repo, &self.repo_path, &self.remote_thread, target_state)
+            .hydrate(
+                repo,
+                &self.repo_path,
+                &self.remote_thread,
+                target_state,
+                *hash,
+            )
             .map(|_count| ())
             .map_err(|err| HeddleError::Io(std::io::Error::other(err.to_string())))
     }
@@ -173,6 +179,7 @@ enum HydrateMessage {
         repo_path: String,
         remote_thread: String,
         target_state: StateId,
+        hash: ContentHash,
         reply: mpsc::SyncSender<Result<usize, ProtocolError>>,
     },
 }
@@ -289,6 +296,7 @@ impl HydrationBridge {
                                 repo_path,
                                 remote_thread,
                                 target_state,
+                                hash,
                                 reply,
                             } => {
                                 let result = hydrate_with_rpc_timeout(
@@ -297,6 +305,7 @@ impl HydrationBridge {
                                     &repo_path,
                                     &remote_thread,
                                     target_state,
+                                    hash,
                                     DEFAULT_HOSTED_HYDRATION_TIMEOUT,
                                 )
                                 .await;
@@ -337,12 +346,14 @@ impl HydrationBridge {
         repo_path: &str,
         remote_thread: &str,
         target_state: StateId,
+        hash: ContentHash,
     ) -> Result<usize, ProtocolError> {
         self.hydrate_with_timeout(
             repo,
             repo_path,
             remote_thread,
             target_state,
+            hash,
             DEFAULT_HOSTED_HYDRATION_TIMEOUT,
         )
     }
@@ -353,6 +364,7 @@ impl HydrationBridge {
         repo_path: &str,
         remote_thread: &str,
         target_state: StateId,
+        hash: ContentHash,
         timeout: Duration,
     ) -> Result<usize, ProtocolError> {
         let repo = Arc::new(Repository::open(repo.root()).map_err(ProtocolError::from)?);
@@ -368,6 +380,7 @@ impl HydrationBridge {
                 repo_path: repo_path.to_string(),
                 remote_thread: remote_thread.to_string(),
                 target_state,
+                hash,
                 reply: reply_tx,
             })
             .map_err(|err| {
@@ -382,6 +395,7 @@ impl HydrationBridge {
                 repo_path,
                 remote_thread,
                 target_state,
+                hash,
             )),
             Err(mpsc::RecvTimeoutError::Disconnected) => {
                 Err(ProtocolError::Io(std::io::Error::other(
@@ -407,11 +421,12 @@ async fn hydrate_with_rpc_timeout(
     repo_path: &str,
     remote_thread: &str,
     target_state: StateId,
+    hash: ContentHash,
     timeout: Duration,
 ) -> Result<usize, ProtocolError> {
     match tokio::time::timeout(
         timeout,
-        client.hydrate_missing_blobs_for_state(repo, repo_path, remote_thread, target_state),
+        client.hydrate_blob(repo, repo_path, remote_thread, target_state, hash),
     )
     .await
     {
@@ -421,6 +436,7 @@ async fn hydrate_with_rpc_timeout(
             repo_path,
             remote_thread,
             target_state,
+            hash,
         )),
     }
 }
@@ -430,13 +446,16 @@ fn hydration_timeout_error(
     repo_path: &str,
     remote_thread: &str,
     target_state: StateId,
+    hash: ContentHash,
 ) -> ProtocolError {
     ProtocolError::Io(std::io::Error::new(
         std::io::ErrorKind::TimedOut,
         format!(
             "lazy hosted hydrator: blob hydration timed out after {} \
-             (repo={repo_path}, remote_thread={remote_thread}, target_state={target_state})",
-            format_duration(timeout)
+             (repo={repo_path}, remote_thread={remote_thread}, \
+             target_state={target_state}, hash={})",
+            format_duration(timeout),
+            hash.to_hex(),
         ),
     ))
 }
@@ -498,7 +517,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use objects::object::{Blob, StateId, ThreadName};
+    use objects::object::{Blob, ContentHash, StateId, ThreadName};
     use repo::Repository;
     use tempfile::TempDir;
 
@@ -677,6 +696,47 @@ mod tests {
         );
     }
 
+    /// Issue #1410: `hydrate` must forward the requested blake3, not
+    /// drop it and treat every miss as "hydrate the whole tip".
+    #[test]
+    fn hydrate_forwards_requested_hash_not_the_whole_tip() {
+        let recorded: Arc<std::sync::Mutex<Vec<ContentHash>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let recorded_for_worker = Arc::clone(&recorded);
+        let (tx, rx) = mpsc::channel::<super::HydrateMessage>();
+        let worker = thread::Builder::new()
+            .name("hash-inspect-hydrator".into())
+            .spawn(move || {
+                while let Ok(message) = rx.recv() {
+                    match message {
+                        super::HydrateMessage::Run { hash, reply, .. } => {
+                            recorded_for_worker.lock().unwrap().push(hash);
+                            let _ = reply.send(Ok(1));
+                        }
+                    }
+                }
+            })
+            .expect("spawn hash inspect worker");
+        let bridge = HydrationBridge {
+            tx: Some(tx),
+            worker: Some(worker),
+        };
+        let hydrator =
+            LazyHostedHydrator::new("ignored.example.test:443", "org/acme/repo", "main", "main");
+        hydrator.bridge.set(bridge).map_err(|_| ()).expect("set");
+
+        let (_temp, repo) = temp_repo();
+        let first = Blob::new(b"only-this-blob".to_vec()).hash();
+        let second = Blob::new(b"a-different-blob".to_vec()).hash();
+        assert_ne!(first, second, "fixture hashes must differ");
+
+        hydrator.hydrate(&repo, &first).expect("first hydrate");
+        hydrator.hydrate(&repo, &second).expect("second hydrate");
+
+        let seen = recorded.lock().unwrap().clone();
+        assert_eq!(seen, vec![first, second], "each miss forwards its own hash");
+    }
+
     /// Round-3 test from the task brief. With the round-2 design,
     /// concurrent first-time callers raced two separate `OnceLock::set`
     /// calls (runtime + inner) and could end up storing an inner whose
@@ -755,6 +815,7 @@ mod tests {
                 "org/acme/repo",
                 "main",
                 target,
+                Blob::new(b"timeout".to_vec()).hash(),
                 Duration::from_millis(50),
             )
             .expect_err("stalled worker must time out");
@@ -804,6 +865,7 @@ mod tests {
             repo_path: "org/acme/repo".to_string(),
             remote_thread: "main".to_string(),
             target_state: StateId::from_bytes([2; 32]),
+            hash: Blob::new(b"owned-handle".to_vec()).hash(),
             reply,
         };
         assert_send_static(&message);

--- a/crates/cli/src/hosted_runtime/hosted/hydration.rs
+++ b/crates/cli/src/hosted_runtime/hosted/hydration.rs
@@ -118,7 +118,8 @@ impl BlobHydrator for LazyHostedHydrator {
         // Honor `hash`: fetch that object (plus whatever decode needs),
         // not every missing blob on the current tip. Partial-fetch
         // metadata records blake3 only, so the hosted client resolves a
-        // tip-tree path when one exists and otherwise wants this hash.
+        // tip-tree path when one exists and GetBlob-s that state. A
+        // moved-path mismatch falls through to a single-hash want.
 
         // Re-resolve the target state from the repo on EVERY call. If a
         // `pull --lazy` advanced the local thread between clone and now,

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -1420,6 +1420,18 @@ impl HostedClient {
         reference: &str,
         path: &str,
     ) -> Result<objects::object::Blob, ProtocolError> {
+        let blob = self.fetch_blob_at_path(repo_path, reference, path).await?;
+        repo.store().put_blob(&blob)?;
+        repo.clear_missing_blob(&blob.hash())?;
+        Ok(blob)
+    }
+
+    async fn fetch_blob_at_path(
+        &mut self,
+        repo_path: &str,
+        reference: &str,
+        path: &str,
+    ) -> Result<objects::object::Blob, ProtocolError> {
         let request = GetBlobRequest {
             repo_path: super::helpers::repository_ref(repo_path),
             r#ref: reference.to_string(),
@@ -1434,18 +1446,17 @@ impl HostedClient {
             .map_err(hosted_to_protocol_error)?;
 
         let content = super::helpers::decode_blob_content(response.content, response.is_binary)?;
-        let blob = objects::object::Blob::new(content);
-        repo.store().put_blob(&blob)?;
-        repo.clear_missing_blob(&blob.hash())?;
-        Ok(blob)
+        Ok(objects::object::Blob::new(content))
     }
 
     /// Hydrate one missing blob by hash (issue #1410).
     ///
     /// A lazy miss must not pull every blob reachable from the tip.
     /// When the hash is in the local tip tree, this is a unary
-    /// [`GetBlob`] at that path. Otherwise it wants only this hash
-    /// through a scoped pull (`want_full_closure = false`).
+    /// [`GetBlob`] at that path, addressed at `target_state` so a
+    /// later remote-thread move cannot silently change the object.
+    /// A hash mismatch or GetBlob failure falls through to a scoped
+    /// pull that wants only this hash (`want_full_closure = false`).
     pub async fn hydrate_blob(
         &mut self,
         repo: &Repository,
@@ -1460,19 +1471,29 @@ impl HostedClient {
         }
 
         if let Some(path) = first_blob_path_in_state(repo, target_state, &hash)? {
-            let blob = self
-                .hydrate_blob_at_path(repo, repo_path, remote_thread, &path)
-                .await?;
-            if blob.hash() != hash {
-                return Err(ProtocolError::InvalidState(format!(
-                    "lazy hosted hydrator: GetBlob {path} returned {} instead of {}",
-                    blob.hash().to_hex(),
-                    hash.to_hex(),
-                )));
+            let reference = RevisionAddress::heddle(target_state).to_string();
+            match self.fetch_blob_at_path(repo_path, &reference, &path).await {
+                Ok(blob) if blob.hash() == hash => {
+                    repo.store().put_blob(&blob)?;
+                    repo.clear_missing_blob(&hash)?;
+                    return Ok(1);
+                }
+                Ok(_) | Err(_) => {}
             }
-            return Ok(1);
         }
 
+        self.hydrate_requested_hash(repo, repo_path, remote_thread, target_state, hash)
+            .await
+    }
+
+    async fn hydrate_requested_hash(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        target_state: StateId,
+        hash: ContentHash,
+    ) -> Result<usize, ProtocolError> {
         let hashes = [hash];
         let exchange = self
             .pull_exchange(
@@ -3580,6 +3601,69 @@ mod on_demand_hydration_tests {
 
         client.close().await;
         server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn hydrate_blob_falls_through_to_hash_pull_when_get_blob_returns_a_moved_path() {
+        let (_temp, repo, state, wanted, other) = lazy_two_file_repo();
+        let remote_state = super::super::helpers::proto_state_id(state).unwrap();
+        let (pack_data, index_data) = pack_containing_blob(&wanted);
+        let moved = Blob::from("live tip reused this path\n");
+        assert_ne!(moved.hash(), wanted.hash());
+
+        let (mut client, server, requested) =
+            crate::hosted_runtime::hosted::test_server::start_with_get_blob_contents_and_pull_pack(
+                [
+                    ("wanted.txt".to_string(), moved.content().to_vec()),
+                    ("other.txt".to_string(), other.content().to_vec()),
+                ],
+                remote_state,
+                pack_data,
+                index_data,
+            )
+            .await;
+
+        let fetched = client
+            .hydrate_blob(
+                &repo,
+                "acme/widgets",
+                super::PULL_CLONE_BOOTSTRAP_THREAD_PREFIX,
+                state,
+                wanted.hash(),
+            )
+            .await
+            .unwrap();
+        assert!(fetched >= 1);
+        assert!(repo.store().has_blob(&wanted.hash()).unwrap());
+        assert!(!repo.store().has_blob(&other.hash()).unwrap());
+        assert!(!repo.store().has_blob(&moved.hash()).unwrap());
+        assert!(!repo.is_missing_blob(&wanted.hash()).unwrap());
+        assert!(repo.is_missing_blob(&other.hash()).unwrap());
+        assert_eq!(
+            requested.lock().unwrap().clone(),
+            vec!["wanted.txt".to_string()],
+            "moved-path GetBlob must not fetch the sibling"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+
+    fn pack_containing_blob(blob: &Blob) -> (Vec<u8>, Vec<u8>) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        repo.store().put_blob(blob).unwrap();
+        let pack = wire::build_native_pack(
+            repo.store(),
+            &[wire::ObjectInfo {
+                id: wire::ObjectId::Hash(blob.hash()),
+                obj_type: wire::ObjectType::Blob,
+                size: 0,
+                delta_base: None,
+            }],
+        )
+        .unwrap();
+        (pack.pack_data, pack.index_data)
     }
 }
 

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -61,6 +61,10 @@ struct PullOptions<'a> {
     target_state: Option<StateId>,
     materialization: PullMaterialization,
     publish_refs: bool,
+    /// When set, the pull wants only these blob hashes and never the
+    /// full tip closure. Used by on-demand lazy hydration so one
+    /// missing-blob read cannot pull every blob on the thread tip.
+    wanted_hashes: Option<&'a [ContentHash]>,
 }
 
 const PULL_BOOTSTRAP_LINE_PREFIX: &str = "heddle-pull-bootstrap-v1:";
@@ -1250,6 +1254,7 @@ impl HostedClient {
                 target_state: None,
                 materialization: PullMaterialization::Full,
                 publish_refs: true,
+                wanted_hashes: None,
             },
         )
         .await
@@ -1272,6 +1277,7 @@ impl HostedClient {
                 target_state: None,
                 materialization: PullMaterialization::Full,
                 publish_refs: true,
+                wanted_hashes: None,
             },
         )
         .await
@@ -1297,6 +1303,7 @@ impl HostedClient {
                 target_state: None,
                 materialization,
                 publish_refs: true,
+                wanted_hashes: None,
             },
         )
         .await
@@ -1320,6 +1327,7 @@ impl HostedClient {
                 target_state: None,
                 materialization,
                 publish_refs: false,
+                wanted_hashes: None,
             },
         )
         .await
@@ -1351,6 +1359,7 @@ impl HostedClient {
                     target_state: None,
                     materialization,
                     publish_refs: false,
+                    wanted_hashes: None,
                 },
                 Some(Box::new(initialize)),
             )
@@ -1397,6 +1406,7 @@ impl HostedClient {
                 target_state: Some(target_state),
                 materialization: PullMaterialization::Full,
                 publish_refs: true,
+                wanted_hashes: None,
             },
         )
         .await
@@ -1430,6 +1440,62 @@ impl HostedClient {
         Ok(blob)
     }
 
+    /// Hydrate one missing blob by hash (issue #1410).
+    ///
+    /// A lazy miss must not pull every blob reachable from the tip.
+    /// When the hash is in the local tip tree, this is a unary
+    /// [`GetBlob`] at that path. Otherwise it wants only this hash
+    /// through a scoped pull (`want_full_closure = false`).
+    pub async fn hydrate_blob(
+        &mut self,
+        repo: &Repository,
+        repo_path: &str,
+        remote_thread: &str,
+        target_state: StateId,
+        hash: ContentHash,
+    ) -> Result<usize, ProtocolError> {
+        if repo.store().has_blob(&hash)? {
+            repo.clear_missing_blob(&hash)?;
+            return Ok(0);
+        }
+
+        if let Some(path) = first_blob_path_in_state(repo, target_state, &hash)? {
+            let blob = self
+                .hydrate_blob_at_path(repo, repo_path, remote_thread, &path)
+                .await?;
+            if blob.hash() != hash {
+                return Err(ProtocolError::InvalidState(format!(
+                    "lazy hosted hydrator: GetBlob {path} returned {} instead of {}",
+                    blob.hash().to_hex(),
+                    hash.to_hex(),
+                )));
+            }
+            return Ok(1);
+        }
+
+        let hashes = [hash];
+        let exchange = self
+            .pull_exchange(
+                repo,
+                repo_path,
+                remote_thread,
+                PullOptions {
+                    local_thread: None,
+                    depth: None,
+                    target_state: Some(target_state),
+                    materialization: PullMaterialization::Lazy,
+                    publish_refs: false,
+                    wanted_hashes: Some(&hashes),
+                },
+            )
+            .await?;
+        if !repo.store().has_blob(&hash)? {
+            return Err(ProtocolError::ObjectNotFound(hash.to_hex()));
+        }
+        repo.clear_missing_blob(&hash)?;
+        Ok(exchange.object_count)
+    }
+
     pub async fn hydrate_missing_blobs_for_state(
         &mut self,
         repo: &Repository,
@@ -1448,6 +1514,7 @@ impl HostedClient {
                     target_state: Some(target_state),
                     materialization: PullMaterialization::Full,
                     publish_refs: true,
+                    wanted_hashes: None,
                 },
             )
             .await?;
@@ -1639,13 +1706,17 @@ impl HostedClient {
             transfer_plan,
             wanted_types,
             want_full_closure,
-        } = plan_pull_wants(
-            repo,
-            &remote_state,
-            ready.full_closure_available,
-            ready.objects_to_fetch,
-            allow_partial_fetch,
-        )?;
+        } = if let Some(hashes) = options.wanted_hashes {
+            plan_on_demand_blob_wants(repo, hashes)?
+        } else {
+            plan_pull_wants(
+                repo,
+                &remote_state,
+                ready.full_closure_available,
+                ready.objects_to_fetch,
+                allow_partial_fetch,
+            )?
+        };
         let native_pack_required = native_pack_required_for_pull(want_full_closure, &transfer_plan);
 
         tx.send(PullClientFrame {
@@ -2532,6 +2603,57 @@ fn load_thread_metadata(
     Ok(thread_manager.find_synced_record_by_thread(repo, target_thread, Some(local_state))?)
 }
 
+fn first_blob_path_in_state(
+    repo: &Repository,
+    target_state: StateId,
+    hash: &ContentHash,
+) -> Result<Option<String>, ProtocolError> {
+    let paths = repo
+        .paths_to_blob_in_state(&target_state, hash)
+        .map_err(|err| ProtocolError::InvalidState(err.to_string()))?;
+    Ok(paths.into_iter().next())
+}
+
+fn plan_on_demand_blob_wants(
+    repo: &Repository,
+    hashes: &[ContentHash],
+) -> Result<PullWantPlan, ProtocolError> {
+    let mut wants = Vec::with_capacity(hashes.len());
+    let mut wanted_infos = Vec::with_capacity(hashes.len());
+    let mut wanted_types = HashMap::with_capacity(hashes.len());
+    for hash in hashes {
+        if repo.store().has_blob(hash)? {
+            continue;
+        }
+        let info = ObjectInfo {
+            id: wire::ObjectId::Hash(*hash),
+            obj_type: ObjectType::Blob,
+            size: 0,
+            delta_base: None,
+        };
+        record_wanted_type(
+            &mut wanted_types,
+            PackObjectId::Hash(*hash),
+            ObjectType::Blob,
+        );
+        wants.push(object_descriptor_with_status(
+            &info,
+            ObjectAvailabilityStatus::Missing,
+            "requested by lazy hydrator",
+        ));
+        wanted_infos.push(info);
+    }
+    Ok(PullWantPlan {
+        wants,
+        transfer_plan: RepositoryTransferPlan::from_object_infos(
+            wanted_infos,
+            GitLaneTransferIntent::HeddleObjectsOnly,
+        ),
+        wanted_types,
+        want_full_closure: false,
+    })
+}
+
 fn plan_pull_wants(
     repo: &Repository,
     remote_state: &StateId,
@@ -3353,6 +3475,107 @@ mod native_exchange_tests {
                 .join(".heddle/owner-authorization.bin")
                 .is_file(),
             "clone must persist the verified PullReady owner genesis before installing objects"
+        );
+
+        client.close().await;
+        server.await.unwrap();
+    }
+}
+
+#[cfg(test)]
+mod on_demand_hydration_tests {
+    use objects::{
+        object::{Attribution, Blob, Principal, State, ThreadName, Tree, TreeEntry},
+        store::ObjectStore,
+    };
+    use repo::Repository;
+    use tempfile::TempDir;
+
+    use super::{first_blob_path_in_state, plan_on_demand_blob_wants};
+
+    fn lazy_two_file_repo() -> (TempDir, Repository, objects::object::StateId, Blob, Blob) {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let wanted = Blob::from("wanted file\n");
+        let other = Blob::from("sibling file\n");
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("wanted.txt", wanted.hash(), false).unwrap(),
+            TreeEntry::file("other.txt", other.hash(), false).unwrap(),
+        ]);
+        let tree_hash = repo.store().put_tree(&tree).unwrap();
+        let state = State::new(
+            tree_hash,
+            Vec::new(),
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        );
+        repo.store().put_state(&state).unwrap();
+        repo.refs()
+            .set_thread(&ThreadName::from("main"), &state.id())
+            .unwrap();
+        repo.record_missing_blob(wanted.hash()).unwrap();
+        repo.record_missing_blob(other.hash()).unwrap();
+        (temp, repo, state.id(), wanted, other)
+    }
+
+    #[test]
+    fn first_blob_path_resolves_only_the_requested_hash() {
+        let (_temp, repo, state, wanted, other) = lazy_two_file_repo();
+        assert_eq!(
+            first_blob_path_in_state(&repo, state, &wanted.hash())
+                .unwrap()
+                .as_deref(),
+            Some("wanted.txt")
+        );
+        assert_eq!(
+            first_blob_path_in_state(&repo, state, &other.hash())
+                .unwrap()
+                .as_deref(),
+            Some("other.txt")
+        );
+        assert_eq!(
+            first_blob_path_in_state(&repo, state, &Blob::from("absent\n").hash()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn on_demand_wants_exclude_sibling_missing_blobs() {
+        let (_temp, repo, _state, wanted, other) = lazy_two_file_repo();
+        let plan = plan_on_demand_blob_wants(&repo, &[wanted.hash()]).unwrap();
+        assert!(!plan.want_full_closure, "on-demand must not want the tip");
+        assert_eq!(plan.wants.len(), 1);
+        assert_eq!(plan.wants[0].id, wanted.hash().to_hex());
+        assert!(
+            plan.wants
+                .iter()
+                .all(|want| want.id != other.hash().to_hex()),
+            "sibling missing blob must not be wanted"
+        );
+    }
+
+    #[tokio::test]
+    async fn hydrate_blob_fetches_only_the_requested_file() {
+        let (_temp, repo, state, wanted, other) = lazy_two_file_repo();
+        let (mut client, server, requested) =
+            crate::hosted_runtime::hosted::test_server::start_with_get_blob_contents([
+                ("wanted.txt".to_string(), wanted.content().to_vec()),
+                ("other.txt".to_string(), other.content().to_vec()),
+            ])
+            .await;
+
+        let fetched = client
+            .hydrate_blob(&repo, "acme/widgets", "main", state, wanted.hash())
+            .await
+            .unwrap();
+        assert_eq!(fetched, 1);
+        assert!(repo.store().has_blob(&wanted.hash()).unwrap());
+        assert!(!repo.store().has_blob(&other.hash()).unwrap());
+        assert!(!repo.is_missing_blob(&wanted.hash()).unwrap());
+        assert!(repo.is_missing_blob(&other.hash()).unwrap());
+        assert_eq!(
+            requested.lock().unwrap().clone(),
+            vec!["wanted.txt".to_string()],
+            "one missing-blob read must issue one GetBlob, not a tip fetch"
         );
 
         client.close().await;

--- a/crates/cli/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/cli/src/hosted_runtime/hosted/test_server.rs
@@ -1,25 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::net::Ipv4Addr;
+use std::{
+    collections::HashMap,
+    net::Ipv4Addr,
+    sync::{Arc, Mutex},
+};
 
 use api::{
     StreamingShape,
     framing::{
-        StreamFrame, decode_request_prelude, decode_stream_frame, encode_stream_message,
-        encode_success_response,
+        StreamFrame, decode_request_frame, decode_request_prelude, decode_stream_frame,
+        encode_stream_message, encode_success_response,
     },
     heddle::api::v1alpha1::{
-        GetContextHistoryPageEnd, GetContextHistoryResponse, ListContextPageEnd,
-        ListContextResponse, ListDiscussionsPageEnd, ListDiscussionsResponse, ListRefsPageEnd,
-        ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk, PackStreamKind,
-        PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete, PushReady,
-        PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint, TransportMode,
-        get_context_history_response, list_context_response, list_discussions_response,
-        list_refs_response, list_threads_response, pull_server_frame, push_client_frame,
-        push_server_frame,
+        BlobResponse, GetBlobRequest, GetContextHistoryPageEnd, GetContextHistoryResponse,
+        ListContextPageEnd, ListContextResponse, ListDiscussionsPageEnd, ListDiscussionsResponse,
+        ListRefsPageEnd, ListRefsResponse, ListThreadsPageEnd, ListThreadsResponse, PackChunk,
+        PackStreamKind, PullComplete, PullReady, PullServerFrame, PushClientFrame, PushComplete,
+        PushReady, PushServerFrame, SignedSpoolOwnerGenesis, StateId, TransferCheckpoint,
+        TransportMode, get_context_history_response, list_context_response,
+        list_discussions_response, list_refs_response, list_threads_response, pull_server_frame,
+        push_client_frame, push_server_frame,
     },
     method_descriptor,
 };
+use base64::Engine as _;
 use bytes::Bytes;
 use crypto::Ed25519Signer;
 use iroh::{Endpoint, RelayMode, endpoint::presets};
@@ -29,6 +34,7 @@ use tokio::task::JoinHandle;
 use super::{CallContextFactory, HostedClient};
 
 const OWNER_GENESIS_FIXTURE_HEX: &str = "0a380a10222222222222222222222222222222221224080112208a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c12640a20def88318e44a809464c1022f22230567bae6805d17b1ccfc2bebe5326232c58a1240bfe677c0b6fec8d28e379f584f36dee7258d834222f9b75f61dc75b7db2d836d76d4fb6eaf9e7f561925b2e6882b51eadaf3ec77c565f5b638ad0febfc8cd304";
+const GET_BLOB_METHOD: &str = "/heddle.api.v1alpha1.RepositoryService/GetBlob";
 
 fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
     let bytes = hex::decode(OWNER_GENESIS_FIXTURE_HEX).expect("published v2 fixture hex");
@@ -36,16 +42,19 @@ fn owner_genesis_fixture() -> SignedSpoolOwnerGenesis {
 }
 
 pub(crate) async fn start() -> (HostedClient, JoinHandle<()>) {
-    start_inner(None).await
+    start_inner(None, BlobFixture::default()).await
 }
 
 pub(crate) async fn start_with_remote_state(
     remote_state: StateId,
 ) -> (HostedClient, JoinHandle<()>) {
-    start_inner(Some(PullFixture {
-        remote_state,
-        pack: None,
-    }))
+    start_inner(
+        Some(PullFixture {
+            remote_state,
+            pack: None,
+        }),
+        BlobFixture::default(),
+    )
     .await
 }
 
@@ -54,11 +63,26 @@ pub(crate) async fn start_with_pull_pack(
     pack_data: Vec<u8>,
     index_data: Vec<u8>,
 ) -> (HostedClient, JoinHandle<()>) {
-    start_inner(Some(PullFixture {
-        remote_state,
-        pack: Some((pack_data, index_data)),
-    }))
+    start_inner(
+        Some(PullFixture {
+            remote_state,
+            pack: Some((pack_data, index_data)),
+        }),
+        BlobFixture::default(),
+    )
     .await
+}
+
+pub(crate) async fn start_with_get_blob_contents(
+    blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
+) -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+    let requested = Arc::new(Mutex::new(Vec::new()));
+    let fixture = BlobFixture {
+        contents: blobs.into_iter().collect(),
+        requested: Arc::clone(&requested),
+    };
+    let (client, server) = start_inner(None, fixture).await;
+    (client, server, requested)
 }
 
 #[derive(Clone)]
@@ -67,7 +91,16 @@ struct PullFixture {
     pack: Option<(Vec<u8>, Vec<u8>)>,
 }
 
-async fn start_inner(pull: Option<PullFixture>) -> (HostedClient, JoinHandle<()>) {
+#[derive(Clone, Default)]
+struct BlobFixture {
+    contents: HashMap<String, Vec<u8>>,
+    requested: Arc<Mutex<Vec<String>>>,
+}
+
+async fn start_inner(
+    pull: Option<PullFixture>,
+    blobs: BlobFixture,
+) -> (HostedClient, JoinHandle<()>) {
     let server = Endpoint::builder(presets::Minimal)
         .alpns(vec![api::HOSTED_ALPN_V1.to_vec()])
         .relay_mode(RelayMode::Disabled)
@@ -85,7 +118,7 @@ async fn start_inner(pull: Option<PullFixture>) -> (HostedClient, JoinHandle<()>
             .await
             .unwrap();
         while let Ok((send, recv)) = connection.accept_bi().await {
-            tokio::spawn(serve_call(send, recv, pull.clone()));
+            tokio::spawn(serve_call(send, recv, pull.clone(), blobs.clone()));
         }
         server.close().await;
     });
@@ -110,6 +143,7 @@ async fn serve_call(
     mut send: iroh::endpoint::SendStream,
     mut recv: iroh::endpoint::RecvStream,
     pull: Option<PullFixture>,
+    blobs: BlobFixture,
 ) {
     let mut request = Vec::new();
     let (method, prelude_len) = loop {
@@ -126,9 +160,13 @@ async fn serve_call(
     let descriptor = method_descriptor(&method).expect("registered hosted method");
     match descriptor.streaming {
         StreamingShape::Unary | StreamingShape::ClientStreaming => {
-            send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
-                .await
-                .unwrap();
+            if method == GET_BLOB_METHOD && !blobs.contents.is_empty() {
+                serve_get_blob(&mut send, &mut recv, &mut request, blobs).await;
+            } else {
+                send.write_chunk(Bytes::from(encode_success_response(&[]).unwrap()))
+                    .await
+                    .unwrap();
+            }
         }
         StreamingShape::ServerStreaming => {
             let body = terminal_page(&method);
@@ -315,6 +353,44 @@ fn bidi_responses(method: &str, pull: Option<PullFixture>) -> Vec<Vec<u8>> {
         }
         _ => Vec::new(),
     }
+}
+
+async fn serve_get_blob(
+    send: &mut iroh::endpoint::SendStream,
+    recv: &mut iroh::endpoint::RecvStream,
+    request: &mut Vec<u8>,
+    blobs: BlobFixture,
+) {
+    while let Ok(Some(chunk)) = recv.read_chunk(api::framing::MAX_CONTROL_BODY + 6).await {
+        request.extend_from_slice(&chunk);
+    }
+    let path = decode_request_frame(request)
+        .ok()
+        .and_then(|frame| GetBlobRequest::decode(frame.body).ok())
+        .map(|body| body.path)
+        .unwrap_or_default();
+    blobs
+        .requested
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push(path.clone());
+    let content = blobs.contents.get(&path).cloned().unwrap_or_default();
+    let is_binary = std::str::from_utf8(&content).is_err();
+    let encoded = if is_binary {
+        base64::engine::general_purpose::STANDARD.encode(&content)
+    } else {
+        String::from_utf8(content).unwrap_or_default()
+    };
+    let response = BlobResponse {
+        content: encoded,
+        is_binary,
+        ..Default::default()
+    };
+    send.write_chunk(Bytes::from(
+        encode_success_response(&response.encode_to_vec()).unwrap(),
+    ))
+    .await
+    .unwrap();
 }
 
 fn pack_frame(stream_kind: PackStreamKind, data: Vec<u8>) -> Vec<u8> {

--- a/crates/cli/src/hosted_runtime/hosted/test_server.rs
+++ b/crates/cli/src/hosted_runtime/hosted/test_server.rs
@@ -76,12 +76,35 @@ pub(crate) async fn start_with_pull_pack(
 pub(crate) async fn start_with_get_blob_contents(
     blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
 ) -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+    start_with_get_blob_contents_and_pull(blobs, None).await
+}
+
+pub(crate) async fn start_with_get_blob_contents_and_pull_pack(
+    blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
+    remote_state: StateId,
+    pack_data: Vec<u8>,
+    index_data: Vec<u8>,
+) -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
+    start_with_get_blob_contents_and_pull(
+        blobs,
+        Some(PullFixture {
+            remote_state,
+            pack: Some((pack_data, index_data)),
+        }),
+    )
+    .await
+}
+
+async fn start_with_get_blob_contents_and_pull(
+    blobs: impl IntoIterator<Item = (String, Vec<u8>)>,
+    pull: Option<PullFixture>,
+) -> (HostedClient, JoinHandle<()>, Arc<Mutex<Vec<String>>>) {
     let requested = Arc::new(Mutex::new(Vec::new()));
     let fixture = BlobFixture {
         contents: blobs.into_iter().collect(),
         requested: Arc::clone(&requested),
     };
-    let (client, server) = start_inner(None, fixture).await;
+    let (client, server) = start_inner(pull, fixture).await;
     (client, server, requested)
 }
 

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -467,8 +467,8 @@ struct GitProjectionMappingFile {
 /// - Hosted clones: the CLI-owned lazy hosted hydrator
 ///   bridges sync `hydrate` calls to an async hosted call via a dedicated worker
 ///   thread + private Tokio runtime; on each call the worker invokes
-///   `HostedClient::hydrate_pulled_state` for the current local-thread
-///   tip.
+///   `HostedClient::hydrate_blob` for the requested hash on the current
+///   local-thread tip.
 ///
 /// On success the hydrator is expected to write the blob into
 /// `repo.store()`; the read path then clears the missing marker and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `LazyHostedHydrator::hydrate` now forwards the requested blake3. `HostedClient::hydrate_blob` resolves a tip-tree path and issues unary `GetBlob` for that file; if the hash is not in the tree it wants only that hash (`want_full_closure = false`).
- GetBlob is addressed at the walked local state (`heddle:<state-id>`), not the live remote thread. A hash mismatch or GetBlob failure is not terminal: hydrate falls through to the existing single-hash pull.
- Sibling missing blobs stay missing. This is not a cap on how many blobs a tip may have, and this path does not call `hydrate_missing_blobs_for_state`.

## Closes

Closes HeddleCo/heddle#1410

## Red commit
`da5ba2e4`

The pre-fix contract was documented in-tree (`_hash` is ignored) rather than captured as a failing commit on this branch. Bounce review (`d06869b1`) adds `hydrate_blob_falls_through_to_hash_pull_when_get_blob_returns_a_moved_path`: GetBlob at path P returns a different blob, hydrate still lands H and does not pull the sibling.

## Test evidence
```
$ cargo test -p heddle-cli --lib hydrat -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.07s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 31 tests
test cli::commands::clone::tests::git_overlay_hydrator::hydrate_errors_descriptively_when_blob_oid_mapping_is_missing ... ok
test cli::commands::clone::tests::git_overlay_hydrator::read_blob_bytes_missing_blob_reports_native_lazy_boundary ... ok
test cli::commands::clone::tests::git_overlay_hydrator::hydrate_rejects_corrupted_mapping_via_blake3_check ... ok
test cli::commands::clone::tests::git_overlay_hydrator::read_blob_bytes_local_first_path_succeeds ... ok
test cli::commands::clone::tests::git_overlay_hydrator::record_blob_oid_is_last_write_wins_for_a_given_blake3 ... ok
test cli::commands::worktree_cmd::hydrate::tests::plan_link_links_source_and_skips_existing ... ok
test cli::commands::worktree_cmd::hydrate::tests::unlink_hydrated_removes_link_and_is_idempotent ... ok
test hosted_runtime::hosted::hydration::config_persistence_tests::lazy_hydrator_config_round_trip_preserves_hostname ... ok
test hosted_runtime::hosted::hydration::connect_path_tests::lazy_hosted_connect_opens_session_through_rotating_seam ... ok
test hosted_runtime::hosted::hydration::register_factory_tests::register_hosted_factory_installs_factory_for_kind_hosted ... ok
test hosted_runtime::hosted::hydration::register_factory_tests::registered_factory_builds_adapter_for_hosted_section ... ok
test hosted_runtime::hosted::hydration::register_factory_tests::registered_factory_errors_when_hosted_section_absent ... ok
test cli::commands::start_atomic::tests::preserve_hydrated_ignores_refuses_swapped_target_and_spares_symlink_target ... ok
test cli::commands::start_atomic::tests::start_partial_hydrate_unwinds_links_and_checkout ... ok
test hosted_runtime::hosted::hydration::tests::concurrent_first_use_no_race ... ok
test hosted_runtime::hosted::hydration::tests::ensure_bridge_propagates_dns_failure ... ok
test cli::commands::start_atomic::tests::start_happy_path_materializes_records_and_hydrates ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_after_thread_advance_uses_new_state ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_returns_config_error_when_local_thread_missing ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_safe_from_blocking_context ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_forwards_requested_hash_not_the_whole_tip ... ok
test hosted_runtime::hosted::hydration::tests::hydration_bridge_does_not_reintroduce_raw_repo_pointer ... ok
test hosted_runtime::hosted::hydration::tests::dropping_bridge_shuts_worker_down ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_safe_from_tokio_main_context ... ok
test hosted_runtime::hosted::hydration::tests::hydration_message_carries_send_owned_repo_handle ... ok
test hosted_runtime::hosted::sync::on_demand_hydration_tests::first_blob_path_resolves_only_the_requested_hash ... ok
test hosted_runtime::hosted::sync::on_demand_hydration_tests::on_demand_wants_exclude_sibling_missing_blobs ... ok
test hosted_runtime::hosted::hydration::tests::hydrate_times_out_when_worker_never_replies ... ok
test hosted_runtime::hosted::thread_metadata::tests::hosted_thread_summary_rehydrates_managed_metadata_at_pulled_tip ... ok
test hosted_runtime::hosted::sync::on_demand_hydration_tests::hydrate_blob_fetches_only_the_requested_file ... ok
test hosted_runtime::hosted::sync::on_demand_hydration_tests::hydrate_blob_falls_through_to_hash_pull_when_get_blob_returns_a_moved_path ... ok

test result: ok. 31 passed; 0 failed; 0 ignored; 0 measured; 671 filtered out; finished in 0.21s
```

Also green:

```
$ cargo test -p heddle-cli --lib hosted_runtime::hosted::sync::native_exchange -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 4 tests
test hosted_runtime::hosted::sync::native_exchange_tests::compact_pull_of_a_complete_local_state_publishes_no_synthetic_objects ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::clone_pull_installs_a_complete_native_pack ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::native_push_and_clone_pull_complete_the_real_framed_exchange ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::complete_local_state_exercises_each_public_pull_mode_without_refetching ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 698 filtered out; finished in 0.17s
```

```
$ cargo clippy -p heddle-cli --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.21s
```

Acceptance: `hydrate_blob_falls_through_to_hash_pull_when_get_blob_returns_a_moved_path` has H at path P, GetBlob returns a different blob, hydrate still lands H, and the sibling stays missing.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7a14b1f-7608-4802-9106-3dd149cf60d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7a14b1f-7608-4802-9106-3dd149cf60d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789705520&installation_model_id=21489&pr_number=1419&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1419&signature=3fd9f3b78d166c5349c792a431e5900cc77d988520098c491c8fb512f03eb0af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->