### PR TITLE
Fix leftover `main` copy in clone help and status labels

### DIFF
--- a/crates/cli-contract/src/cli/help.rs
+++ b/crates/cli-contract/src/cli/help.rs
@@ -628,8 +628,8 @@ Run `heddle clone --help` for the flag list.
 - A Git source is streamed by Sley directly into the destination `.git`, then
   initialized as Git Overlay. No Git executable or `.heddle/git` mirror is used.
 - A native source is cloned into Heddle-owned storage.
-- Native clones target `main` directly; if the remote has no `main` thread,
-  pass `--thread <name>` to select one.
+- Native clones follow the remote default thread; pass `--thread <name>`
+  to override.
 - Clone never prompts.
 
 # Shallow clones (--depth)

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -1174,7 +1174,7 @@ fn status_workspace_label(output: &StatusOutput, mode: &ThreadMode) -> &'static 
         ThreadMode::Materialized if output.repository_capability == "git-overlay" => {
             "Git branch checkout"
         }
-        ThreadMode::Materialized => "main checkout",
+        ThreadMode::Materialized => "attached checkout",
         ThreadMode::Solid => "isolated checkout",
         ThreadMode::Virtualized => "virtual checkout",
     }

--- a/crates/cli/src/cli/commands/status.rs
+++ b/crates/cli/src/cli/commands/status.rs
@@ -1652,13 +1652,13 @@ mod tests {
         ActorInfo, ChangesInfo, PlainGitStatusReport, RepositoryVerificationState,
         repository_mode_label,
     };
-    use repo::{AgentUsageSummary, Repository};
+    use repo::{AgentUsageSummary, Repository, ThreadMode};
     use serde_json::Value;
     use tempfile::TempDir;
 
     use super::{
         MaterializedThreadInfo, assess_materialized_threads, build_status_output,
-        render_status_materialized,
+        render_status_materialized, status_workspace_label,
     };
 
     const AGENT_CONTEXT_STATUS_KEYS: &[&str] = &[
@@ -1706,6 +1706,52 @@ mod tests {
         repo.materialize_thread("main", &dest, &repo::AudienceTier::Internal)
             .unwrap();
         (repo_dir, dest_holder, repo)
+    }
+
+    #[test]
+    fn status_workspace_label_pairs_native_modes_without_main() {
+        let repo_dir = TempDir::new().unwrap();
+        let repo = Repository::init_default(repo_dir.path()).unwrap();
+        fs::write(repo_dir.path().join("hello.txt"), b"hello\n").unwrap();
+        repo.snapshot(Some("seed".into()), None).unwrap();
+        let cli = status_cli(repo_dir.path());
+        let mut output = build_status_output(&cli, false).expect("build status output");
+
+        output.repository_capability = "native-heddle".into();
+        output.repository_context = None;
+        assert_eq!(
+            status_workspace_label(&output, &ThreadMode::Materialized),
+            "attached checkout"
+        );
+        assert_eq!(
+            status_workspace_label(&output, &ThreadMode::Solid),
+            "isolated checkout"
+        );
+        assert_eq!(
+            status_workspace_label(&output, &ThreadMode::Virtualized),
+            "virtual checkout"
+        );
+        assert!(
+            !status_workspace_label(&output, &ThreadMode::Materialized).contains("main"),
+            "native materialized label must not hard-code main"
+        );
+
+        output.repository_capability = "git-overlay".into();
+        assert_eq!(
+            status_workspace_label(&output, &ThreadMode::Materialized),
+            "Git branch checkout"
+        );
+
+        output.repository_context = Some(heddle_core::RepositoryContextInfo {
+            kind: "git-overlay-isolated-checkout".into(),
+            parent_repository: None,
+            target_thread: None,
+            parent_thread: None,
+        });
+        assert_eq!(
+            status_workspace_label(&output, &ThreadMode::Materialized),
+            "Git-overlay isolated checkout"
+        );
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -412,7 +412,7 @@ pub(crate) fn thread_recovery_action_is_primary(
 
 pub(crate) fn thread_workspace_label(mode: &ThreadMode) -> &'static str {
     match mode {
-        ThreadMode::Materialized => "main checkout",
+        ThreadMode::Materialized => "attached checkout",
         ThreadMode::Virtualized => "virtual checkout",
         ThreadMode::Solid => "isolated checkout",
     }

--- a/crates/cli/src/cli/commands/thread.rs
+++ b/crates/cli/src/cli/commands/thread.rs
@@ -2901,6 +2901,26 @@ mod tests {
     use super::*;
 
     #[test]
+    fn thread_workspace_label_pairs_modes_without_main() {
+        assert_eq!(
+            thread_workspace_label(&ThreadMode::Materialized),
+            "attached checkout"
+        );
+        assert_eq!(
+            thread_workspace_label(&ThreadMode::Solid),
+            "isolated checkout"
+        );
+        assert_eq!(
+            thread_workspace_label(&ThreadMode::Virtualized),
+            "virtual checkout"
+        );
+        assert!(
+            !thread_workspace_label(&ThreadMode::Materialized).contains("main"),
+            "native materialized label must not hard-code main"
+        );
+    }
+
+    #[test]
     fn empty_execution_paths_are_suppressed() {
         assert_eq!(display_path_string(&PathBuf::new()), None);
         assert_eq!(non_empty_string(Some("")), None);

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -86,9 +86,11 @@ fn clone_help_pins_behavior_stanza() {
         "clone topic should explain the Git-overlay transport and storage path: {help}"
     );
     assert!(
-        help.contains("Native clones target `main` directly")
-            && help.contains("if the remote has no `main` thread")
-            && help.contains("--thread <name>"),
+        help.contains("Native clones follow the remote default thread")
+            && help.contains("pass `--thread <name>`")
+            && help.contains("to override")
+            && !help.contains("Native clones target `main`")
+            && !help.contains("if the remote has no `main` thread"),
         "clone topic should explain native default-thread selection: {help}"
     );
     // Depth semantics: 0 means full history, N keeps the tip plus N ancestry levels.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- After #1446, native clone without `--thread` follows the remote default thread (HEAD). The `heddle help clone` topic still said clones target `main`.
- `heddle status` / `heddle thread` labeled native materialized workspaces as `main checkout` even when the thread was named something else (for example `trunk`).
- Native materialized copy is now `attached checkout`, pairing with `isolated checkout` and `virtual checkout`. Git-overlay labels are unchanged.

## Closes

Closes HeddleCo/heddle#1450

## Red commit
`8bbc7966`

## Test evidence
```
$ cargo test -p heddle-cli --lib workspace_label -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 03s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 2 tests
test cli::commands::thread::tests::thread_workspace_label_pairs_modes_without_main ... ok
test cli::commands::status::tests::status_workspace_label_pairs_native_modes_without_main ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 741 filtered out; finished in 0.05s

$ cargo test -p heddle-cli --test cli_integration clone_help_pins_behavior_stanza -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 32.31s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test cli_help_consistency::clone_help_pins_behavior_stanza ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 956 filtered out; finished in 0.01s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-065ad25b-221d-4bc8-8d55-5b9fd4ceaa40?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-065ad25b-221d-4bc8-8d55-5b9fd4ceaa40&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789778440&installation_model_id=21489&pr_number=1451&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1451&signature=d15734b5b821c40baedb136337aae4af5652c989eacefa769a21cfe9d66556c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->