### PR TITLE
fix(cli): keep claim URLs on-origin; leave consent wire on v1

### DIFF
--- a/crates/cli-contract/src/cli/commands/schemas.rs
+++ b/crates/cli-contract/src/cli/commands/schemas.rs
@@ -806,7 +806,7 @@ pub struct IdentityOutputSchema {
     pub subject: String,
     /// Stable lowercase-hex Iroh NodeId, present when a claim link is minted.
     pub node_id: Option<String>,
-    /// Short-lived heddle.sh bearer URL, present only on deliberate mint/reissue.
+    /// Short-lived claim URL on the selected server origin, present only on deliberate mint/reissue.
     pub claim_url: Option<String>,
 }
 

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -242,16 +242,12 @@ pub(crate) fn pre_consent_message(
     handle: &str,
     nonce: &[u8],
 ) -> Result<Vec<u8>, CallFailure> {
-    let owner_id = state.owner_id.to_string();
-    let expires_at = consent_expiry_bytes(state)?;
     encode_counted(&[
         PRE_CONSENT_DOMAIN,
-        owner_id.as_bytes(),
+        state.owner_id.to_string().as_bytes(),
         handle.as_bytes(),
         state.node_id.as_bytes(),
         nonce,
-        claim_state_id(state)?,
-        &expires_at,
     ])
 }
 
@@ -260,15 +256,11 @@ pub(crate) fn promote_consent_message(
     handle: &str,
     credential_id: &str,
 ) -> Result<Vec<u8>, CallFailure> {
-    let owner_id = state.owner_id.to_string();
-    let expires_at = consent_expiry_bytes(state)?;
     encode_counted(&[
         PROMOTE_CONSENT_DOMAIN,
-        owner_id.as_bytes(),
+        state.owner_id.to_string().as_bytes(),
         handle.as_bytes(),
         credential_id.as_bytes(),
-        claim_state_id(state)?,
-        &expires_at,
     ])
 }
 
@@ -280,21 +272,6 @@ fn refuse_stale_consent(state: &ClaimState) -> Result<(), CallFailure> {
         CallFailureCode::Unauthenticated,
         "claim consent has expired",
     ))
-}
-
-fn claim_state_id(state: &ClaimState) -> Result<&[u8], CallFailure> {
-    let id = state.authorization_hash().as_bytes();
-    if id.is_empty() {
-        return Err(invalid_failure("claim state is missing an issuance id"));
-    }
-    Ok(id)
-}
-
-fn consent_expiry_bytes(state: &ClaimState) -> Result<[u8; 8], CallFailure> {
-    if state.expires_at_millis <= 0 {
-        return Err(invalid_failure("claim consent is missing an expiry"));
-    }
-    Ok(state.expires_at_millis.to_be_bytes())
 }
 
 fn encode_counted(parts: &[&[u8]]) -> Result<Vec<u8>, CallFailure> {

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -167,6 +167,12 @@ pub(crate) fn consent_reply(
             "account claim is already complete",
         ));
     }
