### PR TITLE
Pin release tag gate to a main-line reusable workflow SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,11 @@ name: Release binaries
 #                                                    ├─► release (aggregates, publishes, posts SHA256SUMS)
 #                                                    └─► publish-manifests (stable only)
 #
-# validate-tag is the single trust gate for the pipeline. It refuses to
-# proceed unless the requested tag (a) exists, (b) is reachable from
+# validate-tag is the single trust gate for the pipeline. The job is a
+# reusable workflow pinned to a SHA on default-branch main
+# (heddle#1415): GitHub fetches that file from the pin, so a tagged
+# tree cannot rewrite the check that authenticates the tag. The gate
+# refuses unless the requested tag (a) exists, (b) is reachable from
 # origin/main, and (c) matches the documented release-tag pattern. All
 # downstream jobs read the validated tag and the publish "kind"
 # (stable | prerelease) from its outputs — no other job should look at
@@ -65,142 +68,15 @@ env:
   CRATE_NAME: heddle-cli
 
 jobs:
+  # Pin is a full commit SHA so GitHub fetches the gate from that object,
+  # not from the tagged tree that supplied this caller. Bump the SHA after
+  # landing a gate change on main. `./` and `$/` follow the caller commit
+  # and would let a tagged rewrite replace the gate — forbidden.
   validate-tag:
     name: validate tag
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      tag: ${{ steps.classify.outputs.tag }}
-      # The validated commit SHA. Downstream jobs MUST check out this
-      # SHA, not refs/tags/<tag> — see TOCTOU note in the classify step.
-      tag_sha: ${{ steps.classify.outputs.tag_sha }}
-      kind: ${{ steps.classify.outputs.kind }}
-      publish_release: ${{ steps.classify.outputs.publish_release }}
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          # Full history is needed for both the tag→commit resolution and
-          # the ancestor check against origin/main.
-          fetch-depth: 0
-
-      - name: Resolve, verify, and classify tag
-        id: classify
-        shell: bash
-        env:
-          EVENT: ${{ github.event_name }}
-          PUSH_REF: ${{ github.ref }}
-          DISPATCH_TAG: ${{ inputs.tag }}
-          BRANCH_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.branch_dry_run }}
-        run: |
-          set -euo pipefail
-
-          # 1. Resolve the requested tag from the trigger.
-          case "$EVENT" in
-            push)
-              if [[ "$PUSH_REF" != refs/tags/* ]]; then
-                echo "::error::push trigger but ref is not a tag: $PUSH_REF"
-                exit 1
-              fi
-              tag="${PUSH_REF#refs/tags/}"
-              ;;
-            workflow_dispatch)
-              tag="$DISPATCH_TAG"
-              ;;
-            *)
-              echo "::error::unsupported event: $EVENT"
-              exit 1
-              ;;
-          esac
-
-          if [[ -z "$tag" ]]; then
-            echo "::error::no tag resolved from trigger ($EVENT)"
-            exit 1
-          fi
-
-          # 2. Classify. Tag pattern decides the *shape* of release;
-          #    event source decides whether it ships as a final release.
-          #    Dispatch runs are *always* prerelease+draft so an operator
-          #    dry-run cannot accidentally publish a public, non-draft
-          #    release — even if they hand-type a stable-looking tag.
-          # SemVer prerelease identifiers permit both `-rc.1` (dot-
-          # separated) and `-rc1` (concatenated) shapes; accept either.
-          stable_re='^v[0-9]+\.[0-9]+\.[0-9]+$'
-          pre_re='^v[0-9]+\.[0-9]+\.[0-9]+-(rc|alpha|beta)(\.?[0-9]+)?$'
-
-          if ! [[ "$tag" =~ $stable_re || "$tag" =~ $pre_re ]]; then
-            echo "::error::tag '${tag}' does not match vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]"
-            exit 1
-          fi
-
-          # A branch-selected workflow definition is not an acceptable
-          # signing boundary: it can replace this validation before asking
-          # GitHub for the Apple credentials or an OIDC token. Keep the
-          # deprecated input long enough to fail existing callers explicitly,
-          # but never build or sign from it. Approved RC dry-runs remain
-          # available by dispatching an existing prerelease tag reachable from
-          # main through the normal path below.
-          if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" == "true" ]]; then
-            echo "::error::branch_dry_run is disabled: branch-selected workflow code cannot receive release signing or publishing credentials. Push an existing prerelease tag reachable from main and dispatch that tag for an approval-protected RC dry-run."
-            exit 1
-          fi
-
-          # 3. Reject anything that is not a real tag in this repo. This
-          #    catches workflow_dispatch with 'main', a typo, or a
-          #    deleted tag — none of which should reach the release job.
-          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
-            echo "::error::'${tag}' is not a tag in this repository"
-            exit 1
-          fi
-
-          # 4. The pipeline only ships releases from main. A tag pointed
-          #    at a feature branch (deliberately or accidentally) must
-          #    not produce signed release assets with the heddle release
-          #    OIDC identity. The tag-push trigger does not enforce
-          #    branch ancestry on its own, so we do it here.
-          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
-          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
-            echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
-            exit 1
-          fi
-
-          publish_release=true
-
-          if [[ "$EVENT" == "workflow_dispatch" ]]; then
-            # Dispatch is the RC/dry-run path. Stable tags MUST go through
-            # the push trigger so they cannot be retroactively downgraded:
-            # softprops/action-gh-release UPDATES an existing release when
-            # tag_name already exists, and dispatch always sets
-            # kind=prerelease+draft. Without this guard, an operator (or
-            # an attacker with workflow-dispatch rights) could re-dispatch
-            # a previously-published vX.Y.Z and silently mark the public
-            # release as prerelease+draft. Refuse loudly.
-            if [[ "$tag" =~ $stable_re ]]; then
-              echo "::error::workflow_dispatch refuses stable tag '${tag}'. Stable releases (vX.Y.Z) must go through the push trigger; dispatch is for prerelease dry-runs only (vX.Y.Z-(rc|alpha|beta)[.N]). See RELEASING.md."
-              exit 1
-            fi
-            kind=prerelease
-          elif [[ "$EVENT" == "push" && "$tag" =~ $stable_re ]]; then
-            kind=stable
-          elif [[ "$EVENT" == "push" ]]; then
-            # Push trigger but the tag is not strict semver. The push
-            # filter should have blocked this; if it slipped through,
-            # fail loudly rather than silently downgrading.
-            echo "::error::push trigger received non-stable tag '${tag}'; refusing"
-            exit 1
-          fi
-
-          # tag_sha is the only ref downstream jobs are allowed to act on.
-          # Emitting it as an output (rather than re-resolving the tag in
-          # each downstream job) closes the TOCTOU window: if the tag is
-          # force-moved AFTER validate-tag passes but BEFORE build/release
-          # check it out, those jobs would otherwise operate on the
-          # attacker-controlled commit. Pinning to the SHA we just
-          # ancestor-checked means every step works on the same commit.
-          echo "Resolved: tag=${tag} commit=${tag_sha} kind=${kind}"
-          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
-          echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
-          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
-          echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"
+    uses: HeddleCo/heddle/.github/workflows/validate-release-tag.yml@ff7d5923e75d675c0e31715f93b8821aaf4da10e
+    permissions:
+      contents: read
 
   build:
     name: build non-mac ${{ matrix.target }}

--- a/.github/workflows/validate-release-tag.yml
+++ b/.github/workflows/validate-release-tag.yml
@@ -1,0 +1,192 @@
+name: Validate release tag
+
+# Trust gate for `.github/workflows/release.yml` (heddle#1415).
+#
+# A tag-push evaluates the *caller* from the tagged commit. If the gate
+# lived in that same file, a tag whose tree rewrote the caller could drop
+# `validate-tag` and still request the `release` environment. This workflow
+# is the gate. `release.yml` must call it with
+# `uses: HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<sha>`
+# where `<sha>` is a full commit on default-branch `main`. GitHub fetches
+# *this* file from that SHA, so a tagged-tree rewrite of the working copy
+# cannot replace the check that authenticates the tag.
+#
+# `./` and `$/` resolve at the caller's commit and are forbidden by
+# `scripts/check-release-pipeline.sh`. Do not add `push` / `workflow_dispatch`
+# here — that would be a second release path.
+
+on:
+  workflow_call:
+    outputs:
+      tag:
+        description: Validated tag name (vX.Y.Z or prerelease shape).
+        value: ${{ jobs.classify.outputs.tag }}
+      tag_sha:
+        description: Commit SHA the tag pointed at when the ancestry check passed.
+        value: ${{ jobs.classify.outputs.tag_sha }}
+      kind:
+        description: stable or prerelease.
+        value: ${{ jobs.classify.outputs.kind }}
+      publish_release:
+        description: Whether downstream jobs may publish a GitHub Release.
+        value: ${{ jobs.classify.outputs.publish_release }}
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    name: validate tag
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      tag: ${{ steps.classify.outputs.tag }}
+      tag_sha: ${{ steps.classify.outputs.tag_sha }}
+      kind: ${{ steps.classify.outputs.kind }}
+      publish_release: ${{ steps.classify.outputs.publish_release }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # Full history is needed for both the tag→commit resolution and
+          # the ancestor check against origin/main.
+          fetch-depth: 0
+
+      - name: Resolve, verify, and classify tag
+        id: classify
+        shell: bash
+        env:
+          # github.* is the caller's context (docs: reusable workflow
+          # configurations). event_name is still recovered from the payload
+          # if a runner reports workflow_call instead of the original trigger.
+          EVENT: ${{ github.event_name }}
+          PUSH_REF: ${{ github.ref }}
+          EVENT_REF: ${{ github.event.ref }}
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+          BRANCH_DRY_RUN: ${{ github.event.inputs.branch_dry_run }}
+        run: |
+          set -euo pipefail
+
+          # Recover the original trigger. A reusable workflow must not
+          # trust caller `with:` inputs for this decision — a rewritten
+          # caller could lie. github.event is the real payload.
+          if [[ "$EVENT" == "workflow_call" ]]; then
+            if [[ -n "${DISPATCH_TAG:-}" ]]; then
+              EVENT=workflow_dispatch
+            elif [[ "${PUSH_REF:-}" == refs/tags/* || "${EVENT_REF:-}" == refs/tags/* ]]; then
+              EVENT=push
+            else
+              echo "::error::workflow_call could not recover the original trigger; refusing"
+              exit 1
+            fi
+          fi
+
+          # 1. Resolve the requested tag from the trigger.
+          case "$EVENT" in
+            push)
+              if [[ "${PUSH_REF:-}" == refs/tags/* ]]; then
+                tag="${PUSH_REF#refs/tags/}"
+              elif [[ "${EVENT_REF:-}" == refs/tags/* ]]; then
+                tag="${EVENT_REF#refs/tags/}"
+              else
+                echo "::error::push trigger but ref is not a tag: push_ref=${PUSH_REF:-} event.ref=${EVENT_REF:-}"
+                exit 1
+              fi
+              ;;
+            workflow_dispatch)
+              tag="${DISPATCH_TAG:-}"
+              ;;
+            *)
+              echo "::error::unsupported event: $EVENT"
+              exit 1
+              ;;
+          esac
+
+          if [[ -z "$tag" ]]; then
+            echo "::error::no tag resolved from trigger ($EVENT)"
+            exit 1
+          fi
+
+          # 2. Classify. Tag pattern decides the *shape* of release;
+          #    event source decides whether it ships as a final release.
+          #    Dispatch runs are *always* prerelease+draft so an operator
+          #    dry-run cannot accidentally publish a public, non-draft
+          #    release — even if they hand-type a stable-looking tag.
+          # SemVer prerelease identifiers permit both `-rc.1` (dot-
+          # separated) and `-rc1` (concatenated) shapes; accept either.
+          stable_re='^v[0-9]+\.[0-9]+\.[0-9]+$'
+          pre_re='^v[0-9]+\.[0-9]+\.[0-9]+-(rc|alpha|beta)(\.?[0-9]+)?$'
+
+          if ! [[ "$tag" =~ $stable_re || "$tag" =~ $pre_re ]]; then
+            echo "::error::tag '${tag}' does not match vX.Y.Z or vX.Y.Z-(rc|alpha|beta)[.N]"
+            exit 1
+          fi
+
+          # A branch-selected workflow definition is not an acceptable
+          # signing boundary: it can replace this validation before asking
+          # GitHub for the Apple credentials or an OIDC token. Keep the
+          # deprecated input long enough to fail existing callers explicitly,
+          # but never build or sign from it. Approved RC dry-runs remain
+          # available by dispatching an existing prerelease tag reachable from
+          # main through the normal path below.
+          if [[ "$EVENT" == "workflow_dispatch" && "$BRANCH_DRY_RUN" == "true" ]]; then
+            echo "::error::branch_dry_run is disabled: branch-selected workflow code cannot receive release signing or publishing credentials. Push an existing prerelease tag reachable from main and dispatch that tag for an approval-protected RC dry-run."
+            exit 1
+          fi
+
+          # 3. Reject anything that is not a real tag in this repo. This
+          #    catches workflow_dispatch with 'main', a typo, or a
+          #    deleted tag — none of which should reach the release job.
+          if ! git rev-parse --verify --quiet "refs/tags/${tag}" >/dev/null; then
+            echo "::error::'${tag}' is not a tag in this repository"
+            exit 1
+          fi
+
+          # 4. The pipeline only ships releases from main. A tag pointed
+          #    at a feature branch (deliberately or accidentally) must
+          #    not produce signed release assets with the heddle release
+          #    OIDC identity. The tag-push trigger does not enforce
+          #    branch ancestry on its own, so we do it here.
+          tag_sha="$(git rev-parse "refs/tags/${tag}^{commit}")"
+          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
+            echo "::error::tag '${tag}' (commit ${tag_sha}) is not reachable from origin/main — refusing to release"
+            exit 1
+          fi
+
+          publish_release=true
+
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            # Dispatch is the RC/dry-run path. Stable tags MUST go through
+            # the push trigger so they cannot be retroactively downgraded:
+            # softprops/action-gh-release UPDATES an existing release when
+            # tag_name already exists, and dispatch always sets
+            # kind=prerelease+draft. Without this guard, an operator (or
+            # an attacker with workflow-dispatch rights) could re-dispatch
+            # a previously-published vX.Y.Z and silently mark the public
+            # release as prerelease+draft. Refuse loudly.
+            if [[ "$tag" =~ $stable_re ]]; then
+              echo "::error::workflow_dispatch refuses stable tag '${tag}'. Stable releases (vX.Y.Z) must go through the push trigger; dispatch is for prerelease dry-runs only (vX.Y.Z-(rc|alpha|beta)[.N]). See RELEASING.md."
+              exit 1
+            fi
+            kind=prerelease
+          elif [[ "$EVENT" == "push" && "$tag" =~ $stable_re ]]; then
+            kind=stable
+          elif [[ "$EVENT" == "push" ]]; then
+            # Push trigger but the tag is not strict semver. The push
+            # filter should have blocked this; if it slipped through,
+            # fail loudly rather than silently downgrading.
+            echo "::error::push trigger received non-stable tag '${tag}'; refusing"
+            exit 1
+          fi
+
+          # tag_sha is the only ref downstream jobs are allowed to act on.
+          # Emitting it as an output (rather than re-resolving the tag in
+          # each downstream job) closes the TOCTOU window: if the tag is
+          # force-moved AFTER validate-tag passes but BEFORE build/release
+          # check it out, those jobs would otherwise operate on the
+          # attacker-controlled commit. Pinning to the SHA we just
+          # ancestor-checked means every step works on the same commit.
+          echo "Resolved: tag=${tag} commit=${tag_sha} kind=${kind}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "tag_sha=${tag_sha}" >> "$GITHUB_OUTPUT"
+          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+          echo "publish_release=${publish_release}" >> "$GITHUB_OUTPUT"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -34,7 +34,12 @@ release-plz → push-to-main flow documented in
 
 3. The `Release binaries` workflow (`.github/workflows/release.yml`)
    triggers on the stable-semver tag push. Before building anything it
-   runs a `validate-tag` gate that:
+   calls `validate-tag`, a reusable workflow pinned to a full commit SHA
+   on default-branch `main` (heddle#1415). A tag push evaluates the
+   *caller* from the tagged commit; GitHub fetches the gate from the
+   pin, so a tagged tree cannot rewrite the check that authenticates the
+   tag. Relative `./` and `$/` refs follow the caller commit and are
+   forbidden. The gate:
 
    - resolves the requested tag from the trigger (push or dispatch)
    - rejects refs that aren't real tags (catches `main`, typos, deleted
@@ -420,20 +425,26 @@ asserter on every PR and push to `main`. It checks
 `.github/workflows/release.yml` and `RELEASING.md` in two passes:
 
 - **Smoke (grep).** Cheap content checks: the five target triples, the
-  strict-semver push trigger, presence of the `validate-tag` trust gate
-  with its ancestry check, packaging/checksum/signing/upload steps, the
-  macOS cask DMG job, the macOS archive ownership by that cask job, the
-  Homebrew cask PR wiring, the draft+prerelease keying off
+  strict-semver push trigger, presence of the SHA-pinned `validate-tag`
+  reusable workflow with its ancestry check read from the pin (not the
+  working tree), packaging/checksum/signing/upload steps, the macOS cask
+  DMG job, the macOS archive ownership by that cask job, the Homebrew
+  cask PR wiring, the draft+prerelease keying off
   `validate-tag.outputs.kind`, and the stable-tag-refusal on the dispatch
   path.
-- **Strict (parsed YAML).** Per-job structural checks: `validate-tag`
-  exports `tag_sha`, and every downstream job (`build`,
-  `build-macos-cask`, `release`, `publish-manifests`) both declares
-  `needs: validate-tag` and pins its `actions/checkout` `ref`
-  to `${{ needs.validate-tag.outputs.tag_sha }}` rather than the
-  mutable `refs/tags/<tag>`. Grep alone would pass if *any* job kept
-  the `needs:` line; the parser confirms each downstream job
-  individually.
+- **Strict (parsed YAML).** Per-job structural checks: `validate-tag` is
+  `uses: HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<sha>`
+  (not `./` or `$/`), the pinned workflow exports `tag_sha`, and every
+  downstream job (`build`, `build-macos-cask`, `release`,
+  `publish-manifests`) both declares `needs: validate-tag` and pins its
+  `actions/checkout` `ref` to `${{ needs.validate-tag.outputs.tag_sha }}`
+  rather than the mutable `refs/tags/<tag>`. Grep alone would pass if
+  *any* job kept the `needs:` line; the parser confirms each downstream
+  job individually.
+
+To change the gate, land the reusable-workflow edit on `main`, then bump
+the `uses:` SHA in `release.yml` to that new main commit in the same PR
+so the pin and the working tree stay identical.
 
 Every binary-signing or publishing job declares the `release` GitHub
 environment. Repository settings must keep that environment

--- a/scripts/check-release-pipeline.sh
+++ b/scripts/check-release-pipeline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Asserter for the binary-release pipeline contract (heddle#56).
+# Asserter for the binary-release pipeline contract (heddle#56, heddle#1415).
 #
 # The release pipeline is invoked only on `v*` tag pushes, so we can't
 # observe its artifacts in normal CI. Instead we statically verify that
@@ -27,6 +27,8 @@
 set -euo pipefail
 
 WF=".github/workflows/release.yml"
+GATE_WF=".github/workflows/validate-release-tag.yml"
+GATE_USES_PREFIX="HeddleCo/heddle/.github/workflows/validate-release-tag.yml@"
 fail=0
 
 err() { echo "::error::$*" >&2; fail=1; }
@@ -36,6 +38,61 @@ if [[ ! -f "$WF" ]]; then
   err "$WF does not exist"
   echo "::error::Release pipeline not implemented. See heddle#56."
   exit 1
+fi
+
+# heddle#1415: the authenticity gate must not be the tagged tree's copy of
+# this file. GitHub evaluates release.yml from the tag; it fetches a
+# `{owner}/{repo}/...@<sha>` reusable workflow from that SHA. `./` and `$/`
+# follow the caller commit and would let a tagged rewrite drop the gate.
+GATE_PIN=""
+if GATE_USES=$(sed -nE 's/^[[:space:]]*uses:[[:space:]]*(HeddleCo\/heddle\/\.github\/workflows\/validate-release-tag\.yml@[0-9a-f]{40}).*/\1/p' "$WF" | head -n1) \
+   && [[ -n "$GATE_USES" ]]; then
+  GATE_PIN="${GATE_USES##*@}"
+  ok "validate-tag calls $GATE_USES"
+else
+  err "validate-tag must call ${GATE_USES_PREFIX}<40-char-sha> (not ./, $/, @main, or an inline job)"
+fi
+
+if grep -E '^    uses:[[:space:]]*(\./|\$/)' "$WF" >/dev/null; then
+  err "release.yml must not call a reusable workflow via ./ or \$/ — those follow the tagged caller commit"
+else
+  ok "release.yml does not use ./ or \$/ reusable-workflow refs"
+fi
+
+if [[ -n "$GATE_PIN" ]]; then
+  if ! git cat-file -e "${GATE_PIN}:${GATE_WF}" 2>/dev/null; then
+    err "gate pin ${GATE_PIN} does not contain ${GATE_WF}"
+  else
+    ok "pinned SHA ${GATE_PIN} contains ${GATE_WF}"
+    if ! git show "${GATE_PIN}:${GATE_WF}" | cmp -s - "$GATE_WF"; then
+      err "working tree ${GATE_WF} differs from pin ${GATE_PIN}; bump the uses SHA in ${WF}"
+    else
+      ok "working tree ${GATE_WF} matches pinned SHA ${GATE_PIN}"
+    fi
+  fi
+  if git rev-parse --verify --quiet origin/main >/dev/null \
+     && git merge-base --is-ancestor HEAD origin/main 2>/dev/null \
+     && git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+    if git merge-base --is-ancestor "$GATE_PIN" origin/main; then
+      ok "gate pin ${GATE_PIN} is on origin/main"
+    else
+      err "gate pin ${GATE_PIN} is not an ancestor of origin/main"
+    fi
+  elif git merge-base --is-ancestor "$GATE_PIN" HEAD 2>/dev/null; then
+    ok "gate pin ${GATE_PIN} is in this history (landing; not yet required to be on origin/main)"
+  else
+    err "gate pin ${GATE_PIN} is not reachable from HEAD"
+  fi
+fi
+
+# Gate semantics are read from the pinned object, not the working tree.
+# A tagged rewrite of the working copy therefore cannot satisfy these
+# checks unless the caller also retargets the pin — and a new pin is a
+# reviewable SHA on main, not an unreviewed tag tree.
+GATE_SRC="$GATE_WF"
+if [[ -n "$GATE_PIN" ]] && git cat-file -e "${GATE_PIN}:${GATE_WF}" 2>/dev/null; then
+  GATE_SRC="$(mktemp)"
+  git show "${GATE_PIN}:${GATE_WF}" > "$GATE_SRC"
 fi
 
 # Tag-push trigger. The contract is strict semver only (vX.Y.Z); RC
@@ -50,17 +107,23 @@ fi
 
 # Verification gate: a validate-tag job must run before build/release and
 # enforce (a) tag existence, (b) ancestry on origin/main, (c) pattern
-# classification. We assert the structural pieces here; the rule
-# content lives in the workflow itself.
+# classification. Rule content lives in the pinned reusable workflow.
 if grep -E "^\s*validate-tag:" "$WF" >/dev/null; then
   ok "validate-tag job present"
 else
   err "missing validate-tag job in $WF"
 fi
-if grep -E "git merge-base --is-ancestor" "$WF" >/dev/null; then
-  ok "validate-tag enforces ancestry on origin/main"
+if grep -E "git merge-base --is-ancestor" "$GATE_SRC" >/dev/null; then
+  ok "pinned gate enforces ancestry on origin/main"
 else
-  err "validate-tag must reject tags not reachable from origin/main"
+  err "pinned gate must reject tags not reachable from origin/main"
+fi
+if grep -E '^on:' "$GATE_SRC" >/dev/null \
+   && grep -E 'workflow_call:' "$GATE_SRC" >/dev/null \
+   && ! grep -E '^[[:space:]]+(push|workflow_dispatch):' "$GATE_SRC" >/dev/null; then
+  ok "pinned gate is workflow_call only (no second release path)"
+else
+  err "pinned gate must be workflow_call only; do not add push or workflow_dispatch"
 fi
 if grep -E "needs:\s*validate-tag|needs:\s*\[validate-tag" "$WF" >/dev/null; then
   ok "build/release jobs depend on validate-tag"
@@ -87,15 +150,16 @@ fi
 # appears near workflow_dispatch") so the assertion is robust to
 # variable renames but still flags a block deletion: removing the guard
 # also removes its error message.
-if grep -F 'workflow_dispatch refuses stable tag' "$WF" >/dev/null; then
-  ok "validate-tag refuses stable tags from workflow_dispatch (downgrade-attack guard)"
+if grep -F 'workflow_dispatch refuses stable tag' "$GATE_SRC" >/dev/null; then
+  ok "pinned gate refuses stable tags from workflow_dispatch (downgrade-attack guard)"
 else
-  err "validate-tag must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
+  err "pinned gate must refuse stable tags (vX.Y.Z) from workflow_dispatch; see RELEASING.md and release.yml comment on softprops update-if-exists"
 fi
 
 if grep -F 'branch_dry_run:' "$WF" >/dev/null \
-   && grep -F 'branch_dry_run is disabled:' "$WF" >/dev/null \
-   && ! grep -F 'tag_sha="$(git rev-parse HEAD)"' "$WF" >/dev/null; then
+   && grep -F 'branch_dry_run is disabled:' "$GATE_SRC" >/dev/null \
+   && ! grep -F 'tag_sha="$(git rev-parse HEAD)"' "$WF" >/dev/null \
+   && ! grep -F 'tag_sha="$(git rev-parse HEAD)"' "$GATE_SRC" >/dev/null; then
   ok "branch-selected release dry-runs fail explicitly before credentialed jobs"
 else
   err "branch_dry_run must fail explicitly; branch-selected workflow code cannot receive release credentials"
@@ -129,7 +193,7 @@ while IFS= read -r action; do
   else
     err "external action must use an exact 40-character commit SHA: $action"
   fi
-done < <(sed -nE 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*([^[:space:]#]+).*/\2/p' "$WF")
+done < <(sed -nE 's/^[[:space:]]*(-[[:space:]]+)?uses:[[:space:]]*([^[:space:]#]+).*/\2/p' "$WF" "$GATE_SRC")
 
 # Least privilege: OIDC is available only to the two artifact-signing jobs,
 # and repository write permission only to the GitHub Release publisher.
@@ -421,7 +485,7 @@ fi
 #     redirect build/release to a different commit than the one that
 #     passed the ancestry check)
 #
-# We also confirm validate-tag exports `tag_sha` as a documented output.
+# We also confirm the pinned reusable workflow exports `tag_sha`.
 # Without that output the pinning above can't reference anything.
 #
 # These are additive: the legacy "any needs: validate-tag" grep still
@@ -450,11 +514,13 @@ ensure_pyyaml() {
 }
 
 if command -v ruby >/dev/null 2>&1 && ruby --disable-gems -e 'require "yaml"' >/dev/null 2>&1; then
-  strict_report=$(ruby --disable-gems - "$WF" <<'RB'
+  strict_report=$(ruby --disable-gems - "$WF" "$GATE_SRC" <<'RB'
 require "yaml"
 
 wf_path = ARGV.fetch(0)
+gate_path = ARGV.fetch(1)
 wf = YAML.load_file(wf_path)
+gate = YAML.load_file(gate_path)
 
 jobs = wf.fetch("jobs", {}) || {}
 errors = []
@@ -464,7 +530,22 @@ vt = jobs["validate-tag"]
 if !vt.is_a?(Hash)
   errors << "validate-tag job missing or malformed"
 else
-  outs = vt.fetch("outputs", {}) || {}
+  uses = vt["uses"].to_s
+  if uses.match?(/\AHEddleCo\/heddle\/\.github\/workflows\/validate-release-tag\.yml@[0-9a-f]{40}\z/)
+    oks << "validate-tag is a SHA-pinned reusable workflow"
+  else
+    errors << "validate-tag must use HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha>, got '#{uses}'"
+  end
+  if vt.key?("steps") || vt.key?("runs-on") || vt.key?("environment")
+    errors << "validate-tag caller must not inline steps/runs-on/environment; the pinned reusable workflow is the gate"
+  else
+    oks << "validate-tag caller has no inline steps"
+  end
+  # YAML 1.1 treats the key `on` as boolean true.
+  on_block = gate["on"]
+  on_block = gate[true] unless on_block.is_a?(Hash)
+  wc = (on_block.is_a?(Hash) ? on_block["workflow_call"] : nil) || {}
+  outs = wc.fetch("outputs", {}) || {}
   if !outs.key?("tag_sha")
     errors << "validate-tag must declare a 'tag_sha' output (used by downstream jobs to pin checkout to the validated commit)"
   else
@@ -603,23 +684,49 @@ elif ! command -v python3 >/dev/null 2>&1; then
 elif ! PY=$(ensure_pyyaml); then
   err "PyYAML not available and venv fallback failed; strict structural checks skipped"
 else
-  strict_report=$("$PY" - "$WF" <<'PY'
+  strict_report=$("$PY" - "$WF" "$GATE_SRC" <<'PY'
 import sys
 import yaml
+import re
 
 wf_path = sys.argv[1]
+gate_path = sys.argv[2]
 with open(wf_path) as f:
     wf = yaml.safe_load(f)
+with open(gate_path) as f:
+    gate = yaml.safe_load(f)
 
 jobs = wf.get("jobs", {}) or {}
 errors = []
 oks = []
 
+PINNED_USES = re.compile(
+    r"^HeddleCo/heddle/\.github/workflows/validate-release-tag\.yml@[0-9a-f]{40}$"
+)
+
 vt = jobs.get("validate-tag")
 if not isinstance(vt, dict):
     errors.append("validate-tag job missing or malformed")
 else:
-    outs = vt.get("outputs", {}) or {}
+    uses = str(vt.get("uses") or "")
+    if PINNED_USES.match(uses):
+        oks.append("validate-tag is a SHA-pinned reusable workflow")
+    else:
+        errors.append(
+            "validate-tag must use HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha>, "
+            f"got '{uses}'"
+        )
+    if any(key in vt for key in ("steps", "runs-on", "environment")):
+        errors.append(
+            "validate-tag caller must not inline steps/runs-on/environment; the pinned reusable workflow is the gate"
+        )
+    else:
+        oks.append("validate-tag caller has no inline steps")
+    on = gate.get("on") if isinstance(gate, dict) else None
+    if not isinstance(on, dict) and isinstance(gate, dict):
+        on = gate.get(True)
+    wc = on.get("workflow_call") if isinstance(on, dict) else None
+    outs = (wc or {}).get("outputs", {}) or {}
     if "tag_sha" not in outs:
         errors.append("validate-tag must declare a 'tag_sha' output (used by downstream jobs to pin checkout to the validated commit)")
     else:
@@ -768,6 +875,27 @@ PY
       err "$line"
     fi
   done <<< "$strict_report"
+fi
+
+# Proof for heddle#1415: a tagged tree can rewrite the working copy of
+# the gate file. GitHub still fetches the object at GATE_PIN. The caller
+# pin is a literal SHA, so emptying a sibling copy cannot drop the check.
+if [[ -n "$GATE_PIN" ]] && git cat-file -e "${GATE_PIN}:${GATE_WF}" 2>/dev/null; then
+  proof_dir="$(mktemp -d)"
+  git show "${GATE_PIN}:${GATE_WF}" > "${proof_dir}/pinned.yml"
+  printf '%s\n' 'on:' '  workflow_call: {}' 'jobs: {}' > "${proof_dir}/rewritten.yml"
+  if grep -F 'git merge-base --is-ancestor' "${proof_dir}/pinned.yml" >/dev/null \
+     && ! grep -F 'git merge-base --is-ancestor' "${proof_dir}/rewritten.yml" >/dev/null \
+     && grep -F "${GATE_USES_PREFIX}${GATE_PIN}" "$WF" >/dev/null; then
+    ok "tagged-tree rewrite of ${GATE_WF} cannot drop the pin at ${GATE_PIN}"
+  else
+    err "could not prove the tagged-tree rewrite cannot drop the pinned gate"
+  fi
+  rm -rf "$proof_dir"
+fi
+
+if [[ "$GATE_SRC" != "$GATE_WF" ]]; then
+  rm -f "$GATE_SRC"
 fi
 
 if (( fail )); then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- A tag push still evaluates `.github/workflows/release.yml` from the tagged commit. An inline `validate-tag` job can be deleted in that tree while credentialed jobs still request `environment: release`.
- The gate now lives in `.github/workflows/validate-release-tag.yml` and is called as `HeddleCo/heddle/.github/workflows/validate-release-tag.yml@ff7d5923e75d675c0e31715f93b8821aaf4da10e`. GitHub fetches that file from the pin, not from the tagged tree.
- Same release path, same tag patterns, same ancestry / dispatch / `branch_dry_run` refusals. Relative `./` and `$/` refs are forbidden because they follow the caller commit.
- `scripts/check-release-pipeline.sh` reads gate semantics from the pinned object and fails if the caller drops the SHA pin.

Environment approval remains a process control for a caller that omits the reusable workflow entirely. This PR is the code fix for the rewritable gate.

## Closes

Closes HeddleCo/heddle#1415

## Red commit

N/A — not a Rust PR

## Test evidence

Workflow structure: the caller job has no inline steps. The gate GitHub runs is the object at `ff7d5923e75d675c0e31715f93b8821aaf4da10e`.

```
$ git show ff7d5923e75d675c0e31715f93b8821aaf4da10e:.github/workflows/validate-release-tag.yml | grep -E 'workflow_call|git merge-base --is-ancestor|workflow_dispatch refuses stable tag'
on:
  workflow_call:
          if ! git merge-base --is-ancestor "$tag_sha" "refs/remotes/origin/main"; then
              echo "::error::workflow_dispatch refuses stable tag '${tag}'. ...
```

Asserter (positive): a tagged-tree rewrite of the working-copy gate file cannot drop the pin.

```
$ bash scripts/check-release-pipeline.sh
ok: validate-tag calls HeddleCo/heddle/.github/workflows/validate-release-tag.yml@ff7d5923e75d675c0e31715f93b8821aaf4da10e
ok: release.yml does not use ./ or $/ reusable-workflow refs
ok: pinned SHA ff7d5923e75d675c0e31715f93b8821aaf4da10e contains .github/workflows/validate-release-tag.yml
ok: working tree .github/workflows/validate-release-tag.yml matches pinned SHA ff7d5923e75d675c0e31715f93b8821aaf4da10e
ok: gate pin ff7d5923e75d675c0e31715f93b8821aaf4da10e is in this history (landing; not yet required to be on origin/main)
ok: pinned gate enforces ancestry on origin/main
ok: pinned gate is workflow_call only (no second release path)
ok: pinned gate refuses stable tags from workflow_dispatch (downgrade-attack guard)
ok: validate-tag is a SHA-pinned reusable workflow
ok: validate-tag caller has no inline steps
ok: validate-tag exports tag_sha output
ok: tagged-tree rewrite of .github/workflows/validate-release-tag.yml cannot drop the pin at ff7d5923e75d675c0e31715f93b8821aaf4da10e
release-pipeline check passed
```

Asserter (negative): replacing the pin with `./.github/workflows/validate-release-tag.yml` (follows the tagged caller commit) fails closed.

```
::error::validate-tag must call HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha> (not ./, $/, @main, or an inline job)
::error::release.yml must not call a reusable workflow via ./ or $/ — those follow the tagged caller commit
::error::validate-tag must use HeddleCo/heddle/.github/workflows/validate-release-tag.yml@<40-char-sha>, got './.github/workflows/validate-release-tag.yml'
release-pipeline check FAILED
```

No Rust changes; no cargo tests invented.

## Manual verification

N/A — covered by `scripts/check-release-pipeline.sh`.

## Blocked by → resolved

None

## Merge note

The pin SHA is the first commit on this branch (the reusable workflow object). Prefer a merge commit so that SHA stays on `main`. After a squash, bump `uses:` to the squash SHA on `main` so the pin and default-branch history stay aligned. Do not retarget the pin to `./`, `$/`, or `@main`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-891b4915-b51d-470d-aeb7-61214212bfab?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-891b4915-b51d-470d-aeb7-61214212bfab&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789758723&installation_model_id=21489&pr_number=1431&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1431&signature=cfe4be7a15c3086866da5948c469c2b83e1bc0efafb4f1ad3004ec43292e9c42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->