### PR TITLE
cli: add public `heddle completions` verb (#1439)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Added
 
+- **`heddle completions` prints tab-completion scripts.** The field-study
+  verb emits install lines, or a bash/zsh/fish script. Same scripts as
+  `heddle shell completion`. First-screen help names it so it is findable
+  without `heddle help advanced`. Hidden `complete` / `__complete` stay
+  internal (heddle#1439).
+
 - **Parse-free semantic graph queries.** `heddle semantic refs` answers
   refs-of, callers-of, and importers-of at any indexed state from the
   attached semantic index and importer index, without re-parsing. The

--- a/crates/cli-args/src/cli/cli_args/commands_main.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_main.rs
@@ -391,6 +391,16 @@ Examples:
         command: ShellCommands,
     },
 
+    /// Print a tab-completion script for bash, zsh, or fish.
+    ///
+    /// With no shell, prints install lines. With `bash`, `zsh`, or `fish`,
+    /// emits the same script as `heddle shell completion`.
+    Completions {
+        /// Shell to generate completion for: bash, zsh, or fish.
+        #[arg(value_name = "SHELL")]
+        shell: Option<String>,
+    },
+
     /// Internal shell-completion candidate helper.
     #[command(name = "complete", alias = "__complete", hide = true)]
     Complete {

--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -2575,6 +2575,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
             ..MUTATION_BASE
         },
     ),
+    entry(&["completions"], front_door(READ_TEXT, 200)),
     entry(&["shell"], category(READ_TEXT, "repo")),
     entry(&["shell", "init"], READ_TEXT),
     entry(&["shell", "completion"], READ_TEXT),
@@ -4637,6 +4638,7 @@ pub fn command_path(command: &Commands) -> Vec<&'static str> {
             ShellCommands::Completion { .. } => vec!["shell", "completion"],
             ShellCommands::Prompt => vec!["shell", "prompt"],
         },
