### PR TITLE
Pin release tag gate to the #1431 squash SHA on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
   # and would let a tagged rewrite replace the gate — forbidden.
   validate-tag:
     name: validate tag
-    uses: HeddleCo/heddle/.github/workflows/validate-release-tag.yml@ff7d5923e75d675c0e31715f93b8821aaf4da10e
+    uses: HeddleCo/heddle/.github/workflows/validate-release-tag.yml@e847f41b146e42e5bd688039469ed0a5ab9eff21
     permissions:
       contents: read
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `#1431` squash-merged as `e847f41b146e42e5bd688039469ed0a5ab9eff21`. The caller still pinned `validate-release-tag.yml` at the pre-squash branch SHA `ff7d5923e75d675c0e31715f93b8821aaf4da10e`.
- Retarget `uses:` to the squash SHA on `main`. GitHub fetches the gate from that object; the tagged tree cannot rewrite it.
- YAML-only. Workflow body unchanged. No Rust change; no cargo tests invented.

## Closes

Refs HeddleCo/heddle#1415 (pin retarget after the #1431 squash; issue stays closed)

## Red commit

N/A — not a Rust PR

## Test evidence

YAML-only. Local asserter:

```
$ bash scripts/check-release-pipeline.sh
ok: validate-tag calls HeddleCo/heddle/.github/workflows/validate-release-tag.yml@e847f41b146e42e5bd688039469ed0a5ab9eff21
ok: release.yml does not use ./ or $/ reusable-workflow refs
ok: pinned SHA e847f41b146e42e5bd688039469ed0a5ab9eff21 contains .github/workflows/validate-release-tag.yml
ok: working tree .github/workflows/validate-release-tag.yml matches pinned SHA e847f41b146e42e5bd688039469ed0a5ab9eff21
ok: gate pin e847f41b146e42e5bd688039469ed0a5ab9eff21 is in this history (landing; not yet required to be on origin/main)
ok: pinned gate enforces ancestry on origin/main
ok: pinned gate is workflow_call only (no second release path)
ok: pinned gate refuses stable tags from workflow_dispatch (downgrade-attack guard)
ok: validate-tag is a SHA-pinned reusable workflow
ok: validate-tag caller has no inline steps
ok: tagged-tree rewrite of .github/workflows/validate-release-tag.yml cannot drop the pin at e847f41b146e42e5bd688039469ed0a5ab9eff21
release-pipeline check passed
```

## Manual verification

N/A — covered by `scripts/check-release-pipeline.sh`.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-de01d59c-a548-4a1e-a0e7-869fecce86ef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-de01d59c-a548-4a1e-a0e7-869fecce86ef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789763097&installation_model_id=21489&pr_number=1432&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1432&signature=fe3015dcb56dacf34533fe65f793351f458cafa2e2ef6585a79fd83b48bb5761"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->