### PR TITLE
Verify wire visibility/redaction sidecars against trusted keys

### DIFF
--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -18,6 +18,7 @@
 
 use std::{fs, process::Command};
 
+use crypto::Signer;
 use serde_json::Value;
 use tempfile::TempDir;
 

--- a/crates/cli/tests/cli_integration/redact_purge.rs
+++ b/crates/cli/tests/cli_integration/redact_purge.rs
@@ -28,6 +28,15 @@ fn write_test_private_key(path: &std::path::Path, pem: &str) {
         .expect("write test private key");
 }
 
+fn trust_redact_public_key(repo: &std::path::Path, public_key_hex: &str) {
+    let config_path = repo.join(".heddle/config.toml");
+    let mut config = fs::read_to_string(&config_path).expect("read config");
+    config.push_str(&format!(
+        "\n[redact]\ntrusted_keys = [{{ algorithm = \"ed25519\", public_key = \"{public_key_hex}\" }}]\n"
+    ));
+    fs::write(&config_path, config).expect("write redact trust list");
+}
+
 /// Bootstrap a repo containing a fake-secret file in a captured state.
 /// Returns the temp dir and the short change-id of the capture.
 fn setup_repo_with_secret() -> (TempDir, String) {
@@ -632,12 +641,12 @@ fn redact_apply_signed_propagates_to_cloned_replica() {
     let apply = signed_redact_on_repo_a(&a, &state, &pem_path);
     let redaction_id = apply["redaction_id"].as_str().unwrap().to_string();
 
-    // Set up B. Transport write authority admits the signed redaction;
-    // the signature protects authorship and integrity.
+    // Set up B: init empty repo, trust A's signing key, then pull.
     let b_dir = TempDir::new().unwrap();
     let b_path = b_dir.path().join("replica-b");
     fs::create_dir_all(&b_path).unwrap();
     heddle(&["init"], Some(&b_path)).expect("init B");
+    trust_redact_public_key(&b_path, &hex::encode(signer.public_key()));
     heddle(
         &["remote", "add", "origin", a.path().to_str().unwrap()],
         Some(&b_path),
@@ -742,6 +751,7 @@ fn ordinary_local_sync_does_not_propagate_owner_gated_purge() {
     let b_path = b_dir.path().join("replica-b");
     fs::create_dir_all(&b_path).unwrap();
     heddle(&["init"], Some(&b_path)).expect("init B");
+    trust_redact_public_key(&b_path, &hex::encode(signer.public_key()));
     heddle(
         &["remote", "add", "origin", a.path().to_str().unwrap()],
         Some(&b_path),
@@ -795,12 +805,14 @@ fn tampered_redaction_is_refused_at_pull_boundary() {
     // The above forfeits A's own materialize-side stub correctness;
     // the local invariant break is the point of the test.
 
-    // Transport write authority admits the operation; the rejection comes
-    // from signature verification failing on the tampered canonical payload.
+    // B trusts the signing key, so the trust gate passes — the
+    // rejection comes from signature verification failing on the
+    // tampered canonical payload (Tampered, not UntrustedKey).
     let b_dir = TempDir::new().unwrap();
     let b_path = b_dir.path().join("replica-b");
     fs::create_dir_all(&b_path).unwrap();
     heddle(&["init"], Some(&b_path)).expect("init B");
+    trust_redact_public_key(&b_path, &hex::encode(signer.public_key()));
     heddle(
         &["remote", "add", "origin", a.path().to_str().unwrap()],
         Some(&b_path),
@@ -1041,7 +1053,8 @@ fn redact_after_peer_pull_still_propagates_on_resync() {
     let _ = signed_redact_on_repo_a(&a, &state, &pem_path);
 
     // Re-sync ferries the ordinary sidecar even though every state/tree/blob
-    // is already present on B.
+    // is already present on B. B must trust A's signing key first.
+    trust_redact_public_key(&b_path, &hex::encode(signer.public_key()));
     heddle(
         &["remote", "add", "origin", a.path().to_str().unwrap()],
         Some(&b_path),
@@ -1066,9 +1079,12 @@ fn redact_after_peer_pull_still_propagates_on_resync() {
 }
 
 #[test]
-fn writer_signed_redaction_is_accepted_at_pull_boundary_without_owner_capability() {
+fn untrusted_signed_redaction_is_refused_at_pull_boundary() {
     use crypto::Ed25519Signer;
 
+    // Without a trust check the receiver accepts any self-signed
+    // redaction. B is initialized with an empty `[redact] trusted_keys`
+    // list. The pull must refuse with `UntrustedKey`.
     let (a, state) = setup_repo_with_secret();
     let attacker = Ed25519Signer::generate().unwrap();
     let pem = attacker.to_pem().unwrap();
@@ -1085,17 +1101,11 @@ fn writer_signed_redaction_is_accepted_at_pull_boundary_without_owner_capability
         Some(&b_path),
     )
     .expect("remote add origin");
-    heddle(&["pull", "origin"], Some(&b_path))
-        .expect("ordinary write authority accepts a valid author signature");
-
-    let list: Value = serde_json::from_str(
-        &heddle(&["--output", "json", "redact", "list"], Some(&b_path)).unwrap(),
-    )
-    .unwrap();
-    assert_eq!(
-        list["redactions"].as_array().unwrap().len(),
-        1,
-        "B must receive the writer-authorized redaction"
+    let err = heddle(&["pull", "origin"], Some(&b_path))
+        .expect_err("pull must refuse untrusted signed redaction");
+    assert!(
+        err.contains("untrusted operator key"),
+        "pull rejection must explain the untrusted-key cause: {err}"
     );
 }
 

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -37,6 +37,31 @@ pub struct RepoConfig {
     pub review: ReviewConfig,
     #[serde(default)]
     pub provenance: ProvenanceConfig,
+    #[serde(default)]
+    pub redact: RedactConfig,
+    #[serde(default)]
+    pub metadata: MetadataConfig,
+}
+
+/// `[redact]` config section. Houses the list of operator public keys
+/// that the receiver trusts when accepting redactions over the wire
+/// (`Repository::accept_wire_redactions`). The list is fail-closed:
+/// an empty list rejects every incoming signed redaction. Operators
+/// populate it by editing `.heddle/config.toml`.
+///
+/// The reason the trust list lives in repo config rather than in the
+/// signed payload itself: a signature only proves *who* declared the
+/// redaction, not whether the receiver should *honor* that operator's
+/// authority for this workspace. Without a separate trust anchor an
+/// attacker can mint a redaction with their own key and pass
+/// signature verification trivially.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct RedactConfig {
+    /// Trusted operator public keys. Every signed redaction received
+    /// over the wire must match one of these (algorithm + hex-encoded
+    /// public key) before the receiver persists the sidecar.
+    #[serde(default)]
+    pub trusted_keys: Vec<TrustedKey>,
 }
 
 /// One trusted operator key entry. Algorithm and key strings use the
@@ -51,6 +76,26 @@ pub struct TrustedKey {
     /// semantics. Optional; doesn't affect matching.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+}
+
+impl TrustedKey {
+    /// Case-insensitive algorithm + hex public-key match against a
+    /// wire signature's claimed identity.
+    pub fn matches(&self, algorithm: &str, public_key_hex: &str) -> bool {
+        self.algorithm.eq_ignore_ascii_case(algorithm)
+            && self.public_key.eq_ignore_ascii_case(public_key_hex)
+    }
+
+    /// The configured entry whose identity matches `(algorithm, public_key_hex)`.
+    pub fn find<'a>(
+        trusted: &'a [Self],
+        algorithm: &str,
+        public_key_hex: &str,
+    ) -> Option<&'a Self> {
+        trusted
+            .iter()
+            .find(|key| key.matches(algorithm, public_key_hex))
+    }
 }
 
 /// `[provenance]` trust configuration for offline identity verification.
@@ -74,6 +119,17 @@ pub struct KeyBindingRegistryAnchor {
     pub epoch: u64,
     /// Authority allowed to endorse registry checkpoints and root bindings.
     pub authority: TrustedKey,
+}
+
+/// Trust anchors for client-authored metadata received from a remote host.
+///
+/// Hosted servers relay these records but are not trusted to author them.
+/// An empty list therefore fails closed for authoritative metadata such as
+/// visibility declarations.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MetadataConfig {
+    #[serde(default)]
+    pub trusted_keys: Vec<TrustedKey>,
 }
 
 /// Review-epic configuration. Houses the `[review.signals]` sub-table read by
@@ -436,6 +492,8 @@ impl Default for RepoConfig {
             hosted: HostedConfig::default(),
             review: ReviewConfig::default(),
             provenance: ProvenanceConfig::default(),
+            redact: RedactConfig::default(),
+            metadata: MetadataConfig::default(),
         }
     }
 }
@@ -558,6 +616,8 @@ mod tests {
         assert_eq!(config.output.format, None);
         assert!(config.policies.default_policy.is_none());
         assert_eq!(config.storage.delta_search, DeltaSearchConfig::default());
+        assert!(config.redact.trusted_keys.is_empty());
+        assert!(config.metadata.trusted_keys.is_empty());
     }
 
     #[test]
@@ -575,6 +635,20 @@ source_authority = "native"
         assert!(config.agent.provider.is_none());
         assert!(config.agent.model.is_none());
         assert_eq!(config.storage.delta_search, DeltaSearchConfig::default());
+        assert!(config.redact.trusted_keys.is_empty());
+        assert!(config.metadata.trusted_keys.is_empty());
+    }
+
+    #[test]
+    fn trusted_key_match_is_case_insensitive() {
+        let key = TrustedKey {
+            algorithm: "Ed25519".to_string(),
+            public_key: "aabb".to_string(),
+            label: None,
+        };
+        assert!(key.matches("ed25519", "AABB"));
+        assert!(TrustedKey::find(std::slice::from_ref(&key), "ED25519", "AaBb").is_some());
+        assert!(TrustedKey::find(&[key], "p256", "aabb").is_none());
     }
 
     #[test]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -652,7 +652,6 @@ source_authority = "native"
     }
 
     #[test]
-    #[test]
     fn empty_trust_tables_are_omitted_from_saved_config() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("config.toml");

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -37,9 +37,9 @@ pub struct RepoConfig {
     pub review: ReviewConfig,
     #[serde(default)]
     pub provenance: ProvenanceConfig,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "RedactConfig::is_empty")]
     pub redact: RedactConfig,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "MetadataConfig::is_empty")]
     pub metadata: MetadataConfig,
 }
 