+        Commands::Completions { .. } => vec!["completions"],
         Commands::Complete { .. } => vec!["complete"],
         Commands::Resolve(_) => vec!["resolve"],
         #[cfg(feature = "git-overlay")]

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -396,6 +396,7 @@ const RUNTIME_CONTRACT_PARSE_SAMPLES: &[RuntimeContractParseSample] = &[
     sample(&["shell", "init"], &["shell", "init", "bash"]),
     sample(&["shell", "completion"], &["shell", "completion", "bash"]),
     sample(&["shell", "prompt"], &["shell", "prompt"]),
+    sample(&["completions"], &["completions", "bash"]),
     sample(&["complete"], &["__complete", "threads"]),
     sample(&["land"], &["land"]),
     sample(&["show"], &["show", "HEAD"]),
@@ -2229,6 +2230,7 @@ fn parsed_command_json_support_reads_contract_table() {
         (vec!["heddle", "status"], true),
         (vec!["heddle", "help"], true),
         (vec!["heddle", "shell", "completion", "bash"], false),
+        (vec!["heddle", "completions", "bash"], false),
         (vec!["heddle", "thread", "cd", "feature"], false),
     ] {
         let cli = Cli::try_parse_from(argv.clone())

--- a/crates/cli-contract/src/cli/commands/surface_conformance.rs
+++ b/crates/cli-contract/src/cli/commands/surface_conformance.rs
@@ -61,12 +61,14 @@ pub const CANONICAL_ROOT_COMMANDS: &[&str] = &[
 /// design and this list in the same review; otherwise the source and
 /// `doctor docs` conformance gates fail. `schemas` is retained as the audited
 /// pre-existing Phase 2 regression and must not be mistaken for a canonical
-/// root when that follow-up is handled.
+/// root when that follow-up is handled. `completions` is the public script
+/// verb from heddle#1439; `shell completion` remains the namespaced path.
 pub const APPROVED_NON_EVERYDAY_ROOT_COMMANDS: &[&str] = &[
     "capture",
     "ci",
     "collapse",
     "complete",
+    "completions",
     "daemon",
     "expand",
     "hook",

--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -127,6 +127,10 @@ fn write_first_screen(out: &mut String, authority: repo::RepositorySourceAuthori
     );
     let _ = writeln!(
         out,
+        "Tab-complete: `heddle completions bash` (also zsh, fish)."
+    );
+    let _ = writeln!(
+        out,
         "In Git Overlay, Heddle uses its embedded Sley engine to operate directly on the checkout's `.git`."
     );
     let _ = writeln!(
@@ -1170,6 +1174,23 @@ mod tests {
                 .lines()
                 .any(|line| line.trim_start().starts_with("commit  ")),
             "default first screen must hide the commit verb unless overlay: {help}"
+        );
+    }
+
+    /// heddle#1439. First-screen help names `heddle completions` so tab
+    /// scripts are findable without `heddle help advanced`.
+    #[test]
+    fn first_screen_mentions_completions() {
+        use clap::CommandFactory;
+        let cmd = crate::cli::cli_args::Cli::command();
+        let help = render_help_for_authority(&cmd, &[], repo::RepositorySourceAuthority::Native);
+        assert!(
+            help.contains("heddle completions"),
+            "first screen must name the public completions verb: {help}"
+        );
+        assert!(
+            help.contains("heddle completions bash"),
+            "first screen should show a concrete install invocation: {help}"
         );
     }
 

--- a/crates/cli/src/cli/commands/completion.rs
+++ b/crates/cli/src/cli/commands/completion.rs
@@ -9,6 +9,20 @@ use heddle_core::completion_plan::{CompletionShell, CompletionShellError, parse_
 use super::advice::RecoveryAdvice;
 use crate::cli::{Cli, CompletionSubject};
 
+/// Public `heddle completions [SHELL]` entry.
+///
+/// No shell prints install lines. A known shell emits the same script as
+/// `heddle shell completion`.
+pub fn cmd_completions(shell: Option<String>) -> Result<()> {
+    match shell {
+        Some(shell) => cmd_completion(shell),
+        None => {
+            print!("{COMPLETIONS_INSTALL_GUIDE}");
+            Ok(())
+        }
+    }
+}
+
 pub fn cmd_completion(shell: String) -> Result<()> {
     let mut cmd = Cli::command();
 
@@ -31,13 +45,23 @@ pub fn cmd_completion(shell: String) -> Result<()> {
                 "completion_shell_unsupported",
                 format!("Unsupported shell: {shell}. Supported shells: bash, zsh, fish"),
                 "Use one of: bash, zsh, fish.",
-                "heddle shell completion bash",
+                "heddle completions bash",
             )));
         }
     }
 
     Ok(())
 }
+
+const COMPLETIONS_INSTALL_GUIDE: &str = "\
+Tab-completion scripts for bash, zsh, and fish.
+
+  heddle completions bash >> ~/.bashrc
+  heddle completions zsh  >> ~/.zshrc
+  heddle completions fish > ~/.config/fish/completions/heddle.fish
+
+Same as `heddle shell completion <SHELL>`.
+";
 
 pub fn cmd_complete(cli: &Cli, subject: CompletionSubject) -> Result<()> {
     let Ok(repo) = cli.open_repo() else {

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -112,7 +112,7 @@ pub use command_catalog::{
     root_commands_for_advanced_help, root_commands_for_help_visibility,
 };
 pub use commit::cmd_commit;
-pub use completion::{cmd_complete, cmd_completion};
+pub use completion::{cmd_complete, cmd_completion, cmd_completions};
 pub use context::{
     cmd_context_audit, cmd_context_check, cmd_context_edit, cmd_context_get, cmd_context_history,
     cmd_context_list, cmd_context_rm, cmd_context_set, cmd_context_suggest, cmd_context_supersede,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -28,13 +28,13 @@ use cli::{
         commands::{
             LogCommandOptions, RetroCommandOptions, SnapshotAgentOverrides, build_command_catalog,
             cmd_abort, cmd_adopt, cmd_agent, cmd_capture_split, cmd_ci, cmd_clone, cmd_collapse,
-            cmd_commit, cmd_complete, cmd_context_audit, cmd_context_check, cmd_context_edit,
-            cmd_context_get, cmd_context_history, cmd_context_list, cmd_context_rm,
-            cmd_context_set, cmd_context_suggest, cmd_context_supersede, cmd_continue,
-            cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff, cmd_discuss,
-            cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_hook, cmd_init,
-            cmd_integration, cmd_land, cmd_log, cmd_maintenance, cmd_oplog, cmd_presence, cmd_pull,
-            cmd_push, cmd_query, cmd_ready, cmd_redo, cmd_remote, cmd_resolve, cmd_retro,
+            cmd_commit, cmd_complete, cmd_completions, cmd_context_audit, cmd_context_check,
+            cmd_context_edit, cmd_context_get, cmd_context_history, cmd_context_list,
+            cmd_context_rm, cmd_context_set, cmd_context_suggest, cmd_context_supersede,
+            cmd_continue, cmd_daemon_serve, cmd_daemon_status, cmd_daemon_stop, cmd_diff,
+            cmd_discuss, cmd_doctor, cmd_doctor_docs, cmd_doctor_schemas, cmd_expand, cmd_hook,
+            cmd_init, cmd_integration, cmd_land, cmd_log, cmd_maintenance, cmd_oplog, cmd_presence,
+            cmd_pull, cmd_push, cmd_query, cmd_ready, cmd_redo, cmd_remote, cmd_resolve, cmd_retro,
             cmd_revert, cmd_review, cmd_run, cmd_schemas, cmd_shell, cmd_show, cmd_snapshot,
             cmd_start, cmd_status, cmd_sync_smart, cmd_thread, cmd_timeline, cmd_try, cmd_undo,
             cmd_undo_recover, cmd_verify, cmd_watch, command_runtime_contract_for_command,
@@ -607,6 +607,8 @@ async fn async_main() -> Result<()> {
         Commands::Thread { command } => cmd_thread(&cli, command.clone()).await,
 
         Commands::Shell { command } => cmd_shell(&cli, command.clone()),
+
+        Commands::Completions { shell } => cmd_completions(shell.clone()),
 
         Commands::Complete { subject } => cmd_complete(&cli, *subject),
 

--- a/crates/cli/tests/completions_discoverability.rs
+++ b/crates/cli/tests/completions_discoverability.rs
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Field-study walk for heddle#1439: `heddle completions` is the public
+//! script verb, first-screen help can find it, and `heddle shell
+//! completion` stays intact.
+
+use std::process::Output;
+
+use tempfile::TempDir;
+
+#[path = "support/mod.rs"]
+mod cli_test_support;
+
+fn heddle(args: &[&str], cwd: Option<&std::path::Path>) -> Result<String, String> {
+    cli_test_support::heddle(args, cwd, &[])
+}
+
+fn heddle_output(args: &[&str], cwd: Option<&std::path::Path>) -> Result<Output, String> {
+    cli_test_support::heddle_output(args, cwd, &[])
+}
+
+/// Exact field-study command from HeddleCo/heddle#1439.
+#[test]
+fn field_study_1439_heddle_completions_is_recognized() {
+    let output = heddle_output(&["completions"], None).expect("invoke heddle completions");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "`heddle completions` should succeed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(
+        stdout.contains("heddle completions bash")
+            && stdout.contains("heddle completions zsh")
+            && stdout.contains("heddle completions fish")
+            && stdout.contains("heddle shell completion"),
+        "`heddle completions` should print install lines for the supported shells: {stdout}"
+    );
+    assert!(
+        !stderr.contains("unrecognized subcommand")
+            && !stdout.contains("__complete")
+            && !stderr.contains("__complete"),
+        "`heddle completions` must not fall through to the hidden candidate printer: stdout={stdout} stderr={stderr}"
+    );
+}
+
+#[test]
+fn first_screen_and_help_find_completions_without_advanced() {
+    for args in [&[][..], &["help"][..], &["--help"][..]] {
+        let help = heddle(args, None).unwrap_or_else(|err| {
+            panic!(
+                "`heddle {}` should print first-screen help: {err}",
+                args.join(" ")
+            )
+        });
+        assert!(
+            help.contains("heddle completions"),
+            "`heddle {}` must name completions without `help advanced`: {help}",
+            args.join(" ")
+        );
+        assert!(
+            !help.contains("heddle help advanced") || help.contains("heddle completions"),
+            "first-screen mention must not depend on opening advanced help: {help}"
+        );
+    }
+
+    let topic = heddle(&["help", "completions"], None)
+        .expect("`heddle help completions` should render the public verb");
+    assert!(
+        topic.contains("Usage:") && topic.contains("completions"),
+        "`heddle help completions` should render clap help for the public verb: {topic}"
+    );
+    assert!(
+        !topic.contains("no topic or command"),
+        "`heddle help completions` must not be an unknown-topic fallback: {topic}"
+    );
+}
+
+#[test]
+fn completions_bash_matches_shell_completion_and_leaves_complete_hidden() {
+    let temp = TempDir::new().unwrap();
+    let public = heddle(&["completions", "bash"], Some(temp.path()))
+        .expect("`heddle completions bash` should emit a script");
+    let namespaced = heddle(&["shell", "completion", "bash"], Some(temp.path()))
+        .expect("`heddle shell completion bash` should keep working");
+
+    assert!(
+        public.contains("heddle") && public.contains("heddle __complete"),
+        "`heddle completions bash` should emit the clap script plus dynamic helper: {public}"
+    );
+    assert_eq!(
+        public, namespaced,
+        "public `completions` and namespaced `shell completion` must emit the same script"
+    );
+
+    let complete_help = heddle(&["complete", "--help"], Some(temp.path()));
+    assert!(
+        complete_help.is_ok(),
+        "hidden `complete` remains callable for scripts: {complete_help:?}"
+    );
+    let first_screen = heddle(&["help"], Some(temp.path())).expect("first-screen help");
+    assert!(
+        !first_screen.contains("\n  complete ") && !first_screen.contains("`heddle complete`"),
+        "first-screen must not advertise the internal candidate printer: {first_screen}"
+    );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Field-study users typed `heddle completions` and clap suggested the hidden candidate printer (`complete` / `__complete`). The real scripts lived at `heddle shell completion <SHELL>`, only listed under `heddle help advanced`.
- This adds a public `heddle completions [SHELL]` verb rather than a one-line shim: no shell prints install lines; `bash` / `zsh` / `fish` emit the same script as `heddle shell completion`.
- First-screen / `heddle help` names `heddle completions bash` so the verb is findable without `help advanced`. The common loop is not expanded. Hidden `complete` / `__complete` stay internal.

## Closes

Closes HeddleCo/heddle#1439

## Red commit

N/A — the failing walk is the field study on main (`heddle completions` unrecognized; clap suggested `__complete` / `complete`). Tests landed with the fix.

## Test evidence

```
$ cargo test -p heddle-cli --test completions_discoverability -- --nocapture
running 3 tests
test field_study_1439_heddle_completions_is_recognized ... ok
test first_screen_and_help_find_completions_without_advanced ... ok
test completions_bash_matches_shell_completion_and_leaves_complete_hidden ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s

$ cargo test -p heddle-cli --test production_features completion -- --nocapture
running 6 tests
test completion::test_completion_fish ... ok
test completion::test_completion_bash ... ok
test completion::bash_dynamic_completion_never_evaluates_ref_names ... ok
test completion::test_completion_zsh ... ok
test completion::test_shell_prompt_reports_thread_and_dirty_marker_only_in_repo ... ok
test completion::test_complete_threads_lists_sorted_repo_threads_only ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 55 filtered out; finished in 0.20s

$ cargo test -p heddle-cli-contract -- --nocapture first_screen_mentions_completions command_contract_table_matches_clap_command_tree parsed_runtime_contract_lookup_matches_contract_table_for_parseable_commands parsed_command_json_support_reads_contract_table current_cli_satisfies_closed_surface
running 5 tests
test cli::commands::surface_conformance::tests::current_cli_satisfies_closed_surface ... ok
test cli::commands::command_catalog::tests::command_contract_table_matches_clap_command_tree ... ok
test cli::help::tests::first_screen_mentions_completions ... ok
test cli::commands::command_catalog::tests::parsed_command_json_support_reads_contract_table ... ok
test cli::commands::command_catalog::tests::parsed_runtime_contract_lookup_matches_contract_table_for_parseable_commands ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 128 filtered out; finished in 0.22s

$ cargo test -p heddle-cli --test tier_coverage -- --nocapture
running 2 tests
test every_commands_variant_is_in_the_closed_root_surface ... ok
test every_commands_variant_has_explicit_root_contract ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Field-study commands against `target/debug/heddle`:

```
$ heddle completions
Tab-completion scripts for bash, zsh, and fish.

  heddle completions bash >> ~/.bashrc
  heddle completions zsh  >> ~/.zshrc
  heddle completions fish > ~/.config/fish/completions/heddle.fish

Same as `heddle shell completion <SHELL>`.

$ heddle help | grep -n -i complet
16:Tab-complete: `heddle completions bash` (also zsh, fish).

$ heddle --help | grep -n -i complet
16:Tab-complete: `heddle completions bash` (also zsh, fish).

$ heddle help completions | head -6
Print a tab-completion script for bash, zsh, or fish

Usage: heddle completions [OPTIONS] [SHELL]

Arguments:
  [SHELL]  Shell to generate completion for: bash, zsh, or fish

$ diff -q <(heddle completions bash) <(heddle shell completion bash) && echo yes
yes
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6e9812c-2c34-4f4b-816c-7c83a35c8d9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6e9812c-2c34-4f4b-816c-7c83a35c8d9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789773874&installation_model_id=21489&pr_number=1445&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1445&signature=c42bd547c323dc35f27123c3cd859b8fbd256abf1183c06d82c12327ed603ef8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->