### PR TITLE
Keep sync as its own verb: main works, prose output, no land --thread

### DIFF
--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -234,7 +234,8 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
     let operation = repo.operation_status()?;
     let remote_tracking = repo.git_remote_tracking_status()?;
     let import_hint = repo.git_import_guidance()?;
-    let mut output = if sync_is_already_current(&thread) {
+    let synthesized_checkout = thread_manager(&repo).load(&thread.id)?.is_none();
+    let mut output = if sync_is_already_current(&thread, synthesized_checkout) {
         let recommended_action = sync_completed_next_action(
             operation.as_ref(),
             remote_tracking.as_ref(),
@@ -1441,23 +1442,13 @@ fn resolve_thread(
 
 /// Resolve the thread `sync` refreshes onto its target.
 ///
-/// The default checkout (including a thread named `main`) has a ref from
-/// `seed_default_thread` but often no ThreadManager record. `load_thread`
-/// would then say `Thread 'main' not found`. Sync accepts the current /
-/// default checkout thread as a first-class subject.
+/// Omit `--thread` to use the current checkout, including a synthesized
+/// default thread such as `main` (ref from `seed_default_thread`, no
+/// ThreadManager record). An explicit `--thread` always goes through
+/// `load_thread` so unmanaged imported refs keep their typed advice.
 fn resolve_sync_thread(repo: &Repository, thread: Option<&str>) -> Result<Thread> {
     match thread {
-        Some(name) => {
-            if let Some(loaded) = thread_manager(repo).load(name)? {
-                return Ok(loaded);
-            }
-            if let Some(current) = current_thread(repo)?
-                && (current.id == name || current.thread == name)
-            {
-                return Ok(current);
-            }
-            load_thread(repo, name)
-        }
+        Some(name) => load_thread(repo, name),
         None => current_thread(repo)?.ok_or_else(|| {
             anyhow!(RecoveryAdvice::no_current_thread(
                 "sync",
@@ -1468,10 +1459,10 @@ fn resolve_sync_thread(repo: &Repository, thread: Option<&str>) -> Result<Thread
     }
 }
 
-fn sync_is_already_current(thread: &Thread) -> bool {
+fn sync_is_already_current(thread: &Thread, synthesized_checkout: bool) -> bool {
     core_sync_is_already_current(
         thread.freshness == repo::ThreadFreshness::Current,
-        thread.target_thread.is_some(),
+        synthesized_checkout,
     )
 }
 
@@ -3751,20 +3742,24 @@ mod tests {
     // the in-thread case (paths equal) and a worktree-less thread (empty path)
     // do not.
     #[test]
-    fn sync_treats_default_thread_without_target_as_already_current() {
+    fn sync_treats_synthesized_checkout_as_already_current() {
         let mut thread = thread_with_execution_path(PathBuf::from("/tmp/main"));
         thread.id = "main".to_string();
         thread.thread = "main".to_string();
         thread.target_thread = None;
         thread.freshness = repo::ThreadFreshness::Unknown;
-        assert!(sync_is_already_current(&thread));
+        assert!(sync_is_already_current(&thread, true));
+        assert!(
+            !sync_is_already_current(&thread, false),
+            "a persisted managed thread with no target is not a no-op"
+        );
 
         thread.target_thread = Some("main".to_string());
         thread.freshness = repo::ThreadFreshness::Stale;
-        assert!(!sync_is_already_current(&thread));
+        assert!(!sync_is_already_current(&thread, false));
 
         thread.freshness = repo::ThreadFreshness::Current;
-        assert!(sync_is_already_current(&thread));
+        assert!(sync_is_already_current(&thread, false));
     }
 
     #[test]

--- a/crates/cli/src/cli/commands/workflow.rs
+++ b/crates/cli/src/cli/commands/workflow.rs
@@ -16,6 +16,8 @@ use heddle_core::{
     op_targets_merge_state as core_op_targets_merge_state,
     recovery_scope_checkout as core_recovery_scope_checkout,
     should_squash_land as core_should_squash_land,
+    sync_completed_next_action as core_sync_completed_next_action,
+    sync_is_already_current as core_sync_is_already_current,
 };
 use objects::{
     lock::{RepositoryLockExt, WriteLockGuard},
@@ -30,7 +32,7 @@ use repo::{
 use serde::{Deserialize, Serialize};
 
 use super::{
-    action_line::print_next,
+    action_line::{print_next, print_next_step},
     advice::RecoveryAdvice,
     checkpoint::{GitCheckpointRequest, create_git_checkpoint},
     collapse::{CollapsePublishedRef, collapse_resolved_states},
@@ -225,24 +227,18 @@ thread_local! {
 
 pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
     let repo = cli.open_repo()?;
-    let mut thread = resolve_thread(
-        &repo,
-        args.thread.as_deref(),
-        "sync",
-        "heddle sync --thread <name>",
-    )?;
+    let mut thread = resolve_sync_thread(&repo, args.thread.as_deref())?;
 
     let stale_report = build_thread_preview_report(&repo, &mut thread, true)?;
     let stale_blockers = non_staleness_blockers(&stale_report.blockers);
     let operation = repo.operation_status()?;
     let remote_tracking = repo.git_remote_tracking_status()?;
     let import_hint = repo.git_import_guidance()?;
-    let mut output = if thread.freshness == repo::ThreadFreshness::Current {
-        let recommended_action = primary_next_action(
+    let mut output = if sync_is_already_current(&thread) {
+        let recommended_action = sync_completed_next_action(
             operation.as_ref(),
             remote_tracking.as_ref(),
             import_hint.as_ref(),
-            Some(&land_local_command(&thread.id)),
         );
         let trust = build_repository_verification_state(&repo);
         SyncOutput {
@@ -252,8 +248,8 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                 message: format!("Thread '{}' is already current", thread.id),
                 blockers: vec![],
                 warnings: Vec::new(),
-                next_action: Some(recommended_action.clone()),
-                recommended_action: Some(recommended_action),
+                next_action: recommended_action.clone(),
+                recommended_action,
             },
             trust,
             thread: thread.id.clone(),
@@ -311,8 +307,8 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
         // heddle#464 r2: the old conflict branch returned here early and
         // emitted `heddle resolve --list` with no merge in progress — a dead
         // breadcrumb that failed with `no_merge_in_progress`. A previewed
-        // conflict that the 3-way merge resolves cleanly also completes here
-        // and recommends `land`.
+        // conflict that the 3-way merge resolves cleanly also completes here.
+        // Sync does not prescribe `land --thread`; landing is a separate job.
         match refresh_thread(&repo, &thread.id, cli) {
             Ok(refreshed) => {
                 update_integration_policy(
@@ -321,11 +317,10 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                     "current",
                     "thread refreshed cleanly",
                 )?;
-                let recommended_action = primary_next_action(
+                let recommended_action = sync_completed_next_action(
                     operation.as_ref(),
                     remote_tracking.as_ref(),
                     import_hint.as_ref(),
-                    Some(&land_local_command(&refreshed.id)),
                 );
                 let trust = build_repository_verification_state(&repo);
                 SyncOutput {
@@ -335,8 +330,8 @@ pub async fn cmd_sync(cli: &Cli, args: SyncArgs) -> Result<()> {
                         message: format!("Refreshed thread '{}'", refreshed.id),
                         blockers: vec![],
                         warnings: Vec::new(),
-                        next_action: Some(recommended_action.clone()),
-                        recommended_action: Some(recommended_action),
+                        next_action: recommended_action.clone(),
+                        recommended_action,
                     },
                     trust,
                     thread: refreshed.id.clone(),
@@ -1444,6 +1439,50 @@ fn resolve_thread(
     }
 }
 
+/// Resolve the thread `sync` refreshes onto its target.
+///
+/// The default checkout (including a thread named `main`) has a ref from
+/// `seed_default_thread` but often no ThreadManager record. `load_thread`
+/// would then say `Thread 'main' not found`. Sync accepts the current /
+/// default checkout thread as a first-class subject.
+fn resolve_sync_thread(repo: &Repository, thread: Option<&str>) -> Result<Thread> {
+    match thread {
+        Some(name) => {
+            if let Some(loaded) = thread_manager(repo).load(name)? {
+                return Ok(loaded);
+            }
+            if let Some(current) = current_thread(repo)?
+                && (current.id == name || current.thread == name)
+            {
+                return Ok(current);
+            }
+            load_thread(repo, name)
+        }
+        None => current_thread(repo)?.ok_or_else(|| {
+            anyhow!(RecoveryAdvice::no_current_thread(
+                "sync",
+                Some("--thread"),
+                "heddle sync --thread <name>",
+            ))
+        }),
+    }
+}
+
+fn sync_is_already_current(thread: &Thread) -> bool {
+    core_sync_is_already_current(
+        thread.freshness == repo::ThreadFreshness::Current,
+        thread.target_thread.is_some(),
+    )
+}
+
+fn sync_completed_next_action(
+    operation: Option<&repo::RepositoryOperationStatus>,
+    remote_tracking: Option<&repo::GitRemoteTrackingStatus>,
+    import_hint: Option<&repo::GitImportGuidance>,
+) -> Option<String> {
+    core_sync_completed_next_action(operation, remote_tracking, import_hint)
+}
+
 /// Resolve the thread `land` integrates.
 ///
 /// `--thread` wins. Otherwise the subject is the current thread of the
@@ -2143,7 +2182,26 @@ fn write_sync_output(cli: &Cli, repo: &Repository, output: &SyncOutput) -> Resul
             NextActionValidationContext::new(&["sync"], repo.capability()),
         )?;
     } else {
-        println!("{}", serde_json::to_string_pretty(output)?);
+        let message = match output.operator.status.as_str() {
+            "blocked" => style::warn(&output.operator.message),
+            "current" | "refreshed" => style::accent(&output.operator.message),
+            _ => output.operator.message.clone(),
+        };
+        println!("{message}");
+        if !output.operator.blockers.is_empty() {
+            println!("{}", style::warn("Blocked by"));
+            for blocker in &output.operator.blockers {
+                println!("  - {}", style::warn(blocker));
+            }
+        }
+        if let Some(next) = output
+            .operator
+            .recommended_action
+            .as_ref()
+            .or(output.operator.next_action.as_ref())
+        {
+            print_next_step(next);
+        }
     }
     Ok(())
 }
@@ -3692,6 +3750,28 @@ mod tests {
     // isolated thread (execution_path differs from the current checkout) scopes;
     // the in-thread case (paths equal) and a worktree-less thread (empty path)
     // do not.
+    #[test]
+    fn sync_treats_default_thread_without_target_as_already_current() {
+        let mut thread = thread_with_execution_path(PathBuf::from("/tmp/main"));
+        thread.id = "main".to_string();
+        thread.thread = "main".to_string();
+        thread.target_thread = None;
+        thread.freshness = repo::ThreadFreshness::Unknown;
+        assert!(sync_is_already_current(&thread));
+
+        thread.target_thread = Some("main".to_string());
+        thread.freshness = repo::ThreadFreshness::Stale;
+        assert!(!sync_is_already_current(&thread));
+
+        thread.freshness = repo::ThreadFreshness::Current;
+        assert!(sync_is_already_current(&thread));
+    }
+
+    #[test]
+    fn sync_completed_next_action_is_not_land_thread() {
+        assert_eq!(sync_completed_next_action(None, None, None), None);
+    }
+
     #[test]
     fn recovery_scope_checkout_distinguishes_isolated_from_in_thread() {
         let isolated = thread_with_execution_path(PathBuf::from("/work/threads/agent-thread"));

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use refs::Head;
 use repo::{Repository, ThreadIntegrationPolicy, ThreadManager, ThreadState};
 use serde_json::Value;
 use tempfile::TempDir;
@@ -398,13 +399,116 @@ fn sync_on_default_main_thread_succeeds() {
         "sync next_action must not unconditionally recommend land --thread: {sync}"
     );
     assert_no_banned_next_actions(&sync);
+}
 
-    let named = json(
+/// heddle#1461 / #1467: `--thread` must not bypass `load_thread`'s
+/// imported-ref advice just because the unmanaged ref is currently checked out.
+#[test]
+fn sync_named_unmanaged_ref_keeps_imported_ref_advice() {
+    let repo = setup_native_repo();
+    let output = heddle_output(
         &["--output", "json", "sync", "--thread", "main"],
+        Some(repo.path()),
+    )
+    .expect("sync --thread main should spawn");
+    assert!(
+        !output.status.success(),
+        "unmanaged main must not silently no-op: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let envelope: Value = serde_json::from_str(
+        stderr
+            .lines()
+            .map(str::trim)
+            .find(|line| !line.is_empty())
+            .unwrap_or(stderr.trim()),
+    )
+    .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{stderr}"));
+    assert_eq!(envelope["kind"], "imported_git_ref_not_managed_thread");
+}
+
+/// heddle#1461 / #1467: a managed thread created from detached HEAD has
+/// `target_thread: None`. Sync must not treat that as already-current.
+#[test]
+fn sync_detached_head_managed_thread_without_target_is_not_noop() {
+    let repo = setup_native_repo();
+    let opened = Repository::open(repo.path()).unwrap();
+    let head = opened
+        .head()
+        .unwrap()
+        .expect("repo should have a current state before detaching");
+    opened
+        .write_head_recorded(&Head::Detached { state: head })
+        .unwrap();
+    drop(opened);
+
+    let checkout = TempDir::new().unwrap();
+    let checkout_arg = checkout.path().join("work");
+    let started = json(
+        &[
+            "--output",
+            "json",
+            "start",
+            "feature/no-target",
+            "--path",
+            checkout_arg.to_str().unwrap(),
+        ],
         repo.path(),
     );
-    assert_eq!(named["status"], "current", "{named}");
-    assert_eq!(named["thread"], "main", "{named}");
+    let _execution_path = started["execution_path"]
+        .as_str()
+        .expect("start should report execution_path");
+
+    let manager = ThreadManager::new(Repository::open(repo.path()).unwrap().heddle_dir());
+    let thread = manager
+        .load("feature/no-target")
+        .unwrap()
+        .expect("managed thread should have a record");
+    assert!(
+        thread.target_thread.is_none(),
+        "detached-HEAD start must persist no target, got {:?}",
+        thread.target_thread
+    );
+
+    let output = heddle_output(
+        &["--output", "json", "sync", "--thread", "feature/no-target"],
+        Some(repo.path()),
+    )
+    .expect("sync --thread feature/no-target should spawn");
+    assert!(
+        !output.status.success(),
+        "no-target managed thread must not report success as a no-op: stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !combined.contains("already current") && !combined.contains("\"chosen_path\":\"no_op\""),
+        "no-target managed sync must not take the synthesized-checkout no-op: {combined}"
+    );
+    let envelope: Value = serde_json::from_str(
+        combined
+            .lines()
+            .map(str::trim)
+            .find(|line| line.starts_with('{'))
+            .unwrap_or(combined.trim()),
+    )
+    .unwrap_or_else(|err| panic!("JSON envelope: {err}\n{combined}"));
+    assert_eq!(envelope["kind"], "missing_target_thread", "{envelope}");
+    assert!(
+        envelope["error"]
+            .as_str()
+            .is_some_and(|error| error.contains("has no target thread")),
+        "missing-target advice must be actionable: {envelope}"
+    );
+
+    drop(checkout);
 }
 
 /// heddle#1461: default human output is prose, not the JSON envelope.

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -379,3 +379,75 @@ fn sync_conflicting_stale_thread_emits_runnable_resolve_breadcrumb() {
 
     drop(checkout_owner);
 }
+
+/// heddle#1461: the default checkout thread is named `main` and has a ref
+/// but often no ThreadManager record. `heddle sync` must treat that as the
+/// current / default thread, not `Thread 'main' not found`.
+#[test]
+fn sync_on_default_main_thread_succeeds() {
+    let repo = setup_native_repo();
+
+    let sync = json(&["--output", "json", "sync"], repo.path());
+    assert_eq!(sync["status"], "current", "{sync}");
+    assert_eq!(sync["thread"], "main", "{sync}");
+    assert_eq!(sync["chosen_path"], "no_op", "{sync}");
+    assert_eq!(sync["output_kind"], "sync", "{sync}");
+    let next = sync["next_action"].as_str().unwrap_or("");
+    assert!(
+        !next.contains("land --thread"),
+        "sync next_action must not unconditionally recommend land --thread: {sync}"
+    );
+    assert_no_banned_next_actions(&sync);
+
+    let named = json(
+        &["--output", "json", "sync", "--thread", "main"],
+        repo.path(),
+    );
+    assert_eq!(named["status"], "current", "{named}");
+    assert_eq!(named["thread"], "main", "{named}");
+}
+
+/// heddle#1461: default human output is prose, not the JSON envelope.
+#[test]
+fn sync_default_text_is_prose_not_json() {
+    let repo = setup_native_repo();
+    let text = heddle(&["sync"], Some(repo.path())).expect("sync text");
+    assert!(
+        text.contains("Thread 'main' is already current"),
+        "sync text should name the current thread in prose:\n{text}"
+    );
+    assert!(
+        !text.trim_start().starts_with('{'),
+        "sync default text must not be a JSON blob:\n{text}"
+    );
+    assert!(
+        !text.contains("land --thread"),
+        "sync text must not unconditionally recommend land --thread:\n{text}"
+    );
+}
+
+/// heddle#1461: after a clean refresh, sync is done — next is not land --thread.
+#[test]
+fn sync_refresh_does_not_prescribe_land_thread() {
+    let (main, checkout_owner, execution_path) = setup_managed_thread("feature/sync-next");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout)).unwrap();
+
+    std::fs::write(main.path().join("base.txt"), "base changed\n").unwrap();
+    heddle(&["capture", "-m", "advance main"], Some(main.path())).unwrap();
+
+    let sync = json(
+        &["--output", "json", "sync", "--thread", "feature/sync-next"],
+        main.path(),
+    );
+    assert_eq!(sync["status"], "refreshed", "{sync}");
+    let next = sync["next_action"].as_str().unwrap_or("");
+    assert!(
+        !next.contains("land --thread"),
+        "refreshed sync must not unconditionally recommend land --thread: {sync}"
+    );
+    assert_no_banned_next_actions(&sync);
+
+    drop(checkout_owner);
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -382,4 +382,5 @@ pub use workflow::{
     ready_scoped_next_action, ready_status_summary, ready_verification_preflight_blocks,
     ready_verification_status_blocks, recovery_scope_checkout, scope_action_to_repo,
     should_squash_land, state_id_matches_display, state_id_matches_op_display,
+    sync_completed_next_action, sync_is_already_current,
 };

--- a/crates/core/src/workflow.rs
+++ b/crates/core/src/workflow.rs
@@ -421,6 +421,32 @@ pub fn land_skipped_steps(
     .collect()
 }
 
+/// Next action after a successful sync (already current or refreshed).
+///
+/// Sync is its own job — refresh this thread onto its target — not land.
+/// Operation / remote / import still win. There is no `land --thread`
+/// fallback: a completed sync does not prescribe landing.
+pub fn sync_completed_next_action(
+    operation: Option<&RepositoryOperationStatus>,
+    remote_tracking: Option<&GitRemoteTrackingStatus>,
+    import_hint: Option<&GitImportGuidance>,
+) -> Option<String> {
+    non_empty_action(Some(&effective_next_action(NextActionInput::default(
+        operation,
+        remote_tracking,
+        import_hint,
+        None,
+    ))))
+    .map(str::to_string)
+}
+
+/// Whether sync has nothing left to refresh: the thread is already
+/// current, or it has no integration target (the default checkout,
+/// including a thread named `main`).
+pub fn sync_is_already_current(freshness_is_current: bool, has_target_thread: bool) -> bool {
+    freshness_is_current || !has_target_thread
+}
+
 /// Next action after a successful local land (push if trust says so, else cleanup).
 pub fn integrated_land_next_action(
     integrated: bool,
@@ -774,6 +800,28 @@ mod tests {
             Some("heddle push".to_string())
         );
         assert_eq!(integrated_land_next_action(false, "heddle push"), None);
+    }
+
+    #[test]
+    fn sync_completed_next_action_is_not_land_thread() {
+        assert_eq!(sync_completed_next_action(None, None, None), None);
+
+        let operation = RepositoryOperationStatus {
+            scope: OperationScope::Heddle,
+            kind: OperationKind::Merge,
+            in_progress: true,
+            state: "in_progress".to_string(),
+            message: "merge in progress".to_string(),
+            next_action: "heddle continue".to_string(),
+        };
+        assert_eq!(
+            sync_completed_next_action(Some(&operation), None, None),
+            Some("heddle continue".to_string())
+        );
+
+        assert!(sync_is_already_current(true, true));
+        assert!(sync_is_already_current(false, false));
+        assert!(!sync_is_already_current(false, true));
     }
 
     #[test]

--- a/crates/core/src/workflow.rs
+++ b/crates/core/src/workflow.rs
@@ -440,11 +440,15 @@ pub fn sync_completed_next_action(
     .map(str::to_string)
 }
 
-/// Whether sync has nothing left to refresh: the thread is already
-/// current, or it has no integration target (the default checkout,
-/// including a thread named `main`).
-pub fn sync_is_already_current(freshness_is_current: bool, has_target_thread: bool) -> bool {
-    freshness_is_current || !has_target_thread
+/// Whether sync has nothing left to refresh.
+///
+/// The no-op is freshness-current **or** the synthesized default
+/// checkout (a HEAD-attached ref with no ThreadManager record, often
+/// named `main`). A persisted managed thread with `target_thread: None`
+/// (created from detached HEAD) is **not** a no-op — it must reach
+/// `refresh_thread` and surface `missing_target_thread`.
+pub fn sync_is_already_current(freshness_is_current: bool, is_synthesized_checkout: bool) -> bool {
+    freshness_is_current || is_synthesized_checkout
 }
 
 /// Next action after a successful local land (push if trust says so, else cleanup).
@@ -819,9 +823,9 @@ mod tests {
             Some("heddle continue".to_string())
         );
 
-        assert!(sync_is_already_current(true, true));
-        assert!(sync_is_already_current(false, false));
-        assert!(!sync_is_already_current(false, true));
+        assert!(sync_is_already_current(true, false));
+        assert!(sync_is_already_current(false, true));
+        assert!(!sync_is_already_current(false, false));
     }
 
     #[test]

--- a/docs/json-schemas.md
+++ b/docs/json-schemas.md
@@ -3314,8 +3314,8 @@ Refresh the active or named thread, or report the verification/action blocker.
   "message": "Refreshed thread 'feature/parser'",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle land",
-  "recommended_action": "heddle land",
+  "next_action": null,
+  "recommended_action": null,
   "thread": "feature/parser",
   "current_state": "hc-sqr398dvx9ay",
   "chosen_path": "refresh"

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -7324,8 +7324,8 @@ Refresh the active or named thread, or report the verification/action blocker.
   "message": "Refreshed thread 'feature/parser'",
   "blockers": [],
   "warnings": [],
-  "next_action": "heddle land",
-  "recommended_action": "heddle land",
+  "next_action": null,
+  "recommended_action": null,
   "thread": "feature/parser",
   "current_state": "hc-sqr398dvx9ay",
   "chosen_path": "refresh"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `heddle sync` on the current / default thread works, including a thread named `main`. The no-op is restricted to the synthesized default checkout (HEAD-attached ref with no ThreadManager record), not every thread with `target_thread: None`.
- A managed thread created from detached HEAD still reaches `refresh_thread` and surfaces `missing_target_thread` instead of silently succeeding as already-current.
- Explicit `--thread` always goes through `load_thread`, so a currently checked-out unmanaged ref keeps imported-ref advice.
- Default human output is prose, not a raw JSON blob. Completed sync does not unconditionally recommend `land --thread`. Sync stays its own verb.

## Closes

Closes HeddleCo/heddle#1461

## Red commit

N/A — bugfix; regression tests landed with the implementation.

## Test evidence

```
$ cargo test -p heddle-core sync_completed_next_action -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/heddle_core-bc4e4de5b874ca71)

running 1 test
test workflow::tests::sync_completed_next_action_is_not_land_thread ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 449 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --lib sync_ -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 3 tests
test cli::commands::workflow::tests::sync_completed_next_action_is_not_land_thread ... ok
test cli::commands::workflow::tests::sync_treats_synthesized_checkout_as_already_current ... ok
test util::once_map::tests::async_init_caches_value ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 743 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --test cli_integration sync_ -- --nocapture
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 24 tests
test next_action_contract::sync_default_text_is_prose_not_json ... ok
test next_action_contract::sync_named_unmanaged_ref_keeps_imported_ref_advice ... ok
test next_action_contract::sync_detached_head_managed_thread_without_target_is_not_noop ... ok
test next_action_contract::sync_on_default_main_thread_succeeds ... ok
test next_action_contract::sync_refresh_does_not_prescribe_land_thread ... ok
test next_action_contract::sync_conflicting_stale_thread_emits_runnable_resolve_breadcrumb ... ok
...
test result: ok. 24 passed; 0 failed; 0 ignored; 0 measured; 939 filtered out; finished in 1.52s

$ cargo test -p heddle-cli --test multi_agent_worktrees sync_refreshes_stale_thread -- --nocapture
     Running tests/multi_agent_worktrees.rs (target/debug/deps/multi_agent_worktrees-3f763b04cc8c6967)

running 1 test
test e2e::sync_refreshes_stale_thread_when_replay_is_clean ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 80 filtered out; finished in 0.36s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-61d5e3bb-f1ab-4cea-9b42-c6f3584b1de5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-61d5e3bb-f1ab-4cea-9b42-c6f3584b1de5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782345&installation_model_id=21489&pr_number=1467&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1467&signature=3505060560d5cbafe67a4f92e89a7a55683098e6e8b8d2420bac82d51f81ed74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->