### PR TITLE
Teach everyday help from source_authority (hide overlay commit on native)

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -146,6 +146,7 @@ fn parse_confidence(s: &str) -> Result<f32, String> {
 
 /// Arguments for the `capture` command.
 #[derive(Clone, Debug, clap::Args)]
+#[command(override_usage = "heddle capture -m <INTENT> [OPTIONS]")]
 #[command(after_help = "\
 Examples:
   heddle capture -m 'add login route'           # capture the worktree with intent
@@ -167,8 +168,8 @@ pub struct SnapshotArgs {
     #[arg(long, hide = true)]
     pub help_agent: bool,
 
-    /// Natural language intent for this recoverable step.
-    #[arg(short = 'm', long, visible_alias = "message")]
+    /// Required natural-language intent for this recoverable step.
+    #[arg(short = 'm', long, visible_alias = "message", value_name = "INTENT")]
     pub intent: Option<String>,
 
     /// Confidence level (0.0-1.0).
@@ -1764,6 +1765,13 @@ mod capture_message_alias_tests {
     fn capture_accepts_short_m() {
         let args = parse_capture(&["-m", "my change"]).expect("-m should parse");
         assert_eq!(args.intent.as_deref(), Some("my change"));
+    }
+
+    #[test]
+    fn capture_parses_without_intent_so_the_refuse_can_fire() {
+        let args =
+            parse_capture(&[]).expect("omitted -m is a semantic refuse, not a clap usage error");
+        assert!(args.intent.is_none());
     }
 
     #[test]

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -250,7 +250,7 @@ Heddle options must appear before `--`. Everything after `--` is passed unchange
     /// Capture a recoverable Heddle step for undo, provenance, and review.
     Capture(SnapshotArgs),
 
-    /// Commit the current captured state to the authoritative Git checkout.
+    /// Write captured source history to `.git` in Git Overlay.
     Commit(CommitArgs),
 
     /// Show state history.

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -1096,6 +1096,29 @@ mod tests {
         }
     }
 
+    /// heddle#1435. Default first screen follows Native source authority:
+    /// capture is the save, and overlay `commit` stays off the front door.
+    #[test]
+    fn first_screen_hides_overlay_commit_by_default() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let help = render_help(&cmd, &[]);
+        assert!(
+            help.contains("heddle capture -m"),
+            "default first screen still teaches capture: {help}"
+        );
+        assert!(
+            !help.contains("-> heddle commit ->"),
+            "default first screen must not teach overlay commit: {help}"
+        );
+        assert!(
+            !help
+                .lines()
+                .any(|line| line.trim_start().starts_with("commit  ")),
+            "default first screen must hide the commit verb unless overlay: {help}"
+        );
+    }
+
     /// The everyday surface should mirror the core loop rather than
     /// mixing in every collaboration feature. A first-time user should
     /// be able to orient, commit work, check readiness, inspect,

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -48,8 +48,12 @@ pub fn everyday_verbs() -> Vec<&'static str> {
 
 /// The first screen of help is smaller than the complete everyday set:
 /// it shows the primary work loop, then points at setup, sync, proof,
-/// and recovery as nearby verbs.
-fn primary_loop_verbs(catalog: &crate::cli::commands::CommandCatalogOutput) -> Vec<&'static str> {
+/// and recovery as nearby verbs. Overlay-only `commit` stays off the
+/// native / no-repo front door (heddle#1435).
+fn primary_loop_verbs(
+    catalog: &crate::cli::commands::CommandCatalogOutput,
+    authority: repo::RepositorySourceAuthority,
+) -> Vec<&'static str> {
     everyday_verbs()
         .into_iter()
         .filter(|verb| {
@@ -57,7 +61,101 @@ fn primary_loop_verbs(catalog: &crate::cli::commands::CommandCatalogOutput) -> V
                 .command_by_display(verb)
                 .is_some_and(|entry| entry.help_rank <= 70)
         })
+        .filter(|verb| {
+            *verb != "commit" || authority == repo::RepositorySourceAuthority::GitOverlay
+        })
         .collect()
+}
+
+/// Discover source authority for first-screen help. Fail closed to Native
+/// (hide overlay `commit`) when no repository is proven.
+fn probed_source_authority() -> repo::RepositorySourceAuthority {
+    let Ok(cwd) = std::env::current_dir() else {
+        return repo::RepositorySourceAuthority::Native;
+    };
+    let Some(root) = repo::discover_heddle_root(&cwd) else {
+        return repo::RepositorySourceAuthority::Native;
+    };
+    match repo::RepoConfig::load_for_repository(&root.join(".heddle").join("config.toml")) {
+        Ok(config) => config.repository.source_authority,
+        Err(_) => repo::RepositorySourceAuthority::Native,
+    }
+}
+
+fn write_first_screen(out: &mut String, authority: repo::RepositorySourceAuthority) {
+    use std::fmt::Write;
+
+    use heddle_core::source_authority::{SourceAction, SourceAuthorityActions};
+
+    let catalog = crate::cli::commands::build_command_catalog();
+    let overlay = authority == repo::RepositorySourceAuthority::GitOverlay;
+    let actions = SourceAuthorityActions::new(authority);
+    let capture = actions.display(SourceAction::Capture);
+    let push = actions.display(SourceAction::Push);
+
+    let _ = writeln!(out, "Heddle — agent-native version control");
+    let _ = writeln!(out);
+    let _ = writeln!(out, "Common loop:");
+    for name in primary_loop_verbs(&catalog, authority) {
+        let blurb = catalog_summary(&catalog, name);
+        if blurb.is_empty() {
+            continue;
+        }
+        let _ = writeln!(out, "  {:<10}  {}", name, blurb);
+    }
+    let _ = writeln!(out);
+    if overlay {
+        let _ = writeln!(
+            out,
+            "Existing Git: heddle status -> heddle init -> {capture} -> heddle commit -> {push}"
+        );
+    } else {
+        let _ = writeln!(out, "Save: heddle init -> {capture}");
+    }
+    let _ = writeln!(
+        out,
+        "Isolated work: heddle start <name> --path ../<name> -> {capture} -> heddle ready -> heddle land"
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Nearby: `heddle pull`, `heddle undo`, and `heddle verify`."
+    );
+    let _ = writeln!(
+        out,
+        "Start here: `heddle init`, `heddle clone`, or `heddle capture`."
+    );
+    let _ = writeln!(
+        out,
+        "In Git Overlay, Heddle uses its embedded Sley engine to operate directly on the checkout's `.git`."
+    );
+    let _ = writeln!(
+        out,
+        "Coming from Git? Run `heddle help git-concepts` for the concept map."
+    );
+    let _ = writeln!(out);
+    // The ONE place the --output machine-contract blurb is stated
+    // in full on a help screen; per-command --help carries only the
+    // one-line global flag plus the `heddle help output-formats`
+    // breadcrumb (heddle#652).
+    let _ = writeln!(
+        out,
+        "Output: text is the default; pass `--output json` for the \
+         full machine contract (stable `output_kind`, exit codes, recovery \
+         templates), or `--output json-compact` for the decision surface \
+         only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection. \
+         Details: `heddle help output-formats`."
+    );
+    let _ = writeln!(out);
+    let _ = writeln!(
+        out,
+        "Run `heddle help model` for the short mental model, \
+         `heddle help advanced` for power surfaces, automation, and Git interop, \
+         or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
+         `git-overlay`, \
+         `threads`, `daemon`, `signals`, `git-projection`, `operation-ids`, \
+         `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`)."
+    );
 }
 
 /// Verbs surfaced by `heddle help advanced`, in command-contract order.
