### PR TITLE
Hard-deny reserved `.heddle/` after user ignore rules

### DIFF
--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -370,7 +370,7 @@ fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
         .filter_map(Value::as_str)
         .collect();
     assert!(
-        paths.iter().any(|path| *path == "kept.txt"),
+        paths.contains(&"kept.txt"),
         "status must still list real worktree files: {paths:?}"
     );
     assert!(
@@ -380,9 +380,7 @@ fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
         "status must not list reserved root .heddle paths: {paths:?}"
     );
     assert!(
-        paths
-            .iter()
-            .any(|path| *path == "examples/calculator/.heddle/identity.toml"),
+        paths.contains(&"examples/calculator/.heddle/identity.toml"),
         "status must still list nested fixture .heddle: {paths:?}"
     );
 

--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -374,7 +374,9 @@ fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
         "status must still list real worktree files: {paths:?}"
     );
     assert!(
-        paths.iter().all(|path| !path.starts_with(".heddle")),
+        paths
+            .iter()
+            .all(|path| *path != ".heddle" && !path.starts_with(".heddle/")),
         "status must not list reserved root .heddle paths: {paths:?}"
     );
     assert!(
@@ -399,6 +401,7 @@ fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
     ));
 }
 
+#[test]
 fn init_text_points_at_ignore_help_when_heddleignore_not_installed() {
     let temp = TempDir::new().unwrap();
     let out = heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -165,6 +165,10 @@ fn heddleignore_help_topic_prints_the_documented_contract() {
     assert!(help.contains("500 or more paths"));
     assert!(help.contains("[worktree] ignore"));
     assert!(help.contains("no `--path` filter") || help.contains("no `--path`"));
+    assert!(
+        help.contains("cannot un-ignore") && help.contains("identity.toml"),
+        "help must document the reserved .heddle hard-deny: {help}"
+    );
 }
 
 #[test]

--- a/crates/cli/tests/cli_integration/ignore_mechanics.rs
+++ b/crates/cli/tests/cli_integration/ignore_mechanics.rs
@@ -326,6 +326,75 @@ fn removing_gitignore_rule_makes_junk_reappear_in_status_and_capture() {
 }
 
 #[test]
+fn native_capture_cannot_unignore_heddle_identity_via_gitignore() {
+    // heddle#1413: last-match-wins used to let `!.heddle/` pull
+    // identity.toml into captured history. Root `.heddle/` is reserved
+    // after user rules; nested fixture `.heddle/` stays ordinary content.
+    let temp = TempDir::new().unwrap();
+    std::fs::write(
+        temp.path().join(".gitignore"),
+        "!.heddle/\n!.heddle/**\n!.heddle/identity.toml\n",
+    )
+    .unwrap();
+    std::fs::write(
+        temp.path().join(".heddleignore"),
+        "!.heddle/\n!.heddle/identity.toml\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("kept.txt"), "captured\n").unwrap();
+
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(
+        temp.path().join(".heddle").join("identity.toml"),
+        "secret-key-material\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(temp.path().join("examples/calculator/.heddle")).unwrap();
+    std::fs::write(
+        temp.path()
+            .join("examples/calculator/.heddle/identity.toml"),
+        "fixture\n",
+    )
+    .unwrap();
+
+    let status = heddle(&["status", "--output", "json-compact"], Some(temp.path())).unwrap();
+    let parsed: Value = serde_json::from_str(&status).expect("status json");
+    let paths: Vec<&str> = parsed["changed_paths"]
+        .as_array()
+        .unwrap_or_else(|| panic!("status must carry changed_paths: {status}"))
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    assert!(
+        paths.iter().any(|path| *path == "kept.txt"),
+        "status must still list real worktree files: {paths:?}"
+    );
+    assert!(
+        paths.iter().all(|path| !path.starts_with(".heddle")),
+        "status must not list reserved root .heddle paths: {paths:?}"
+    );
+    assert!(
+        paths
+            .iter()
+            .any(|path| *path == "examples/calculator/.heddle/identity.toml"),
+        "status must still list nested fixture .heddle: {paths:?}"
+    );
+
+    heddle(
+        &["capture", "-m", "must not capture reserved identity"],
+        Some(temp.path()),
+    )
+    .unwrap();
+
+    assert!(!captured_path_exists(temp.path(), ".heddle/identity.toml"));
+    assert!(!captured_path_exists(temp.path(), ".heddle"));
+    assert!(captured_path_exists(temp.path(), "kept.txt"));
+    assert!(captured_path_exists(
+        temp.path(),
+        "examples/calculator/.heddle/identity.toml"
+    ));
+}
+
 fn init_text_points_at_ignore_help_when_heddleignore_not_installed() {
     let temp = TempDir::new().unwrap();
     let out = heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/objects/src/worktree/mod.rs
+++ b/crates/objects/src/worktree/mod.rs
@@ -4,6 +4,7 @@
 mod worktree_compare;
 mod worktree_diff;
 pub mod worktree_ignore;
+mod worktree_reserved;
 mod worktree_types;
 
 #[cfg(test)]
@@ -12,4 +13,5 @@ mod worktree_tests;
 pub use worktree_compare::compare_worktree;
 pub use worktree_diff::{DiffLine, diff_blobs};
 pub use worktree_ignore::{WorktreeIgnoreMatcher, build_worktree_ignore, should_ignore};
+pub use worktree_reserved::{is_reserved_directory_child, is_reserved_worktree_path};
 pub use worktree_types::{FileStatus, WorktreeChange, WorktreeStatus};

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -16,10 +16,16 @@
 //! fixture) is *captured*, not silently dropped. Operators who want
 //! the gitignore-spec "match anywhere" behavior for those names can
 //! write `**/<name>` explicitly.
+//!
+//! Root `.heddle/` is also a reserved-path hard-deny evaluated after
+//! user rules. A later `!.heddle/` (or similar) cannot un-ignore
+//! identity material. Nested fixture `.heddle/` trees are not reserved.
 
 use std::path::Path;
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+
+use super::worktree_reserved::is_reserved_worktree_path;
 
 /// Whether `path` is covered by any of the `.heddleignore` patterns.
 ///
@@ -111,6 +117,9 @@ fn canonical_line(pattern: &str) -> String {
 /// directory entry as well as paths inside it. See the docstring on
 /// `should_ignore` for the migration rationale.
 fn matched(gi: &Gitignore, path: &Path) -> bool {
+    if is_reserved_worktree_path(path) {
+        return true;
+    }
     matches!(
         gi.matched_path_or_any_parents(path, /* is_dir */ true),
         ignore::Match::Ignore(_)

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -352,15 +352,24 @@ mod tests {
             vec!["**".to_string(), "!.heddle/".to_string()],
             Vec::new(),
         ];
-        for patterns in negations {
+        for patterns in &negations {
             assert!(
-                should_ignore(&PathBuf::from(".heddle/identity.toml"), &patterns),
+                should_ignore(&PathBuf::from(".heddle/identity.toml"), patterns),
                 "reserved identity must stay ignored under {patterns:?}"
             );
             assert!(
-                should_ignore(&PathBuf::from(".heddle"), &patterns),
+                should_ignore(&PathBuf::from(".heddle"), patterns),
                 "reserved root .heddle must stay ignored under {patterns:?}"
             );
+        }
+        // Nested fixtures are not reserved. User rules still apply, so
+        // only assert capturable when the pattern set does not ignore
+        // them on its own (`**` would).
+        for patterns in [
+            vec!["!.heddle/".to_string()],
+            vec!["!.heddle".to_string()],
+            Vec::new(),
+        ] {
             assert!(
                 !should_ignore(
                     &PathBuf::from("examples/calculator/.heddle/identity.toml"),

--- a/crates/objects/src/worktree/worktree_ignore.rs
+++ b/crates/objects/src/worktree/worktree_ignore.rs
@@ -329,4 +329,36 @@ mod tests {
         let patterns = vec!["[unbalanced".to_string(), "*.log".to_string()];
         assert!(should_ignore(&PathBuf::from("foo.log"), &patterns));
     }
+
+    #[test]
+    fn user_negation_cannot_unignore_reserved_heddle_tree() {
+        // heddle#1413: last-match-wins would otherwise let `!.heddle/`
+        // pull identity.toml into capture. Reserved-path hard-deny
+        // wins after user rules, including an empty pattern list.
+        let negations = [
+            vec!["!.heddle/".to_string()],
+            vec!["!.heddle".to_string()],
+            vec!["!.heddle/**".to_string()],
+            vec!["!.heddle/identity.toml".to_string()],
+            vec!["**".to_string(), "!.heddle/".to_string()],
+            Vec::new(),
+        ];
+        for patterns in negations {
+            assert!(
+                should_ignore(&PathBuf::from(".heddle/identity.toml"), &patterns),
+                "reserved identity must stay ignored under {patterns:?}"
+            );
+            assert!(
+                should_ignore(&PathBuf::from(".heddle"), &patterns),
+                "reserved root .heddle must stay ignored under {patterns:?}"
+            );
+            assert!(
+                !should_ignore(
+                    &PathBuf::from("examples/calculator/.heddle/identity.toml"),
+                    &patterns
+                ),
+                "nested fixture .heddle must stay capturable under {patterns:?}"
+            );
+        }
+    }
 }

--- a/crates/objects/src/worktree/worktree_reserved.rs
+++ b/crates/objects/src/worktree/worktree_reserved.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Reserved worktree paths that user ignore rules cannot un-ignore.
+//!
+//! Root `.heddle/` holds identity material (`identity.toml`), credentials,
+//! and repository-engine state. Gitignore last-match-wins would otherwise
+//! let `!.heddle/` pull that tree into capture. Nested `.heddle/`
+//! directories (fixtures) stay ordinary content.
+
+use std::path::{Component, Path};
+
+/// Whether `path` is the worktree-root `.heddle` entry or a path under it.
+///
+/// Root-anchored only: `examples/calculator/.heddle/` is not reserved.
+/// Leading `./` is skipped so `./.heddle/identity.toml` matches.
+#[must_use]
+pub fn is_reserved_worktree_path(path: &Path) -> bool {
+    first_normal_component(path).is_some_and(|name| name == ".heddle")
+}
+
+/// Whether a directory child is reserved without allocating a joined path.
+///
+/// Used by the walker prune so root `.heddle` and anything already under
+/// that tree are skipped even if a matcher is later refactored.
+#[must_use]
+pub fn is_reserved_directory_child(parent: &Path, name: &str) -> bool {
+    if is_reserved_worktree_path(parent) {
+        return true;
+    }
+    name == ".heddle" && is_worktree_root(parent)
+}
+
+fn is_worktree_root(path: &Path) -> bool {
+    path.as_os_str().is_empty() || path == Path::new(".")
+}
+
+fn first_normal_component(path: &Path) -> Option<&std::ffi::OsStr> {
+    for component in path.components() {
+        match component {
+            Component::CurDir => continue,
+            Component::Normal(name) => return Some(name),
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => return None,
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{is_reserved_directory_child, is_reserved_worktree_path};
+
+    #[test]
+    fn reserves_root_heddle_tree_and_identity() {
+        for path in [
+            ".heddle",
+            ".heddle/identity.toml",
+            ".heddle/objects/pack",
+            ".heddle/info/exclude",
+            "./.heddle/identity.toml",
+        ] {
+            assert!(
+                is_reserved_worktree_path(Path::new(path)),
+                "expected reserved: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn does_not_reserve_nested_or_unrelated_paths() {
+        for path in [
+            "",
+            ".",
+            "src/main.rs",
+            "heddle",
+            ".heddleignore",
+            "examples/calculator/.heddle/identity.toml",
+            "examples/calculator/.heddle",
+            "../.heddle/identity.toml",
+        ] {
+            assert!(
+                !is_reserved_worktree_path(Path::new(path)),
+                "expected not reserved: {path}"
+            );
+        }
+    }
+
+    #[test]
+    fn directory_child_reserves_root_heddle_and_descendants() {
+        assert!(is_reserved_directory_child(Path::new(""), ".heddle"));
+        assert!(is_reserved_directory_child(Path::new("."), ".heddle"));
+        assert!(is_reserved_directory_child(
+            Path::new(".heddle"),
+            "identity.toml"
+        ));
+        assert!(!is_reserved_directory_child(Path::new(""), "src"));
+        assert!(!is_reserved_directory_child(
+            Path::new("examples/calculator"),
+            ".heddle"
+        ));
+    }
+}

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -2958,6 +2958,9 @@ impl Repository {
 
     pub fn ignore_patterns(&self) -> Result<Vec<String>> {
         let mut patterns = self.config.worktree.ignore.clone();
+        // Default config includes `.heddle`, but that is a last-match
+        // pattern. Root `.heddle/` is reserved after this list is
+        // compiled — see `objects::worktree::is_reserved_worktree_path`.
         // Reserve the operator-local courtesy-stub filename. It is a Heddle
         // artifact written for under-tier checkouts, never tracked content.
         // Excluding it here is the single tree-build chokepoint every capture path

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -1327,7 +1327,9 @@ impl WorktreeWalkPolicy for TreeBuildPolicy<'_> {
 
 #[cfg(test)]
 mod tests {
-    use objects::object::{ContentHash, Tree, TreeEntry};
+    use std::path::Path;
+
+    use objects::object::{ContentHash, LeafPolicy, Tree, TreeEntry, resolve_tree_path};
     use tempfile::TempDir;
 
     use crate::{
@@ -1412,5 +1414,75 @@ mod tests {
         let hash = read_file_hash(&path, initial_size).unwrap();
 
         assert_eq!(hash, ContentHash::compute_typed("blob", b"abcdef"));
+    }
+
+    #[test]
+    fn build_tree_hard_denies_root_heddle_after_gitignore_unignore() {
+        let temp_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp_dir.path()).unwrap();
+        std::fs::write(
+            temp_dir.path().join(".gitignore"),
+            "!.heddle/\n!.heddle/**\n",
+        )
+        .unwrap();
+        std::fs::write(
+            temp_dir.path().join(".heddleignore"),
+            "!.heddle/\n!.heddle/identity.toml\n",
+        )
+        .unwrap();
+        std::fs::write(temp_dir.path().join("kept.txt"), "ok\n").unwrap();
+        std::fs::write(
+            temp_dir.path().join(".heddle").join("identity.toml"),
+            "secret-key-material\n",
+        )
+        .unwrap();
+        std::fs::create_dir_all(temp_dir.path().join("examples/calculator/.heddle")).unwrap();
+        std::fs::write(
+            temp_dir
+                .path()
+                .join("examples/calculator/.heddle/identity.toml"),
+            "fixture\n",
+        )
+        .unwrap();
+
+        let tree = repo.build_tree(temp_dir.path()).unwrap();
+        repo.store().put_tree(&tree).unwrap();
+        let hash = tree.hash();
+
+        assert!(
+            resolve_tree_path(
+                repo.store(),
+                &hash,
+                Path::new("kept.txt"),
+                LeafPolicy::Entry
+            )
+            .unwrap()
+            .is_some()
+        );
+        assert!(
+            tree.get(".heddle").is_none(),
+            "root .heddle must stay out of the captured tree"
+        );
+        assert!(
+            resolve_tree_path(
+                repo.store(),
+                &hash,
+                Path::new(".heddle/identity.toml"),
+                LeafPolicy::Entry,
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            resolve_tree_path(
+                repo.store(),
+                &hash,
+                Path::new("examples/calculator/.heddle/identity.toml"),
+                LeafPolicy::Entry,
+            )
+            .unwrap()
+            .is_some(),
+            "nested fixture .heddle must remain capturable"
+        );
     }
 }

--- a/crates/repo/src/repository_tree.rs
+++ b/crates/repo/src/repository_tree.rs
@@ -1330,6 +1330,7 @@ mod tests {
     use std::path::Path;
 
     use objects::object::{ContentHash, LeafPolicy, Tree, TreeEntry, resolve_tree_path};
+    use objects::store::ObjectStore;
     use tempfile::TempDir;
 
     use crate::{

--- a/crates/repo/src/worktree_ignore.rs
+++ b/crates/repo/src/worktree_ignore.rs
@@ -308,4 +308,26 @@ mod tests {
         assert!(matcher.should_ignore(&PathBuf::from("build/output")));
         assert!(!matcher.should_ignore(&PathBuf::from("nested/build/file")));
     }
+
+    #[test]
+    fn compiled_matcher_hard_denies_reserved_heddle_after_user_negation() {
+        let matcher = WorktreeIgnoreMatcher::new(&[
+            ".heddle".to_string(),
+            "!.heddle/".to_string(),
+            "!.heddle/identity.toml".to_string(),
+        ]);
+        assert!(matcher.should_ignore(&PathBuf::from(".heddle")));
+        assert!(matcher.should_ignore(&PathBuf::from(".heddle/identity.toml")));
+        assert!(matcher.should_prune_directory_child(Path::new(""), ".heddle"));
+        assert!(
+            !matcher.should_ignore(&PathBuf::from("examples/calculator/.heddle/identity.toml"))
+        );
+        assert_eq!(
+            matcher.should_ignore(&PathBuf::from(".heddle/identity.toml")),
+            should_ignore(
+                &PathBuf::from(".heddle/identity.toml"),
+                &[".heddle".to_string(), "!.heddle/".to_string(),]
+            ),
+        );
+    }
 }

--- a/crates/repo/src/worktree_ignore.rs
+++ b/crates/repo/src/worktree_ignore.rs
@@ -13,7 +13,7 @@
 use std::path::{Path, PathBuf};
 
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
-use objects::object::ContentHash;
+use objects::{object::ContentHash, worktree::is_reserved_worktree_path};
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WorktreeIgnoreMatcher {
@@ -96,6 +96,9 @@ impl WorktreeIgnoreMatcher {
     }
 
     fn matched_relative(&self, path: &Path, is_dir: bool) -> bool {
+        if is_reserved_worktree_path(path) {
+            return true;
+        }
         let Some(gi) = &self.matcher else {
             return false;
         };

--- a/crates/repo/src/worktree_walk.rs
+++ b/crates/repo/src/worktree_walk.rs
@@ -12,6 +12,7 @@ use objects::{
     error::{HeddleError, Result},
     object::{ContentHash, Tree, TreeEntry},
     store::ObjectStore,
+    worktree::is_reserved_directory_child,
 };
 
 use crate::{
@@ -208,6 +209,11 @@ fn walk_directory<P: WorktreeWalkPolicy>(
         let mut entry_key = location.key.to_string();
         for entry in &dir_entries {
             let name = entry.name.as_str();
+            // Reserved-path hard-deny (heddle#1413): root `.heddle/` is
+            // identity/engine state. User ignore rules cannot un-ignore it.
+            if is_reserved_directory_child(directory.rel_path, name) {
+                continue;
+            }
             if ignore_matcher.should_prune_directory_child(directory.rel_path, name) {
                 continue;
             }

--- a/docs/heddleignore.md
+++ b/docs/heddleignore.md
@@ -54,8 +54,12 @@ and in isolated thread checkouts (`heddle start --path …`). Build junk that
 matches a root ignore rule is never listed as unsaved work and never enters
 permanent history.
 
-Heddle always protects its own `.heddle/` metadata. Other paths must
-be explicit in `.gitignore`, `.heddleignore`, or the config key below.
+Root `.heddle/` is reserved: identity, credentials, and repository-engine
+state. User ignore rules cannot un-ignore it. A `.gitignore` or
+`.heddleignore` negation such as `!.heddle/` does not pull
+`identity.toml` into capture. Nested `.heddle/` directories (fixtures)
+remain ordinary paths. Other paths must be explicit in `.gitignore`,
+`.heddleignore`, or the config key below.
 
 ## Config key: `[worktree] ignore`
 
@@ -70,7 +74,9 @@ Config patterns are loaded first, then root `.gitignore`, then
 `.heddle/info/exclude`, then root `.heddleignore`. Prefer the ignore files
 for project policy; use `[worktree] ignore` for operator-local or
 repo-engine defaults that should not appear as a tracked ignore file.
-Default config always includes `.heddle`.
+Default config always includes `.heddle`. That default is last-match
+and can be contradicted by a later user rule; the reserved-path hard-deny
+is what keeps root `.heddle/` out of capture.
 
 ## Capture path scoping
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Root `.heddle/` (including `identity.toml`) is reserved after user ignore rules. A `.gitignore` or `.heddleignore` negation such as `!.heddle/` cannot pull identity material into capture or status.
- The deny is a reserved-path check on both ignore matchers and the worktree walker, not another last-match pattern that a later `!` rule can override.
- Nested fixture `.heddle/` directories remain ordinary capturable content.
- Rebased onto current main. Fast Lane clippy now uses `contains` for the reserved-path status asserts (`clippy::manual_contains`); the deny itself is unchanged.

## Closes

Closes HeddleCo/heddle#1413

## Red commit
`c506c847`

## Test evidence
```
$ cargo clippy --locked -p heddle-objects -p heddle-repo -p heddle-cli --all-targets -- -D warnings -D dead-code
Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.02s

$ cargo test -p heddle-objects --lib worktree -- --nocapture
running 26 tests
test worktree::worktree_ignore::tests::user_negation_cannot_unignore_reserved_heddle_tree ... ok
test worktree::worktree_reserved::tests::reserves_root_heddle_tree_and_identity ... ok
test worktree::worktree_reserved::tests::does_not_reserve_nested_or_unrelated_paths ... ok
test worktree::worktree_reserved::tests::directory_child_reserves_root_heddle_and_descendants ... ok
...
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 173 filtered out

$ cargo test -p heddle-repo --lib -- reserved_heddle build_tree_hard_denies_root_heddle --nocapture
test worktree_ignore::tests::compiled_matcher_hard_denies_reserved_heddle_after_user_negation ... ok
test repository::repository_tree::tests::build_tree_hard_denies_root_heddle_after_gitignore_unignore ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 674 filtered out

$ cargo test -p heddle-repo --lib worktree_ignore -- --nocapture
running 9 tests
...
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 667 filtered out

$ cargo test -p heddle-cli --test cli_integration -- --nocapture native_capture_cannot_unignore heddleignore_help_topic
running 2 tests
test ignore_mechanics::heddleignore_help_topic_prints_the_documented_contract ... ok
test ignore_mechanics::native_capture_cannot_unignore_heddle_identity_via_gitignore ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 935 filtered out
```

Fast Lane / fast-check is green on `b0bd7880`:
https://github.com/HeddleCo/heddle/actions/runs/32303839962

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-945d4ece-a72e-4ca8-bbec-e9e99cbe796f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-945d4ece-a72e-4ca8-bbec-e9e99cbe796f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789744194&installation_model_id=21489&pr_number=1422&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1422&signature=2468d6350e14f3ba05cb6ff8ef75f18373d98471c00491bad0cfa9901859612b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->