### PR TITLE
Land the current native thread without --thread

### DIFF
--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -13,7 +13,6 @@ use heddle_core::{
     ThreadRefreshOptions, ThreadRefreshPlan, format_refresh_conflict_markers,
     plan_cleanup_thread_drop, plan_thread_drop, plan_thread_promote, plan_thread_refresh,
     promote_confirm_in_place_removal, should_materialize_refresh_conflict_markers,
-    status::next_action::canonical_git_repair_ref_preview_command,
 };
 use objects::{
     fs_ops::remove_path_recursively,
@@ -991,18 +990,15 @@ pub(crate) fn thread_not_found_advice(thread_id: &str, action: &str) -> Recovery
 }
 
 fn imported_git_ref_not_managed_thread_advice(thread_id: &str) -> RecoveryAdvice {
-    let reconcile_preview = canonical_git_repair_ref_preview_command(None, thread_id);
     RecoveryAdvice::safety_refusal(
         "imported_git_ref_not_managed_thread",
         format!("'{thread_id}' is an imported Git ref, not a managed Heddle thread"),
-        format!(
-            "Preview Git/Heddle reconciliation with `{reconcile_preview}`. Use managed threads for `ready` and `land`."
-        ),
+        "Inspect managed threads with `heddle thread list`, then `ready`/`land` a managed thread.",
         format!("thread ref '{thread_id}' exists, but no managed thread metadata exists for it"),
         "ready/land require managed thread metadata and explicit integration authority; treating an imported Git ref as landable would be ambiguous",
-        "thread refs, Git refs, checkout files, and thread metadata were left unchanged",
-        reconcile_preview.clone(),
-        vec![reconcile_preview, "heddle thread list".to_string()],
+        "thread refs, checkout files, and thread metadata were left unchanged",
+        "heddle thread list",
+        vec!["heddle thread list".to_string()],
     )
 }
 
@@ -2279,6 +2275,22 @@ mod cleanup_tests {
         assert_eq!(
             resolved, state.state_id,
             "fallback must resolve thread-record short current_state values"
+        );
+    }
+
+    #[test]
+    fn unmanaged_thread_advice_stays_on_native_verbs() {
+        let advice = imported_git_ref_not_managed_thread_advice("main");
+        assert_eq!(advice.kind, "imported_git_ref_not_managed_thread");
+        assert_eq!(advice.primary_command, "heddle thread list");
+        assert!(
+            !advice.primary_command.contains("repair git")
+                && !advice.hint.contains("repair git")
+                && advice
+                    .recovery_commands
+                    .iter()
+                    .all(|command| !command.contains("repair git")),
+            "unmanaged-thread recovery must stay on native verbs: {advice:?}"
         );
     }
 }

--- a/crates/cli/src/cli/commands/thread_shaping.rs
+++ b/crates/cli/src/cli/commands/thread_shaping.rs
@@ -580,23 +580,17 @@ fn map_thread_shaping_error(err: ThreadShapingError) -> anyhow::Error {
             ))
         }
         ThreadShapingError::ImportedGitRefNotManaged { thread_id } => {
-            let reconcile_preview =
-                heddle_core::status::next_action::canonical_git_repair_ref_preview_command(
-                    None, &thread_id,
-                );
             anyhow!(RecoveryAdvice::safety_refusal(
                 "imported_git_ref_not_managed_thread",
                 format!("'{thread_id}' is an imported Git ref, not a managed Heddle thread"),
-                format!(
-                    "Preview Git/Heddle reconciliation with `{reconcile_preview}`. Use managed threads for `ready` and `land`."
-                ),
+                "Inspect managed threads with `heddle thread list`, then `ready`/`land` a managed thread.",
                 format!(
                     "thread ref '{thread_id}' exists, but no managed thread metadata exists for it"
                 ),
                 "ready/land require managed thread metadata and explicit integration authority; treating an imported Git ref as landable would be ambiguous",
-                "thread refs, Git refs, checkout files, and thread metadata were left unchanged",
-                reconcile_preview.clone(),
-                vec![reconcile_preview, "heddle thread list".to_string()],
+                "thread refs, checkout files, and thread metadata were left unchanged",
+                "heddle thread list",
+                vec!["heddle thread list".to_string()],
             ))
         }
     }
