### PR TITLE
Drop diverged mirror refs from the export/push frontier

### DIFF
--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -4215,7 +4215,8 @@ mod tests {
         let mut record = HashMap::new();
         record.insert("refs/heads/main".to_string(), owned);
         record.insert("refs/heads/kept".to_string(), owned);
-        let frontier = collect_managed_ref_updates(&repo, &record).expect("collect managed updates");
+        let frontier =
+            collect_managed_ref_updates(&repo, &record).expect("collect managed updates");
 
         let mut old_at_destination = HashMap::new();
         old_at_destination.insert("refs/heads/main".to_string(), owned);

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -4112,6 +4112,142 @@ mod tests {
         assert_eq!(full_names, vec!["refs/heads/main".to_string()]);
     }
 
+    /// heddle#1414: name membership is not enough. A Git-side writer can
+    /// advance a managed branch; the on-disk tip then no longer matches the
+    /// OID Heddle last recorded writing. The export/push frontier must drop
+    /// that name rather than serve the foreign tip under the managed name.
+    #[test]
+    fn collect_managed_ref_updates_drops_diverged_on_disk_tip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
+        let owned = seed_commit(&repo, "owned");
+        let foreign = seed_commit(&repo, "foreign");
+        let notes = seed_commit(&repo, "notes");
+        set_reference(
+            &repo,
+            "refs/heads/main",
+            foreign,
+            RefPrecondition::MustNotExist,
+            "test: diverged main",
+        )
+        .expect("write diverged main");
+        set_reference(
+            &repo,
+            "refs/heads/kept",
+            owned,
+            RefPrecondition::MustNotExist,
+            "test: matching kept",
+        )
+        .expect("write kept");
+        set_reference(
+            &repo,
+            "refs/heads/unmanaged",
+            owned,
+            RefPrecondition::MustNotExist,
+            "test: foreign name at a heddle oid",
+        )
+        .expect("write unmanaged");
+        set_reference(
+            &repo,
+            "refs/notes/heddle",
+            notes,
+            RefPrecondition::MustNotExist,
+            "test: notes",
+        )
+        .expect("write notes");
+
+        let mut record = HashMap::new();
+        record.insert("refs/heads/main".to_string(), owned);
+        record.insert("refs/heads/kept".to_string(), owned);
+
+        let updates = collect_managed_ref_updates(&repo, &record).expect("collect managed updates");
+        let mut names: Vec<String> = updates.iter().map(full_ref_name).collect();
+        names.sort();
+
+        assert_eq!(
+            names,
+            vec![
+                "refs/heads/kept".to_string(),
+                "refs/notes/heddle".to_string(),
+            ],
+            "diverged main must leave the frontier; matching kept and notes remain"
+        );
+        let main = updates.iter().find(|update| update.name == "main");
+        assert!(
+            main.is_none(),
+            "must not serve the on-disk foreign tip under refs/heads/main, got {main:?}"
+        );
+    }
+
+    /// heddle#1414: dropping a diverged name from the served frontier must
+    /// also keep `plan_destination_reconcile` from copying/pushing that
+    /// foreign tip. A previously exported heddle-owned dest tip is retracted
+    /// rather than fast-forwarded to Git's fork.
+    #[test]
+    fn destination_reconcile_does_not_push_diverged_foreign_tip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = SleyRepository::init_bare(tmp.path()).expect("init bare repo");
+        let owned = seed_commit(&repo, "owned");
+        let foreign = seed_commit(&repo, "foreign");
+        set_reference(
+            &repo,
+            "refs/heads/main",
+            foreign,
+            RefPrecondition::MustNotExist,
+            "test: diverged main",
+        )
+        .expect("write diverged main");
+        set_reference(
+            &repo,
+            "refs/heads/kept",
+            owned,
+            RefPrecondition::MustNotExist,
+            "test: matching kept",
+        )
+        .expect("write kept");
+
+        let mut record = HashMap::new();
+        record.insert("refs/heads/main".to_string(), owned);
+        record.insert("refs/heads/kept".to_string(), owned);
+        let frontier = collect_managed_ref_updates(&repo, &record).expect("collect managed updates");
+
+        let mut old_at_destination = HashMap::new();
+        old_at_destination.insert("refs/heads/main".to_string(), owned);
+        old_at_destination.insert("refs/heads/kept".to_string(), owned);
+        let previously_exported = old_at_destination.clone();
+
+        let plan = plan_destination_reconcile(
+            &repo,
+            &frontier,
+            None,
+            &old_at_destination,
+            &previously_exported,
+            false,
+        )
+        .expect("plan destination reconcile");
+
+        assert!(
+            plan.writes
+                .iter()
+                .all(|write| write.new != foreign && write.full_name != "refs/heads/main"),
+            "must not write the foreign tip under the managed name, writes={:?}",
+            plan.writes
+                .iter()
+                .map(|write| (&write.full_name, write.new))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            plan.deletes
+                .iter()
+                .any(|delete| delete.full_name == "refs/heads/main" && delete.old == owned),
+            "heddle-owned dest tip for a diverged mirror ref must retract, deletes={:?}",
+            plan.deletes
+                .iter()
+                .map(|delete| (&delete.full_name, delete.old))
+                .collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn fast_forward_guard_reports_exact_rewrite_before_after() {
         let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/git-projection/src/git_core.rs
+++ b/crates/git-projection/src/git_core.rs
@@ -937,7 +937,9 @@ impl<'a> GitProjection<'a> {
 
         // Export only the managed frontier reconstructed from the store. A foreign
         // branch/tag heddle never wrote — even one at a heddle-minted commit —
-        // must not enter the destination's desired set.
+        // must not enter the destination's desired set. A managed name whose
+        // on-disk tip no longer matches the recorded OID is dropped the same
+        // way (heddle#1414): do not copy/push Git's fork under that name.
         let managed_record = read_projection_managed_refs(self.heddle_repo.heddle_dir())?;
         let served_frontier = collect_managed_ref_updates(&projection_repo, &managed_record)?;
         copy_reachable_objects(
@@ -2721,14 +2723,18 @@ pub fn materialize_projection_managed_refs(
 }
 
 /// The mirror refs heddle MANAGES, as [`RefUpdate`]s — [`collect_ref_updates`]
-/// filtered to the names in the managed-refs `record`, PLUS every `refs/notes/*`
-/// ref (heddle's metadata namespace, always heddle-managed and content-rebuilt
-/// rather than target-claimed through the reconcile). The export/push frontier
-/// MUST source from this rather than the raw [`collect_ref_updates`] so a foreign
-/// branch/tag heddle never wrote — even one pointing at a heddle-minted commit —
-/// never enters the served frontier nor the destination's desired set (heddle#316).
-/// Fetch/import paths keep using [`collect_ref_updates`] because they must see
-/// every ref; only the export/push frontier is managed-filtered.
+/// filtered to names in the managed-refs `record` whose on-disk tip still equals
+/// the recorded OID, PLUS every `refs/notes/*` ref (heddle's metadata namespace,
+/// always heddle-managed and content-rebuilt rather than target-claimed through
+/// the reconcile). The export/push frontier MUST source from this rather than
+/// the raw [`collect_ref_updates`] so a foreign branch/tag heddle never wrote —
+/// even one pointing at a heddle-minted commit — never enters the served
+/// frontier nor the destination's desired set (heddle#316). Name membership
+/// alone is not enough: a Git-side writer can advance a managed ref, and
+/// serving that on-disk tip would publish the fork. A recorded name whose
+/// on-disk target no longer matches is dropped until reconcile succeeds
+/// (heddle#1414). Fetch/import paths keep using [`collect_ref_updates`] because
+/// they must see every ref; only the export/push frontier is managed-filtered.
 pub fn collect_managed_ref_updates(
     repo: &SleyRepository,
     record: &HashMap<String, ObjectId>,
@@ -2737,7 +2743,7 @@ pub fn collect_managed_ref_updates(
         .into_iter()
         .filter(|update| {
             matches!(update.namespace, RefNamespace::Note)
-                || record.contains_key(&full_ref_name(update))
+                || record.get(&full_ref_name(update)) == Some(&update.target)
         })
         .collect())
 }

--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -929,6 +929,10 @@ fn export_scoped(
                 }
             }
             ReconcileOp::Diverged => {
+                // Preserve the Git-side tip and keep the last heddle-owned OID
+                // in the record so a later reset can still ForceRewind. Do not
+                // claim the foreign tip: `collect_managed_ref_updates` drops a
+                // name whose on-disk target no longer matches (heddle#1414).
                 stats.failed_refs.push((
                     branch_ref.clone(),
                     FailedRefExportReason::ModifiedConcurrentlyInGit {
@@ -1048,7 +1052,8 @@ fn export_scoped(
     }
 
     // Persist the updated ownership record so the next reconcile — and the push
-    // frontier (`collect_managed_ref_updates`) — read heddle's managed set by name.
+    // frontier (`collect_managed_ref_updates`) — read heddle's managed set by
+    // name and recorded tip. A diverged on-disk tip is not a managed update.
     write_projection_managed_refs(bridge.heddle_repo.heddle_dir(), &managed_record)?;
 
     for update in collect_ref_updates(&repo)?


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `collect_managed_ref_updates` no longer treats managed-ref **name membership** as enough for the export/push frontier.
- A managed name whose on-disk tip no longer matches the recorded OID is dropped, so a Git-side fork is not copied or pushed under that name.
- `ReconcileOp::Diverged` still records `failed_refs` and keeps the last Heddle-owned OID in the managed record (so a later reset can still force-rewind); it does not claim the foreign tip.

## Closes

Closes HeddleCo/heddle#1414

## Red commit
`49c5902134c7672921f71da0217d394b3fe6baf4`

On that commit the new tests failed as:

```
assertion `left == right` failed: diverged main must leave the frontier; matching kept and notes remain
  left: ["refs/heads/kept", "refs/heads/main", "refs/notes/heddle"]
 right: ["refs/heads/kept", "refs/notes/heddle"]

plan destination reconcile: NonFastForwardRef { name: "refs/heads/main", ... remote_destination: true }
```

Name membership alone put the foreign on-disk tip in the served frontier.

## Test evidence
```
$ cargo test -p heddle-git-projection --lib diverged -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.06s
     Running unittests src/lib.rs (target/debug/deps/heddle_git_projection-d515cf7d22009f7f)

running 2 tests
test git_core::tests::destination_reconcile_does_not_push_diverged_foreign_tip ... ok
test git_core::tests::collect_managed_ref_updates_drops_diverged_on_disk_tip ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 59 filtered out; finished in 0.00s
```

```
$ cargo test -p heddle-git-projection --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running unittests src/lib.rs (target/debug/deps/heddle_git_projection-d515cf7d22009f7f)

running 61 tests
test git_core::tests::collect_managed_ref_updates_drops_diverged_on_disk_tip ... ok
test git_core::tests::destination_reconcile_does_not_push_diverged_foreign_tip ... ok
...
test result: ok. 61 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.28s
```

```
$ cargo clippy -p heddle-git-projection --lib -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.03s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a893f12-34fa-4005-9af9-e3a1f25c8a6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a893f12-34fa-4005-9af9-e3a1f25c8a6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789744188&installation_model_id=21489&pr_number=1421&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1421&signature=cda0fc4c962f2c07582423e3ccc16c2637bdaff4302a397a477f16bc8a924cf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->