### PR TITLE
fix(fsmonitor): default monitor off until explicitly enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **Default fsmonitor is off.** `FsMonitorMode` now defaults to `Off`, so a
+  stock install never binds the unauthenticated localhost helper or skips
+  status/capture directories from its baseline. Enable `native`, `auto`, or
+  `watchman` (or `HEDDLE_FSMONITOR`) when that workstation model is acceptable
+  (heddle#1411).
+
 - **Compact frames reject attacker-declared object counts before prealloc.**
   `get_count` now caps declarations against the 12 MiB writer frame object
   ceiling and a real per-entry encoded floor, so a hostile pack cannot force

--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -879,11 +879,11 @@ mod tests {
     }
 
     #[test]
-    fn user_worktree_status_options_default_to_auto() {
+    fn user_worktree_status_options_default_to_off() {
         let config = UserConfig::default();
         let options = config.worktree_status_options(None);
 
-        assert_eq!(options.fsmonitor.mode, FsMonitorMode::Auto);
+        assert_eq!(options.fsmonitor.mode, FsMonitorMode::Off);
     }
 
     #[test]

--- a/crates/repo/src/fsmonitor.rs
+++ b/crates/repo/src/fsmonitor.rs
@@ -1506,7 +1506,7 @@ mod tests {
         helper_endpoint_path, local_helper_binary_for_executable, shutdown_local_monitor_helper,
         subtree_has_changes, try_spawn_local_helper_with, try_spawn_local_helper_with_probe,
     };
-    use crate::{DirectoryCacheEntry, WorktreeIndex};
+    use crate::{DirectoryCacheEntry, FsMonitorSettings, WorktreeIndex};
 
     #[test]
     fn subtree_matching_handles_root_and_prefixes() {
@@ -1766,6 +1766,84 @@ mod tests {
     #[test]
     fn auto_native_backend_is_explicitly_platform_gated() {
         assert_eq!(super::native_backend_supported(), cfg!(target_os = "linux"));
+    }
+
+    #[test]
+    fn default_prepare_does_not_expose_an_unauthenticated_helper() {
+        let temp = TempDir::new().unwrap();
+        let repo_root = temp.path();
+        std::fs::create_dir_all(repo_root.join(".heddle/state")).unwrap();
+
+        let session = ChangeMonitorSession::prepare(repo_root, FsMonitorSettings::default());
+        let report = session.report();
+
+        assert_eq!(report.status, "disabled");
+        assert_eq!(report.backend, "off");
+        assert_eq!(report.reason.as_deref(), Some("disabled"));
+        assert!(report.changed_paths.is_empty());
+        assert!(!session.can_skip_directory(Path::new("src"), None, &WorktreeIndex::new()));
+
+        let state_path = repo_root.join(".heddle/state/fsmonitor.toml");
+        assert!(
+            !helper_endpoint_path(&state_path).exists(),
+            "default Off must not advertise a localhost helper"
+        );
+        assert!(
+            !super::helper_start_lock_path(&state_path).exists(),
+            "default Off must not take the helper start lock"
+        );
+        assert!(
+            !super::helper_lifetime_lock_path(&state_path).exists(),
+            "default Off must not take the helper lifetime lock"
+        );
+    }
+
+    #[test]
+    fn default_prepare_does_not_consume_a_live_helper_baseline() {
+        let temp = TempDir::new().unwrap();
+        let checkout = temp.path().join("checkout");
+        std::fs::create_dir_all(checkout.join(".heddle/state")).unwrap();
+        std::fs::write(checkout.join("tracked.txt"), b"tracked\n").unwrap();
+        let state_path = checkout.join(".heddle/state/fsmonitor.toml");
+        let endpoint_path = helper_endpoint_path(&state_path);
+        let helper_root = checkout.clone();
+        let helper = thread::spawn(move || super::run_local_monitor_helper(&helper_root));
+
+        for _ in 0..400 {
+            if endpoint_path.exists() {
+                break;
+            }
+            thread::sleep(std::time::Duration::from_millis(5));
+        }
+        assert!(
+            endpoint_path.exists(),
+            "native helper endpoint should appear"
+        );
+
+        let unauthenticated = crate::daemon::send_json_request::<_, super::MonitorHelperResponse>(
+            &crate::daemon::load_endpoint(&endpoint_path).unwrap(),
+            &super::MonitorHelperRequest {
+                version: HELPER_PROTOCOL_VERSION,
+                command: "query".to_string(),
+                since: None,
+            },
+        )
+        .unwrap();
+        assert!(
+            unauthenticated.ok,
+            "a leftover helper still answers any localhost peer; default Off must not use it"
+        );
+
+        let session = ChangeMonitorSession::prepare(&checkout, FsMonitorSettings::default());
+        let report = session.report();
+        assert_eq!(report.status, "disabled");
+        assert_eq!(report.backend, "off");
+        assert!(report.changed_paths.is_empty());
+        assert!(!session.can_skip_directory(Path::new(""), None, &WorktreeIndex::new()));
+
+        let shutdown = shutdown_local_monitor_helper(&checkout).unwrap();
+        drop(shutdown);
+        helper.join().unwrap().unwrap();
     }
 
     #[cfg(unix)]

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -550,7 +550,7 @@ mod tests {
         let config = RepoConfig::default();
 
         assert_eq!(config.worktree.ignore, vec![".heddle".to_string()]);
-        assert_eq!(config.worktree.fsmonitor.mode, crate::FsMonitorMode::Auto);
+        assert_eq!(config.worktree.fsmonitor.mode, crate::FsMonitorMode::Off);
         assert_eq!(
             config.repository.source_authority,
             RepositorySourceAuthority::Native

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -2924,9 +2924,9 @@ impl Repository {
     /// spawn the long-lived `heddle-fsmonitor-worker` daemon as a child of the
     /// clone process, leaving anything that waits on the clone's process tree
     /// blocked on the helper's idle lifetime long after the clone finished
-    /// (heddle#1243). The monitor is deferred, not removed: the first
-    /// `heddle status` in the cloned repository starts the helper on demand
-    /// exactly as it always has.
+    /// (heddle#1243). The monitor is deferred, not removed: an explicit
+    /// `native`/`auto`/`watchman` setting (or `HEDDLE_FSMONITOR`) starts the
+    /// helper on demand. A default install leaves it off (heddle#1411).
     #[must_use]
     pub fn without_fsmonitor(mut self) -> Self {
         self.config.worktree.fsmonitor.mode = crate::FsMonitorMode::Off;

--- a/crates/repo/src/worktree_status_options.rs
+++ b/crates/repo/src/worktree_status_options.rs
@@ -8,9 +8,15 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "lowercase")]
 pub enum FsMonitorMode {
     /// Disable fsmonitor integration.
+    ///
+    /// Fail-closed default: a stock install never binds the localhost helper
+    /// or consumes its baseline (heddle#1411).
+    #[default]
     Off,
     /// Auto-detect a supported backend at runtime.
-    #[default]
+    ///
+    /// Opt-in. On Linux this still starts the native helper, which currently
+    /// accepts any localhost TCP peer.
     Auto,
     /// Use Heddle's local native backend.
     Native,

--- a/crates/repo/src/worktree_status_options.rs
+++ b/crates/repo/src/worktree_status_options.rs
@@ -52,6 +52,22 @@ impl From<FsMonitorConfig> for FsMonitorSettings {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{FsMonitorConfig, FsMonitorMode, FsMonitorSettings, WorktreeStatusOptions};
+
+    #[test]
+    fn default_fsmonitor_mode_is_off() {
+        assert_eq!(FsMonitorMode::default(), FsMonitorMode::Off);
+        assert_eq!(FsMonitorConfig::default().mode, FsMonitorMode::Off);
+        assert_eq!(FsMonitorSettings::default().mode, FsMonitorMode::Off);
+        assert_eq!(
+            WorktreeStatusOptions::default().fsmonitor.mode,
+            FsMonitorMode::Off
+        );
+    }
+}
+
 /// Resolved options for worktree status operations.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct WorktreeStatusOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Default `FsMonitorMode` is now `Off`. A stock install no longer auto-starts the native helper on `127.0.0.1`.
- Status/capture therefore cannot skip directories from an unauthenticated localhost `query`/`baseline`, and a default install cannot be shut down over that socket.
- `native`, `auto`, and `watchman` remain explicit opt-in (`HEDDLE_FSMONITOR` or config). No new auth scheme: fail-closed default is enough and still usable (full worktree scan).

## Closes

Closes HeddleCo/heddle#1411

## Red commit
`9133ede2`

## Test evidence
```
$ cargo test -p heddle-repo --lib -- --nocapture fsmonitor::
    Finished `test` profile [unoptimized + debuginfo] target(s) in 59.42s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 15 tests
test fsmonitor::tests::auto_native_backend_is_explicitly_platform_gated ... ok
test fsmonitor::tests::default_prepare_does_not_expose_an_unauthenticated_helper ... ok
test fsmonitor::tests::helper_exits_when_watched_repository_is_removed ... ok
test fsmonitor::tests::cold_start_checks_worker_readiness_only_before_and_after_spawn ... ok
test fsmonitor::tests::helper_resolution_follows_a_symlinked_cli_to_its_package ... ok
test fsmonitor::tests::internal_other_events_do_not_desync_the_worktree_monitor ... ok
test fsmonitor::tests::overflow_and_missing_cursor_force_fresh_instance ... ok
test fsmonitor::tests::helper_restart_invalidates_a_durable_cursor ... ok
test fsmonitor::tests::shutdown_tolerates_stale_endpoint_after_watcher_exit ... ok
test fsmonitor::tests::skip_requires_matching_clean_tree_hash ... ok
test fsmonitor::tests::subtree_matching_handles_root_and_prefixes ... ok
test fsmonitor::tests::unchanged_child_reuse_is_anchored_by_its_parent_index_entry ... ok
test fsmonitor::tests::default_prepare_does_not_consume_a_live_helper_baseline ... ok
test fsmonitor::tests::shutdown_drains_native_watcher_before_checkout_removal ... ok
test fsmonitor::tests::concurrent_cold_start_spawns_one_worker ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 655 filtered out; finished in 0.03s

$ cargo test -p heddle-repo --lib -- --nocapture status_monitor
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.72s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 4 tests
test repository::status_monitor_tests::missing_or_cursor_lagging_index_never_reports_false_clean ... ok
test repository::status_monitor_tests::ignore_rule_transitions_force_the_same_safe_result_as_a_full_scan ... ok
test repository::status_monitor_tests::gitignore_rule_transitions_force_the_same_safe_result_as_a_full_scan ... ok
test repository::status_monitor_tests::monitor_and_full_scan_match_randomized_mutation_sequences ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 666 filtered out; finished in 0.06s

$ cargo test -p heddle-repo --lib -- --nocapture default_fsmonitor_mode_is_off
    Finished `test` profile [unoptimized + debuginfo] target(s) in 33.51s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 1 test
test worktree_status_options::tests::default_fsmonitor_mode_is_off ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 669 filtered out; finished in 0.00s

$ cargo test -p heddle-repo --lib -- --nocapture test_default_config_values
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.70s
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 1 test
test repository::repo_config::tests::test_default_config_values ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 669 filtered out; finished in 0.00s

$ cargo test -p heddle-cli-shared --lib -- --nocapture user_worktree_status_options_default_to_off
    Finished `test` profile [unoptimized + debuginfo] target(s) in 33.48s
     Running unittests src/lib.rs (target/debug/deps/cli_shared-a6850b479be9e0d8)

running 1 test
test config::user_config::tests::user_worktree_status_options_default_to_off ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 38 filtered out; finished in 0.00s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-613b0bec-d455-4f09-b318-b1b281217edd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-613b0bec-d455-4f09-b318-b1b281217edd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755043&installation_model_id=21489&pr_number=1428&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1428&signature=8b63ff764f5fe15ce0e227d6313e44c158ce472eaa20ada5188c762c439a4bc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->