### PR TITLE
feat(auth): mint every biscuit root locally

### DIFF
--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -26,10 +26,14 @@ first call.
                   └─────────────────┘
 ```
 
-Revocation works the same way. The server's revocation cache is
-keyed on the `session()` fact in the authority block; a sub-agent
-inherits that fact, so revoking the parent's session id rejects
-every descendant on the next request.
+Revocation works the same way. The verifier's revocation cache is
+keyed on the `session()` fact in the authority block — the registered
+client public key (`key:{hex}`) or `issued_credentials.id`
+(`cred:{id}`), or a server-issued session id when Weft returns one.
+A remint of the same registered key keeps that fact, so
+`RevokeSession` cannot be escaped by minting a fresh random UUID. A
+sub-agent inherits the fact, so revoking the parent's session id
+rejects every descendant on the next request.
 
 ## CLI: `heddle auth derive-agent`
 
@@ -57,7 +61,8 @@ enrollment, and presence-token issuance, plus `DeleteRepository` and
 `auth.proto`, so a new auth RPC cannot land without an explicit agent-policy
 classification. These checks also apply to direct callers of the Rust helper.
 They restrict use of the derived token. Clients mint every root
-locally, including anon; Weft only registers the public key.
+locally; Weft only registers the public key. Anon mint is not a
+Heddle CLI surface (`MintAnonBiscuit` is intentionally unsupported).
 
 By default the child replaces the active stored credential for `--server`, so
 the next push/pull and any further derivation use that child and its fresh PoP
@@ -293,14 +298,13 @@ child credential.
   checks. There is no way to add rights the parent didn't have.
 - **Remove a parent's checks.** If the parent restricts itself to
   read-only, a child that "needs write" is simply impossible — the
-  child must come from a different parent or directly from the
-  server's mint.
+  child must come from a different parent root.
 - **Hide an attenuation block.** Every block is visible to the
   verifier; an agent can't strip checks before presenting the
   token.
-- **Re-sign the chain.** The server's public key is the trust
-  anchor. The server rejects any chain whose authority block
-  doesn't trace back to it.
+- **Re-sign the chain.** The registered client public key is the
+  trust anchor. Weft rejects any chain whose authority block is
+  not signed by a key it registered.
 - **Enforce CLI `--scope` on today's server.** W1 carries each scope as an
   `agent_scope` fact and prevents sub-derivation from declaring a broader
   scope. Request-level repository enforcement begins with W3. Operation and

--- a/.agents/agent-attenuation.md
+++ b/.agents/agent-attenuation.md
@@ -6,10 +6,10 @@
 ## Mental model
 
 A Biscuit is a chain of cryptographic blocks. The first (authority)
-block is signed by Heddle; every subsequent block is appended by
-whoever currently holds the token, no server contact required. The
-verifier runs every block's checks on every request — so a child
-block can only narrow authority, never widen it.
+block is signed by the client that minted the root; every subsequent
+block is appended by whoever currently holds the token, no server
+contact required. The verifier runs every block's checks on every
+request — so a child block can only narrow authority, never widen it.
 
 When you spawn a sub-agent, you don't ask the server for a new
 token. You append a new block to your own. The agent gets the
@@ -18,7 +18,7 @@ first call.
 
 ```
                   ┌─────────────────┐
-  server ────┤ authority block │  signed by Heddle
+  client ────┤ authority block │  signed by the client's independent root
                   ├─────────────────┤
   parent agent ───┤   block 1       │  parent's attenuation (e.g. "expires in 4h")
                   ├─────────────────┤
@@ -56,8 +56,8 @@ enrollment, and presence-token issuance, plus `DeleteRepository` and
 `DeleteNamespace`. Its `AuthService` table is checked for exact agreement with
 `auth.proto`, so a new auth RPC cannot land without an explicit agent-policy
 classification. These checks also apply to direct callers of the Rust helper.
-They restrict use of the derived token; they do not constrain
-device-key-authenticated `MintBiscuit`.
+They restrict use of the derived token. Clients mint every root
+locally, including anon; Weft only registers the public key.
 
 By default the child replaces the active stored credential for `--server`, so
 the next push/pull and any further derivation use that child and its fresh PoP
@@ -281,7 +281,7 @@ boundary is:
   client-side attenuation, no server registration.
 - **Persistent** (weeks to months, organizational principal) →
   service account with keypair, autonomous renewal via
-  `MintBiscuit + KeypairProof`.
+  a local remint of the same independent root. Weft never remints.
 
 ## What you can't do
 

--- a/api-capabilities/heddle.json
+++ b/api-capabilities/heddle.json
@@ -826,24 +826,16 @@
       "rpc": "heddle.api.v1alpha1.IdentityService/MintBiscuit",
       "layers": {
         "client": {
-          "status": "shipped",
-          "evidence": [
-            {
-              "path": "crates/cli/src/hosted_runtime/auth.rs",
-              "contains": "mint_biscuit"
-            }
-          ],
-          "follow_up": null
+          "status": "intentionally-unsupported",
+          "evidence": [],
+          "follow_up": null,
+          "reason": "Clients mint every biscuit root locally. Weft only registers the public key."
         },
         "cli": {
-          "status": "shipped",
-          "evidence": [
-            {
-              "path": "crates/cli/src/hosted_runtime/auth.rs",
-              "contains": ".mint_biscuit("
-            }
-          ],
-          "follow_up": null
+          "status": "intentionally-unsupported",
+          "evidence": [],
+          "follow_up": null,
+          "reason": "Clients mint every biscuit root locally. Weft only registers the public key."
         }
       }
     },

--- a/api-capabilities/provenance.json
+++ b/api-capabilities/provenance.json
@@ -5,6 +5,6 @@
   "api_revision": "1ee2da0a84b0d56df24d2f42fd1cdfe7849f1ae0",
   "api_snapshot": "capabilities/declarations/heddle.json",
   "local_declaration": "heddle.json",
-  "local_sha256": "393e161b8dedbc163fb3c950b365c991d3f992b6b69b5eae41e59615526ae7d3",
-  "sanitized_sha256": "d8ab473625ad367e0404a87763a07430c0f0bb3a339b819a11e0b30d5a009e5e"
+  "local_sha256": "3732711c83f9a82c0eab8834d9e3d420a366edfbe15a41a34bb74e3184cbedfb",
+  "sanitized_sha256": "845c0c12609b08deee951220333488cf4ba880fc9d681b9afd42c890bd7ce8e8"
 }

--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -515,6 +515,7 @@ fn scope_is_within(child: &(String, String), parent: &(String, String)) -> bool 
     }
 }
 