@@ -60,8 +60,14 @@ pub struct RedactConfig {
     /// Trusted operator public keys. Every signed redaction received
     /// over the wire must match one of these (algorithm + hex-encoded
     /// public key) before the receiver persists the sidecar.
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trusted_keys: Vec<TrustedKey>,
+}
+
+impl RedactConfig {
+    fn is_empty(&self) -> bool {
+        self.trusted_keys.is_empty()
+    }
 }
 
 /// One trusted operator key entry. Algorithm and key strings use the
@@ -128,8 +134,14 @@ pub struct KeyBindingRegistryAnchor {
 /// visibility declarations.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MetadataConfig {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub trusted_keys: Vec<TrustedKey>,
+}
+
+impl MetadataConfig {
+    fn is_empty(&self) -> bool {
+        self.trusted_keys.is_empty()
+    }
 }
 
 /// Review-epic configuration. Houses the `[review.signals]` sub-table read by
@@ -637,6 +649,23 @@ source_authority = "native"
         assert_eq!(config.storage.delta_search, DeltaSearchConfig::default());
         assert!(config.redact.trusted_keys.is_empty());
         assert!(config.metadata.trusted_keys.is_empty());
+    }
+
+    #[test]
+    #[test]
+    fn empty_trust_tables_are_omitted_from_saved_config() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("config.toml");
+        RepoConfig::default().save(&path).unwrap();
+        let saved = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !saved.contains("[redact]"),
+            "empty redact trust must stay off disk: {saved}"
+        );
+        assert!(
+            !saved.contains("[metadata]"),
+            "empty metadata trust must stay off disk: {saved}"
+        );
     }
 
     #[test]

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -50,6 +50,14 @@ pub enum WireRejection {
     /// The record carries a signature, but it doesn't verify against
     /// the canonical signing payload. Tampering or wrong key.
     Tampered,
+    /// The signature verifies against the embedded key, but that key
+    /// is not on the receiver's `[redact] trusted_keys` list. Signing
+    /// proves *who* declared the redaction; the trust list proves the
+    /// receiver has *authorized* that operator to act on this workspace.
+    UntrustedKey {
+        algorithm: String,
+        public_key: String,
+    },
 }
 
 /// Outcome of an `accept_wire_redactions` call. Receiver-side sync
