### PR TITLE
Path-shaped diff, restore story, and visible start checkouts

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -724,8 +724,9 @@ Examples:
   heddle start scratch --path ../scratch            # place the checkout explicitly
   heddle start fix-flake --path ../fix-flake --task 'fix CI flake'
 
-`--path` is required for the default `auto` workspace. Without it, start
+`--path` is required when workspace is omitted or `auto`. Without it, start
 refuses instead of hiding a checkout under `.heddle/threads/<name>/`.
+`--workspace auto` is the same default and still requires `--path`.
 Pass `--path ../<name>`, or an explicit `--workspace solid|materialized|virtualized`
 if you want the managed layout. To stay on this checkout, use
 `heddle thread create <name>` then `heddle thread switch <name>`.
@@ -750,8 +751,8 @@ pub struct ThreadStartArgs {
     #[arg(long)]
     pub path: Option<std::path::PathBuf>,
 
-    /// Workspace mode for the thread. Omitted means `auto`, and then `--path`
-    /// is required so the checkout is not hidden under `.heddle/threads/`.
+    /// Workspace mode for the thread. Omitted or `auto` requires `--path`
+    /// so the checkout is not hidden under `.heddle/threads/`.
     #[arg(long, value_enum)]
     pub workspace: Option<WorkspaceModeArg>,
 

--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -525,15 +525,39 @@ pub struct RetroArgs {
 /// Arguments for the `diff` command.
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
+Examples:
+  heddle diff                     # worktree vs HEAD
+  heddle diff NOTES.md            # only that path
+  heddle diff -- NOTES.md         # same, after the path separator
+  heddle diff --path NOTES.md     # same, explicit path filter
+  heddle diff HEAD~1 HEAD -- src  # two states, filtered to src/
+
+Path-shaped positionals and arguments after `--` are worktree/path filters,
+not missing states. `log --path` uses the same filter spelling.
+
+Restore:
+  Heddle does not restore one file from a saved state (no restore/checkout/reset).
+  Materialize one state in a new checkout: heddle start <name> --from <state> --path <dir>
+  Apply the inverse of one state to this worktree: heddle revert <state> [--no-commit]
+  Restore the tree preserved by the last undo: heddle undo --recover
+
 Patch compatibility:
   --patch output uses Git-compatible unified diff, including extended headers for type and mode changes.
 ")]
 pub struct DiffArgs {
-    /// Base state (default: HEAD).
+    /// Base state (default: HEAD). A path-shaped value is a worktree filter.
     pub from: Option<String>,
 
-    /// Target state (default: worktree).
+    /// Target state (default: worktree). A path-shaped value is a worktree filter.
     pub to: Option<String>,
+
+    /// Restrict the diff to these repository-relative paths.
+    #[arg(long = "path", value_name = "PATH")]
+    pub path_filters: Vec<String>,
+
+    /// Paths after `--`. Always treated as worktree/path filters.
+    #[arg(last = true, value_name = "PATH")]
+    pub paths: Vec<String>,
 
     /// Show semantic changes.
     #[arg(long)]
@@ -562,6 +586,14 @@ pub struct DiffArgs {
 
 /// Arguments for the `revert` command.
 #[derive(Clone, Debug, clap::Args)]
+#[command(after_help = "\
+Restore:
+  `revert` applies the inverse of one state's changes. It is not a single-file
+  restore, and Heddle has no restore/checkout/reset verb.
+  Materialize one state in a new checkout: heddle start <name> --from <state> --path <dir>
+  Restore the tree preserved by the last undo: heddle undo --recover
+  Heddle cannot put one file back from a saved state.
+")]
 pub struct RevertArgs {
     /// State to revert.
     pub state: String,
@@ -570,7 +602,7 @@ pub struct RevertArgs {
     #[arg(short = 'm', long)]
     pub message: Option<String>,
 
-    /// Apply changes to worktree without committing.
+    /// Apply the inverse to the worktree without capturing a new state.
     #[arg(long)]
     pub no_commit: bool,
 }
@@ -580,11 +612,19 @@ pub struct RevertArgs {
 #[command(after_help = "\
 Examples:
   heddle undo --preview      # inspect the most recent operation
+  heddle undo --hard --preview  # preview the worktree rewind --hard would apply
   heddle undo --hard         # roll it back and rewind the worktree
   heddle undo -n 3 --hard    # roll back the last three operations
   heddle undo --recover      # restore the state preserved by the last undo
   heddle undo --list         # preview undoable operations on this thread
   heddle undo --dry-run      # show what would change without applying
+
+Restore:
+  `--recover` restores only the last undo's preserved tree as worktree changes.
+  Heddle does not restore one arbitrary file or an arbitrary saved state
+  (no restore/checkout/reset). Materialize a state with
+  `heddle start <name> --from <state> --path <dir>`, or invert one with
+  `heddle revert <state>`.
 
 Undoable operations:
   - heddle capture           (restores HEAD to the pre-capture parent)
@@ -633,7 +673,7 @@ pub struct UndoArgs {
     /// Permit undo to rewind worktree files to the selected operation's prior
     /// state. Without this explicit opt-in, an undo that would rewrite the
     /// worktree refuses before changing repository state or files.
-    #[arg(long, conflicts_with_all = ["list", "preview", "redo", "recover"])]
+    #[arg(long, conflicts_with_all = ["list", "redo", "recover"])]
     pub hard: bool,
 
     /// Re-apply operations that a prior `undo` rewound.
@@ -682,7 +722,13 @@ pub enum WorkspaceModeArg {
 Examples:
   heddle start feature/auth --path ../feature-auth  # create an isolated checkout
   heddle start scratch --path ../scratch            # place the checkout explicitly
-  heddle start fix-flake --task 'fix CI flake'      # attach a task description
+  heddle start fix-flake --path ../fix-flake --task 'fix CI flake'
+
+`--path` is required for the default `auto` workspace. Without it, start
+refuses instead of hiding a checkout under `.heddle/threads/<name>/`.
+Pass `--path ../<name>`, or an explicit `--workspace solid|materialized|virtualized`
+if you want the managed layout. To stay on this checkout, use
+`heddle thread create <name>` then `heddle thread switch <name>`.
 
 Isolated checkouts are Heddle-managed working directories. They do not contain a .git directory; use Heddle commands inside them, and run Git-authority operations through Heddle from the parent Git-overlay repository.
 
@@ -699,13 +745,15 @@ pub struct ThreadStartArgs {
     #[arg(long)]
     pub from: Option<String>,
 
-    /// Filesystem path for the isolated checkout.
+    /// Filesystem path for the isolated checkout. Required so the checkout
+    /// is not hidden under `.heddle/threads/`.
     #[arg(long)]
     pub path: Option<std::path::PathBuf>,
 
-    /// Workspace mode for the thread.
-    #[arg(long, value_enum, default_value_t = WorkspaceModeArg::Auto)]
-    pub workspace: WorkspaceModeArg,
+    /// Workspace mode for the thread. Omitted means `auto`, and then `--path`
+    /// is required so the checkout is not hidden under `.heddle/threads/`.
+    #[arg(long, value_enum)]
+    pub workspace: Option<WorkspaceModeArg>,
 
     /// AI provider name for the registered agent thread.
     #[arg(long, hide = true)]

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -767,7 +767,7 @@ identically. The mode only controls bytes-on-disk semantics.\n\
 \n\
 - Use `heddle start <name> --path <dir>` when you want an isolated\n\
   checkout. It creates the thread ref and materializes the checkout in\n\
-  one step. `--path` is required for the default workspace; without it\n\
+  one step. `--path` is required when workspace is omitted or `auto`; without it\n\
   start refuses instead of hiding a checkout under `.heddle/threads/<name>/`.\n\
 - To stay on this checkout, use `heddle thread create <name>` then\n\
   `heddle thread switch <name>`.\n\

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -674,6 +674,13 @@ Existing Git checkout:
 
 If a command refuses, read the first `Next:` line. Heddle fails closed when it
 cannot prove the move is safe.
+
+Restore:
+
+Heddle does not restore one file from a saved state (no restore/checkout/reset).
+Materialize one state in a new checkout with `heddle start <name> --from <state>
+--path <dir>`. Invert one state onto this worktree with `heddle revert <state>`.
+Restore the tree preserved by the last undo with `heddle undo --recover`.
 "#;
 
 const GIT_CONCEPTS_TOPIC: &str = r#"Git and Heddle own different layers.
@@ -760,7 +767,10 @@ identically. The mode only controls bytes-on-disk semantics.\n\
 \n\
 - Use `heddle start <name> --path <dir>` when you want an isolated\n\
   checkout. It creates the thread ref and materializes the checkout in\n\
-  one step.\n\
+  one step. `--path` is required for the default workspace; without it\n\
+  start refuses instead of hiding a checkout under `.heddle/threads/<name>/`.\n\
+- To stay on this checkout, use `heddle thread create <name>` then\n\
+  `heddle thread switch <name>`.\n\
 - Advanced split form: `heddle thread create <name>` creates only the\n\
   ref, and `heddle thread promote <name> --path <dir>` materializes it\n\
   later. Use this only when you intentionally need to create the ref\n\

--- a/crates/cli/src/cli/commands/agent_cmd.rs
+++ b/crates/cli/src/cli/commands/agent_cmd.rs
@@ -725,7 +725,7 @@ fn cmd_agent_fanout_start(cli: &Cli, args: AgentFanoutStartArgs) -> Result<()> {
                     name: lane.thread.clone(),
                     from: Some(base_state.clone()),
                     path: Some(lane.path.clone()),
-                    workspace: WorkspaceModeArg::Auto,
+                    workspace: Some(WorkspaceModeArg::Auto),
                     agent_provider: None,
                     agent_model: None,
                     task: Some(lane.title.clone()),

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //! CLI adapter for the core diff facade.
 
+use std::path::Path;
+
 use anyhow::{Result, anyhow};
 use heddle_core::{
     DiffOptions, DiffReport, PlainGitDiffProbe, diff as core_diff, diff_worktree_status,
     plain_git_head_diff,
 };
 use objects::worktree::WorktreeStatus;
-use repo::{Config, Repository, RepositoryCapability};
+use repo::{Config, Repository, RepositoryCapability, discover_heddle_root};
 
 use super::{
     super::verification_health::{
@@ -40,10 +42,10 @@ pub fn cmd_diff(
 ) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
-    let repo = Repository::open(start).ok();
+    let opened = open_repo_for_classification(start)?;
     let mut extra_paths = path_filters;
     extra_paths.extend(trailing_paths);
-    let classified = classify_diff_refs(start, repo.as_ref(), from, to, extra_paths);
+    let classified = classify_diff_refs(start, opened.as_ref(), from, to, extra_paths);
     let from = classified.from;
     let to = classified.to;
     let paths = classified.paths;
@@ -52,7 +54,8 @@ pub fn cmd_diff(
         .map(|spec| matches!(spec, "HEAD" | "@"))
         .unwrap_or(true);
 
-    if to.is_none()
+    if opened.is_none()
+        && to.is_none()
         && from_is_head_or_default
         && let Some(probe) = build_plain_git_verification_probe(start)?
     {
@@ -81,7 +84,10 @@ pub fn cmd_diff(
         return render_diff_report(cli, None, &report, stat, name_only, show_context, patch);
     }
 
-    let repo = Repository::open(start)?;
+    let repo = match opened {
+        Some(repo) => repo,
+        None => Repository::open(start)?,
+    };
     let trust = (repo.capability() == RepositoryCapability::GitOverlay)
         .then(|| build_repository_verification_state(&repo));
     let json = should_output_json(cli, Some(repo.config()));
@@ -218,6 +224,16 @@ fn render_diff_report(
         }
     }
     Ok(())
+}
+
+/// Open an existing Heddle store for `diff` classification. Missing stores
+/// stay missing so plain Git can still be probed; any other open error
+/// is returned instead of being dropped.
+fn open_repo_for_classification(start: &Path) -> Result<Option<Repository>> {
+    if discover_heddle_root(start).is_none() {
+        return Ok(None);
+    }
+    Ok(Some(Repository::open(start)?))
 }
 
 fn clone_worktree_status(status: &WorktreeStatus) -> WorktreeStatus {

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -17,6 +17,7 @@ use super::{
     diff_output::{
         print_context, print_diff, print_diff_patch, print_semantic_changes, print_stat,
     },
+    diff_paths::classify_diff_refs,
 };
 use crate::{
     cli::{Cli, should_output_json},
@@ -28,6 +29,8 @@ pub fn cmd_diff(
     cli: &Cli,
     from: Option<String>,
     to: Option<String>,
+    path_filters: Vec<String>,
+    trailing_paths: Vec<String>,
     semantic: bool,
     stat: bool,
     name_only: bool,
@@ -37,6 +40,13 @@ pub fn cmd_diff(
 ) -> Result<()> {
     let cwd = std::env::current_dir()?;
     let start = cli.repo.as_ref().unwrap_or(&cwd);
+    let repo = Repository::open(start).ok();
+    let mut extra_paths = path_filters;
+    extra_paths.extend(trailing_paths);
+    let classified = classify_diff_refs(start, repo.as_ref(), from, to, extra_paths);
+    let from = classified.from;
+    let to = classified.to;
+    let paths = classified.paths;
     let from_is_head_or_default = from
         .as_deref()
         .map(|spec| matches!(spec, "HEAD" | "@"))
@@ -52,6 +62,7 @@ pub fn cmd_diff(
         let options = diff_options(
             from,
             to,
+            paths,
             semantic,
             stat,
             name_only,
@@ -77,6 +88,7 @@ pub fn cmd_diff(
     let options = diff_options(
         from.clone(),
         to.clone(),
+        paths,
         semantic,
         stat,
         name_only,
@@ -155,6 +167,7 @@ pub fn cmd_diff(
 fn diff_options(
     from: Option<String>,
     to: Option<String>,
+    paths: Vec<String>,
     semantic: bool,
     stat: bool,
     name_only: bool,
@@ -172,6 +185,7 @@ fn diff_options(
         unified,
         show_context,
         include_patch_text: patch || json,
+        paths,
     }
 }
 

--- a/crates/cli/src/cli/commands/diff/diff_paths.rs
+++ b/crates/cli/src/cli/commands/diff/diff_paths.rs
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Classify `diff` positionals as states vs worktree/path filters.
+
+use std::path::Path;
+
+use repo::Repository;
+
+/// Resolved `diff` refs after path-shaped positionals are peeled off.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ClassifiedDiffRefs {
+    pub from: Option<String>,
+    pub to: Option<String>,
+    pub paths: Vec<String>,
+}
+
+/// Split `from`/`to` into states and path filters.
+///
+/// A spec that resolves as a state stays a state. Otherwise a path-shaped
+/// value (separator, extension, or a path that exists under `root`) becomes
+/// a worktree filter instead of a missing state. Arguments collected after
+/// `--` and `--path` are always filters.
+pub fn classify_diff_refs(
+    root: &Path,
+    repo: Option<&Repository>,
+    from: Option<String>,
+    to: Option<String>,
+    extra_paths: Vec<String>,
+) -> ClassifiedDiffRefs {
+    let mut paths = extra_paths;
+    let from = classify_spec(root, repo, from, &mut paths);
+    let to = classify_spec(root, repo, to, &mut paths);
+    ClassifiedDiffRefs { from, to, paths }
+}
+
+fn classify_spec(
+    root: &Path,
+    repo: Option<&Repository>,
+    spec: Option<String>,
+    paths: &mut Vec<String>,
+) -> Option<String> {
+    let spec = spec?;
+    if spec_is_state(repo, &spec) {
+        return Some(spec);
+    }
+    if spec_is_path_filter(root, &spec) {
+        paths.push(spec);
+        return None;
+    }
+    Some(spec)
+}
+
+fn spec_is_state(repo: Option<&Repository>, spec: &str) -> bool {
+    is_head_spec(spec) || repo.is_some_and(|repo| repo.resolve_state(spec).ok().flatten().is_some())
+}
+
+fn is_head_spec(spec: &str) -> bool {
+    spec == "HEAD"
+        || spec == "@"
+        || spec
+            .strip_prefix("HEAD~")
+            .or_else(|| spec.strip_prefix("@~"))
+            .is_some_and(|rest| !rest.is_empty() && rest.chars().all(|ch| ch.is_ascii_digit()))
+}
+
+fn spec_is_path_filter(root: &Path, spec: &str) -> bool {
+    looks_path_shaped(spec) || root.join(spec).exists()
+}
+
+fn looks_path_shaped(spec: &str) -> bool {
+    spec.contains('/') || spec.contains('\\') || Path::new(spec).extension().is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn path_shaped_positional_becomes_filter() {
+        let root = TempDir::new().unwrap();
+        fs::write(root.path().join("NOTES.md"), "dirty\n").unwrap();
+        let classified = classify_diff_refs(
+            root.path(),
+            None,
+            Some("NOTES.md".to_string()),
+            None,
+            Vec::new(),
+        );
+        assert_eq!(classified.from, None);
+        assert_eq!(classified.to, None);
+        assert_eq!(classified.paths, ["NOTES.md"]);
+    }
+
+    #[test]
+    fn separator_paths_stay_filters() {
+        let root = TempDir::new().unwrap();
+        let classified =
+            classify_diff_refs(root.path(), None, None, None, vec!["NOTES.md".to_string()]);
+        assert_eq!(classified.paths, ["NOTES.md"]);
+        assert_eq!(classified.from, None);
+    }
+
+    #[test]
+    fn head_specs_stay_states() {
+        let root = TempDir::new().unwrap();
+        let classified = classify_diff_refs(
+            root.path(),
+            None,
+            Some("HEAD~1".to_string()),
+            Some("HEAD".to_string()),
+            Vec::new(),
+        );
+        assert_eq!(classified.from.as_deref(), Some("HEAD~1"));
+        assert_eq!(classified.to.as_deref(), Some("HEAD"));
+        assert!(classified.paths.is_empty());
+    }
+
+    #[test]
+    fn existing_directory_without_separator_is_a_filter() {
+        let root = TempDir::new().unwrap();
+        fs::create_dir(root.path().join("src")).unwrap();
+        let classified =
+            classify_diff_refs(root.path(), None, Some("src".to_string()), None, Vec::new());
+        assert_eq!(classified.from, None);
+        assert_eq!(classified.paths, ["src"]);
+    }
+}

--- a/crates/cli/src/cli/commands/diff/diff_paths.rs
+++ b/crates/cli/src/cli/commands/diff/diff_paths.rs
@@ -15,10 +15,11 @@ pub struct ClassifiedDiffRefs {
 
 /// Split `from`/`to` into states and path filters.
 ///
-/// A spec that resolves as a state stays a state. Otherwise a path-shaped
-/// value (separator, extension, or a path that exists under `root`) becomes
-/// a worktree filter instead of a missing state. Arguments collected after
-/// `--` and `--path` are always filters.
+/// A spec that resolves as a state stays a state. An unresolved version-like
+/// tag (`v1.2.0`) stays a state so later resolution fails closed instead of
+/// becoming a silent empty filter. Otherwise a path-shaped value (separator
+/// or a path that exists under `root`) becomes a worktree filter. Arguments
+/// collected after `--` and `--path` are always filters.
 pub fn classify_diff_refs(
     root: &Path,
     repo: Option<&Repository>,
@@ -63,11 +64,38 @@ fn is_head_spec(spec: &str) -> bool {
 }
 
 fn spec_is_path_filter(root: &Path, spec: &str) -> bool {
+    if looks_like_version_tag(spec) {
+        return false;
+    }
     looks_path_shaped(spec) || root.join(spec).exists()
 }
 
 fn looks_path_shaped(spec: &str) -> bool {
-    spec.contains('/') || spec.contains('\\') || Path::new(spec).extension().is_some()
+    spec.contains('/') || spec.contains('\\')
+}
+
+/// Dotted numeric tags such as `v1.2.0` / `1.2.0`. These must not become
+/// path filters via a file-extension heuristic when they do not resolve.
+fn looks_like_version_tag(spec: &str) -> bool {
+    if spec.contains('/') || spec.contains('\\') {
+        return false;
+    }
+    let rest = spec.strip_prefix('v').unwrap_or(spec);
+    let mut parts = rest.split('.');
+    let Some(first) = parts.next() else {
+        return false;
+    };
+    if first.is_empty() || !first.chars().all(|ch| ch.is_ascii_digit()) {
+        return false;
+    }
+    let mut rest_count = 0usize;
+    for part in parts {
+        if part.is_empty() || !part.chars().all(|ch| ch.is_ascii_digit()) {
+            return false;
+        }
+        rest_count += 1;
+    }
+    rest_count >= 1
 }
 
 #[cfg(test)]
@@ -124,5 +152,33 @@ mod tests {
             classify_diff_refs(root.path(), None, Some("src".to_string()), None, Vec::new());
         assert_eq!(classified.from, None);
         assert_eq!(classified.paths, ["src"]);
+    }
+
+    #[test]
+    fn unresolved_version_tag_stays_state_spec() {
+        let root = TempDir::new().unwrap();
+        let classified = classify_diff_refs(
+            root.path(),
+            None,
+            Some("v1.2.0".to_string()),
+            None,
+            Vec::new(),
+        );
+        assert_eq!(classified.from.as_deref(), Some("v1.2.0"));
+        assert!(classified.paths.is_empty());
+    }
+
+    #[test]
+    fn missing_file_with_extension_is_not_a_silent_filter() {
+        let root = TempDir::new().unwrap();
+        let classified = classify_diff_refs(
+            root.path(),
+            None,
+            Some("NOTES.md".to_string()),
+            None,
+            Vec::new(),
+        );
+        assert_eq!(classified.from.as_deref(), Some("NOTES.md"));
+        assert!(classified.paths.is_empty());
     }
 }

--- a/crates/cli/src/cli/commands/diff/mod.rs
+++ b/crates/cli/src/cli/commands/diff/mod.rs
@@ -3,5 +3,6 @@
 
 mod diff_compute;
 mod diff_output;
+mod diff_paths;
 
 pub use diff_compute::cmd_diff;

--- a/crates/cli/src/cli/commands/start_atomic.rs
+++ b/crates/cli/src/cli/commands/start_atomic.rs
@@ -1402,7 +1402,7 @@ mod tests {
             name: name.to_string(),
             from: Some(from.to_string()),
             path: Some(path.to_path_buf()),
-            workspace: WorkspaceModeArg::Solid,
+            workspace: Some(WorkspaceModeArg::Solid),
             agent_provider: None,
             agent_model: None,
             task: None,
@@ -1425,7 +1425,7 @@ mod tests {
         hydrate: bool,
     ) -> ThreadStartArgs {
         let mut args = solid_args(name, path, from, hydrate);
-        args.workspace = WorkspaceModeArg::Materialized;
+        args.workspace = Some(WorkspaceModeArg::Materialized);
         args
     }
 

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -182,7 +182,7 @@ pub fn cmd_start(cli: &Cli, args: ThreadStartArgs) -> Result<()> {
     // Pure option preflight (name + path isolation flags) before materialization.
     let start_plan = plan_thread_start(&thread_start_options_from_args(&args))
         .map_err(|ThreadPlanError::InvalidName(err)| anyhow!(thread_name_invalid_advice(&err)))?;
-    if args.path.is_none() && args.workspace.is_none() {
+    if start_would_hide_checkout(&args) {
         return Err(anyhow!(start_requires_explicit_path_advice(&args.name)));
     }
     if start_plan.requires_clean_worktree {
@@ -1599,6 +1599,12 @@ fn resolve_auto_workspace_default(
 
 fn requested_workspace(args: &ThreadStartArgs) -> WorkspaceModeArg {
     args.workspace.unwrap_or(WorkspaceModeArg::Auto)
+}
+
+/// Omitted workspace and `--workspace auto` are the same default: without
+/// `--path` they hide the checkout under `.heddle/threads/`.
+fn start_would_hide_checkout(args: &ThreadStartArgs) -> bool {
+    args.path.is_none() && matches!(requested_workspace(args), WorkspaceModeArg::Auto)
 }
 
 fn workspace_mode_request_from_arg(arg: WorkspaceModeArg) -> WorkspaceModeRequest {

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -182,6 +182,9 @@ pub fn cmd_start(cli: &Cli, args: ThreadStartArgs) -> Result<()> {
     // Pure option preflight (name + path isolation flags) before materialization.
     let start_plan = plan_thread_start(&thread_start_options_from_args(&args))
         .map_err(|ThreadPlanError::InvalidName(err)| anyhow!(thread_name_invalid_advice(&err)))?;
+    if args.path.is_none() && args.workspace.is_none() {
+        return Err(anyhow!(start_requires_explicit_path_advice(&args.name)));
+    }
     if start_plan.requires_clean_worktree {
         ensure_worktree_clean(&repo, "start thread")?;
     }
@@ -928,6 +931,19 @@ pub(crate) fn thread_name_invalid_advice(err: &ThreadIdError) -> RecoveryAdvice 
     )
 }
 
+/// Refuse a user-facing `start` that would hide the checkout under `.heddle/threads/`.
+pub(crate) fn start_requires_explicit_path_advice(name: &str) -> RecoveryAdvice {
+    let primary = format!("heddle start {name} --path ../{name}");
+    RecoveryAdvice::invalid_usage(
+        "start_requires_path",
+        "start without --path would hide the checkout under .heddle/threads/",
+        format!(
+            "Pass an explicit checkout directory: `{primary}`. To stay on this checkout, use `heddle thread create {name}` then `heddle thread switch {name}`."
+        ),
+        primary,
+    )
+}
+
 pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<ThreadOpOutput> {
     // The single user/external creation boundary for every thread start
     // (`heddle start`, `heddle thread start`, `try`, `attempt`, workflow). Reject
@@ -1010,7 +1026,7 @@ pub(crate) fn start_thread(repo: &Repository, args: ThreadStartArgs) -> Result<T
     // to stderr so JSON consumers on stdout are unaffected.
     // Pure warn decision lives in heddle-core; CLI still owns the message.
     if should_warn_materialized_without_reflink(
-        args.workspace == WorkspaceModeArg::Materialized,
+        args.workspace == Some(WorkspaceModeArg::Materialized),
         objects::fs_clone::filesystem_supports_reflink(repo.root()),
     ) {
         eprintln!(
@@ -1540,12 +1556,12 @@ fn resolve_thread_mode(repo: &Repository, args: &ThreadStartArgs) -> ThreadMode 
     let auto_default = resolve_auto_workspace_default(repo, args);
     let supports_reflink = objects::fs_clone::filesystem_supports_reflink(repo.root());
     let mode = plan_thread_mode(
-        workspace_mode_request_from_arg(args.workspace),
+        workspace_mode_request_from_arg(requested_workspace(args)),
         args.path.is_some(),
         auto_default,
         supports_reflink,
     );
-    if matches!(args.workspace, WorkspaceModeArg::Auto)
+    if matches!(requested_workspace(args), WorkspaceModeArg::Auto)
         && mode == ThreadMode::Solid
         && !supports_reflink
     {
@@ -1581,6 +1597,10 @@ fn resolve_auto_workspace_default(
     }
 }
 
+fn requested_workspace(args: &ThreadStartArgs) -> WorkspaceModeArg {
+    args.workspace.unwrap_or(WorkspaceModeArg::Auto)
+}
+
 fn workspace_mode_request_from_arg(arg: WorkspaceModeArg) -> WorkspaceModeRequest {
     match arg {
         WorkspaceModeArg::Auto => WorkspaceModeRequest::Auto,
@@ -1595,7 +1615,7 @@ fn thread_start_options_from_args(args: &ThreadStartArgs) -> ThreadStartOptions 
         name: args.name.clone(),
         from: args.from.clone(),
         path: args.path.clone(),
-        workspace: workspace_mode_request_from_arg(args.workspace),
+        workspace: workspace_mode_request_from_arg(requested_workspace(args)),
         parent_thread: args.parent_thread.clone(),
         automated: args.automated,
         task: args.task.clone(),

--- a/crates/cli/src/cli/commands/try_cmd.rs
+++ b/crates/cli/src/cli/commands/try_cmd.rs
@@ -177,7 +177,7 @@ pub fn cmd_try(cli: &Cli, args: TryArgs) -> Result<()> {
         name: thread_name.clone(),
         from: None,
         path: None,
-        workspace,
+        workspace: Some(workspace),
         agent_provider: None,
         agent_model: None,
         task: Some(format!("try: {}", display_cmd(&args.command))),

--- a/crates/cli/src/exit.rs
+++ b/crates/cli/src/exit.rs
@@ -116,6 +116,7 @@ impl HeddleExitCode {
             "nothing_to_capture"
             | "commit_requires_git_overlay"
             | "commit_capture_required"
+            | "start_requires_path"
             | "git_repair_requires_adoption"
             | "git_repair_requires_import"
             | "dirty_worktree"
@@ -496,6 +497,7 @@ mod tests {
             ("hosted_tls_trust", HeddleExitCode::Config),
             ("try_global_option_after_separator", HeddleExitCode::Usage),
             ("nothing_to_capture", HeddleExitCode::DataErr),
+            ("start_requires_path", HeddleExitCode::DataErr),
             ("dirty_worktree", HeddleExitCode::DataErr),
             ("state_corrupted", HeddleExitCode::DataErr),
             ("state_not_found", HeddleExitCode::DataErr),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -531,6 +531,8 @@ async fn async_main() -> Result<()> {
         Commands::Diff(DiffArgs {
             from,
             to,
+            path_filters,
+            paths,
             semantic,
             stat,
             name_only,
@@ -541,6 +543,8 @@ async fn async_main() -> Result<()> {
             &cli,
             from.clone(),
             to.clone(),
+            path_filters.clone(),
+            paths.clone(),
             *semantic,
             *stat,
             *name_only,

--- a/crates/cli/tests/cli_integration/basics.rs
+++ b/crates/cli/tests/cli_integration/basics.rs
@@ -1947,7 +1947,7 @@ fn test_cli_start_bootstraps_current_state_in_plain_git_repo() {
                 "start",
                 "feature/overlay-thread",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(temp.path()),
         )

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -272,8 +272,9 @@ fn restore_story_is_documented_and_start_requires_path() {
     assert!(
         start.contains("`--path` is required")
             && start.contains(".heddle/threads/")
+            && start.contains("`--workspace auto`")
             && start.contains("heddle thread create"),
-        "start help must say --path is required so the checkout is not hidden: {start}"
+        "start help must say --path is required for omitted and auto workspace: {start}"
     );
 
     let model = heddle_help(&["help", "model"]);

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -242,6 +242,48 @@ fn diff_help_explains_git_compatible_patch_headers() {
     );
 }
 
+#[test]
+fn restore_story_is_documented_and_start_requires_path() {
+    let diff = heddle_help(&["diff", "--help"]);
+    assert!(
+        diff.contains("Heddle does not restore one file")
+            && diff.contains("heddle undo --recover")
+            && diff.contains("heddle revert"),
+        "diff help must document the restore story: {diff}"
+    );
+
+    let revert = heddle_help(&["revert", "--help"]);
+    assert!(
+        revert.contains("no restore/checkout/reset")
+            && revert.contains("heddle start")
+            && revert.contains("heddle undo --recover"),
+        "revert help must say single-file restore is unavailable: {revert}"
+    );
+
+    let undo = heddle_help(&["undo", "--help"]);
+    assert!(
+        undo.contains("heddle undo --hard --preview")
+            && undo.contains("last undo")
+            && undo.contains("no restore/checkout/reset"),
+        "undo help must document --hard --preview and the restore limit: {undo}"
+    );
+
+    let start = heddle_help(&["start", "--help"]);
+    assert!(
+        start.contains("`--path` is required")
+            && start.contains(".heddle/threads/")
+            && start.contains("heddle thread create"),
+        "start help must say --path is required so the checkout is not hidden: {start}"
+    );
+
+    let model = heddle_help(&["help", "model"]);
+    assert!(
+        model.contains("Heddle does not restore one file")
+            && model.contains("heddle undo --recover"),
+        "help model must document the restore story: {model}"
+    );
+}
+
 /// Commit help must explain the capture-to-Git authority boundary.
 #[test]
 fn commit_help_explains_capture_boundary() {

--- a/crates/cli/tests/cli_integration/cli_premium_output.rs
+++ b/crates/cli/tests/cli_integration/cli_premium_output.rs
@@ -70,7 +70,7 @@ fn merged_thread_list_reads_integrated_not_actionable() {
                 "start",
                 "feature/polish",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(temp.path()),
         )

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -3392,8 +3392,17 @@ fn dirty_git_repo_after_init_can_save_without_adoption() {
     assert_eq!(commit["verification"]["status"], "clean");
     assert_eq!(commit["recommended_action"], Value::Null);
 
+    let checkout = sibling_checkout_path(temp.path(), "improvements");
+    let checkout_str = checkout.to_str().expect("utf-8 path");
     let start = heddle_output(
-        &["--output", "json", "start", "feat/improvements"],
+        &[
+            "--output",
+            "json",
+            "start",
+            "feat/improvements",
+            "--path",
+            checkout_str,
+        ],
         Some(temp.path()),
     )
     .expect("start should run");
@@ -7553,8 +7562,17 @@ fn start_emits_cd_hint_in_text_mode() {
     )
     .unwrap();
 
+    let checkout = sibling_checkout_path(temp.path(), "scratch-thread");
+    let checkout_str = checkout.to_str().expect("utf-8 path");
     let output = heddle(
-        &["--output", "text", "start", "scratch-thread"],
+        &[
+            "--output",
+            "text",
+            "start",
+            "scratch-thread",
+            "--path",
+            checkout_str,
+        ],
         Some(temp.path()),
     )
     .expect("start scratch-thread");
@@ -7696,8 +7714,16 @@ fn start_print_cd_path_returns_only_the_path() {
     )
     .unwrap();
 
+    let checkout = sibling_checkout_path(temp.path(), "scratch-cd");
+    let checkout_str = checkout.to_str().expect("utf-8 path");
     let output = heddle_output(
-        &["start", "scratch-cd", "--print-cd-path"],
+        &[
+            "start",
+            "scratch-cd",
+            "--path",
+            checkout_str,
+            "--print-cd-path",
+        ],
         Some(temp.path()),
     )
     .expect("start --print-cd-path");

--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -242,7 +242,17 @@ fn thread_operator_envelopes_emit_approved_thread_kinds() {
 #[test]
 fn thread_promote_and_cleanup_emit_approved_thread_kinds() {
     let temp = init_and_capture();
-    heddle(&["start", "promo"], Some(temp.path())).expect("start promo thread");
+    let promo = temp.path().join("promo-checkout");
+    heddle(
+        &[
+            "start",
+            "promo",
+            "--path",
+            promo.to_str().expect("utf-8 promo path"),
+        ],
+        Some(temp.path()),
+    )
+    .expect("start promo thread");
 
     let promote = heddle_json(&["thread", "promote", "promo"], &temp);
     assert_output_kind(&promote, "thread_promote");

--- a/crates/cli/tests/cli_integration/realworld_git.rs
+++ b/crates/cli/tests/cli_integration/realworld_git.rs
@@ -855,7 +855,7 @@ fn marketing_moments_walkthrough_against_real_fixture() {
                 "start",
                 slug,
                 "--workspace",
-                "auto",
+                "solid",
                 "--task",
                 task,
                 "--agent-provider",

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -3386,7 +3386,7 @@ fn test_cli_push_defaults_to_current_attached_thread() {
                 "start",
                 "feature/push-default",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(source.path()),
         )
@@ -3659,7 +3659,7 @@ fn native_push_named_mismatched_thread_refuses_without_force() {
     // tip differs from main's.
     let started: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "start", "feat-x", "--workspace", "auto"],
+            &["--output", "json", "start", "feat-x", "--workspace", "solid"],
             Some(source.path()),
         )
         .unwrap(),
@@ -3794,7 +3794,7 @@ fn native_push_explicit_state_overrides_named_thread_tip() {
 
     let started: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "start", "feat-x", "--workspace", "auto"],
+            &["--output", "json", "start", "feat-x", "--workspace", "solid"],
             Some(source.path()),
         )
         .unwrap(),
@@ -3842,7 +3842,7 @@ fn native_push_all_threads_fans_out_every_thread() {
 
     let started: Value = serde_json::from_str(
         &heddle(
-            &["--output", "json", "start", "feat-x", "--workspace", "auto"],
+            &["--output", "json", "start", "feat-x", "--workspace", "solid"],
             Some(source.path()),
         )
         .unwrap(),

--- a/crates/cli/tests/comprehensive/integration.rs
+++ b/crates/cli/tests/comprehensive/integration.rs
@@ -18,7 +18,7 @@ fn test_full_workflow_basic() {
                 "start",
                 "feature",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(temp.path()),
         )

--- a/crates/cli/tests/core_functionality/diff_and_status.rs
+++ b/crates/cli/tests/core_functionality/diff_and_status.rs
@@ -411,3 +411,50 @@ fn path_shaped_diff_filters_worktree_instead_of_missing_state() {
         "`diff --path` must filter the worktree: {flag}"
     );
 }
+
+#[test]
+fn unresolved_version_tag_is_missing_state_not_empty_filter() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("NOTES.md"), "keep\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    std::fs::write(temp.path().join("NOTES.md"), "dirty notes\n").unwrap();
+
+    let err = heddle(&["diff", "v1.2.0"], Some(temp.path()))
+        .expect_err("unresolved version tag must fail closed");
+    assert!(
+        err.contains("State not found") && err.contains("v1.2.0"),
+        "unresolved tag must be a missing state, not an empty path filter: {err}"
+    );
+}
+
+#[test]
+fn thread_named_feature_search_wins_as_diff_state() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "main\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "main"], temp.path());
+
+    let checkout = temp.path().with_extension("feature-search");
+    let checkout_arg = checkout.to_str().expect("checkout path should be utf8");
+    heddle_must_succeed(
+        &["start", "feature/search", "--path", checkout_arg],
+        temp.path(),
+    );
+    std::fs::write(checkout.join("file.txt"), "thread\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "thread"], &checkout);
+    std::fs::write(temp.path().join("NOTES.md"), "dirty notes\n").unwrap();
+
+    let out = heddle_must_succeed(
+        &["diff", "--name-only", "feature/search", "HEAD"],
+        temp.path(),
+    );
+    assert!(
+        out.contains("file.txt"),
+        "thread name must resolve as a state, not a path filter: {out}"
+    );
+    assert!(
+        !out.contains("NOTES.md"),
+        "thread name must not become a worktree path filter: {out}"
+    );
+}

--- a/crates/cli/tests/core_functionality/diff_and_status.rs
+++ b/crates/cli/tests/core_functionality/diff_and_status.rs
@@ -378,3 +378,36 @@ fn test_native_status_warms_helper_for_second_run() {
         "native helper must report a file changed after it becomes ready: {changed}"
     );
 }
+
+#[test]
+fn path_shaped_diff_filters_worktree_instead_of_missing_state() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("NOTES.md"), "keep\n").unwrap();
+    std::fs::write(temp.path().join("other.txt"), "other\n").unwrap();
+    heddle_must_succeed(&["capture", "-m", "base"], temp.path());
+    std::fs::write(temp.path().join("NOTES.md"), "dirty notes\n").unwrap();
+    std::fs::write(temp.path().join("other.txt"), "dirty other\n").unwrap();
+
+    let positional = heddle_must_succeed(&["diff", "--name-only", "NOTES.md"], temp.path());
+    assert!(
+        positional.contains("NOTES.md"),
+        "positional path must be a worktree filter: {positional}"
+    );
+    assert!(
+        !positional.contains("other.txt"),
+        "positional path must not include other dirty files: {positional}"
+    );
+
+    let separator = heddle_must_succeed(&["diff", "--name-only", "--", "NOTES.md"], temp.path());
+    assert!(
+        separator.contains("NOTES.md") && !separator.contains("other.txt"),
+        "`diff -- PATH` must filter the worktree: {separator}"
+    );
+
+    let flag = heddle_must_succeed(&["diff", "--name-only", "--path", "NOTES.md"], temp.path());
+    assert!(
+        flag.contains("NOTES.md") && !flag.contains("other.txt"),
+        "`diff --path` must filter the worktree: {flag}"
+    );
+}

--- a/crates/cli/tests/core_functionality/refs_and_remotes.rs
+++ b/crates/cli/tests/core_functionality/refs_and_remotes.rs
@@ -171,6 +171,33 @@ fn test_start_creates_named_thread() {
 }
 
 #[test]
+fn test_start_without_path_refuses_hidden_checkout() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "content").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Initial"], temp.path());
+
+    let err = heddle(&["start", "feature/search"], Some(temp.path()))
+        .expect_err("start without --path must refuse");
+    assert!(
+        err.contains("start without --path")
+            && err.contains(".heddle/threads/")
+            && err.contains("heddle start feature/search --path ../feature/search"),
+        "start without --path must name the hidden checkout and recovery: {err}"
+    );
+    assert!(
+        !temp.path().join(".heddle/threads").exists()
+            || temp
+                .path()
+                .join(".heddle/threads")
+                .read_dir()
+                .map(|entries| entries.count() == 0)
+                .unwrap_or(true),
+        "refusing start must not hide a checkout under .heddle/threads"
+    );
+}
+
+#[test]
 fn test_thread_and_marker_listing_survives_ref_summary_maintenance() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());

--- a/crates/cli/tests/core_functionality/refs_and_remotes.rs
+++ b/crates/cli/tests/core_functionality/refs_and_remotes.rs
@@ -198,6 +198,36 @@ fn test_start_without_path_refuses_hidden_checkout() {
 }
 
 #[test]
+fn test_start_workspace_auto_without_path_refuses_hidden_checkout() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("file.txt"), "content").unwrap();
+    heddle_must_succeed(&["capture", "-m", "Initial"], temp.path());
+
+    let err = heddle(
+        &["start", "feature/search", "--workspace", "auto"],
+        Some(temp.path()),
+    )
+    .expect_err("start --workspace auto without --path must refuse");
+    assert!(
+        err.contains("start without --path")
+            && err.contains(".heddle/threads/")
+            && err.contains("heddle start feature/search --path ../feature/search"),
+        "start --workspace auto must name the hidden checkout and recovery: {err}"
+    );
+    assert!(
+        !temp.path().join(".heddle/threads").exists()
+            || temp
+                .path()
+                .join(".heddle/threads")
+                .read_dir()
+                .map(|entries| entries.count() == 0)
+                .unwrap_or(true),
+        "refusing --workspace auto must not hide a checkout under .heddle/threads"
+    );
+}
+
+#[test]
 fn test_thread_and_marker_listing_survives_ref_summary_maintenance() {
     let temp = TempDir::new().unwrap();
     heddle_must_succeed(&["init"], temp.path());

--- a/crates/cli/tests/core_functionality/undo_and_special.rs
+++ b/crates/cli/tests/core_functionality/undo_and_special.rs
@@ -740,6 +740,33 @@ fn test_undo_dry_run_alias_does_not_apply() {
     assert_eq!(head_short(temp.path()), before);
 }
 
+#[test]
+fn test_undo_hard_preview_previews_without_applying() {
+    let temp = TempDir::new().unwrap();
+    heddle_must_succeed(&["init"], temp.path());
+    std::fs::write(temp.path().join("a.txt"), "v1").unwrap();
+    heddle_must_succeed(&["capture", "-m", "first"], temp.path());
+    std::fs::write(temp.path().join("a.txt"), "v2").unwrap();
+    heddle_must_succeed(&["capture", "-m", "second"], temp.path());
+    let before = head_short(temp.path());
+
+    let out = heddle_must_succeed(&["undo", "--hard", "--preview"], temp.path());
+    assert_eq!(
+        head_short(temp.path()),
+        before,
+        "--hard --preview must not move HEAD"
+    );
+    assert!(
+        out.to_lowercase().contains("would undo"),
+        "--hard --preview must preview: {out}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("a.txt")).unwrap(),
+        "v2",
+        "--hard --preview must not rewind the worktree"
+    );
+}
+
 /// When the state that undo would restore to has been removed from the object
 /// store (gc, oplog truncation, etc.), undo must refuse with a clear,
 /// actionable error rather than partially applying or surfacing a raw

--- a/crates/cli/tests/multi_agent_worktrees/actor_presence.rs
+++ b/crates/cli/tests/multi_agent_worktrees/actor_presence.rs
@@ -20,7 +20,7 @@ fn start_registers_thread_with_agent_metadata() {
             "start",
             "feature/spawned",
             "--workspace",
-            "auto",
+            "solid",
             "--agent-provider",
             "anthropic",
             "--agent-model",
@@ -54,12 +54,12 @@ fn thread_list_returns_all_started_threads() {
     let main = setup_repo("base.txt", "base");
 
     heddle(
-        &["start", "feature/list-a", "--workspace", "auto"],
+        &["start", "feature/list-a", "--workspace", "solid"],
         Some(main.path()),
     )
     .unwrap();
     heddle(
-        &["start", "feature/list-b", "--workspace", "auto"],
+        &["start", "feature/list-b", "--workspace", "solid"],
         Some(main.path()),
     )
     .unwrap();
@@ -146,7 +146,7 @@ fn actor_show_defaults_to_current_thread_actor() {
             "start",
             "feature/current-actor",
             "--workspace",
-            "auto",
+            "solid",
             "--agent-provider",
             "anthropic",
             "--agent-model",
@@ -184,7 +184,7 @@ fn actor_explain_reports_attach_reason_for_current_actor() {
             "start",
             "feature/explain-actor",
             "--workspace",
-            "auto",
+            "solid",
             "--agent-provider",
             "anthropic",
             "--agent-model",

--- a/crates/cli/tests/multi_agent_worktrees/e2e.rs
+++ b/crates/cli/tests/multi_agent_worktrees/e2e.rs
@@ -424,7 +424,7 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
             "start",
             "feature/native-cli",
             "--workspace",
-            "auto",
+            "solid",
             "--agent-provider",
             "anthropic",
             "--agent-model",
@@ -436,17 +436,10 @@ fn thread_start_creates_isolated_thread_and_aliases_work() {
     let started: Value = serde_json::from_str(&start_json).unwrap();
     let thread_path = started["execution_path"].as_str().unwrap();
     let thread = std::path::PathBuf::from(thread_path);
-    // Auto-mode resolves to materialized on reflink-capable filesystems
-    // (APFS, btrfs, xfs+reflink) and downgrades to solid on ext4 / HFS+ /
-    // NTFS so the mode label reflects on-disk truth.
-    let expected_mode = if objects::fs_clone::filesystem_supports_reflink(main.path()) {
-        "materialized"
-    } else {
-        "solid"
-    };
+    // Explicit `--workspace solid` uses the managed layout without hiding
+    // behind the Auto default that now requires `--path`.
+    let expected_mode = "solid";
     assert_eq!(started["thread"]["thread_mode"], expected_mode);
-    // Auto-mode threads materialize at a Heddle-managed path, surfaced
-    // both as the user-visible `path` and the work-site `execution_path`.
     assert_eq!(started["path"], started["execution_path"]);
 
     assert!(
@@ -594,7 +587,7 @@ fn ready_blocks_stale_or_heavy_impact_threads_and_status_reports_next_step() {
             "start",
             "feature/dep",
             "--workspace",
-            "auto",
+            "solid",
             "--task",
             "update dependencies",
         ],
@@ -690,7 +683,7 @@ fn genuine_blocked_thread_surfaces_coordination_axis_in_long_status() {
                 "start",
                 "feature/dep",
                 "--workspace",
-                "auto",
+                "solid",
                 "--task",
                 "update dependencies",
             ],
@@ -759,7 +752,7 @@ fn sync_refreshes_stale_thread_when_replay_is_clean() {
                 "start",
                 "feature/sync-me",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -809,7 +802,7 @@ fn land_auto_captures_and_merges_clean_thread() {
                 "start",
                 "feature/land-it",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -875,7 +868,7 @@ fn land_from_isolated_checkout_integrates_ready_fast_forward() {
                 "start",
                 "feature/land-from-thread",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -938,7 +931,7 @@ fn ready_and_land_name_low_confidence_without_sync_loop() {
                 "start",
                 "feature/low-confidence",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1049,7 +1042,7 @@ fn delegate_assigns_per_task_agents_when_spec_includes_them() {
                 "start",
                 "feature/race",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1160,7 +1153,7 @@ fn delegate_creates_child_threads_with_parent_relationship() {
                 "start",
                 "feature/orchestrator",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1236,7 +1229,7 @@ fn undo_is_scoped_to_the_current_thread() {
                 "start",
                 "feature/auth",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1251,7 +1244,7 @@ fn undo_is_scoped_to_the_current_thread() {
                 "start",
                 "feature/search",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1346,7 +1339,7 @@ fn thread_and_workspace_json_match_dirty_current_checkout() {
             "start",
             "feature/dirty-json",
             "--workspace",
-            "auto",
+            "solid",
         ],
         Some(main.path()),
     )
@@ -1387,7 +1380,7 @@ fn lightweight_thread_capture_marks_heavy_impact_and_ready_blocks_it() {
             "start",
             "feature/deps",
             "--workspace",
-            "auto",
+            "solid",
             "--task",
             "update dependencies",
         ],
@@ -1457,7 +1450,7 @@ fn thread_promote_materializes_visible_checkout_without_changing_thread_identity
             "start",
             "feature/promote",
             "--workspace",
-            "auto",
+            "solid",
             "--task",
             "prepare visible thread",
         ],
@@ -1549,7 +1542,7 @@ fn status_watch_bounded_runs_are_transcript_friendly() {
 fn thread_show_watch_emits_initial_snapshot_for_local_repos() {
     let main = setup_repo("base.txt", "base");
     heddle(
-        &["start", "feature/watch-thread", "--workspace", "auto"],
+        &["start", "feature/watch-thread", "--workspace", "solid"],
         Some(main.path()),
     )
     .unwrap();
@@ -1585,7 +1578,7 @@ fn thread_list_shows_current_stacked_and_parallel_threads() {
                 "start",
                 "feature/orchestrator",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1599,6 +1592,8 @@ fn thread_list_shows_current_stacked_and_parallel_threads() {
             "json",
             "start",
             "feature/orchestrator/parser",
+            "--workspace",
+            "solid",
             "--parent-thread",
             "feature/orchestrator",
             "--task",
@@ -1608,7 +1603,7 @@ fn thread_list_shows_current_stacked_and_parallel_threads() {
     )
     .unwrap();
     heddle(
-        &["start", "feature/search", "--workspace", "auto"],
+        &["start", "feature/search", "--workspace", "solid"],
         Some(main.path()),
     )
     .unwrap();
@@ -1637,7 +1632,7 @@ fn capture_split_moves_selected_dirty_paths_into_target_thread() {
                 "start",
                 "feature/source",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1652,7 +1647,7 @@ fn capture_split_moves_selected_dirty_paths_into_target_thread() {
                 "start",
                 "feature/target",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1701,7 +1696,7 @@ fn thread_move_reassigns_selected_captured_paths_between_threads() {
                 "start",
                 "feature/source",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1716,7 +1711,7 @@ fn thread_move_reassigns_selected_captured_paths_between_threads() {
                 "start",
                 "feature/target",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1763,7 +1758,7 @@ fn thread_absorb_merges_child_thread_into_parent_workspace() {
                 "start",
                 "feature/orchestrator",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1822,7 +1817,7 @@ fn thread_resolve_refreshes_clean_stale_threads() {
                 "start",
                 "feature/stale",
                 "--workspace",
-                "auto",
+                "solid",
             ],
             Some(main.path()),
         )
@@ -1898,7 +1893,7 @@ fn log_never_surfaces_unknown_principal_after_init() {
     .unwrap();
 
     heddle(
-        &["start", "feature/parent", "--workspace", "auto"],
+        &["start", "feature/parent", "--workspace", "solid"],
         Some(temp.path()),
     )
     .unwrap();

--- a/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
+++ b/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
@@ -54,6 +54,35 @@ fn top_level_start_without_path_refuses_hidden_checkout() {
 }
 
 #[test]
+fn top_level_start_workspace_auto_without_path_refuses_hidden_checkout() {
+    let main = setup_repo("hello.txt", "world");
+
+    let err = heddle(
+        &[
+            "--output",
+            "json",
+            "start",
+            "feature/search",
+            "--workspace",
+            "auto",
+        ],
+        Some(main.path()),
+    )
+    .expect_err("start --workspace auto without --path must refuse a hidden checkout");
+    assert!(
+        err.contains("start without --path")
+            && err.contains(".heddle/threads/")
+            && err.contains("heddle start feature/search --path ../feature/search"),
+        "start --workspace auto must name the hidden checkout and the --path recovery: {err}"
+    );
+    assert!(
+        !main.path().join(".heddle/threads").join("feature").exists()
+            && !main.path().join(".heddle/threads").join("search").exists(),
+        "refusing --workspace auto must not create a hidden checkout"
+    );
+}
+
+#[test]
 fn materialized_start_honors_from_state() {
     let main = setup_repo("v.txt", "v1");
 
@@ -86,7 +115,7 @@ fn thread_promote_preserves_thread_identity() {
     let thread_dir = TempDir::new().unwrap();
 
     heddle(
-        &["start", "feature/promote-me", "--workspace", "auto"],
+        &["start", "feature/promote-me", "--workspace", "solid"],
         Some(main.path()),
     )
     .unwrap();

--- a/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
+++ b/crates/cli/tests/multi_agent_worktrees/worktree_add.rs
@@ -27,31 +27,29 @@ fn materialized_start_writes_base_state_files() {
 }
 
 #[test]
-fn top_level_start_defaults_to_lightweight_in_auto_mode() {
+fn top_level_start_without_path_refuses_hidden_checkout() {
     let main = setup_repo("hello.txt", "world");
 
-    let output = heddle(
+    let err = heddle(
         &["--output", "json", "start", "feature/default-visible"],
         Some(main.path()),
     )
-    .unwrap();
-    let started: Value = serde_json::from_str(&output).unwrap();
-
-    // Top-level `start` with no `--path` resolves to ThreadMode::Materialized
-    // on filesystems that support reflinks (APFS, btrfs, xfs+reflink). On
-    // ext4 / HFS+ / NTFS the auto-mode probe downgrades to `solid` so the
-    // mode label matches what's actually on disk. Both outcomes are correct
-    // — assert the FS-conditional shape.
-    let expected_mode = if objects::fs_clone::filesystem_supports_reflink(main.path()) {
-        "materialized"
-    } else {
-        "solid"
-    };
-    assert_eq!(started["thread"]["thread_mode"], expected_mode);
-    assert_eq!(started["path"], started["execution_path"]);
+    .expect_err("start without --path must refuse a hidden checkout");
     assert!(
-        started["execution_path"].as_str().is_some(),
-        "auto-mode thread still has a managed execution path"
+        err.contains("start without --path")
+            && err.contains(".heddle/threads/")
+            && err
+                .contains("heddle start feature/default-visible --path ../feature/default-visible"),
+        "start without --path must name the hidden checkout and the --path recovery: {err}"
+    );
+    assert!(
+        !main.path().join(".heddle/threads").join("feature").exists()
+            && !main
+                .path()
+                .join(".heddle/threads")
+                .join("default-visible")
+                .exists(),
+        "refusing start must not create a hidden checkout"
     );
 }
 

--- a/crates/core/src/diff/mod.rs
+++ b/crates/core/src/diff/mod.rs
@@ -27,6 +27,7 @@ use sley::{EntryKind, Repository as SleyRepository};
 use crate::ExecutionContext;
 
 mod patch;
+mod path_filter;
 mod types;
 
 pub use patch::{render_diff_patch, render_diff_patch_bytes, write_diff_patch};
@@ -55,6 +56,8 @@ pub struct DiffOptions {
     /// patch-compatible representation is available. CLI callers set this for
     /// `--patch` and for JSON output, preserving the existing machine contract.
     pub include_patch_text: bool,
+    /// Repository-relative path filters. Empty means the full change set.
+    pub paths: Vec<String>,
 }
 
 impl Default for DiffOptions {
@@ -68,6 +71,7 @@ impl Default for DiffOptions {
             unified: 3,
             show_context: false,
             include_patch_text: false,
+            paths: Vec::new(),
         }
     }
 }
@@ -365,6 +369,7 @@ pub fn plain_git_head_diff(probe: &PlainGitDiffProbe, options: &DiffOptions) -> 
 }
 
 fn finalize_diff_report(mut output: DiffReport, options: &DiffOptions) -> Result<DiffReport> {
+    path_filter::apply_path_filters(&mut output, &options.paths)?;
     if options.include_patch_text {
         populate_patch_text(&mut output);
     }

--- a/crates/core/src/diff/path_filter.rs
+++ b/crates/core/src/diff/path_filter.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Path filters for diff reports.
+
+use anyhow::Result;
+use repo::ChangedPathFilters;
+
+use super::types::{DiffReport, DiffStats, FileChange, FileContextEntry, SemanticChangeEntry};
+
+/// Restrict a computed diff report to the given repository-relative paths.
+///
+/// Empty `paths` leaves the report unchanged. Filters match an exact path or
+/// any descendant (`src` matches `src/lib.rs`).
+pub fn apply_path_filters(report: &mut DiffReport, paths: &[String]) -> Result<()> {
+    if paths.is_empty() {
+        return Ok(());
+    }
+    let filters = ChangedPathFilters::try_from_paths(paths)?;
+    report
+        .changes
+        .retain(|change| change_matches(change, &filters));
+    if let Some(semantic) = report.semantic_changes.as_mut() {
+        semantic.retain(|change| semantic_matches(change, &filters));
+        if semantic.is_empty() {
+            report.semantic_changes = None;
+        }
+    }
+    if let Some(context) = report.context.as_mut() {
+        context.retain(|entry| context_matches(entry, &filters));
+        if context.is_empty() {
+            report.context = None;
+        }
+    }
+    report.stats = DiffStats::from_changes(&report.changes, report.semantic_changes.as_deref());
+    report.changed_path_count = report.changes.len();
+    report.patch = None;
+    Ok(())
+}
+
+fn change_matches(change: &FileChange, filters: &ChangedPathFilters) -> bool {
+    filters.matches(&change.path)
+        || change
+            .old_path
+            .as_deref()
+            .is_some_and(|old| filters.matches(old))
+}
+
+fn semantic_matches(change: &SemanticChangeEntry, filters: &ChangedPathFilters) -> bool {
+    change
+        .path
+        .as_deref()
+        .is_some_and(|path| filters.matches(path))
+        || change
+            .from_path
+            .as_deref()
+            .is_some_and(|path| filters.matches(path))
+        || change
+            .to_path
+            .as_deref()
+            .is_some_and(|path| filters.matches(path))
+}
+
+fn context_matches(entry: &FileContextEntry, filters: &ChangedPathFilters) -> bool {
+    filters.matches(&entry.path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::types::FileChange;
+
+    fn report_with(paths: &[&str]) -> DiffReport {
+        let changes = paths
+            .iter()
+            .map(|path| FileChange {
+                path: (*path).to_string(),
+                kind: "modified".to_string(),
+                ..FileChange::default()
+            })
+            .collect();
+        DiffReport::new(Some("HEAD".to_string()), None, changes, None, None, None)
+    }
+
+    #[test]
+    fn empty_filters_leave_report_unchanged() {
+        let mut report = report_with(&["NOTES.md", "src/lib.rs"]);
+        apply_path_filters(&mut report, &[]).expect("empty filters");
+        assert_eq!(report.changed_path_count, 2);
+    }
+
+    #[test]
+    fn exact_path_keeps_only_that_file() {
+        let mut report = report_with(&["NOTES.md", "src/lib.rs"]);
+        apply_path_filters(&mut report, &["NOTES.md".to_string()]).expect("filter");
+        assert_eq!(
+            report
+                .changes
+                .iter()
+                .map(|change| change.path.as_str())
+                .collect::<Vec<_>>(),
+            ["NOTES.md"]
+        );
+        assert_eq!(report.changed_path_count, 1);
+        assert_eq!(report.stats.files_changed, 1);
+    }
+
+    #[test]
+    fn directory_filter_keeps_descendants() {
+        let mut report = report_with(&["src/lib.rs", "NOTES.md", "src/cli.rs"]);
+        apply_path_filters(&mut report, &["src".to_string()]).expect("filter");
+        let kept: Vec<_> = report
+            .changes
+            .iter()
+            .map(|change| change.path.as_str())
+            .collect();
+        assert_eq!(kept, ["src/lib.rs", "src/cli.rs"]);
+    }
+}

--- a/crates/repo/src/repository_history.rs
+++ b/crates/repo/src/repository_history.rs
@@ -76,7 +76,8 @@ impl ChangedPathFilters {
         self.filters.iter().map(|filter| filter.path.as_str())
     }
 
-    fn matches(&self, candidate: &str) -> bool {
+    /// True when `candidate` matches any filter (exact path or descendant).
+    pub fn matches(&self, candidate: &str) -> bool {
         self.filters.iter().any(|filter| filter.matches(candidate))
     }
 

--- a/docs/undo.md
+++ b/docs/undo.md
@@ -11,9 +11,11 @@ it refuses without changing files only when the recovery state is absent or
 when recovery would overwrite a differing local change at the same path.
 
 Undo operations that materialize an earlier tree are explicitly destructive.
-Run `heddle undo --preview` to inspect them and `heddle undo --hard` to permit
-the worktree rewind. Plain `heddle undo` refuses before changing repository
-state or files when the selected inverse would rewrite the worktree.
+Run `heddle undo --preview` (or `heddle undo --hard --preview`) to inspect them
+and `heddle undo --hard` to permit the worktree rewind. `--preview` is a
+read-only alias of `--dry-run` and can be combined with `--hard`. Plain
+`heddle undo` refuses before changing repository state or files when the
+selected inverse would rewrite the worktree.
 
 This document describes the user-facing surface shipped under
 [HeddleCo/heddle#23](https://github.com/HeddleCo/heddle/issues/23). The
@@ -84,7 +86,8 @@ contracts below are enforced by integration tests in
 
 - **Explicit destructive opt-in.** If the selected inverse would materialize
   an earlier tree, plain `heddle undo` refuses before mutation and points to
-  `--preview` and `--hard`. `heddle undo --hard` still refuses if the worktree
+  `--preview` and `--hard`. `heddle undo --hard --preview` previews that
+  rewind without applying it. `heddle undo --hard` still refuses if the worktree
   is dirty and surfaces the exact paths that would otherwise be lost. Capture
   the changes with `heddle capture -m "..."` (or move them) and retry.
 - **Recovery overlays unrelated changes.** `heddle undo --recover` restores


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Path-shaped `heddle diff NOTES.md` / `diff -- NOTES.md` / `diff --path NOTES.md` filter the worktree. Positionals that resolve as states still compare states.
- Help on `diff`, `revert`, `undo`, `start`, and `heddle help model` states that Heddle cannot restore one file (no restore/checkout/reset). Documented alternatives: `start --from <state> --path <dir>`, `revert <state> [--no-commit]`, `undo --recover`.
- `undo --hard --preview` previews. `--preview` is no longer clap-rejected against `--hard`.
- `heddle start <name>` without `--path` refuses when workspace is omitted **or** `--workspace auto`. Auto is the old default that hid the checkout under `.heddle/threads/`.
- Unresolved `v1.2.0`-style specs stay states (`State not found`) instead of becoming a silent empty path filter.
- `diff` classification opens an existing store or returns the open error; it does not drop `Repository::open` failures.

Done-criteria are the exact #1438 field-study commands and exits.

Leave weft 1329 and 1545 open.

## Closes

Closes HeddleCo/heddle#1438

## Red commit

`519450554669b7c80aebf8d105df054f544cb57e`

Field-study repros on #1438 (0.12.0 from main) were the failing baseline: `diff NOTES.md` / `diff -- NOTES.md` → State not found (exit 65); `undo --hard --preview` clap-rejected (exit 64); `start feature/search` hid the checkout.

## Test evidence

```
$ cargo clippy --locked --workspace --all-targets -- -D warnings -D dead-code
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 12s

$ cargo test -p heddle-core --lib diff::path_filter -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running unittests src/lib.rs (target/debug/deps/heddle_core-bc4e4de5b874ca71)

running 3 tests
test diff::path_filter::tests::empty_filters_leave_report_unchanged ... ok
test diff::path_filter::tests::directory_filter_keeps_descendants ... ok
test diff::path_filter::tests::exact_path_keeps_only_that_file ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 442 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --lib cli::commands::diff::diff_paths -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 11.65s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 6 tests
test cli::commands::diff::diff_paths::tests::missing_file_with_extension_is_not_a_silent_filter ... ok
test cli::commands::diff::diff_paths::tests::head_specs_stay_states ... ok
test cli::commands::diff::diff_paths::tests::existing_directory_without_separator_is_a_filter ... ok
test cli::commands::diff::diff_paths::tests::unresolved_version_tag_stays_state_spec ... ok
test cli::commands::diff::diff_paths::tests::separator_paths_stay_filters ... ok
test cli::commands::diff::diff_paths::tests::path_shaped_positional_becomes_filter ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 726 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --test core_functionality -- --nocapture \
    path_shaped_diff_filters_worktree_instead_of_missing_state \
    test_undo_hard_preview_previews_without_applying \
    test_start_without_path_refuses_hidden_checkout \
    test_start_workspace_auto_without_path_refuses_hidden_checkout \
    unresolved_version_tag_is_missing_state_not_empty_filter \
    thread_named_feature_search_wins_as_diff_state
    Finished `test` profile [unoptimized + debuginfo] target(s) in 7.90s
     Running tests/core_functionality.rs (target/debug/deps/core_functionality-1220081185702cfa)

running 6 tests
test refs_and_remotes::test_start_without_path_refuses_hidden_checkout ... ok
test diff_and_status::unresolved_version_tag_is_missing_state_not_empty_filter ... ok
test diff_and_status::path_shaped_diff_filters_worktree_instead_of_missing_state ... ok
test refs_and_remotes::test_start_workspace_auto_without_path_refuses_hidden_checkout ... ok
test diff_and_status::thread_named_feature_search_wins_as_diff_state ... ok
test undo_and_special::test_undo_hard_preview_previews_without_applying ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 93 filtered out; finished in 0.38s

$ cargo test -p heddle-cli --test cli_integration -- --nocapture restore_story_is_documented_and_start_requires_path
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.88s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test cli_help_consistency::restore_story_is_documented_and_start_requires_path ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 937 filtered out; finished in 0.01s

$ cargo test -p heddle-cli --test multi_agent_worktrees -- --nocapture \
    top_level_start_without_path_refuses_hidden_checkout \
    top_level_start_workspace_auto_without_path_refuses_hidden_checkout
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.26s
     Running tests/multi_agent_worktrees.rs (target/debug/deps/multi_agent_worktrees-3f763b04cc8c6967)

running 2 tests
test worktree_add::top_level_start_workspace_auto_without_path_refuses_hidden_checkout ... ok
test worktree_add::top_level_start_without_path_refuses_hidden_checkout ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 79 filtered out; finished in 0.12s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c403ff62-9c59-45a0-92cb-13f8ae1d24f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c403ff62-9c59-45a0-92cb-13f8ae1d24f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789772400&installation_model_id=21489&pr_number=1443&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1443&signature=8f1e4b53930148ee209c49f5b320d1cbb783d095eafc9370a64b48453eeaa901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->