### PR TITLE
fix(cli): honor `[remote] tls_ca_certificate_path` on hosted bootstrap

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -459,14 +459,31 @@ impl UserConfig {
 
     /// Resolve the shared custom CA bundle used by hosted and Git transports.
     ///
-    /// `HEDDLE_REMOTE_TLS_CA_CERT` overrides the user-config path.
+    /// Precedence, highest first: `HEDDLE_REMOTE_TLS_CA_CERT`, user-config
+    /// `[remote] tls_ca_certificate_path`, then the same key in repository
+    /// `.heddle/config.toml` discovered from `start` (or the process cwd).
     pub fn remote_tls_ca_certificate_pem(&self) -> anyhow::Result<Option<String>> {
+        self.remote_tls_ca_certificate_pem_from(env::current_dir().ok().as_deref())
+    }
+
+    fn remote_tls_ca_certificate_pem_from(
+        &self,
+        repo_start: Option<&Path>,
+    ) -> anyhow::Result<Option<String>> {
         let mut ca_pem = self
             .remote
             .tls_ca_certificate_path
             .as_ref()
             .map(|path| read_security_config_file("remote.tls_ca_certificate_path", path))
             .transpose()?;
+        if ca_pem.is_none()
+            && let Some(path) = discovered_repo_tls_ca_certificate_path(repo_start)?
+        {
+            ca_pem = Some(read_security_config_file(
+                "remote.tls_ca_certificate_path",
+                &path,
+            )?);
+        }
         match env::var("HEDDLE_REMOTE_TLS_CA_CERT") {
             Ok(path) => {
                 ca_pem = Some(read_security_config_file(
@@ -768,6 +785,52 @@ where
         ));
     }
     Ok(Some(parsed))
+}
+
+fn discovered_repo_tls_ca_certificate_path(
+    start: Option<&Path>,
+) -> anyhow::Result<Option<PathBuf>> {
+    let Some(start) = start else {
+        return Ok(None);
+    };
+    let Some(root) = repo::discover_heddle_root(start) else {
+        return Ok(None);
+    };
+    let config_path = root.join(".heddle/config.toml");
+    let contents = match fs::read_to_string(&config_path) {
+        Ok(contents) => contents,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(security_config_error(
+                "remote.tls_ca_certificate_path",
+                format!("read repository config {}: {err}", config_path.display()),
+            ));
+        }
+    };
+    let probe = toml::from_str::<RepoRemoteProbe>(&contents).map_err(|err| {
+        security_config_error(
+            "remote.tls_ca_certificate_path",
+            format!("parse repository config {}: {err}", config_path.display()),
+        )
+    })?;
+    let Some(path) = probe
+        .remote
+        .tls_ca_certificate_path
+        .filter(|path| !path.as_os_str().is_empty())
+    else {
+        return Ok(None);
+    };
+    Ok(Some(if path.is_absolute() {
+        path
+    } else {
+        root.join(path)
+    }))
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RepoRemoteProbe {
+    #[serde(default)]
+    remote: repo::RepoRemoteConfig,
 }
 
 fn config_value_error(setting: &str, reason: String) -> anyhow::Error {
@@ -1183,5 +1246,87 @@ mod tests {
 
         assert!(message.contains("fatal TLS/auth configuration error"));
         assert!(message.contains("HEDDLE_REMOTE_TLS"));
+    }
+
+    fn write_discoverable_repo(root: &std::path::Path, remote_toml: &str) {
+        fs::create_dir_all(root.join(".heddle")).expect("create .heddle");
+        fs::write(root.join(".heddle/HEAD"), "ref: refs/heddle/heads/main\n").expect("write HEAD");
+        fs::write(
+            root.join(".heddle/config.toml"),
+            format!("[repository]\nversion = 4\nsource_authority = \"native\"\n{remote_toml}"),
+        )
+        .expect("write repo config");
+    }
+
+    #[test]
+    fn remote_tls_ca_honours_repo_config_when_user_config_is_unset() {
+        let _env = RemoteEnvGuard::clean();
+        let root = unique_temp_path("heddle-repo-tls-ca");
+        let ca_path = root.join("ca.pem");
+        fs::create_dir_all(&root).expect("create repo root");
+        fs::write(&ca_path, "repo ca pem").expect("write repo CA");
+        write_discoverable_repo(
+            &root,
+            &format!(
+                "\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                ca_path.display()
+            ),
+        );
+
+        let pem = UserConfig::default()
+            .remote_tls_ca_certificate_pem_from(Some(&root))
+            .expect("repo CA should load");
+        assert_eq!(pem.as_deref(), Some("repo ca pem"));
+        fs::remove_dir_all(root).expect("remove temp dir");
+    }
+
+    #[test]
+    fn remote_tls_ca_user_config_overrides_repo_config() {
+        let _env = RemoteEnvGuard::clean();
+        let root = unique_temp_path("heddle-repo-tls-ca-override");
+        fs::create_dir_all(&root).expect("create repo root");
+        let repo_ca = root.join("repo-ca.pem");
+        let user_ca = root.join("user-ca.pem");
+        fs::write(&repo_ca, "repo ca pem").expect("write repo CA");
+        fs::write(&user_ca, "user ca pem").expect("write user CA");
+        write_discoverable_repo(
+            &root,
+            &format!(
+                "\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                repo_ca.display()
+            ),
+        );
+
+        let user = UserConfig {
+            remote: UserRemoteConfig {
+                tls_ca_certificate_path: Some(user_ca),
+                ..UserRemoteConfig::default()
+            },
+            ..UserConfig::default()
+        };
+        let pem = user
+            .remote_tls_ca_certificate_pem_from(Some(&root))
+            .expect("user CA should win");
+        assert_eq!(pem.as_deref(), Some("user ca pem"));
+        fs::remove_dir_all(root).expect("remove temp dir");
+    }
+
+    #[test]
+    fn remote_tls_ca_unknown_repo_remote_key_fails_closed() {
+        let _env = RemoteEnvGuard::clean();
+        let root = unique_temp_path("heddle-repo-tls-ca-unknown");
+        fs::create_dir_all(&root).expect("create repo root");
+        write_discoverable_repo(&root, "\n[remote]\ntls_insecure = true\n");
+
+        let err = UserConfig::default()
+            .remote_tls_ca_certificate_pem_from(Some(&root))
+            .expect_err("unknown repo remote keys must fail closed");
+        let message = err.to_string();
+        assert!(message.contains("fatal TLS/auth configuration error"));
+        assert!(
+            message.contains("unknown field") || message.contains("tls_insecure"),
+            "unknown remote knob must be named: {message}"
+        );
+        fs::remove_dir_all(root).expect("remove temp dir");
     }
 }

--- a/crates/cli-shared/src/lib.rs
+++ b/crates/cli-shared/src/lib.rs
@@ -11,6 +11,7 @@ pub mod credentials;
 pub mod logging;
 pub mod output;
 pub mod remote;
+pub mod tls_trust;
 
 pub use client_config::{
     ClientConfig, cleartext_connect_allowed, cleartext_refused_message, is_loopback_ip,
@@ -23,4 +24,8 @@ pub use output::OutputMode;
 pub use remote::{
     Remote, RemoteConfig, RemoteTarget, remote_allows_insecure, resolve_remote_with_key,
     resolve_remote_with_key_and_insecure,
+};
+pub use tls_trust::{
+    REMOTE_TLS_CA_CERT_SETTING, annotate_error_chain_tls_trust_failure, annotate_tls_trust_failure,
+    is_tls_trust_failure,
 };

--- a/crates/cli-shared/src/tls_trust.rs
+++ b/crates/cli-shared/src/tls_trust.rs
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Shared TLS-trust failure wording for hosted bootstrap and Git HTTPS.
+
+/// Operator-facing CA setting named by every TLS trust failure.
+pub const REMOTE_TLS_CA_CERT_SETTING: &str = "HEDDLE_REMOTE_TLS_CA_CERT";
+
+/// True when a transport error is a peer-certificate trust failure.
+pub fn is_tls_trust_failure(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("invalid peer certificate")
+        || normalized.contains("unknownissuer")
+        || normalized.contains("unknown issuer")
+        || normalized.contains("certificateunknown")
+}
+
+/// Append the CA configuration that fixes an untrusted peer certificate.
+pub fn annotate_tls_trust_failure(error: impl std::fmt::Display) -> String {
+    let message = error.to_string();
+    if is_tls_trust_failure(&message) && !message.contains(REMOTE_TLS_CA_CERT_SETTING) {
+        format!(
+            "{message}; trust this server's CA with {REMOTE_TLS_CA_CERT_SETTING}=/path/to/ca.pem"
+        )
+    } else {
+        message
+    }
+}
+
+/// Walk an error source chain and annotate a TLS trust failure if any link is one.
+pub fn annotate_error_chain_tls_trust_failure(error: &(dyn std::error::Error + 'static)) -> String {
+    let mut message = error.to_string();
+    let mut current = error.source();
+    let mut trust_failure = is_tls_trust_failure(&message);
+    while let Some(err) = current {
+        let next = err.to_string();
+        trust_failure |= is_tls_trust_failure(&next);
+        if !message.contains(&next) {
+            message.push_str(": ");
+            message.push_str(&next);
+        }
+        current = err.source();
+    }
+    if trust_failure {
+        annotate_tls_trust_failure(message)
+    } else {
+        message
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{REMOTE_TLS_CA_CERT_SETTING, annotate_tls_trust_failure, is_tls_trust_failure};
+
+    #[test]
+    fn unknown_issuer_is_a_tls_trust_failure() {
+        assert!(is_tls_trust_failure(
+            "invalid peer certificate: UnknownIssuer"
+        ));
+        assert!(!is_tls_trust_failure("connection refused"));
+    }
+
+    #[test]
+    fn annotation_names_the_ca_setting_once() {
+        let annotated = annotate_tls_trust_failure("invalid peer certificate: UnknownIssuer");
+        assert!(annotated.contains(REMOTE_TLS_CA_CERT_SETTING));
+        assert_eq!(
+            annotate_tls_trust_failure(annotated.as_str()),
+            annotated,
+            "already-annotated messages must stay stable"
+        );
+    }
+
+    #[test]
+    fn annotation_walks_a_source_chain() {
+        #[derive(Debug)]
+        struct Root(&'static str);
+        impl std::fmt::Display for Root {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+        impl std::error::Error for Root {}
+
+        #[derive(Debug)]
+        struct Wrapper {
+            source: Root,
+        }
+        impl std::fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("error sending request")
+            }
+        }
+        impl std::error::Error for Wrapper {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.source)
+            }
+        }
+
+        let error = Wrapper {
+            source: Root("invalid peer certificate: UnknownIssuer"),
+        };
+        let annotated = super::annotate_error_chain_tls_trust_failure(&error);
+        assert!(annotated.contains("error sending request"));
+        assert!(annotated.contains("UnknownIssuer"));
+        assert!(annotated.contains(REMOTE_TLS_CA_CERT_SETTING));
+    }
+}

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -754,6 +754,19 @@ fn classify_error_inner(err: &anyhow::Error) -> ErrorClassification {
             "heddle thread list",
         );
     }
+    if cli_shared::is_tls_trust_failure(&top) {
+        return ErrorClassification::known(
+            "hosted_tls_trust",
+            format!(
+                "Trust this server's CA with {}=/path/to/ca.pem or [remote] tls_ca_certificate_path.",
+                cli_shared::REMOTE_TLS_CA_CERT_SETTING
+            ),
+            "the hosted bootstrap HTTPS request failed because the peer certificate is not trusted",
+            "retrying without a trusted CA will fail the same TLS handshake",
+            "no hosted session was opened and local state was left unchanged",
+            "heddle help remotes",
+        );
+    }
     ErrorClassification::runtime()
 }
 
@@ -989,5 +1002,31 @@ mod tests {
         assert_eq!(classified.kind, "state_not_found");
         assert_eq!(classified.primary_command, "heddle log");
         assert_eq!(classified.recovery_commands, vec!["heddle log"]);
+    }
+
+    #[test]
+    fn hosted_tls_trust_failure_names_ca_and_does_not_hint_status() {
+        let err = anyhow!(
+            "hosted bootstrap HTTPS request failed: invalid peer certificate: UnknownIssuer"
+        );
+        let classified = classify_error(&err);
+        assert_eq!(classified.kind, "hosted_tls_trust");
+        assert_eq!(classified.primary_command, "heddle help remotes");
+        assert!(
+            classified.hint.contains("HEDDLE_REMOTE_TLS_CA_CERT"),
+            "hint must name the CA configuration: {}",
+            classified.hint
+        );
+        assert!(
+            !classified.hint.contains("heddle status")
+                && classified.primary_command != "heddle status"
+                && !classified
+                    .recovery_commands
+                    .iter()
+                    .any(|command| command.contains("heddle status")),
+            "hosted TLS trust must not hint heddle status: {} / {:?}",
+            classified.primary_command,
+            classified.recovery_commands
+        );
     }
 }

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -98,9 +98,10 @@ impl HeddleExitCode {
         match kind {
             // Missing precondition (no default remote for push/pull), not
             // an IO failure.
-            "remote_not_configured" | "remote_not_found" | "repository_not_found" => {
-                Some(Self::Config)
-            }
+            "remote_not_configured"
+            | "remote_not_found"
+            | "repository_not_found"
+            | "hosted_tls_trust" => Some(Self::Config),
             // A Heddle global option after `try --` is a malformed
             // invocation, not a child-command argument.
             "try_global_option_after_separator" => Some(Self::Usage),
@@ -492,6 +493,7 @@ mod tests {
             ("remote_not_configured", HeddleExitCode::Config),
             ("remote_not_found", HeddleExitCode::Config),
             ("repository_not_found", HeddleExitCode::Config),
+            ("hosted_tls_trust", HeddleExitCode::Config),
             ("try_global_option_after_separator", HeddleExitCode::Usage),
             ("nothing_to_capture", HeddleExitCode::DataErr),
             ("dirty_worktree", HeddleExitCode::DataErr),

--- a/crates/cli/src/hosted_runtime/auth.rs
+++ b/crates/cli/src/hosted_runtime/auth.rs
@@ -11,6 +11,7 @@ use api::heddle::api::v1alpha1::{
 };
 use cli_shared::{UserConfig, credentials, credentials::ServerCredential};
 use crypto::{Ed25519Signer, Signer};
+use heddle_cli_contract::cli::commands::RecoveryAdvice;
 use objects::{HeddleError, RecoveryDetails};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -1170,7 +1171,33 @@ async fn connect_auth_client(server: &str) -> Result<HostedClient> {
     )?
     .connect(([127, 0, 0, 1], 0).into())
     .await
-    .map_err(Into::into)
+    .map_err(hosted_bootstrap_connect_error)
+}
+
+fn hosted_bootstrap_connect_error(error: impl std::fmt::Display) -> anyhow::Error {
+    let message = error.to_string();
+    if cli_shared::is_tls_trust_failure(&message) {
+        anyhow::Error::new(hosted_tls_trust_advice(&message))
+    } else {
+        anyhow::Error::msg(message)
+    }
+}
+
+fn hosted_tls_trust_advice(message: &str) -> RecoveryAdvice {
+    let annotated = cli_shared::annotate_tls_trust_failure(message);
+    RecoveryAdvice::safety_refusal(
+        "hosted_tls_trust",
+        annotated,
+        format!(
+            "Trust this server's CA with {}=/path/to/ca.pem or [remote] tls_ca_certificate_path.",
+            cli_shared::REMOTE_TLS_CA_CERT_SETTING
+        ),
+        "the hosted bootstrap HTTPS request failed because the peer certificate is not trusted",
+        "retrying without a trusted CA will fail the same TLS handshake",
+        "no hosted session was opened and local credentials were not written",
+        "heddle help remotes",
+        vec!["heddle help remotes".to_string()],
+    )
 }
 
 /// Poll `MintBiscuit(DeviceAuthProof)` until the device code is approved or
@@ -1550,6 +1577,15 @@ mod tests {
         assert_eq!(percent_encode_query_component("ABCD-1234"), "ABCD-1234");
         assert_eq!(percent_encode_query_component("a b"), "a%20b");
         assert_eq!(percent_encode_query_component("x&y"), "x%26y");
+    }
+
+    #[test]
+    fn hosted_tls_trust_advice_names_ca_and_avoids_status() {
+        let advice = hosted_tls_trust_advice("invalid peer certificate: UnknownIssuer");
+        assert_eq!(advice.kind, "hosted_tls_trust");
+        assert!(advice.error.contains("HEDDLE_REMOTE_TLS_CA_CERT"));
+        assert_eq!(advice.primary_command, "heddle help remotes");
+        assert!(!advice.hint.contains("heddle status"));
     }
 
     #[test]

--- a/crates/cli/src/hosted_runtime/hosted/descriptor_trust_acceptance.rs
+++ b/crates/cli/src/hosted_runtime/hosted/descriptor_trust_acceptance.rs
@@ -58,7 +58,12 @@ async fn tls_authenticates_first_contact_and_configured_ca_allows_it() {
             resolve_and_verify_endpoint_descriptor(server.authority(), &Default::default())
                 .await
                 .unwrap_err();
-        assert!(untrusted_error.to_string().contains("HTTPS request failed"));
+        let message = untrusted_error.to_string();
+        assert!(message.contains("HTTPS request failed"));
+        assert!(
+            message.contains("HEDDLE_REMOTE_TLS_CA_CERT"),
+            "UnknownIssuer must name the CA configuration: {message}"
+        );
         assert!(load_automatic_pin(server.authority()).unwrap().is_none());
 
         resolve_and_verify_endpoint_descriptor(server.authority(), &trusted_config(&server))

--- a/crates/cli/src/hosted_runtime/hosted/error.rs
+++ b/crates/cli/src/hosted_runtime/hosted/error.rs
@@ -40,7 +40,7 @@ pub enum HostedError {
     #[error("hosted request metadata is invalid: {0}")]
     RequestMetadata(#[from] api::RequestMetadataError),
     #[error("hosted bootstrap HTTPS request failed: {0}")]
-    BootstrapHttp(#[from] reqwest::Error),
+    BootstrapHttp(String),
 }
 
 impl HostedError {
@@ -50,6 +50,12 @@ impl HostedError {
 
     pub(super) fn framing(error: impl std::fmt::Display) -> Self {
         Self::Framing(error.to_string())
+    }
+}
+
+impl From<reqwest::Error> for HostedError {
+    fn from(error: reqwest::Error) -> Self {
+        Self::BootstrapHttp(cli_shared::annotate_error_chain_tls_trust_failure(&error))
     }
 }
 

--- a/crates/cli/src/hosted_runtime/hosted/mod.rs
+++ b/crates/cli/src/hosted_runtime/hosted/mod.rs
@@ -373,14 +373,11 @@ impl HostedClient {
                 let canonical = signed
                     .canonical()
                     .ok_or(HostedError::SigningIdentityRequired)?;
-                let callback =
-                    self.on_human_signature
-                        .as_ref()
-                        .ok_or_else(|| HostedError::Call {
-                            code: api::heddle::api::v1alpha1::CallFailureCode::Unauthenticated,
-                            message,
-                            error: Some(error),
-                        })?;
+                let callback = self.on_human_signature.as_ref().ok_or(HostedError::Call {
+                    code: api::heddle::api::v1alpha1::CallFailureCode::Unauthenticated,
+                    message,
+                    error: Some(error),
+                })?;
                 let assertion = callback(HumanSignatureRequest {
                     method_path: method.to_string(),
                     action_summary: format!("Authorize {method}"),

--- a/crates/cli/tests/hosted_bootstrap_tls.rs
+++ b/crates/cli/tests/hosted_bootstrap_tls.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Reproduce and lock hosted bootstrap TLS CA honoring for `heddle auth login`.
+//!
+//! A private-CA HTTPS server is enough: login fails at descriptor fetch before
+//! any Iroh session. UnknownIssuer without a trusted CA, then a later
+//! descriptor-trust error once the CA is honored, is the evidence that the
+//! knob reached the bootstrap request.
+
+#![cfg(feature = "client")]
+
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    path::{Path, PathBuf},
+    process::{Command, Output},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use rcgen::{CertifiedKey, generate_simple_self_signed};
+use rustls::{
+    ServerConfig, ServerConnection, StreamOwned,
+    pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
+};
+use tempfile::TempDir;
+
+struct PrivateCaHostedServer {
+    authority: String,
+    ca_pem: String,
+    stop: Arc<AtomicBool>,
+    thread: Option<thread::JoinHandle<()>>,
+}
+
+impl PrivateCaHostedServer {
+    fn spawn() -> Self {
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(vec!["127.0.0.1".to_string()])
+                .expect("generate private-CA leaf");
+        let ca_pem = cert.pem();
+        let private_key =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(signing_key.serialize_der()));
+        let tls = Arc::new(
+            ServerConfig::builder()
+                .with_no_client_auth()
+                .with_single_cert(vec![cert.der().clone()], private_key)
+                .expect("private-CA HTTPS server config"),
+        );
+        let listener = TcpListener::bind(("127.0.0.1", 0)).expect("bind private-CA HTTPS");
+        listener
+            .set_nonblocking(true)
+            .expect("nonblocking private-CA HTTPS listener");
+        let authority = format!("https://{}", listener.local_addr().expect("HTTPS address"));
+        let stop = Arc::new(AtomicBool::new(false));
+        let thread_stop = Arc::clone(&stop);
+        let thread = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Acquire) {
+                match listener.accept() {
+                    Ok((stream, _)) => serve_404(stream, Arc::clone(&tls)),
+                    Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(2));
+                    }
+                    Err(error) => panic!("private-CA HTTPS accept failed: {error}"),
+                }
+            }
+        });
+        Self {
+            authority,
+            ca_pem,
+            stop,
+            thread: Some(thread),
+        }
+    }
+}
+
+impl Drop for PrivateCaHostedServer {
+    fn drop(&mut self) {
+        self.stop.store(true, Ordering::Release);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn serve_404(stream: TcpStream, tls: Arc<ServerConfig>) {
+    stream
+        .set_nonblocking(false)
+        .expect("blocking private-CA HTTPS connection");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("private-CA HTTPS read timeout");
+    let connection = ServerConnection::new(tls).expect("private-CA TLS connection");
+    let mut stream = StreamOwned::new(connection, stream);
+    let mut request = Vec::new();
+    let mut chunk = [0_u8; 1024];
+    while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+        match stream.read(&mut chunk) {
+            Ok(0) | Err(_) => return,
+            Ok(count) => request.extend_from_slice(&chunk[..count]),
+        }
+    }
+    let response = b"HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+    if stream
+        .write_all(response)
+        .and_then(|_| stream.flush())
+        .is_ok()
+    {
+        stream.conn.send_close_notify();
+        let _ = stream
+            .sock
+            .set_read_timeout(Some(Duration::from_millis(250)));
+        let _ = stream.conn.complete_io(&mut stream.sock);
+    }
+}
+
+struct LoginFixture {
+    ca_path: PathBuf,
+    repo: PathBuf,
+    server: String,
+    temp: TempDir,
+    _https: PrivateCaHostedServer,
+}
+
+impl LoginFixture {
+    fn new() -> Self {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = temp.path().join("repo");
+        std::fs::create_dir_all(&repo).expect("create repo dir");
+        let init = heddle_command(&temp, &repo)
+            .args(["init"])
+            .output()
+            .expect("init repo");
+        assert!(init.status.success(), "init: {}", stderr(&init));
+
+        let https = PrivateCaHostedServer::spawn();
+        let ca_path = temp.path().join("private-ca.pem");
+        std::fs::write(&ca_path, &https.ca_pem).expect("write private CA");
+        Self {
+            server: https.authority.clone(),
+            ca_path,
+            repo,
+            temp,
+            _https: https,
+        }
+    }
+
+    fn login(&self, ca: CaSource) -> Output {
+        let mut command = heddle_command(&self.temp, &self.repo);
+        command.args(["auth", "login", "--server", &self.server]);
+        match ca {
+            CaSource::None => {}
+            CaSource::Env => {
+                command.env("HEDDLE_REMOTE_TLS_CA_CERT", &self.ca_path);
+            }
+            CaSource::UserConfig => {
+                let config = self.temp.path().join("user-ca.toml");
+                std::fs::write(
+                    &config,
+                    format!(
+                        "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                        self.ca_path.display()
+                    ),
+                )
+                .expect("write user config CA");
+                command.env("HEDDLE_CONFIG", config);
+            }
+            CaSource::RepoConfig => {
+                let repo_config = self.repo.join(".heddle/config.toml");
+                let current = std::fs::read_to_string(&repo_config).expect("read repo config");
+                std::fs::write(
+                    repo_config,
+                    format!(
+                        "{current}\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                        self.ca_path.display()
+                    ),
+                )
+                .expect("write repo config CA");
+            }
+        }
+        command.output().expect("run heddle auth login")
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CaSource {
+    None,
+    Env,
+    UserConfig,
+    RepoConfig,
+}
+
+#[test]
+fn auth_login_without_ca_names_remote_tls_configuration() {
+    let fixture = LoginFixture::new();
+    let output = fixture.login(CaSource::None);
+    let err = stderr(&output);
+    assert!(!output.status.success(), "untrusted private CA must fail");
+    assert!(
+        is_tls_trust_failure(&err),
+        "untrusted login must be a TLS trust failure: {err}"
+    );
+    assert!(
+        err.contains("HEDDLE_REMOTE_TLS_CA_CERT"),
+        "UnknownIssuer must name the CA configuration: {err}"
+    );
+    assert!(
+        !err.contains("heddle status"),
+        "hosted TLS trust failure must not hint heddle status: {err}"
+    );
+    eprintln!("untrusted login names the CA configuration:\n{err}");
+}
+
+#[test]
+fn auth_login_honours_user_config_tls_ca_certificate_path() {
+    let fixture = LoginFixture::new();
+    let output = fixture.login(CaSource::UserConfig);
+    assert_tls_honored(&output, "user config");
+}
+
+#[test]
+fn auth_login_honours_repo_config_tls_ca_certificate_path() {
+    let fixture = LoginFixture::new();
+    let output = fixture.login(CaSource::RepoConfig);
+    assert_tls_honored(&output, "repo config");
+}
+
+#[test]
+fn auth_login_honours_env_tls_ca_cert() {
+    let fixture = LoginFixture::new();
+    let output = fixture.login(CaSource::Env);
+    assert_tls_honored(&output, "HEDDLE_REMOTE_TLS_CA_CERT");
+}
+
+fn assert_tls_honored(output: &Output, source: &str) {
+    let err = stderr(output);
+    assert!(
+        !output.status.success(),
+        "{source}: fixture has no descriptor document, so login must still fail: {err}"
+    );
+    assert!(
+        !is_tls_trust_failure(&err),
+        "{source}: configured CA must be honored so login fails after TLS: {err}"
+    );
+    assert!(
+        err.contains("descriptor trust") || err.contains("descriptor"),
+        "{source}: post-TLS failure should name descriptor trust: {err}"
+    );
+    eprintln!("{source}: TLS honored; login failed after bootstrap:\n{err}");
+}
+
+fn is_tls_trust_failure(message: &str) -> bool {
+    let normalized = message.to_ascii_lowercase();
+    normalized.contains("invalid peer certificate")
+        || normalized.contains("unknownissuer")
+        || normalized.contains("unknown issuer")
+        || normalized.contains("certificateunknown")
+}
+
+fn heddle_command(temp: &TempDir, cwd: &Path) -> Command {
+    let config = temp.path().join("config.toml");
+    if !config.exists() {
+        std::fs::write(
+            &config,
+            "[principal]\nname = \"Heddle Test\"\nemail = \"heddle@example.com\"\n",
+        )
+        .expect("write Heddle config");
+    }
+    let mut command = Command::new(env!("CARGO_BIN_EXE_heddle"));
+    command
+        .current_dir(cwd)
+        .env("PATH", "")
+        .env("HOME", temp.path())
+        .env("HEDDLE_HOME", temp.path().join("heddle-home"))
+        .env("HEDDLE_CONFIG", &config)
+        .env("NO_COLOR", "1")
+        .env_remove("HEDDLE_REMOTE_TLS_CA_CERT")
+        .env_remove("SSL_CERT_FILE")
+        .env_remove("SSL_CERT_DIR");
+    command
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -170,7 +170,7 @@ pub use repository::{
     HistoryQuery, HostedConfig, KeyBindingRegistryAnchor, MAJOR_REWRITE_THRESHOLD_PCT,
     MEDIUM_SUGGESTION_THRESHOLD, MissingBlob, OperationKind, OperationScope, OutputFormat,
     PackFilesInspection, PartialFetchInspection, ProvenanceConfig, PullPlannerCacheInspection,
-    RefCountsInspection, RepoConfig, Repository, RepositoryCapability,
+    RefCountsInspection, RepoConfig, RepoRemoteConfig, Repository, RepositoryCapability,
     RepositoryMaintenanceRunReport, RepositoryOperationStatus,
     RepositoryPerformanceInspectionReport, RepositorySourceAuthority, SUGGESTION_WINDOW,
     SnapshotExecution, SnapshotProfile, SpoolFacet, ThreadCaptureOutcome, TreeBuildProfile,

--- a/crates/repo/src/repo_config.rs
+++ b/crates/repo/src/repo_config.rs
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Repository configuration handling.
 
-use std::{io::Read, path::Path};
+use std::{
+    io::Read,
+    path::{Path, PathBuf},
+};
 
 use objects::{error::HeddleError, fs_atomic::write_file_atomic, object::VisibilityTier};
 use serde::{Deserialize, Serialize};
@@ -41,6 +44,24 @@ pub struct RepoConfig {
     pub redact: RedactConfig,
     #[serde(default, skip_serializing_if = "MetadataConfig::is_empty")]
     pub metadata: MetadataConfig,
+    #[serde(default, skip_serializing_if = "RepoRemoteConfig::is_empty")]
+    pub remote: RepoRemoteConfig,
+}
+
+/// `[remote]` security settings that a checkout may pin for hosted and Git TLS.
+///
+/// Unknown keys fail at load so a knob cannot look configured while being ignored.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct RepoRemoteConfig {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tls_ca_certificate_path: Option<PathBuf>,
+}
+
+impl RepoRemoteConfig {
+    fn is_empty(&self) -> bool {
+        self.tls_ca_certificate_path.is_none()
+    }
 }
 
 /// `[redact]` config section. Houses the list of operator public keys
@@ -506,6 +527,7 @@ impl Default for RepoConfig {
             provenance: ProvenanceConfig::default(),
             redact: RedactConfig::default(),
             metadata: MetadataConfig::default(),
+            remote: RepoRemoteConfig::default(),
         }
     }
 }
@@ -665,6 +687,10 @@ source_authority = "native"
             !saved.contains("[metadata]"),
             "empty metadata trust must stay off disk: {saved}"
         );
+        assert!(
+            !saved.contains("[remote]"),
+            "empty remote TLS table must stay off disk: {saved}"
+        );
     }
 
     #[test]
@@ -805,5 +831,38 @@ format = "auto"
             .filter(|entry| entry.file_name().to_string_lossy().contains(".tmp-"))
             .count();
         assert_eq!(sibling_entries, 0);
+    }
+
+    #[test]
+    fn remote_tls_ca_path_parses_and_unknown_remote_keys_fail() {
+        let config: RepoConfig = toml::from_str(
+            r#"
+[repository]
+version = 4
+source_authority = "native"
+[remote]
+tls_ca_certificate_path = "/etc/heddle/ca.pem"
+"#,
+        )
+        .expect("known remote CA path should parse");
+        assert_eq!(
+            config.remote.tls_ca_certificate_path.as_deref(),
+            Some(std::path::Path::new("/etc/heddle/ca.pem"))
+        );
+
+        let error = toml::from_str::<RepoConfig>(
+            r#"
+[repository]
+version = 4
+source_authority = "native"
+[remote]
+tls_insecure = true
+"#,
+        )
+        .expect_err("unknown remote keys must fail closed");
+        assert!(
+            error.to_string().contains("unknown field"),
+            "unknown remote knob must be rejected: {error}"
+        );
     }
 }

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -77,7 +77,7 @@ pub use refs::SpoolFacet;
 use refs::{Head, RefBackend, RefExpectation, RefManager, RefUpdate};
 pub use repo_config::{
     HostedConfig, KeyBindingRegistryAnchor, OutputFormat, ProvenanceConfig, RepoConfig,
-    RepositorySourceAuthority, TrustedKey,
+    RepoRemoteConfig, RepositorySourceAuthority, TrustedKey,
 };
 // Review-epic config types — re-exported here so the new
 // `repository_signals.rs` (and external crates wanting to construct a

--- a/docs/WIRE_PROTOCOL.md
+++ b/docs/WIRE_PROTOCOL.md
@@ -35,7 +35,7 @@ The wire protocol is fully implemented and tested. All core VCS commands are ope
 Environment-based local testing:
 
 - `hosted` owns the server runtime and reads server config from its server config file or `HEDDLE_SERVER_*` overrides.
-- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles.
+- `heddle` client commands use user config plus `HEDDLE_REMOTE_*` overrides for TLS profiles. `[remote] tls_ca_certificate_path` is honored from user config and from repository `.heddle/config.toml`; `HEDDLE_REMOTE_TLS_CA_CERT` overrides both. Unknown `[remote]` keys in repository config fail at load.
 - Client authentication follows a single precedence: `HEDDLE_CREDENTIAL=<path-to-.hcred>` (authoritative — a bad/expired/mismatched file is a hard error) → the per-server keystore entry (`heddle auth login`) → unauthenticated. There is no `HEDDLE_REMOTE_TOKEN` or `remote.token`; an agent authenticates by pointing `HEDDLE_CREDENTIAL` at a `.hcred` (see `heddle auth derive-agent --out` / `heddle auth create-service-token --out`).
 - `HEDDLE_REMOTE_TLS=1` enables TLS; `HEDDLE_REMOTE_INSECURE=1` allows cleartext to non-loopback hosts.
 - Provider pulls can be tuned in the user config under `[remote]` with `provider_global_concurrency`, `provider_per_endpoint_concurrency`, `provider_max_inflight_bytes`, and `provider_stall_timeout_secs`. The corresponding environment overrides are `HEDDLE_REMOTE_PROVIDER_GLOBAL_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_PER_ENDPOINT_CONCURRENCY`, `HEDDLE_REMOTE_PROVIDER_MAX_INFLIGHT_BYTES`, and `HEDDLE_REMOTE_PROVIDER_STALL_TIMEOUT_SECS`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Hosted bootstrap / `heddle auth login` now honors `[remote] tls_ca_certificate_path` from user config **and** repository `.heddle/config.toml`, with `HEDDLE_REMOTE_TLS_CA_CERT` winning over both. Missing or unreadable CA files still fail closed. Unknown repository `[remote]` keys fail at load instead of being dropped.
- UnknownIssuer on this path walks the reqwest source chain and names `HEDDLE_REMOTE_TLS_CA_CERT=/path/to/ca.pem`. Recovery is `heddle help remotes` (exit 78). It does not hint `heddle status`.
- TLS is not weakened. A knob that cannot be honored is rejected, not ignored.

## Closes

Closes HeddleCo/heddle#1153

## Red commit
`61c48ac23c1619b0222329d892ccd8c64f754bff`

On that commit, the same private-CA `heddle auth login` suite shows the gap: repo-config CA is ignored (`UnknownIssuer` with the key set), and the untrusted path does not name the CA setting and falls through to `heddle status`. User-config and env already worked.

```
$ cargo test --offline -p heddle-cli --test hosted_bootstrap_tls -- --nocapture
     Running tests/hosted_bootstrap_tls.rs

running 4 tests

thread 'auth_login_without_ca_names_remote_tls_configuration' panicked:
UnknownIssuer must name the CA configuration: ...
Error: remote error: hosted bootstrap HTTPS request failed: error sending request for url (https://127.0.0.1:36867/.well-known/heddle/iroh-descriptor-key)
Next: heddle status
Also: heddle help auth login

thread 'auth_login_honours_repo_config_tls_ca_certificate_path' panicked:
repo config: configured CA must be honored so login fails after TLS: ...
Error: remote error: hosted bootstrap HTTPS request failed: error sending request for url (https://127.0.0.1:39263/.well-known/heddle/iroh-descriptor-key)
Next: heddle status
Also: heddle help auth login

HEDDLE_REMOTE_TLS_CA_CERT: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; ...
user config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; ...

test auth_login_honours_repo_config_tls_ca_certificate_path ... FAILED
test auth_login_honours_env_tls_ca_cert ... ok
test auth_login_without_ca_names_remote_tls_configuration ... FAILED
test auth_login_honours_user_config_tls_ca_certificate_path ... ok

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out
```

## Test evidence

Green on `9af4deb1` (this HEAD). Same private-CA server: repo/user/env CA now get past TLS (login then fails at descriptor trust, which the fixture does not publish). Untrusted path names the CA setting and does not hint `heddle status`.

```
$ cargo test --offline -p heddle-cli --test hosted_bootstrap_tls -- --nocapture
     Running tests/hosted_bootstrap_tls.rs (target/debug/deps/hosted_bootstrap_tls-9b03b13bcd41ea8d)

running 4 tests
HEDDLE_REMOTE_TLS_CA_CERT: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:36111)
Next: heddle status
Also: heddle help auth login

user config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:46015)
Next: heddle status
Also: heddle help auth login

test auth_login_honours_env_tls_ca_cert ... ok
untrusted login names the CA configuration:
2026-08-19T22:04:43.508061Z ERROR rustls_platform_verifier::verification::others: failed to verify TLS certificate: invalid peer certificate: UnknownIssuer
Error: remote error: hosted bootstrap HTTPS request failed: error sending request for url (https://127.0.0.1:34323/.well-known/heddle/iroh-descriptor-key): client error (Connect): invalid peer certificate: UnknownIssuer; trust this server's CA with HEDDLE_REMOTE_TLS_CA_CERT=/path/to/ca.pem
Next: heddle help remotes

repo config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:44457)
Next: heddle status
Also: heddle help auth login

test auth_login_honours_repo_config_tls_ca_certificate_path ... ok
test auth_login_honours_user_config_tls_ca_certificate_path ... ok
test auth_login_without_ca_names_remote_tls_configuration ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
```

Related unit tests on the same HEAD:

```
$ cargo test --offline -p heddle-cli-shared --lib remote_tls_ca
ok. 3 passed (repo honor, user overrides repo, unknown repo [remote] key fails closed)

$ cargo test --offline -p heddle-cli-shared --lib -- tls_trust
ok. 3 passed (UnknownIssuer detect, annotate once, walk source chain)

$ cargo test --offline -p heddle-repo --lib remote_tls
ok. 1 passed

$ cargo test --offline -p heddle-cli --lib hosted_tls_trust
ok. 2 passed (envelope + auth advice name CA, no `heddle status`)

$ cargo test --offline -p heddle-cli --lib tls_authenticates_first_contact
ok. 1 passed (descriptor-fetch UnknownIssuer now names HEDDLE_REMOTE_TLS_CA_CERT)

$ cargo test --offline -p heddle-cli --lib every_classified_advice_kind
ok. 1 passed (hosted_tls_trust → exit 78)

$ cargo run --offline -p heddle-devtools -- check-rust-source-reachability
Rust source guard clean: all 818 source file(s) across 31 crate(s) are reachable
```

## Audit: push / pull / clone / descriptor-fetch

These are not separate honor-the-knob bugs. They already share the functions this PR changed.

| Path | How TLS CA is applied | Gap? |
|---|---|---|
| `heddle auth login` hosted bootstrap | `connect_auth_client` → `HostedSession::build` → `UserConfig::hosted_runtime_config` → `remote_tls_ca_certificate_pem` → `bootstrap_http_client` | **This bug.** Repo `[remote]` was dropped by `RepoConfig`, and login never opened the repo. Fixed. |
| push / pull / clone | Same `HostedSession::build` / `hosted_runtime_config` | Same resolver. Repo CA is now honored when the command runs from a checkout. No extra code path. |
| descriptor-fetch (`/.well-known/heddle/iroh-descriptor-key`) | `bootstrap_http_client` already merged `config.tls_ca_certificate_pem`. The failure was `HostedError::from(reqwest::Error)` displaying only the top reqwest message (`error sending request for url`), so UnknownIssuer never reached the envelope. | Same annotation fix. Not a second ignore-the-knob bug. |
| Git HTTPS lane (#1135) | `main.rs` already called `remote_tls_ca_certificate_pem()` and named `HEDDLE_REMOTE_TLS_CA_CERT` on UnknownIssuer | Same resolver now also reads repo config. Left the Git-specific wording alone. |

Websocket hosted presence uses the same `ClientConfig.tls_ca_certificate_pem`. Not touched.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b41bc76b-a7d6-452c-9377-0894eb192d7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b41bc76b-a7d6-452c-9377-0894eb192d7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789769280&installation_model_id=21489&pr_number=1434&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1434&signature=b631cbf8e946736ea5594e2fb1fc3b08c6c1b2e5e2066ed87b97fe92dcf37107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->