### PR TITLE
fix(hosted): grow pull raw body from received chunks

### DIFF
--- a/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use wire::{MAX_RECEIVED_PACK_SIZE, ProtocolError};
+
+use super::{admit_declared_received_len, receive_pull_raw_chunks};
+
+#[test]
+fn huge_declared_raw_body_is_rejected_before_any_reserve() {
+    // Call the admit gate only: the pre-fix receive path still reserve()s the
+    // declared usize, and exercising that with MAX+1 would abort the process.
+    let error = admit_declared_received_len(
+        MAX_RECEIVED_PACK_SIZE + 1,
+        MAX_RECEIVED_PACK_SIZE,
+        "pull raw body",
+    )
+    .expect_err("huge declared length must fail closed before reserve");
+    assert!(
+        error.to_string().contains("exceeds receive size limit"),
+        "got {error}"
+    );
+}
+
+#[test]
+fn declared_length_under_ceiling_grows_from_chunks_only() {
+    let mut buf = Vec::new();
+    let declared = 8 * 1024 * 1024;
+    let error = receive_pull_raw_chunks(
+        &mut buf,
+        declared,
+        MAX_RECEIVED_PACK_SIZE,
+        [b"abcd".as_slice()],
+    )
+    .expect_err("short body must fail after receive");
+    assert!(
+        matches!(error, ProtocolError::InvalidState(message) if message.contains("length changed")),
+        "got {error}"
+    );
+    assert_eq!(buf, b"abcd");
+    assert!(
+        buf.capacity() < declared as usize,
+        "must grow from received chunks, not reserve(declared); capacity={}",
+        buf.capacity()
+    );
+}
+
+#[test]
+fn received_chunks_matching_declared_length_are_accepted() {
+    let mut buf = Vec::new();
+    receive_pull_raw_chunks(
+        &mut buf,
+        4,
+        MAX_RECEIVED_PACK_SIZE,
+        [b"ab".as_slice(), b"cd".as_slice()],
+    )
+    .unwrap();
+    assert_eq!(buf, b"abcd");
+    assert!(
+        buf.capacity() < 64 * 1024,
+        "small body must not reserve a large declared-independent slab, capacity={}",
+        buf.capacity()
+    );
+}
+
+#[test]
+fn received_bytes_over_declared_length_are_rejected_before_append() {
+    let mut buf = Vec::new();
+    let error = receive_pull_raw_chunks(&mut buf, 3, MAX_RECEIVED_PACK_SIZE, [b"abcd".as_slice()])
+        .unwrap_err();
+    assert!(
+        buf.is_empty(),
+        "overflow chunk must not be appended, buf={buf:?}"
+    );
+    assert!(
+        error
+            .to_string()
+            .contains("exceeded declared length during receive"),
+        "got {error}"
+    );
+}
+
+#[test]
+fn admit_helper_is_the_shared_declared_length_gate() {
+    admit_declared_received_len(0, MAX_RECEIVED_PACK_SIZE, "pull raw body").unwrap();
+    admit_declared_received_len(
+        MAX_RECEIVED_PACK_SIZE,
+        MAX_RECEIVED_PACK_SIZE,
+        "pull raw body",
+    )
+    .unwrap();
+}

--- a/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
@@ -38,7 +38,7 @@ fn declared_length_under_ceiling_grows_from_chunks_only() {
     )
     .expect_err("short body must fail after receive");
     assert!(
-        matches!(error, ProtocolError::InvalidState(message) if message.contains("length changed")),
+        matches!(error, ProtocolError::InvalidState(ref message) if message.contains("length changed")),
         "got {error}"
     );
     assert_eq!(buf, b"abcd");

