### PR TITLE
fix(pull): untrust local thread landing metadata

### DIFF
--- a/crates/cli/src/cli/commands/remote/remote_ops.rs
+++ b/crates/cli/src/cli/commands/remote/remote_ops.rs
@@ -1324,6 +1324,9 @@ fn save_pulled_thread_metadata(
     metadata.thread = local_thread.to_string();
     metadata.current_state = Some(pulled_state.short());
     metadata.shared_target_dir = None;
+    metadata
+        .integration_policy_result
+        .clear_untrusted_landing_fields();
     ThreadManager::new(repo.heddle_dir()).save_record(&metadata)?;
     Ok(())
 }

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -723,7 +723,11 @@ fn test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_targ
     heddle(&["thread", "create", "feature"], Some(source.path())).unwrap();
     heddle(&["thread", "switch", "feature"], Some(source.path())).unwrap();
     std::fs::write(source.path().join("feature.txt"), "attacker tip\n").unwrap();
-    heddle(&["capture", "-m", "forged landing tip"], Some(source.path())).unwrap();
+    heddle(
+        &["capture", "-m", "forged landing tip"],
+        Some(source.path()),
+    )
+    .unwrap();
     heddle(&["thread", "switch", "main"], Some(source.path())).unwrap();
 
     let source_repo = Repository::open(source.path()).unwrap();
@@ -774,9 +778,7 @@ fn test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_targ
         "local pull must drop forged manual_resolution_state"
     );
     assert!(
-        !pulled
-            .integration_policy_result
-            .conflicts_resolved_manually,
+        !pulled.integration_policy_result.conflicts_resolved_manually,
         "local pull must drop forged conflicts_resolved_manually"
     );
 

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use cli::remote::RemoteConfig;
 use objects::object::{MarkerName, ThreadName};
-use repo::ThreadManager;
+use repo::{ThreadFreshness, ThreadManager, ThreadState};
 use sley::{ConfigEdit, ConfigEditPlan};
 
 use super::{git_overlay_fixtures::GitOverlayFixture, *};