@@ -457,6 +465,11 @@ impl Repository {
     ///   would let an unsigned sibling smuggle in via a signed peer).
     /// - [`WireRejection::Tampered`] if any signature fails to verify
     ///   against the canonical payload.
+    /// - [`WireRejection::UntrustedKey`] if the signer's public key is
+    ///   not on this receiver's `[redact] trusted_keys` list. The list
+    ///   is fail-closed: an empty list rejects every incoming signed
+    ///   redaction, forcing operators to make an explicit trust
+    ///   decision before secrets-scrubbing primitives are accepted.
     /// - Other errors propagate as `anyhow::Error` (decode failure, io,
     ///   crypto subsystem failure).
     pub fn accept_wire_redactions(
@@ -467,6 +480,7 @@ impl Repository {
         let _lock = self.locker().write()?;
         let mut incoming = RedactionsBlob::decode(bytes)
             .with_context(|| format!("decode incoming redactions for blob {}", blob.short()))?;
+        let trusted_keys = &self.config().redact.trusted_keys;
 
         // Pre-validate every entry before we touch the local store —
         // an all-or-nothing accept keeps the audit trail honest.
@@ -478,7 +492,7 @@ impl Repository {
                     blob.short()
                 );
             }
-            verify_redaction_signature(redaction)
+            verify_wire_redaction(redaction, trusted_keys)
                 .with_context(|| format!("verify incoming redaction for blob {}", blob.short()))?;
         }
 
@@ -760,16 +774,54 @@ fn walk_tree_for_blob(
     Ok(())
 }
 
+/// Verify an incoming redaction against the receiver's trusted-key list.
+///
+/// Rejection variants:
+/// - [`WireRejection::Unsigned`] when no signature is present.
+/// - [`WireRejection::UntrustedKey`] when the signer's public key is
+///   not on the trust list. Checked *before* `verify_payload_signature`
+///   so an attacker can't probe the trust list via a timing oracle —
+///   the cryptographic cost is paid only for keys we trust.
+/// - [`WireRejection::Tampered`] when verification fails.
+///
+/// Cryptographic verification uses the configured trusted key, not the
+/// attacker-supplied key bytes from the sidecar.
+fn verify_wire_redaction(redaction: &Redaction, trusted_keys: &[crate::TrustedKey]) -> Result<()> {
+    let Some(signature) = &redaction.signature else {
+        anyhow::bail!(WireRejection::Unsigned);
+    };
+    let Some(trusted) =
+        crate::TrustedKey::find(trusted_keys, &signature.algorithm, &signature.public_key)
+    else {
+        anyhow::bail!(WireRejection::UntrustedKey {
+            algorithm: signature.algorithm.clone(),
+            public_key: signature.public_key.clone(),
+        });
+    };
+    verify_redaction_against_key(redaction, &trusted.algorithm, &trusted.public_key)
+}
+
 fn verify_redaction_signature(redaction: &Redaction) -> Result<()> {
     let Some(signature) = &redaction.signature else {
         anyhow::bail!(WireRejection::Unsigned);
     };
+    verify_redaction_against_key(redaction, &signature.algorithm, &signature.public_key)
+}
+
+fn verify_redaction_against_key(
+    redaction: &Redaction,
+    algorithm: &str,
+    public_key_hex: &str,
+) -> Result<()> {
+    let Some(signature) = &redaction.signature else {
+        anyhow::bail!(WireRejection::Unsigned);
+    };
     let payload = redaction.canonical_signing_payload();
-    let public_key = hex::decode(&signature.public_key)
-        .with_context(|| "decode incoming redaction signature public key")?;
+    let public_key =
+        hex::decode(public_key_hex).with_context(|| "decode redaction signature public key")?;
     let sig_bytes = hex::decode(&signature.signature)
         .with_context(|| "decode incoming redaction signature bytes")?;
-    if verify_payload_signature(&payload, &signature.algorithm, &public_key, &sig_bytes).is_err() {
+    if verify_payload_signature(&payload, algorithm, &public_key, &sig_bytes).is_err() {
         anyhow::bail!(WireRejection::Tampered);
     }
     Ok(())
@@ -785,6 +837,14 @@ impl std::fmt::Display for WireRejection {
             WireRejection::Tampered => f.write_str(
                 "redaction signature failed to verify — the canonical payload \
                  was modified after signing or the wrong key was used",
+            ),
+            WireRejection::UntrustedKey {
+                algorithm,
+                public_key,
+            } => write!(
+                f,
+                "redaction signed by an untrusted operator key ({algorithm}:{public_key}) — \
+                 add the key to `[redact] trusted_keys` in `.heddle/config.toml` to accept it"
             ),
         }
     }
@@ -842,6 +902,7 @@ fn remove_blob_bytes(repo: &Repository, hash: &ContentHash) -> Result<(bool, boo
 #[cfg(test)]
 mod tests {
     use chrono::TimeZone;
+    use crypto::Signer;
     use objects::{
         object::{Blob, Principal, StateId},
         store::pack::PackObjectId,
@@ -883,6 +944,21 @@ mod tests {
 
     fn fresh_repo_with_local_purge_authority() -> (TempDir, Repository) {
         fresh_repo()
+    }
+
+    fn fresh_repo_trusting(signer: &dyn crypto::Signer) -> (TempDir, Repository) {
+        let dir = TempDir::new().unwrap();
+        Repository::init_default(dir.path()).unwrap();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let mut config = crate::repository::repo_config::RepoConfig::load(&config_path).unwrap();
+        config.redact.trusted_keys.push(crate::TrustedKey {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            label: Some("test-redactor".to_string()),
+        });
+        config.save(&config_path).expect("save trust configuration");
+        let repo = Repository::open(dir.path()).expect("reopen trusted repo");
+        (dir, repo)
     }
 
     #[test]
@@ -1243,16 +1319,20 @@ mod tests {
     }
 
     #[test]
-    fn writer_signed_redaction_needs_no_owner_capability_or_trust_entry() {
+    fn empty_redact_trust_list_rejects_valid_self_signature() {
         let (_dir, repo) = fresh_repo();
         let writer = crypto::Ed25519Signer::generate().expect("keygen");
         let payload = RedactionsBlob::new(vec![signed_sample_redaction(&writer)])
             .encode()
             .unwrap();
-        let outcome = repo
+        let err = repo
             .accept_wire_redactions(sample_blob(), &payload)
-            .expect("ordinary write-authorized redaction");
-        assert_eq!(outcome.redactions_added, 1);
+            .expect_err("fail-closed empty trust list must reject every signed redaction");
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain.iter().any(|m| m.contains("untrusted operator key")),
+            "rejection reason must explain untrusted-key, got chain: {chain:?}"
+        );
     }
 
     #[test]
@@ -1304,7 +1384,7 @@ mod tests {
     #[test]
     fn accept_wire_redactions_persists_signed_redaction_idempotently() {
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
-        let (_dir, repo) = fresh_repo();
+        let (_dir, repo) = fresh_repo_trusting(&signer);
         let signed = signed_sample_redaction(&signer);
         let payload = RedactionsBlob::new(vec![signed]).encode().unwrap();
 
@@ -1325,7 +1405,7 @@ mod tests {
     #[test]
     fn accept_wire_redactions_rejects_tampered_signature() {
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
-        let (_dir, repo) = fresh_repo();
+        let (_dir, repo) = fresh_repo_trusting(&signer);
         let mut tampered = signed_sample_redaction(&signer);
         // Mutate the reason AFTER signing — the canonical payload
         // changes but the signature does not, so verification fails.
@@ -1345,7 +1425,7 @@ mod tests {
     fn ordinary_redaction_transfer_strips_purge_evidence() {
         let redactor = crypto::Ed25519Signer::generate().expect("redactor keygen");
         let purger = crypto::Ed25519Signer::generate().expect("purger keygen");
-        let (_dir, repo) = fresh_repo();
+        let (_dir, repo) = fresh_repo_trusting(&redactor);
         let mut signed = signed_sample_redaction(&redactor);
         attach_purge_evidence(
             &mut signed,

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -1346,17 +1346,7 @@ mod tests {
             attacker.public_key(),
             "fixture keys must be distinct"
         );
-
-        let dir = TempDir::new().unwrap();
-        Repository::init_default(dir.path()).unwrap();
-        let config_path = dir.path().join(".heddle/config.toml");
-        let mut config = std::fs::read_to_string(&config_path).expect("read config");
-        config.push_str(&format!(
-            "\n[redact]\ntrusted_keys = [{{ algorithm = \"ed25519\", public_key = \"{}\" }}]\n",
-            hex::encode(trusted.public_key())
-        ));
-        std::fs::write(&config_path, config).expect("write trusted redact key");
-        let repo = Repository::open(dir.path()).expect("reopen with trust list");
+        let (_dir, repo) = fresh_repo_trusting(&trusted);
 
         let payload = RedactionsBlob::new(vec![signed_sample_redaction(&attacker)])
             .encode()

--- a/crates/repo/src/repository_redaction.rs
+++ b/crates/repo/src/repository_redaction.rs
@@ -1256,6 +1256,52 @@ mod tests {
     }
 
     #[test]
+    fn accept_wire_redactions_refuses_untrusted_signer_even_with_valid_signature() {
+        // heddle#1405: a mathematically valid self-signature is not
+        // authority. The receiver must honor only `[redact] trusted_keys`.
+        let trusted = crypto::Ed25519Signer::generate().expect("trusted keygen");
+        let attacker = crypto::Ed25519Signer::generate().expect("attacker keygen");
+        assert_ne!(
+            trusted.public_key(),
+            attacker.public_key(),
+            "fixture keys must be distinct"
+        );
+
+        let dir = TempDir::new().unwrap();
+        Repository::init_default(dir.path()).unwrap();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let mut config = std::fs::read_to_string(&config_path).expect("read config");
+        config.push_str(&format!(
+            "\n[redact]\ntrusted_keys = [{{ algorithm = \"ed25519\", public_key = \"{}\" }}]\n",
+            hex::encode(trusted.public_key())
+        ));
+        std::fs::write(&config_path, config).expect("write trusted redact key");
+        let repo = Repository::open(dir.path()).expect("reopen with trust list");
+
+        let payload = RedactionsBlob::new(vec![signed_sample_redaction(&attacker)])
+            .encode()
+            .unwrap();
+        let err = repo
+            .accept_wire_redactions(sample_blob(), &payload)
+            .expect_err(
+                "a sidecar signed by a key outside the trusted set must be rejected even when \
+                 the embedded key verifies the payload",
+            );
+        let chain: Vec<String> = err.chain().map(|e| e.to_string()).collect();
+        assert!(
+            chain
+                .iter()
+                .any(|m| m.contains("untrusted") || m.contains("not trusted")),
+            "rejection reason must explain untrusted-key, got chain: {chain:?}"
+        );
+        let stored = repo.get_redactions_for_blob(&sample_blob()).unwrap();
+        assert!(
+            stored.redactions.is_empty(),
+            "untrusted redaction must not persist"
+        );
+    }
+
+    #[test]
     fn accept_wire_redactions_persists_signed_redaction_idempotently() {
         let signer = crypto::Ed25519Signer::generate().expect("keygen");
         let (_dir, repo) = fresh_repo();

--- a/crates/repo/src/repository_signing.rs
+++ b/crates/repo/src/repository_signing.rs
@@ -128,9 +128,12 @@ impl Repository {
         })
     }
 
-    /// Verify the author signature on client-authored metadata. Transport
-    /// write authority decides whether the principal may submit the record;
-    /// this signature only protects authorship and payload integrity.
+    /// Verify hosted metadata against this repository's trusted client keys.
+    ///
+    /// A signature only proves the payload was signed by the key *embedded in
+    /// the record*. Acceptance requires that key to appear in
+    /// `[metadata] trusted_keys`, and cryptographic verification uses that
+    /// configured key — not attacker-supplied key bytes.
     pub(crate) fn verify_client_metadata_signature(
         &self,
         payload: &[u8],
@@ -138,16 +141,27 @@ impl Repository {
     ) -> Result<()> {
         let signature = signature.ok_or_else(|| {
             HeddleError::InvalidObject(
-                "hosted metadata is unsigned; a client signature is required".to_string(),
+                "hosted metadata is unsigned; a trusted client signature is required".to_string(),
             )
         })?;
-        let public_key = hex::decode(&signature.public_key).map_err(|error| {
+        let trusted = super::repo_config::TrustedKey::find(
+            &self.config().metadata.trusted_keys,
+            &signature.algorithm,
+            &signature.public_key,
+        )
+        .ok_or_else(|| {
+            HeddleError::InvalidObject(format!(
+                "hosted metadata signer is not trusted ({}:{})",
+                signature.algorithm, signature.public_key
+            ))
+        })?;
+        let public_key = hex::decode(&trusted.public_key).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata public key: {error}"))
         })?;
         let signature_bytes = hex::decode(&signature.signature).map_err(|error| {
             HeddleError::InvalidObject(format!("invalid metadata signature: {error}"))
         })?;
-        verify_payload_signature(payload, &signature.algorithm, &public_key, &signature_bytes)
+        verify_payload_signature(payload, &trusted.algorithm, &public_key, &signature_bytes)
             .map_err(|error| {
                 HeddleError::InvalidObject(format!(
                     "hosted metadata signature failed verification: {error}"

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -913,6 +913,21 @@ mod tests {
         }
     }
 
+    fn repo_trusting_metadata(signer: &dyn Signer) -> (TempDir, Repository) {
+        let dir = TempDir::new().unwrap();
+        Repository::init_default(dir.path()).unwrap();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let mut config = crate::repository::repo_config::RepoConfig::load(&config_path).unwrap();
+        config.metadata.trusted_keys.push(crate::TrustedKey {
+            algorithm: signer.algorithm().to_string(),
+            public_key: hex::encode(signer.public_key()),
+            label: Some("test-client".to_string()),
+        });
+        config.save(&config_path).unwrap();
+        let repo = Repository::open(dir.path()).unwrap();
+        (dir, repo)
+    }
+
     fn sign_visibility(record: &mut StateVisibility, signer: &dyn Signer) {
         let signature = signer
             .sign(&record.canonical_signing_payload())
@@ -925,9 +940,9 @@ mod tests {
     }
 
     #[test]
-    fn writer_signed_visibility_needs_no_owner_capability_and_covers_tier() {
+    fn wire_visibility_requires_trusted_signature_and_covers_tier() {
         let signer = Ed25519Signer::generate().expect("keygen");
-        let (_dir, repo) = fresh_repo();
+        let (_dir, repo) = repo_trusting_metadata(&signer);
         let state = StateId::from_bytes([4u8; 32]);
         let mut record = sample_record(state, VisibilityTier::Internal);
 
@@ -942,7 +957,7 @@ mod tests {
             .encode()
             .unwrap();
         repo.accept_wire_state_visibility(state, &signed)
-            .expect("ordinary write-authorized visibility");
+            .expect("trusted signed visibility");
 
         let tampered_state = StateId::from_bytes([5u8; 32]);
         let mut tampered = sample_record(

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -985,17 +985,7 @@ mod tests {
             attacker.public_key(),
             "fixture keys must be distinct"
         );
-
-        let dir = TempDir::new().unwrap();
-        Repository::init_default(dir.path()).unwrap();
-        let config_path = dir.path().join(".heddle/config.toml");
-        let mut config = std::fs::read_to_string(&config_path).expect("read config");
-        config.push_str(&format!(
-            "\n[metadata]\ntrusted_keys = [{{ algorithm = \"ed25519\", public_key = \"{}\" }}]\n",
-            hex::encode(trusted.public_key())
-        ));
-        std::fs::write(&config_path, config).expect("write trusted metadata key");
-        let repo = Repository::open(dir.path()).expect("reopen with trust list");
+        let (_dir, repo) = repo_trusting_metadata(&trusted);
 
         let state = StateId::from_bytes([9u8; 32]);
         let mut record = sample_record(state, VisibilityTier::Internal);

--- a/crates/repo/src/repository_state_visibility.rs
+++ b/crates/repo/src/repository_state_visibility.rs
@@ -959,6 +959,53 @@ mod tests {
     }
 
     #[test]
+    fn wire_visibility_rejects_self_signed_key_not_in_trusted_set() {
+        // heddle#1405: cryptographic validity against the key embedded in
+        // the sidecar is not enough. The signer must be in the receiver's
+        // configured `[metadata] trusted_keys` list.
+        let trusted = Ed25519Signer::generate().expect("trusted keygen");
+        let attacker = Ed25519Signer::generate().expect("attacker keygen");
+        assert_ne!(
+            trusted.public_key(),
+            attacker.public_key(),
+            "fixture keys must be distinct"
+        );
+
+        let dir = TempDir::new().unwrap();
+        Repository::init_default(dir.path()).unwrap();
+        let config_path = dir.path().join(".heddle/config.toml");
+        let mut config = std::fs::read_to_string(&config_path).expect("read config");
+        config.push_str(&format!(
+            "\n[metadata]\ntrusted_keys = [{{ algorithm = \"ed25519\", public_key = \"{}\" }}]\n",
+            hex::encode(trusted.public_key())
+        ));
+        std::fs::write(&config_path, config).expect("write trusted metadata key");
+        let repo = Repository::open(dir.path()).expect("reopen with trust list");
+
+        let state = StateId::from_bytes([9u8; 32]);
+        let mut record = sample_record(state, VisibilityTier::Internal);
+        sign_visibility(&mut record, &attacker);
+        let signed = StateVisibilityBlob::new(vec![record]).encode().unwrap();
+        let err = repo
+            .accept_wire_state_visibility(state, &signed)
+            .expect_err(
+                "a sidecar signed by a key outside the trusted set must be rejected even when \
+                 the embedded key verifies the payload",
+            );
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("not trusted") || chain.contains("untrusted"),
+            "rejection must name the missing trust, got: {chain}"
+        );
+        assert!(
+            !repo
+                .has_visibility_for_state(&state)
+                .expect("has visibility"),
+            "untrusted visibility must not persist"
+        );
+    }
+
+    #[test]
     fn put_then_read_back_and_has_visibility_true() {
         let (_dir, repo) = fresh_repo();
         let state = StateId::from_bytes([5u8; 32]);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Incoming visibility and redaction sidecars were accepted if the **embedded** public key verified the payload. That is self-signed trust: an attacker mints a key, signs the sidecar, and the receiver persists it.
- Restore the fail-closed receiver lists that #1400 removed for ordinary sidecars: `[metadata] trusted_keys` for visibility, `[redact] trusted_keys` for redaction. Cryptographic verification uses the **configured** key, not attacker-supplied key bytes.
- Purge stays on owner-authorization v2. Legacy `[purge] trusted_keys` still grant nothing.

## Closes

Closes HeddleCo/heddle#1405

## Red commit
`69928c6354340af5e0961ffdecb58163c147a71a`

## Test evidence
```
$ cargo test -p heddle-repo --lib -- repository_redaction::tests repository_state_visibility::tests repository::repo_config::tests owner_authorization_tests && cargo test -p heddle-cli --test cli_integration redact_purge

    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 53 tests
test repository::repo_config::tests::empty_trust_tables_are_omitted_from_saved_config ... ok
test repository::repo_config::tests::trusted_key_match_is_case_insensitive ... ok
test owner_authorization_tests::purge_without_authorization_is_denied_even_with_legacy_trust_tables ... ok
test repository_redaction::tests::accept_wire_redactions_refuses_untrusted_signer_even_with_valid_signature ... ok
test repository_redaction::tests::empty_redact_trust_list_rejects_valid_self_signature ... ok
test repository_state_visibility::tests::wire_visibility_rejects_self_signed_key_not_in_trusted_set ... ok
test repository_state_visibility::tests::wire_visibility_requires_trusted_signature_and_covers_tier ... ok
...
test result: ok. 53 passed; 0 failed; 0 ignored; 0 measured; 618 filtered out; finished in 1.07s

    Finished `test` profile [unoptimized + debuginfo] target(s) in 31.16s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 25 tests
test redact_purge::redact_apply_signed_propagates_to_cloned_replica ... ok
test redact_purge::tampered_redaction_is_refused_at_pull_boundary ... ok
test redact_purge::untrusted_signed_redaction_is_refused_at_pull_boundary ... ok
...
test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 910 filtered out; finished in 1.25s
```

`cargo clippy -p heddle-repo --lib -- -D warnings` finished clean.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c43fd306-dca3-4116-a247-cbe4c3d0e7dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c43fd306-dca3-4116-a247-cbe4c3d0e7dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789751843&installation_model_id=21489&pr_number=1424&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1424&signature=4e45ddb453199641053bbcc5b96a357b90ef5dd70732e2d89fb3395fb38a8c70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->