### PR TITLE
Bind annotated tags to Git target, target_tag, and peeled_state

### DIFF
--- a/crates/git-projection/src/git_export.rs
+++ b/crates/git-projection/src/git_export.rs
@@ -5,7 +5,7 @@ use std::collections::HashSet;
 
 use objects::{
     error::HeddleError,
-    object::{ContentHash, MarkerName, State, StateId, ThreadName, TreeEntryTarget},
+    object::{AnnotatedTag, ContentHash, MarkerName, State, StateId, ThreadName, TreeEntryTarget},
     store::ObjectStore,
 };
 use repo::{AudienceTier, Repository as HeddleRepository, visible};
@@ -1377,8 +1377,8 @@ fn project_desired_refs(
             continue;
         };
         if let Some(git_oid) = mapping.get_git(&state_id) {
-            let target =
-                native_annotated_tag_oid(heddle_repo, marker_name, state_id)?.unwrap_or(git_oid);
+            let target = native_annotated_tag_oid(heddle_repo, marker_name, state_id, git_oid)?
+                .unwrap_or(git_oid);
             desired.insert(format!("refs/tags/{marker_name}"), target);
         }
     }
@@ -1405,6 +1405,7 @@ fn native_annotated_tag_oid(
     heddle_repo: &HeddleRepository,
     marker_name: &MarkerName,
     state_id: StateId,
+    mapped_commit: ObjectId,
 ) -> GitProjectionResult<Option<ObjectId>> {
     for hash in heddle_repo.store().list_annotated_tags()? {
         let Some(tag) = heddle_repo.store().get_annotated_tag(&hash)? else {
@@ -1413,6 +1414,12 @@ fn native_annotated_tag_oid(
         if tag.marker().is_some_and(|marker| {
             marker.name == marker_name.as_str() && marker.peeled_state == state_id
         }) {
+            let peeled = peel_native_annotated_tag(heddle_repo, &tag)?;
+            if peeled != mapped_commit {
+                return Err(GitProjectionError::Git(format!(
+                    "annotated tag {marker_name} Git target peels to {peeled}, which disagrees with mapped commit {mapped_commit} for peeled_state {state_id}"
+                )));
+            }
             return tag
                 .git_oid()
                 .map(Some)
@@ -1420,6 +1427,55 @@ fn native_annotated_tag_oid(
         }
     }
     Ok(None)
+}
+
+fn peel_native_annotated_tag(
+    heddle_repo: &HeddleRepository,
+    tag: &AnnotatedTag,
+) -> GitProjectionResult<ObjectId> {
+    let mut current = tag.clone();
+    let mut seen = HashSet::new();
+    loop {
+        let hash = current.hash();
+        if !seen.insert(hash) {
+            return Err(GitProjectionError::Git(format!(
+                "annotated tag {hash} has a cycle in target_tag"
+            )));
+        }
+        let git_target = current
+            .git_target()
+            .map_err(|error| GitProjectionError::Git(error.to_string()))?;
+        let git_type = current
+            .git_target_type()
+            .map_err(|error| GitProjectionError::Git(error.to_string()))?;
+        match git_type {
+            GitObjectType::Commit => return Ok(git_target),
+            GitObjectType::Tag => {
+                let inner_hash = current.target_tag().ok_or_else(|| {
+                    GitProjectionError::Git(format!(
+                        "annotated tag {hash} has Git type tag but no target_tag"
+                    ))
+                })?;
+                let inner = heddle_repo
+                    .store()
+                    .get_annotated_tag(&inner_hash)?
+                    .ok_or_else(|| {
+                        GitProjectionError::Git(format!(
+                            "annotated tag {hash} references missing inner tag {inner_hash}"
+                        ))
+                    })?;
+                current
+                    .bind_target_tag(&inner)
+                    .map_err(|error| GitProjectionError::Git(error.to_string()))?;
+                current = inner;
+            }
+            GitObjectType::Blob | GitObjectType::Tree => {
+                return Err(GitProjectionError::Git(format!(
+                    "annotated tag {hash} Git target {git_target} is a {git_type:?}, not a commit"
+                )));
+            }
+        }
+    }
 }
 
 /// The Git OID the public branch should lag to for a thread whose raw tip is
@@ -1533,3 +1589,7 @@ mod tests {
         );
     }
 }
+
+#[cfg(test)]
+#[path = "git_export_annotated_tag_tests.rs"]
+mod annotated_tag_export_tests;

--- a/crates/git-projection/src/git_export_annotated_tag_tests.rs
+++ b/crates/git-projection/src/git_export_annotated_tag_tests.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use objects::object::{AnnotatedTagMarker, MarkerName};
+use objects::object::{AnnotatedTagMarker, Attribution, MarkerName, Principal};
 use repo::Repository as HeddleRepository;
 use sley::{
     CommitObject, EntryKind, GitObjectType, GitTime, ObjectFormat, ObjectId, RefPrecondition,
@@ -200,7 +200,13 @@ fn export_peels_annotated_tag_before_writing_refs_tags() {
 fn export_rejects_annotated_tag_whose_git_target_disagrees_with_peeled_state() {
     let temp = tempfile::TempDir::new().unwrap();
     let repo = HeddleRepository::init_default(temp.path()).unwrap();
-    let state = repo.snapshot(Some("tagged".to_string()), None).unwrap();
+    let state = repo
+        .snapshot_with_attribution(
+            Some("tagged".to_string()),
+            None,
+            Attribution::human(Principal::new("Test", "test@example.com")),
+        )
+        .unwrap();
     repo.create_marker_recorded(&MarkerName::new("v1.0"), &state.state_id)
         .unwrap();
     let tag = AnnotatedTag::new(

--- a/crates/git-projection/src/git_export_annotated_tag_tests.rs
+++ b/crates/git-projection/src/git_export_annotated_tag_tests.rs
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use objects::object::{AnnotatedTagMarker, MarkerName};
+use repo::Repository as HeddleRepository;
+use sley::{
+    CommitObject, EntryKind, GitObjectType, GitTime, ObjectFormat, ObjectId, RefPrecondition,
+    Repository as SleyRepository, Signature, TagObject, TreeEditor,
+    plumbing::{sley_core::ByteString, sley_object::EncodedObject},
+};
+
+use super::*;
+use crate::GitProjection;
+
+const COMMIT_OID: &str = "1111111111111111111111111111111111111111";
+const OTHER_OID: &str = "2222222222222222222222222222222222222222";
+
+fn tag_body(object: &str, kind: &str, name: &str) -> Vec<u8> {
+    format!(
+        "object {object}\ntype {kind}\ntag {name}\ntagger Test <test@example.com> 1700000000 +0000\n\nrelease\n"
+    )
+    .into_bytes()
+}
+
+fn write_commit(repo: &SleyRepository, message: &str) -> ObjectId {
+    let blob = repo.write_blob(b"hello\n").expect("write blob");
+    let mut tree = TreeEditor::new();
+    tree.upsert("hello.txt", EntryKind::Blob, blob);
+    let tree_oid = repo.write_tree(tree).expect("write tree");
+    let signature = Signature {
+        name: ByteString::new(b"Test".to_vec()),
+        email: ByteString::new(b"test@example.com".to_vec()),
+        time: GitTime::new(1_700_000_000, 0),
+        raw: b"Test <test@example.com> 1700000000 +0000".to_vec(),
+    };
+    let commit = CommitObject {
+        tree: tree_oid,
+        parents: Vec::new(),
+        author: signature.to_ident_bytes(),
+        committer: signature.to_ident_bytes(),
+        encoding: None,
+        message: format!("{message}\n").into_bytes(),
+    };
+    repo.write_object(EncodedObject::new(GitObjectType::Commit, commit.write()))
+        .expect("write commit")
+}
+
+fn write_annotated_tag(repo: &SleyRepository, name: &str, target: ObjectId) -> ObjectId {
+    let tag = TagObject {
+        object: target,
+        object_type: GitObjectType::Commit,
+        name: name.as_bytes().to_vec(),
+        tagger: Some(
+            Signature {
+                name: ByteString::new(b"Test".to_vec()),
+                email: ByteString::new(b"test@example.com".to_vec()),
+                time: GitTime::new(1_700_000_001, 0),
+                raw: b"Test <test@example.com> 1700000001 +0000".to_vec(),
+            }
+            .to_ident_bytes(),
+        ),
+        message: b"annotated release\n".to_vec(),
+        raw_body: None,
+    };
+    repo.write_object(EncodedObject::new(GitObjectType::Tag, tag.write()))
+        .expect("write annotated tag")
+}
+
+#[test]
+fn peel_native_annotated_tag_rejects_git_target_disagreeing_with_target_tag() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let repo = HeddleRepository::init_default(temp.path()).unwrap();
+    let inner = AnnotatedTag::new(
+        ObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "inner"),
+        None,
+        None,
+    )
+    .expect("inner tag");
+    let inner_hash = repo.store().put_annotated_tag(&inner).unwrap();
+    let outer = AnnotatedTag::new(
+        ObjectFormat::Sha1,
+        tag_body(OTHER_OID, "tag", "outer"),
+        Some(inner_hash),
+        Some(AnnotatedTagMarker {
+            name: "outer".to_string(),
+            peeled_state: StateId::from_bytes([9; 32]),
+        }),
+    )
+    .expect("outer tag shape");
+    let error =
+        peel_native_annotated_tag(&repo, &outer).expect_err("Git target must match inner git_oid");
+    assert!(
+        error.to_string().contains("disagrees"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn native_annotated_tag_oid_rejects_peel_disagreeing_with_peeled_state() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let repo = HeddleRepository::init_default(temp.path()).unwrap();
+    let state = repo.snapshot(Some("tagged".to_string()), None).unwrap();
+    repo.create_marker_recorded(&MarkerName::new("v1.0"), &state.state_id)
+        .unwrap();
+    let tag = AnnotatedTag::new(
+        ObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "v1.0"),
+        None,
+        Some(AnnotatedTagMarker {
+            name: "v1.0".to_string(),
+            peeled_state: state.state_id,
+        }),
+    )
+    .expect("lying tag shape is valid until peel is checked");
+    repo.store().put_annotated_tag(&tag).unwrap();
+    let mapped = ObjectId::from_hex(ObjectFormat::Sha1, OTHER_OID).expect("mapped oid");
+    let error = native_annotated_tag_oid(&repo, &MarkerName::new("v1.0"), state.state_id, mapped)
+        .expect_err("peeled_state mapping must match Git target");
+    assert!(
+        error.to_string().contains("disagrees"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn native_annotated_tag_oid_returns_tag_oid_after_peel_matches_mapped_commit() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let repo = HeddleRepository::init_default(temp.path()).unwrap();
+    let state = repo.snapshot(Some("tagged".to_string()), None).unwrap();
+    repo.create_marker_recorded(&MarkerName::new("v1.0"), &state.state_id)
+        .unwrap();
+    let mapped = ObjectId::from_hex(ObjectFormat::Sha1, COMMIT_OID).expect("mapped oid");
+    let tag = AnnotatedTag::new(
+        ObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "v1.0"),
+        None,
+        Some(AnnotatedTagMarker {
+            name: "v1.0".to_string(),
+            peeled_state: state.state_id,
+        }),
+    )
+    .expect("bound tag");
+    repo.store().put_annotated_tag(&tag).unwrap();
+    let chosen = native_annotated_tag_oid(&repo, &MarkerName::new("v1.0"), state.state_id, mapped)
+        .expect("peel agrees")
+        .expect("annotated tag present");
+    assert_eq!(chosen, tag.git_oid().expect("tag git oid"));
+    assert_ne!(
+        chosen, mapped,
+        "refs/tags must name the tag object, not the commit"
+    );
+}
+
+#[test]
+fn export_peels_annotated_tag_before_writing_refs_tags() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source_path = tmp.path().join("source.git");
+    let source = SleyRepository::init_bare(&source_path).unwrap();
+    let commit = write_commit(&source, "release base");
+    set_reference(
+        &source,
+        "refs/heads/main",
+        commit,
+        RefPrecondition::MustNotExist,
+        "test: main",
+    )
+    .unwrap();
+    let tag_oid = write_annotated_tag(&source, "v1.0", commit);
+    set_reference(
+        &source,
+        "refs/tags/v1.0",
+        tag_oid,
+        RefPrecondition::MustNotExist,
+        "test: annotated tag",
+    )
+    .unwrap();
+    std::fs::write(source_path.join("HEAD"), b"ref: refs/heads/main\n").unwrap();
+
+    let heddle_path = tmp.path().join("heddle");
+    ingest::import_git_into(&source_path, &heddle_path).expect("import annotated tag");
+    let repo = HeddleRepository::open(&heddle_path).unwrap();
+    let mut bridge = GitProjection::new(&repo);
+    let dest_path = tmp.path().join("export.git");
+    bridge.export_to_path(&dest_path).expect("export");
+
+    let exported = SleyRepository::open(&dest_path).expect("open export");
+    let written = direct_ref_oid(&exported, "refs/tags/v1.0").expect("exported tag ref");
+    assert_eq!(
+        written, tag_oid,
+        "export must write the annotated tag object"
+    );
+    let peeled = peel_to_commit_oid(&exported, written).expect("peel exported tag");
+    assert_eq!(
+        peeled, commit,
+        "export must peel before publishing refs/tags"
+    );
+}
+
+#[test]
+fn export_rejects_annotated_tag_whose_git_target_disagrees_with_peeled_state() {
+    let temp = tempfile::TempDir::new().unwrap();
+    let repo = HeddleRepository::init_default(temp.path()).unwrap();
+    let state = repo.snapshot(Some("tagged".to_string()), None).unwrap();
+    repo.create_marker_recorded(&MarkerName::new("v1.0"), &state.state_id)
+        .unwrap();
+    let tag = AnnotatedTag::new(
+        ObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "v1.0"),
+        None,
+        Some(AnnotatedTagMarker {
+            name: "v1.0".to_string(),
+            peeled_state: state.state_id,
+        }),
+    )
+    .expect("lying tag");
+    repo.store().put_annotated_tag(&tag).unwrap();
+
+    let mut bridge = GitProjection::new(&repo);
+    let dest = temp.path().join("export.git");
+    let error = bridge
+        .export_to_path(&dest)
+        .expect_err("export must fail closed when peel disagrees");
+    assert!(
+        error.to_string().contains("disagrees"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/object-model/src/object/annotated_tag.rs
+++ b/crates/object-model/src/object/annotated_tag.rs
@@ -27,7 +27,8 @@ pub struct AnnotatedTagMarker {
 /// tagger identity and timezone, message, and any appended signature verbatim.
 /// `target_tag` links an outer tag to the native CAS object for an inner tag;
 /// the eventual commit target is represented by `marker.peeled_state` on the
-/// outermost object.
+/// outermost object. Construct and decode reject a Git target that disagrees
+/// with `target_tag`; export binds `peeled_state` to the mapped commit.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AnnotatedTag {
     format_version: u8,
@@ -45,8 +46,7 @@ impl AnnotatedTag {
         target_tag: Option<ContentHash>,
         marker: Option<AnnotatedTagMarker>,
     ) -> Result<Self, AnnotatedTagError> {
-        TagObject::parse_ref(git_format, &body)
-            .map_err(|error| AnnotatedTagError::InvalidGitTag(error.to_string()))?;
+        bind_git_target(git_format, &body, target_tag)?;
         Ok(Self {
             format_version: ANNOTATED_TAG_FORMAT_VERSION,
             git_format: git_format_tag(git_format),
@@ -65,8 +65,7 @@ impl AnnotatedTag {
                 supported: ANNOTATED_TAG_FORMAT_VERSION,
             });
         }
-        TagObject::parse_ref(tag.git_format()?, &tag.body)
-            .map_err(|error| AnnotatedTagError::InvalidGitTag(error.to_string()))?;
+        bind_git_target(tag.git_format()?, &tag.body, tag.target_tag)?;
         Ok(tag)
     }
 
@@ -101,6 +100,16 @@ impl AnnotatedTag {
             .map_err(|error| AnnotatedTagError::InvalidGitTag(error.to_string()))
     }
 
+    /// Git object named by this tag body (`object <oid>`).
+    pub fn git_target(&self) -> Result<GitObjectId, AnnotatedTagError> {
+        Ok(self.parsed_git_tag()?.object)
+    }
+
+    /// Git object type named by this tag body (`type commit` / `type tag`).
+    pub fn git_target_type(&self) -> Result<GitObjectType, AnnotatedTagError> {
+        Ok(self.parsed_git_tag()?.object_type)
+    }
+
     /// Native CAS link to an inner tag object for tag-of-tag chains.
     pub fn target_tag(&self) -> Option<ContentHash> {
         self.target_tag
@@ -110,6 +119,68 @@ impl AnnotatedTag {
     pub fn marker(&self) -> Option<&AnnotatedTagMarker> {
         self.marker.as_ref()
     }
+
+    /// Prove `inner` is the native object this tag's Git target names.
+    pub fn bind_target_tag(&self, inner: &AnnotatedTag) -> Result<(), AnnotatedTagError> {
+        let parsed = self.parsed_git_tag()?;
+        let Some(expected_hash) = self.target_tag else {
+            return Err(target_tag_disagree(&parsed, false));
+        };
+        if parsed.object_type != GitObjectType::Tag {
+            return Err(target_tag_disagree(&parsed, true));
+        }
+        if inner.hash() != expected_hash {
+            return Err(AnnotatedTagError::GitTargetDisagree {
+                git_target: parsed.object.to_string(),
+                actual: inner.hash().to_string(),
+            });
+        }
+        let inner_oid = inner.git_oid()?;
+        if inner_oid != parsed.object {
+            return Err(AnnotatedTagError::GitTargetDisagree {
+                git_target: parsed.object.to_string(),
+                actual: inner_oid.to_string(),
+            });
+        }
+        Ok(())
+    }
+
+    fn parsed_git_tag(&self) -> Result<TagObject, AnnotatedTagError> {
+        parse_git_tag(self.git_format()?, &self.body)
+    }
+}
+
+fn bind_git_target(
+    git_format: GitObjectFormat,
+    body: &[u8],
+    target_tag: Option<ContentHash>,
+) -> Result<TagObject, AnnotatedTagError> {
+    let parsed = parse_git_tag(git_format, body)?;
+    let has_target_tag = target_tag.is_some();
+    match parsed.object_type {
+        GitObjectType::Commit if !has_target_tag => Ok(parsed),
+        GitObjectType::Tag if has_target_tag => Ok(parsed),
+        GitObjectType::Commit | GitObjectType::Tag => {
+            Err(target_tag_disagree(&parsed, has_target_tag))
+        }
+        GitObjectType::Blob | GitObjectType::Tree => Err(AnnotatedTagError::UnsupportedGitTarget {
+            git_target: parsed.object.to_string(),
+            git_type: git_object_type_name(parsed.object_type),
+        }),
+    }
+}
+
+fn parse_git_tag(git_format: GitObjectFormat, body: &[u8]) -> Result<TagObject, AnnotatedTagError> {
+    TagObject::parse(git_format, body)
+        .map_err(|error| AnnotatedTagError::InvalidGitTag(error.to_string()))
+}
+
+fn target_tag_disagree(parsed: &TagObject, has_target_tag: bool) -> AnnotatedTagError {
+    AnnotatedTagError::TargetTagDisagree {
+        git_target: parsed.object.to_string(),
+        git_type: git_object_type_name(parsed.object_type),
+        has_target_tag,
+    }
 }
 
 fn git_format_tag(format: GitObjectFormat) -> u8 {
@@ -117,6 +188,10 @@ fn git_format_tag(format: GitObjectFormat) -> u8 {
         GitObjectFormat::Sha1 => GIT_FORMAT_SHA1,
         GitObjectFormat::Sha256 => GIT_FORMAT_SHA256,
     }
+}
+
+fn git_object_type_name(kind: GitObjectType) -> &'static str {
+    kind.as_str()
 }
 
 #[derive(Debug, Error)]
@@ -129,44 +204,25 @@ pub enum AnnotatedTagError {
     UnknownGitFormat(u8),
     #[error("invalid annotated Git tag object: {0}")]
     InvalidGitTag(String),
+    #[error(
+        "annotated tag Git target {git_target} ({git_type}) disagrees with target_tag present={has_target_tag}"
+    )]
+    TargetTagDisagree {
+        git_target: String,
+        git_type: &'static str,
+        has_target_tag: bool,
+    },
+    #[error("annotated tag Git target {git_target} disagrees with target_tag object {actual}")]
+    GitTargetDisagree { git_target: String, actual: String },
+    #[error("annotated tags cannot name a {git_type} Git target {git_target}")]
+    UnsupportedGitTarget {
+        git_target: String,
+        git_type: &'static str,
+    },
     #[error("invalid annotated-tag encoding: {0}")]
     Decode(#[from] rmp_serde::decode::Error),
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn exemplar() -> AnnotatedTag {
-        AnnotatedTag::new(
-            GitObjectFormat::Sha1,
-            b"object 1111111111111111111111111111111111111111\ntype commit\ntag v1.0\ntagger Tagger <tagger@example.com> 1700000000 -0730\n\nrelease\n-----BEGIN PGP SIGNATURE-----\nsigned bytes\n-----END PGP SIGNATURE-----\n".to_vec(),
-            Some(ContentHash::from_bytes([2; 32])),
-            Some(AnnotatedTagMarker {
-                name: "release/v1.0".to_string(),
-                peeled_state: StateId::from_bytes([3; 32]),
-            }),
-        )
-        .expect("valid annotated tag")
-    }
-
-    #[test]
-    fn msgpack_roundtrip_preserves_exact_body() {
-        let tag = exemplar();
-        let decoded = AnnotatedTag::decode_current_msgpack(&tag.encode_current_msgpack())
-            .expect("decode annotated tag");
-        assert_eq!(decoded, tag);
-        assert_eq!(decoded.body(), tag.body());
-        assert_eq!(decoded.git_oid().unwrap(), tag.git_oid().unwrap());
-    }
-
-    #[test]
-    fn canonical_encoding_is_format_locked() {
-        let encoded = exemplar().encode_current_msgpack();
-        assert_eq!(
-            hex::encode(encoded),
-            "85ae666f726d61745f76657273696f6e01aa6769745f666f726d617401a4626f6479dc00c96f626a65637420313131313131313131313131313131313131313131313131313131313131313131313131313131310a7479706520636f6d6d69740a7461672076312e300a74616767657220546167676572203c746167676572406578616d706c652e636f6d3e2031373030303030303030202d303733300a0a72656c656173650a2d2d2d2d2d424547494e20504750205349474e41545552452d2d2d2d2d0a7369676e65642062797465730a2d2d2d2d2d454e4420504750205349474e41545552452d2d2d2d2d0aaa7461726765745f746167dc00200202020202020202020202020202020202020202020202020202020202020202a66d61726b657282a46e616d65ac72656c656173652f76312e30ac7065656c65645f7374617465dc00200303030303030303030303030303030303030303030303030303030303030303",
-            "changing annotated-tag bytes requires a format-version decision and migration"
-        );
-    }
-}
+#[path = "annotated_tag_tests.rs"]
+mod tests;

--- a/crates/object-model/src/object/annotated_tag_tests.rs
+++ b/crates/object-model/src/object/annotated_tag_tests.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+const COMMIT_OID: &str = "1111111111111111111111111111111111111111";
+const OTHER_OID: &str = "2222222222222222222222222222222222222222";
+
+/// Previously accepted encoding: `type commit` with `target_tag` set.
+const COMMIT_WITH_TARGET_TAG_HEX: &str = "85ae666f726d61745f76657273696f6e01aa6769745f666f726d617401a4626f6479dc00c96f626a65637420313131313131313131313131313131313131313131313131313131313131313131313131313131310a7479706520636f6d6d69740a7461672076312e300a74616767657220546167676572203c746167676572406578616d706c652e636f6d3e2031373030303030303030202d303733300a0a72656c656173650a2d2d2d2d2d424547494e20504750205349474e41545552452d2d2d2d2d0a7369676e65642062797465730a2d2d2d2d2d454e4420504750205349474e41545552452d2d2d2d2d0aaa7461726765745f746167dc00200202020202020202020202020202020202020202020202020202020202020202a66d61726b657282a46e616d65ac72656c656173652f76312e30ac7065656c65645f7374617465dc00200303030303030303030303030303030303030303030303030303030303030303";
+
+fn tag_body(object: &str, kind: &str, name: &str) -> Vec<u8> {
+    format!(
+        "object {object}\ntype {kind}\ntag {name}\ntagger Tagger <tagger@example.com> 1700000000 -0730\n\nrelease\n"
+    )
+    .into_bytes()
+}
+
+fn signed_commit_tag_body() -> Vec<u8> {
+    format!(
+        "object {COMMIT_OID}\ntype commit\ntag v1.0\ntagger Tagger <tagger@example.com> 1700000000 -0730\n\nrelease\n-----BEGIN PGP SIGNATURE-----\nsigned bytes\n-----END PGP SIGNATURE-----\n"
+    )
+    .into_bytes()
+}
+
+fn marker() -> AnnotatedTagMarker {
+    AnnotatedTagMarker {
+        name: "release/v1.0".to_string(),
+        peeled_state: StateId::from_bytes([3; 32]),
+    }
+}
+
+fn exemplar() -> AnnotatedTag {
+    AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        signed_commit_tag_body(),
+        None,
+        Some(marker()),
+    )
+    .expect("valid annotated tag")
+}
+
+fn unchecked(
+    body: Vec<u8>,
+    target_tag: Option<ContentHash>,
+    marker: Option<AnnotatedTagMarker>,
+) -> Vec<u8> {
+    AnnotatedTag {
+        format_version: ANNOTATED_TAG_FORMAT_VERSION,
+        git_format: GIT_FORMAT_SHA1,
+        body,
+        target_tag,
+        marker,
+    }
+    .encode_current_msgpack()
+}
+
+#[test]
+fn msgpack_roundtrip_preserves_exact_body() {
+    let tag = exemplar();
+    let decoded = AnnotatedTag::decode_current_msgpack(&tag.encode_current_msgpack())
+        .expect("decode annotated tag");
+    assert_eq!(decoded, tag);
+    assert_eq!(decoded.body(), tag.body());
+    assert_eq!(decoded.git_oid().unwrap(), tag.git_oid().unwrap());
+    assert_eq!(decoded.git_target().unwrap().to_string(), COMMIT_OID);
+    assert_eq!(decoded.git_target_type().unwrap(), GitObjectType::Commit);
+}
+
+#[test]
+fn canonical_encoding_is_format_locked() {
+    let encoded = exemplar().encode_current_msgpack();
+    assert_eq!(
+        hex::encode(encoded),
+        "85ae666f726d61745f76657273696f6e01aa6769745f666f726d617401a4626f6479dc00c96f626a65637420313131313131313131313131313131313131313131313131313131313131313131313131313131310a7479706520636f6d6d69740a7461672076312e300a74616767657220546167676572203c746167676572406578616d706c652e636f6d3e2031373030303030303030202d303733300a0a72656c656173650a2d2d2d2d2d424547494e20504750205349474e41545552452d2d2d2d2d0a7369676e65642062797465730a2d2d2d2d2d454e4420504750205349474e41545552452d2d2d2d2d0aaa7461726765745f746167c0a66d61726b657282a46e616d65ac72656c656173652f76312e30ac7065656c65645f7374617465dc00200303030303030303030303030303030303030303030303030303030303030303",
+        "changing annotated-tag bytes requires a format-version decision and migration"
+    );
+}
+
+#[test]
+fn new_rejects_commit_target_with_target_tag() {
+    let error = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "v1.0"),
+        Some(ContentHash::from_bytes([2; 32])),
+        Some(marker()),
+    )
+    .expect_err("commit tag with target_tag must be rejected");
+    assert!(
+        matches!(
+            error,
+            AnnotatedTagError::TargetTagDisagree {
+                has_target_tag: true,
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn new_rejects_tag_target_without_target_tag() {
+    let error = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(OTHER_OID, "tag", "outer"),
+        None,
+        Some(marker()),
+    )
+    .expect_err("tag-of-tag without target_tag must be rejected");
+    assert!(
+        matches!(
+            error,
+            AnnotatedTagError::TargetTagDisagree {
+                has_target_tag: false,
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn new_rejects_blob_git_target() {
+    let error = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "blob", "gpg-pub"),
+        None,
+        None,
+    )
+    .expect_err("blob-pointing tag must be rejected");
+    assert!(
+        matches!(error, AnnotatedTagError::UnsupportedGitTarget { .. }),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn decode_rejects_commit_target_disagreeing_with_target_tag() {
+    let bytes = hex::decode(COMMIT_WITH_TARGET_TAG_HEX).expect("fixture hex");
+    let error = AnnotatedTag::decode_current_msgpack(&bytes)
+        .expect_err("legacy disagreeing encoding must fail closed");
+    assert!(
+        matches!(
+            error,
+            AnnotatedTagError::TargetTagDisagree {
+                has_target_tag: true,
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn decode_rejects_tag_target_without_target_tag() {
+    let bytes = unchecked(tag_body(OTHER_OID, "tag", "outer"), None, Some(marker()));
+    let error = AnnotatedTag::decode_current_msgpack(&bytes)
+        .expect_err("tag-of-tag without target_tag must fail closed");
+    assert!(
+        matches!(
+            error,
+            AnnotatedTagError::TargetTagDisagree {
+                has_target_tag: false,
+                ..
+            }
+        ),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn bind_target_tag_rejects_git_target_disagreeing_with_inner_oid() {
+    let inner = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "inner"),
+        None,
+        None,
+    )
+    .expect("inner tag");
+    let outer = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(OTHER_OID, "tag", "outer"),
+        Some(inner.hash()),
+        Some(marker()),
+    )
+    .expect("outer tag shape is valid");
+    let error = outer
+        .bind_target_tag(&inner)
+        .expect_err("Git target must match inner git_oid");
+    assert!(
+        matches!(error, AnnotatedTagError::GitTargetDisagree { .. }),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn bind_target_tag_accepts_matching_inner_tag() {
+    let inner = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(COMMIT_OID, "commit", "inner"),
+        None,
+        None,
+    )
+    .expect("inner tag");
+    let inner_oid = inner.git_oid().expect("inner git oid");
+    let outer = AnnotatedTag::new(
+        GitObjectFormat::Sha1,
+        tag_body(&inner_oid.to_string(), "tag", "outer"),
+        Some(inner.hash()),
+        Some(marker()),
+    )
+    .expect("outer tag");
+    outer
+        .bind_target_tag(&inner)
+        .expect("Git target and target_tag agree");
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `AnnotatedTag::new` and `decode_current_msgpack` now reject a Git tag body whose target type disagrees with `target_tag` (`type commit` requires no inner tag; `type tag` requires one; blob/tree targets are refused).
- `bind_target_tag` proves a tag-of-tag Git `object` id is the inner native tag's `git_oid`.
- Git export peels the chosen native annotated tag and fails closed unless that peel equals the mapped commit for `marker.peeled_state` before writing `refs/tags/<marker>`.

## Closes

Closes HeddleCo/heddle#1406

## Red commit
`54c46b3f2790206a77d1806ffb31eeaebe31a82b`

On that commit, `AnnotatedTag::new` / `decode_current_msgpack` accepted a `type commit` body with `target_tag` set (the durable msgpack fixture now rejected by `decode_rejects_commit_target_disagreeing_with_target_tag`). Export wrote `refs/tags/<marker>` from the outer tag object id without peeling it against the mapped commit for `peeled_state`.

## Test evidence
```
$ cargo test -p heddle-object-model --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.59s
     Running unittests src/lib.rs (target/debug/deps/heddle_object_model-dbffae9332fc3a8e)

running 214 tests
test object::annotated_tag::tests::bind_target_tag_accepts_matching_inner_tag ... ok
test object::annotated_tag::tests::bind_target_tag_rejects_git_target_disagreeing_with_inner_oid ... ok
test object::annotated_tag::tests::canonical_encoding_is_format_locked ... ok
test object::annotated_tag::tests::decode_rejects_commit_target_disagreeing_with_target_tag ... ok
test object::annotated_tag::tests::decode_rejects_tag_target_without_target_tag ... ok
test object::annotated_tag::tests::msgpack_roundtrip_preserves_exact_body ... ok
test object::annotated_tag::tests::new_rejects_blob_git_target ... ok
test object::annotated_tag::tests::new_rejects_commit_target_with_target_tag ... ok
test object::annotated_tag::tests::new_rejects_tag_target_without_target_tag ... ok
...
test result: ok. 214 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.26s
```

```
$ cargo test -p heddle-git-projection --lib
    Finished `test` profile [unoptimized + debuginfo] target(s) in 18.06s
     Running unittests src/lib.rs (target/debug/deps/heddle_git_projection-d515cf7d22009f7f)

running 66 tests
test git_export::annotated_tag_export_tests::export_rejects_annotated_tag_whose_git_target_disagrees_with_peeled_state ... ok
test git_export::annotated_tag_export_tests::export_peels_annotated_tag_before_writing_refs_tags ... ok
test git_export::annotated_tag_export_tests::native_annotated_tag_oid_rejects_peel_disagreeing_with_peeled_state ... ok
test git_export::annotated_tag_export_tests::peel_native_annotated_tag_rejects_git_target_disagreeing_with_target_tag ... ok
test git_export::annotated_tag_export_tests::native_annotated_tag_oid_returns_tag_oid_after_peel_matches_mapped_commit ... ok
...
test result: ok. 66 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.33s
```

```
$ cargo test -p heddle-objects --lib fs_variant_dispatches
test store::any_store_tests::fs_variant_dispatches_every_object_store_method ... ok

$ cargo test -p heddle-wire --lib state_closure_includes_annotated_tag
test object_graph::tests::state_closure_includes_annotated_tag_chain ... ok

$ cargo test -p heddle-wire --lib native_pack_transfers_first_class_annotated_tag
test native_pack::tests::native_pack_transfers_first_class_annotated_tag ... ok

$ cargo test -p heddle-cli --test roundtrip_fidelity roundtrip_annotated_and_lightweight_tags -- --nocapture
test roundtrip_annotated_and_lightweight_tags ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 16 filtered out; finished in 0.23s
```

```
$ cargo clippy -p heddle-object-model -p heddle-git-projection --tests -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 51.73s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fc592473-3fa3-4f58-9945-034987cdd460?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc592473-3fa3-4f58-9945-034987cdd460&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789752085&installation_model_id=21489&pr_number=1425&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1425&signature=a7b4c661a1b06ea3377c005db810ebe6f64c0ccf27ab37bbb472ec8ea924b9cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->