@@ -95,71 +193,22 @@ pub fn print_help(cmd: &clap::Command, topic: &[String]) -> std::io::Result<()> 
 /// this, so the bytes are identical. Extracted so in-process tests can
 /// assert on help prose without spawning the binary (HeddleCo/heddle#381).
 pub fn render_help(cmd: &clap::Command, topic: &[String]) -> String {
+    render_help_for_authority(cmd, topic, probed_source_authority())
+}
+
+/// Render curated help for an explicit source authority.
+///
+/// Topic pages stay authority-independent. The empty-topic first screen
+/// hides overlay `commit` unless [`RepositorySourceAuthority::GitOverlay`].
+pub fn render_help_for_authority(
+    cmd: &clap::Command,
+    topic: &[String],
+    authority: repo::RepositorySourceAuthority,
+) -> String {
     use std::fmt::Write;
     let mut out = String::new();
     match topic {
-        [] => {
-            let catalog = crate::cli::commands::build_command_catalog();
-            let _ = writeln!(out, "Heddle — agent-native version control");
-            let _ = writeln!(out);
-            let _ = writeln!(out, "Common loop:");
-            for name in primary_loop_verbs(&catalog) {
-                let blurb = catalog_summary(&catalog, name);
-                if blurb.is_empty() {
-                    continue;
-                }
-                let _ = writeln!(out, "  {:<10}  {}", name, blurb);
-            }
-            let _ = writeln!(out);
-            let _ = writeln!(
-                out,
-                "Existing Git: heddle status -> heddle init -> heddle capture -m \"...\" -> heddle commit -> heddle push"
-            );
-            let _ = writeln!(
-                out,
-                "Isolated work: heddle start <name> --path ../<name> -> heddle capture -m \"...\" -> heddle ready -> heddle land"
-            );
-            let _ = writeln!(out);
-            let _ = writeln!(
-                out,
-                "Nearby: `heddle pull`, `heddle undo`, and `heddle verify`."
-            );
-            let _ = writeln!(
-                out,
-                "Start here: `heddle init`, `heddle clone`, or `heddle capture`."
-            );
-            let _ = writeln!(
-                out,
-                "In Git Overlay, Heddle uses its embedded Sley engine to operate directly on the checkout's `.git`."
-            );
-            let _ = writeln!(
-                out,
-                "Coming from Git? Run `heddle help git-concepts` for the concept map."
-            );
-            let _ = writeln!(out);
-            // The ONE place the --output machine-contract blurb is stated
-            // in full on a help screen; per-command --help carries only the
-            // one-line global flag plus the `heddle help output-formats`
-            // breadcrumb (heddle#652).
-            let _ = writeln!(
-                out,
-                "Output: text is the default; pass `--output json` for the \
-                 full machine contract (stable `output_kind`, exit codes, recovery \
-                 templates), or `--output json-compact` for the decision surface \
-                 only (fewer tokens, same `output_kind`). No TTY/pipe auto-detection. \
-                 Details: `heddle help output-formats`."
-            );
-            let _ = writeln!(out);
-            let _ = writeln!(
-                out,
-                "Run `heddle help model` for the short mental model, \
-                 `heddle help advanced` for power surfaces, automation, and Git interop, \
-                 or `heddle help <topic>` for a topic page (e.g. `git-concepts`, \
-                 `git-overlay`, \
-                 `threads`, `daemon`, `signals`, `git-projection`, `operation-ids`, \
-                 `remotes`, `output-formats`, `ignore`/`heddleignore`, `git-dependencies`)."
-            );
-        }
+        [] => write_first_screen(&mut out, authority),
         [name] if name == "advanced" => {
             let catalog = crate::cli::commands::build_command_catalog();
             let _ = writeln!(out, "{}", ADVANCED_HELP);
@@ -445,8 +494,9 @@ fn command_path_from_raw_help_request(cmd: &clap::Command, raw: &[String]) -> Op
 /// reveal, and the `heddle help <topics>` arm. Because the underlying printers
 /// are now `write_stdout(&render_*(..))` wrappers, the in-process text is
 /// byte-identical to the spawned binary's stdout — only the execution
-/// mechanism differs (HeddleCo/heddle#381). Help is repo-, cwd-, and
-/// env-independent, so this is safe to call from parallel tests.
+/// mechanism differs (HeddleCo/heddle#381). Topic and per-verb help is
+/// repo-, cwd-, and env-independent. The empty-topic first screen probes
+/// source authority and fails closed to Native when no repository is proven.
 pub fn render_for_args(args: &[&str]) -> Option<String> {
     use clap::{CommandFactory, Parser};
 
@@ -1102,10 +1152,14 @@ mod tests {
     fn first_screen_hides_overlay_commit_by_default() {
         use clap::CommandFactory;
         let cmd = crate::cli::cli_args::Cli::command();
-        let help = render_help(&cmd, &[]);
+        let help = render_help_for_authority(&cmd, &[], repo::RepositorySourceAuthority::Native);
         assert!(
             help.contains("heddle capture -m"),
             "default first screen still teaches capture: {help}"
+        );
+        assert!(
+            help.contains("Save: heddle init -> heddle capture -m \"...\""),
+            "native first screen follows the unborn save path: {help}"
         );
         assert!(
             !help.contains("-> heddle commit ->"),
@@ -1116,6 +1170,23 @@ mod tests {
                 .lines()
                 .any(|line| line.trim_start().starts_with("commit  ")),
             "default first screen must hide the commit verb unless overlay: {help}"
+        );
+    }
+
+    #[test]
+    fn first_screen_shows_overlay_commit_for_git_overlay() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let help =
+            render_help_for_authority(&cmd, &[], repo::RepositorySourceAuthority::GitOverlay);
+        assert!(
+            help.contains("Existing Git: heddle status -> heddle init -> heddle capture -m \"...\" -> heddle commit -> heddle push"),
+            "overlay first screen still teaches commit after capture: {help}"
+        );
+        assert!(
+            help.lines()
+                .any(|line| line.trim_start().starts_with("commit  ")),
+            "overlay first screen lists the commit verb: {help}"
         );
     }
 

--- a/crates/cli-render/src/cli/tips.rs
+++ b/crates/cli-render/src/cli/tips.rs
@@ -18,8 +18,8 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Tip {
-    /// "tip: Git Overlay source history stays in direct Git commands."
-    /// Emitted after a successful capture.
+    /// "tip: in Git Overlay, run `heddle commit` when the captured state is ready."
+    /// Emitted after a successful capture in Git Overlay only.
     CheckpointAfterCapture,
     /// "tip: `heddle query` searches saved change history."
     /// Emitted after the first heavy `heddle log` view.

--- a/crates/cli/src/cli/commands/commit.rs
+++ b/crates/cli/src/cli/commands/commit.rs
@@ -10,6 +10,7 @@ use super::{
     checkpoint::{GitCheckpointRequest, create_git_checkpoint},
     command_catalog::ActionTemplate,
     git_overlay_txn,
+    ready_cmd::worktree_dirty,
     verification_health::{
         RepositoryVerificationState, action_template, build_repository_verification_state,
     },
@@ -42,19 +43,7 @@ pub fn cmd_commit(cli: &Cli, args: CommitArgs) -> Result<()> {
 
     let repo = cli.open_repo()?;
     if repo.source_authority() != repo::RepositorySourceAuthority::GitOverlay {
-        return Err(anyhow!(RecoveryAdvice::safety_refusal(
-            "commit_requires_git_overlay",
-            "`heddle commit` writes Git-overlay source history",
-            "Use `heddle capture -m \"...\"` in a native Heddle repository.",
-            format!(
-                "repository source authority is {}",
-                repo.storage_model_label()
-            ),
-            "commit would try to update a Git ref where Git is not the source authority",
-            "Heddle refs and worktree files were left unchanged",
-            "heddle capture -m \"...\"",
-            vec!["heddle capture -m \"...\"".to_string()],
-        )));
+        return Err(anyhow!(native_commit_refusal(&repo)?));
     }
 
     let state = repo.current_state()?.ok_or_else(|| {
@@ -125,4 +114,26 @@ pub fn cmd_commit(cli: &Cli, args: CommitArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn native_commit_refusal(repo: &repo::Repository) -> Result<RecoveryAdvice> {
+    let dirty = worktree_dirty(repo, &worktree_status_options(Some(repo.config())))?;
+    let next = if dirty {
+        "heddle capture -m \"...\""
+    } else {
+        "heddle status"
+    };
+    Ok(RecoveryAdvice::safety_refusal(
+        "commit_requires_git_overlay",
+        "`heddle commit` writes Git-overlay source history",
+        "In a native repository, `heddle capture` is the save. `commit` writes `.git` in Git Overlay only.",
+        format!(
+            "repository source authority is {}",
+            repo.storage_model_label()
+        ),
+        "commit would try to update a Git ref where Git is not the source authority",
+        "Heddle refs and worktree files were left unchanged",
+        next,
+        vec![next.to_string()],
+    ))
 }

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -382,11 +382,9 @@ pub async fn cmd_snapshot(
         .flatten()
         .and_then(|thread| thread.target_thread)
         .is_some();
-    if !git_overlay && !captured_thread_targets_integration {
-        // Discoverability tip after a successful capture in native Heddle
-        // repos. In Git-overlay repos the concrete checkpoint next step
-        // above is more useful; in isolated feature checkouts, `ready`
-        // is the next product step.
+    if git_overlay && !captured_thread_targets_integration {
+        // Overlay-only discoverability: commit writes the captured tree
+        // to `.git`. Native capture is already the save boundary.
         crate::cli::tips::maybe_emit(
             repo.root(),
             Some(repo.config()),

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -164,6 +164,19 @@ fn capture_help_agent_reveals_hidden_flags_through_clap() {
 /// the reveal surface. Progressive disclosure: discover via the pointer, not
 /// by seeing the flag in the human help.
 #[test]
+fn capture_help_marks_intent_required_on_the_usage_line() {
+    let help = heddle_help(&["capture", "--help"]);
+    let usage = help
+        .lines()
+        .find(|line| line.contains("Usage:"))
+        .unwrap_or(help.as_str());
+    assert!(
+        usage.contains("-m") && usage.contains("<INTENT>") && !usage.contains("[-m"),
+        "capture usage must mark -m required so agents do not guess a default intent: {help}"
+    );
+}
+
+#[test]
 fn capture_help_keeps_help_agent_hidden_but_keeps_the_pointer() {
     let help = heddle_help(&["capture", "--help"]);
     // The discovery pointer in after-help stays so agents can still find it.

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6835,6 +6835,95 @@ fn native_capture_does_not_tip_overlay_commit() {
     );
 }
 
+/// Exact field-study walk from HeddleCo/heddle#1435 (native, no `.git`).
+#[test]
+fn field_study_1435_native_help_capture_commit_exits() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("native init");
+    assert!(
+        !temp.path().join(".git").exists(),
+        "field study is native-only"
+    );
+
+    for args in [&["--help"][..], &["help"][..]] {
+        let help = heddle(args, Some(temp.path())).expect("first-screen help");
+        assert!(
+            !help.contains("-> heddle commit ->")
+                && !help.contains("authoritative Git checkout")
+                && !help.contains("\n  commit"),
+            "`heddle {}` must not teach overlay commit on native: {help}",
+            args.join(" ")
+        );
+        assert!(
+            help.contains("heddle capture -m"),
+            "`heddle {}` still teaches capture: {help}",
+            args.join(" ")
+        );
+    }
+
+    let usage = heddle(&["capture", "--help"], Some(temp.path())).expect("capture usage");
+    let usage_line = usage
+        .lines()
+        .find(|line| line.contains("Usage:"))
+        .unwrap_or(usage.as_str());
+    assert!(
+        usage_line.contains("-m") && usage_line.contains("<INTENT>") && !usage_line.contains("[-m"),
+        "capture usage must mark -m required: {usage}"
+    );
+
+    std::fs::write(temp.path().join("NOTES.md"), "field study\n").expect("dirty worktree");
+    let capture = heddle_output(&["capture", "-m", "field study"], Some(temp.path()))
+        .expect("invoke native capture");
+    assert_eq!(
+        capture.status.code(),
+        Some(0),
+        "native capture should succeed: {}",
+        String::from_utf8_lossy(&capture.stderr)
+    );
+    let capture_err = String::from_utf8_lossy(&capture.stderr);
+    assert!(
+        !capture_err.contains("tip: in Git Overlay, run heddle commit"),
+        "native capture must not print the overlay tip: {capture_err}"
+    );
+
+    let commit = heddle_output(&["commit"], Some(temp.path())).expect("invoke native commit");
+    assert_eq!(
+        commit.status.code(),
+        Some(65),
+        "native commit must stay a semantic refuse: stdout={} stderr={}",
+        String::from_utf8_lossy(&commit.stdout),
+        String::from_utf8_lossy(&commit.stderr)
+    );
+    let commit_err = String::from_utf8_lossy(&commit.stderr);
+    assert!(
+        commit_err.contains("`heddle commit` writes Git-overlay source history"),
+        "native commit must name the overlay boundary: {commit_err}"
+    );
+    assert!(
+        !commit_err.contains("Next: heddle capture"),
+        "Next must not tell an already-captured native repo to capture again: {commit_err}"
+    );
+    assert!(
+        commit_err.contains("Next: heddle status"),
+        "already-captured native commit should point at status: {commit_err}"
+    );
+
+    let missing_intent =
+        heddle_output(&["capture"], Some(temp.path())).expect("invoke capture without -m");
+    assert_eq!(
+        missing_intent.status.code(),
+        Some(74),
+        "omitted -m must stay the intent refuse: stdout={} stderr={}",
+        String::from_utf8_lossy(&missing_intent.stdout),
+        String::from_utf8_lossy(&missing_intent.stderr)
+    );
+    let missing_err = String::from_utf8_lossy(&missing_intent.stderr);
+    assert!(
+        missing_err.contains("refusing to capture without an intent"),
+        "omitted -m must keep the intent refuse: {missing_err}"
+    );
+}
+
 #[test]
 fn global_flags_only_json_renders_command_catalog_for_agents() {
     let output = heddle_output(&["--output", "json"], None).expect("invoke heddle");

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6801,6 +6801,22 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
 }
 
 #[test]
+fn overlay_help_teaches_commit_after_capture() {
+    let temp = TempDir::new().unwrap();
+    git_hermetic(&["init", "-b", "main"], temp.path());
+    heddle(&["init"], Some(temp.path())).expect("initialize Git Overlay");
+    let help = heddle(&["help"], Some(temp.path())).expect("overlay help");
+    assert!(
+        help.contains("Existing Git:") && help.contains("-> heddle commit ->"),
+        "overlay first screen must teach commit after capture: {help}"
+    );
+    assert!(
+        help.contains("\n  commit"),
+        "overlay first screen must list the commit verb: {help}"
+    );
+}
+
+#[test]
 fn native_capture_does_not_tip_overlay_commit() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).expect("native init");

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -6746,12 +6746,16 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
         !stdout.contains("compatibility") && !stdout.contains(concat!("Git ", "adapter")),
         "default help should not frame Git Projection commands as old compatibility wording: {stdout}"
     );
-    for verb in ["status", "diff", "commit", "start", "ready", "land"] {
+    for verb in ["status", "diff", "capture", "start", "ready", "land"] {
         assert!(
             stdout.contains(&format!("\n  {verb}")),
             "core-loop verb `{verb}` should be on the curated surface: {stdout}"
         );
     }
+    assert!(
+        !stdout.contains("\n  commit"),
+        "no-repo first screen must hide overlay commit: {stdout}"
+    );
     for verb in [
         "review",
         "discuss",
@@ -6780,10 +6784,11 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
         "default help should keep adjacent commands discoverable without expanding the first-screen loop: {stdout}"
     );
     assert!(
-        stdout.contains("Existing Git: heddle status -> heddle init -> heddle capture -m \"...\" -> heddle commit -> heddle push")
+        stdout.contains("Save: heddle init -> heddle capture -m \"...\"")
+            && !stdout.contains("-> heddle commit ->")
             && stdout
                 .contains("Isolated work: heddle start <name> --path ../<name> -> heddle capture -m \"...\" -> heddle ready -> heddle land"),
-        "default help should connect first-run adoption and isolated work to the same product loop: {stdout}"
+        "default help should teach native capture-as-save, not overlay commit: {stdout}"
     );
     assert!(
         !stdout.contains("error: 'heddle' requires a subcommand"),
@@ -6792,6 +6797,25 @@ fn global_flags_only_renders_curated_help_not_clap_error() {
     assert!(
         !stderr.contains("error: 'heddle' requires a subcommand"),
         "clap's missing-subcommand error must not surface on stderr: stderr={stderr}"
+    );
+}
+
+#[test]
+fn native_capture_does_not_tip_overlay_commit() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("native init");
+    std::fs::write(temp.path().join("note.txt"), "save me\n").expect("write worktree file");
+    let output = heddle_output(&["capture", "-m", "save the note"], Some(temp.path()))
+        .expect("invoke native capture");
+    assert!(
+        output.status.success(),
+        "native capture should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Git Overlay") && !stderr.contains("heddle commit"),
+        "native capture must not teach overlay commit: {stderr}"
     );
 }
 
@@ -7485,7 +7509,7 @@ fn command_catalog_exposes_public_surface_for_agents() {
     assert!(
         text.contains("Heddle")
             && text.contains("Common loop:")
-            && text.contains("Existing Git:")
+            && text.contains("Save:")
             && text.contains("Output:"),
         "help text should be scannable: {text}"
     );

--- a/docs/adr/0043-workflow-command-vocabulary.md
+++ b/docs/adr/0043-workflow-command-vocabulary.md
@@ -1,8 +1,15 @@
 ---
-status: accepted
+status: superseded
+superseded-by: ADR 0046
 ---
 
 # Workflow Command Vocabulary
+
+This decision preferred `commit` as the everyday human save, with `capture`
+as an advanced granular savepoint. Shipped CLI and ADR 0046 / ADR 0047 made
+`capture` the save boundary. `commit` is the Git Overlay write to `.git`;
+it is unnecessary in Native Heddle because a capture is already source
+history. The text below is retained as historical decision context.
 
 Heddle's everyday workflow vocabulary is `commit`, `ready`, `land`, `push`/`sync`, with top-level `resolve`, `continue`, and `abort` for recovery. `capture` remains a public advanced granular savepoint, and `checkpoint` remains a public Git-facing milestone primitive for agent and advanced workflows; neither is legacy. The old `ship` landing verb and bridge-oriented breadcrumbs should be retired while Heddle is alpha so the command surface reflects the intended model instead of carrying alias and compatibility complexity.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Default `heddle help` / `heddle --help` now follows `source_authority`: native and no-repo first screens teach `init → capture` and hide `commit`; Git Overlay still shows `init → capture → commit → push`.
- Post-capture tip `in Git Overlay, run heddle commit` is overlay-only. Native capture no longer prints it.
- After a native capture, `heddle commit` still exits 65 and names the overlay boundary, but `Next:` is `heddle status` instead of the stale capture line.
- `heddle capture --help` usage marks `-m <INTENT>` required. Omitting it still refuses with the existing intent error (exit 74).
- ADR 0043 is superseded by ADR 0046 / shipped capture-as-save.

Done-criteria are the exact #1435 field-study commands and exits.

Refs HeddleCo/heddle#1392 for the first-screen / post-capture tip slice only. Schema regen stays on that card.

## Closes

Closes HeddleCo/heddle#1435

## Red commit
`a7d850b148474764cbfe9462885f0f3699d57d3d`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- --nocapture field_study_1435_native_help_capture_commit_exits
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test oss_cli_polish::field_study_1435_native_help_capture_commit_exits ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.17s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture native_capture_does_not_tip_overlay_commit
test oss_cli_polish::native_capture_does_not_tip_overlay_commit ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.08s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture overlay_help_teaches_commit_after_capture
test oss_cli_polish::overlay_help_teaches_commit_after_capture ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.07s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture global_flags_only_renders_curated_help_not_clap_error
test oss_cli_polish::global_flags_only_renders_curated_help_not_clap_error ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.02s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture capture_help_marks_intent_required_on_the_usage_line
test cli_help_consistency::capture_help_marks_intent_required_on_the_usage_line ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture git_overlay_matrix_isolated
test git_overlay_matrix::git_overlay_matrix_isolated_checkout_uses_native_capture_with_parent_git_identity ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 940 filtered out; finished in 0.29s

$ cargo test -p heddle-cli-contract --lib first_screen -- --nocapture
running 2 tests
test cli::help::tests::first_screen_shows_overlay_commit_for_git_overlay ... ok
test cli::help::tests::first_screen_hides_overlay_commit_by_default ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 130 filtered out; finished in 0.01s

$ cargo test -p heddle-cli --test comprehensive test_empty_commit_message -- --nocapture
test error_paths::test_empty_commit_message ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 0.10s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03d46fde-50c6-47ab-bc33-37f28c752ad6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03d46fde-50c6-47ab-bc33-37f28c752ad6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1440"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789771283&installation_model_id=21489&pr_number=1440&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1440&signature=dc4d9d49bef40cace5a2d5c5b28920fed9aba3450308831e6820e8a8573e6608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->