### PR TITLE
fix(ci): bind result-cache hits to full check identity

### DIFF
--- a/crates/ci-engine/src/result_cache/entry.rs
+++ b/crates/ci-engine/src/result_cache/entry.rs
@@ -10,7 +10,7 @@ use crate::model::{AttemptRecord, CheckResult};
 /// Schema version of [`ResultCacheEntry`]. Bump when the bytes change.
 pub const RESULT_CACHE_SCHEMA_VERSION: u32 = 1;
 
-/// A portable cached check result, keyed only on the content-addressed triple.
+/// A portable cached check result, bound to env, inputs, and check identity.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResultCacheEntry {
     /// Entry schema version.
@@ -126,12 +126,16 @@ impl ResultCacheEntry {
             && self.definition_digest == key.definition_digest
             && self.check_name == check_name
             && self.evidence_digest == evidence_digest(&self.combined_output)
+            && self.binds_check_identity(key, check_name)
     }
 
     /// Fail-closed comparison of a cached entry against a fresh run.
     pub fn verify_fresh(&self, fresh: &CheckResult) -> Result<(), ResultCacheError> {
         let fresh_evidence = evidence_digest(&fresh.combined_output);
-        if self.body.outcome == fresh.body.outcome && self.evidence_digest == fresh_evidence {
+        if self.body.outcome == fresh.body.outcome
+            && self.evidence_digest == fresh_evidence
+            && same_check_identity(&self.body, &fresh.body)
+        {
             return Ok(());
         }
         Err(ResultCacheError::SpotCheckDivergence(Box::new(
@@ -147,6 +151,39 @@ impl ResultCacheEntry {
             },
         )))
     }
+
+    pub(super) fn cache_key(&self) -> CacheKey {
+        CacheKey {
+            env_digest: self.env_digest.clone(),
+            input_digests: self.input_digests.clone(),
+            definition_digest: self.definition_digest.clone(),
+            repo: self.body.repo.clone(),
+            state: self.body.state.clone(),
+            basis: self.body.basis.clone(),
+            command: self.body.check.command.clone(),
+            class: self.body.check.class,
+        }
+    }
+
+    fn binds_check_identity(&self, key: &CacheKey, check_name: &str) -> bool {
+        self.body.repo == key.repo
+            && self.body.state == key.state
+            && self.body.basis == key.basis
+            && self.body.check.definition_digest == key.definition_digest
+            && self.body.check.command == key.command
+            && self.body.check.class == key.class
+            && self.body.check.name == check_name
+    }
+}
+
+fn same_check_identity(cached: &CiVerdictBody, fresh: &CiVerdictBody) -> bool {
+    cached.repo == fresh.repo
+        && cached.state == fresh.state
+        && cached.basis == fresh.basis
+        && cached.check.definition_digest == fresh.check.definition_digest
+        && cached.check.command == fresh.check.command
+        && cached.check.class == fresh.check.class
+        && cached.check.name == fresh.check.name
 }
 
 /// Domain-separated BLAKE3 of captured check output.

--- a/crates/ci-engine/src/result_cache/key.rs
+++ b/crates/ci-engine/src/result_cache/key.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Content-addressed cache key: `(env-digest, input-digests, definition-digest)`.
+//! Content-addressed cache key bound to env, inputs, and check identity.
 
 use std::collections::BTreeMap;
 
+use ci_config::Check;
+use crypto::{Basis, CheckClass, StateRef};
 use serde::Serialize;
 
 use crate::{cache::CACHE_ENV_PREFIX, model::ExecutionContext};
 
-/// The portable triple that addresses a cached check result.
+/// Addresses a cached check result.
 ///
 /// The key contains no machine-local state (paths, host identity, cache-slot
 /// directories). Changing any component yields a different [`CacheKey::id`].
+/// Identity fields bind a hit to one check; output digest alone is not enough.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct CacheKey {
     /// Digest of the content-addressed execution environment `E`.
@@ -19,6 +22,16 @@ pub struct CacheKey {
     pub input_digests: Vec<String>,
     /// Digest of the authored definition (`ci.toml` typed-blob hash).
     pub definition_digest: String,
+    /// Repository the verdict was produced for.
+    pub repo: String,
+    /// Source state the verdict was produced for.
+    pub state: StateRef,
+    /// Evaluated basis the verdict was produced for.
+    pub basis: Basis,
+    /// Exact argv executed by the check.
+    pub command: Vec<String>,
+    /// Gating class of the check.
+    pub class: CheckClass,
 }
 
 #[derive(Serialize)]
@@ -30,23 +43,25 @@ struct EnvMaterial<'a> {
     env: BTreeMap<&'a str, &'a str>,
 }
 
