### PR TITLE
Label heddle show parenthetical as content_hash

### DIFF
--- a/crates/cli/src/cli/commands/show.rs
+++ b/crates/cli/src/cli/commands/show.rs
@@ -273,6 +273,15 @@ fn render_plain_git_show(
     Ok(())
 }
 
+/// Short content-hash prefix labeled so it is not offered as a state spec.
+fn labeled_content_hash_prefix(content_hash: &str) -> String {
+    let prefix = match content_hash.get(..8) {
+        Some(prefix) => prefix,
+        None => content_hash,
+    };
+    format!("content_hash {prefix}")
+}
+
 fn render_state(output: &ShowOutput, verbose: bool) {
     // Mode preamble is read-path noise (heddle#275); show it only under
     // `-v`. `heddle status` covers it for the common case.
@@ -304,11 +313,12 @@ fn render_state(output: &ShowOutput, verbose: bool) {
         println!();
     }
     // Identifiers are dimmed: structurally important but not the
-    // editorial focus.
+    // editorial focus. The parenthetical is content_hash, not a
+    // state spec — label it so `heddle show <paren>` is not offered.
     println!(
         "State: {} ({})",
         style::state_id(&output.state_id),
-        style::dim(&output.content_hash[..8])
+        style::dim(&labeled_content_hash_prefix(&output.content_hash))
     );
     println!("Full ID: {}", style::dim(&output.state_id_full));
     println!("Tree: {}", style::dim(&output.tree));

--- a/crates/cli/tests/cli_integration/state_id_acceptance.rs
+++ b/crates/cli/tests/cli_integration/state_id_acceptance.rs
@@ -204,3 +204,51 @@ fn unknown_state_id_yields_state_not_found() {
         "expected `State not found` message, got: {err}"
     );
 }
+
+/// `heddle show` used to print `State: hs-… (3a6c582f)` where the
+/// parenthetical was `content_hash`. Feeding that hex to `heddle show`
+/// produced `State not found`. The printed paren must either be a
+/// resolvable spec, or carry a label that makes it obvious it is not.
+#[test]
+fn show_parenthetical_is_resolvable_spec_or_labeled_not_a_spec() {
+    let temp = setup_repo();
+    let text = heddle(&["--output", "text", "show"], Some(temp.path())).expect("heddle show");
+    let paren = show_state_parenthetical(&text);
+
+    if let Some(hex) = paren.strip_prefix("content_hash ") {
+        let labeled_err = heddle(&["show", paren], Some(temp.path())).expect_err(
+            "labeled content_hash parenthetical is not a resolvable spec",
+        );
+        assert!(
+            labeled_err.contains("State not found"),
+            "show <printed-paren> should fail once the paren is labeled; got: {labeled_err}"
+        );
+        let hex_err = heddle(&["show", hex], Some(temp.path()))
+            .expect_err("content_hash hex is not a state spec");
+        assert!(
+            hex_err.contains("State not found"),
+            "show <content_hash hex> must stay unresolved; got: {hex_err}"
+        );
+    } else {
+        heddle(&["show", paren], Some(temp.path())).unwrap_or_else(|err| {
+            panic!(
+                "unlabeled parenthetical {paren:?} must be a resolvable spec; show failed: {err}"
+            )
+        });
+    }
+}
+
+fn show_state_parenthetical(text: &str) -> &str {
+    let line = text
+        .lines()
+        .find(|line| line.trim_start().starts_with("State:"))
+        .expect("show should print a State line");
+    let start = line
+        .rfind('(')
+        .expect("State line should include a parenthetical");
+    let end = line[start..]
+        .find(')')
+        .map(|offset| start + offset)
+        .expect("State line parenthetical should close");
+    line[start + 1..end].trim()
+}

--- a/crates/cli/tests/cli_integration/state_id_acceptance.rs
+++ b/crates/cli/tests/cli_integration/state_id_acceptance.rs
@@ -216,9 +216,8 @@ fn show_parenthetical_is_resolvable_spec_or_labeled_not_a_spec() {
     let paren = show_state_parenthetical(&text);
 
     if let Some(hex) = paren.strip_prefix("content_hash ") {
-        let labeled_err = heddle(&["show", paren], Some(temp.path())).expect_err(
-            "labeled content_hash parenthetical is not a resolvable spec",
-        );
+        let labeled_err = heddle(&["show", paren], Some(temp.path()))
+            .expect_err("labeled content_hash parenthetical is not a resolvable spec");
         assert!(
             labeled_err.contains("State not found"),
             "show <printed-paren> should fail once the paren is labeled; got: {labeled_err}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle show` printed `State: hs-… (3a6c582f)` where the parenthetical was `content_hash`, not a state spec. `heddle show 3a6c582f` failed with `State not found`.
- The printed paren is now labeled `content_hash <prefix>` so it is not offered as a resolvable spec.
- A CLI test extracts the printed paren and covers `show <printed-paren>`: labeled form fails as `State not found`; an unlabeled paren would have to resolve.

## Closes

Closes HeddleCo/heddle#1455

## Red commit
`cab0fbc9970f73ed5fb3a2bfaaffbd418c570f86`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration -- state_id_acceptance -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.28s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 12 tests
test state_id_acceptance::blame_accepts_short_id ... ok
test state_id_acceptance::discuss_list_accepts_short_id ... ok
test state_id_acceptance::diff_accepts_short_id ... ok
test state_id_acceptance::compare_accepts_short_id ... ok
test state_id_acceptance::marker_then_show_accepts_marker_name ... ok
test state_id_acceptance::log_since_accepts_short_id ... ok
test state_id_acceptance::revert_accepts_short_id ... ok
test state_id_acceptance::review_show_accepts_short_id ... ok
test state_id_acceptance::review_show_respects_global_repo_argument ... ok
test state_id_acceptance::unknown_state_id_yields_state_not_found ... ok
test state_id_acceptance::show_accepts_short_id ... ok
test state_id_acceptance::show_parenthetical_is_resolvable_spec_or_labeled_not_a_spec ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 947 filtered out; finished in 0.41s

$ cargo test -p heddle-cli --test cli_integration -- show_accepts_short_id unknown_state_id_yields_state_not_found test_cli_show_accepts_short_state_id test_cli_show_renders_absent_confidence_as_em_dash show_and_thread_show -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.55s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 7 tests
test basics::test_cli_show_renders_absent_confidence_as_em_dash ... ok
test refs_and_history::test_cli_show_accepts_short_state_id ... ok
test output_kind_runtime::show_and_thread_show_emit_distinct_output_kinds ... ok
test output_kind_runtime::show_and_thread_show_schemas_accept_payloads ... ok
test state_id_acceptance::review_show_accepts_short_id ... ok
test state_id_acceptance::unknown_state_id_yields_state_not_found ... ok
test state_id_acceptance::show_accepts_short_id ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 952 filtered out; finished in 0.24s

$ cargo clippy -p heddle-cli --tests -- -D warnings
    Checking heddle-cli v0.12.0 (/workspace/crates/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 00s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7cb5a095-670d-4cdc-bb6f-d136c0c126ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cb5a095-670d-4cdc-bb6f-d136c0c126ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782119&installation_model_id=21489&pr_number=1465&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1465&signature=2b777f5ee5598422c4a37ce1f8f696d370dc94319884c6d8b523ff0194905709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->