--- a/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/pull_raw_body_tests.rs
@@ -6,14 +6,20 @@ use super::{admit_declared_received_len, receive_pull_raw_chunks};
 
 #[test]
 fn huge_declared_raw_body_is_rejected_before_any_reserve() {
-    // Call the admit gate only: the pre-fix receive path still reserve()s the
-    // declared usize, and exercising that with MAX+1 would abort the process.
-    let error = admit_declared_received_len(
+    let mut buf = Vec::new();
+    let error = receive_pull_raw_chunks(
+        &mut buf,
         MAX_RECEIVED_PACK_SIZE + 1,
         MAX_RECEIVED_PACK_SIZE,
-        "pull raw body",
+        std::iter::empty::<&[u8]>(),
     )
     .expect_err("huge declared length must fail closed before reserve");
+    assert_eq!(
+        buf.capacity(),
+        0,
+        "attacker-chosen length must not reserve, capacity={}",
+        buf.capacity()
+    );
     assert!(
         error.to_string().contains("exceeds receive size limit"),
         "got {error}"

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -2437,8 +2437,6 @@ async fn next_pull_message(
         };
         let declared_len =
             admit_declared_received_len(length, wire::MAX_RECEIVED_PACK_SIZE, "pull raw body")?;
-        // Current contract: reserve the declared length, then append.
-        raw_target.reserve(declared_len);
         while let Some(chunk) = response
             .read_raw_chunk(1024 * 1024)
             .await
@@ -2454,8 +2452,17 @@ async fn next_pull_message(
 fn append_pull_raw_chunk(
     raw_target: &mut Vec<u8>,
     chunk: &[u8],
-    _declared_len: usize,
+    declared_len: usize,
 ) -> Result<(), ProtocolError> {
+    let next_len = raw_target
+        .len()
+        .checked_add(chunk.len())
+        .ok_or_else(|| ProtocolError::InvalidState("pull raw body length overflow".to_string()))?;
+    if next_len > declared_len {
+        return Err(ProtocolError::InvalidState(
+            "pull raw body exceeded declared length during receive".to_string(),
+        ));
+    }
     raw_target.extend_from_slice(chunk);
     Ok(())
 }
@@ -2477,7 +2484,6 @@ fn receive_pull_raw_chunks<'a>(
     chunks: impl IntoIterator<Item = &'a [u8]>,
 ) -> Result<(), ProtocolError> {
     let declared_len = admit_declared_received_len(declared, max_bytes, "pull raw body")?;
-    raw_target.reserve(declared_len);
     for chunk in chunks {
         append_pull_raw_chunk(raw_target, chunk, declared_len)?;
     }

--- a/crates/cli/src/hosted_runtime/hosted/sync.rs
+++ b/crates/cli/src/hosted_runtime/hosted/sync.rs
@@ -42,6 +42,7 @@ use tokio::sync::mpsc;
 use wire::{
     GitLaneTransferIntent, ObjectInfo, ObjectType, ObjectTypeBucket, PlannedObject, ProtocolError,
     PullComplete, PushComplete, RefEntry, RefUpdated, RepositoryTransferPlan,
+    admit_declared_received_len,
 };
 
 use super::{
@@ -2434,24 +2435,53 @@ async fn next_pull_message(
                 "pull pack header was not followed by a raw body".to_string(),
             ));
         };
-        let capacity = usize::try_from(length).map_err(|_| {
-            ProtocolError::InvalidState("pull raw body exceeds this platform".to_string())
-        })?;
-        raw_target.reserve(capacity);
+        let declared_len =
+            admit_declared_received_len(length, wire::MAX_RECEIVED_PACK_SIZE, "pull raw body")?;
+        // Current contract: reserve the declared length, then append.
+        raw_target.reserve(declared_len);
         while let Some(chunk) = response
             .read_raw_chunk(1024 * 1024)
             .await
             .map_err(hosted_to_protocol_error)?
         {
-            raw_target.extend_from_slice(&chunk);
+            append_pull_raw_chunk(raw_target, &chunk, declared_len)?;
         }
-        if raw_target.len() != capacity {
-            return Err(ProtocolError::InvalidState(
-                "pull raw body length changed during receive".to_string(),
-            ));
-        }
+        finish_pull_raw_body(raw_target, declared_len)?;
     }
     Ok(Some(message))
+}
+
+fn append_pull_raw_chunk(
+    raw_target: &mut Vec<u8>,
+    chunk: &[u8],
+    _declared_len: usize,
+) -> Result<(), ProtocolError> {
+    raw_target.extend_from_slice(chunk);
+    Ok(())
+}
+
+fn finish_pull_raw_body(raw_target: &[u8], declared_len: usize) -> Result<(), ProtocolError> {
+    if raw_target.len() != declared_len {
+        return Err(ProtocolError::InvalidState(
+            "pull raw body length changed during receive".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+fn receive_pull_raw_chunks<'a>(
+    raw_target: &mut Vec<u8>,
+    declared: u64,
+    max_bytes: u64,
+    chunks: impl IntoIterator<Item = &'a [u8]>,
+) -> Result<(), ProtocolError> {
+    let declared_len = admit_declared_received_len(declared, max_bytes, "pull raw body")?;
+    raw_target.reserve(declared_len);
+    for chunk in chunks {
+        append_pull_raw_chunk(raw_target, chunk, declared_len)?;
+    }
+    finish_pull_raw_body(raw_target, declared_len)
 }
 
 fn redaction_push_message(
@@ -5663,3 +5693,7 @@ mod pure_helpers_tests {
 #[cfg(test)]
 #[path = "git_lane_pack_plan_tests.rs"]
 mod git_lane_pack_plan_tests;
+
+#[cfg(test)]
+#[path = "pull_raw_body_tests.rs"]
+mod pull_raw_body_tests;

--- a/crates/wire/src/lib.rs
+++ b/crates/wire/src/lib.rs
@@ -54,8 +54,9 @@ pub use object_graph::{
 };
 pub use object_transfer::{
     MAX_PULL_FRAME_MESSAGE_SIZE, MAX_RECEIVED_REDACTIONS_BLOB_SIZE,
-    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, check_received_transfer_blob_size, chunk_bounds,
-    chunk_count, chunk_offset, load_object_data, load_requested_object, store_received_object,
+    MAX_RECEIVED_STATE_VISIBILITY_BLOB_SIZE, admit_declared_received_len,
+    check_received_transfer_blob_size, chunk_bounds, chunk_count, chunk_offset, load_object_data,
+    load_requested_object, store_received_object,
 };
 pub use provider_pack::{
     CompletedProviderPack, ProviderPackBundle, ProviderPackExtent, ProviderPackIndexEntry,

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -83,6 +83,19 @@ pub fn check_received_transfer_blob_size(
     Ok(())
 }
 
+/// Admit a declared receive length before any buffer is reserved or grown.
+///
+/// `declared` is untrusted wire input. Compare it to `max_bytes` as `u64`
+/// before converting to `usize` so a hostile header cannot pick the
+/// allocation. This function does not reserve or allocate.
+pub fn admit_declared_received_len(declared: u64, max_bytes: u64, kind: &str) -> Result<usize> {
+    // Intentionally matches the current next_pull_message contract: convert
+    // the declared u64 to usize only. The max-bytes gate is the #1409 fix.
+    let _ = max_bytes;
+    usize::try_from(declared)
+        .map_err(|_| ProtocolError::InvalidState(format!("{kind} exceeds this platform")))
+}
+
 #[allow(dead_code)]
 pub fn chunk_count(object_size: usize, chunk_size: usize) -> usize {
     if object_size == 0 || chunk_size == 0 {
@@ -583,6 +596,39 @@ mod tests {
             "state-visibility",
         )
         .unwrap();
+    }
+
+    #[test]
+    fn declared_receive_len_above_max_is_rejected_before_any_alloc() {
+        let error = admit_declared_received_len(9, 8, "pull raw body")
+            .expect_err("declared length above max must fail closed");
+        assert!(
+            error.to_string().contains("exceeds receive size limit"),
+            "got {error}"
+        );
+        assert!(error.to_string().contains("9 bytes (max 8)"), "got {error}");
+    }
+
+    #[test]
+    fn declared_receive_len_above_pack_cap_is_rejected_before_any_alloc() {
+        let error = admit_declared_received_len(
+            crate::MAX_RECEIVED_PACK_SIZE + 1,
+            crate::MAX_RECEIVED_PACK_SIZE,
+            "pull raw body",
+        )
+        .expect_err("attacker-chosen pack length must fail closed");
+        assert!(
+            error.to_string().contains("exceeds receive size limit"),
+            "got {error}"
+        );
+    }
+
+    #[test]
+    fn declared_receive_len_at_max_is_admitted() {
+        assert_eq!(
+            admit_declared_received_len(8, 8, "pull raw body").unwrap(),
+            8
+        );
     }
 
     #[test]

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -89,9 +89,11 @@ pub fn check_received_transfer_blob_size(
 /// before converting to `usize` so a hostile header cannot pick the
 /// allocation. This function does not reserve or allocate.
 pub fn admit_declared_received_len(declared: u64, max_bytes: u64, kind: &str) -> Result<usize> {
-    // Intentionally matches the current next_pull_message contract: convert
-    // the declared u64 to usize only. The max-bytes gate is the #1409 fix.
-    let _ = max_bytes;
+    if declared > max_bytes {
+        return Err(ProtocolError::InvalidState(format!(
+            "{kind} exceeds receive size limit: {declared} bytes (max {max_bytes})"
+        )));
+    }
     usize::try_from(declared)
         .map_err(|_| ProtocolError::InvalidState(format!("{kind} exceeds this platform")))
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `next_pull_message` no longer converts a declared raw-body `u64` into `usize` and `reserve`s that capacity before any bytes arrive.
- Declared length is fail-closed against `MAX_RECEIVED_PACK_SIZE` as `u64` (`admit_declared_received_len`). The receive `Vec` then grows only from streamed chunks.
- An under-ceiling declaration still does not `reserve(declared)`. Overflow chunks are rejected before append. This is a different site from #366 (`receive_chunk` after the body exists).

## Closes

Closes HeddleCo/heddle#1409

## Red commit
`91bbfa7b`

## Test evidence
```
$ cargo test -p heddle-wire --lib declared_receive -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 57.31s
     Running unittests src/lib.rs (target/debug/deps/wire-138815972a90457b)

running 3 tests
test object_transfer::tests::declared_receive_len_at_max_is_admitted ... ok
test object_transfer::tests::declared_receive_len_above_pack_cap_is_rejected_before_any_alloc ... ok
test object_transfer::tests::declared_receive_len_above_max_is_rejected_before_any_alloc ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 63 filtered out; finished in 0.00s
```

```
$ cargo test -p heddle-cli --lib pull_raw_body -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 22.44s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 5 tests
test hosted_runtime::hosted::sync::pull_raw_body_tests::huge_declared_raw_body_is_rejected_before_any_reserve ... ok
test hosted_runtime::hosted::sync::pull_raw_body_tests::admit_helper_is_the_shared_declared_length_gate ... ok
test hosted_runtime::hosted::sync::pull_raw_body_tests::received_bytes_over_declared_length_are_rejected_before_append ... ok
test hosted_runtime::hosted::sync::pull_raw_body_tests::declared_length_under_ceiling_grows_from_chunks_only ... ok
test hosted_runtime::hosted::sync::pull_raw_body_tests::received_chunks_matching_declared_length_are_accepted ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 702 filtered out; finished in 0.00s
```

```
$ cargo test -p heddle-cli --lib hosted_runtime::hosted::sync::native_exchange -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 4 tests
test hosted_runtime::hosted::sync::native_exchange_tests::compact_pull_of_a_complete_local_state_publishes_no_synthetic_objects ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::clone_pull_installs_a_complete_native_pack ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::native_push_and_clone_pull_complete_the_real_framed_exchange ... ok
test hosted_runtime::hosted::sync::native_exchange_tests::complete_local_state_exercises_each_public_pull_mode_without_refetching ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 703 filtered out; finished in 0.16s
```

```
$ cargo test -p heddle-wire --lib object_transfer -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.20s
     Running unittests src/lib.rs (target/debug/deps/wire-138815972a90457b)

running 14 tests
test object_transfer::tests::declared_receive_len_at_max_is_admitted ... ok
test object_transfer::tests::declared_receive_len_above_pack_cap_is_rejected_before_any_alloc ... ok
test object_transfer::tests::declared_receive_len_above_max_is_rejected_before_any_alloc ... ok
test object_transfer::tests::received_transfer_blob_caps_are_enforced_against_production_limits ... ok
test object_transfer::tests::received_transfer_blob_at_limit_is_accepted ... ok
test object_transfer::tests::received_transfer_blob_over_limit_is_rejected ... ok
test object_transfer::tests::load_object_data_reports_missing_and_id_type_mismatch_errors ... ok
test object_transfer::tests::store_received_object_rejects_mismatched_object_identity ... ok
test object_transfer::tests::test_chunk_bounds_returns_ranges ... ok
test object_transfer::tests::test_chunk_count_rounds_up ... ok
test object_transfer::tests::test_chunk_offset_returns_position ... ok
test object_transfer::tests::store_received_object_rejects_raw_sidecar_objects ... ok
test object_transfer::tests::primary_objects_roundtrip_through_wire_data ... ok
test object_transfer::tests::state_attachment_roundtrips_through_wire_data ... ok

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 52 filtered out; finished in 0.02s
```

```
$ cargo clippy -p heddle-cli --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 53.22s
```

```
$ cargo clippy -p heddle-wire --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.07s
```

Acceptance: `huge_declared_raw_body_is_rejected_before_any_reserve` rejects `MAX_RECEIVED_PACK_SIZE + 1` with the receive `Vec` still at capacity 0. `declared_length_under_ceiling_grows_from_chunks_only` receives 4 bytes against an 8 MiB declaration and keeps capacity below that declaration.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef67ee58-0a95-4092-a551-747a56bee867?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef67ee58-0a95-4092-a551-747a56bee867&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789707721&installation_model_id=21489&pr_number=1420&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1420&signature=fcf01cf053a57d6303c9a5ae3e20bfd09bcb2d1b5af91baf31f0f7ff599cf283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->