@@ -824,6 +818,20 @@ mod tests {
             advice.primary_hint().contains("heddle thread show"),
             "hint should name the inspection command: {}",
             advice.primary_hint()
+        );
+
+        let unmanaged = map_thread_shaping_error(ThreadShapingError::ImportedGitRefNotManaged {
+            thread_id: "main".to_string(),
+        });
+        let advice = unmanaged
+            .downcast_ref::<RecoveryAdvice>()
+            .expect("mapped error should carry RecoveryAdvice");
+        assert_eq!(advice.kind, "imported_git_ref_not_managed_thread");
+        assert_eq!(advice.primary_command, "heddle thread list");
+        assert!(
+            !advice.primary_command.contains("repair git")
+                && !advice.primary_hint().contains("repair git"),
+            "unmanaged-thread recovery must stay on native verbs: {advice}"
         );
     }
 }

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -415,12 +415,7 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
     });
     recover_incomplete_land_if_present(&repo)?;
     let user_config = UserConfig::load_default().unwrap_or_default();
-    let thread = resolve_thread(
-        &repo,
-        args.thread.as_deref(),
-        "land",
-        "heddle land --thread <name>",
-    )?;
+    let thread = resolve_land_subject_thread(cli, &repo, args.thread.as_deref())?;
     let thread_repo = if thread.execution_path.as_os_str().is_empty() {
         None
     } else if thread.execution_path.exists() {
@@ -494,6 +489,12 @@ pub async fn cmd_land(cli: &Cli, args: LandArgs) -> Result<()> {
         "heddle land --thread <name>",
     )?;
     refresh_thread_freshness(&repo, &mut refreshed_thread)?;
+    {
+        let already_preview = build_thread_preview_report(&repo, &mut refreshed_thread, true)?;
+        if already_preview.merge_relation == "already_integrated" {
+            return write_already_landed_output(cli, &repo, &refreshed_thread, captured, synced);
+        }
+    }
     if refreshed_thread.freshness == repo::ThreadFreshness::Stale {
         let preview = build_thread_preview_report(&repo, &mut refreshed_thread, true)?;
         let stale_blockers = non_staleness_blockers(&preview.blockers);
@@ -1443,6 +1444,82 @@ fn resolve_thread(
     }
 }
 
+/// Resolve the thread `land` integrates.
+///
+/// `--thread` wins. Otherwise the subject is the current thread of the
+/// working checkout, not the integration target. Isolated checkouts share
+/// the target's `.heddle` but have their own execution root; resolving
+/// against the target HEAD would land `main`.
+fn resolve_land_subject_thread(
+    cli: &Cli,
+    target_repo: &Repository,
+    explicit: Option<&str>,
+) -> Result<Thread> {
+    let thread_id = match explicit {
+        Some(thread) => thread.to_string(),
+        None => {
+            let checkout = cli.open_repo()?;
+            current_thread(&checkout)?
+                .ok_or_else(|| {
+                    anyhow!(RecoveryAdvice::no_current_thread(
+                        "land",
+                        Some("--thread"),
+                        "heddle land --thread <name>",
+                    ))
+                })?
+                .id
+        }
+    };
+    load_thread(target_repo, &thread_id)
+}
+
+fn write_already_landed_output(
+    cli: &Cli,
+    repo: &Repository,
+    thread: &Thread,
+    captured: bool,
+    synced: bool,
+) -> Result<()> {
+    let trust = build_repository_verification_state(repo);
+    let next_action = integrated_land_next_action(true, &trust);
+    write_land_output(
+        cli,
+        repo,
+        &LandOutput {
+            operator: OperatorCommandOutput {
+                status: "already_landed".to_string(),
+                action: OperatorAction::Land,
+                message: format!("Thread '{}' is already landed", thread.id),
+                blockers: Vec::new(),
+                warnings: Vec::new(),
+                next_action: next_action.clone(),
+                recommended_action: next_action,
+            },
+            thread: thread.id.clone(),
+            captured,
+            checkpointed: false,
+            git_commit: None,
+            synced,
+            integrated: false,
+            merge_state: None,
+            blocker_details: Vec::new(),
+            siblings_restacked: Vec::new(),
+            siblings_restack_failed: Vec::new(),
+            trust,
+            chosen_path: "already_integrated".to_string(),
+            performed_steps: land_performed_steps(captured, synced, false, false),
+            skipped_steps: {
+                let mut steps = land_skipped_steps(captured, synced, false, false);
+                steps
+                    .retain(|step| !step.starts_with("merge(") && !step.starts_with("checkpoint("));
+                steps.push("merge(already_integrated)".to_string());
+                steps.push("checkpoint(not needed)".to_string());
+                steps
+            },
+        },
+    )
+}
+
 fn update_integration_policy(
     repo: &Repository,
     thread_id: &str,
@@ -2146,7 +2223,7 @@ fn write_land_output(cli: &Cli, repo: &Repository, output: &LandOutput) -> Resul
         )?;
     } else {
         let marker = match output.operator.status.as_str() {
-            "landed" => style::ok_marker(),
+            "landed" | "already_landed" => style::ok_marker(),
             "blocked" => style::warn_marker(),
             _ => style::working_marker(),
         };
@@ -2937,10 +3014,9 @@ fn emit_land_dry_run(cli: &Cli, args: &LandArgs) -> Result<()> {
         }
     }
     if thread_ids.is_empty() {
-        // Fall back to the current thread, matching a bare `heddle land`.
-        if let Some(current) = current_thread(&repo)?.map(|thread| thread.id) {
-            thread_ids.push(current);
-        }
+        // Fall back to the current checkout thread, matching a bare `heddle land`.
+        // Do not read the target repo HEAD — that lands `main` from an isolated checkout.
+        thread_ids.push(resolve_land_subject_thread(cli, &repo, None)?.id);
     }
 
     let squash = should_squash_land(args, &UserConfig::load_default().unwrap_or_default());