+#[derive(Clone)]
 pub(crate) struct HeadlessTokenMetadata {
     pub(crate) subject: String,
     pub(crate) is_derived: bool,
@@ -736,12 +737,18 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
     .await;
     auth_client.close().await;
     let registered = registered?;
+    let expires_at = device_root_expiry(registered.expires_at.as_ref())?;
     let root = crate::hosted_runtime::root_mint::mint_independent_root(
-        &signer.to_seed(),
-        &registered.subject,
-        crate::hosted_runtime::root_mint::IndependentRootKind::Account,
-        crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
-        (!registered.credential_id.is_empty()).then_some(registered.credential_id.as_str()),
+        crate::hosted_runtime::root_mint::IndependentRootMint {
+            seed: &signer.to_seed(),
+            subject: &registered.subject,
+            ttl: crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
+            credential_id: (!registered.credential_id.is_empty())
+                .then_some(registered.credential_id.as_str()),
+            session_id: (!registered.session_id.is_empty())
+                .then_some(registered.session_id.as_str()),
+            expires_at,
+        },
     )?;
 
     // 7. Store the client-minted root. Weft registered the public key; it
@@ -1318,7 +1325,27 @@ async fn exchange_device_authorization(
     Ok(RegisteredDevice {
         subject,
         credential_id: inner.credential_id,
+        session_id: inner.session_id,
+        expires_at: inner.expires_at,
     })
+}
+
+fn device_root_expiry(
+    expires_at: Option<&prost_types::Timestamp>,
+) -> Result<Option<chrono::DateTime<chrono::Utc>>> {
+    let Some(expires_at) = expires_at else {
+        return Ok(None);
+    };
+    let nanos = u32::try_from(expires_at.nanos.max(0))
+        .map_err(|_| anyhow::anyhow!("device authorization expiry nanos are invalid"))?;
+    let expires_at =
+        chrono::DateTime::from_timestamp(expires_at.seconds, nanos).ok_or_else(|| {
+            anyhow::anyhow!("device authorization expiry is outside the supported range")
+        })?;
+    if expires_at <= chrono::Utc::now() {
+        bail!("device authorization returned an expired credential");
+    }
+    Ok(Some(expires_at))
 }
 
 fn device_authorization_signature(device_code: &str, signer: &Ed25519Signer) -> Result<Vec<u8>> {
@@ -1331,6 +1358,8 @@ fn device_authorization_signature(device_code: &str, signer: &Ed25519Signer) -> 
 struct RegisteredDevice {
     subject: String,
     credential_id: String,
+    session_id: String,
+    expires_at: Option<prost_types::Timestamp>,
 }
 
 /// Validate a URL before handing it to a browser helper.
@@ -1532,11 +1561,14 @@ mod tests {
         let signer = Ed25519Signer::generate().expect("device key");
         let subject = "alice@example.com";
         let root = crate::hosted_runtime::root_mint::mint_independent_root(
-            &signer.to_seed(),
-            subject,
-            crate::hosted_runtime::root_mint::IndependentRootKind::Account,
-            crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
-            Some("cred-device"),
+            crate::hosted_runtime::root_mint::IndependentRootMint {
+                seed: &signer.to_seed(),
+                subject,
+                ttl: crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
+                credential_id: Some("cred-device"),
+                session_id: None,
+                expires_at: None,
+            },
         )
         .expect("client-minted device root");
 
@@ -1546,6 +1578,32 @@ mod tests {
         assert!(!metadata.is_derived);
         assert_eq!(metadata.subject, subject);
         assert_eq!(metadata.credential_id.as_deref(), Some("cred-device"));
+        assert_eq!(
+            crate::hosted_runtime::root_mint::authority_session_fact(&root.token)
+                .expect("device session"),
+            "cred:cred-device"
+        );
+    }
+
+    #[test]
+    fn device_root_honors_returned_expiry_and_rejects_an_already_expired_one() {
+        let future = chrono::Utc::now() + chrono::Duration::hours(6);
+        let honored = device_root_expiry(Some(&prost_types::Timestamp {
+            seconds: future.timestamp(),
+            nanos: 0,
+        }))
+        .expect("future expiry")
+        .expect("present");
+        assert!((honored - future).num_seconds().abs() <= 1);
+
+        let past = chrono::Utc::now() - chrono::Duration::hours(1);
+        let error = device_root_expiry(Some(&prost_types::Timestamp {
+            seconds: past.timestamp(),
+            nanos: 0,
+        }))
+        .expect_err("expired server expiry must fail closed");
+        assert!(error.to_string().contains("expired credential"));
+        assert!(device_root_expiry(None).expect("omitted expiry").is_none());
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -4,10 +4,9 @@ use std::{collections::BTreeSet, path::Path};
 
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::{
-    CreateDeviceAuthorizationRequest, CreateServiceAccountRequest, DeviceAuthProof,
-    DeviceAuthorizationEvent, DeviceAuthorizationResponse, DeviceAuthorizationStatus,
-    ExchangeDeviceAuthorizationRequest, IssueServiceAccountCredentialRequest, MintBiscuitRequest,
-    WaitForDeviceAuthorizationRequest, mint_biscuit_request::Proof,
+    CreateDeviceAuthorizationRequest, CreateServiceAccountRequest, DeviceAuthorizationEvent,
+    DeviceAuthorizationResponse, DeviceAuthorizationStatus, ExchangeDeviceAuthorizationRequest,
+    IssueServiceAccountCredentialRequest, WaitForDeviceAuthorizationRequest,
 };
 use cli_shared::{UserConfig, credentials, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer};
@@ -324,8 +323,8 @@ pub(crate) fn cmd_auth_derive_agent(
             token: child_token,
             proof_key_pem: child_private_key_pem,
             expires_at: Some(expires_at.to_rfc3339()),
-            // A derived child must never auto-rotate through MintBiscuit (that
-            // would drop this block's caveats), so it carries no credential id.
+            // A derived child must never auto-rotate (that would drop this
+            // block's caveats), so it carries no credential id.
             credential_id: None,
             provenance: Some(provenance),
         };
@@ -340,10 +339,10 @@ pub(crate) fn cmd_auth_derive_agent(
         return Ok(());
     }
 
-    // The installed derived token must not auto-rotate through MintBiscuit:
-    // renewal would produce a fresh authority token without this block's
-    // caveats. Keeping credential_id unset disables the client's rotation path
-    // while preserving the authority block and server-side revocation bindings.
+    // The installed derived token must not auto-rotate: reminting the
+    // authority block would drop this block's caveats. Keeping credential_id
+    // unset disables the client's rotation path while preserving the
+    // authority block and server-side revocation bindings.
     credentials::store_server_credential(
         server,
         ServerCredential {
@@ -584,7 +583,7 @@ pub(crate) fn headless_token_metadata(token: &str) -> Result<HeadlessTokenMetada
     let subject = string_fact("user")?
         .filter(|subject| !subject.trim().is_empty())
         .ok_or_else(|| anyhow::anyhow!("Biscuit authority block is missing user(subject)"))?;
-    // An attenuated token must never use keypair renewal: MintBiscuit would
+    // An attenuated token must never use authority remint: that would
     // return a new authority token without the appended caveats. The
     // authority credential id remains cryptographically intact in the token,
     // but is intentionally omitted from the local child credential metadata.
@@ -727,7 +726,7 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
     // 6. Poll for approval.
     println!("Waiting for authorization...");
 
-    let access_token = poll_for_approval(
+    let registered = poll_for_approval(
         &mut auth_client,
         device_code,
         &public_key_bytes,
@@ -736,23 +735,24 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
     )
     .await;
     auth_client.close().await;
-    let access_token = access_token?;
+    let registered = registered?;
+    let root = crate::hosted_runtime::root_mint::mint_independent_root(
+        &signer.to_seed(),
+        &registered.subject,
+        crate::hosted_runtime::root_mint::IndependentRootKind::Account,
+        crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
+        (!registered.credential_id.is_empty()).then_some(registered.credential_id.as_str()),
+    )?;
 
-    // 7. Store credential.
+    // 7. Store the client-minted root. Weft registered the public key; it
+    // does not mint or remint the bearer.
     let credential = ServerCredential {
-        token: access_token.token,
-        subject: access_token.subject.clone(),
+        token: root.token,
+        subject: root.subject.clone(),
         device_id: None,
-        credential_id: if access_token.credential_id.is_empty() {
-            None
-        } else {
-            Some(access_token.credential_id)
-        },
-        private_key_pem: Some(private_key_pem.clone()),
-        expires_at: access_token.expires_at.as_ref().and_then(|ts| {
-            chrono::DateTime::from_timestamp(ts.seconds, ts.nanos.max(0) as u32)
-                .map(|dt| dt.to_rfc3339())
-        }),
+        credential_id: root.credential_id.clone(),
+        private_key_pem: Some(root.private_key_pem),
+        expires_at: Some(root.expires_at.to_rfc3339()),
     };
 
     credentials::store_server_credential(server, credential)?;
@@ -768,10 +768,7 @@ async fn cmd_auth_login(server: &str, open_browser: bool) -> Result<()> {
     }
 
     println!();
-    println!(
-        "Authenticated as {}. Credentials saved.",
-        access_token.subject
-    );
+    println!("Authenticated as {}. Credentials saved.", root.subject);
     Ok(())
 }
 
@@ -1200,15 +1197,15 @@ fn hosted_tls_trust_advice(message: &str) -> RecoveryAdvice {
     )
 }
 
-/// Poll `MintBiscuit(DeviceAuthProof)` until the device code is approved or
-/// the authorization expires.
+/// Wait until the device code is approved, then register the device public
+/// key. The caller mints the root locally; Weft does not return a bearer.
 async fn poll_for_approval(
     client: &mut HostedClient,
     device_code: &str,
     public_key: &[u8],
     signer: &Ed25519Signer,
     expires_at: Option<prost_types::Timestamp>,
-) -> Result<AccessToken> {
+) -> Result<RegisteredDevice> {
     let proof_bytes = device_authorization_signature(device_code, signer)?;
 
     let expires_at_secs = expires_at
@@ -1255,18 +1252,7 @@ async fn poll_for_approval(
         }
     }
 
-    match mint_biscuit_with_device_auth(client, device_code, public_key, proof_bytes.clone()).await
-    {
-        Ok(token) => Ok(token),
-        Err(error) if should_fallback_to_exchange_device_authorization(&error) => {
-            tracing::debug!(
-                error = %error,
-                "falling back to ExchangeDeviceAuthorization for lagging auth server"
-            );
-            exchange_device_authorization(client, device_code, public_key, proof_bytes).await
-        }
-        Err(error) => Err(anyhow::anyhow!("device authorization failed: {error}")),
-    }
+    exchange_device_authorization(client, device_code, public_key, proof_bytes).await
 }
 
 async fn wait_for_device_authorization_event(
@@ -1308,29 +1294,12 @@ fn device_authorization_wait_stream_error(
     anyhow::anyhow!("device authorization approval stream failed: {error}")
 }
 
-async fn mint_biscuit_with_device_auth(
-    client: &mut HostedClient,
-    device_code: &str,
-    public_key: &[u8],
-    signature: Vec<u8>,
-) -> std::result::Result<AccessToken, HostedError> {
-    let request = device_auth_mint_biscuit_request(device_code, public_key, signature);
-    let inner = client.routes().mint_biscuit(&request).await?;
-
-    Ok(AccessToken {
-        token: inner.token,
-        subject: inner.subject,
-        expires_at: inner.expires_at,
-        credential_id: inner.credential_id,
-    })
-}
-
 async fn exchange_device_authorization(
     client: &mut HostedClient,
     device_code: &str,
     public_key: &[u8],
     proof: Vec<u8>,
-) -> Result<AccessToken> {
+) -> Result<RegisteredDevice> {
     let inner = client
         .routes()
         .exchange_device_authorization(&ExchangeDeviceAuthorizationRequest {
@@ -1341,31 +1310,15 @@ async fn exchange_device_authorization(
         .await
         .map_err(|error| anyhow::anyhow!("device authorization failed: {error}"))?;
 
-    Ok(AccessToken {
-        token: inner.token,
-        subject: inner.subject,
-        expires_at: inner.expires_at,
+    let subject = if inner.subject.is_empty() {
+        format!("device:{}", hex::encode(public_key))
+    } else {
+        inner.subject
+    };
+    Ok(RegisteredDevice {
+        subject,
         credential_id: inner.credential_id,
     })
-}
-
-fn device_auth_mint_biscuit_request(
-    device_code: &str,
-    public_key: &[u8],
-    signature: Vec<u8>,
-) -> MintBiscuitRequest {
-    MintBiscuitRequest {
-        subject: String::new(),
-        requested_scope: String::new(),
-        user_agent: String::new(),
-        ip: String::new(),
-        proof: Some(Proof::DeviceAuth(DeviceAuthProof {
-            device_code: device_code.to_string(),
-            device_public_key: public_key.to_vec(),
-            signature,
-        })),
-        client_operation_id: String::new(),
-    }
 }
 
 fn device_authorization_signature(device_code: &str, signer: &Ed25519Signer) -> Result<Vec<u8>> {
@@ -1374,23 +1327,9 @@ fn device_authorization_signature(device_code: &str, signer: &Ed25519Signer) -> 
         .map_err(|e| anyhow::anyhow!("failed to sign proof: {e}"))
 }
 
-fn should_fallback_to_exchange_device_authorization(error: &HostedError) -> bool {
-    matches!(
-        error,
-        HostedError::Call {
-            code: api::heddle::api::v1alpha1::CallFailureCode::Unimplemented,
-            message,
-            ..
-        } if message.contains("DeviceAuthProof")
-            && message.contains("ExchangeDeviceAuthorization")
-    )
-}
-
-/// Extracted token fields from `AccessTokenResponse`.
-struct AccessToken {
-    token: String,
+/// Public-key registration result. The bearer is minted locally.
+struct RegisteredDevice {
     subject: String,
-    expires_at: Option<prost_types::Timestamp>,
     credential_id: String,
 }
 
@@ -1589,20 +1528,24 @@ mod tests {
     }
 
     #[test]
-    fn device_auth_mint_request_uses_device_auth_proof_variant() {
-        let request =
-            device_auth_mint_biscuit_request("device-123", &[1, 2, 3, 4], vec![5, 6, 7, 8]);
+    fn device_login_mints_the_bearer_from_the_registered_device_key() {
+        let signer = Ed25519Signer::generate().expect("device key");
+        let subject = "alice@example.com";
+        let root = crate::hosted_runtime::root_mint::mint_independent_root(
+            &signer.to_seed(),
+            subject,
+            crate::hosted_runtime::root_mint::IndependentRootKind::Account,
+            crate::hosted_runtime::root_mint::ACCOUNT_ROOT_TTL,
+            Some("cred-device"),
+        )
+        .expect("client-minted device root");
 
-        assert!(request.subject.is_empty());
-        assert!(request.requested_scope.is_empty());
-        match request.proof.expect("proof variant") {
-            Proof::DeviceAuth(proof) => {
-                assert_eq!(proof.device_code, "device-123");
-                assert_eq!(proof.device_public_key, vec![1, 2, 3, 4]);
-                assert_eq!(proof.signature, vec![5, 6, 7, 8]);
-            }
-            Proof::Keypair(_) => panic!("device login must use DeviceAuthProof"),
-        }
+        assert_eq!(root.subject, subject);
+        assert_eq!(root.public_key.as_slice(), signer.public_key());
+        let metadata = headless_token_metadata(&root.token).expect("metadata");
+        assert!(!metadata.is_derived);
+        assert_eq!(metadata.subject, subject);
+        assert_eq!(metadata.credential_id.as_deref(), Some("cred-device"));
     }
 
     #[test]
@@ -1730,31 +1673,16 @@ mod tests {
     }
 
     #[test]
-    fn device_auth_fallback_is_limited_to_lagging_weft_stub() {
-        let call_error = |code, message: &str| HostedError::Call {
-            code,
-            message: message.to_string(),
-            error: None,
-        };
-        let lagging = call_error(
-            api::heddle::api::v1alpha1::CallFailureCode::Unimplemented,
-            "MintBiscuit DeviceAuthProof is not implemented yet; use ExchangeDeviceAuthorization for now",
+    fn login_and_rotation_never_call_a_weft_mint_rpc() {
+        let source = include_str!("auth.rs");
+        assert!(
+            !source.contains(concat!("mint", "_biscuit")),
+            "device login must mint locally and must not call a weft mint RPC"
         );
-        assert!(should_fallback_to_exchange_device_authorization(&lagging));
-
-        let unrelated = call_error(
-            api::heddle::api::v1alpha1::CallFailureCode::Unimplemented,
-            "some other endpoint is missing",
+        assert!(
+            !source.contains(concat!("Mint", "AnonBiscuit")),
+            "anon roots are minted locally"
         );
-        assert!(!should_fallback_to_exchange_device_authorization(
-            &unrelated
-        ));
-
-        let denied = call_error(
-            api::heddle::api::v1alpha1::CallFailureCode::PermissionDenied,
-            "MintBiscuit DeviceAuthProof signature verification failed",
-        );
-        assert!(!should_fallback_to_exchange_device_authorization(&denied));
     }
 
     /// Minimal `CliContext` for the logout tests — text output, no repo.

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -16,6 +16,7 @@ use super::{
         VerifiedClaimPrincipal,
     },
     identity_state::{self, ClaimState},
+    root_mint::is_local_agent_root,
 };
 
 const PRE_CONSENT_DOMAIN: &[u8] = b"heddle-agent-pre-consent-v1";
@@ -289,7 +290,10 @@ fn claim_signer(state: &ClaimState) -> Result<Ed25519Signer, CallFailure> {
     let store = cli_shared::credentials::load_credentials().map_err(internal_failure)?;
     let credential = store.servers.get(&state.server).ok_or_else(auth_failure)?;
     let metadata = headless_token_metadata(&credential.token).map_err(internal_failure)?;
-    if !metadata.is_derived || metadata.subject != state.subject {
+    if metadata.subject != state.subject
+        || !(metadata.is_derived
+            || is_local_agent_root(&metadata.subject, &metadata.proof_public_key_hex))
+    {
         return Err(auth_failure());
     }
     let pem = credential

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -402,6 +402,34 @@ impl AgentAttenuation {
 /// chains off the parent's keys, and the server validates the full
 /// chain against its trust list when the agent presents the token.
 /// The CLI never holds the server's signing key.
+/// Narrow a client-minted agent account root with the same deny floor and
+/// safe-operation ceiling that `heddle auth derive-agent` applies. The leaf
+/// PoP stays the registered Iroh key (self-delegation) so identity ensure
+/// can remint from that seed after expiry.
+pub(crate) fn restrict_agent_account_root(
+    root_token: &str,
+    signer: &Ed25519Signer,
+    expires_at: DateTime<Utc>,
+) -> Result<String> {
+    attenuate_for_agent(
+        root_token,
+        AgentAttenuation {
+            agent_id: "local-agent-root".to_string(),
+            expires_at,
+            allowed_operations: Some(
+                SAFE_AGENT_OPERATIONS
+                    .iter()
+                    .map(|operation| (*operation).to_string())
+                    .collect(),
+            ),
+            allowed_resources: None,
+            declared_scopes: Vec::new(),
+        },
+        signer,
+        signer.public_key(),
+    )
+}
+
 pub fn attenuate_for_agent(
     parent_token_b64: &str,
     restrictions: AgentAttenuation,

--- a/crates/cli/src/hosted_runtime/device_flow.rs
+++ b/crates/cli/src/hosted_runtime/device_flow.rs
@@ -101,8 +101,8 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
         "BindSignupInviteEmail",
         AgentAuthOperationDisposition::Denied,
     ),
-    // Durable invite claim mints a signup bearer; derived agents must not
-    // consume invite codes on behalf of a parent principal.
+    // Invite claim registers a client-minted signup root; derived agents
+    // must not consume invite codes on behalf of a parent principal.
     ("ClaimSignupInvite", AgentAuthOperationDisposition::Denied),
     // Public drop selection accepts an optional verified agent subject only
     // to choose the subject-scoped anti-abuse budget.
@@ -146,16 +146,13 @@ const AUTH_SERVICE_AGENT_POLICY: &[(&str, AgentAuthOperationDisposition)] = &[
     ("RevokeSession", AgentAuthOperationDisposition::Denied),
     ("RequestHeldName", AgentAuthOperationDisposition::Denied),
     ("ResolveHandle", AgentAuthOperationDisposition::ReviewedSafe),
-    // MintBiscuit authenticates its own keypair/device proof; an attached
-    // derived bearer cannot authorize or widen the minted credential.
-    ("MintBiscuit", AgentAuthOperationDisposition::ReviewedSafe),
+    // Clients mint every root locally. The RPC remains on the shared
+    // descriptor until Weft removes it; a derived bearer cannot mint.
+    ("MintBiscuit", AgentAuthOperationDisposition::Denied),
     // Presence currently re-mints an authority token instead of preserving
     // the caller's complete attenuation chain, so agents must not invoke it.
     ("IssuePresenceToken", AgentAuthOperationDisposition::Denied),
-    (
-        "MintAnonBiscuit",
-        AgentAuthOperationDisposition::ReviewedSafe,
-    ),
+    ("MintAnonBiscuit", AgentAuthOperationDisposition::Denied),
     (
         "DeclareRecoveryMethod",
         AgentAuthOperationDisposition::Denied,

--- a/crates/cli/src/hosted_runtime/hosted/methods.rs
+++ b/crates/cli/src/hosted_runtime/hosted/methods.rs
@@ -78,13 +78,6 @@ impl HostedRoutes<'_> {
         IssuedCredentialResponse
     );
     unary_method!(
-        mint_biscuit,
-        "IdentityService",
-        "MintBiscuit",
-        MintBiscuitRequest,
-        AccessTokenResponse
-    );
-    unary_method!(
         create_agent_account,
         "IdentityService",
         "CreateAgentAccount",
@@ -433,7 +426,20 @@ mod tests {
     };
 
     #[test]
-    fn shipped_native_inventory_is_39_unary_seven_server_streams_and_two_bidi() {
+    fn hosted_rotation_never_calls_a_weft_mint_rpc() {
+        let source = include_str!("mod.rs");
+        assert!(
+            !source.contains(concat!("mint", "_biscuit")),
+            "rotation remints locally and must not call a weft mint RPC"
+        );
+        assert!(
+            !source.contains("MintBiscuitRequest"),
+            "rotation must not build a weft mint request"
+        );
+    }
+
+    #[test]
+    fn shipped_native_inventory_is_38_unary_seven_server_streams_and_two_bidi() {
         const ROUTES: &[MethodRoute] = &[
             MethodRoute::CollaborationServiceAppendTurn,
             MethodRoute::CollaborationServiceListByState,
@@ -443,7 +449,6 @@ mod tests {
             MethodRoute::IdentityServiceCreateServiceAccount,
             MethodRoute::IdentityServiceExchangeDeviceAuthorization,
             MethodRoute::IdentityServiceIssueServiceAccountCredential,
-            MethodRoute::IdentityServiceMintBiscuit,
             MethodRoute::IdentityServiceWaitForDeviceAuthorization,
             MethodRoute::IdentityServiceWhoAmI,
             MethodRoute::RegistryServiceCreateGrant,
@@ -493,13 +498,13 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        assert_eq!(shipped.len(), 48);
+        assert_eq!(shipped.len(), 47);
         assert_eq!(
             shipped
                 .iter()
                 .filter(|method| method.streaming == StreamingShape::Unary)
                 .count(),
-            39
+            38
         );
         assert_eq!(
             shipped

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -275,73 +275,29 @@ impl HostedClient {
             tracing::debug!("credential rotation: stored authority has no renewal key");
             return;
         };
-        let signer = match Ed25519Signer::from_pem(&private_key_pem) {
-            Ok(signer) => signer,
+        let root = match crate::hosted_runtime::root_mint::remint_stored_root(
+            &private_key_pem,
+            &credential.subject,
+            Some(public_key_id.as_str()),
+        ) {
+            Ok(root) => root,
             Err(error) => {
-                tracing::warn!("credential rotation: failed to load signing key: {error}");
+                tracing::warn!("credential rotation: local remint failed: {error}");
                 return;
             }
         };
-        let timestamp = match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
-            Ok(duration) => duration.as_secs(),
-            Err(error) => {
-                tracing::warn!("credential rotation: clock skew: {error}");
-                return;
-            }
-        };
-        let signature = match signer.sign(format!("{timestamp}\n{public_key_id}\n").as_bytes()) {
-            Ok(signature) => signature,
-            Err(error) => {
-                tracing::warn!("credential rotation: failed to sign challenge: {error}");
-                return;
-            }
-        };
-        let request = api::heddle::api::v1alpha1::MintBiscuitRequest {
-            subject: credential.subject.clone(),
-            requested_scope: String::new(),
-            user_agent: String::new(),
-            ip: String::new(),
-            proof: Some(
-                api::heddle::api::v1alpha1::mint_biscuit_request::Proof::Keypair(
-                    api::heddle::api::v1alpha1::KeypairProof {
-                        public_key_id,
-                        timestamp,
-                        signature,
-                    },
-                ),
-            ),
-            client_operation_id: String::new(),
-        };
-        let response = match self.routes().mint_biscuit(&request).await {
-            Ok(response) => response,
-            Err(error) => {
-                tracing::warn!("credential rotation: MintBiscuit failed: {error}");
-                return;
-            }
-        };
-        let expires_at = response
-            .expires_at
-            .as_ref()
-            .and_then(|timestamp| chrono::DateTime::from_timestamp(timestamp.seconds.max(0), 0))
-            .map(|timestamp| timestamp.to_rfc3339())
-            .or(credential.expires_at.clone());
         let updated = cli_shared::credentials::ServerCredential {
-            token: response.token.clone(),
-            subject: if response.subject.is_empty() {
-                credential.subject
-            } else {
-                response.subject
-            },
+            token: root.token.clone(),
+            subject: root.subject,
             device_id: credential.device_id,
-            credential_id: credential.credential_id,
+            credential_id: Some(public_key_id),
             private_key_pem: Some(private_key_pem),
-            expires_at,
+            expires_at: Some(root.expires_at.to_rfc3339()),
         };
         if let Err(error) = cli_shared::credentials::store_server_credential(&server_key, updated) {
             tracing::warn!("credential rotation: failed to persist credential: {error}");
         }
-        self.context
-            .set_bearer_capability(response.token.into_bytes());
+        self.context.set_bearer_capability(root.token.into_bytes());
     }
 
     pub async fn call_unary<Request, Response>(

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -275,10 +275,13 @@ impl HostedClient {
             tracing::debug!("credential rotation: stored authority has no renewal key");
             return;
         };
+        let session_id =
+            crate::hosted_runtime::root_mint::authority_session_fact(&credential.token).ok();
         let root = match crate::hosted_runtime::root_mint::remint_stored_root(
             &private_key_pem,
             &credential.subject,
             Some(public_key_id.as_str()),
+            session_id.as_deref(),
         ) {
             Ok(root) => root,
             Err(error) => {

--- a/crates/cli/src/hosted_runtime/hosted/session.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session.rs
@@ -6,7 +6,7 @@ use anyhow::{Context, Result};
 use biscuit_auth::builder::BlockBuilder;
 use cli_shared::{ClientConfig, UserConfig};
 use crypto::{Ed25519Signer, Signer as _};
-use wire::ProtocolError;
+use wire::{AuthToken, ProtocolError};
 
 use super::{
     HostedClient, RenewableAuthorityCredential, credential::server_keys_match,
@@ -18,6 +18,12 @@ pub enum HostedAuthMode {
     ProofOnly {
         proof_key_pem: String,
         signing_identity: String,
+    },
+    /// Present a client-minted independent root as the request bearer.
+    PresentedRoot {
+        token: String,
+        proof_key_pem: String,
+        subject: String,
     },
     CredentialFallback,
 }
@@ -44,6 +50,16 @@ impl HostedSession {
                 proof_key_pem,
                 signing_identity,
             } => (None, Some(proof_key_pem), None, Some(signing_identity)),
+            HostedAuthMode::PresentedRoot {
+                token,
+                proof_key_pem,
+                subject,
+            } => (
+                Some(AuthToken::new(token, "independent-root")),
+                Some(proof_key_pem),
+                None,
+                Some(subject),
+            ),
             HostedAuthMode::CredentialFallback => {
                 let resolved = resolve_hosted_credential(server_key.as_deref())?;
                 (

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -14,6 +14,7 @@ use super::{
     hosted::{canonical_server_authority, resolve_hosted_credential},
     identity_server,
     identity_state::{self, ClaimState},
+    root_mint::{is_local_agent_root, mint_agent_root},
 };
 use crate::cli::IdentityCommands;
 
@@ -66,6 +67,9 @@ async fn ensure(
     match ensure_action(
         metadata.as_ref().map(|value| value.is_derived),
         invite.is_some(),
+        metadata
+            .as_ref()
+            .is_some_and(|value| is_local_agent_root(&value.subject, &value.proof_public_key_hex)),
     ) {
         EnsureAction::Reuse => {
             let metadata = metadata
@@ -116,9 +120,14 @@ async fn ensure(
     }
 }
 
-pub(crate) fn ensure_action(derived: Option<bool>, has_invite: bool) -> EnsureAction {
+pub(crate) fn ensure_action(
+    derived: Option<bool>,
+    has_invite: bool,
+    local_agent_root: bool,
+) -> EnsureAction {
     match derived {
         Some(true) => EnsureAction::Reuse,
+        Some(false) if local_agent_root => EnsureAction::Reuse,
         Some(false) => EnsureAction::Derive,
         None if has_invite => EnsureAction::Provision,
         None => EnsureAction::RequireInvite,
@@ -131,20 +140,25 @@ async fn create_on_behalf(
     invite: String,
 ) -> Result<()> {
     let identity = agent_node_identity::load_or_create()?;
-    let signer = Ed25519Signer::from_seed(&identity.secret_key().to_bytes())
+    let seed = identity.secret_key().to_bytes();
+    let signer = Ed25519Signer::from_seed(&seed)
         .context("deriving the agent credential key from the persisted node identity")?;
     let node_id = identity.node_id().to_string();
     if hex::encode(signer.public_key()) != node_id {
         bail!("persisted Iroh node key does not map to the agent credential key");
     }
-    let proof_pem = signer.to_pem().context("exporting agent proof key")?;
+    let root = mint_agent_root(&seed).context("minting the agent independent root locally")?;
+    if root.public_key_hex() != node_id {
+        bail!("agent independent root is not bound to this node key");
+    }
     let user_config = UserConfig::load_default()?;
     let session = HostedSession::build(
         &user_config,
         Some(server.clone()),
-        HostedAuthMode::ProofOnly {
-            proof_key_pem: proof_pem.clone(),
-            signing_identity: format!("principal:agent-key:{node_id}"),
+        HostedAuthMode::PresentedRoot {
+            token: root.token.clone(),
+            proof_key_pem: root.private_key_pem.clone(),
+            subject: root.subject.clone(),
         },
     )?;
     let mut client = session.connect(([127, 0, 0, 1], 0).into()).await?;
@@ -155,7 +169,7 @@ async fn create_on_behalf(
     let response = client
         .create_agent_account(CreateAgentAccountRequest {
             invite_code: invite,
-            agent_public_key: signer.public_key().to_vec(),
+            agent_public_key: root.public_key.to_vec(),
             client_operation_id: operation_id,
         })
         .await
@@ -164,22 +178,23 @@ async fn create_on_behalf(
         });
     client.close().await;
     let response = response?;
-    let token = String::from_utf8(response.agent_capability)
-        .context("server returned a non-text agent capability")?;
-    let metadata =
-        headless_token_metadata(&token).context("validating the returned agent capability")?;
-    if !metadata.is_derived || !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id) {
-        bail!("server returned an agent capability not derived for this node key");
+    let metadata = headless_token_metadata(&root.token)
+        .context("validating the client-minted agent capability")?;
+    if metadata.is_derived
+        || !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id)
+        || metadata.subject != root.subject
+    {
+        bail!("client-minted agent capability is not bound to this node key");
     }
     cli_shared::credentials::store_server_credential(
         &server,
         ServerCredential {
-            token,
+            token: root.token,
             subject: metadata.subject.clone(),
             device_id: None,
             credential_id: None,
-            private_key_pem: Some(proof_pem),
-            expires_at: metadata.expires_at,
+            private_key_pem: Some(root.private_key_pem),
+            expires_at: Some(root.expires_at.to_rfc3339()),
         },
     )?;
     let owner_id = uuid::Uuid::parse_str(&response.account_id)

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -3,6 +3,7 @@
 use anyhow::{Context, Result, bail};
 use api::heddle::api::v1alpha1::CreateAgentAccountRequest;
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::Utc;
 use cli_shared::{UserConfig, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer as _};
 use serde::Serialize;
@@ -10,11 +11,12 @@ use weft_client_shim::CliContext;
 
 use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
-    auth::{cmd_auth_derive_agent, headless_token_metadata, resolve_server},
+    auth::{HeadlessTokenMetadata, cmd_auth_derive_agent, headless_token_metadata, resolve_server},
+    device_flow::restrict_agent_account_root,
     hosted::{canonical_server_authority, resolve_hosted_credential},
     identity_server,
     identity_state::{self, ClaimState},
-    root_mint::{is_local_agent_root, mint_agent_root},
+    root_mint::{is_local_agent_root, local_agent_credential_needs_refresh, mint_agent_root},
 };
 use crate::cli::IdentityCommands;
 
@@ -74,6 +76,7 @@ async fn ensure(
         EnsureAction::Reuse => {
             let metadata = metadata
                 .ok_or_else(|| anyhow::anyhow!("identity decision lost credential metadata"))?;
+            let metadata = refresh_expired_local_agent(&server, &metadata)?;
             print_identity(
                 ctx,
                 "identity_ensure",
@@ -134,6 +137,55 @@ pub(crate) fn ensure_action(
     }
 }
 
+fn refresh_expired_local_agent(
+    server: &str,
+    metadata: &HeadlessTokenMetadata,
+) -> Result<HeadlessTokenMetadata> {
+    if !is_local_agent_root(&metadata.subject, &metadata.proof_public_key_hex) {
+        return Ok(metadata.clone());
+    }
+    if !local_agent_credential_needs_refresh(metadata.expires_at.as_deref(), Utc::now()) {
+        return Ok(metadata.clone());
+    }
+    let identity = agent_node_identity::load_or_create()?;
+    let seed = identity.secret_key().to_bytes();
+    let signer = Ed25519Signer::from_seed(&seed)
+        .context("deriving the agent credential key from the persisted node identity")?;
+    let node_id = identity.node_id().to_string();
+    if hex::encode(signer.public_key()) != node_id
+        || !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id)
+    {
+        bail!("expired local agent root is not bound to this node's Iroh seed");
+    }
+    let root = mint_agent_root(&seed).context("reminting the expired local agent root")?;
+    if root.public_key_hex() != node_id {
+        bail!("reminted agent independent root is not bound to this node key");
+    }
+    let restricted = restrict_agent_account_root(&root.token, &signer, root.expires_at)
+        .context("reapplying the local agent deny floor after remint")?;
+    let refreshed =
+        headless_token_metadata(&restricted).context("validating the reminted agent capability")?;
+    if !refreshed
+        .proof_public_key_hex
+        .eq_ignore_ascii_case(&node_id)
+        || refreshed.subject != root.subject
+    {
+        bail!("reminted agent capability is not bound to this node key");
+    }
+    cli_shared::credentials::store_server_credential(
+        server,
+        ServerCredential {
+            token: restricted,
+            subject: refreshed.subject.clone(),
+            device_id: None,
+            credential_id: None,
+            private_key_pem: Some(root.private_key_pem),
+            expires_at: Some(root.expires_at.to_rfc3339()),
+        },
+    )?;
+    Ok(refreshed)
+}
+
 async fn create_on_behalf(
     ctx: &(dyn CliContext + 'static),
     server: String,
@@ -178,10 +230,11 @@ async fn create_on_behalf(
         });
     client.close().await;
     let response = response?;
-    let metadata = headless_token_metadata(&root.token)
-        .context("validating the client-minted agent capability")?;
-    if metadata.is_derived
-        || !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id)
+    let restricted = restrict_agent_account_root(&root.token, &signer, root.expires_at)
+        .context("applying the local agent deny floor and safe operation ceiling")?;
+    let metadata = headless_token_metadata(&restricted)
+        .context("validating the restricted client-minted agent capability")?;
+    if !metadata.proof_public_key_hex.eq_ignore_ascii_case(&node_id)
         || metadata.subject != root.subject
     {
         bail!("client-minted agent capability is not bound to this node key");
@@ -189,7 +242,7 @@ async fn create_on_behalf(
     cli_shared::credentials::store_server_credential(
         &server,
         ServerCredential {
-            token: root.token,
+            token: restricted,
             subject: metadata.subject.clone(),
             device_id: None,
             credential_id: None,

--- a/crates/cli/src/hosted_runtime/identity_tests.rs
+++ b/crates/cli/src/hosted_runtime/identity_tests.rs
@@ -1,15 +1,35 @@
 use super::identity::{EnsureAction, claim_link_url, ensure_action};
 
 #[test]
+fn create_on_behalf_stores_the_client_minted_root() {
+    let source = include_str!("identity.rs");
+    assert!(
+        !source.contains("agent_capability"),
+        "CreateAgentAccount must store the locally minted root, not a weft-minted capability"
+    );
+    assert!(
+        source.contains("mint_agent_root"),
+        "CreateAgentAccount must reuse the independent-root mint"
+    );
+}
+
+#[test]
 fn invite_is_never_selected_when_any_credential_exists() {
-    assert_eq!(ensure_action(Some(true), true), EnsureAction::Reuse);
-    assert_eq!(ensure_action(Some(false), true), EnsureAction::Derive);
+    assert_eq!(ensure_action(Some(true), true, false), EnsureAction::Reuse);
+    assert_eq!(
+        ensure_action(Some(false), true, false),
+        EnsureAction::Derive
+    );
+    assert_eq!(ensure_action(Some(false), true, true), EnsureAction::Reuse);
 }
 
 #[test]
 fn provisioning_is_only_the_no_credential_fallback() {
-    assert_eq!(ensure_action(None, true), EnsureAction::Provision);
-    assert_eq!(ensure_action(None, false), EnsureAction::RequireInvite);
+    assert_eq!(ensure_action(None, true, false), EnsureAction::Provision);
+    assert_eq!(
+        ensure_action(None, false, false),
+        EnsureAction::RequireInvite
+    );
 }
 
 #[test]

--- a/crates/cli/src/hosted_runtime/identity_tests.rs
+++ b/crates/cli/src/hosted_runtime/identity_tests.rs
@@ -1,4 +1,5 @@
 use super::identity::{EnsureAction, claim_link_url, ensure_action};
+use super::root_mint::local_agent_credential_needs_refresh;
 
 #[test]
 fn create_on_behalf_stores_the_client_minted_root() {
@@ -11,6 +12,23 @@ fn create_on_behalf_stores_the_client_minted_root() {
         source.contains("mint_agent_root"),
         "CreateAgentAccount must reuse the independent-root mint"
     );
+    assert!(
+        source.contains("restrict_agent_account_root"),
+        "CreateAgentAccount must keep the local deny floor after Weft registers the key"
+    );
+    assert!(
+        source.contains("refresh_expired_local_agent"),
+        "identity ensure must remint an expired local agent root without an invite"
+    );
+}
+
+#[test]
+fn expired_local_agent_root_is_refreshed_without_an_invite() {
+    assert_eq!(ensure_action(Some(false), false, true), EnsureAction::Reuse);
+    assert!(local_agent_credential_needs_refresh(
+        Some("2020-01-01T00:00:00+00:00"),
+        chrono::Utc::now()
+    ));
 }
 
 #[test]

--- a/crates/cli/src/hosted_runtime/mod.rs
+++ b/crates/cli/src/hosted_runtime/mod.rs
@@ -20,6 +20,7 @@ mod identity_server;
 mod identity_state;
 #[cfg(test)]
 mod identity_tests;
+pub(crate) mod root_mint;
 pub(crate) mod websocket;
 pub(crate) mod whoami;
 

--- a/crates/cli/src/hosted_runtime/mod.rs
+++ b/crates/cli/src/hosted_runtime/mod.rs
@@ -21,6 +21,8 @@ mod identity_state;
 #[cfg(test)]
 mod identity_tests;
 pub(crate) mod root_mint;
+#[cfg(test)]
+mod root_mint_tests;
 pub(crate) mod websocket;
 pub(crate) mod whoami;
 

--- a/crates/cli/src/hosted_runtime/root_mint.rs
+++ b/crates/cli/src/hosted_runtime/root_mint.rs
@@ -1,8 +1,13 @@
 //! Client-side independent-root Biscuit mint.
 //!
 //! One ceremony: the caller's Ed25519 seed is the Biscuit authority key and
-//! the request-proof key. Signup, claim, passkey finish, anon, and
-//! `CreateAgentAccount` all call this. Weft only registers the public key.
+//! the request-proof key. Device login, rotation, and `CreateAgentAccount`
+//! call this. Weft only registers the public key.
+//!
+//! `session()` is the RevokeSession id. It is never a caller-chosen random
+//! UUID: a server-issued session id wins, otherwise `cred:{credential_id}`
+//! or `key:{public_key}`. Reminting the same registered key cannot mint a
+//! new live session.
 
 use anyhow::{Context, Result, bail};
 use biscuit_auth::{Algorithm, KeyPair, PrivateKey};
@@ -11,14 +16,6 @@ use crypto::{Ed25519Signer, Signer as _};
 
 /// Default lifetime for an account, claim, passkey, or device root.
 pub(crate) const ACCOUNT_ROOT_TTL: Duration = Duration::days(30);
-/// Anon roots stay short-lived; continuity is a local remint of the same seed.
-pub(crate) const ANON_ROOT_TTL: Duration = Duration::hours(24);
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum IndependentRootKind {
-    Account,
-    Anon,
-}
 
 #[derive(Clone, Debug)]
 pub(crate) struct IndependentRoot {
@@ -36,26 +33,40 @@ impl IndependentRoot {
     }
 }
 
+/// Inputs for one independent-root mint. `expires_at` wins when set
+/// (device login honors the server's returned expiry); otherwise `ttl`
+/// is added to now.
+pub(crate) struct IndependentRootMint<'a> {
+    pub seed: &'a [u8; 32],
+    pub subject: &'a str,
+    pub ttl: Duration,
+    pub credential_id: Option<&'a str>,
+    pub session_id: Option<&'a str>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
 /// Mint a root from an existing seed. `CreateAgentAccount` uses the persisted
 /// Iroh node seed so the claim signer and the authority key stay the same key.
-pub(crate) fn mint_independent_root(
-    seed: &[u8; 32],
-    subject: &str,
-    kind: IndependentRootKind,
-    ttl: Duration,
-    credential_id: Option<&str>,
-) -> Result<IndependentRoot> {
-    validate_root_string("subject", subject)?;
-    if let Some(credential_id) = credential_id {
+pub(crate) fn mint_independent_root(mint: IndependentRootMint<'_>) -> Result<IndependentRoot> {
+    validate_root_string("subject", mint.subject)?;
+    if let Some(credential_id) = mint.credential_id {
         validate_root_string("credential_id", credential_id)?;
     }
-    if ttl <= Duration::zero() {
-        bail!("independent-root TTL must be greater than zero");
+    let now = Utc::now();
+    let expires_at = match mint.expires_at {
+        Some(expires_at) => expires_at,
+        None => {
+            if mint.ttl <= Duration::zero() {
+                bail!("independent-root TTL must be greater than zero");
+            }
+            now.checked_add_signed(mint.ttl)
+                .context("independent-root TTL overflows the calendar")?
+        }
+    };
+    if expires_at <= now {
+        bail!("independent-root expiry must be in the future");
     }
-    let expires_at = Utc::now()
-        .checked_add_signed(ttl)
-        .context("independent-root TTL overflows the calendar")?;
-    let signer = Ed25519Signer::from_seed(seed).context("loading independent-root seed")?;
+    let signer = Ed25519Signer::from_seed(mint.seed).context("loading independent-root seed")?;
     let public_key: [u8; 32] = signer
         .public_key()
         .try_into()
@@ -63,13 +74,13 @@ pub(crate) fn mint_independent_root(
     let private_key_pem = signer
         .to_pem()
         .context("exporting independent-root proof key")?;
-    let authority = authority_keypair(seed)?;
+    let authority = authority_keypair(mint.seed)?;
     let pop_hex = hex::encode(public_key);
-    let session = format!("sess-{}", uuid::Uuid::new_v4());
+    let session = resolve_revocation_session(&pop_hex, mint.credential_id, mint.session_id)?;
     let expiry = expires_at.to_rfc3339();
     let mut builder = biscuit_auth::Biscuit::builder();
     builder = builder
-        .fact(format!("user({})", quote(subject)).as_str())
+        .fact(format!("user({})", quote(mint.subject)).as_str())
         .context("independent-root user fact")?;
     builder = builder
         .fact(format!("session({})", quote(&session)).as_str())
@@ -77,18 +88,10 @@ pub(crate) fn mint_independent_root(
     builder = builder
         .fact(format!("device_pop_key({})", quote(&pop_hex)).as_str())
         .context("independent-root device_pop_key fact")?;
-    if let Some(credential_id) = credential_id {
+    if let Some(credential_id) = mint.credential_id {
         builder = builder
             .fact(format!("credential_id({})", quote(credential_id)).as_str())
             .context("independent-root credential_id fact")?;
-    }
-    match kind {
-        IndependentRootKind::Account => {}
-        IndependentRootKind::Anon => {
-            builder = builder
-                .fact(r#"subject_kind("anon")"#)
-                .context("independent-root anon subject_kind fact")?;
-        }
     }
     builder = builder
         .fact(format!("expires_at({expiry})").as_str())
@@ -103,57 +106,43 @@ pub(crate) fn mint_independent_root(
         .context("encoding the independent-root token")?;
     Ok(IndependentRoot {
         token,
-        subject: subject.to_string(),
+        subject: mint.subject.to_string(),
         public_key,
         private_key_pem,
         expires_at,
-        credential_id: credential_id.map(ToOwned::to_owned),
+        credential_id: mint.credential_id.map(ToOwned::to_owned),
     })
-}
-
-/// Fresh seed plus mint. Anon and device-login roots start here.
-pub(crate) fn mint_new_independent_root(
-    subject: &str,
-    kind: IndependentRootKind,
-    ttl: Duration,
-    credential_id: Option<&str>,
-) -> Result<IndependentRoot> {
-    let mut seed = [0_u8; 32];
-    getrandom::fill(&mut seed).context("generating independent-root seed")?;
-    mint_independent_root(&seed, subject, kind, ttl, credential_id)
 }
 
 pub(crate) fn mint_agent_root(seed: &[u8; 32]) -> Result<IndependentRoot> {
     let signer = Ed25519Signer::from_seed(seed).context("loading agent root seed")?;
-    let subject = format!("agent-key:{}", hex::encode(signer.public_key()));
-    mint_independent_root(
+    let subject = agent_root_subject(signer.public_key());
+    mint_independent_root(IndependentRootMint {
         seed,
-        &subject,
-        IndependentRootKind::Account,
-        ACCOUNT_ROOT_TTL,
-        None,
-    )
-}
-
-pub(crate) fn mint_anon_root() -> Result<IndependentRoot> {
-    let subject = format!("anon:{}", uuid::Uuid::new_v4());
-    mint_new_independent_root(&subject, IndependentRootKind::Anon, ANON_ROOT_TTL, None)
+        subject: &subject,
+        ttl: ACCOUNT_ROOT_TTL,
+        credential_id: None,
+        session_id: None,
+        expires_at: None,
+    })
 }
 
 pub(crate) fn remint_stored_root(
     private_key_pem: &str,
     subject: &str,
     credential_id: Option<&str>,
+    session_id: Option<&str>,
 ) -> Result<IndependentRoot> {
     let signer =
         Ed25519Signer::from_pem(private_key_pem).context("loading stored independent-root key")?;
-    mint_independent_root(
-        &signer.to_seed(),
+    mint_independent_root(IndependentRootMint {
+        seed: &signer.to_seed(),
         subject,
-        IndependentRootKind::Account,
-        ACCOUNT_ROOT_TTL,
+        ttl: ACCOUNT_ROOT_TTL,
         credential_id,
-    )
+        session_id,
+        expires_at: None,
+    })
 }
 
 pub(crate) fn agent_root_subject(public_key: &[u8]) -> String {
@@ -173,6 +162,64 @@ pub(crate) fn is_local_agent_root(subject: &str, proof_public_key_hex: &str) -> 
             Err(_) => return false,
         },
     ))
+}
+
+/// True when a stored local agent root is missing expiry or is already stale.
+pub(crate) fn local_agent_credential_needs_refresh(
+    expires_at: Option<&str>,
+    now: DateTime<Utc>,
+) -> bool {
+    match expires_at {
+        None => true,
+        Some(value) => chrono::DateTime::parse_from_rfc3339(value)
+            .map(|parsed| parsed.with_timezone(&Utc) <= now)
+            .unwrap_or(true),
+    }
+}
+
+pub(crate) fn authority_session_fact(token: &str) -> Result<String> {
+    use biscuit_auth::builder::{BlockBuilder, Term};
+
+    let biscuit = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes())
+        .context("parsing independent-root session")?;
+    let source = biscuit
+        .print_block_source(0)
+        .context("reading independent-root authority block")?;
+    let authority = BlockBuilder::new()
+        .code(&source)
+        .context("parsing independent-root authority facts")?;
+    let mut sessions = authority.facts.iter().filter_map(|fact| {
+        if fact.predicate.name != "session" || fact.predicate.terms.len() != 1 {
+            return None;
+        }
+        match &fact.predicate.terms[0] {
+            Term::Str(value) => Some(value.clone()),
+            _ => None,
+        }
+    });
+    let session = sessions
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("independent-root authority is missing session"))?;
+    if sessions.next().is_some() {
+        bail!("independent-root authority contains multiple session facts");
+    }
+    Ok(session)
+}
+
+fn resolve_revocation_session(
+    public_key_hex: &str,
+    credential_id: Option<&str>,
+    session_id: Option<&str>,
+) -> Result<String> {
+    if let Some(session) = session_id.filter(|value| !value.is_empty()) {
+        validate_root_string("session", session)?;
+        return Ok(session.to_string());
+    }
+    if let Some(credential_id) = credential_id.filter(|value| !value.is_empty()) {
+        validate_root_string("credential_id", credential_id)?;
+        return Ok(format!("cred:{credential_id}"));
+    }
+    Ok(format!("key:{public_key_hex}"))
 }
 
 fn validate_root_string(field: &str, value: &str) -> Result<()> {

--- a/crates/cli/src/hosted_runtime/root_mint.rs
+++ b/crates/cli/src/hosted_runtime/root_mint.rs
@@ -1,0 +1,208 @@
+//! Client-side independent-root Biscuit mint.
+//!
+//! One ceremony: the caller's Ed25519 seed is the Biscuit authority key and
+//! the request-proof key. Signup, claim, passkey finish, anon, and
+//! `CreateAgentAccount` all call this. Weft only registers the public key.
+
+use anyhow::{Context, Result, bail};
+use biscuit_auth::{Algorithm, KeyPair, PrivateKey};
+use chrono::{DateTime, Duration, Utc};
+use crypto::{Ed25519Signer, Signer as _};
+
+/// Default lifetime for an account, claim, passkey, or device root.
+pub(crate) const ACCOUNT_ROOT_TTL: Duration = Duration::days(30);
+/// Anon roots stay short-lived; continuity is a local remint of the same seed.
+pub(crate) const ANON_ROOT_TTL: Duration = Duration::hours(24);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum IndependentRootKind {
+    Account,
+    Anon,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct IndependentRoot {
+    pub(crate) token: String,
+    pub(crate) subject: String,
+    pub(crate) public_key: [u8; 32],
+    pub(crate) private_key_pem: String,
+    pub(crate) expires_at: DateTime<Utc>,
+    pub(crate) credential_id: Option<String>,
+}
+
+impl IndependentRoot {
+    pub(crate) fn public_key_hex(&self) -> String {
+        hex::encode(self.public_key)
+    }
+}
+
+/// Mint a root from an existing seed. `CreateAgentAccount` uses the persisted
+/// Iroh node seed so the claim signer and the authority key stay the same key.
+pub(crate) fn mint_independent_root(
+    seed: &[u8; 32],
+    subject: &str,
+    kind: IndependentRootKind,
+    ttl: Duration,
+    credential_id: Option<&str>,
+) -> Result<IndependentRoot> {
+    validate_root_string("subject", subject)?;
+    if let Some(credential_id) = credential_id {
+        validate_root_string("credential_id", credential_id)?;
+    }
+    if ttl <= Duration::zero() {
+        bail!("independent-root TTL must be greater than zero");
+    }
+    let expires_at = Utc::now()
+        .checked_add_signed(ttl)
+        .context("independent-root TTL overflows the calendar")?;
+    let signer = Ed25519Signer::from_seed(seed).context("loading independent-root seed")?;
+    let public_key: [u8; 32] = signer
+        .public_key()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("independent-root public key must be 32 bytes"))?;
+    let private_key_pem = signer
+        .to_pem()
+        .context("exporting independent-root proof key")?;
+    let authority = authority_keypair(seed)?;
+    let pop_hex = hex::encode(public_key);
+    let session = format!("sess-{}", uuid::Uuid::new_v4());
+    let expiry = expires_at.to_rfc3339();
+    let mut builder = biscuit_auth::Biscuit::builder();
+    builder = builder
+        .fact(format!("user({})", quote(subject)).as_str())
+        .context("independent-root user fact")?;
+    builder = builder
+        .fact(format!("session({})", quote(&session)).as_str())
+        .context("independent-root session fact")?;
+    builder = builder
+        .fact(format!("device_pop_key({})", quote(&pop_hex)).as_str())
+        .context("independent-root device_pop_key fact")?;
+    if let Some(credential_id) = credential_id {
+        builder = builder
+            .fact(format!("credential_id({})", quote(credential_id)).as_str())
+            .context("independent-root credential_id fact")?;
+    }
+    match kind {
+        IndependentRootKind::Account => {}
+        IndependentRootKind::Anon => {
+            builder = builder
+                .fact(r#"subject_kind("anon")"#)
+                .context("independent-root anon subject_kind fact")?;
+        }
+    }
+    builder = builder
+        .fact(format!("expires_at({expiry})").as_str())
+        .context("independent-root expires_at fact")?;
+    builder = builder
+        .check(format!("check if time($now), $now < {expiry}").as_str())
+        .context("independent-root expiry check")?;
+    let token = builder
+        .build(&authority)
+        .context("signing the independent-root authority block")?
+        .to_base64()
+        .context("encoding the independent-root token")?;
+    Ok(IndependentRoot {
+        token,
+        subject: subject.to_string(),
+        public_key,
+        private_key_pem,
+        expires_at,
+        credential_id: credential_id.map(ToOwned::to_owned),
+    })
+}
+
+/// Fresh seed plus mint. Anon and device-login roots start here.
+pub(crate) fn mint_new_independent_root(
+    subject: &str,
+    kind: IndependentRootKind,
+    ttl: Duration,
+    credential_id: Option<&str>,
+) -> Result<IndependentRoot> {
+    let mut seed = [0_u8; 32];
+    getrandom::fill(&mut seed).context("generating independent-root seed")?;
+    mint_independent_root(&seed, subject, kind, ttl, credential_id)
+}
+
+pub(crate) fn mint_agent_root(seed: &[u8; 32]) -> Result<IndependentRoot> {
+    let signer = Ed25519Signer::from_seed(seed).context("loading agent root seed")?;
+    let subject = format!("agent-key:{}", hex::encode(signer.public_key()));
+    mint_independent_root(
+        seed,
+        &subject,
+        IndependentRootKind::Account,
+        ACCOUNT_ROOT_TTL,
+        None,
+    )
+}
+
+pub(crate) fn mint_anon_root() -> Result<IndependentRoot> {
+    let subject = format!("anon:{}", uuid::Uuid::new_v4());
+    mint_new_independent_root(&subject, IndependentRootKind::Anon, ANON_ROOT_TTL, None)
+}
+
+pub(crate) fn remint_stored_root(
+    private_key_pem: &str,
+    subject: &str,
+    credential_id: Option<&str>,
+) -> Result<IndependentRoot> {
+    let signer =
+        Ed25519Signer::from_pem(private_key_pem).context("loading stored independent-root key")?;
+    mint_independent_root(
+        &signer.to_seed(),
+        subject,
+        IndependentRootKind::Account,
+        ACCOUNT_ROOT_TTL,
+        credential_id,
+    )
+}
+
+pub(crate) fn agent_root_subject(public_key: &[u8]) -> String {
+    format!("agent-key:{}", hex::encode(public_key))
+}
+
+pub(crate) fn authority_keypair(seed: &[u8; 32]) -> Result<KeyPair> {
+    let private = PrivateKey::from_bytes(seed, Algorithm::Ed25519)
+        .context("deriving the Biscuit authority key from the independent-root seed")?;
+    Ok(KeyPair::from(&private))
+}
+
+pub(crate) fn is_local_agent_root(subject: &str, proof_public_key_hex: &str) -> bool {
+    subject.eq_ignore_ascii_case(&agent_root_subject(
+        &match hex::decode(proof_public_key_hex) {
+            Ok(bytes) => bytes,
+            Err(_) => return false,
+        },
+    ))
+}
+
+fn validate_root_string(field: &str, value: &str) -> Result<()> {
+    if value.is_empty() {
+        bail!("{field} must not be empty");
+    }
+    for ch in value.chars() {
+        if !matches!(
+            ch,
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '.' | '_' | '/' | '@' | ':' | '+' | '-'
+        ) {
+            bail!("{field} contains forbidden character {ch:?}; allowed: [A-Za-z0-9._/@:+-]");
+        }
+    }
+    Ok(())
+}
+
+fn quote(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(ch),
+        }
+    }
+    out.push('"');
+    out
+}

--- a/crates/cli/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/cli/src/hosted_runtime/root_mint_tests.rs
@@ -1,0 +1,113 @@
+use chrono::Utc;
+use crypto::{Ed25519Signer, Signer as _};
+
+use super::root_mint::{
+    ACCOUNT_ROOT_TTL, IndependentRootKind, agent_root_subject, authority_keypair,
+    is_local_agent_root, mint_anon_root, mint_independent_root, mint_new_independent_root,
+    remint_stored_root,
+};
+use crate::hosted_runtime::{auth::headless_token_metadata, device_flow::authenticated_subject};
+
+#[test]
+fn agent_root_is_signed_by_the_same_seed_weft_will_register() {
+    let signer = Ed25519Signer::generate().expect("seed");
+    let root = mint_independent_root(
+        &signer.to_seed(),
+        &agent_root_subject(signer.public_key()),
+        IndependentRootKind::Account,
+        ACCOUNT_ROOT_TTL,
+        None,
+    )
+    .expect("mint agent root");
+
+    let authority = authority_keypair(&signer.to_seed()).expect("authority");
+    biscuit_auth::Biscuit::from_base64(root.token.as_bytes(), authority.public())
+        .expect("Weft verifies a client-minted root against the registered public key");
+    let metadata = headless_token_metadata(&root.token).expect("metadata");
+    assert!(!metadata.is_derived);
+    assert_eq!(metadata.subject, root.subject);
+    assert!(
+        metadata
+            .proof_public_key_hex
+            .eq_ignore_ascii_case(&root.public_key_hex())
+    );
+    assert!(is_local_agent_root(
+        &metadata.subject,
+        &metadata.proof_public_key_hex
+    ));
+    let parsed_expiry = chrono::DateTime::parse_from_rfc3339(
+        metadata.expires_at.as_deref().expect("authority expiry"),
+    )
+    .expect("rfc3339 expiry")
+    .with_timezone(&Utc);
+    assert!((parsed_expiry - root.expires_at).num_seconds().abs() <= 1);
+}
+
+#[test]
+fn anon_root_carries_subject_kind_and_never_asks_weft() {
+    let root = mint_anon_root().expect("mint anon");
+    assert!(root.subject.starts_with("anon:"));
+    let source = biscuit_auth::UnverifiedBiscuit::from_base64(root.token.as_bytes())
+        .expect("parse")
+        .print_block_source(0)
+        .expect("authority");
+    assert!(source.contains(r#"subject_kind("anon")"#), "{source}");
+    assert_eq!(
+        authenticated_subject(&root.token).expect("subject"),
+        root.subject
+    );
+}
+
+#[test]
+fn remint_keeps_the_registered_key_and_replaces_only_the_token() {
+    let first = mint_new_independent_root(
+        "alice@example.com",
+        IndependentRootKind::Account,
+        ACCOUNT_ROOT_TTL,
+        Some("cred-1"),
+    )
+    .expect("first root");
+    let renewed = remint_stored_root(
+        &first.private_key_pem,
+        &first.subject,
+        first.credential_id.as_deref(),
+    )
+    .expect("remint");
+    assert_eq!(renewed.public_key, first.public_key);
+    assert_eq!(renewed.subject, first.subject);
+    assert_eq!(renewed.credential_id.as_deref(), Some("cred-1"));
+    assert_ne!(renewed.token, first.token);
+    let authority = authority_keypair(
+        &Ed25519Signer::from_pem(&first.private_key_pem)
+            .expect("pem")
+            .to_seed(),
+    )
+    .expect("authority");
+    biscuit_auth::Biscuit::from_base64(renewed.token.as_bytes(), authority.public())
+        .expect("reminted root still verifies with the registered key");
+}
+
+#[test]
+fn mint_rejects_an_empty_or_injected_subject() {
+    let seed = [7_u8; 32];
+    assert!(
+        mint_independent_root(
+            &seed,
+            "",
+            IndependentRootKind::Account,
+            ACCOUNT_ROOT_TTL,
+            None
+        )
+        .is_err()
+    );
+    assert!(
+        mint_independent_root(
+            &seed,
+            r#"alice") fact("evil"("#,
+            IndependentRootKind::Account,
+            ACCOUNT_ROOT_TTL,
+            None,
+        )
+        .is_err()
+    );
+}

--- a/crates/cli/src/hosted_runtime/root_mint_tests.rs
+++ b/crates/cli/src/hosted_runtime/root_mint_tests.rs
@@ -1,23 +1,27 @@
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use crypto::{Ed25519Signer, Signer as _};
 
 use super::root_mint::{
-    ACCOUNT_ROOT_TTL, IndependentRootKind, agent_root_subject, authority_keypair,
-    is_local_agent_root, mint_anon_root, mint_independent_root, mint_new_independent_root,
-    remint_stored_root,
+    ACCOUNT_ROOT_TTL, IndependentRootMint, agent_root_subject, authority_keypair,
+    authority_session_fact, is_local_agent_root, local_agent_credential_needs_refresh,
+    mint_agent_root, mint_independent_root, remint_stored_root,
 };
-use crate::hosted_runtime::{auth::headless_token_metadata, device_flow::authenticated_subject};
+use crate::hosted_runtime::{
+    auth::headless_token_metadata,
+    device_flow::{SAFE_AGENT_OPERATIONS, restrict_agent_account_root},
+};
 
 #[test]
 fn agent_root_is_signed_by_the_same_seed_weft_will_register() {
     let signer = Ed25519Signer::generate().expect("seed");
-    let root = mint_independent_root(
-        &signer.to_seed(),
-        &agent_root_subject(signer.public_key()),
-        IndependentRootKind::Account,
-        ACCOUNT_ROOT_TTL,
-        None,
-    )
+    let root = mint_independent_root(IndependentRootMint {
+        seed: &signer.to_seed(),
+        subject: &agent_root_subject(signer.public_key()),
+        ttl: ACCOUNT_ROOT_TTL,
+        credential_id: None,
+        session_id: None,
+        expires_at: None,
+    })
     .expect("mint agent root");
 
     let authority = authority_keypair(&signer.to_seed()).expect("authority");
@@ -41,48 +45,59 @@ fn agent_root_is_signed_by_the_same_seed_weft_will_register() {
     .expect("rfc3339 expiry")
     .with_timezone(&Utc);
     assert!((parsed_expiry - root.expires_at).num_seconds().abs() <= 1);
-}
-
-#[test]
-fn anon_root_carries_subject_kind_and_never_asks_weft() {
-    let root = mint_anon_root().expect("mint anon");
-    assert!(root.subject.starts_with("anon:"));
-    let source = biscuit_auth::UnverifiedBiscuit::from_base64(root.token.as_bytes())
-        .expect("parse")
-        .print_block_source(0)
-        .expect("authority");
-    assert!(source.contains(r#"subject_kind("anon")"#), "{source}");
     assert_eq!(
-        authenticated_subject(&root.token).expect("subject"),
-        root.subject
+        authority_session_fact(&root.token).expect("session"),
+        format!("key:{}", root.public_key_hex())
     );
 }
 
 #[test]
-fn remint_keeps_the_registered_key_and_replaces_only_the_token() {
-    let first = mint_new_independent_root(
-        "alice@example.com",
-        IndependentRootKind::Account,
-        ACCOUNT_ROOT_TTL,
-        Some("cred-1"),
-    )
+fn remint_cannot_escape_the_registered_key_session() {
+    let signer = Ed25519Signer::generate().expect("seed");
+    let subject = "alice@example.com";
+    let first = mint_independent_root(IndependentRootMint {
+        seed: &signer.to_seed(),
+        subject,
+        ttl: ACCOUNT_ROOT_TTL,
+        credential_id: Some("cred-1"),
+        session_id: None,
+        expires_at: None,
+    })
     .expect("first root");
+    let first_session = authority_session_fact(&first.token).expect("first session");
+    assert_eq!(first_session, "cred:cred-1");
+
     let renewed = remint_stored_root(
         &first.private_key_pem,
         &first.subject,
         first.credential_id.as_deref(),
+        Some(&first_session),
     )
     .expect("remint");
     assert_eq!(renewed.public_key, first.public_key);
     assert_eq!(renewed.subject, first.subject);
     assert_eq!(renewed.credential_id.as_deref(), Some("cred-1"));
     assert_ne!(renewed.token, first.token);
-    let authority = authority_keypair(
-        &Ed25519Signer::from_pem(&first.private_key_pem)
-            .expect("pem")
-            .to_seed(),
+    assert_eq!(
+        authority_session_fact(&renewed.token).expect("reminted session"),
+        first_session,
+        "RevokeSession on the registered credential/session must hit every remint"
+    );
+
+    let forgotten_session = remint_stored_root(
+        &first.private_key_pem,
+        &first.subject,
+        first.credential_id.as_deref(),
+        None,
     )
-    .expect("authority");
+    .expect("deterministic remint");
+    assert_eq!(
+        authority_session_fact(&forgotten_session.token).expect("fallback session"),
+        first_session,
+        "omitting the previous session must still bind remint to cred:{{id}}, not a new UUID"
+    );
+
+    let authority = authority_keypair(&signer.to_seed()).expect("authority");
     biscuit_auth::Biscuit::from_base64(renewed.token.as_bytes(), authority.public())
         .expect("reminted root still verifies with the registered key");
 }
@@ -91,23 +106,103 @@ fn remint_keeps_the_registered_key_and_replaces_only_the_token() {
 fn mint_rejects_an_empty_or_injected_subject() {
     let seed = [7_u8; 32];
     assert!(
-        mint_independent_root(
-            &seed,
-            "",
-            IndependentRootKind::Account,
-            ACCOUNT_ROOT_TTL,
-            None
-        )
+        mint_independent_root(IndependentRootMint {
+            seed: &seed,
+            subject: "",
+            ttl: ACCOUNT_ROOT_TTL,
+            credential_id: None,
+            session_id: None,
+            expires_at: None,
+        })
         .is_err()
     );
     assert!(
-        mint_independent_root(
-            &seed,
-            r#"alice") fact("evil"("#,
-            IndependentRootKind::Account,
-            ACCOUNT_ROOT_TTL,
-            None,
-        )
+        mint_independent_root(IndependentRootMint {
+            seed: &seed,
+            subject: r#"alice") fact("evil"("#,
+            ttl: ACCOUNT_ROOT_TTL,
+            credential_id: None,
+            session_id: None,
+            expires_at: None,
+        })
         .is_err()
     );
+    assert!(
+        mint_independent_root(IndependentRootMint {
+            seed: &seed,
+            subject: "alice",
+            ttl: ACCOUNT_ROOT_TTL,
+            credential_id: None,
+            session_id: None,
+            expires_at: Some(Utc::now() - Duration::hours(1)),
+        })
+        .is_err()
+    );
+}
+
+#[test]
+fn expired_or_missing_local_agent_expiry_needs_refresh() {
+    assert!(local_agent_credential_needs_refresh(None, Utc::now()));
+    assert!(local_agent_credential_needs_refresh(
+        Some("2020-01-01T00:00:00+00:00"),
+        Utc::now()
+    ));
+    assert!(!local_agent_credential_needs_refresh(
+        Some(&(Utc::now() + Duration::hours(2)).to_rfc3339()),
+        Utc::now()
+    ));
+}
+
+#[test]
+fn expired_local_agent_root_remints_the_same_registered_key() {
+    let signer = Ed25519Signer::generate().expect("seed");
+    let seed = signer.to_seed();
+    let first = mint_agent_root(&seed).expect("first agent root");
+    let reminted = mint_agent_root(&seed).expect("remint from the same Iroh seed");
+    assert_eq!(reminted.public_key, first.public_key);
+    assert_eq!(
+        authority_session_fact(&reminted.token).expect("reminted session"),
+        authority_session_fact(&first.token).expect("first session")
+    );
+    assert_eq!(
+        authority_session_fact(&first.token).expect("session"),
+        format!("key:{}", first.public_key_hex())
+    );
+    assert!(reminted.expires_at > Utc::now());
+}
+
+#[test]
+fn restricted_agent_capability_keeps_the_deny_floor() {
+    let signer = Ed25519Signer::generate().expect("seed");
+    let root = mint_agent_root(&signer.to_seed()).expect("agent root");
+    let restricted =
+        restrict_agent_account_root(&root.token, &signer, root.expires_at).expect("restrict");
+    let metadata = headless_token_metadata(&restricted).expect("metadata");
+    assert!(metadata.is_derived);
+    assert!(is_local_agent_root(
+        &metadata.subject,
+        &metadata.proof_public_key_hex
+    ));
+    let biscuit =
+        biscuit_auth::UnverifiedBiscuit::from_base64(restricted.as_bytes()).expect("parse");
+    let block = biscuit.print_block_source(1).expect("attenuation");
+    for denied in [
+        "MintBiscuit",
+        "CreateServiceAccount",
+        "DeleteRepository",
+        "DeleteNamespace",
+        "RevokeSession",
+        "CreateAgentAccount",
+    ] {
+        assert!(
+            block.contains(&format!(r#"$op != "{denied}""#)),
+            "deny floor missing {denied}: {block}"
+        );
+    }
+    for allowed in SAFE_AGENT_OPERATIONS {
+        assert!(
+            block.contains(&format!(r#"$op == "{allowed}""#)),
+            "safe ceiling missing {allowed}: {block}"
+        );
+    }
 }

--- a/crates/crypto/src/ed25519.rs
+++ b/crates/crypto/src/ed25519.rs
@@ -86,6 +86,13 @@ impl Ed25519Signer {
             .map_err(|e| SignerError::Pkcs8(e.to_string()))
     }
 
+    /// 32-byte Ed25519 seed. The independent-root Biscuit mint uses the same
+    /// bytes as the biscuit-auth signing key so Weft can verify the authority
+    /// block against the registered public key.
+    pub fn to_seed(&self) -> [u8; 32] {
+        self.signing_key.to_bytes()
+    }
+
     pub fn verify_with_public_key(
         data: &[u8],
         public_key: &[u8],

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -140,6 +140,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn ed25519_seed_round_trips_through_pem() {
+        let signer = Ed25519Signer::generate().expect("generate key");
+        let seed = signer.to_seed();
+        let from_seed = Ed25519Signer::from_seed(&seed).expect("reload seed");
+        let from_pem =
+            Ed25519Signer::from_pem(&signer.to_pem().expect("export pem")).expect("reload pem");
+        assert_eq!(from_seed.to_seed(), seed);
+        assert_eq!(from_pem.to_seed(), seed);
+        assert_eq!(from_seed.public_key(), signer.public_key());
+    }
+
+    #[test]
     fn test_ed25519_sign_verify_roundtrip() {
         let signer = Ed25519Signer::generate().expect("generate key");
         let data = b"test data for signing";

--- a/docs/SELF_SOVEREIGN_AUTH.md
+++ b/docs/SELF_SOVEREIGN_AUTH.md
@@ -8,8 +8,8 @@
 > trust anchor it has been configured with.
 
 This walkthrough covers the local-only flow. For the hosted flow
-(where the server is the trust anchor and the CLI receives a Biscuit
-via `MintBiscuit` then attenuates it for sub-agents), see
+(where the client mints the root and Weft registers the public key,
+then the CLI attenuates offline for sub-agents), see
 [`.agents/agent-attenuation.md`](../.agents/agent-attenuation.md).
 
 ## When this applies
@@ -25,8 +25,9 @@ The self-sovereign path is the right shape when:
   identity layer (e.g. a workspace tool, a daemon) and that system
   is the trust anchor — not Heddle's hosted server.
 
-If you have a hosted Biscuit (issued via `MintBiscuit` or a device
-flow), you should attenuate *that* token instead. See `.agents/agent-attenuation.md`.
+If you already have a hosted Biscuit (client-minted at signup, claim,
+passkey finish, device login, or anon), you should attenuate *that*
+token instead. See `.agents/agent-attenuation.md`. Weft never remints.
 
 ## Concept
 
@@ -160,10 +161,10 @@ out of band: the system that consumes these tokens (your own
 service, a test harness, a non-hosted Heddle deployment) must be
 configured with `root.public()` from step 1.
 
-The hosted Heddle server is configured with its own root key and
-will reject Biscuits minted by a different root. If you need tokens
-that the hosted server will accept, use `MintBiscuit` or the device
-flow — see `.agents/agent-attenuation.md`.
+Weft verifies a hosted Biscuit against the public key it registered
+for that account. The client is the authority-block signer. Existing
+accounts attenuate offline; Weft never remints. See
+`.agents/agent-attenuation.md`.
 
 ## What you can't do
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1674,8 +1674,8 @@ Source: docs/SELF_SOVEREIGN_AUTH.md
 > trust anchor it has been configured with.
 
 This walkthrough covers the local-only flow. For the hosted flow
-(where the server is the trust anchor and the CLI receives a Biscuit
-via `MintBiscuit` then attenuates it for sub-agents), see
+(where the client mints the root and Weft registers the public key,
+then the CLI attenuates offline for sub-agents), see
 [`.agents/agent-attenuation.md`](../.agents/agent-attenuation.md).
 
 ## When this applies
@@ -1691,8 +1691,9 @@ The self-sovereign path is the right shape when:
   identity layer (e.g. a workspace tool, a daemon) and that system
   is the trust anchor — not Heddle's hosted server.
 
-If you have a hosted Biscuit (issued via `MintBiscuit` or a device
-flow), you should attenuate *that* token instead. See `.agents/agent-attenuation.md`.
+If you already have a hosted Biscuit (client-minted at signup, claim,
+passkey finish, device login, or anon), you should attenuate *that*
+token instead. See `.agents/agent-attenuation.md`. Weft never remints.
 
 ## Concept
 
@@ -1826,10 +1827,10 @@ out of band: the system that consumes these tokens (your own
 service, a test harness, a non-hosted Heddle deployment) must be
 configured with `root.public()` from step 1.
 
-The hosted Heddle server is configured with its own root key and
-will reject Biscuits minted by a different root. If you need tokens
-that the hosted server will accept, use `MintBiscuit` or the device
-flow — see `.agents/agent-attenuation.md`.
+Weft verifies a hosted Biscuit against the public key it registered
+for that account. The client is the authority-block signer. Existing
+accounts attenuate offline; Weft never remints. See
+`.agents/agent-attenuation.md`.
 
 ## What you can't do
 
@@ -7610,6 +7611,14 @@ for its two state arguments without parsing source:
 
 ```json
 {"output_kind": "semantic_diff", "from_state": "hs-0000000000000000000000000000000000000000000000000000", "to_state": "hs-1111111111111111111111111111111111111111111111111111", "deltas": [{"change": "modified", "anchor": {"file": "src/lib.rs", "symbol": "calculate"}, "kind": "function", "old_hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "new_hash": "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"}]}
+```
+
+`heddle semantic refs --output json` emits persisted refs-of, callers-of, or
+importers-of at one state without parsing source. This envelope is the
+weft#451 Tier-2 body (`SemanticGraphQueryResponse`); hosted RPCs remain residual.
+
+```json
+{"output_kind": "semantic_refs", "state_id": "hs-0000000000000000000000000000000000000000000000000000", "kind": "refs_of", "anchor": {"file": "src/api.rs", "symbol": "greet"}, "path": null, "index_present": true, "refs": [{"source_path": "src/client.rs", "source_occurrence": 1, "name": "greet", "role": "call", "kind": "calls", "span": {"start": 40, "end": 45}, "target": {"file": "src/api.rs", "symbol": "greet"}, "target_definition": 0}], "importers": []}
 ```
 
 ## Other verbs


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Heddle mints every independent-root Biscuit locally (CreateAgentAccount, device login, rotation) and presents it as the request bearer. Weft only registers the public key.
- `MintBiscuit` is no longer a hosted client RPC. There is no fallback that asks Weft to mint, and no second mint stack.
- Existing accounts keep attenuating offline. Derived agents are denied `MintBiscuit` / `MintAnonBiscuit`.
- `heddle identity ensure --server api.heddle.sh` with no invite still reuses a local agent root, and remints that same Iroh seed when the stored bearer is expired or missing `expires_at`.

## Bounce (2026-08-20, on `90d48904`)

Fast Lane `-D dead-code` plus Codex P1s on that SHA.

- **Dead code.** Anon mint (`ANON_ROOT_TTL`, `IndependentRootKind::Anon`, `mint_anon_root`, `mint_new_independent_root`) had no CLI caller (`MintAnonBiscuit` is intentionally unsupported). Deleted that surface rather than `#[allow(dead_code)]`. One mint path remains: `mint_independent_root`.
- **Revocation.** `session()` is no longer a random UUID. Server-issued `session_id` wins when present; otherwise `cred:{credential_id}` or `key:{public_key}`. Remint of the same registered key cannot mint a new live session. Rotation reuses the previous token's session fact.
- **Deny floor.** `create_on_behalf` still never reads `response.agent_capability` (prod Weft leaves it empty). After Weft registers the key, the stored credential is the client-minted root plus local `restrict_agent_account_root` (same deny floor + `SAFE_AGENT_OPERATIONS` ceiling as `derive-agent`, self-delegated so the leaf PoP stays the Iroh key).
- **Expiry.** Reuse of a local agent root checks `expires_at` and remints from the persisted Iroh seed before reporting success.
- **Device expiry (P2).** Device login honors `ExchangeDeviceAuthorization.expires_at` when present and fails closed if the server returns an already-expired timestamp.
- **Docs (P2).** `.agents/agent-attenuation.md` now names the registered client key as the verifier and the bound `session()` as the revoke id.

### API revision pin (investigated; not a fake bump)

`HeddleCo/api` still declares `IdentityService/MintBiscuit` as `shipped` at pin `1ee2da0a` **and** at current `main` (`1fbd2e27`). No API commit contains the `intentionally-unsupported` row this branch attests. Pinning a newer SHA would not make `verify_sync.py` match, and would also drag in 18 unrelated RPC rows. Local `heddle.json` stays honest (no `mint_biscuit` callers, so it cannot remain `shipped` with evidence). Cross-repo follow-up remains an API declaration change.

## Closes

Closes HeddleCo/heddle#1426
Part of HeddleCo/weft#1677

## Red commit

N/A — cutover of existing mint callers; new tests landed with the implementation rather than a prior failing SHA.

## Test evidence

```
$ cargo test -p heddle-cli --lib --features client root_mint
running 6 tests
test hosted_runtime::root_mint_tests::expired_or_missing_local_agent_expiry_needs_refresh ... ok
test hosted_runtime::root_mint_tests::mint_rejects_an_empty_or_injected_subject ... ok
test hosted_runtime::root_mint_tests::expired_local_agent_root_remints_the_same_registered_key ... ok
test hosted_runtime::root_mint_tests::agent_root_is_signed_by_the_same_seed_weft_will_register ... ok
test hosted_runtime::root_mint_tests::remint_cannot_escape_the_registered_key_session ... ok
test hosted_runtime::root_mint_tests::restricted_agent_capability_keeps_the_deny_floor ... ok
test result: ok. 6 passed; 0 failed; 0 ignored

$ cargo test -p heddle-cli --lib --features client create_on_behalf
test hosted_runtime::identity_tests::create_on_behalf_stores_the_client_minted_root ... ok

$ cargo test -p heddle-cli --lib --features client expired_local_agent
test hosted_runtime::identity_tests::expired_local_agent_root_is_refreshed_without_an_invite ... ok
test hosted_runtime::root_mint_tests::expired_local_agent_root_remints_the_same_registered_key ... ok

$ cargo test -p heddle-cli --lib --features client device_login_mints
test hosted_runtime::auth::tests::device_login_mints_the_bearer_from_the_registered_device_key ... ok

$ cargo test -p heddle-cli --lib --features client device_root_honors
test hosted_runtime::auth::tests::device_root_honors_returned_expiry_and_rejects_an_already_expired_one ... ok

$ cargo test -p heddle-cli --lib --features client login_and_rotation_never
test hosted_runtime::auth::tests::login_and_rotation_never_call_a_weft_mint_rpc ... ok

$ cargo test -p heddle-cli --lib --features client hosted_rotation_never
test hosted_runtime::hosted::methods::tests::hosted_rotation_never_calls_a_weft_mint_rpc ... ok

$ cargo test -p heddle-cli --lib hosted_runtime --features client
test result: ok. 247 passed; 0 failed; 1 ignored

$ RUSTFLAGS="-D dead_code" cargo check -p heddle-cli --features client
Finished `dev` profile [unoptimized + debuginfo] target(s)

$ cargo run --locked -p heddle-devtools -- check-rust-source-reachability
Rust source guard clean: all 827 source file(s) across 31 crate(s) are reachable; no blanket dead_code allows
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

## Notes for reviewers

- One mint path: `hosted_runtime/root_mint.rs`. CreateAgentAccount presents the unrestricted Iroh-seed root, then stores the restricted token. Device login and rotation remint from the stored proof key with a stable session.
- Wire: existing `CreateAgentAccount` / `ExchangeDeviceAuthorization` messages plus CallContext bearer. No second view RPC.
- Capability declaration marks `IdentityService/MintBiscuit` `intentionally-unsupported`. API has not landed the matching sanitized row yet (see bounce note above).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f9511ff6-921f-48da-9b2f-f8c1ae6e55ee?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f9511ff6-921f-48da-9b2f-f8c1ae6e55ee&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789753846&installation_model_id=21489&pr_number=1427&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1427&signature=3b08500c90f39a1a8d67bca089c3ab98d73a3e4993cbfec995a77e17c4ed29bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->