### PR TITLE
Drop leftover git-main copy from clone --help and thread refresh advice

### DIFF
--- a/crates/cli-args/src/cli/cli_args/commands_args.rs
+++ b/crates/cli-args/src/cli/cli_args/commands_args.rs
@@ -1325,7 +1325,7 @@ pub struct PullArgs {
 #[derive(Clone, Debug, clap::Args)]
 #[command(after_help = "\
 Behavior:
-  Clones native Heddle or Git repositories and checks out the selected default branch. Git transport runs through Sley and does not require a Git executable. Never prompts. Full details: `heddle help clone`.
+  Clones native Heddle or Git repositories. Native clones follow the remote default thread; `--thread` overrides. Git clones check out the selected default branch. Git transport runs through Sley and does not require a Git executable. Never prompts. Full details: `heddle help clone`.
 
 Advanced/planned flags: see `heddle help clone`.
 

--- a/crates/cli/src/cli/commands/thread_cmd.rs
+++ b/crates/cli/src/cli/commands/thread_cmd.rs
@@ -963,7 +963,7 @@ fn thread_refresh_checkout_unavailable_advice(
         "thread_refresh_checkout_unavailable",
         format!("Thread '{thread_id}' checkout could not be opened"),
         format!(
-            "Inspect the recorded checkout with `{inspect_command}`. If this is a branch-like thread, run `{switch_command}` from the main checkout before refreshing."
+            "Inspect the recorded checkout with `{inspect_command}`. If this is a branch-like thread, run `{switch_command}` from the attached checkout before refreshing."
         ),
         format!(
             "recorded checkout path '{}' is unavailable: {error}",
@@ -2291,6 +2291,22 @@ mod cleanup_tests {
                     .iter()
                     .all(|command| !command.contains("repair git")),
             "unmanaged-thread recovery must stay on native verbs: {advice:?}"
+        );
+    }
+
+    /// heddle#1452: refresh-unavailable advice names the attached
+    /// checkout, matching status after #1451 — not git-main.
+    #[test]
+    fn refresh_unavailable_advice_names_attached_checkout() {
+        let advice = thread_refresh_checkout_unavailable_advice(
+            "feature/stale",
+            Path::new("/missing-checkout"),
+            "checkout path is unavailable",
+        );
+        assert_eq!(advice.kind, "thread_refresh_checkout_unavailable");
+        assert!(
+            advice.hint.contains("attached checkout") && !advice.hint.contains("main checkout"),
+            "refresh-unavailable advice should name the attached checkout: {advice:?}"
         );
     }
 }

--- a/crates/cli/tests/cli_integration/cli_help_consistency.rs
+++ b/crates/cli/tests/cli_integration/cli_help_consistency.rs
@@ -65,10 +65,14 @@ fn clone_help_pins_behavior_stanza() {
     );
     // The one-screen summary still answers the headline questions —
     // where an unhinted clone lands per remote kind — and points at the
-    // topic page for the rest.
+    // topic page for the rest. Native checkout is a default thread, not
+    // a Git branch (heddle#1452); Git clones may still name a default branch.
     assert!(
-        summary.contains("selected default branch"),
-        "clone help summary should say where clones land: {summary}"
+        summary.contains("Native clones follow the remote default thread")
+            && summary.contains("`--thread` overrides")
+            && summary.contains("Git clones check out the selected default branch")
+            && !summary.contains("and checks out the selected default branch"),
+        "clone help summary should name the native default thread and keep Git default-branch language: {summary}"
     );
     assert!(
         summary.contains("--thread"),

--- a/crates/cli/tests/cli_integration/remotes.rs
+++ b/crates/cli/tests/cli_integration/remotes.rs
@@ -1047,6 +1047,10 @@ fn test_cli_pull_local_dirty_refusal_leaves_thread_ref_unchanged() {
 /// heddle#646: the planned lazy/partial-clone flags stay `hide = true`
 /// (out of the human options list), and human help carries a one-line
 /// breadcrumb to the detailed topic.
+///
+/// heddle#1452: `clone --help` must name the native default **thread**
+/// (with `--thread` as the override) and must not describe native
+/// checkout as a Git default branch.
 #[test]
 fn test_cli_clone_help_keeps_planned_lazy_flag_to_breadcrumb() {
     let output = heddle_help(&["clone", "--help"]);
@@ -1057,6 +1061,62 @@ fn test_cli_clone_help_keeps_planned_lazy_flag_to_breadcrumb() {
     assert!(
         !output.contains("--lazy") && !output.contains("--filter"),
         "clone help should keep planned lazy/partial clone flags out of first-run help: {output}"
+    );
+    assert!(
+        output.contains("Native clones follow the remote default thread")
+            && output.contains("`--thread` overrides")
+            && output.contains("Git clones check out the selected default branch")
+            && !output.contains("and checks out the selected default branch"),
+        "clone --help should match `heddle help clone` (native default thread, Git default branch): {output}"
+    );
+}
+
+/// heddle#1452: when an isolated thread's recorded checkout cannot be
+/// opened, refresh advice names the **attached checkout**, not git-main.
+#[test]
+fn test_cli_thread_refresh_unavailable_advice_names_attached_checkout() {
+    let root = TempDir::new().unwrap();
+    let source = root.path().join("attached");
+    let checkout = root.path().join("feature-stale");
+    std::fs::create_dir_all(&source).unwrap();
+
+    heddle(&["init"], Some(&source)).unwrap();
+    std::fs::write(source.join("base.txt"), "from attached\n").unwrap();
+    heddle(&["capture", "-m", "Attached base"], Some(&source)).unwrap();
+
+    let checkout_arg = checkout.to_str().expect("checkout path utf8");
+    heddle(
+        &["start", "feature/stale", "--path", checkout_arg],
+        Some(&source),
+    )
+    .unwrap();
+
+    std::fs::write(source.join("advance.txt"), "advance attached\n").unwrap();
+    heddle(&["capture", "-m", "Advance attached"], Some(&source)).unwrap();
+
+    std::fs::remove_dir_all(&checkout).expect("remove isolated checkout so refresh cannot open it");
+
+    let output = heddle_output(
+        &["--output", "json", "thread", "refresh", "feature/stale"],
+        Some(&source),
+    )
+    .expect("thread refresh should emit typed advice");
+    assert!(
+        !output.status.success(),
+        "refresh against a missing isolated checkout must refuse; stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&output.stderr)
+        .expect("refresh-unavailable refusal should emit JSON advice");
+    assert_eq!(envelope["kind"], "thread_refresh_checkout_unavailable");
+    assert_json_recovery_advice_fields(&envelope, "thread refresh checkout unavailable");
+    let hint = envelope["hint"]
+        .as_str()
+        .expect("refresh-unavailable advice should carry a hint");
+    assert!(
+        hint.contains("attached checkout") && !hint.contains("main checkout"),
+        "refresh-unavailable advice should name the attached checkout, not git-main: {envelope}"
     );
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle clone --help` now matches `heddle help clone`: native clones follow the remote default **thread**; `--thread` overrides. Git clones still name a default branch.
- Thread refresh-unavailable advice now says **attached checkout** (same language as status after #1451), not “main checkout”.
- Pins both leftover strings in the existing help-consistency and remotes tests.

## Closes

Closes HeddleCo/heddle#1452

## Red commit
`b3971dacb1a5379f26663556f1ce0ff149d44e92`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- clone_help -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2m 00s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 3 tests
test remotes::test_cli_clone_help_keeps_planned_lazy_flag_to_breadcrumb ... ok
test cli_help_consistency::clone_help_carries_hidden_flag_breadcrumb ... ok
test cli_help_consistency::clone_help_pins_behavior_stanza ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 955 filtered out; finished in 0.01s

$ cargo test -p heddle-cli --test cli_integration -- test_cli_thread_refresh_unavailable_advice_names_attached_checkout -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 24.25s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 1 test
test remotes::test_cli_thread_refresh_unavailable_advice_names_attached_checkout ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 957 filtered out; finished in 0.19s

$ cargo test -p heddle-cli --lib -- refresh_unavailable_advice_names_attached_checkout -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 24.18s
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 1 test
test cli::commands::thread_cmd::cleanup_tests::refresh_unavailable_advice_names_attached_checkout ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 743 filtered out; finished in 0.00s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2126026-a036-48be-89f1-c6b784c9e960?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2126026-a036-48be-89f1-c6b784c9e960&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789781034&installation_model_id=21489&pr_number=1453&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1453&signature=18bdd4aa5e776e3ee1e11711f99deeb65ba34e2929d0624f76cd7519946e0452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->