@@ -708,6 +708,106 @@ fn test_cli_pull_local_updates_requested_track() {
     heddle(&["thread", "switch", "imported"], Some(target.path())).unwrap();
     let blob = std::fs::read_to_string(target.path().join("hello.txt")).unwrap();
     assert_eq!(blob, "from source");
+}
+
+/// heddle#1412: a source `ThreadRecord` can claim a manual resolution at the
+/// pulled tip. Hosted conversion zeros those fields; local pull must too, or
+/// `land` fast-forwards the attached target through `adopt_manual_resolution`.
+#[test]
+fn test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_target() {
+    let source = TempDir::new().unwrap();
+    heddle(&["init"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("shared.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "base"], Some(source.path())).unwrap();
+
+    heddle(&["thread", "create", "feature"], Some(source.path())).unwrap();
+    heddle(&["thread", "switch", "feature"], Some(source.path())).unwrap();
+    std::fs::write(source.path().join("feature.txt"), "attacker tip\n").unwrap();
+    heddle(&["capture", "-m", "forged landing tip"], Some(source.path())).unwrap();
+    heddle(&["thread", "switch", "main"], Some(source.path())).unwrap();
+
+    let source_repo = Repository::open(source.path()).unwrap();
+    let feature_tip = source_repo
+        .refs()
+        .get_thread(&ThreadName::new("feature"))
+        .unwrap()
+        .expect("source feature tip");
+    let source_manager = ThreadManager::new(source_repo.heddle_dir());
+    let mut forged = source_manager
+        .find_record_by_thread("feature")
+        .unwrap()
+        .expect("source feature record");
+    forged.state = ThreadState::Blocked;
+    forged.freshness = ThreadFreshness::Current;
+    forged.integration_policy_result.manual_resolution_state = Some(feature_tip.short());
+    forged.integration_policy_result.conflicts_resolved_manually = true;
+    source_manager.save_record(&forged).unwrap();
+
+    let target = TempDir::new().unwrap();
+    heddle(&["init"], Some(target.path())).unwrap();
+    let source_path = source.path().to_str().unwrap().to_string();
+    heddle(
+        &["pull", &source_path, "--thread", "main"],
+        Some(target.path()),
+    )
+    .expect("pull main from the local source");
+    heddle(
+        &[
+            "pull",
+            &source_path,
+            "--thread",
+            "feature",
+            "--local-thread",
+            "feature",
+        ],
+        Some(target.path()),
+    )
+    .expect("pull forged feature metadata from the local source");
+
+    let target_repo = Repository::open(target.path()).unwrap();
+    let pulled = ThreadManager::new(target_repo.heddle_dir())
+        .find_record_by_thread("feature")
+        .unwrap()
+        .expect("pulled feature record");
+    assert_eq!(
+        pulled.integration_policy_result.manual_resolution_state, None,
+        "local pull must drop forged manual_resolution_state"
+    );
+    assert!(
+        !pulled
+            .integration_policy_result
+            .conflicts_resolved_manually,
+        "local pull must drop forged conflicts_resolved_manually"
+    );
+
+    let main_before = current_thread_state(target.path(), "main");
+    let land = heddle_output(
+        &["--output", "json", "land", "--thread", "feature"],
+        Some(target.path()),
+    )
+    .expect("invoke land after forged local pull");
+    let land_stdout = String::from_utf8_lossy(&land.stdout);
+    let land_stderr = String::from_utf8_lossy(&land.stderr);
+    let land_text = format!("{land_stdout}{land_stderr}");
+    assert!(
+        !land_text.contains("manually resolved"),
+        "forged landing metadata must not take the adopt path: {land_text}"
+    );
+    assert!(
+        !land_text.contains("capture_sync_manual_resolution"),
+        "forged landing metadata must not choose the manual-resolution land path: {land_text}"
+    );
+
+    let main_after = current_thread_state(target.path(), "main");
+    assert_eq!(
+        main_after, main_before,
+        "forged local-pull landing metadata must not fast-forward the attached target"
+    );
+    assert_ne!(
+        main_after,
+        feature_tip.to_string(),
+        "attached target must not become the forged feature tip"
+    );
 }
 
 #[test]

--- a/crates/repo/src/thread_model.rs
+++ b/crates/repo/src/thread_model.rs
@@ -306,6 +306,14 @@ pub struct ThreadIntegrationPolicy {
     pub conflicts_resolved_manually: bool,
 }
 
+impl ThreadIntegrationPolicy {
+    /// Zero landing fields an unauthenticated peer can forge.
+    pub fn clear_untrusted_landing_fields(&mut self) {
+        self.manual_resolution_state = None;
+        self.conflicts_resolved_manually = false;
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadRecord {
     pub id: String,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Local `pull` persisted a source `ThreadRecord` and only rewrote identity fields. Hosted conversion already zeros `manual_resolution_state` / `conflicts_resolved_manually`; local pull did not.
- Those forged fields let `manual_resolution_current` plus `adopt_manual_resolution` fast-forward the attached target to the pulled tip.
- `save_pulled_thread_metadata` now calls `ThreadIntegrationPolicy::clear_untrusted_landing_fields` before persist, so landing metadata is untrusted on local pull.

## Closes

Closes HeddleCo/heddle#1412

## Red commit
`839c487fbd3f07df436ee8047eb83e9e12fc4a3f`

On that commit the new test failed as:

```
assertion `left == right` failed: local pull must drop forged manual_resolution_state
  left: Some("hs-czy0sscv7vkb295")
 right: None
```

Local pull copied the forged `manual_resolution_state` through to the destination record.

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_target -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 25.47s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test remotes::test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_target ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 935 filtered out; finished in 0.51s
```

```
$ cargo test -p heddle-cli --test cli_integration test_cli_pull_local -- --test-threads=8
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.39s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 8 tests
test remotes::test_cli_pull_local_lazy_is_rejected ... ok
test remotes::test_cli_pull_local_updates_requested_track ... ok
test remotes::test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged ... ok
test remotes::test_cli_pull_local_creates_remote_thread_and_marker ... ok
test remotes::test_cli_pull_local_side_thread_updates_ref_without_materializing_checkout ... ok
test remotes::test_cli_pull_local_detached_head_materializes_then_publishes_thread ... ok
test remotes::test_cli_pull_local_clean_active_checkout_materializes_before_publish ... ok
test remotes::test_cli_pull_local_forged_landing_metadata_cannot_fast_forward_attached_target ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 928 filtered out; finished in 0.69s
```

```
$ cargo clippy -p heddle-repo -p heddle-cli -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 58.02s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0028fc3-7b55-4e41-a072-4dc1dd1bb8fb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0028fc3-7b55-4e41-a072-4dc1dd1bb8fb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789751756&installation_model_id=21489&pr_number=1423&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1423&signature=e7aef6f8219db4f488cc9e9d4502cb89e7eb723d28e7f3f66a276a411d3f9eef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->