@@ -2957,6 +3033,10 @@ fn emit_land_dry_run(cli: &Cli, args: &LandArgs) -> Result<()> {
             format!("land {} threads ({target_label})", thread_ids.len())
         },
     );
+    if repo.source_authority() == repo::RepositorySourceAuthority::Native {
+        dry.side_effects.writes_git_refs = false;
+        dry.side_effects.network_io = false;
+    }
 
     if thread_ids.is_empty() {
         dry.blockers
@@ -3002,7 +3082,11 @@ fn emit_land_dry_run(cli: &Cli, args: &LandArgs) -> Result<()> {
             conflict_count: report.conflict_count,
             conflicts: report.conflicts.clone(),
             changed_path_count: report.changed_path_count,
-            would_transition_to: Some("landed".to_string()),
+            would_transition_to: Some(if report.merge_relation == "already_integrated" {
+                "already_landed".to_string()
+            } else {
+                "landed".to_string()
+            }),
             would_capture_dirty: would_capture,
         });
         for blocker in &report.blockers {

--- a/crates/cli/tests/cli_integration.rs
+++ b/crates/cli/tests/cli_integration.rs
@@ -318,6 +318,8 @@ mod identity_resolution;
 mod ignore_mechanics;
 #[path = "cli_integration/interactive_selection.rs"]
 mod interactive_selection;
+#[path = "cli_integration/land_current_thread.rs"]
+mod land_current_thread;
 #[path = "cli_integration/misc.rs"]
 mod misc;
 #[path = "cli_integration/native_scope_boundary.rs"]

--- a/crates/cli/tests/cli_integration/land_current_thread.rs
+++ b/crates/cli/tests/cli_integration/land_current_thread.rs
@@ -146,7 +146,7 @@ fn field_study_ready_then_double_land_thread_is_already_landed() {
     );
     assert_no_repair_git(&ready, "ready");
 
-    let first = run_land_thread(&main.path(), &checkout);
+    let first = run_land_thread(main.path(), &checkout);
     assert_eq!(
         first.status.code(),
         Some(0),
@@ -164,7 +164,7 @@ fn field_study_ready_then_double_land_thread_is_already_landed() {
         "find it\n"
     );
 
-    let second = run_land_thread(&main.path(), &checkout);
+    let second = run_land_thread(main.path(), &checkout);
     assert_eq!(
         second.status.code(),
         Some(0),

--- a/crates/cli/tests/cli_integration/land_current_thread.rs
+++ b/crates/cli/tests/cli_integration/land_current_thread.rs
@@ -1,8 +1,17 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Bare `land` from an isolated native checkout must land the current
-//! thread, not the target `main` ref (heddle#1436).
+//! Exact field-study repros from HeddleCo/heddle#1436 (comment 2026-08-19).
+//!
+//! Isolated native thread `feature/search` via
+//! `heddle start feature/search --path ../<repo>-search`.
+//! Done-criteria are those commands and exits:
+//! - bare `heddle land` must not exit 74 / treat `main` as an imported Git ref
+//! - bare `heddle land --dry-run` must preview the current thread, not `main`,
+//!   and must not claim Git-ref writes or network I/O
+//! - `heddle ready` then `land --thread feature/search` works; a second run
+//!   is already-landed, not another "automatic integration merge" at exit 0
+//! - Next verbs stay native (`heddle thread list`). No `repair git`.
 
-use std::{fs, path::PathBuf, str};
+use std::{fs, path::Path, path::PathBuf, process::Output, str};
 
 use serde_json::Value;
 use tempfile::TempDir;
@@ -17,13 +26,20 @@ fn sibling_checkout_path(repo: &std::path::Path, suffix: &str) -> PathBuf {
     repo.with_file_name(format!("{repo_name}-{suffix}"))
 }
 
-fn json_value(cwd: &std::path::Path, args: &[&str]) -> Value {
-    let stdout = heddle(args, Some(cwd)).unwrap_or_else(|err| panic!("{}: {err}", args.join(" ")));
-    serde_json::from_str(&stdout)
-        .unwrap_or_else(|err| panic!("JSON from `{}`: {err}\n{stdout}", args.join(" ")))
+fn stdout(output: &Output) -> &str {
+    str::from_utf8(&output.stdout).unwrap_or("")
 }
 
-fn setup_isolated_native_thread(thread: &str, file: &str, contents: &str) -> (TempDir, PathBuf) {
+fn stderr(output: &Output) -> &str {
+    str::from_utf8(&output.stderr).unwrap_or("")
+}
+
+fn combined(output: &Output) -> String {
+    format!("{}\n{}", stdout(output), stderr(output))
+}
+
+/// Native isolated checkout with captured work. Does not run `ready`.
+fn setup_feature_search() -> (TempDir, PathBuf) {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();
     fs::write(temp.path().join("seed.txt"), "seed\n").unwrap();
@@ -32,95 +48,175 @@ fn setup_isolated_native_thread(thread: &str, file: &str, contents: &str) -> (Te
     let checkout = sibling_checkout_path(temp.path(), "search");
     let checkout_arg = checkout.to_str().expect("checkout path utf8");
     heddle(
-        &["start", thread, "--path", checkout_arg],
+        &["start", "feature/search", "--path", checkout_arg],
         Some(temp.path()),
     )
     .unwrap();
-    fs::write(checkout.join(file), contents).unwrap();
+    fs::write(checkout.join("search.txt"), "find it\n").unwrap();
     heddle(&["capture", "-m", "feature work"], Some(&checkout)).unwrap();
-    heddle(&["ready"], Some(&checkout)).unwrap();
     (temp, checkout)
 }
 
+fn assert_no_repair_git(output: &Output, context: &str) {
+    let text = combined(output);
+    assert!(
+        !text.contains("repair git") && !text.contains("fsck repair"),
+        "{context} must not recommend repair git on a native repo:\n{text}"
+    );
+}
+
+/// Field study: from the isolated checkout, `heddle land --dry-run` then
+/// bare `heddle land`. Pre-fix: dry-run previewed `main` and claimed Git
+/// writes; bare land exited 74 with `repair git --ref main`.
 #[test]
-fn bare_land_from_isolated_native_checkout_lands_current_thread() {
-    let (main, checkout) =
-        setup_isolated_native_thread("feature/search", "search.txt", "find it\n");
+fn field_study_bare_land_and_dry_run_use_current_thread() {
+    let (main, checkout) = setup_feature_search();
 
-    let dry = json_value(&checkout, &["--output", "json", "land", "--dry-run"]);
-    assert_eq!(dry["command"], "land", "{dry}");
-    assert!(
-        dry["summary"].as_str().is_some_and(
-            |summary| summary.contains("feature/search") && !summary.contains("'main'")
-        ),
-        "bare land --dry-run must preview the current thread, not main: {dry}"
+    let dry = heddle_output(&["land", "--dry-run"], Some(&checkout))
+        .expect("land --dry-run should spawn");
+    assert_eq!(
+        dry.status.code(),
+        Some(0),
+        "bare land --dry-run must succeed:\n{}",
+        combined(&dry)
     );
-    assert_eq!(dry["integrations"][0]["thread"], "feature/search", "{dry}");
-    assert_eq!(dry["integrations"][0]["target"], "main", "{dry}");
-    assert_eq!(dry["side_effects"]["writes_git_refs"], false, "{dry}");
-    assert_eq!(dry["side_effects"]["network_io"], false, "{dry}");
+    let dry_text = combined(&dry);
     assert!(
-        dry["blockers"]
-            .as_array()
-            .is_none_or(|blockers| blockers.is_empty()),
-        "current-thread dry-run should not invent a missing-main blocker: {dry}"
+        dry_text.contains("feature/search"),
+        "dry-run must preview the current thread:\n{dry_text}"
     );
+    assert!(
+        !dry_text.contains("land thread 'main'") && !dry_text.contains("thread 'main' not found"),
+        "dry-run must not preview main as the land subject:\n{dry_text}"
+    );
+    assert!(
+        !dry_text.contains("writes Git refs") && !dry_text.contains("network I/O"),
+        "native dry-run must not claim Git-ref writes or network I/O:\n{dry_text}"
+    );
+    assert_no_repair_git(&dry, "land --dry-run");
 
-    let landed = json_value(&checkout, &["--output", "json", "land"]);
-    assert_eq!(landed["status"], "landed", "{landed}");
-    assert_eq!(landed["thread"], "feature/search", "{landed}");
-    assert_eq!(landed["integrated"], true, "{landed}");
+    let land = heddle_output(&["land"], Some(&checkout)).expect("heddle land should spawn");
+    assert_ne!(
+        land.status.code(),
+        Some(74),
+        "bare land must not exit 74 treating main as an imported Git ref:\n{}",
+        combined(&land)
+    );
+    assert_eq!(
+        land.status.code(),
+        Some(0),
+        "bare land from the isolated checkout must land the current thread:\n{}",
+        combined(&land)
+    );
+    let land_text = combined(&land);
+    assert!(
+        land_text.contains("feature/search"),
+        "bare land must name the current thread:\n{land_text}"
+    );
+    assert!(
+        !land_text.contains("imported Git ref"),
+        "bare land must not treat main as an imported Git ref:\n{land_text}"
+    );
+    assert_no_repair_git(&land, "bare land");
+    assert_eq!(
+        fs::read_to_string(main.path().join("search.txt")).unwrap(),
+        "find it\n",
+        "bare land must integrate the current thread into the target"
+    );
+}
+
+/// Field study: `heddle ready` prints `heddle --repo … land --thread
+/// feature/search`. That command works. A second run must be already-landed,
+/// not another successful "automatic integration merge" at exit 0.
+#[test]
+fn field_study_ready_then_double_land_thread_is_already_landed() {
+    let (main, checkout) = setup_feature_search();
+
+    let ready = heddle_output(&["ready"], Some(&checkout)).expect("ready should spawn");
+    assert_eq!(
+        ready.status.code(),
+        Some(0),
+        "ready must succeed:\n{}",
+        combined(&ready)
+    );
+    let ready_text = combined(&ready);
+    assert!(
+        ready_text.contains("land --thread feature/search"),
+        "ready must recommend land --thread feature/search:\n{ready_text}"
+    );
+    assert_no_repair_git(&ready, "ready");
+
+    let first = run_land_thread(&main.path(), &checkout);
+    assert_eq!(
+        first.status.code(),
+        Some(0),
+        "land --thread feature/search must succeed after ready:\n{}",
+        combined(&first)
+    );
+    assert!(
+        combined(&first).contains("feature/search"),
+        "first land --thread must name the thread:\n{}",
+        combined(&first)
+    );
+    assert_no_repair_git(&first, "first land --thread");
     assert_eq!(
         fs::read_to_string(main.path().join("search.txt")).unwrap(),
         "find it\n"
     );
 
-    let replay = json_value(&checkout, &["--output", "json", "land"]);
-    assert_eq!(replay["status"], "already_landed", "{replay}");
-    assert_eq!(replay["thread"], "feature/search", "{replay}");
-    assert_eq!(replay["integrated"], false, "{replay}");
-    assert_eq!(replay["chosen_path"], "already_integrated", "{replay}");
-    assert!(
-        replay["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("already landed")),
-        "second land must name already-landed, not a second merge: {replay}"
-    );
-    assert!(
-        !replay["message"]
-            .as_str()
-            .is_some_and(|message| message.contains("automatic integration merge")),
-        "second land must not claim a new automatic merge: {replay}"
-    );
-    let next = replay["next_action"].as_str().unwrap_or("");
-    assert!(
-        !next.contains("repair git") && !next.contains("fsck"),
-        "already-landed next action must stay native: {replay}"
-    );
-
-    let replay_dry = json_value(&checkout, &["--output", "json", "land", "--dry-run"]);
+    let second = run_land_thread(&main.path(), &checkout);
     assert_eq!(
-        replay_dry["integrations"][0]["would_transition_to"], "already_landed",
-        "{replay_dry}"
+        second.status.code(),
+        Some(0),
+        "second land --thread must stay a clean exit 0:\n{}",
+        combined(&second)
     );
+    let second_text = combined(&second);
+    assert!(
+        second_text.contains("already landed"),
+        "second land --thread must be already-landed, not a second merge:\n{second_text}"
+    );
+    assert!(
+        !second_text.contains("automatic integration merge"),
+        "second land --thread must not claim another automatic integration merge:\n{second_text}"
+    );
+    assert_no_repair_git(&second, "second land --thread");
 }
 
+fn run_land_thread(main: &Path, checkout: &Path) -> Output {
+    // Field study ran the ready breadcrumb: `heddle --repo … land --thread feature/search`.
+    heddle_output(
+        &[
+            "--repo",
+            main.to_str().expect("main path utf8"),
+            "land",
+            "--thread",
+            "feature/search",
+        ],
+        Some(checkout),
+    )
+    .expect("land --thread feature/search should spawn")
+}
+
+/// Same comment: exit 74 / `repair git --ref main` is the wrong recovery
+/// when authority is native. Explicit `--thread main` must stay on
+/// `heddle thread list`.
 #[test]
 fn land_unmanaged_main_on_native_recommends_thread_list() {
-    let (_main, checkout) =
-        setup_isolated_native_thread("feature/search", "search.txt", "find it\n");
+    let (_main, checkout) = setup_feature_search();
 
     let output = heddle_output(
         &["--output", "json", "land", "--thread", "main"],
         Some(&checkout),
     )
     .expect("land --thread main should spawn");
-    assert_ne!(
+    assert_eq!(
         output.status.code(),
-        Some(0),
-        "landing unmanaged main must fail closed"
+        Some(74),
+        "unmanaged main still fails closed (field-study exit 74), but recovery must change:\n{}",
+        combined(&output)
     );
-    let stderr = str::from_utf8(&output.stderr).unwrap_or("");
+    let stderr = stderr(&output);
     let envelope: Value = serde_json::from_str(
         stderr
             .lines()
@@ -131,11 +227,5 @@ fn land_unmanaged_main_on_native_recommends_thread_list() {
     .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
     assert_eq!(envelope["kind"], "imported_git_ref_not_managed_thread");
     assert_eq!(envelope["primary_command"], "heddle thread list");
-    assert!(
-        !stderr.contains("repair git")
-            && !envelope["primary_command"]
-                .as_str()
-                .is_some_and(|command| command.contains("repair git")),
-        "native authority must not recommend repair git: {envelope}"
-    );
+    assert_no_repair_git(&output, "land --thread main");
 }

--- a/crates/cli/tests/cli_integration/land_current_thread.rs
+++ b/crates/cli/tests/cli_integration/land_current_thread.rs
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Bare `land` from an isolated native checkout must land the current
+//! thread, not the target `main` ref (heddle#1436).
+
+use std::{fs, path::PathBuf, str};
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{heddle, heddle_output};
+
+fn sibling_checkout_path(repo: &std::path::Path, suffix: &str) -> PathBuf {
+    let repo_name = repo
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("repo");
+    repo.with_file_name(format!("{repo_name}-{suffix}"))
+}
+
+fn json_value(cwd: &std::path::Path, args: &[&str]) -> Value {
+    let stdout = heddle(args, Some(cwd)).unwrap_or_else(|err| panic!("{}: {err}", args.join(" ")));
+    serde_json::from_str(&stdout)
+        .unwrap_or_else(|err| panic!("JSON from `{}`: {err}\n{stdout}", args.join(" ")))
+}
+
+fn setup_isolated_native_thread(thread: &str, file: &str, contents: &str) -> (TempDir, PathBuf) {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    fs::write(temp.path().join("seed.txt"), "seed\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).unwrap();
+
+    let checkout = sibling_checkout_path(temp.path(), "search");
+    let checkout_arg = checkout.to_str().expect("checkout path utf8");
+    heddle(
+        &["start", thread, "--path", checkout_arg],
+        Some(temp.path()),
+    )
+    .unwrap();
+    fs::write(checkout.join(file), contents).unwrap();
+    heddle(&["capture", "-m", "feature work"], Some(&checkout)).unwrap();
+    heddle(&["ready"], Some(&checkout)).unwrap();
+    (temp, checkout)
+}
+
+#[test]
+fn bare_land_from_isolated_native_checkout_lands_current_thread() {
+    let (main, checkout) =
+        setup_isolated_native_thread("feature/search", "search.txt", "find it\n");
+
+    let dry = json_value(&checkout, &["--output", "json", "land", "--dry-run"]);
+    assert_eq!(dry["command"], "land", "{dry}");
+    assert!(
+        dry["summary"].as_str().is_some_and(
+            |summary| summary.contains("feature/search") && !summary.contains("'main'")
+        ),
+        "bare land --dry-run must preview the current thread, not main: {dry}"
+    );
+    assert_eq!(dry["integrations"][0]["thread"], "feature/search", "{dry}");
+    assert_eq!(dry["integrations"][0]["target"], "main", "{dry}");
+    assert_eq!(dry["side_effects"]["writes_git_refs"], false, "{dry}");
+    assert_eq!(dry["side_effects"]["network_io"], false, "{dry}");
+    assert!(
+        dry["blockers"]
+            .as_array()
+            .is_none_or(|blockers| blockers.is_empty()),
+        "current-thread dry-run should not invent a missing-main blocker: {dry}"
+    );
+
+    let landed = json_value(&checkout, &["--output", "json", "land"]);
+    assert_eq!(landed["status"], "landed", "{landed}");
+    assert_eq!(landed["thread"], "feature/search", "{landed}");
+    assert_eq!(landed["integrated"], true, "{landed}");
+    assert_eq!(
+        fs::read_to_string(main.path().join("search.txt")).unwrap(),
+        "find it\n"
+    );
+
+    let replay = json_value(&checkout, &["--output", "json", "land"]);
+    assert_eq!(replay["status"], "already_landed", "{replay}");
+    assert_eq!(replay["thread"], "feature/search", "{replay}");
+    assert_eq!(replay["integrated"], false, "{replay}");
+    assert_eq!(replay["chosen_path"], "already_integrated", "{replay}");
+    assert!(
+        replay["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("already landed")),
+        "second land must name already-landed, not a second merge: {replay}"
+    );
+    assert!(
+        !replay["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("automatic integration merge")),
+        "second land must not claim a new automatic merge: {replay}"
+    );
+    let next = replay["next_action"].as_str().unwrap_or("");
+    assert!(
+        !next.contains("repair git") && !next.contains("fsck"),
+        "already-landed next action must stay native: {replay}"
+    );
+
+    let replay_dry = json_value(&checkout, &["--output", "json", "land", "--dry-run"]);
+    assert_eq!(
+        replay_dry["integrations"][0]["would_transition_to"], "already_landed",
+        "{replay_dry}"
+    );
+}
+
+#[test]
+fn land_unmanaged_main_on_native_recommends_thread_list() {
+    let (_main, checkout) =
+        setup_isolated_native_thread("feature/search", "search.txt", "find it\n");
+
+    let output = heddle_output(
+        &["--output", "json", "land", "--thread", "main"],
+        Some(&checkout),
+    )
+    .expect("land --thread main should spawn");
+    assert_ne!(
+        output.status.code(),
+        Some(0),
+        "landing unmanaged main must fail closed"
+    );
+    let stderr = str::from_utf8(&output.stderr).unwrap_or("");
+    let envelope: Value = serde_json::from_str(
+        stderr
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .unwrap_or(stderr.trim()),
+    )
+    .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
+    assert_eq!(envelope["kind"], "imported_git_ref_not_managed_thread");
+    assert_eq!(envelope["primary_command"], "heddle thread list");
+    assert!(
+        !stderr.contains("repair git")
+            && !envelope["primary_command"]
+                .as_str()
+                .is_some_and(|command| command.contains("repair git")),
+        "native authority must not recommend repair git: {envelope}"
+    );
+}

--- a/crates/core/src/workflow.rs
+++ b/crates/core/src/workflow.rs
@@ -295,6 +295,7 @@ pub fn land_text_step(step: &str) -> String {
         "capture(no changes)" => "no unsaved changes".to_string(),
         "sync(current)" => "already refreshed".to_string(),
         "merge(blocked)" => "merge blocked".to_string(),
+        "merge(already_integrated)" => "already landed".to_string(),
         "checkpoint(not needed)" => "no Git commit needed".to_string(),
         "checkpoint(not reached)" => "Git commit skipped because merge did not run".to_string(),
         other => other.to_string(),
@@ -839,6 +840,10 @@ mod tests {
     fn land_text_scope_and_manual_review() {
         assert_eq!(land_text_step("capture"), "saved");
         assert_eq!(land_text_step("merge(blocked)"), "merge blocked");
+        assert_eq!(
+            land_text_step("merge(already_integrated)"),
+            "already landed"
+        );
         assert_eq!(
             land_text_step("checkpoint(not reached)"),
             "Git commit skipped because merge did not run"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bare `heddle land` / `land --dry-run` from an isolated native checkout now lands (or previews) the current thread into its target, not `main` as an imported Git ref.
- A second `land --thread feature/search` after a successful ready/land is an explicit `already_landed` no-op, not another successful merge at exit 0.
- Unmanaged-thread recovery stays on native verbs (`heddle thread list`). No `repair git` on this path.

## Closes

Closes HeddleCo/heddle#1436

## Red commit

Field study on 0.12.0 from main (2026-08-19), issue comment: isolated native checkout `feature/search`, bare `heddle land` exited 74 with `'main' is an imported Git ref` / `Next: maintenance fsck repair git --ref main`. Tests follow those exact commands and exits.

## Test evidence

```
$ cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4m 23s

$ cargo test -p heddle-cli --test cli_integration land_current -- --nocapture
   Compiling heddle-cli v0.12.0 (/workspace/crates/cli)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.33s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 3 tests
test land_current_thread::land_unmanaged_main_on_native_recommends_thread_list ... ok
test land_current_thread::field_study_bare_land_and_dry_run_use_current_thread ... ok
test land_current_thread::field_study_ready_then_double_land_thread_is_already_landed ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 937 filtered out; finished in 0.32s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-afc13f09-b16c-4990-b994-2594dd22e44a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-afc13f09-b16c-4990-b994-2594dd22e44a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789771472&installation_model_id=21489&pr_number=1442&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1442&signature=c1d947f5e756595082cbd58e1b58f8eeefa833ee30af726292a71283b8032d4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->