### PR TITLE
Fail locally when a PoP-bound remote token has no matching proof key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **PoP-bound hosted tokens fail locally without a matching proof key.**
+  Session construction now distinguishes an unbound bearer from a bearer
+  whose effective leaf proof-of-possession key requires proof, and refuses
+  to connect when that key is missing or does not match. Root device,
+  derived child, and PoP-bound service-account credentials still attach
+  proof with the matching key; historical unbound tokens stay token-only
+  (heddle#1027).
+
 - **Default fsmonitor is off.** `FsMonitorMode` now defaults to `Off`, so a
   stock install never binds the unauthenticated localhost helper or skips
   status/capture directories from its baseline. Enable `native`, `auto`, or

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -24,6 +24,8 @@ mod provider_pull;
 mod provider_transport;
 mod resolver;
 mod session;
+#[cfg(test)]
+mod session_tests;
 mod state_review;
 mod sync;
 #[cfg(test)]

--- a/crates/cli/src/hosted_runtime/hosted/session.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session.rs
@@ -3,7 +3,9 @@
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
+use biscuit_auth::builder::BlockBuilder;
 use cli_shared::{ClientConfig, UserConfig};
+use crypto::{Ed25519Signer, Signer as _};
 use wire::ProtocolError;
 
 use super::{
@@ -88,6 +90,7 @@ impl HostedSession {
                 anyhow::bail!("hosted request signing has no stable signing identity");
             }
         }
+        enforce_bearer_proof(&config)?;
         Ok(Self {
             config,
             renewable_authority_credential,
@@ -167,6 +170,67 @@ impl HostedClient {
             .connect(addr)
             .await?)
     }
+}
+
+fn enforce_bearer_proof(config: &ClientConfig) -> Result<()> {
+    let Some(token) = config.token.as_ref() else {
+        return Ok(());
+    };
+    let Some(leaf_public_key_hex) = required_leaf_pop_key(&token.id)? else {
+        return Ok(());
+    };
+    let Some(pem) = config.auth_proof_key_pem.as_deref() else {
+        let server = config.server_key.as_deref().unwrap_or("<server>");
+        anyhow::bail!(
+            "this hosted bearer is bound to a proof-of-possession key, but no matching \
+             private key is configured; sending it would only fail at weft. Restore the \
+             matching leaf key with `heddle auth login --server {server}`, point \
+             HEDDLE_CREDENTIAL at a .hcred that includes the key, or set \
+             remote.auth_proof_key_pem_path to the leaf key PEM"
+        );
+    };
+    let signer = Ed25519Signer::from_pem(pem).context("loading the configured hosted proof key")?;
+    if !hex::encode(signer.public_key()).eq_ignore_ascii_case(&leaf_public_key_hex) {
+        anyhow::bail!(
+            "the configured hosted proof key does not match this bearer's effective \
+             leaf proof-of-possession key; sending it would only fail at weft. Use the \
+             private key bound to this token (the child key for a derived agent, or \
+             the device key for a root credential)"
+        );
+    }
+    Ok(())
+}
+
+fn required_leaf_pop_key(token: &str) -> Result<Option<String>> {
+    let Ok(biscuit) = biscuit_auth::UnverifiedBiscuit::from_base64(token.as_bytes()) else {
+        return Ok(None);
+    };
+    if !biscuit_declares_pop_binding(&biscuit)? {
+        return Ok(None);
+    }
+    crate::hosted_runtime::device_flow::effective_pop_public_key_hex(token)
+        .map(Some)
+        .context("reading the hosted bearer's effective leaf proof-of-possession key")
+}
+
+fn biscuit_declares_pop_binding(biscuit: &biscuit_auth::UnverifiedBiscuit) -> Result<bool> {
+    for index in 0..biscuit.block_count() {
+        let source = biscuit.print_block_source(index).with_context(|| {
+            format!("read Biscuit block {index} while classifying proof binding")
+        })?;
+        let block = BlockBuilder::new().code(&source).with_context(|| {
+            format!("parse Biscuit block {index} while classifying proof binding")
+        })?;
+        if block.facts.iter().any(|fact| {
+            matches!(
+                fact.predicate.name.as_str(),
+                "device_pop_key" | "pop_delegation"
+            )
+        }) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn shared_device_proof_key(server_key: &str, token: &str) -> Result<Option<String>> {

--- a/crates/cli/src/hosted_runtime/hosted/session.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session.rs
@@ -94,6 +94,11 @@ impl HostedSession {
         })
     }
 
+    #[cfg(test)]
+    pub(super) fn client_config(&self) -> &ClientConfig {
+        &self.config
+    }
+
     pub fn with_allow_insecure(mut self, allow: bool) -> Self {
         if allow {
             self.config.allow_insecure = true;

--- a/crates/cli/src/hosted_runtime/hosted/session_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session_tests.rs
@@ -1,0 +1,353 @@
+//! Local PoP-binding checks for [`super::HostedSession::build`].
+//!
+//! A PoP-bound bearer must fail in session construction when no matching
+//! leaf key is available. These tests never open a connection.
+
+use std::path::{Path, PathBuf};
+
+use cli_shared::{UserConfig, credentials};
+use crypto::{Ed25519Signer, Signer};
+
+use super::{
+    CallContextFactory, HostedAuthMode, HostedSession,
+    context::SignedCallContext,
+};
+
+const SERVER: &str = "api.heddle.test";
+
+fn mint_pop_token(subject: &str, signer: &Ed25519Signer) -> String {
+    biscuit_auth::Biscuit::builder()
+        .fact(format!("user(\"{subject}\")").as_str())
+        .expect("user fact")
+        .fact(format!("device_pop_key(\"{}\")", hex::encode(signer.public_key())).as_str())
+        .expect("proof key fact")
+        .build(&biscuit_auth::KeyPair::new())
+        .expect("mint token")
+        .to_base64()
+        .expect("encode token")
+}
+
+fn mint_unbound_token(subject: &str) -> String {
+    biscuit_auth::Biscuit::builder()
+        .fact(format!("user(\"{subject}\")").as_str())
+        .expect("user fact")
+        .build(&biscuit_auth::KeyPair::new())
+        .expect("mint unbound token")
+        .to_base64()
+        .expect("encode unbound token")
+}
+
+fn mint_derived_child(parent_token: &str, parent: &Ed25519Signer, child: &Ed25519Signer) -> String {
+    crate::hosted_runtime::device_flow::attenuate_for_agent(
+        parent_token,
+        crate::hosted_runtime::device_flow::AgentAttenuation {
+            agent_id: "agent-review".to_string(),
+            expires_at: chrono::Utc::now() + chrono::Duration::hours(1),
+            allowed_operations: Some(vec!["WhoAmI".to_string()]),
+            allowed_resources: None,
+            declared_scopes: Vec::new(),
+        },
+        parent,
+        child.public_key(),
+    )
+    .expect("derive child token")
+}
+
+fn store_credential(token: &str, subject: &str, proof_key_pem: Option<String>) {
+    credentials::store_server_credential(
+        SERVER,
+        credentials::ServerCredential {
+            token: token.to_string(),
+            subject: subject.to_string(),
+            device_id: None,
+            credential_id: None,
+            private_key_pem: proof_key_pem,
+            expires_at: None,
+        },
+    )
+    .expect("store credential");
+}
+
+fn write_hcred(path: &Path, subject: &str, token: &str, proof_key_pem: &str) {
+    crate::hosted_runtime::credential_file::write_credential_file(
+        path,
+        &crate::hosted_runtime::credential_file::VerifiedCredential {
+            server: SERVER.to_string(),
+            kind: crate::hosted_runtime::credential_file::CredentialKind::Device,
+            subject: subject.to_string(),
+            token: token.to_string(),
+            proof_key_pem: proof_key_pem.to_string(),
+            expires_at: None,
+            credential_id: None,
+            provenance: None,
+        },
+    )
+    .expect("write .hcred");
+}
+
+fn user_config_with_proof_key(path: PathBuf) -> UserConfig {
+    let mut user_config = UserConfig::default();
+    user_config.remote.auth_proof_key_pem_path = Some(path);
+    user_config
+}
+
+fn build_session(user_config: &UserConfig) -> anyhow::Result<HostedSession> {
+    HostedSession::build(
+        user_config,
+        Some(SERVER.to_string()),
+        HostedAuthMode::CredentialFallback,
+    )
+}
+
+fn whoami_context(session: &HostedSession) -> SignedCallContext {
+    CallContextFactory::from_client_config(session.client_config())
+        .expect("session config must be a valid call context")
+        .unary("/heddle.api.v1alpha1.IdentityService/WhoAmI", &[], "")
+        .expect("build WhoAmI context")
+}
+
+fn assert_proof_attached(session: &HostedSession, expected_pem: &str) {
+    assert_eq!(
+        session.client_config().auth_proof_key_pem.as_deref(),
+        Some(expected_pem)
+    );
+    assert!(
+        whoami_context(session).context.bearer_proof.is_some(),
+        "a matching leaf key must attach proof before any RPC"
+    );
+}
+
+fn assert_token_only(session: &HostedSession) {
+    assert!(session.client_config().auth_proof_key_pem.is_none());
+    assert!(
+        whoami_context(session).context.bearer_proof.is_none(),
+        "an unbound bearer must keep its documented token-only behavior"
+    );
+}
+
+fn with_isolated_env<T>(run: impl FnOnce(&Path) -> T) -> T {
+    let _guard = credentials::lock_test_env();
+    let home = tempfile::TempDir::new().expect("temp Heddle home");
+    let previous_home = std::env::var_os("HEDDLE_HOME");
+    let previous_credential = std::env::var_os("HEDDLE_CREDENTIAL");
+    unsafe {
+        std::env::set_var("HEDDLE_HOME", home.path());
+        std::env::remove_var("HEDDLE_CREDENTIAL");
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| run(home.path())));
+    unsafe {
+        match previous_home {
+            Some(path) => std::env::set_var("HEDDLE_HOME", path),
+            None => std::env::remove_var("HEDDLE_HOME"),
+        }
+        match previous_credential {
+            Some(path) => std::env::set_var("HEDDLE_CREDENTIAL", path),
+            None => std::env::remove_var("HEDDLE_CREDENTIAL"),
+        }
+    }
+    match result {
+        Ok(value) => value,
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+#[test]
+fn environment_credential_attaches_matching_proof() {
+    with_isolated_env(|home| {
+        let signer = Ed25519Signer::generate().expect("env proof key");
+        let pem = signer.to_pem().expect("env PEM");
+        let token = mint_pop_token("alice", &signer);
+        let path = home.join("agent.hcred");
+        write_hcred(&path, "alice", &token, &pem);
+        unsafe { std::env::set_var("HEDDLE_CREDENTIAL", &path) };
+
+        let session = build_session(&UserConfig::default()).expect("HEDDLE_CREDENTIAL session");
+        assert_eq!(
+            session
+                .client_config()
+                .token
+                .as_ref()
+                .map(|token| token.id.as_str()),
+            Some(token.as_str())
+        );
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn credential_store_root_attaches_matching_proof() {
+    with_isolated_env(|_| {
+        let signer = Ed25519Signer::generate().expect("root proof key");
+        let pem = signer.to_pem().expect("root PEM");
+        store_credential(&mint_pop_token("alice", &signer), "alice", Some(pem.clone()));
+
+        let session = build_session(&UserConfig::default()).expect("keystore root session");
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn credential_store_derived_child_attaches_matching_leaf_key() {
+    with_isolated_env(|_| {
+        let parent = Ed25519Signer::generate().expect("parent proof key");
+        let child = Ed25519Signer::generate().expect("child proof key");
+        let parent_token = mint_pop_token("alice", &parent);
+        let child_token = mint_derived_child(&parent_token, &parent, &child);
+        let pem = child.to_pem().expect("child PEM");
+        store_credential(&child_token, "alice", Some(pem.clone()));
+
+        let session = build_session(&UserConfig::default()).expect("keystore child session");
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn pop_bound_service_account_attaches_matching_proof() {
+    with_isolated_env(|_| {
+        let signer = Ed25519Signer::generate().expect("service-account key");
+        let pem = signer.to_pem().expect("service-account PEM");
+        store_credential(
+            &mint_pop_token("sa:github-ci", &signer),
+            "sa:github-ci",
+            Some(pem.clone()),
+        );
+
+        let session = build_session(&UserConfig::default()).expect("service-account session");
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn configured_key_attaches_matching_proof() {
+    with_isolated_env(|home| {
+        let signer = Ed25519Signer::generate().expect("configured proof key");
+        let pem = signer.to_pem().expect("configured PEM");
+        let pem_path = home.join("proof.pem");
+        std::fs::write(&pem_path, &pem).expect("write configured PEM");
+        store_credential(&mint_pop_token("alice", &signer), "alice", None);
+
+        let session = build_session(&user_config_with_proof_key(pem_path))
+            .expect("configured-key session");
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn same_host_identity_attaches_matching_root_key() {
+    with_isolated_env(|_| {
+        let signer = Ed25519Signer::generate().expect("device key");
+        let pem = signer.to_pem().expect("device PEM");
+        let token = mint_pop_token("alice", &signer);
+        store_credential(&token, "alice", None);
+        repo::identity::link_device_key(&signer.public_key(), &pem, SERVER)
+            .expect("link same-host identity");
+
+        let session = build_session(&UserConfig::default()).expect("same-host session");
+        assert_proof_attached(&session, &pem);
+    });
+}
+
+#[test]
+fn pop_bound_credential_store_token_without_key_fails_before_connect() {
+    with_isolated_env(|_| {
+        store_credential(&mint_pop_token("alice", &Ed25519Signer::generate().expect("unused key")), "alice", None);
+
+        let error = build_session(&UserConfig::default())
+            .expect_err("a PoP-bound keystore token with no key must fail locally");
+        let message = error.to_string();
+        assert!(
+            message.contains("proof-of-possession") && message.contains("no matching"),
+            "missing-key error must be actionable: {message}"
+        );
+    });
+}
+
+#[test]
+fn same_host_identity_does_not_satisfy_a_derived_child() {
+    with_isolated_env(|_| {
+        let parent = Ed25519Signer::generate().expect("parent device key");
+        let child = Ed25519Signer::generate().expect("child leaf key");
+        let parent_pem = parent.to_pem().expect("parent PEM");
+        let parent_token = mint_pop_token("alice", &parent);
+        let child_token = mint_derived_child(&parent_token, &parent, &child);
+        store_credential(&child_token, "alice", None);
+        repo::identity::link_device_key(&parent.public_key(), &parent_pem, SERVER)
+            .expect("link ancestor identity");
+
+        let error = build_session(&UserConfig::default()).expect_err(
+            "a token-only derived child must not borrow the ancestor same-host key",
+        );
+        let message = error.to_string();
+        assert!(
+            message.contains("proof-of-possession") && message.contains("no matching"),
+            "child-without-leaf-key error must be actionable: {message}"
+        );
+    });
+}
+
+#[test]
+fn credential_store_mismatched_key_fails_locally() {
+    with_isolated_env(|_| {
+        let bound = Ed25519Signer::generate().expect("bound key");
+        let other = Ed25519Signer::generate().expect("other key");
+        store_credential(
+            &mint_pop_token("alice", &bound),
+            "alice",
+            Some(other.to_pem().expect("other PEM")),
+        );
+
+        let error = build_session(&UserConfig::default())
+            .expect_err("a keystore key that is not the leaf key must fail locally");
+        assert!(
+            error.to_string().contains("does not match"),
+            "mismatch error must be actionable: {error}"
+        );
+    });
+}
+
+#[test]
+fn configured_key_mismatch_fails_locally() {
+    with_isolated_env(|home| {
+        let bound = Ed25519Signer::generate().expect("bound key");
+        let other = Ed25519Signer::generate().expect("other key");
+        let pem_path = home.join("wrong.pem");
+        std::fs::write(&pem_path, other.to_pem().expect("wrong PEM")).expect("write wrong PEM");
+        store_credential(&mint_pop_token("alice", &bound), "alice", None);
+
+        let error = build_session(&user_config_with_proof_key(pem_path))
+            .expect_err("a configured key that is not the leaf key must fail locally");
+        assert!(
+            error.to_string().contains("does not match"),
+            "configured-key mismatch must be actionable: {error}"
+        );
+    });
+}
+
+#[test]
+fn unbound_biscuit_without_pop_key_keeps_token_only_behavior() {
+    with_isolated_env(|_| {
+        store_credential(&mint_unbound_token("legacy-sa"), "legacy-sa", None);
+
+        let session = build_session(&UserConfig::default()).expect("unbound biscuit session");
+        assert_token_only(&session);
+    });
+}
+
+#[test]
+fn opaque_unbound_bearer_keeps_token_only_behavior() {
+    with_isolated_env(|_| {
+        store_credential("not-a-biscuit", "opaque", None);
+
+        let session = build_session(&UserConfig::default()).expect("opaque bearer session");
+        assert_token_only(&session);
+    });
+}
+
+#[test]
+fn unauthenticated_session_has_no_bearer() {
+    with_isolated_env(|_| {
+        let session = build_session(&UserConfig::default()).expect("unauthenticated session");
+        assert!(session.client_config().token.is_none());
+        assert!(session.client_config().auth_proof_key_pem.is_none());
+    });
+}

--- a/crates/cli/src/hosted_runtime/hosted/session_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session_tests.rs
@@ -240,7 +240,7 @@ fn same_host_identity_attaches_matching_root_key() {
         let pem = signer.to_pem().expect("device PEM");
         let token = mint_pop_token("alice", &signer);
         store_credential(&token, "alice", None);
-        repo::identity::link_device_key(&signer.public_key(), &pem, SERVER)
+        repo::identity::link_device_key(signer.public_key(), &pem, SERVER)
             .expect("link same-host identity");
 
         let session = build_session(&UserConfig::default()).expect("same-host session");
@@ -277,7 +277,7 @@ fn same_host_identity_does_not_satisfy_a_derived_child() {
         let parent_token = mint_pop_token("alice", &parent);
         let child_token = mint_derived_child(&parent_token, &parent, &child);
         store_credential(&child_token, "alice", None);
-        repo::identity::link_device_key(&parent.public_key(), &parent_pem, SERVER)
+        repo::identity::link_device_key(parent.public_key(), &parent_pem, SERVER)
             .expect("link ancestor identity");
 
         let Err(error) = build_session(&UserConfig::default()) else {

--- a/crates/cli/src/hosted_runtime/hosted/session_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session_tests.rs
@@ -8,10 +8,7 @@ use std::path::{Path, PathBuf};
 use cli_shared::{UserConfig, credentials};
 use crypto::{Ed25519Signer, Signer};
 
-use super::{
-    CallContextFactory, HostedAuthMode, HostedSession,
-    context::SignedCallContext,
-};
+use super::{CallContextFactory, HostedAuthMode, HostedSession, context::SignedCallContext};
 
 const SERVER: &str = "api.heddle.test";
 
@@ -179,7 +176,11 @@ fn credential_store_root_attaches_matching_proof() {
     with_isolated_env(|_| {
         let signer = Ed25519Signer::generate().expect("root proof key");
         let pem = signer.to_pem().expect("root PEM");
-        store_credential(&mint_pop_token("alice", &signer), "alice", Some(pem.clone()));
+        store_credential(
+            &mint_pop_token("alice", &signer),
+            "alice",
+            Some(pem.clone()),
+        );
 
         let session = build_session(&UserConfig::default()).expect("keystore root session");
         assert_proof_attached(&session, &pem);
@@ -226,8 +227,8 @@ fn configured_key_attaches_matching_proof() {
         std::fs::write(&pem_path, &pem).expect("write configured PEM");
         store_credential(&mint_pop_token("alice", &signer), "alice", None);
 
-        let session = build_session(&user_config_with_proof_key(pem_path))
-            .expect("configured-key session");
+        let session =
+            build_session(&user_config_with_proof_key(pem_path)).expect("configured-key session");
         assert_proof_attached(&session, &pem);
     });
 }
@@ -250,7 +251,11 @@ fn same_host_identity_attaches_matching_root_key() {
 #[test]
 fn pop_bound_credential_store_token_without_key_fails_before_connect() {
     with_isolated_env(|_| {
-        store_credential(&mint_pop_token("alice", &Ed25519Signer::generate().expect("unused key")), "alice", None);
+        store_credential(
+            &mint_pop_token("alice", &Ed25519Signer::generate().expect("unused key")),
+            "alice",
+            None,
+        );
 
         let error = build_session(&UserConfig::default())
             .expect_err("a PoP-bound keystore token with no key must fail locally");
@@ -274,9 +279,8 @@ fn same_host_identity_does_not_satisfy_a_derived_child() {
         repo::identity::link_device_key(&parent.public_key(), &parent_pem, SERVER)
             .expect("link ancestor identity");
 
-        let error = build_session(&UserConfig::default()).expect_err(
-            "a token-only derived child must not borrow the ancestor same-host key",
-        );
+        let error = build_session(&UserConfig::default())
+            .expect_err("a token-only derived child must not borrow the ancestor same-host key");
         let message = error.to_string();
         assert!(
             message.contains("proof-of-possession") && message.contains("no matching"),

--- a/crates/cli/src/hosted_runtime/hosted/session_tests.rs
+++ b/crates/cli/src/hosted_runtime/hosted/session_tests.rs
@@ -257,8 +257,9 @@ fn pop_bound_credential_store_token_without_key_fails_before_connect() {
             None,
         );
 
-        let error = build_session(&UserConfig::default())
-            .expect_err("a PoP-bound keystore token with no key must fail locally");
+        let Err(error) = build_session(&UserConfig::default()) else {
+            panic!("a PoP-bound keystore token with no key must fail locally");
+        };
         let message = error.to_string();
         assert!(
             message.contains("proof-of-possession") && message.contains("no matching"),
@@ -279,8 +280,9 @@ fn same_host_identity_does_not_satisfy_a_derived_child() {
         repo::identity::link_device_key(&parent.public_key(), &parent_pem, SERVER)
             .expect("link ancestor identity");
 
-        let error = build_session(&UserConfig::default())
-            .expect_err("a token-only derived child must not borrow the ancestor same-host key");
+        let Err(error) = build_session(&UserConfig::default()) else {
+            panic!("a token-only derived child must not borrow the ancestor same-host key");
+        };
         let message = error.to_string();
         assert!(
             message.contains("proof-of-possession") && message.contains("no matching"),
@@ -300,8 +302,9 @@ fn credential_store_mismatched_key_fails_locally() {
             Some(other.to_pem().expect("other PEM")),
         );
 
-        let error = build_session(&UserConfig::default())
-            .expect_err("a keystore key that is not the leaf key must fail locally");
+        let Err(error) = build_session(&UserConfig::default()) else {
+            panic!("a keystore key that is not the leaf key must fail locally");
+        };
         assert!(
             error.to_string().contains("does not match"),
             "mismatch error must be actionable: {error}"
@@ -318,8 +321,9 @@ fn configured_key_mismatch_fails_locally() {
         std::fs::write(&pem_path, other.to_pem().expect("wrong PEM")).expect("write wrong PEM");
         store_credential(&mint_pop_token("alice", &bound), "alice", None);
 
-        let error = build_session(&user_config_with_proof_key(pem_path))
-            .expect_err("a configured key that is not the leaf key must fail locally");
+        let Err(error) = build_session(&user_config_with_proof_key(pem_path)) else {
+            panic!("a configured key that is not the leaf key must fail locally");
+        };
         assert!(
             error.to_string().contains("does not match"),
             "configured-key mismatch must be actionable: {error}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Session construction now distinguishes an unbound bearer from a bearer whose effective leaf proof-of-possession key requires proof.
- A PoP-bound bearer with no matching configured key, or a supplied key that is not that leaf, fails in `HostedSession::build` before connection or RPC dispatch, with an actionable recovery message.
- Root device, derived child, and PoP-bound service-account credentials still attach proof with the matching key. Historical unbound biscuits and opaque bearers keep their documented token-only behavior.
- Tests cover `HEDDLE_CREDENTIAL`, the credential store, `remote.auth_proof_key_pem_path`, and same-host device identity.

**Fable (human) should review these auth changes before merge.** This PR does not wait on that review.

The issue named `crates/client/src/grpc_hosted/session.rs`. That seam now lives at `crates/cli/src/hosted_runtime/hosted/session.rs` after the client crate retirement.

## Closes

Closes HeddleCo/heddle#1027

## Red commit
`ac3f36e5`

## Test evidence
```
$ git rev-parse HEAD
5fde82e1d54c2f14003a77e047a7638eca201b6f

$ cargo test --locked -p heddle-cli --lib -- hosted::session_tests hosted::credential device_flow
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.31s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 39 tests
test hosted_runtime::hosted::session_tests::configured_key_attaches_matching_proof ... ok
test hosted_runtime::hosted::session_tests::credential_store_derived_child_attaches_matching_leaf_key ... ok
test hosted_runtime::hosted::session_tests::configured_key_mismatch_fails_locally ... ok
test hosted_runtime::hosted::session_tests::credential_store_mismatched_key_fails_locally ... ok
test hosted_runtime::hosted::session_tests::credential_store_root_attaches_matching_proof ... ok
test hosted_runtime::hosted::session_tests::environment_credential_attaches_matching_proof ... ok
test hosted_runtime::hosted::session_tests::opaque_unbound_bearer_keeps_token_only_behavior ... ok
test hosted_runtime::hosted::session_tests::pop_bound_credential_store_token_without_key_fails_before_connect ... ok
test hosted_runtime::hosted::session_tests::pop_bound_service_account_attaches_matching_proof ... ok
test hosted_runtime::hosted::session_tests::same_host_identity_attaches_matching_root_key ... ok
test hosted_runtime::hosted::session_tests::same_host_identity_does_not_satisfy_a_derived_child ... ok
test hosted_runtime::hosted::session_tests::unauthenticated_session_has_no_bearer ... ok
test hosted_runtime::hosted::session_tests::unbound_biscuit_without_pop_key_keeps_token_only_behavior ... ok
test hosted_runtime::hosted::credential::tests::... ok
test hosted_runtime::device_flow::tests::... ok

test result: ok. 39 passed; 0 failed; 0 ignored; 0 measured; 685 filtered out; finished in 0.37s

$ cargo clippy --locked -p heddle-cli --all-targets -- -D warnings -D dead-code
    Checking heddle-cli v0.12.0 (/workspace/crates/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.74s
```

## Manual verification

N/A — covered by tests

## Blocked by → resolved

None. Blockers HeddleCo/heddle#1022 and HeddleCo/weft#577 are already merged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d9635da-23b9-4425-b83a-68877e770efe?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d9635da-23b9-4425-b83a-68877e770efe&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789767548&installation_model_id=21489&pr_number=1433&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1433&signature=942bb8de74e01d02cdae117a7238aede980633af7447754a7d19196bbecbdfff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->