### PR TITLE
Omit --thread/--repo from next_action when the current checkout is enough

### DIFF
--- a/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
+++ b/crates/cli-contract/src/cli/commands/command_catalog/mod.rs
@@ -411,6 +411,8 @@ const RECOMMENDED_ACTION_PLACEHOLDERS: &[&str] = &[
     "heddle start <name> --path <empty-path>",
     "heddle start <name> --path ../<name>",
     "heddle presence show <session>",
+    "heddle presence complete --session <session>",
+    "heddle presence explain <session>",
     "heddle thread show <THREAD>",
     // Remote setup requires filling in a real name and URL after
     // inspecting current configuration.
@@ -528,6 +530,18 @@ const RECOMMENDED_ACTION_TEMPLATES: &[(&str, &[&str], &[&str], bool)] = &[
     (
         "heddle presence show <session>",
         &["heddle", "presence", "show", "<session>"],
+        &["session"],
+        true,
+    ),
+    (
+        "heddle presence complete --session <session>",
+        &["heddle", "presence", "complete", "--session", "<session>"],
+        &["session"],
+        true,
+    ),
+    (
+        "heddle presence explain <session>",
+        &["heddle", "presence", "explain", "<session>"],
         &["session"],
         true,
     ),

--- a/crates/cli/src/cli/commands/agent_presence.rs
+++ b/crates/cli/src/cli/commands/agent_presence.rs
@@ -174,7 +174,7 @@ pub async fn show(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle presence show <SESSION>",
+        "heddle presence show <session>",
     )?;
     let show = show_actor_from_entry(&registry, &entry)?;
 
@@ -281,7 +281,7 @@ pub async fn complete(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle presence complete --session <SESSION>",
+        "heddle presence complete --session <session>",
     )?;
     let plan = plan_actor_done(&entry);
     mark_actor_done(&registry, &plan.session_id)?;
@@ -333,7 +333,7 @@ pub async fn explain(cli: &Cli, session_id: Option<String>) -> Result<()> {
         &repo,
         &registry,
         session_id.as_deref(),
-        "heddle presence explain <SESSION>",
+        "heddle presence explain <session>",
     ) {
         Ok(entry) => entry,
         Err(err) if session_id.is_none() && is_no_active_actor_error(&err) => {
@@ -614,7 +614,7 @@ fn select_actor_candidate(
         .collect();
     let selected = super::interactive_select::select_ambiguous_target(
         "actor",
-        "<SESSION>",
+        "<session>",
         command_template,
         choices,
     )?;

--- a/crates/cli/src/cli/commands/interactive_select.rs
+++ b/crates/cli/src/cli/commands/interactive_select.rs
@@ -172,4 +172,28 @@ mod tests {
         assert_eq!(advice.kind, "ambiguous_thread_selection");
         assert_eq!(advice.primary_command, "heddle thread show <THREAD>");
     }
+
+    #[test]
+    fn actor_ambiguity_primary_command_stays_a_presence_show() {
+        use super::super::command_catalog::validate_recommended_action;
+
+        let advice = ambiguous_target_advice(
+            "actor",
+            "<session>",
+            "heddle presence show <session>",
+            &choices(),
+        );
+        assert_eq!(advice.kind, "ambiguous_actor_selection");
+        assert_eq!(advice.primary_command, "heddle presence show <session>");
+        assert_ne!(advice.primary_command, "heddle help --output json");
+        validate_recommended_action(&advice.primary_command)
+            .unwrap_or_else(|err| panic!("presence show multi-match next must validate: {err}"));
+        assert_eq!(
+            advice.recovery_commands,
+            vec![
+                "heddle presence show alpha".to_string(),
+                "heddle presence show beta".to_string(),
+            ]
+        );
+    }
 }

--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -35,7 +35,7 @@ use super::{
     thread_cmd::{
         current_thread, load_thread, refresh_thread, thread_manager, thread_not_found_advice,
     },
-    thread_landing::land_local_command,
+    thread_landing::land_action_for_ready,
     verification_health::{
         RepositoryVerificationState, build_plain_git_verification_probe,
         build_repository_verification_state,
@@ -400,7 +400,7 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         && decision.integration_clear
     {
         report.thread_health = "ready".to_string();
-        report.recommended_action = land_local_command(&thread.id);
+        report.recommended_action = land_action_for_ready(&repo, &thread.id);
         report.refresh_recommended_action_metadata();
     }
 

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -17,6 +17,27 @@ pub(crate) fn land_command_for_thread(_repo: &repo::Repository, thread_id: &str)
     land_local_command(thread_id)
 }
 
+/// Land of the current checkout is `heddle land`. `--thread` / `--repo` are
+/// invisible defaults once the caller is already on that thread (heddle#1456).
+pub(crate) fn land_action_when(thread_id: &str, current_checkout: bool) -> String {
+    if current_checkout {
+        heddle_action(["land"])
+    } else {
+        land_local_command(thread_id)
+    }
+}
+
+pub(crate) fn land_action_for_ready(repo: &repo::Repository, thread_id: &str) -> String {
+    land_action_when(thread_id, checkout_is_thread(repo, thread_id))
+}
+
+fn checkout_is_thread(repo: &repo::Repository, thread_id: &str) -> bool {
+    super::thread_cmd::current_thread(repo)
+        .ok()
+        .flatten()
+        .is_some_and(|thread| thread.id == thread_id)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -29,6 +50,11 @@ mod tests {
         );
         assert_eq!(
             land_local_command("feature/demo"),
+            "heddle land --thread feature/demo"
+        );
+        assert_eq!(land_action_when("feature/demo", true), "heddle land");
+        assert_eq!(
+            land_action_when("feature/demo", false),
             "heddle land --thread feature/demo"
         );
         assert_eq!(
@@ -51,6 +77,9 @@ mod tests {
                 panic!("breadcrumb `{cmd}` must validate for a leading-dash id: {e}")
             });
         }
+        assert_eq!(land_action_when(id, true), "heddle land");
+        validate_recommended_action("heddle land")
+            .unwrap_or_else(|e| panic!("current-checkout land breadcrumb must validate: {e}"));
         assert_eq!(land_local_command(id), "heddle land '--thread=-foo'");
         assert_eq!(merge_preview_command(id), "heddle ready '--thread=-foo'");
         assert_eq!(switch_thread_command(id), "heddle thread switch -- -foo");

--- a/crates/cli/tests/cli_integration/interactive_selection.rs
+++ b/crates/cli/tests/cli_integration/interactive_selection.rs
@@ -132,11 +132,25 @@ fn piped_actor_ambiguity_never_prompts_or_consumes_a_selection() {
         "1\n",
     )
     .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
     assert_non_tty_ambiguity(
         output,
         "ambiguous_actor_selection",
-        "heddle presence show <SESSION>",
+        "heddle presence show <session>",
     );
+    let envelope: serde_json::Value = serde_json::from_str(
+        stderr
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .unwrap_or(stderr.trim()),
+    )
+    .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
+    assert_eq!(
+        envelope["primary_command"],
+        "heddle presence show <session>"
+    );
+    assert_ne!(envelope["primary_command"], "heddle help --output json");
 }
 
 #[test]
@@ -161,7 +175,7 @@ fn piped_actor_completion_never_picks_a_destructive_target() {
     assert_non_tty_ambiguity(
         output,
         "ambiguous_actor_selection",
-        "heddle presence complete --session <SESSION>",
+        "heddle presence complete --session <session>",
     );
     assert!(matches!(
         actors.load("agent-alpha").unwrap().unwrap().status,

--- a/crates/cli/tests/cli_integration/land_current_thread.rs
+++ b/crates/cli/tests/cli_integration/land_current_thread.rs
@@ -125,9 +125,10 @@ fn field_study_bare_land_and_dry_run_use_current_thread() {
     );
 }
 
-/// Field study: `heddle ready` prints `heddle --repo … land --thread
-/// feature/search`. That command works. A second run must be already-landed,
-/// not another successful "automatic integration merge" at exit 0.
+/// Field study: `heddle ready` from the isolated checkout now prints
+/// `heddle land` (heddle#1456). An explicit `--repo … land --thread`
+/// still works. A second run must be already-landed, not another
+/// successful "automatic integration merge" at exit 0.
 #[test]
 fn field_study_ready_then_double_land_thread_is_already_landed() {
     let (main, checkout) = setup_feature_search();
@@ -141,8 +142,12 @@ fn field_study_ready_then_double_land_thread_is_already_landed() {
     );
     let ready_text = combined(&ready);
     assert!(
-        ready_text.contains("land --thread feature/search"),
-        "ready must recommend land --thread feature/search:\n{ready_text}"
+        ready_text.contains("Next:") && ready_text.contains("heddle land"),
+        "ready must recommend land:\n{ready_text}"
+    );
+    assert!(
+        !ready_text.contains("land --thread") && !ready_text.contains("--repo"),
+        "ready next from the current checkout must omit --thread/--repo:\n{ready_text}"
     );
     assert_no_repair_git(&ready, "ready");
 

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -185,6 +185,104 @@ fn ready_thread_surfaces_land_across_ready_show_and_list() {
 }
 
 #[test]
+fn ready_from_isolated_checkout_recommends_bare_land() {
+    let (_main, checkout_owner, execution_path) = setup_managed_thread("feature/current-land");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout)).unwrap();
+
+    let ready = json(&["--output", "json", "ready"], checkout);
+    assert_eq!(ready["next_action"], "heddle land", "{ready}");
+    assert_eq!(ready["recommended_action"], "heddle land", "{ready}");
+    assert_eq!(
+        ready["report"]["recommended_action"], "heddle land",
+        "{ready}"
+    );
+    let next = ready["next_action"]
+        .as_str()
+        .expect("ready next_action should be a string");
+    assert!(
+        !next.contains("--thread") && !next.contains("--repo"),
+        "current-checkout land must not emit selectors: {ready}"
+    );
+    assert_no_banned_next_actions(&ready);
+
+    drop(checkout_owner);
+}
+
+#[test]
+fn presence_show_multi_match_next_is_not_help_catalog() {
+    use chrono::Utc;
+    use objects::store::{
+        ActorPresence, ActorPresenceStatus, ActorPresenceStore, AgentUsageSummary,
+    };
+
+    let repo = setup_native_repo();
+    let opened = Repository::open(repo.path()).unwrap();
+    let actors = ActorPresenceStore::new(opened.heddle_dir());
+    for session_id in ["agent-alpha", "agent-beta"] {
+        actors
+            .save(&ActorPresence {
+                session_id: session_id.to_string(),
+                client_instance_id: None,
+                native_actor_key: None,
+                native_parent_actor_key: None,
+                native_instance_key: None,
+                heddle_session_id: None,
+                thread_id: None,
+                thread: "main".to_string(),
+                anchor_state: None,
+                anchor_root: None,
+                path: Some(repo.path().to_path_buf()),
+                base_state: "test-base".to_string(),
+                started_at: Utc::now(),
+                provider: Some("openai".to_string()),
+                model: Some("gpt-test".to_string()),
+                harness: Some("codex".to_string()),
+                thinking_level: None,
+                usage_summary: AgentUsageSummary::default(),
+                last_progress_at: None,
+                report_flush_state: None,
+                attach_reason: Some("test fixture".to_string()),
+                task_assignment_id: None,
+                attach_precedence: vec![],
+                winning_attach_rule: None,
+                probe_source: None,
+                probe_confidence: None,
+                status: ActorPresenceStatus::Active,
+                completed_at: None,
+                context_queries: vec![],
+            })
+            .unwrap();
+    }
+
+    let output = heddle_output(&["--output", "json", "presence", "show"], Some(repo.path()))
+        .expect("presence show should spawn");
+    assert!(
+        !output.status.success(),
+        "multi-match presence show must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let envelope: Value = serde_json::from_str(
+        stderr
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .unwrap_or(stderr.trim()),
+    )
+    .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
+    assert_eq!(envelope["kind"], "ambiguous_actor_selection", "{envelope}");
+    assert_eq!(
+        envelope["primary_command"], "heddle presence show <session>",
+        "{envelope}"
+    );
+    assert_ne!(
+        envelope["primary_command"], "heddle help --output json",
+        "{envelope}"
+    );
+}
+
+#[test]
 fn ready_clean_stale_managed_thread_refreshes_and_surfaces_land() {
     let (main, checkout_owner, execution_path) = setup_managed_thread("feature/stale-sync");
     let checkout = std::path::Path::new(&execution_path);

--- a/crates/cli/tests/cli_integration/oss_cli_polish.rs
+++ b/crates/cli/tests/cli_integration/oss_cli_polish.rs
@@ -7284,10 +7284,12 @@ fn isolated_thread_capture_points_to_ready_not_checkpoint_tip() {
 
     let ready = heddle(&["ready", "--output", "text"], Some(&checkout)).unwrap();
     assert!(
-        ready.contains("Next:")
-            && ready.contains("heddle --repo")
-            && ready.contains("land --thread feature/capture-next"),
-        "ready should use a shared next-action label that runs from the isolated checkout: {ready}"
+        ready.contains("Next:") && ready.contains("heddle land"),
+        "ready should recommend land from the isolated checkout: {ready}"
+    );
+    assert!(
+        !ready.contains("heddle --repo") && !ready.contains("land --thread"),
+        "ready next from the current checkout must omit --thread/--repo: {ready}"
     );
     assert!(
         !ready.contains("\nnext:"),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `ready` from the current thread's checkout now recommends `heddle land`. `--thread` / `--repo` stay off when those defaults already select the current thing.
- `presence show` multi-match next is the registered `heddle presence show <session>` template, not `heddle help --output json`.
- Targeting a different thread from another checkout still emits `heddle land --thread <name>`.

## Closes

Closes HeddleCo/heddle#1456

## Red commit
`f2577bc198ba0fc87c2ff4af7bfdd6dc5780a9a8`

## Test evidence
```
$ cargo test -p heddle-cli --test cli_integration next_action_contract -- --nocapture
running 9 tests
test next_action_contract::dirty_isolated_checkout_suggests_capture ... ok
test next_action_contract::native_dirty_status_and_thread_list_suggest_capture ... ok
test next_action_contract::land_blocker_payload_names_thread_state_condition ... ok
test next_action_contract::presence_show_multi_match_next_is_not_help_catalog ... ok
test next_action_contract::land_never_recommends_no_op_sync_for_current_thread_state_blocker ... ok
test next_action_contract::ready_from_isolated_checkout_recommends_bare_land ... ok
test next_action_contract::ready_clean_stale_managed_thread_refreshes_and_surfaces_land ... ok
test next_action_contract::ready_thread_surfaces_land_across_ready_show_and_list ... ok
test next_action_contract::sync_conflicting_stale_thread_emits_runnable_resolve_breadcrumb ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 951 filtered out; finished in 0.61s

$ cargo test -p heddle-cli --test cli_integration piped_actor_ambiguity_never_prompts_or_consumes_a_selection -- --nocapture
test interactive_selection::piped_actor_ambiguity_never_prompts_or_consumes_a_selection ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 959 filtered out; finished in 0.08s

$ cargo test -p heddle-cli --test cli_integration field_study_ready_then_double_land_thread_is_already_landed -- --nocapture
test land_current_thread::field_study_ready_then_double_land_thread_is_already_landed ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 959 filtered out; finished in 0.33s

$ cargo test -p heddle-cli --test cli_integration isolated_thread_capture_points_to_ready_not_checkpoint_tip -- --nocapture
test oss_cli_polish::isolated_thread_capture_points_to_ready_not_checkpoint_tip ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 959 filtered out; finished in 0.35s

$ cargo test -p heddle-cli landing_commands_are_stable_and_copy_pasteable -- --nocapture
test cli::commands::thread_landing::tests::landing_commands_are_stable_and_copy_pasteable ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 744 filtered out; finished in 0.01s

$ cargo test -p heddle-cli land_breadcrumbs_handle_leading_dash_thread_ids -- --nocapture
test cli::commands::thread_landing::tests::land_breadcrumbs_handle_leading_dash_thread_ids ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 744 filtered out; finished in 0.02s

$ cargo test -p heddle-cli actor_ambiguity_primary_command_stays_a_presence_show -- --nocapture
test cli::commands::interactive_select::tests::actor_ambiguity_primary_command_stays_a_presence_show ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 744 filtered out; finished in 0.00s

$ cargo test -p heddle-cli-contract recommended_action_templates_describe_display_only_placeholders -- --nocapture
test cli::commands::command_catalog::tests::recommended_action_templates_describe_display_only_placeholders ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 134 filtered out; finished in 0.01s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53456a93-70da-47e4-ad9d-fbd5995f8dfd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53456a93-70da-47e4-ad9d-fbd5995f8dfd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782258&installation_model_id=21489&pr_number=1466&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1466&signature=eba57e7a21ad67b6f5a54d6ef19bae63c4030fdfd335fecec44ba84a1acb5ee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->