### PR TITLE
fix(cli): make json-compact a real decision surface

### DIFF
--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -1774,7 +1774,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["context", "set"],
         json_discriminators(
-            opaque_schemas(REF_AND_METADATA_MUTATION, &["context set"]),
+            compact_json(opaque_schemas(REF_AND_METADATA_MUTATION, &["context set"])),
             &[json_discriminator(
                 Some("context set"),
                 "output_kind",
@@ -1917,7 +1917,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["diff"],
         front_door(
-            documented_core_report_schema(READ_JSON, DiffReport::CONTRACT),
+            documented_core_report_schema(compact_json(READ_JSON), DiffReport::CONTRACT),
             20,
         ),
     ),
@@ -1925,7 +1925,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
     entry(
         &["discuss", "open"],
         json_discriminators(
-            documented_schemas(METADATA_MUTATION, &["discuss open"]),
+            documented_schemas(compact_json(METADATA_MUTATION), &["discuss open"]),
             &[json_discriminator(
                 Some("discuss open"),
                 "output_kind",
@@ -2153,7 +2153,10 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["log"],
         front_door(
             json_discriminators(
-                documented_schemas(READ_JSON, &["log", "log --reflog", "log --timeline"]),
+                documented_schemas(
+                    compact_json(READ_JSON),
+                    &["log", "log --reflog", "log --timeline"],
+                ),
                 &[
                     json_discriminator(Some("log"), "output_kind", "log"),
                     json_discriminator(Some("log --reflog"), "output_kind", "log_reflog"),
@@ -2614,7 +2617,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["start"],
         front_door(
             json_discriminators(
-                documented_schemas(WORKTREE_MUTATION, &["start"]),
+                documented_schemas(compact_json(WORKTREE_MUTATION), &["start"]),
                 &[json_discriminator(
                     Some("start"),
                     "output_kind",
@@ -2932,7 +2935,7 @@ const CONTRACTS: &[CommandContractEntry] = &[
         &["verify"],
         exits(
             front_door(
-                documented_core_report_schema(READ_JSON, VerifyReport::CONTRACT),
+                documented_core_report_schema(compact_json(READ_JSON), VerifyReport::CONTRACT),
                 110,
             ),
             &[

--- a/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/tests.rs
@@ -952,11 +952,17 @@ fn json_compact_runtime_contract_is_projection_or_rejection() {
     let expected_compact = BTreeSet::from([
         "abort".to_string(),
         "capture".to_string(),
+        "context set".to_string(),
         "continue".to_string(),
+        "diff".to_string(),
+        "discuss open".to_string(),
         "land".to_string(),
+        "log".to_string(),
         "ready".to_string(),
+        "start".to_string(),
         "status".to_string(),
         "sync".to_string(),
+        "verify".to_string(),
     ]);
     let actual_compact = active_command_contract_entries()
         .iter()

--- a/crates/cli/src/cli/commands/compact.rs
+++ b/crates/cli/src/cli/commands/compact.rs
@@ -31,11 +31,24 @@ const COMPACT_ALLOWED_KEYS: &[&str] = &[
     "changed_path_count",
     "conflicts",
     "conflict_count",
+    "state_id",
 ];
 
+/// Decision-surface keys for a compact *error* envelope. Same recovery
+/// message as `--output json`; this is a projection, not a second schema.
+const COMPACT_ERROR_KEYS: &[&str] = &["kind", "error", "exit_code", "hint", "primary_command"];
+
 pub(crate) fn retain_compact_surface_fields(value: &mut Value) {
+    retain_allowed_keys(value, COMPACT_ALLOWED_KEYS);
+}
+
+pub(crate) fn retain_compact_error_fields(value: &mut Value) {
+    retain_allowed_keys(value, COMPACT_ERROR_KEYS);
+}
+
+fn retain_allowed_keys(value: &mut Value, allowed: &[&str]) {
     if let Some(object) = value.as_object_mut() {
-        object.retain(|key, _| COMPACT_ALLOWED_KEYS.contains(&key.as_str()));
+        object.retain(|key, _| allowed.contains(&key.as_str()));
     }
 }
 
@@ -70,6 +83,11 @@ pub(crate) struct CompactOutput {
     pub conflicts: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conflict_count: Option<usize>,
+    /// Identifier the command just produced or is sitting on. Capture
+    /// needs this as the decision-surface fact; other verbs emit it when
+    /// they have a single current state.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state_id: Option<String>,
 }
 
 impl CompactOutput {
@@ -85,6 +103,7 @@ impl CompactOutput {
             changed_path_count: None,
             conflicts: None,
             conflict_count: None,
+            state_id: None,
         }
     }
 }

--- a/crates/cli/src/cli/commands/compact_projections.rs
+++ b/crates/cli/src/cli/commands/compact_projections.rs
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Compact projections for command outputs defined outside this module.
+
+use heddle_core::{DiffReport, VerifyReport};
+
+use super::compact::{CompactOutput, CompactProjection};
+use super::next_action::normalized_action;
+
+impl CompactProjection for DiffReport {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact.changed_path_count = Some(self.changed_path_count);
+        compact.changed_paths = Some(
+            self.changes
+                .iter()
+                .map(|change| change.path.clone())
+                .collect(),
+        );
+        compact
+    }
+}
+
+impl CompactProjection for VerifyReport {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(if self.clean {
+            "clean".to_string()
+        } else {
+            "blocked".to_string()
+        });
+        let next_action = normalized_action(self.trust.recommended_action.clone());
+        compact.next_action_template = next_action
+            .as_ref()
+            .and_then(|_| self.trust.recommended_action_template.clone());
+        compact.next_action = next_action;
+        compact.blockers = self
+            .trust
+            .checks
+            .iter()
+            .filter(|check| !check.clean && check.status != "not_checked")
+            .map(|check| format!("{}: {}", check.name, check.summary))
+            .collect();
+        compact
+    }
+}

--- a/crates/cli/src/cli/commands/context/context_mutate.rs
+++ b/crates/cli/src/cli/commands/context/context_mutate.rs
@@ -13,6 +13,7 @@ use objects::{
     object::{Annotation, ContextBlob},
 };
 use repo::compute_rewrite_pct;
+use serde::Serialize;
 
 use super::{
     compute_source_hash, context_root_for_state, parse_kind, parse_scope, put_context_attachment,
@@ -23,10 +24,12 @@ use crate::{
         Cli,
         commands::{
             RecoveryAdvice,
+            compact::{CompactOutput, CompactProjection},
             native_scope::{
                 AnnotationStore, AnnotationSurface, emit_locality_notice_once,
                 open_annotation_store, report_absent_store,
             },
+            next_action::write_projected_command_json,
             snapshot::resolve_attribution,
         },
         should_output_json,
@@ -43,6 +46,22 @@ fn content_source_advice(err: ContextContentPlanError) -> RecoveryAdvice {
             "Pass `-m <text>` or `--file <path>` with annotation content.",
             "heddle context set --path <path> -m \"...\"",
         ),
+    }
+}
+
+#[derive(Serialize)]
+struct ContextSetOutput {
+    output_kind: &'static str,
+    target: String,
+    annotations: usize,
+    state: String,
+}
+
+impl CompactProjection for ContextSetOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.state_id = Some(self.state.clone());
+        compact
     }
 }
 
@@ -101,15 +120,16 @@ pub async fn cmd_context_set(
     put_context_attachment(&repo, &head_state, Some(new_context_root))?;
 
     if should_output_json(cli, None) {
-        println!(
-            "{}",
-            serde_json::json!({
-                "output_kind": "context_set",
-                "target": label,
-                "annotations": blob.annotations.len(),
-                "state": head_state.state_id.short(),
-            })
-        );
+        write_projected_command_json(
+            cli,
+            &ContextSetOutput {
+                output_kind: "context_set",
+                target: label,
+                annotations: blob.annotations.len(),
+                state: head_state.state_id.short(),
+            },
+            &["context", "set"],
+        )?;
     } else {
         let active = count_active_annotations(&blob.annotations);
         println!(

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -10,16 +10,19 @@ use objects::worktree::WorktreeStatus;
 use repo::{Config, Repository, RepositoryCapability};
 
 use super::{
-    super::verification_health::{
-        build_plain_git_verification_probe, build_repository_verification_state,
-        plain_git_setup_advice, trust_visible_worktree_status,
+    super::{
+        next_action::write_projected_command_json,
+        verification_health::{
+            build_plain_git_verification_probe, build_repository_verification_state,
+            plain_git_setup_advice, trust_visible_worktree_status,
+        },
     },
     diff_output::{
         print_context, print_diff, print_diff_patch, print_semantic_changes, print_stat,
     },
 };
 use crate::{
-    cli::{Cli, should_output_json},
+    cli::{Cli, output_is_compact, should_output_json},
     config::UserConfig,
 };
 
@@ -185,7 +188,11 @@ fn render_diff_report(
     patch: bool,
 ) -> Result<()> {
     if should_output_json(cli, config) {
-        println!("{}", serde_json::to_string(report)?);
+        if output_is_compact(cli) {
+            write_projected_command_json(cli, report, &["diff"])?;
+        } else {
+            println!("{}", serde_json::to_string(report)?);
+        }
     } else if name_only {
         for change in &report.changes {
             println!("{}", change.path);

--- a/crates/cli/src/cli/commands/discuss.rs
+++ b/crates/cli/src/cli/commands/discuss.rs
@@ -17,11 +17,13 @@ use serde::Serialize;
 
 use super::{
     advice::RecoveryAdvice,
+    compact::{CompactOutput, CompactProjection},
     history_target::resolve_state_id,
     native_scope::{
         AnnotationStore, AnnotationSurface, emit_locality_notice_once, open_annotation_store,
         report_absent_store,
     },
+    next_action::write_projected_command_json,
     snapshot::ensure_current_state,
 };
 use crate::{
@@ -133,6 +135,18 @@ struct DiscussionWriteOutput {
     operation_id: String,
     disposition: CollaborationWriteDisposition,
     discussion: DiscussionOutput,
+}
+
+impl CompactProjection for DiscussionWriteOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(match self.disposition {
+            CollaborationWriteDisposition::Created => "created".to_string(),
+            CollaborationWriteDisposition::ExistingOperation => "existing_operation".to_string(),
+            CollaborationWriteDisposition::IdempotentReplay => "idempotent_replay".to_string(),
+        });
+        compact
+    }
 }
 
 #[derive(Serialize)]
@@ -372,7 +386,14 @@ fn emit_write(
         discussion: to_view(store, &discussion)?,
     };
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        let emitting = match output_kind {
+            "discuss_open" => &["discuss", "open"][..],
+            "discuss_append" => &["discuss", "append"][..],
+            "discuss_resolve" => &["discuss", "resolve"][..],
+            "discuss_reopen" => &["discuss", "reopen"][..],
+            _ => &["discuss"][..],
+        };
+        write_projected_command_json(cli, &output, emitting)?;
     } else {
         println!(
             "{} {} ({})",

--- a/crates/cli/src/cli/commands/error_envelope.rs
+++ b/crates/cli/src/cli/commands/error_envelope.rs
@@ -9,7 +9,7 @@ use super::{
     command_catalog::{ActionTemplate, recommended_action_template, validate_recommended_action},
 };
 use crate::{
-    cli::{Cli, render::shell_quote, should_output_json},
+    cli::{Cli, output_is_compact, render::shell_quote, should_output_json},
     exit::HeddleExitCode,
 };
 
@@ -56,22 +56,29 @@ fn print_error_with_hint_inner(cli: &Cli, err: &anyhow::Error, config: Option<&C
             "recovery_commands": classification.recovery_commands,
             "recovery_action_templates": recovery_action_templates,
         });
-        if let Some(op_id) = cli.op_id.as_deref()
-            && let Some(object) = body.as_object_mut()
-        {
-            object.insert(
-                "op_id".to_string(),
-                serde_json::Value::String(op_id.to_string()),
-            );
-            object.insert(
-                "idempotency_status".to_string(),
-                serde_json::Value::String(idempotency_status_for_error(&kind).to_string()),
-            );
-            object.insert("replayed".to_string(), serde_json::Value::Bool(false));
-        }
-        if let Some(object) = body.as_object_mut() {
-            for (key, value) in classification.extra_json_fields {
-                object.insert(key, value);
+        if output_is_compact(cli) {
+            // Compact is a projection of this envelope, not a second
+            // schema: keep the decision surface and drop recovery
+            // telemetry / self-validation noise.
+            super::compact::retain_compact_error_fields(&mut body);
+        } else {
+            if let Some(op_id) = cli.op_id.as_deref()
+                && let Some(object) = body.as_object_mut()
+            {
+                object.insert(
+                    "op_id".to_string(),
+                    serde_json::Value::String(op_id.to_string()),
+                );
+                object.insert(
+                    "idempotency_status".to_string(),
+                    serde_json::Value::String(idempotency_status_for_error(&kind).to_string()),
+                );
+                object.insert("replayed".to_string(), serde_json::Value::Bool(false));
+            }
+            if let Some(object) = body.as_object_mut() {
+                for (key, value) in classification.extra_json_fields {
+                    object.insert(key, value);
+                }
             }
         }
         eprintln!("{body}");

--- a/crates/cli/src/cli/commands/log.rs
+++ b/crates/cli/src/cli/commands/log.rs
@@ -30,8 +30,10 @@ use serde::Serialize;
 use super::{
     action_line::{format_next_step_dim, print_next_step},
     advice::RecoveryAdvice,
+    compact::{CompactOutput, CompactProjection},
     expand::{CollapseAnnotation, collapse_annotations_for_states},
     history_target::resolve_state_id,
+    next_action::{normalized_action, write_projected_command_json},
     snapshot::ensure_current_state,
     verification_health::{PlainGitVerificationProbe, build_plain_git_verification_probe},
 };
@@ -388,7 +390,7 @@ pub async fn cmd_log(cli: &Cli, options: LogCommandOptions) -> Result<()> {
 
     let as_json = should_output_json(cli, Some(repo.config()));
     if as_json {
-        println!("{}", serde_json::to_string(&output)?);
+        write_projected_command_json(cli, &output, &["log"])?;
     } else {
         // Render to stdout via the writer-based helpers so the same
         // formatting logic is unit-testable against a `Vec<u8>` —
@@ -462,7 +464,7 @@ fn render_unbound_overlay_log(
         states: entries,
     };
     if should_output_json(cli, Some(repo.config())) {
-        println!("{}", serde_json::to_string(&output)?);
+        write_projected_command_json(cli, &output, &["log"])?;
     } else {
         let stdout = std::io::stdout();
         let mut handle = stdout.lock();
@@ -475,21 +477,70 @@ fn render_unbound_overlay_log(
     Ok(())
 }
 
+#[derive(Serialize)]
+struct PlainGitLogOutput<'a> {
+    output_kind: &'static str,
+    status: &'static str,
+    repository_capability: &'static str,
+    storage_model: &'static str,
+    states: &'a [StateEntry],
+    #[serde(rename = "verification")]
+    trust: &'a heddle_core::RepositoryVerificationState,
+    recommended_action: &'a str,
+    recovery_commands: &'a [String],
+}
+
+impl CompactProjection for LogOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact.state_id = self.states.first().map(|state| state.state_id.clone());
+        compact
+    }
+}
+
+impl CompactProjection for ReflogOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact
+    }
+}
+
+impl CompactProjection for TimelineLogOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact.state_id = self.cursor.state.clone();
+        compact
+    }
+}
+
+impl CompactProjection for PlainGitLogOutput<'_> {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact.next_action = normalized_action(self.recommended_action);
+        compact
+    }
+}
+
 fn render_plain_git_log(cli: &Cli, probe: &PlainGitVerificationProbe, oneline: bool) -> Result<()> {
     if should_output_json(cli, None) {
-        println!(
-            "{}",
-            serde_json::to_string(&serde_json::json!({
-                "output_kind": "log",
-                "status": "blocked",
-                "repository_capability": "plain-git",
-                "storage_model": "git",
-                "states": [],
-                "verification": &probe.trust,
-                "recommended_action": &probe.trust.recommended_action,
-                "recovery_commands": &probe.trust.recovery_commands,
-            }))?
-        );
+        write_projected_command_json(
+            cli,
+            &PlainGitLogOutput {
+                output_kind: "log",
+                status: "blocked",
+                repository_capability: "plain-git",
+                storage_model: "git",
+                states: &[],
+                trust: &probe.trust,
+                recommended_action: &probe.trust.recommended_action,
+                recovery_commands: &probe.trust.recovery_commands,
+            },
+            &["log"],
+        )?;
     } else if oneline {
         println!("plain-git Heddle not initialized; next: heddle init");
     } else {
@@ -515,7 +566,7 @@ fn cmd_log_timeline(cli: &Cli, repo: &Repository, thread: &str, oneline: bool) -
     let output = TimelineLogOutput::from_snapshot(repo, snapshot);
 
     if should_output_json(cli, Some(repo.config())) {
-        println!("{}", serde_json::to_string(&output)?);
+        write_projected_command_json(cli, &output, &["log"])?;
     } else {
         let stdout = std::io::stdout();
         let mut handle = stdout.lock();
@@ -539,7 +590,7 @@ fn cmd_log_reflog(cli: &Cli, repo: &Repository, limit: usize, oneline: bool) -> 
     };
 
     if should_output_json(cli, Some(repo.config())) {
-        println!("{}", serde_json::to_string(&output)?);
+        write_projected_command_json(cli, &output, &["log"])?;
     } else {
         let stdout = std::io::stdout();
         let mut handle = stdout.lock();

--- a/crates/cli/src/cli/commands/mod.rs
+++ b/crates/cli/src/cli/commands/mod.rs
@@ -16,6 +16,7 @@ mod clone;
 mod collapse;
 mod commit;
 pub(crate) mod compact;
+mod compact_projections;
 mod completion;
 pub(crate) mod context;
 mod daemon;

--- a/crates/cli/src/cli/commands/next_action.rs
+++ b/crates/cli/src/cli/commands/next_action.rs
@@ -76,6 +76,24 @@ where
     }
 }
 
+/// Emit JSON using the caller's CLI output mode. Compact goes through
+/// [`super::compact::CompactProjection`] so a new verb cannot leak the
+/// full envelope under `--output json-compact`.
+pub(crate) fn write_projected_command_json<T>(
+    cli: &crate::cli::Cli,
+    output: &T,
+    emitting_command: &[&str],
+) -> Result<()>
+where
+    T: Serialize + super::compact::CompactProjection,
+{
+    write_command_json(
+        output,
+        crate::cli::output_is_compact(cli),
+        NextActionValidationContext::without_repo(emitting_command),
+    )
+}
+
 pub(crate) fn validate_next_actions_in_value(
     value: &Value,
     context: NextActionValidationContext<'_>,

--- a/crates/cli/src/cli/commands/snapshot.rs
+++ b/crates/cli/src/cli/commands/snapshot.rs
@@ -83,6 +83,7 @@ impl super::compact::CompactProjection for SnapshotOutput {
     fn compact(&self) -> super::compact::CompactOutput {
         let mut compact = super::compact::CompactOutput::new(self.output_kind);
         compact.status = Some(self.status.to_string());
+        compact.state_id = Some(self.state_id.clone());
         let action = self
             .recommended_action
             .as_ref()

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -309,11 +309,15 @@ fn build_status_command_output(cli: &Cli, short: bool) -> Result<StatusCommandOu
     let cli_repo_open_ms = repo_open_start.elapsed().as_millis();
     let repo_config = repo.config().clone();
     let as_json = should_output_json(cli, Some(&repo_config));
-    let compact_json = as_json && output_is_compact(cli);
     let detail = if short && !as_json {
         StatusDetail::ShortText
-    } else if compact_json || (short && as_json) {
+    } else if short && as_json {
         StatusDetail::CompactMachine
+    } else if as_json && output_is_compact(cli) {
+        // Compact is a projection of the same report text uses. The
+        // short machine path drops thread-ready `land` advice, which is
+        // exactly the next_action compact callers need after `ready`.
+        StatusDetail::DefaultText
     } else if cli.verbose > 0 || as_json {
         StatusDetail::Full
     } else {
@@ -547,6 +551,7 @@ impl super::compact::CompactProjection for StatusOutput {
         compact.next_action_template = next_action_template;
         compact.changed_paths = Some(self.changed_paths.clone());
         compact.changed_path_count = Some(self.changed_paths.len());
+        compact.state_id = self.current_state.clone();
         compact
     }
 }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -46,8 +46,11 @@ use super::{
     action_line::{print_nested_next_step, print_nested_optional, print_next_step, print_optional},
     advice::RecoveryAdvice,
     command_catalog::{ActionTemplate, recommended_action_template},
+    compact::{CompactOutput, CompactProjection},
     mount_lifecycle,
-    next_action::{NextActionValidationContext, write_full_command_json},
+    next_action::{
+        NextActionValidationContext, write_full_command_json, write_projected_command_json,
+    },
     operator_loop::primary_next_action_with_verification,
     snapshot::{ensure_current_state, summarize_confidence, summarize_verification},
     start_atomic,
@@ -66,7 +69,10 @@ use super::{
     worktree_safety::ensure_worktree_clean,
 };
 use crate::{
-    cli::{Cli, ThreadListArgs, ThreadStartArgs, WorkspaceModeArg, should_output_json, style},
+    cli::{
+        Cli, ThreadListArgs, ThreadStartArgs, WorkspaceModeArg, output_is_compact,
+        should_output_json, style,
+    },
     config::{UserConfig, UserThreadWorkspaceMode},
     perf::{ProfileField, ProfileMode, emit_profile, instrumentation_enabled, profile_mode},
 };
@@ -145,6 +151,16 @@ pub(crate) struct ThreadOpOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "verification")]
     pub trust: Option<RepositoryVerificationState>,
+}
+
+impl CompactProjection for ThreadOpOutput {
+    fn compact(&self) -> CompactOutput {
+        let mut compact = CompactOutput::new(self.output_kind);
+        compact.status = Some(self.status.to_string());
+        compact.next_action = self.next_action.clone();
+        compact.next_action_template = self.next_action_template.clone();
+        compact
+    }
 }
 
 #[derive(Serialize)]
@@ -2619,7 +2635,15 @@ pub(crate) fn cmd_thread_rename(
 
 fn render_thread_op(cli: &Cli, output: ThreadOpOutput) -> Result<()> {
     if should_output_json(cli, None) {
-        println!("{}", serde_json::to_string(&output)?);
+        if output_is_compact(cli) {
+            let emitting = match output.output_kind {
+                "thread_start" => &["start"][..],
+                _ => &["thread"][..],
+            };
+            write_projected_command_json(cli, &output, emitting)?;
+        } else {
+            println!("{}", serde_json::to_string(&output)?);
+        }
     } else {
         println!("{}", style::accent(&output.message));
         if let Some(thread) = &output.thread {

--- a/crates/cli/src/cli/commands/verify.rs
+++ b/crates/cli/src/cli/commands/verify.rs
@@ -10,7 +10,7 @@ use heddle_core::{
 };
 use repo::{Repository, discover_heddle_root};
 
-use super::{RecoveryAdvice, action_line::print_next};
+use super::{RecoveryAdvice, action_line::print_next, next_action::write_projected_command_json};
 use crate::{
     cli::{Cli, should_output_json, style},
     config::UserConfig,
@@ -77,7 +77,7 @@ pub fn cmd_verify(cli: &Cli, verbose: bool, provenance: bool) -> Result<()> {
     if !output.clean && as_json {
         return Err(anyhow!(verify_failed_advice(&output)));
     }
-    render_verify(&output, verbose, as_json)?;
+    render_verify(cli, &output, verbose, as_json)?;
     if !output.clean {
         return Err(anyhow!(verify_failed_advice(&output)));
     }
@@ -153,9 +153,9 @@ fn heddle_sidecar_present(start: &Path) -> bool {
     })
 }
 
-fn render_verify(output: &VerifyReport, verbose: bool, as_json: bool) -> Result<()> {
+fn render_verify(cli: &Cli, output: &VerifyReport, verbose: bool, as_json: bool) -> Result<()> {
     if as_json {
-        crate::cli::render::write_json_stdout(output)?;
+        write_projected_command_json(cli, output, &["verify"])?;
         return Ok(());
     }
     if !verbose {

--- a/crates/cli/tests/cli_integration/compact_output.rs
+++ b/crates/cli/tests/cli_integration/compact_output.rs
@@ -30,6 +30,7 @@ const COMPACT_ALLOWED_KEYS: &[&str] = &[
     "changed_path_count",
     "conflicts",
     "conflict_count",
+    "state_id",
 ];
 
 fn assert_only_compact_keys(value: &Value, context: &str) {
@@ -49,6 +50,12 @@ fn compact_json(args: &[&str], temp: &TempDir) -> Value {
     argv.extend(args.iter().copied());
     let out =
         heddle_output(&argv, Some(temp.path())).unwrap_or_else(|err| panic!("spawn failed: {err}"));
+    assert!(
+        out.status.success(),
+        "heddle {argv:?} should succeed; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
     let stdout = str::from_utf8(&out.stdout).expect("stdout utf8");
     let line = stdout.lines().next().unwrap_or_else(|| {
         panic!(
@@ -283,5 +290,193 @@ fn json_compact_rejects_commands_without_projection() {
     assert!(
         stderr.contains("json-compact is not supported"),
         "rejection should explain unsupported compact mode: {stderr}"
+    );
+}
+
+fn compact_error_envelope(args: &[&str], cwd: Option<&std::path::Path>) -> Value {
+    let out = heddle_output(args, cwd).unwrap_or_else(|err| panic!("spawn failed: {err}"));
+    assert!(
+        !out.status.success(),
+        "heddle {args:?} should fail; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = str::from_utf8(&out.stderr).expect("stderr utf8");
+    serde_json::from_str(stderr.trim())
+        .unwrap_or_else(|err| panic!("stderr not JSON: {err}\n  stderr: {stderr}"))
+}
+
+const COMPACT_ERROR_KEYS: &[&str] = &["kind", "error", "exit_code", "hint", "primary_command"];
+
+fn assert_only_compact_error_keys(value: &Value, context: &str) {
+    let obj = value
+        .as_object()
+        .unwrap_or_else(|| panic!("{context}: compact error must be a JSON object: {value}"));
+    for key in obj.keys() {
+        assert!(
+            COMPACT_ERROR_KEYS.contains(&key.as_str()),
+            "{context}: compact error leaked non-decision-surface key `{key}`: {value}"
+        );
+    }
+    for key in COMPACT_ERROR_KEYS {
+        assert!(
+            obj.contains_key(*key),
+            "{context}: compact error missing `{key}`: {value}"
+        );
+    }
+}
+
+#[test]
+fn field_study_everyday_verbs_accept_json_compact() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    std::fs::write(temp.path().join("main.rs"), "fn main() {}\n").unwrap();
+    heddle(&["capture", "-m", "seed"], Some(temp.path())).expect("seed");
+
+    for args in [
+        &["log"][..],
+        &["diff"][..],
+        &["verify"][..],
+        &[
+            "context",
+            "set",
+            "--path",
+            "main.rs",
+            "--scope",
+            "file",
+            "--kind",
+            "rationale",
+            "-m",
+            "entry point",
+        ][..],
+        &["discuss", "open", "main.rs", "main", "first turn"][..],
+    ] {
+        let compact = compact_json(args, &temp);
+        assert!(
+            compact.get("output_kind").and_then(Value::as_str).is_some(),
+            "heddle {args:?} --output json-compact must emit output_kind: {compact}"
+        );
+        assert_only_compact_keys(&compact, &format!("field-study {}", args.join(" ")));
+        assert!(
+            compact.get("verification").is_none()
+                && compact.get("machine_contract_coverage").is_none(),
+            "compact {args:?} must not embed machine-contract self-noise: {compact}"
+        );
+    }
+
+    let checkout = TempDir::new().unwrap();
+    let checkout_arg = checkout.path().join("work");
+    let started = compact_json(
+        &[
+            "start",
+            "feature/search",
+            "--path",
+            checkout_arg.to_str().unwrap(),
+        ],
+        &temp,
+    );
+    assert_eq!(started["output_kind"].as_str(), Some("thread_start"));
+    assert_only_compact_keys(&started, "field-study start");
+}
+
+#[test]
+fn capture_compact_includes_state_id() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    std::fs::write(temp.path().join("work.txt"), "pending\n").unwrap();
+
+    let compact = compact_json(&["capture", "-m", "compact state_id"], &temp);
+    assert_eq!(compact["output_kind"].as_str(), Some("capture"));
+    let state_id = compact["state_id"]
+        .as_str()
+        .unwrap_or_else(|| panic!("capture compact must include state_id: {compact}"));
+    assert!(
+        !state_id.is_empty(),
+        "capture compact state_id must be non-empty: {compact}"
+    );
+    assert_only_compact_keys(&compact, "capture state_id");
+
+    let full = full_json(&["log", "--limit", "1"], &temp);
+    assert_eq!(
+        full["states"][0]["state_id"].as_str(),
+        Some(state_id),
+        "compact capture state_id must match the tip state"
+    );
+}
+
+#[test]
+fn status_compact_after_ready_has_land_next_action() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).expect("init");
+    std::fs::write(temp.path().join("base.txt"), "base\n").unwrap();
+    heddle(&["capture", "-m", "base"], Some(temp.path())).expect("base");
+
+    let checkout = TempDir::new().unwrap();
+    let checkout_arg = checkout.path().join("work");
+    let started = full_json(
+        &[
+            "start",
+            "feature/search",
+            "--path",
+            checkout_arg.to_str().unwrap(),
+        ],
+        &temp,
+    );
+    let execution_path = started["execution_path"]
+        .as_str()
+        .expect("start should report execution_path");
+    let checkout_path = std::path::Path::new(execution_path);
+    std::fs::write(checkout_path.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout_path)).expect("feature");
+    heddle(&["ready"], Some(checkout_path)).expect("ready");
+
+    let status_out = heddle_output(&["--output", "json-compact", "status"], Some(checkout_path))
+        .expect("status compact after ready");
+    assert!(
+        status_out.status.success(),
+        "compact status after ready should succeed; stderr={}",
+        String::from_utf8_lossy(&status_out.stderr)
+    );
+    let compact: Value = serde_json::from_str(
+        str::from_utf8(&status_out.stdout)
+            .expect("stdout utf8")
+            .lines()
+            .next()
+            .expect("status compact stdout"),
+    )
+    .expect("status compact JSON");
+    let next_action = compact["next_action"]
+        .as_str()
+        .unwrap_or_else(|| panic!("compact status after ready must have next_action: {compact}"));
+    assert!(
+        next_action.contains("land --thread feature/search"),
+        "compact status after ready must recommend land: {compact}"
+    );
+    assert_only_compact_keys(&compact, "status after ready");
+    assert!(
+        compact.get("verification").is_none(),
+        "compact status must drop the coverage report: {compact}"
+    );
+}
+
+#[test]
+fn status_compact_before_init_stays_compact() {
+    let temp = TempDir::new().unwrap();
+    let envelope =
+        compact_error_envelope(&["--output", "json-compact", "status"], Some(temp.path()));
+    assert_eq!(envelope["kind"], "repository_not_found");
+    assert_only_compact_error_keys(&envelope, "status compact before init");
+    let primary = envelope["primary_command"]
+        .as_str()
+        .unwrap_or_else(|| panic!("compact pre-init error must keep primary_command: {envelope}"));
+    assert!(
+        primary.contains("heddle init"),
+        "compact pre-init next step must be init: {envelope}"
+    );
+    assert!(
+        envelope.get("advice_contract_valid").is_none()
+            && envelope.get("recovery_commands").is_none()
+            && envelope.get("unsafe_condition").is_none(),
+        "compact pre-init must not dump the full recovery envelope: {envelope}"
     );
 }

--- a/crates/cli/tests/cli_integration/exit_codes.rs
+++ b/crates/cli/tests/cli_integration/exit_codes.rs
@@ -212,8 +212,8 @@ fn unsupported_output_json_compact_is_data_err() {
     // compact projection. Same semantics, same code (HeddleCo/heddle#648).
     // The envelope's `exit_code` field must agree with the process exit.
     let repo = init_repo();
-    let output = heddle_output(&["--output", "json-compact", "log"], Some(repo.path()))
-        .expect("spawn log --output json-compact");
+    let output = heddle_output(&["--output", "json-compact", "query"], Some(repo.path()))
+        .expect("spawn query --output json-compact");
     assert_eq!(
         output.status.code(),
         Some(65),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `--output json-compact` now covers the everyday agent verbs from the field study: `log`, `diff`, `verify`, `start`, `context set`, and `discuss open`, in addition to `status` / `capture` / `ready`.
- `capture --output json-compact` includes `state_id`. Compact status after `ready` on an isolated native thread now carries the same `land --thread` next_action as text. Pre-init compact errors stay compact (same envelope, decision-surface keys only).
- Compact remains a projection of the existing messages — no second schema. The machine-contract coverage report stays out of compact output.

## Closes

Closes HeddleCo/heddle#1156

## Red commit

`531b4241801042cc51a042ef9d83f59c974757f4`

Field study 2026-08-19 on 0.12.0 native: compact accepted only status/capture/ready; `log`/`diff`/`verify`/`start`/`context set`/`discuss open` exited 65; capture compact omitted `state_id`; compact status after `ready` had `next_action: null` while text printed `land --thread`; compact-before-init dumped the full recovery envelope.

## Test evidence

```
$ cargo test -p heddle-cli-contract json_compact -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 05s
     Running unittests src/lib.rs (target/debug/deps/heddle_cli_contract-f0c2d8d867351a2f)

running 1 test
test cli::commands::command_catalog::tests::json_compact_runtime_contract_is_projection_or_rejection ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 131 filtered out; finished in 0.24s

$ cargo test -p heddle-cli --test cli_integration compact_output -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 37s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 11 tests
test compact_output::continue_compact_drops_operator_metadata ... ok
test compact_output::capture_op_id_compact_failure_preserves_error_envelope ... ok
test compact_output::capture_compact_includes_state_id ... ok
test compact_output::capture_op_id_compact_replay_emits_only_decision_surface ... ok
test compact_output::json_compact_is_a_valid_output_value ... ok
test compact_output::status_compact_before_init_stays_compact ... ok
test compact_output::json_compact_rejects_commands_without_projection ... ok
test compact_output::status_compact_keeps_uncaptured_changed_path_count_consistent ... ok
test compact_output::status_compact_emits_only_decision_surface ... ok
test compact_output::field_study_everyday_verbs_accept_json_compact ... ok
test compact_output::status_compact_after_ready_has_land_next_action ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 938 filtered out; finished in 0.43s

$ cargo test -p heddle-cli --test cli_integration unsupported_output_json_compact -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.30s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test exit_codes::unsupported_output_json_compact_is_data_err ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 948 filtered out; finished in 0.09s

$ cargo test -p heddle-cli --lib next_action -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 21.95s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 7 tests
test cli::commands::next_action::tests::normalized_action_maps_empty_and_whitespace_to_none ... ok
test cli::commands::next_action::tests::boundary_accepts_null_and_absent_actions ... ok
test cli::commands::next_action::tests::boundary_rejects_empty_string_actions ... ok
test cli::commands::next_action::tests::recursive_validator_covers_nested_recommended_actions ... ok
test cli::commands::next_action::tests::validator_rejects_self_loops ... ok
test cli::commands::next_action::tests::validator_rejects_demoted_breadcrumbs ... ok
test cli::commands::next_action::tests::validator_accepts_canonical_everyday_actions ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 719 filtered out; finished in 0.01s

$ cargo test -p heddle-cli-contract leaf_catalog -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running unittests src/lib.rs (target/debug/deps/heddle_cli_contract-f0c2d8d867351a2f)

running 1 test
test cli::commands::command_catalog::tests::leaf_catalog_entries_publish_exact_output_modes ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 131 filtered out; finished in 0.01s

$ cargo clippy -p heddle-cli -p heddle-cli-contract --tests -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 39.55s
```

## Manual verification

N/A — covered by tests.

## Identifier audit

Compact identifiers added or confirmed:

| Verb | Identifier on compact | Notes |
|---|---|---|
| `capture` | `state_id` | The fact an agent needs from a capture. |
| `status` | `state_id` (current state) + `next_action` | After ready, `next_action` is `land --thread …`. |
| `log` | tip `state_id` | First visible state. |
| `diff` | `changed_paths` / `changed_path_count` | From/to state ids stay on full json. |
| `verify` | `status` + `next_action` + `blockers` | Coverage report dropped. |
| `start` | `status` + `next_action` | Thread path stays on full json. |
| `context set` | `state_id` | Mapped from existing `state`. |
| `discuss open` | `status` (disposition) | Discussion id stays on full json. |

Out of scope for this card (original issue items not in the field-study machine-contract cut): `auth login --help` vs runtime, `retro` undone marking, removing the coverage report from full `--output json`.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3ff731c2-d118-42ff-8944-213a5bc385b7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ff731c2-d118-42ff-8944-213a5bc385b7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789774162&installation_model_id=21489&pr_number=1448&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1448&signature=c7081d2351e8e7c8cb3d3f2885f88490745dc4d6b4fda5cafaf174e91576463e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->