+    if !state.consent_unexpired(chrono::Utc::now().timestamp_millis()) {
+        return Err(failure(
+            CallFailureCode::Unauthenticated,
+            "claim consent has expired",
+        ));
+    }
     match parse_request(body)? {
         ClaimRequest::PreConsent { handle, nonce } => {
             validate_handle(&handle)?;
@@ -205,6 +211,7 @@ pub(crate) fn signed_pre_consent(
     nonce: &[u8],
     signer: &Ed25519Signer,
 ) -> Result<AgentConsent, CallFailure> {
+    refuse_stale_consent(state)?;
     let statement = pre_consent_message(state, handle, nonce)?;
     let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
     Ok(AgentConsent {
@@ -220,6 +227,7 @@ pub(crate) fn signed_promote_consent(
     credential_id: &str,
     signer: &Ed25519Signer,
 ) -> Result<AgentConsent, CallFailure> {
+    refuse_stale_consent(state)?;
     let statement = promote_consent_message(state, handle, credential_id)?;
     let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
     Ok(AgentConsent {
@@ -234,12 +242,16 @@ pub(crate) fn pre_consent_message(
     handle: &str,
     nonce: &[u8],
 ) -> Result<Vec<u8>, CallFailure> {
+    let owner_id = state.owner_id.to_string();
+    let expires_at = consent_expiry_bytes(state)?;
     encode_counted(&[
         PRE_CONSENT_DOMAIN,
-        state.owner_id.to_string().as_bytes(),
+        owner_id.as_bytes(),
         handle.as_bytes(),
         state.node_id.as_bytes(),
         nonce,
+        claim_state_id(state)?,
+        &expires_at,
     ])
 }
 
@@ -248,12 +260,41 @@ pub(crate) fn promote_consent_message(
     handle: &str,
     credential_id: &str,
 ) -> Result<Vec<u8>, CallFailure> {
+    let owner_id = state.owner_id.to_string();
+    let expires_at = consent_expiry_bytes(state)?;
     encode_counted(&[
         PROMOTE_CONSENT_DOMAIN,
-        state.owner_id.to_string().as_bytes(),
+        owner_id.as_bytes(),
         handle.as_bytes(),
         credential_id.as_bytes(),
+        claim_state_id(state)?,
+        &expires_at,
     ])
+}
+
+fn refuse_stale_consent(state: &ClaimState) -> Result<(), CallFailure> {
+    if state.consent_unexpired(chrono::Utc::now().timestamp_millis()) {
+        return Ok(());
+    }
+    Err(failure(
+        CallFailureCode::Unauthenticated,
+        "claim consent has expired",
+    ))
+}
+
+fn claim_state_id(state: &ClaimState) -> Result<&[u8], CallFailure> {
+    let id = state.authorization_hash().as_bytes();
+    if id.is_empty() {
+        return Err(invalid_failure("claim state is missing an issuance id"));
+    }
+    Ok(id)
+}
+
+fn consent_expiry_bytes(state: &ClaimState) -> Result<[u8; 8], CallFailure> {
+    if state.expires_at_millis <= 0 {
+        return Err(invalid_failure("claim consent is missing an expiry"));
+    }
+    Ok(state.expires_at_millis.to_be_bytes())
 }
 
 fn encode_counted(parts: &[&[u8]]) -> Result<Vec<u8>, CallFailure> {

--- a/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
@@ -84,7 +84,7 @@ impl MockWeftAccount {
 }
 
 #[test]
-fn consent_signatures_match_the_landed_weft_contract() {
+fn consent_signatures_round_trip_the_local_builders() {
     let signer = Ed25519Signer::generate().expect("signer");
     let mut claim = state(hex::encode(signer.public_key()));
     assert!(claim.reissue(b"claim-secret", i64::MAX));
@@ -98,7 +98,7 @@ fn consent_signatures_match_the_landed_weft_contract() {
         signer.public_key(),
         &pre_signature,
     )
-    .expect("weft-compatible pre-consent verifies");
+    .expect("local pre-consent verifies");
 
     let promote = signed_promote_consent(&claim, "human-handle", "Y3JlZGVudGlhbA", &signer)
         .expect("signed promote-consent");
@@ -108,38 +108,39 @@ fn consent_signatures_match_the_landed_weft_contract() {
         signer.public_key(),
         &promote_signature,
     )
-    .expect("weft-compatible promote-consent verifies");
+    .expect("local promote-consent verifies");
 
     assert_eq!(pre.account_id, OWNER_ID);
     assert_eq!(promote.account_id, OWNER_ID);
 }
 
 #[test]
-fn consent_messages_bind_expiry_and_claim_state_id() {
+fn consent_builders_encode_the_v1_counted_fields() {
     let mut claim = state("11".repeat(32));
     assert!(claim.reissue(b"claim-secret", 1_700_000_000_000));
     let nonce = b"0123456789abcdef";
     let pre = pre_consent_message(&claim, "human-handle", nonce).expect("pre-consent bytes");
     let promote = promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA")
         .expect("promote-consent bytes");
-    let expiry = 1_700_000_000_000_i64.to_be_bytes();
-    let claim_id = claim.authorization_hash().as_bytes();
-    let pre_parts = counted_parts(&pre);
-    let promote_parts = counted_parts(&promote);
-    assert_eq!(pre_parts[pre_parts.len() - 2], claim_id);
-    assert_eq!(pre_parts[pre_parts.len() - 1], expiry);
-    assert_eq!(promote_parts[promote_parts.len() - 2], claim_id);
-    assert_eq!(promote_parts[promote_parts.len() - 1], expiry);
 
-    claim.expires_at_millis = 1_700_000_000_001;
-    assert_ne!(
+    assert_eq!(
         pre,
-        pre_consent_message(&claim, "human-handle", nonce).unwrap()
+        counted(&[
+            b"heddle-agent-pre-consent-v1",
+            OWNER_ID.as_bytes(),
+            b"human-handle",
+            claim.node_id.as_bytes(),
+            nonce,
+        ])
     );
-    assert!(claim.reissue(b"other-secret", 1_700_000_000_000));
-    assert_ne!(
-        pre,
-        pre_consent_message(&claim, "human-handle", nonce).unwrap()
+    assert_eq!(
+        promote,
+        counted(&[
+            b"heddle-agent-promote-consent-v1",
+            OWNER_ID.as_bytes(),
+            b"human-handle",
+            b"Y3JlZGVudGlhbA",
+        ])
     );
 }
 
@@ -183,32 +184,18 @@ fn expired_consent_is_not_produced_or_accepted() {
                 promote_signature: &promote_signature,
             },
         ),
-        "expired consent bytes must not be accepted locally"
+        "expired consent must not be accepted locally"
     );
 }
 
-#[test]
-fn dormant_consent_is_not_encoded_without_expiry() {
-    let claim = state("11".repeat(32));
-    assert!(pre_consent_message(&claim, "human-handle", b"0123456789abcdef").is_err());
-    assert!(promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA").is_err());
-}
-
-fn counted_parts(bytes: &[u8]) -> Vec<Vec<u8>> {
-    let mut parts = Vec::new();
-    let mut rest = bytes;
-    while rest.len() >= 4 {
-        let length = usize::try_from(u32::from_be_bytes(rest[..4].try_into().unwrap())).unwrap();
-        rest = &rest[4..];
-        assert!(rest.len() >= length, "truncated counted consent field");
-        parts.push(rest[..length].to_vec());
-        rest = &rest[length..];
+fn counted(parts: &[&[u8]]) -> Vec<u8> {
+    let mut encoded = Vec::new();
+    for part in parts {
+        let length = u32::try_from(part.len()).expect("test field fits in u32");
+        encoded.extend_from_slice(&length.to_be_bytes());
+        encoded.extend_from_slice(part);
     }
-    assert!(
-        rest.is_empty(),
-        "trailing bytes after counted consent fields"
-    );
-    parts
+    encoded
 }
 
 #[test]

--- a/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
@@ -62,6 +62,7 @@ impl MockWeftAccount {
         promotion: &MockPromotion<'_>,
     ) -> bool {
         if self.root_credential_id.is_some()
+            || !claim.consent_unexpired(chrono::Utc::now().timestamp_millis())
             || Ed25519Signer::verify_with_public_key(
                 &pre_consent_message(claim, promotion.handle, promotion.nonce).unwrap(),
                 agent_public_key,
@@ -111,6 +112,103 @@ fn consent_signatures_match_the_landed_weft_contract() {
 
     assert_eq!(pre.account_id, OWNER_ID);
     assert_eq!(promote.account_id, OWNER_ID);
+}
+
+#[test]
+fn consent_messages_bind_expiry_and_claim_state_id() {
+    let mut claim = state("11".repeat(32));
+    assert!(claim.reissue(b"claim-secret", 1_700_000_000_000));
+    let nonce = b"0123456789abcdef";
+    let pre = pre_consent_message(&claim, "human-handle", nonce).expect("pre-consent bytes");
+    let promote = promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA")
+        .expect("promote-consent bytes");
+    let expiry = 1_700_000_000_000_i64.to_be_bytes();
+    let claim_id = claim.authorization_hash().as_bytes();
+    let pre_parts = counted_parts(&pre);
+    let promote_parts = counted_parts(&promote);
+    assert_eq!(pre_parts[pre_parts.len() - 2], claim_id);
+    assert_eq!(pre_parts[pre_parts.len() - 1], expiry);
+    assert_eq!(promote_parts[promote_parts.len() - 2], claim_id);
+    assert_eq!(promote_parts[promote_parts.len() - 1], expiry);
+
+    claim.expires_at_millis = 1_700_000_000_001;
+    assert_ne!(
+        pre,
+        pre_consent_message(&claim, "human-handle", nonce).unwrap()
+    );
+    assert!(claim.reissue(b"other-secret", 1_700_000_000_000));
+    assert_ne!(
+        pre,
+        pre_consent_message(&claim, "human-handle", nonce).unwrap()
+    );
+}
+
+#[test]
+fn expired_consent_is_not_produced_or_accepted() {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let mut claim = state(hex::encode(signer.public_key()));
+    assert!(claim.reissue(b"claim-secret", chrono::Utc::now().timestamp_millis() - 1));
+    let nonce = b"0123456789abcdef";
+
+    assert!(
+        signed_pre_consent(&claim, "human-handle", nonce, &signer).is_err(),
+        "expired pre-consent must not be issued"
+    );
+    assert!(
+        signed_promote_consent(&claim, "human-handle", "Y3JlZGVudGlhbA", &signer).is_err(),
+        "expired promote-consent must not be issued"
+    );
+
+    let pre_bytes = pre_consent_message(&claim, "human-handle", nonce).expect("expired encoding");
+    let promote_bytes = promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA")
+        .expect("expired encoding");
+    let pre_signature = signer.sign(&pre_bytes).expect("sign stale pre-consent");
+    let promote_signature = signer
+        .sign(&promote_bytes)
+        .expect("sign stale promote-consent");
+    let mut account = MockWeftAccount {
+        owner_id: claim.owner_id,
+        spool_owner_id: claim.owner_id,
+        root_credential_id: None,
+    };
+    assert!(
+        !account.promote(
+            &claim,
+            signer.public_key(),
+            &MockPromotion {
+                handle: "human-handle",
+                nonce,
+                pre_signature: &pre_signature,
+                credential_id: "Y3JlZGVudGlhbA",
+                promote_signature: &promote_signature,
+            },
+        ),
+        "expired consent bytes must not be accepted locally"
+    );
+}
+
+#[test]
+fn dormant_consent_is_not_encoded_without_expiry() {
+    let claim = state("11".repeat(32));
+    assert!(pre_consent_message(&claim, "human-handle", b"0123456789abcdef").is_err());
+    assert!(promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA").is_err());
+}
+
+fn counted_parts(bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut parts = Vec::new();
+    let mut rest = bytes;
+    while rest.len() >= 4 {
+        let length = usize::try_from(u32::from_be_bytes(rest[..4].try_into().unwrap())).unwrap();
+        rest = &rest[4..];
+        assert!(rest.len() >= length, "truncated counted consent field");
+        parts.push(rest[..length].to_vec());
+        rest = &rest[length..];
+    }
+    assert!(
+        rest.is_empty(),
+        "trailing bytes after counted consent fields"
+    );
+    parts
 }
 
 #[test]

--- a/crates/cli/src/hosted_runtime/identity.rs
+++ b/crates/cli/src/hosted_runtime/identity.rs
@@ -11,7 +11,7 @@ use weft_client_shim::CliContext;
 use super::{
     HostedAuthMode, HostedSession, agent_node_identity,
     auth::{cmd_auth_derive_agent, headless_token_metadata, resolve_server},
-    hosted::resolve_hosted_credential,
+    hosted::{canonical_server_authority, resolve_hosted_credential},
     identity_server,
     identity_state::{self, ClaimState},
 };
@@ -240,6 +240,7 @@ fn reissue(server: &str, ttl_secs: u64) -> Result<(String, String)> {
     if state.server != server {
         bail!("claim state belongs to {}, not {server}", state.server);
     }
+    let origin = claim_web_origin(server)?;
     let mut secret = [0_u8; 32];
     getrandom::fill(&mut secret).context("generating claim secret")?;
     let ttl_millis = i64::try_from(ttl_secs)?
@@ -254,11 +255,46 @@ fn reissue(server: &str, ttl_secs: u64) -> Result<(String, String)> {
     }
     identity_state::store(&state)?;
     let encoded_secret = URL_SAFE_NO_PAD.encode(secret);
-    let url = format!(
-        "https://heddle.sh/claim/hcl1.{}.{}",
-        state.node_id, encoded_secret
-    );
-    Ok((state.node_id, url))
+    let node_id = state.node_id;
+    let url = claim_url(&origin, &node_id, &encoded_secret);
+    Ok((node_id, url))
+}
+
+#[cfg(test)]
+pub(crate) fn claim_link_url(server: &str, node_id: &str, encoded_secret: &str) -> Result<String> {
+    Ok(claim_url(
+        &claim_web_origin(server)?,
+        node_id,
+        encoded_secret,
+    ))
+}
+
+/// Public web origin that may host `/claim/...` for `server`.
+///
+/// Default Heddle API hosts share `https://heddle.sh`. Any other HTTPS
+/// authority is used as-is. Non-HTTPS or unparseable servers are refused so a
+/// self-hosted claim secret is never placed on heddle.sh.
+pub(crate) fn claim_web_origin(server: &str) -> Result<String> {
+    let authority = canonical_server_authority(server).with_context(|| {
+        format!("refusing to mint a claim URL for {server}: need an HTTPS server origin")
+    })?;
+    let url = reqwest::Url::parse(&authority).context("claim server origin is not a valid URL")?;
+    let Some(host) = url.host_str() else {
+        bail!("refusing to mint a claim URL for {server}: origin has no host");
+    };
+    if hosted_heddle_web_host(host) {
+        return Ok("https://heddle.sh".to_string());
+    }
+    Ok(authority)
+}
+
+fn claim_url(origin: &str, node_id: &str, encoded_secret: &str) -> String {
+    format!("{origin}/claim/hcl1.{node_id}.{encoded_secret}")
+}
+
+fn hosted_heddle_web_host(host: &str) -> bool {
+    let host = host.to_ascii_lowercase();
+    host == "heddle.sh" || host.ends_with(".heddle.sh")
 }
 
 fn print_identity(

--- a/crates/cli/src/hosted_runtime/identity_state.rs
+++ b/crates/cli/src/hosted_runtime/identity_state.rs
@@ -79,7 +79,16 @@ impl ClaimState {
 
     pub(crate) fn is_active(&self, now: i64) -> bool {
         matches!(self.status, ClaimStatus::Active | ClaimStatus::Prepared)
-            && now < self.expires_at_millis
+            && self.consent_unexpired(now)
+    }
+
+    /// True when this issuance has a bound expiry that has not yet elapsed.
+    ///
+    /// Promote consent is signed after [`Self::claim`] flips status to
+    /// `Claimed`, so callers that only need the signature TTL must use this
+    /// instead of [`Self::is_active`].
+    pub(crate) fn consent_unexpired(&self, now: i64) -> bool {
+        self.expires_at_millis > 0 && now < self.expires_at_millis
     }
 
     pub(crate) fn accepts(&self, secret: &[u8], now: i64) -> bool {
@@ -247,6 +256,8 @@ mod tests {
         let path = directory.path().join("claim.toml");
         let mut state = state();
         assert!(state.reissue(b"super-secret-value", 2_000));
+        assert!(state.consent_unexpired(1_999));
+        assert!(!state.consent_unexpired(2_000));
         assert!(!state.accepts(b"super-secret-value", 2_000));
         store_at(&path, &state).expect("store claim state");
         let contents = std::fs::read_to_string(path).expect("read claim state");

--- a/crates/cli/src/hosted_runtime/identity_tests.rs
+++ b/crates/cli/src/hosted_runtime/identity_tests.rs
@@ -1,4 +1,4 @@
-use super::identity::{EnsureAction, ensure_action};
+use super::identity::{EnsureAction, claim_link_url, ensure_action};
 
 #[test]
 fn invite_is_never_selected_when_any_credential_exists() {
@@ -10,4 +10,38 @@ fn invite_is_never_selected_when_any_credential_exists() {
 fn provisioning_is_only_the_no_credential_fallback() {
     assert_eq!(ensure_action(None, true), EnsureAction::Provision);
     assert_eq!(ensure_action(None, false), EnsureAction::RequireInvite);
+}
+
+#[test]
+fn claim_url_uses_selected_server_origin() {
+    assert_eq!(
+        claim_link_url("https://git.example.com", "aa", "c2VjcmV0",).expect("custom HTTPS origin"),
+        "https://git.example.com/claim/hcl1.aa.c2VjcmV0"
+    );
+    assert_eq!(
+        claim_link_url("selfhosted.example:8443", "node", "secret").expect("host:port origin"),
+        "https://selfhosted.example:8443/claim/hcl1.node.secret"
+    );
+    assert_eq!(
+        claim_link_url("api.heddle.sh", "aa", "c2VjcmV0").expect("default hosted origin"),
+        "https://heddle.sh/claim/hcl1.aa.c2VjcmV0"
+    );
+}
+
+#[test]
+fn claim_url_refuses_non_https_and_never_rewrites_custom_hosts_to_heddle() {
+    assert!(
+        claim_link_url("http://evil.example", "aa", "secret").is_err(),
+        "plain HTTP must be refused"
+    );
+    assert!(
+        claim_link_url("https://user@git.example.com", "aa", "secret").is_err(),
+        "userinfo must be refused"
+    );
+    let url = claim_link_url("selfhosted.example", "node", "secret").expect("custom origin");
+    assert!(url.starts_with("https://selfhosted.example/claim/hcl1."));
+    assert!(
+        !url.contains("heddle.sh"),
+        "self-hosted claim secrets must not be placed on heddle.sh"
+    );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Claim links use the selected HTTPS origin. Official `*.heddle.sh` API hosts still use `https://heddle.sh`; any other server uses its own origin. HTTP / userinfo / unparseable authorities are refused so a self-hosted claim secret is never sent to heddle.sh.
- Local sign/accept still refuses stale claim state (`refuse_stale_consent` / `consent_unexpired`). That is defense in depth only — not server-side reject.
- Consent builders stay on the landed v1 counted field list. No extra `authorization_hash` / `expires_at` fields, no v2 domain. Binding those into the signature waits for the weft verify cutover.

## Closes

Part of HeddleCo/heddle#1404

## Red commit

`0ec1914a`

## Test evidence

```
$ cargo test -p heddle-cli --lib -- hosted_runtime::claim_authorization hosted_runtime::identity hosted_runtime::identity_state

running 13 tests
test hosted_runtime::claim_authorization_tests::consent_builders_encode_the_v1_counted_fields ... ok
test hosted_runtime::claim_authorization_tests::expired_consent_is_not_produced_or_accepted ... ok
test hosted_runtime::claim_authorization_tests::malformed_claim_inputs_are_rejected ... ok
test hosted_runtime::identity_state::tests::expired_secret_is_rejected_and_not_persisted_in_plaintext ... ok
test hosted_runtime::identity_state::tests::prepared_claim_is_bound_to_one_handle_and_nonce ... ok
test hosted_runtime::identity_state::tests::reissue_invalidates_the_previous_secret ... ok
test hosted_runtime::identity_tests::claim_url_refuses_non_https_and_never_rewrites_custom_hosts_to_heddle ... ok
test hosted_runtime::identity_tests::claim_url_uses_selected_server_origin ... ok
test hosted_runtime::identity_tests::invite_is_never_selected_when_any_credential_exists ... ok
test hosted_runtime::identity_tests::provisioning_is_only_the_no_credential_fallback ... ok
test hosted_runtime::claim_authorization_tests::consent_signatures_round_trip_the_local_builders ... ok
test hosted_runtime::claim_authorization_tests::expired_iroh_claim_link_is_rejected_before_dispatch ... ok
test hosted_runtime::claim_authorization_tests::iroh_claim_happy_path_and_deny_paths_match_weft_promotion ... ok

test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 698 filtered out; finished in 0.10s
```

## Manual verification

N/A — covered by tests.

## Weft follow-up (still required for #1404)

Landed weft (`crates/weft-hosted/src/server/hosted/agent_consent.rs`) still rebuilds:

- pre: domain, account_id, username, agent_node_id, nonce
- promote: domain, account_id, handle, credential_id

It never sees a claim-state id or `expires_at`. #1404 stays open until weft reconstructs the same two trailing fields and rejects `now >= expires_at`:

1. claim-state id = hex SHA-256 of the claim secret (`ClaimState.authorization_hash`)
2. expiry = `expires_at_millis` as 8-byte big-endian `i64`

Do not edit weft from this repo. Do not treat local TTL as the HIGH fix.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bce86a4c-6bae-4c0d-8d58-ed133ed19ef4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bce86a4c-6bae-4c0d-8d58-ed133ed19ef4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755148&installation_model_id=21489&pr_number=1429&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1429&signature=4a5ed3306b0c3e5007a7423402fcb8695c8c14e006e73dc754e2f76317824d16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->