-#[derive(Serialize)]
-struct EntryMaterial<'a> {
-    env_digest: &'a str,
-    input_digests: &'a [String],
-    definition_digest: &'a str,
-    check_name: &'a str,
-}
-
 impl CacheKey {
-    /// Derive the triple from the portable projection of `environment` plus
-    /// the execution context's image, toolchain, tree, state, and definition.
+    /// Derive the key from the portable projection of `environment`, the
+    /// execution context, and the check identity (command, class, repo, state,
+    /// basis, definition).
     #[must_use]
-    pub fn derive(environment: &BTreeMap<String, String>, context: &ExecutionContext) -> Self {
+    pub fn derive(
+        environment: &BTreeMap<String, String>,
+        context: &ExecutionContext,
+        check: &Check,
+    ) -> Self {
         Self {
             env_digest: env_digest(environment, context),
             input_digests: input_digests(context),
             definition_digest: context.definition_digest.clone(),
+            repo: context.repo.clone(),
+            state: context.state.clone(),
+            basis: context.basis.clone(),
+            command: check.command.clone(),
+            class: map_class(check.class),
         }
     }
 
@@ -58,27 +73,19 @@ impl CacheKey {
 }
 
 pub(super) fn entry_id(key: &CacheKey, check_name: &str) -> String {
-    digest_json(
-        b"entry",
-        &EntryMaterial {
-            env_digest: &key.env_digest,
-            input_digests: &key.input_digests,
-            definition_digest: &key.definition_digest,
-            check_name,
-        },
-    )
+    digest_json(b"entry", &(key, check_name))
 }
 
 pub(super) fn entry_id_bytes(key: &CacheKey, check_name: &str) -> [u8; 32] {
-    hash_json(
-        b"entry",
-        &EntryMaterial {
-            env_digest: &key.env_digest,
-            input_digests: &key.input_digests,
-            definition_digest: &key.definition_digest,
-            check_name,
-        },
-    )
+    hash_json(b"entry", &(key, check_name))
+}
+
+fn map_class(class: ci_config::CheckClass) -> CheckClass {
+    match class {
+        ci_config::CheckClass::Required => CheckClass::Required,
+        ci_config::CheckClass::Advisory => CheckClass::Advisory,
+        ci_config::CheckClass::Informational => CheckClass::Informational,
+    }
 }
 
 fn env_digest(environment: &BTreeMap<String, String>, context: &ExecutionContext) -> String {
@@ -152,10 +159,27 @@ fn hash_json(label: &[u8], value: &impl Serialize) -> [u8; 32] {
 
 #[cfg(test)]
 mod tests {
+    use ci_config::{CheckClass as ConfigClass, Retry};
     use crypto::{Basis, BasisKind, StateRef};
 
     use super::*;
     use crate::model::ExecutionContext;
+
+    fn check() -> Check {
+        Check {
+            name: "marker".to_string(),
+            class: ConfigClass::Required,
+            command: vec!["echo".to_string(), "ok".to_string()],
+            timeout_secs: 60,
+            env: BTreeMap::new(),
+            services: Vec::new(),
+            cache_paths: Vec::new(),
+            retry: Retry::default(),
+            triggers: Vec::new(),
+            supersede: false,
+            isolation: None,
+        }
+    }
 
     fn context() -> ExecutionContext {
         ExecutionContext {
@@ -187,27 +211,56 @@ mod tests {
 
     #[test]
     fn each_triple_component_changes_the_key() {
-        let base = CacheKey::derive(&env(&[("FOO", "1")]), &context());
+        let check = check();
+        let base = CacheKey::derive(&env(&[("FOO", "1")]), &context(), &check);
         let mut changed_env = context();
-        let env_miss = CacheKey::derive(&env(&[("FOO", "2")]), &changed_env);
+        let env_miss = CacheKey::derive(&env(&[("FOO", "2")]), &changed_env, &check);
         assert_ne!(base.env_digest, env_miss.env_digest);
         assert_ne!(base.id(), env_miss.id());
 
         changed_env.basis.evaluated_tree_digest = "tree-2".to_string();
-        let input_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_env);
+        let input_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_env, &check);
         assert_ne!(base.input_digests, input_miss.input_digests);
         assert_ne!(base.id(), input_miss.id());
 
         let mut changed_definition = context();
         changed_definition.definition_digest = "definition-2".to_string();
-        let definition_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_definition);
+        let definition_miss = CacheKey::derive(&env(&[("FOO", "1")]), &changed_definition, &check);
         assert_ne!(base.definition_digest, definition_miss.definition_digest);
         assert_ne!(base.id(), definition_miss.id());
     }
 
     #[test]
+    fn check_identity_changes_the_key() {
+        let env = env(&[("FOO", "1")]);
+        let base = CacheKey::derive(&env, &context(), &check());
+
+        let mut other_class = check();
+        other_class.class = ConfigClass::Informational;
+        assert_ne!(
+            base.id(),
+            CacheKey::derive(&env, &context(), &other_class).id()
+        );
+
+        let mut other_command = check();
+        other_command.command = vec!["false".to_string()];
+        assert_ne!(
+            base.id(),
+            CacheKey::derive(&env, &context(), &other_command).id()
+        );
+
+        let mut other_repo = context();
+        other_repo.repo = "other/repo".to_string();
+        assert_ne!(
+            base.id(),
+            CacheKey::derive(&env, &other_repo, &check()).id()
+        );
+    }
+
+    #[test]
     fn machine_local_env_is_not_in_the_key() {
-        let portable = CacheKey::derive(&env(&[("FOO", "1"), ("LANG", "C")]), &context());
+        let check = check();
+        let portable = CacheKey::derive(&env(&[("FOO", "1"), ("LANG", "C")]), &context(), &check);
         let local = CacheKey::derive(
             &env(&[
                 ("FOO", "1"),
@@ -217,6 +270,7 @@ mod tests {
                 ("HCI_CACHE_CARGO", "/tmp/machine-a/CARGO"),
             ]),
             &context(),
+            &check,
         );
         assert_eq!(portable.env_digest, local.env_digest);
         assert_eq!(portable.id(), local.id());
@@ -224,18 +278,19 @@ mod tests {
 
     #[test]
     fn image_and_toolchain_are_part_of_env_digest() {
-        let base = CacheKey::derive(&env(&[]), &context());
+        let check = check();
+        let base = CacheKey::derive(&env(&[]), &context(), &check);
         let mut changed = context();
         changed.image_digest = Some("sha256:other".to_string());
         assert_ne!(
             base.env_digest,
-            CacheKey::derive(&env(&[]), &changed).env_digest
+            CacheKey::derive(&env(&[]), &changed, &check).env_digest
         );
         changed = context();
         changed.toolchain = Some("rustc 1.88.0".to_string());
         assert_ne!(
             base.env_digest,
-            CacheKey::derive(&env(&[]), &changed).env_digest
+            CacheKey::derive(&env(&[]), &changed, &check).env_digest
         );
     }
 }

--- a/crates/ci-engine/src/result_cache/mod.rs
+++ b/crates/ci-engine/src/result_cache/mod.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Content-addressed check-result cache keyed on `(env, inputs, definition)`.
+//! Content-addressed check-result cache bound to env, inputs, and check identity.
 
 mod entry;
 mod key;
@@ -11,8 +11,8 @@ use std::collections::BTreeMap;
 use ci_config::Check;
 use crypto::Conclusion;
 pub use entry::{
-    RESULT_CACHE_SCHEMA_VERSION, ResultCacheEntry, ResultCacheError, SpotCheckDivergence,
-    evidence_digest,
+    evidence_digest, ResultCacheEntry, ResultCacheError, SpotCheckDivergence,
+    RESULT_CACHE_SCHEMA_VERSION,
 };
 pub use key::CacheKey;
 pub use spot_check::SpotCheck;
@@ -33,7 +33,7 @@ pub(crate) fn with_cache(
     let Some(cache) = run.result_cache else {
         return Ok(run_fresh());
     };
-    let key = CacheKey::derive(key_environment, context);
+    let key = CacheKey::derive(key_environment, context, check);
     if let Some(entry) = cache.get(&key, &check.name)? {
         if run.spot_check.should_sample(&key, &check.name) {
             let fresh = run_fresh();

--- a/crates/ci-engine/src/result_cache/spot_check.rs
+++ b/crates/ci-engine/src/result_cache/spot_check.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Deterministic sampling of cache hits for fail-closed re-execution.
 
-use super::key::{CacheKey, entry_id_bytes};
+use super::key::{entry_id_bytes, CacheKey};
 
 /// Policy for re-running a sampled fraction of cache hits.
 ///
@@ -84,6 +84,19 @@ mod tests {
                 attempt: 1,
                 runner: None,
                 image_digest: None,
+            },
+            &ci_config::Check {
+                name: "build".to_string(),
+                class: ci_config::CheckClass::Required,
+                command: vec!["true".to_string()],
+                timeout_secs: 1,
+                env: std::collections::BTreeMap::new(),
+                services: Vec::new(),
+                cache_paths: Vec::new(),
+                retry: ci_config::Retry::default(),
+                triggers: Vec::new(),
+                supersede: false,
+                isolation: None,
             },
         )
     }

--- a/crates/ci-engine/src/result_cache/store.rs
+++ b/crates/ci-engine/src/result_cache/store.rs
@@ -11,7 +11,7 @@ use std::{
 
 use super::{
     entry::{ResultCacheEntry, ResultCacheError},
-    key::{CacheKey, entry_id},
+    key::{entry_id, CacheKey},
 };
 
 /// Lookup and seed a content-addressed result cache.
@@ -69,11 +69,7 @@ impl ResultCache for MemoryResultCache {
     }
 
     fn put(&self, entry: &ResultCacheEntry) -> Result<(), ResultCacheError> {
-        let key = CacheKey {
-            env_digest: entry.env_digest.clone(),
-            input_digests: entry.input_digests.clone(),
-            definition_digest: entry.definition_digest.clone(),
-        };
+        let key = entry.cache_key();
         self.entries
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -135,11 +131,7 @@ impl ResultCache for FsResultCache {
     }
 
     fn put(&self, entry: &ResultCacheEntry) -> Result<(), ResultCacheError> {
-        let key = CacheKey {
-            env_digest: entry.env_digest.clone(),
-            input_digests: entry.input_digests.clone(),
-            definition_digest: entry.definition_digest.clone(),
-        };
+        let key = entry.cache_key();
         let path = self.path_for(&key, &entry.check_name);
         let bytes = serde_json::to_vec(entry).map_err(|error| {
             std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string())

--- a/crates/ci-engine/tests/result_cache_identity.rs
+++ b/crates/ci-engine/tests/result_cache_identity.rs
@@ -78,8 +78,10 @@ fn plant_json(root: &Path, entry: &ci_engine::ResultCacheEntry) {
     let slot = std::fs::read_dir(root)
         .expect("cache")
         .filter_map(|entry| entry.ok())
+        .filter(|shard| shard.path().is_dir())
         .flat_map(|shard| std::fs::read_dir(shard.path()).ok())
         .flatten()
+        .filter_map(|file| file.ok())
         .map(|file| file.path())
         .find(|path| path.extension().is_some_and(|ext| ext == "json"))
         .expect("required cache slot");

--- a/crates/ci-engine/tests/result_cache_identity.rs
+++ b/crates/ci-engine/tests/result_cache_identity.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{collections::BTreeMap, path::Path};
+
+use ci_engine::{
+    run_checks_with, ExecutionContext, FsResultCache, HermeticEnv, MemoryResultCache, NoopProvider,
+    ResultCache, RunControls, RunOptions, SpotCheck,
+};
+use crypto::{Basis, BasisKind, CheckClass, StateRef};
+
+fn context() -> ExecutionContext {
+    ExecutionContext {
+        repo: "test/repo".to_string(),
+        state: StateRef {
+            content_hash: "state-content".to_string(),
+            change_id: "change".to_string(),
+            logical_change_id: None,
+        },
+        basis: Basis {
+            kind: BasisKind::Branch,
+            evaluated_tree_digest: "tree".to_string(),
+        },
+        definition_digest: "definition".to_string(),
+        toolchain: None,
+        pick_id: None,
+        attempt: 1,
+        runner: None,
+        image_digest: None,
+    }
+}
+
+fn echo_ok(name: &str, class: &str) -> String {
+    format!(
+        r#"
+[meta]
+schema = 1
+[[check]]
+name = "{name}"
+class = "{class}"
+command = ["/bin/sh", "-c", "echo ran >> marker; echo ok"]
+"#
+    )
+}
+
+fn run(
+    raw: &str,
+    workdir: &Path,
+    cache: &dyn ResultCache,
+) -> Result<Vec<ci_engine::CheckResult>, ci_engine::ResultCacheError> {
+    let config = ci_config::parse(raw).expect("config");
+    let environment = HermeticEnv::with_host(BTreeMap::new());
+    run_checks_with(
+        &config,
+        &context(),
+        &RunOptions {
+            workdir,
+            services: &NoopProvider,
+            now_rfc3339: &|| "2026-08-14T12:00:00Z".to_string(),
+        },
+        &RunControls {
+            hermetic_env: Some(&environment),
+            result_cache: Some(cache),
+            spot_check: SpotCheck::Never,
+            ..RunControls::default()
+        },
+    )
+}
+
+fn marker_runs(workdir: &Path) -> usize {
+    std::fs::read_to_string(workdir.join("marker"))
+        .unwrap_or_default()
+        .lines()
+        .filter(|line| !line.is_empty())
+        .count()
+}
+
+fn plant_json(root: &Path, entry: &ci_engine::ResultCacheEntry) {
+    let slot = std::fs::read_dir(root)
+        .expect("cache")
+        .filter_map(|entry| entry.ok())
+        .flat_map(|shard| std::fs::read_dir(shard.path()).ok())
+        .flatten()
+        .map(|file| file.path())
+        .find(|path| path.extension().is_some_and(|ext| ext == "json"))
+        .expect("required cache slot");
+    std::fs::write(slot, serde_json::to_vec(entry).expect("plant")).expect("overwrite");
+}
+
+#[test]
+fn planted_output_digest_from_a_different_check_identity_does_not_hit() {
+    let workdir = tempfile::tempdir().expect("workdir");
+    let cache_dir = tempfile::tempdir().expect("cache");
+    let cache = FsResultCache::new(cache_dir.path());
+    let required = echo_ok("required", "required");
+    run(&required, workdir.path(), &cache).expect("seed required");
+
+    let planted_cache = MemoryResultCache::new();
+    run(
+        &echo_ok("untrusted", "informational"),
+        workdir.path(),
+        &planted_cache,
+    )
+    .expect("seed untrusted");
+    let planted = planted_cache.entries().pop().expect("untrusted entry");
+    assert_eq!(planted.body.check.class, CheckClass::Informational);
+    assert_eq!(planted.combined_output, "ok\n");
+
+    let mut slotted = planted.clone();
+    slotted.check_name = "required".to_string();
+    plant_json(cache_dir.path(), &slotted);
+
+    let honest = MemoryResultCache::new();
+    run(&required, workdir.path(), &honest).expect("seed honest");
+    honest
+        .entries()
+        .pop()
+        .expect("required entry")
+        .verify_fresh(&planted.into_check_result())
+        .expect_err("same output from another check must not verify");
+
+    let hit = run(&required, workdir.path(), &cache).expect("required must miss the plant");
+    assert_eq!(hit[0].body.check.class, CheckClass::Required);
+    assert_eq!(
+        marker_runs(workdir.path()),
+        4,
+        "planted informational output must not satisfy the required check"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Cache hits were accepted when only `evidence_digest` (from `combined_output`) matched. An earlier informational check could plant that output and later satisfy a required check.
- `CacheKey` now includes repo, state, basis, command, and class. `is_valid_for` / `verify_fresh` reject an entry whose stored verdict body was not produced for that identity.
- A planted informational entry with the same output digest no longer hits and is not treated as a required-check pass.

## Closes

Closes HeddleCo/heddle#1407

## Red commit

N/A — the bug is already on `main`; the regression test lands with the fix.

## Test evidence

```
$ cargo test -p heddle-ci-engine --lib result_cache -- --nocapture && cargo test -p heddle-ci-engine --test result_cache --test result_cache_identity -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests src/lib.rs (target/debug/deps/ci_engine-52b9715ab4e44b8f)

running 5 tests
test result_cache::key::tests::image_and_toolchain_are_part_of_env_digest ... ok
test result_cache::key::tests::each_triple_component_changes_the_key ... ok
test result_cache::key::tests::check_identity_changes_the_key ... ok
test result_cache::key::tests::machine_local_env_is_not_in_the_key ... ok
test result_cache::spot_check::tests::fraction_is_deterministic_for_a_key ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Compiling heddle-ci-engine v0.12.0 (/workspace/crates/ci-engine)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.91s
     Running tests/result_cache.rs (target/debug/deps/result_cache-17a667159570aa45)

running 7 tests
test cache_hit_reuses_result_and_does_not_rerun ... ok
test changed_definition_is_a_cache_miss ... ok
test changed_env_is_a_cache_miss ... ok
test changed_input_is_a_cache_miss ... ok
test honest_spot_check_accepts_a_matching_entry ... ok
test spot_check_fails_closed_on_a_divergent_entry ... ok
test serialized_entry_seeds_a_separate_cache_instance ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

     Running tests/result_cache_identity.rs (target/debug/deps/result_cache_identity-4517ffa2e5e6c9e8)

running 1 test
test planted_output_digest_from_a_different_check_identity_does_not_hit ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s
```

`cargo clippy -p heddle-ci-engine --all-targets -- -D warnings` also passed.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-529fd580-2c92-4bbf-bd37-ab89bf8e3fec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-529fd580-2c92-4bbf-bd37-ab89bf8e3fec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789755521&installation_model_id=21489&pr_number=1430&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1430&signature=55bd7d13c49a4bafaec24a3db56bab3d9e0598ab06be89e06e870312c58dacef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->