### PR TITLE
review: fire real capture-time risk signals from SemanticContext

### DIFF
--- a/crates/cli/tests/cli_integration/output_kind_runtime.rs
+++ b/crates/cli/tests/cli_integration/output_kind_runtime.rs
@@ -610,6 +610,43 @@ fn discuss_open_show_append_emit_output_kind() {
 }
 
 #[test]
+fn review_show_and_health_emit_real_signals_when_semantic_diff_sees_a_change() {
+    let temp = TempDir::new().expect("tempdir");
+    heddle(&["init"], Some(temp.path())).expect("heddle init");
+    fs::write(
+        temp.path().join("changed.rs"),
+        "fn alpha() { let total = first + second + third + fourth; }\n\
+         fn beta() { for widget in inventory { ship(widget); } }\n\
+         fn gamma() { match colour { Red => stop(), Green => go() } }\n\
+         fn delta() { while pending { dequeue().handle(); } flush(); }\n",
+    )
+    .expect("write novel functions");
+    heddle(&["capture", "-m", "novel shape"], Some(temp.path())).expect("capture");
+
+    let show = heddle_json(&["review", "show"], &temp);
+    assert_output_kind(&show, "review_show");
+    let signals = show["in_budget_signals"]
+        .as_array()
+        .expect("in_budget_signals array");
+    assert!(
+        signals.iter().any(|signal| {
+            signal["kind"] != "diff_summary" && signal["producer"] == "novelty.tree_sitter"
+        }),
+        "review show must emit a real SemanticContext signal, got {show}"
+    );
+
+    let health = heddle_json(&["review", "health"], &temp);
+    assert_output_kind(&health, "review_health");
+    let entries = health["entries"].as_array().expect("health entries");
+    assert!(
+        entries
+            .iter()
+            .any(|entry| entry["module_id"] == "novelty.tree_sitter"),
+        "review health must not be empty after a semantic change: {health}"
+    );
+}
+
+#[test]
 fn review_show_emits_output_kind() {
     let temp = init_and_capture();
     let value = heddle_json(&["review", "show", "HEAD"], &temp);

--- a/crates/daemon/src/local_review/state_review.rs
+++ b/crates/daemon/src/local_review/state_review.rs
@@ -165,24 +165,15 @@ impl LocalStateReview {
             None
         };
 
-        // Surface fired risk signals if requested. The signal registry will
-        // Trimmed budget split: every signal is visible. The former ranked
-        // `state_review::budget` helper was unused and removed (HEDDLE-DR-10);
-        // reintroduce a ranked partition here if tick budgeting ships.
-        let mut all_signals = Vec::new();
-        if include_all_signals
-            && let Some(hash) =
-                attachment_hash(repo, &state.state_id, StateAttachmentKind::RiskSignals)?
-            && let Some(blob) = repo.store().get_blob(&hash).map_err(map_repository_error)?
-        {
-            let decoded = RiskSignalBlob::decode(blob.content())
-                .map_err(|err| LocalReviewError::internal(format!("decode risk signals: {err}")))?;
-            all_signals = decoded
-                .signals
-                .into_iter()
-                .map(|signal| review_signal(signal, ReviewSignalVisibility::Visible))
-                .collect();
-        }
+        // Persist-time risk signals are always in-budget. `--all-signals`
+        // also copies them onto `all_signals` (no hidden partition yet;
+        // HEDDLE-DR-10 removed the unused ranked budgeter).
+        let risk_signals = load_persisted_risk_signals(repo, &state.state_id)?;
+        let all_signals = if include_all_signals {
+            risk_signals.clone()
+        } else {
+            Vec::new()
+        };
 
         // Synthesize a structured `diff_summary` signal so the
         // `in_budget_signals` array is non-empty even before the real
@@ -246,6 +237,7 @@ impl LocalStateReview {
                 });
             }
         }
+        in_budget_signals.extend(risk_signals);
 
         // Build the reading-order partition from the same domain symbols
         // used at the hosted boundary: tree-sitter when the
@@ -531,6 +523,25 @@ fn append_review_signature(
 /// single state. (A future schema bump may add an explicit id.)
 fn synthetic_signature_id(index: usize) -> String {
     format!("rs-{index}")
+}
+
+fn load_persisted_risk_signals(
+    repo: &Repository,
+    state_id: &StateId,
+) -> Result<Vec<ReviewSignal>, LocalReviewError> {
+    let Some(hash) = attachment_hash(repo, state_id, StateAttachmentKind::RiskSignals)? else {
+        return Ok(Vec::new());
+    };
+    let Some(blob) = repo.store().get_blob(&hash).map_err(map_repository_error)? else {
+        return Ok(Vec::new());
+    };
+    let decoded = RiskSignalBlob::decode(blob.content())
+        .map_err(|err| LocalReviewError::internal(format!("decode risk signals: {err}")))?;
+    Ok(decoded
+        .signals
+        .into_iter()
+        .map(|signal| review_signal(signal, ReviewSignalVisibility::Visible))
+        .collect())
 }
 
 fn attachment_hash(
@@ -1239,6 +1250,60 @@ mod tests {
         assert_eq!(
             payload.in_budget_signals[0].producer.module,
             "review_show.diff_summary"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(process_global)]
+    fn local_payload_surfaces_persisted_risk_signals_without_all_signals_flag() {
+        let (review, repo, _temp) = fresh_review();
+        let state_id = capture_state(&repo, b"hello\n");
+        let signal = objects::object::RiskSignal {
+            kind: objects::object::RiskSignalKind::Novelty,
+            anchor: objects::object::SignalAnchor::symbol("changed.rs", "delta"),
+            reason: "function shape unique in repo".to_string(),
+            producer: objects::object::ProducerId::new("novelty.tree_sitter", 1),
+            computed_at: 1,
+            computed_against: Some(state_id),
+        };
+        let bytes = objects::object::RiskSignalBlob::new(vec![signal])
+            .encode()
+            .expect("encode risk signals");
+        let hash = repo
+            .store()
+            .put_blob(&objects::object::Blob::new(bytes))
+            .expect("put risk blob");
+        repo.put_state_attachment(&objects::object::StateAttachment {
+            state_id,
+            body: objects::object::StateAttachmentBody::RiskSignals(hash),
+            attribution: repo.get_attribution().expect("attribution"),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach risk signals");
+
+        let payload = review.get_review_payload(state_id, false).expect("payload");
+        assert!(
+            payload.in_budget_signals.iter().any(|signal| {
+                signal.kind == ReviewSignalKind::Risk(objects::object::RiskSignalKind::Novelty)
+                    && signal.producer.module == "novelty.tree_sitter"
+            }),
+            "review show must emit persisted risk signals, got {:?}",
+            payload.in_budget_signals
+        );
+        assert!(
+            payload.all_signals.is_empty(),
+            "all_signals stays empty unless --all-signals"
+        );
+
+        let health = crate::local_review::get_repo_signal_health(&repo, 10).expect("health");
+        assert!(
+            health
+                .entries
+                .iter()
+                .any(|entry| entry.module_id == "novelty.tree_sitter"),
+            "review health must see persisted signals: {:?}",
+            health.entries
         );
     }
 

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -75,6 +75,8 @@ pub use repository_symbol_graph_query::ResolvedSemanticEdgeSet;
 #[cfg(all(test, feature = "tree-sitter-symbols"))]
 mod repository_semantic_graph_e2e_tests;
 #[cfg(feature = "tree-sitter-symbols")]
+mod repository_semantic_context;
+#[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
 mod repository_state_visibility;
 #[cfg(all(test, feature = "tree-sitter-symbols"))]

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -72,10 +72,10 @@ mod repository_symbol_graph_frontier;
 mod repository_symbol_graph_load;
 mod repository_symbol_graph_query;
 pub use repository_symbol_graph_query::ResolvedSemanticEdgeSet;
-#[cfg(all(test, feature = "tree-sitter-symbols"))]
-mod repository_semantic_graph_e2e_tests;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_semantic_context;
+#[cfg(all(test, feature = "tree-sitter-symbols"))]
+mod repository_semantic_graph_e2e_tests;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_signals;
 mod repository_state_visibility;

--- a/crates/repo/src/lib.rs
+++ b/crates/repo/src/lib.rs
@@ -74,6 +74,8 @@ mod repository_symbol_graph_query;
 pub use repository_symbol_graph_query::ResolvedSemanticEdgeSet;
 #[cfg(feature = "tree-sitter-symbols")]
 mod repository_semantic_context;
+#[cfg(feature = "tree-sitter-symbols")]
+mod repository_semantic_corpus;
 #[cfg(all(test, feature = "tree-sitter-symbols"))]
 mod repository_semantic_graph_e2e_tests;
 #[cfg(feature = "tree-sitter-symbols")]

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -3,8 +3,10 @@
 //!
 //! `changed_paths` come from the snapshot tree diff, then formatting-only
 //! churn is pruned by the merkle index (`digest_at_path`, the same
-//! comparison [`Repository::semantic_changed`] uses). Functions are parsed
-//! only for that pruned set via the shared [`SemanticParseCache`].
+//! comparison [`Repository::semantic_changed`] uses). Emit-scope functions
+//! are parsed for that pruned set via the shared [`SemanticParseCache`].
+//! The new-state comparison corpus is then filled from the semantic index
+//! under fail-closed page/byte budgets.
 
 #![cfg(feature = "tree-sitter-symbols")]
 
@@ -31,7 +33,7 @@ use tracing::warn;
 use crate::{Repository, Result};
 
 /// Skip generated/vendored blobs the semantic index also treats as opaque.
-const PARSE_BUDGET_BYTES: usize = 1 << 20;
+pub(crate) const PARSE_BUDGET_BYTES: usize = 1 << 20;
 
 /// In-memory objects from a packed worktree snapshot, then the durable store.
 struct OverlaySource<'a, S: ObjectStore> {
@@ -134,10 +136,25 @@ pub(crate) fn build_semantic_context(
         }
     }
 
+    let corpus_complete = crate::repository_semantic_corpus::populate_new_function_corpus(
+        &overlay,
+        new_root.as_ref(),
+        &new.tree,
+        cache,
+        &mut new_functions,
+    )?;
+    let changed_symbols = crate::repository_semantic_corpus::collect_changed_symbols(
+        &changed_paths,
+        &prior_functions,
+        &new_functions,
+    );
+
     Ok(SemanticContext {
         prior_functions,
         new_functions,
         changed_paths,
+        changed_symbols,
+        corpus_complete,
     })
 }
 
@@ -206,7 +223,10 @@ fn digest_at_path(
     Ok(None)
 }
 
-fn load_semantic_tree(source: &impl ObjectSource, hash: &ContentHash) -> Result<SemanticTreeNode> {
+pub(crate) fn load_semantic_tree(
+    source: &impl ObjectSource,
+    hash: &ContentHash,
+) -> Result<SemanticTreeNode> {
     let blob = source
         .get_blob(hash)?
         .ok_or_else(|| HeddleError::NotFound(format!("semantic tree node {hash}")))?;
@@ -220,6 +240,15 @@ fn parse_tree_functions(
     path: &str,
     cache: &SemanticParseCache,
 ) -> Option<Vec<FunctionDef>> {
+    parse_tree_functions_sized(source, tree, path, cache).map(|(fns, _)| fns)
+}
+
+pub(crate) fn parse_tree_functions_sized(
+    source: &impl ObjectSource,
+    tree: Option<&ContentHash>,
+    path: &str,
+    cache: &SemanticParseCache,
+) -> Option<(Vec<FunctionDef>, usize)> {
     let tree = tree?;
     let language = Language::from_path(Path::new(path));
     if matches!(language, Language::Unknown) {
@@ -236,9 +265,10 @@ fn parse_tree_functions(
     if bytes.len() > PARSE_BUDGET_BYTES {
         return None;
     }
+    let byte_len = bytes.len();
     let source = std::str::from_utf8(&bytes).ok()?;
     let parsed = cache.parse(source, language)?;
-    Some(parsed.extract_functions())
+    Some((parsed.extract_functions(), byte_len))
 }
 
 fn blob_bytes_at_path(

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -126,23 +126,34 @@ pub(crate) fn build_semantic_context(
     let prior_tree = prior.map(|state| state.tree);
     let mut prior_functions = BTreeMap::new();
     let mut new_functions = BTreeMap::new();
+    let mut budget = crate::repository_semantic_corpus::CorpusBudget::default();
+    let mut corpus_complete = true;
     for path in &changed_paths {
         let path_str = path.to_string_lossy();
         if let Some(fns) = parse_tree_functions(&overlay, prior_tree.as_ref(), &path_str, cache) {
             prior_functions.insert(path.clone(), fns);
         }
-        if let Some(fns) = parse_tree_functions(&overlay, Some(&new.tree), &path_str, cache) {
+        if let Some((fns, bytes)) =
+            parse_tree_functions_sized(&overlay, Some(&new.tree), &path_str, cache)
+        {
+            if !budget.try_add(bytes) {
+                corpus_complete = false;
+                break;
+            }
             new_functions.insert(path.clone(), fns);
         }
     }
 
-    let corpus_complete = crate::repository_semantic_corpus::populate_new_function_corpus(
-        &overlay,
-        new_root.as_ref(),
-        &new.tree,
-        cache,
-        &mut new_functions,
-    )?;
+    if corpus_complete {
+        corpus_complete = crate::repository_semantic_corpus::populate_new_function_corpus(
+            &overlay,
+            new_root.as_ref(),
+            &new.tree,
+            cache,
+            &mut budget,
+            &mut new_functions,
+        )?;
+    }
     let changed_symbols = crate::repository_semantic_corpus::collect_changed_symbols(
         &changed_paths,
         &prior_functions,

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -9,12 +9,16 @@
 #![cfg(feature = "tree-sitter-symbols")]
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet, HashMap},
     path::{Path, PathBuf},
 };
 
 use objects::{
-    object::{ContentHash, LeafPolicy, SemanticIndexRoot, State, Tree, resolve_tree_path},
+    error::HeddleError,
+    object::{
+        Blob, ContentHash, LeafPolicy, ObjectSource, SemanticEntryKind, SemanticIndexRoot,
+        SemanticTreeNode, State, StateId, Tree, diff_trees, resolve_tree_path,
+    },
     store::ObjectStore,
 };
 use semantic::{
@@ -29,25 +33,74 @@ use crate::{Repository, Result};
 /// Skip generated/vendored blobs the semantic index also treats as opaque.
 const PARSE_BUDGET_BYTES: usize = 1 << 20;
 
+/// In-memory objects from a packed worktree snapshot, then the durable store.
+struct OverlaySource<'a, S: ObjectStore> {
+    store: &'a S,
+    blobs: Option<&'a HashMap<ContentHash, &'a [u8]>>,
+    trees: Option<&'a HashMap<ContentHash, &'a Tree>>,
+}
+
+impl<S: ObjectStore> ObjectSource for OverlaySource<'_, S> {
+    fn get_tree(&self, hash: &ContentHash) -> objects::error::Result<Option<Tree>> {
+        if let Some(trees) = self.trees
+            && let Some(tree) = trees.get(hash)
+        {
+            return Ok(Some((*tree).clone()));
+        }
+        if let Some(tree) = self.store.get_tree(hash)? {
+            return Ok(Some(tree));
+        }
+        if *hash == Tree::new().hash() {
+            return Ok(Some(Tree::new()));
+        }
+        Ok(None)
+    }
+
+    fn get_blob(&self, hash: &ContentHash) -> objects::error::Result<Option<Blob>> {
+        if let Some(blobs) = self.blobs
+            && let Some(bytes) = blobs.get(hash)
+        {
+            return Ok(Some(Blob::new(bytes.to_vec())));
+        }
+        self.store.get_blob(hash)
+    }
+
+    fn get_state(&self, id: &StateId) -> objects::error::Result<Option<State>> {
+        self.store.get_state(id)
+    }
+}
+
 /// Build the capture-time context for `run_all`.
 ///
 /// `new_index` is the just-computed merkle root hash (not yet attached).
-/// When both that root and the prior state's attached index are readable,
-/// paths whose digests match are dropped so a fmt-sweep parses nothing.
+/// Packed snapshots pass in-memory blobs/trees so parse does not wait for
+/// the commit pack. When both that root and the prior attached index are
+/// readable, paths whose digests match are dropped so a fmt-sweep parses
+/// nothing.
 pub(crate) fn build_semantic_context(
     repo: &Repository,
     prior: Option<&State>,
     new: &State,
     new_index: Option<&ContentHash>,
+    source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
+    source_trees: Option<&HashMap<ContentHash, &Tree>>,
 ) -> Result<SemanticContext> {
-    let from_tree = prior_tree_hash(repo, prior)?;
-    let changes = repo.diff_trees(&from_tree, &new.tree)?;
+    let overlay = OverlaySource {
+        store: repo.store(),
+        blobs: source_blobs,
+        trees: source_trees,
+    };
+    let from_tree = prior
+        .map(|state| state.tree)
+        .unwrap_or_else(|| Tree::new().hash());
+    let changes = diff_trees(&overlay, &from_tree, &new.tree)
+        .map_err(|err| HeddleError::InvalidObject(format!("tree diff failed: {err}")))?;
     let prior_root = prior
         .map(|state| repo.attached_semantic_index(&state.id()))
         .transpose()?
         .flatten();
     let new_root = new_index
-        .map(|hash| load_new_index_root(repo, hash))
+        .map(|hash| load_new_index_root(repo, hash, source_blobs))
         .transpose()?
         .flatten();
 
@@ -56,7 +109,12 @@ pub(crate) fn build_semantic_context(
         if !change.kind.is_change() {
             continue;
         }
-        if !path_semantically_changed(repo, prior_root.as_ref(), new_root.as_ref(), &change.path)? {
+        if !path_semantically_changed(
+            &overlay,
+            prior_root.as_ref(),
+            new_root.as_ref(),
+            &change.path,
+        )? {
             continue;
         }
         changed_paths.insert(PathBuf::from(&change.path));
@@ -68,10 +126,10 @@ pub(crate) fn build_semantic_context(
     let mut new_functions = BTreeMap::new();
     for path in &changed_paths {
         let path_str = path.to_string_lossy();
-        if let Some(fns) = parse_tree_functions(repo, prior_tree.as_ref(), &path_str, cache) {
+        if let Some(fns) = parse_tree_functions(&overlay, prior_tree.as_ref(), &path_str, cache) {
             prior_functions.insert(path.clone(), fns);
         }
-        if let Some(fns) = parse_tree_functions(repo, Some(&new.tree), &path_str, cache) {
+        if let Some(fns) = parse_tree_functions(&overlay, Some(&new.tree), &path_str, cache) {
             new_functions.insert(path.clone(), fns);
         }
     }
@@ -83,18 +141,18 @@ pub(crate) fn build_semantic_context(
     })
 }
 
-fn prior_tree_hash(repo: &Repository, prior: Option<&State>) -> Result<ContentHash> {
-    if let Some(state) = prior {
-        return Ok(state.tree);
-    }
-    let empty = Tree::new();
-    repo.store().put_tree(&empty)
-}
-
 fn load_new_index_root(
     repo: &Repository,
     hash: &ContentHash,
+    source_blobs: Option<&HashMap<ContentHash, &[u8]>>,
 ) -> Result<Option<SemanticIndexRoot>> {
+    if let Some(blobs) = source_blobs
+        && let Some(bytes) = blobs.get(hash)
+    {
+        return SemanticIndexRoot::decode(bytes)
+            .map(Some)
+            .map_err(|err| HeddleError::InvalidObject(err.to_string()));
+    }
     match repo.load_index_root(hash) {
         Ok(root) => Ok(Some(root)),
         Err(err) => {
@@ -110,7 +168,7 @@ fn load_new_index_root(
 /// Same digest comparison as `semantic_changed`, but only prunes when both
 /// indexes exist. Missing indexes keep the tree-diff path (fail toward parse).
 fn path_semantically_changed(
-    repo: &Repository,
+    source: &impl ObjectSource,
     prior_root: Option<&SemanticIndexRoot>,
     new_root: Option<&SemanticIndexRoot>,
     path: &str,
@@ -118,13 +176,46 @@ fn path_semantically_changed(
     let (Some(prior_root), Some(new_root)) = (prior_root, new_root) else {
         return Ok(true);
     };
-    let prior_digest = repo.digest_at_path(prior_root, path)?;
-    let new_digest = repo.digest_at_path(new_root, path)?;
+    let prior_digest = digest_at_path(source, prior_root, path)?;
+    let new_digest = digest_at_path(source, new_root, path)?;
     Ok(prior_digest != new_digest)
 }
 
+fn digest_at_path(
+    source: &impl ObjectSource,
+    root: &SemanticIndexRoot,
+    path_prefix: &str,
+) -> Result<Option<ContentHash>> {
+    let components: Vec<&str> = path_prefix.split('/').filter(|c| !c.is_empty()).collect();
+    if components.is_empty() {
+        return Ok(Some(root.semantic_digest));
+    }
+    let mut node = load_semantic_tree(source, &root.tree)?;
+    for (i, comp) in components.iter().enumerate() {
+        let Some(entry) = node.get(comp) else {
+            return Ok(None);
+        };
+        if i + 1 == components.len() {
+            return Ok(Some(entry.semantic_digest));
+        }
+        if entry.kind != SemanticEntryKind::Dir {
+            return Ok(None);
+        }
+        node = load_semantic_tree(source, &entry.node)?;
+    }
+    Ok(None)
+}
+
+fn load_semantic_tree(source: &impl ObjectSource, hash: &ContentHash) -> Result<SemanticTreeNode> {
+    let blob = source
+        .get_blob(hash)?
+        .ok_or_else(|| HeddleError::NotFound(format!("semantic tree node {hash}")))?;
+    SemanticTreeNode::decode(blob.content())
+        .map_err(|err| HeddleError::InvalidObject(err.to_string()))
+}
+
 fn parse_tree_functions(
-    repo: &Repository,
+    source: &impl ObjectSource,
     tree: Option<&ContentHash>,
     path: &str,
     cache: &SemanticParseCache,
@@ -134,7 +225,7 @@ fn parse_tree_functions(
     if matches!(language, Language::Unknown) {
         return None;
     }
-    let bytes = match blob_bytes_at_path(repo, tree, path) {
+    let bytes = match blob_bytes_at_path(source, tree, path) {
         Ok(Some(bytes)) => bytes,
         Ok(None) => return None,
         Err(err) => {
@@ -150,122 +241,18 @@ fn parse_tree_functions(
     Some(parsed.extract_functions())
 }
 
-fn blob_bytes_at_path(repo: &Repository, tree: &ContentHash, path: &str) -> Result<Option<Vec<u8>>> {
-    let resolved = resolve_tree_path(repo.store(), tree, Path::new(path), LeafPolicy::BlobOnly)?;
+fn blob_bytes_at_path(
+    source: &impl ObjectSource,
+    tree: &ContentHash,
+    path: &str,
+) -> Result<Option<Vec<u8>>> {
+    let resolved = resolve_tree_path(source, tree, Path::new(path), LeafPolicy::BlobOnly)?;
     let Some(hash) = resolved.and_then(|target| target.content_hash) else {
         return Ok(None);
     };
-    Ok(repo
-        .store()
-        .get_blob(&hash)?
-        .map(|blob| blob.content().to_vec()))
+    Ok(source.get_blob(&hash)?.map(|blob| blob.content().to_vec()))
 }
 
 #[cfg(test)]
-mod tests {
-    use objects::object::{Attribution, Principal, RiskSignalKind};
-    use tempfile::TempDir;
-
-    use super::*;
-    use crate::StateAttachmentKind;
-
-    fn author() -> Attribution {
-        Attribution::human(Principal::new("Test", "test@example.com"))
-    }
-
-    fn snapshot(repo: &Repository, root: &std::path::Path, path: &str, content: &str) -> State {
-        std::fs::write(root.join(path), content).unwrap();
-        repo.snapshot_with_attribution(Some("capture".to_string()), None, author())
-            .unwrap()
-    }
-
-    fn attachment_hash(
-        repo: &Repository,
-        state: &State,
-        kind: StateAttachmentKind,
-    ) -> Option<ContentHash> {
-        repo.latest_state_attachment(&state.id(), kind)
-            .unwrap()
-            .and_then(|attachment| match attachment.body {
-                objects::object::StateAttachmentBody::RiskSignals(hash)
-                | objects::object::StateAttachmentBody::SemanticIndex(hash) => Some(hash),
-                _ => None,
-            })
-    }
-
-    fn load_risk_kinds(repo: &Repository, state: &State) -> Vec<RiskSignalKind> {
-        let hash = match attachment_hash(repo, state, StateAttachmentKind::RiskSignals) {
-            Some(hash) => hash,
-            None => return Vec::new(),
-        };
-        let blob = repo.store().get_blob(&hash).unwrap().unwrap();
-        objects::object::RiskSignalBlob::decode(blob.content())
-            .unwrap()
-            .signals
-            .into_iter()
-            .map(|signal| signal.kind)
-            .collect()
-    }
-
-    const CORPUS: &str = "\
-fn alpha() { let total = first + second + third + fourth; }
-fn beta() { for widget in inventory { ship(widget); } }
-fn gamma() { match colour { Red => stop(), Green => go() } }
-fn delta() { while pending { dequeue().handle(); } flush(); }
-";
-
-    #[test]
-    fn fmt_sweep_prunes_changed_paths_and_persists_no_tree_sitter_signals() {
-        let temp = TempDir::new().unwrap();
-        let repo = Repository::init_default(temp.path()).unwrap();
-        let first = snapshot(&repo, temp.path(), "hello.rs", "fn foo() -> i32 { 1 }\n");
-        let reformatted = snapshot(
-            &repo,
-            temp.path(),
-            "hello.rs",
-            "fn foo() -> i32 {\n    1\n}\n",
-        );
-
-        let new_index = attachment_hash(&repo, &reformatted, StateAttachmentKind::SemanticIndex);
-        let ctx =
-            build_semantic_context(&repo, Some(&first), &reformatted, new_index.as_ref()).unwrap();
-        assert!(
-            ctx.changed_paths.is_empty(),
-            "fmt-sweep must prune semantic changed_paths: {ctx:?}"
-        );
-        assert!(ctx.new_functions.is_empty());
-        assert!(
-            load_risk_kinds(&repo, &reformatted)
-                .iter()
-                .all(|kind| !matches!(
-                    kind,
-                    RiskSignalKind::Novelty
-                        | RiskSignalKind::PatternDeviation
-                        | RiskSignalKind::TestReachability
-                )),
-            "fmt-sweep must persist zero tree-sitter signals"
-        );
-    }
-
-    #[test]
-    fn novel_shape_populates_context_and_fires_novelty() {
-        let temp = TempDir::new().unwrap();
-        let repo = Repository::init_default(temp.path()).unwrap();
-        let state = snapshot(&repo, temp.path(), "changed.rs", CORPUS);
-
-        let kinds = load_risk_kinds(&repo, &state);
-        assert!(
-            kinds.contains(&RiskSignalKind::Novelty),
-            "novel-shape capture must persist novelty, got {kinds:?}"
-        );
-
-        let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
-        let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref()).unwrap();
-        assert!(ctx.changed_paths.contains(&PathBuf::from("changed.rs")));
-        let fns = ctx
-            .new_functions
-            .get(&PathBuf::from("changed.rs"))
-            .expect("changed.rs must be parsed");
-        assert_eq!(fns.len(), 4, "parse only the changed file: {fns:?}");
-    }
-}
+#[path = "repository_semantic_context_tests.rs"]
+mod tests;

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Capture-time [`SemanticContext`] for the risk-signal registry.
+//!
+//! `changed_paths` come from the snapshot tree diff, then formatting-only
+//! churn is pruned by the merkle index (`digest_at_path`, the same
+//! comparison [`Repository::semantic_changed`] uses). Functions are parsed
+//! only for that pruned set via the shared [`SemanticParseCache`].
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+};
+
+use objects::{
+    object::{ContentHash, LeafPolicy, SemanticIndexRoot, State, Tree, resolve_tree_path},
+    store::ObjectStore,
+};
+use semantic::{
+    SemanticParseCache,
+    parser::{FunctionDef, Language},
+};
+use state_review::SemanticContext;
+use tracing::warn;
+
+use crate::{Repository, Result};
+
+/// Skip generated/vendored blobs the semantic index also treats as opaque.
+const PARSE_BUDGET_BYTES: usize = 1 << 20;
+
+/// Build the capture-time context for `run_all`.
+///
+/// `new_index` is the just-computed merkle root hash (not yet attached).
+/// When both that root and the prior state's attached index are readable,
+/// paths whose digests match are dropped so a fmt-sweep parses nothing.
+pub(crate) fn build_semantic_context(
+    repo: &Repository,
+    prior: Option<&State>,
+    new: &State,
+    new_index: Option<&ContentHash>,
+) -> Result<SemanticContext> {
+    let from_tree = prior_tree_hash(repo, prior)?;
+    let changes = repo.diff_trees(&from_tree, &new.tree)?;
+    let prior_root = prior
+        .map(|state| repo.attached_semantic_index(&state.id()))
+        .transpose()?
+        .flatten();
+    let new_root = new_index
+        .map(|hash| load_new_index_root(repo, hash))
+        .transpose()?
+        .flatten();
+
+    let mut changed_paths = BTreeSet::new();
+    for change in changes.iter() {
+        if !change.kind.is_change() {
+            continue;
+        }
+        if !path_semantically_changed(repo, prior_root.as_ref(), new_root.as_ref(), &change.path)? {
+            continue;
+        }
+        changed_paths.insert(PathBuf::from(&change.path));
+    }
+
+    let cache = SemanticParseCache::shared();
+    let prior_tree = prior.map(|state| state.tree);
+    let mut prior_functions = BTreeMap::new();
+    let mut new_functions = BTreeMap::new();
+    for path in &changed_paths {
+        let path_str = path.to_string_lossy();
+        if let Some(fns) = parse_tree_functions(repo, prior_tree.as_ref(), &path_str, cache) {
+            prior_functions.insert(path.clone(), fns);
+        }
+        if let Some(fns) = parse_tree_functions(repo, Some(&new.tree), &path_str, cache) {
+            new_functions.insert(path.clone(), fns);
+        }
+    }
+
+    Ok(SemanticContext {
+        prior_functions,
+        new_functions,
+        changed_paths,
+    })
+}
+
+fn prior_tree_hash(repo: &Repository, prior: Option<&State>) -> Result<ContentHash> {
+    if let Some(state) = prior {
+        return Ok(state.tree);
+    }
+    let empty = Tree::new();
+    repo.store().put_tree(&empty)
+}
+
+fn load_new_index_root(
+    repo: &Repository,
+    hash: &ContentHash,
+) -> Result<Option<SemanticIndexRoot>> {
+    match repo.load_index_root(hash) {
+        Ok(root) => Ok(Some(root)),
+        Err(err) => {
+            warn!(
+                error = %err,
+                "semantic context: new index root unavailable; parse tree-diff paths"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Same digest comparison as `semantic_changed`, but only prunes when both
+/// indexes exist. Missing indexes keep the tree-diff path (fail toward parse).
+fn path_semantically_changed(
+    repo: &Repository,
+    prior_root: Option<&SemanticIndexRoot>,
+    new_root: Option<&SemanticIndexRoot>,
+    path: &str,
+) -> Result<bool> {
+    let (Some(prior_root), Some(new_root)) = (prior_root, new_root) else {
+        return Ok(true);
+    };
+    let prior_digest = repo.digest_at_path(prior_root, path)?;
+    let new_digest = repo.digest_at_path(new_root, path)?;
+    Ok(prior_digest != new_digest)
+}
+
+fn parse_tree_functions(
+    repo: &Repository,
+    tree: Option<&ContentHash>,
+    path: &str,
+    cache: &SemanticParseCache,
+) -> Option<Vec<FunctionDef>> {
+    let tree = tree?;
+    let language = Language::from_path(Path::new(path));
+    if matches!(language, Language::Unknown) {
+        return None;
+    }
+    let bytes = match blob_bytes_at_path(repo, tree, path) {
+        Ok(Some(bytes)) => bytes,
+        Ok(None) => return None,
+        Err(err) => {
+            warn!(error = %err, path, "semantic context: blob load failed; skip parse");
+            return None;
+        }
+    };
+    if bytes.len() > PARSE_BUDGET_BYTES {
+        return None;
+    }
+    let source = std::str::from_utf8(&bytes).ok()?;
+    let parsed = cache.parse(source, language)?;
+    Some(parsed.extract_functions())
+}
+
+fn blob_bytes_at_path(repo: &Repository, tree: &ContentHash, path: &str) -> Result<Option<Vec<u8>>> {
+    let resolved = resolve_tree_path(repo.store(), tree, Path::new(path), LeafPolicy::BlobOnly)?;
+    let Some(hash) = resolved.and_then(|target| target.content_hash) else {
+        return Ok(None);
+    };
+    Ok(repo
+        .store()
+        .get_blob(&hash)?
+        .map(|blob| blob.content().to_vec()))
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{Attribution, Principal, RiskSignalKind};
+    use tempfile::TempDir;
+
+    use super::*;
+    use crate::StateAttachmentKind;
+
+    fn author() -> Attribution {
+        Attribution::human(Principal::new("Test", "test@example.com"))
+    }
+
+    fn snapshot(repo: &Repository, root: &std::path::Path, path: &str, content: &str) -> State {
+        std::fs::write(root.join(path), content).unwrap();
+        repo.snapshot_with_attribution(Some("capture".to_string()), None, author())
+            .unwrap()
+    }
+
+    fn attachment_hash(
+        repo: &Repository,
+        state: &State,
+        kind: StateAttachmentKind,
+    ) -> Option<ContentHash> {
+        repo.latest_state_attachment(&state.id(), kind)
+            .unwrap()
+            .and_then(|attachment| match attachment.body {
+                objects::object::StateAttachmentBody::RiskSignals(hash)
+                | objects::object::StateAttachmentBody::SemanticIndex(hash) => Some(hash),
+                _ => None,
+            })
+    }
+
+    fn load_risk_kinds(repo: &Repository, state: &State) -> Vec<RiskSignalKind> {
+        let hash = match attachment_hash(repo, state, StateAttachmentKind::RiskSignals) {
+            Some(hash) => hash,
+            None => return Vec::new(),
+        };
+        let blob = repo.store().get_blob(&hash).unwrap().unwrap();
+        objects::object::RiskSignalBlob::decode(blob.content())
+            .unwrap()
+            .signals
+            .into_iter()
+            .map(|signal| signal.kind)
+            .collect()
+    }
+
+    const CORPUS: &str = "\
+fn alpha() { let total = first + second + third + fourth; }
+fn beta() { for widget in inventory { ship(widget); } }
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { while pending { dequeue().handle(); } flush(); }
+";
+
+    #[test]
+    fn fmt_sweep_prunes_changed_paths_and_persists_no_tree_sitter_signals() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let first = snapshot(&repo, temp.path(), "hello.rs", "fn foo() -> i32 { 1 }\n");
+        let reformatted = snapshot(
+            &repo,
+            temp.path(),
+            "hello.rs",
+            "fn foo() -> i32 {\n    1\n}\n",
+        );
+
+        let new_index = attachment_hash(&repo, &reformatted, StateAttachmentKind::SemanticIndex);
+        let ctx =
+            build_semantic_context(&repo, Some(&first), &reformatted, new_index.as_ref()).unwrap();
+        assert!(
+            ctx.changed_paths.is_empty(),
+            "fmt-sweep must prune semantic changed_paths: {ctx:?}"
+        );
+        assert!(ctx.new_functions.is_empty());
+        assert!(
+            load_risk_kinds(&repo, &reformatted)
+                .iter()
+                .all(|kind| !matches!(
+                    kind,
+                    RiskSignalKind::Novelty
+                        | RiskSignalKind::PatternDeviation
+                        | RiskSignalKind::TestReachability
+                )),
+            "fmt-sweep must persist zero tree-sitter signals"
+        );
+    }
+
+    #[test]
+    fn novel_shape_populates_context_and_fires_novelty() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let state = snapshot(&repo, temp.path(), "changed.rs", CORPUS);
+
+        let kinds = load_risk_kinds(&repo, &state);
+        assert!(
+            kinds.contains(&RiskSignalKind::Novelty),
+            "novel-shape capture must persist novelty, got {kinds:?}"
+        );
+
+        let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
+        let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref()).unwrap();
+        assert!(ctx.changed_paths.contains(&PathBuf::from("changed.rs")));
+        let fns = ctx
+            .new_functions
+            .get(&PathBuf::from("changed.rs"))
+            .expect("changed.rs must be parsed");
+        assert_eq!(fns.len(), 4, "parse only the changed file: {fns:?}");
+    }
+}

--- a/crates/repo/src/repository_semantic_context.rs
+++ b/crates/repo/src/repository_semantic_context.rs
@@ -1,12 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-//! Capture-time [`SemanticContext`] for the risk-signal registry.
-//!
-//! `changed_paths` come from the snapshot tree diff, then formatting-only
-//! churn is pruned by the merkle index (`digest_at_path`, the same
-//! comparison [`Repository::semantic_changed`] uses). Emit-scope functions
-//! are parsed for that pruned set via the shared [`SemanticParseCache`].
-//! The new-state comparison corpus is then filled from the semantic index
-//! under fail-closed page/byte budgets.
+//! Capture-time [`SemanticContext`]: tree-diff paths, fmt-prune, bounded parse.
 
 #![cfg(feature = "tree-sitter-symbols")]
 
@@ -18,8 +11,8 @@ use std::{
 use objects::{
     error::HeddleError,
     object::{
-        Blob, ContentHash, LeafPolicy, ObjectSource, SemanticEntryKind, SemanticIndexRoot,
-        SemanticTreeNode, State, StateId, Tree, diff_trees, resolve_tree_path,
+        Blob, ContentHash, DiffKind, LeafPolicy, ObjectSource, SemanticEntryKind,
+        SemanticIndexRoot, SemanticTreeNode, State, StateId, Tree, diff_trees, resolve_tree_path,
     },
     store::ObjectStore,
 };
@@ -32,10 +25,8 @@ use tracing::warn;
 
 use crate::{Repository, Result};
 
-/// Skip generated/vendored blobs the semantic index also treats as opaque.
 pub(crate) const PARSE_BUDGET_BYTES: usize = 1 << 20;
 
-/// In-memory objects from a packed worktree snapshot, then the durable store.
 struct OverlaySource<'a, S: ObjectStore> {
     store: &'a S,
     blobs: Option<&'a HashMap<ContentHash, &'a [u8]>>,
@@ -73,12 +64,6 @@ impl<S: ObjectStore> ObjectSource for OverlaySource<'_, S> {
 }
 
 /// Build the capture-time context for `run_all`.
-///
-/// `new_index` is the just-computed merkle root hash (not yet attached).
-/// Packed snapshots pass in-memory blobs/trees so parse does not wait for
-/// the commit pack. When both that root and the prior attached index are
-/// readable, paths whose digests match are dropped so a fmt-sweep parses
-/// nothing.
 pub(crate) fn build_semantic_context(
     repo: &Repository,
     prior: Option<&State>,
@@ -107,6 +92,8 @@ pub(crate) fn build_semantic_context(
         .flatten();
 
     let mut changed_paths = BTreeSet::new();
+    let mut added = Vec::new();
+    let mut deleted = Vec::new();
     for change in changes.iter() {
         if !change.kind.is_change() {
             continue;
@@ -119,28 +106,48 @@ pub(crate) fn build_semantic_context(
         )? {
             continue;
         }
-        changed_paths.insert(PathBuf::from(&change.path));
+        let path = PathBuf::from(&change.path);
+        match change.kind {
+            DiffKind::Added => added.push(path.clone()),
+            DiffKind::Deleted => deleted.push(path.clone()),
+            DiffKind::Modified | DiffKind::Unchanged => {}
+        }
+        changed_paths.insert(path);
     }
 
     let cache = SemanticParseCache::shared();
     let prior_tree = prior.map(|state| state.tree);
+    let renames = crate::repository_semantic_corpus::pair_exact_blob_renames(
+        &overlay,
+        prior_tree.as_ref(),
+        &new.tree,
+        &added,
+        &deleted,
+    )?;
     let mut prior_functions = BTreeMap::new();
     let mut new_functions = BTreeMap::new();
     let mut budget = crate::repository_semantic_corpus::CorpusBudget::default();
     let mut corpus_complete = true;
     for path in &changed_paths {
         let path_str = path.to_string_lossy();
-        if let Some(fns) = parse_tree_functions(&overlay, prior_tree.as_ref(), &path_str, cache) {
-            prior_functions.insert(path.clone(), fns);
-        }
-        if let Some((fns, bytes)) =
+        let Some((fns, bytes)) =
             parse_tree_functions_sized(&overlay, Some(&new.tree), &path_str, cache)
-        {
-            if !budget.try_add(bytes) {
-                corpus_complete = false;
-                break;
-            }
-            new_functions.insert(path.clone(), fns);
+        else {
+            continue;
+        };
+        if !budget.try_add(bytes) {
+            corpus_complete = false;
+            break;
+        }
+        new_functions.insert(path.clone(), fns);
+        let prior_path = renames.get(path).unwrap_or(path);
+        if let Some(fns) = parse_tree_functions(
+            &overlay,
+            prior_tree.as_ref(),
+            &prior_path.to_string_lossy(),
+            cache,
+        ) {
+            prior_functions.insert(path.clone(), fns);
         }
     }
 
@@ -184,17 +191,12 @@ fn load_new_index_root(
     match repo.load_index_root(hash) {
         Ok(root) => Ok(Some(root)),
         Err(err) => {
-            warn!(
-                error = %err,
-                "semantic context: new index root unavailable; parse tree-diff paths"
-            );
+            warn!(error = %err, "semantic context: new index root unavailable");
             Ok(None)
         }
     }
 }
 
-/// Same digest comparison as `semantic_changed`, but only prunes when both
-/// indexes exist. Missing indexes keep the tree-diff path (fail toward parse).
 fn path_semantically_changed(
     source: &impl ObjectSource,
     prior_root: Option<&SemanticIndexRoot>,

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -313,6 +313,35 @@ fn unchanged_tests_join_corpus_and_fire_reachability() {
 }
 
 #[test]
+fn more_than_thirty_two_function_files_can_complete_the_corpus() {
+    let count = 40;
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    for index in 0..count {
+        std::fs::write(
+            temp.path().join(format!("f{index}.rs")),
+            format!("fn f{index}() {{ {index} }}\n"),
+        )
+        .unwrap();
+    }
+    let state = repo
+        .snapshot_with_attribution(Some("wide-ok".to_string()), None, author())
+        .unwrap();
+    let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref(), None, None).unwrap();
+    assert!(
+        ctx.corpus_complete,
+        "40 function files are inside the shared page and must complete"
+    );
+    assert_eq!(
+        ctx.new_functions.len(),
+        count,
+        "all function files must join the corpus: {}",
+        ctx.new_functions.len()
+    );
+}
+
+#[test]
 fn wide_changed_path_parse_marks_corpus_incomplete_when_file_budget_exceeded() {
     use crate::repository_semantic_corpus::CORPUS_FILE_BUDGET;
 

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -224,6 +224,52 @@ fn test_three() { assert!(true); }
 ";
 
 #[test]
+fn object_literal_methods_do_not_poison_the_corpus() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    std::fs::write(
+        temp.path().join("handlers.js"),
+        "export const handlers = {\n  save: async () => { persist(); },\n};\n",
+    )
+    .unwrap();
+    std::fs::write(temp.path().join("changed.rs"), CORPUS).unwrap();
+    let seed = repo
+        .snapshot_with_attribution(Some("seed".to_string()), None, author())
+        .unwrap();
+    let edited = snapshot(
+        &repo,
+        temp.path(),
+        "changed.rs",
+        "\
+fn alpha() { let total = first + second + third + fourth; }
+fn beta() { for widget in inventory { ship(widget); } }
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { if ready { launch(); } else { wait(); } abort(); }
+",
+    );
+
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(
+        ctx.corpus_complete,
+        "object-literal methods must not fail-close the corpus"
+    );
+    let js_fns = ctx
+        .new_functions
+        .get(&PathBuf::from("handlers.js"))
+        .expect("handlers.js must join the new-state corpus");
+    assert!(
+        js_fns.iter().any(|f| f.name == "save"),
+        "object-literal save must be extracted: {js_fns:?}"
+    );
+    assert!(
+        load_risk_kinds(&repo, &edited).contains(&RiskSignalKind::Novelty),
+        "complete corpus must still allow novelty on a novel rust shape"
+    );
+}
+
+#[test]
 fn unchanged_tests_join_corpus_and_fire_reachability() {
     let temp = TempDir::new().unwrap();
     let repo = Repository::init_default(temp.path()).unwrap();

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -168,6 +168,53 @@ fn delta() { if ready { launch(); } else { wait(); } abort(); }
     );
 }
 
+/// Merkle digest moves (new type / const / use) but no function body or
+/// name changes. Emit-scope is `changed_symbols`; empty means persist
+/// zero sibling tree-sitter signals.
+#[test]
+fn non_function_edit_persists_no_sibling_tree_sitter_signals() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let seed = snapshot(&repo, temp.path(), "changed.rs", CORPUS);
+    let edited = snapshot(
+        &repo,
+        temp.path(),
+        "changed.rs",
+        "\
+use std::fmt;
+const MARKER: i32 = 0;
+struct Marker;
+fn alpha() { let total = first + second + third + fourth; }
+fn beta() { for widget in inventory { ship(widget); } }
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { while pending { dequeue().handle(); } flush(); }
+",
+    );
+
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(
+        ctx.changed_paths.contains(&PathBuf::from("changed.rs")),
+        "non-function edit must remain in changed_paths: {ctx:?}"
+    );
+    assert!(
+        ctx.changed_symbols.is_empty(),
+        "function bodies unchanged so changed_symbols must be empty: {ctx:?}"
+    );
+    assert!(
+        load_risk_kinds(&repo, &edited)
+            .iter()
+            .all(|kind| !matches!(
+                kind,
+                RiskSignalKind::Novelty
+                    | RiskSignalKind::PatternDeviation
+                    | RiskSignalKind::TestReachability
+            )),
+        "non-function edit must persist zero sibling tree-sitter signals"
+    );
+}
+
 const TESTS: &str = "\
 fn test_one() { assert!(true); }
 fn test_two() { assert!(true); }

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -342,6 +342,69 @@ fn delta() { while pending { dequeue().handle(); } flush(); }
     );
 }
 
+#[test]
+fn mass_delete_skips_prior_parse_and_does_not_blow_the_budget() {
+    use crate::repository_semantic_corpus::CORPUS_FILE_BUDGET;
+
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    for index in 0..=CORPUS_FILE_BUDGET {
+        std::fs::write(
+            temp.path().join(format!("gone{index}.rs")),
+            format!("fn gone{index}() {{ {index} }}\n"),
+        )
+        .unwrap();
+    }
+    std::fs::write(temp.path().join("keep.rs"), "fn keep() { 0 }\n").unwrap();
+    let seed = repo
+        .snapshot_with_attribution(Some("seed".to_string()), None, author())
+        .unwrap();
+    for index in 0..=CORPUS_FILE_BUDGET {
+        std::fs::remove_file(temp.path().join(format!("gone{index}.rs"))).unwrap();
+    }
+    let edited = repo
+        .snapshot_with_attribution(Some("delete".to_string()), None, author())
+        .unwrap();
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(
+        ctx.prior_functions
+            .keys()
+            .all(|path| path == &PathBuf::from("keep.rs")),
+        "deleted paths must not be prior-parsed: {:?}",
+        ctx.prior_functions.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        ctx.corpus_complete,
+        "deletes must not exhaust the new-state corpus budget"
+    );
+}
+
+#[test]
+fn content_preserving_rename_marks_no_changed_symbols() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let seed = snapshot(&repo, temp.path(), "old.rs", CORPUS);
+    std::fs::write(temp.path().join("new.rs"), CORPUS).unwrap();
+    std::fs::remove_file(temp.path().join("old.rs")).unwrap();
+    let edited = repo
+        .snapshot_with_attribution(Some("rename".to_string()), None, author())
+        .unwrap();
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(
+        ctx.changed_paths.contains(&PathBuf::from("new.rs")),
+        "rename destination stays in changed_paths: {ctx:?}"
+    );
+    assert!(
+        changed_identities(&ctx, "new.rs").is_empty(),
+        "exact blob rename must not mark destination functions changed: {:?}",
+        ctx.changed_symbols
+    );
+}
+
 fn changed_identities(ctx: &state_review::SemanticContext, path: &str) -> BTreeSet<String> {
     ctx.changed_symbols
         .iter()

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Capture-time SemanticContext tests (heddle#1069).
 
-use std::path::PathBuf;
+use std::{collections::BTreeSet, path::PathBuf};
 
 use objects::{
     object::{Attribution, ContentHash, Principal, RiskSignalKind, State},
@@ -83,7 +83,10 @@ fn fmt_sweep_prunes_changed_paths_and_persists_no_tree_sitter_signals() {
         ctx.changed_paths.is_empty(),
         "fmt-sweep must prune semantic changed_paths: {ctx:?}"
     );
-    assert!(ctx.new_functions.is_empty());
+    assert!(
+        ctx.changed_symbols.is_empty(),
+        "fmt-sweep must emit no changed symbols: {ctx:?}"
+    );
     assert!(
         load_risk_kinds(&repo, &reformatted)
             .iter()
@@ -112,9 +115,111 @@ fn novel_shape_populates_context_and_fires_novelty() {
     let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
     let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref(), None, None).unwrap();
     assert!(ctx.changed_paths.contains(&PathBuf::from("changed.rs")));
+    assert!(
+        ctx.corpus_complete,
+        "single-file repo must finish the corpus walk"
+    );
     let fns = ctx
         .new_functions
         .get(&PathBuf::from("changed.rs"))
         .expect("changed.rs must be parsed");
-    assert_eq!(fns.len(), 4, "parse only the changed file: {fns:?}");
+    assert_eq!(fns.len(), 4, "changed.rs functions: {fns:?}");
+    assert_eq!(
+        ctx.changed_symbols.len(),
+        4,
+        "first capture marks every new symbol"
+    );
+}
+
+#[test]
+fn one_function_edit_does_not_mark_siblings_changed() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let seed = snapshot(&repo, temp.path(), "changed.rs", CORPUS);
+    let edited = snapshot(
+        &repo,
+        temp.path(),
+        "changed.rs",
+        "\
+fn alpha() { let total = first + second + third + fourth; }
+fn beta() { for widget in inventory { ship(widget); } }
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { if ready { launch(); } else { wait(); } abort(); }
+",
+    );
+
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(ctx.corpus_complete);
+    assert_eq!(
+        ctx.changed_symbols,
+        BTreeSet::from([(PathBuf::from("changed.rs"), "delta".to_string())])
+    );
+
+    let novelty_symbols: BTreeSet<String> = load_risk_signals(&repo, &edited)
+        .into_iter()
+        .filter(|signal| signal.kind == RiskSignalKind::Novelty)
+        .filter_map(|signal| signal.anchor.symbol)
+        .collect();
+    assert!(
+        novelty_symbols.iter().all(|name| name == "delta"),
+        "untouched siblings must not persist novelty: {novelty_symbols:?}"
+    );
+}
+
+const TESTS: &str = "\
+fn test_one() { assert!(true); }
+fn test_two() { assert!(true); }
+fn test_three() { assert!(true); }
+";
+
+#[test]
+fn unchanged_tests_join_corpus_and_fire_reachability() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    std::fs::write(temp.path().join("lib.rs"), "fn orphan() { do_work(); }\n").unwrap();
+    std::fs::write(temp.path().join("tests.rs"), TESTS).unwrap();
+    let seed = repo
+        .snapshot_with_attribution(Some("seed".to_string()), None, author())
+        .unwrap();
+    let edited = snapshot(
+        &repo,
+        temp.path(),
+        "lib.rs",
+        "fn orphan() { do_other(); }\n",
+    );
+
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    assert!(
+        ctx.corpus_complete,
+        "small repo must finish the corpus walk"
+    );
+    assert_eq!(ctx.changed_paths, BTreeSet::from([PathBuf::from("lib.rs")]));
+    assert!(
+        ctx.new_functions.contains_key(&PathBuf::from("tests.rs")),
+        "unchanged tests must join the new-state corpus: {:?}",
+        ctx.new_functions.keys().collect::<Vec<_>>()
+    );
+    assert_eq!(
+        ctx.changed_symbols,
+        BTreeSet::from([(PathBuf::from("lib.rs"), "orphan".to_string())])
+    );
+    assert!(
+        load_risk_kinds(&repo, &edited).contains(&RiskSignalKind::TestReachability),
+        "corpus must see unchanged tests so reachability can fire"
+    );
+}
+
+fn load_risk_signals(repo: &Repository, state: &State) -> Vec<objects::object::RiskSignal> {
+    let hash = match attachment_hash(repo, state, StateAttachmentKind::RiskSignals) {
+        Some(hash) => hash,
+        None => return Vec::new(),
+    };
+    let blob = repo.store().get_blob(&hash).unwrap().unwrap();
+    objects::object::RiskSignalBlob::decode(blob.content())
+        .unwrap()
+        .signals
 }

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -152,9 +152,13 @@ fn delta() { if ready { launch(); } else { wait(); } abort(); }
     let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
         .unwrap();
     assert!(ctx.corpus_complete);
-    assert_eq!(
-        ctx.changed_symbols,
-        BTreeSet::from([(PathBuf::from("changed.rs"), "delta".to_string())])
+    assert_eq!(ctx.changed_symbols.len(), 1);
+    assert!(
+        changed_identities(&ctx, "changed.rs")
+            .iter()
+            .any(|id| id.contains("delta")),
+        "only delta should change: {:?}",
+        ctx.changed_symbols
     );
 
     let novelty_symbols: BTreeSet<String> = load_risk_signals(&repo, &edited)
@@ -203,14 +207,12 @@ fn delta() { while pending { dequeue().handle(); } flush(); }
         "function bodies unchanged so changed_symbols must be empty: {ctx:?}"
     );
     assert!(
-        load_risk_kinds(&repo, &edited)
-            .iter()
-            .all(|kind| !matches!(
-                kind,
-                RiskSignalKind::Novelty
-                    | RiskSignalKind::PatternDeviation
-                    | RiskSignalKind::TestReachability
-            )),
+        load_risk_kinds(&repo, &edited).iter().all(|kind| !matches!(
+            kind,
+            RiskSignalKind::Novelty
+                | RiskSignalKind::PatternDeviation
+                | RiskSignalKind::TestReachability
+        )),
         "non-function edit must persist zero sibling tree-sitter signals"
     );
 }
@@ -250,14 +252,102 @@ fn unchanged_tests_join_corpus_and_fire_reachability() {
         "unchanged tests must join the new-state corpus: {:?}",
         ctx.new_functions.keys().collect::<Vec<_>>()
     );
-    assert_eq!(
-        ctx.changed_symbols,
-        BTreeSet::from([(PathBuf::from("lib.rs"), "orphan".to_string())])
+    assert_eq!(ctx.changed_symbols.len(), 1);
+    assert!(
+        changed_identities(&ctx, "lib.rs")
+            .iter()
+            .any(|id| id.contains("orphan")),
+        "only orphan should change: {:?}",
+        ctx.changed_symbols
     );
     assert!(
         load_risk_kinds(&repo, &edited).contains(&RiskSignalKind::TestReachability),
         "corpus must see unchanged tests so reachability can fire"
     );
+}
+
+#[test]
+fn wide_changed_path_parse_marks_corpus_incomplete_when_file_budget_exceeded() {
+    use crate::repository_semantic_corpus::CORPUS_FILE_BUDGET;
+
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    for index in 0..=CORPUS_FILE_BUDGET {
+        std::fs::write(
+            temp.path().join(format!("f{index}.rs")),
+            format!("fn f{index}() {{ {index} }}\n"),
+        )
+        .unwrap();
+    }
+    let state = repo
+        .snapshot_with_attribution(Some("wide".to_string()), None, author())
+        .unwrap();
+    let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref(), None, None).unwrap();
+    assert!(
+        !ctx.corpus_complete,
+        "parsing more than {CORPUS_FILE_BUDGET} changed files must mark the corpus incomplete"
+    );
+    assert!(
+        ctx.new_functions.len() <= CORPUS_FILE_BUDGET,
+        "budget must cap the new-state corpus: {}",
+        ctx.new_functions.len()
+    );
+}
+
+#[test]
+fn duplicate_name_edit_marks_only_the_qualified_identity() {
+    let seed_src = "\
+impl Foo {
+    fn run() { let total = first + second + third + fourth; }
+}
+impl Bar {
+    fn run() { for widget in inventory { ship(widget); } }
+}
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { while pending { dequeue().handle(); } flush(); }
+";
+    let edited_src = "\
+impl Foo {
+    fn run() { if ready { launch(); } else { wait(); } abort(); }
+}
+impl Bar {
+    fn run() { for widget in inventory { ship(widget); } }
+}
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { while pending { dequeue().handle(); } flush(); }
+";
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let seed = snapshot(&repo, temp.path(), "dup.rs", seed_src);
+    let edited = snapshot(&repo, temp.path(), "dup.rs", edited_src);
+    let index_hash = attachment_hash(&repo, &edited, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, Some(&seed), &edited, index_hash.as_ref(), None, None)
+        .unwrap();
+    let identities = changed_identities(&ctx, "dup.rs");
+    assert_eq!(
+        identities.len(),
+        1,
+        "expected one changed symbol: {identities:?}"
+    );
+    assert!(
+        identities
+            .iter()
+            .any(|id| id.contains("Foo") && id.contains("run")),
+        "edited Foo::run must be the emit target: {identities:?}"
+    );
+    assert!(
+        identities.iter().all(|id| !id.contains("Bar")),
+        "untouched Bar::run must not be an emit target: {identities:?}"
+    );
+}
+
+fn changed_identities(ctx: &state_review::SemanticContext, path: &str) -> BTreeSet<String> {
+    ctx.changed_symbols
+        .iter()
+        .filter(|(changed_path, _)| changed_path == &PathBuf::from(path))
+        .map(|(_, identity)| identity.clone())
+        .collect()
 }
 
 fn load_risk_signals(repo: &Repository, state: &State) -> Vec<objects::object::RiskSignal> {

--- a/crates/repo/src/repository_semantic_context_tests.rs
+++ b/crates/repo/src/repository_semantic_context_tests.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Capture-time SemanticContext tests (heddle#1069).
+
+use std::path::PathBuf;
+
+use objects::{
+    object::{Attribution, ContentHash, Principal, RiskSignalKind, State},
+    store::ObjectStore,
+};
+use tempfile::TempDir;
+
+use super::{Repository, build_semantic_context};
+use crate::StateAttachmentKind;
+
+fn author() -> Attribution {
+    Attribution::human(Principal::new("Test", "test@example.com"))
+}
+
+fn snapshot(repo: &Repository, root: &std::path::Path, path: &str, content: &str) -> State {
+    std::fs::write(root.join(path), content).unwrap();
+    repo.snapshot_with_attribution(Some("capture".to_string()), None, author())
+        .unwrap()
+}
+
+fn attachment_hash(
+    repo: &Repository,
+    state: &State,
+    kind: StateAttachmentKind,
+) -> Option<ContentHash> {
+    repo.latest_state_attachment(&state.id(), kind)
+        .unwrap()
+        .and_then(|attachment| match attachment.body {
+            objects::object::StateAttachmentBody::RiskSignals(hash)
+            | objects::object::StateAttachmentBody::SemanticIndex(hash) => Some(hash),
+            _ => None,
+        })
+}
+
+fn load_risk_kinds(repo: &Repository, state: &State) -> Vec<RiskSignalKind> {
+    let hash = match attachment_hash(repo, state, StateAttachmentKind::RiskSignals) {
+        Some(hash) => hash,
+        None => return Vec::new(),
+    };
+    let blob = repo.store().get_blob(&hash).unwrap().unwrap();
+    objects::object::RiskSignalBlob::decode(blob.content())
+        .unwrap()
+        .signals
+        .into_iter()
+        .map(|signal| signal.kind)
+        .collect()
+}
+
+const CORPUS: &str = "\
+fn alpha() { let total = first + second + third + fourth; }
+fn beta() { for widget in inventory { ship(widget); } }
+fn gamma() { match colour { Red => stop(), Green => go() } }
+fn delta() { while pending { dequeue().handle(); } flush(); }
+";
+
+#[test]
+fn fmt_sweep_prunes_changed_paths_and_persists_no_tree_sitter_signals() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let first = snapshot(&repo, temp.path(), "hello.rs", "fn foo() -> i32 { 1 }\n");
+    let reformatted = snapshot(
+        &repo,
+        temp.path(),
+        "hello.rs",
+        "fn foo() -> i32 {\n    1\n}\n",
+    );
+
+    let new_index = attachment_hash(&repo, &reformatted, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(
+        &repo,
+        Some(&first),
+        &reformatted,
+        new_index.as_ref(),
+        None,
+        None,
+    )
+    .unwrap();
+    assert!(
+        ctx.changed_paths.is_empty(),
+        "fmt-sweep must prune semantic changed_paths: {ctx:?}"
+    );
+    assert!(ctx.new_functions.is_empty());
+    assert!(
+        load_risk_kinds(&repo, &reformatted)
+            .iter()
+            .all(|kind| !matches!(
+                kind,
+                RiskSignalKind::Novelty
+                    | RiskSignalKind::PatternDeviation
+                    | RiskSignalKind::TestReachability
+            )),
+        "fmt-sweep must persist zero tree-sitter signals"
+    );
+}
+
+#[test]
+fn novel_shape_populates_context_and_fires_novelty() {
+    let temp = TempDir::new().unwrap();
+    let repo = Repository::init_default(temp.path()).unwrap();
+    let state = snapshot(&repo, temp.path(), "changed.rs", CORPUS);
+
+    let kinds = load_risk_kinds(&repo, &state);
+    assert!(
+        kinds.contains(&RiskSignalKind::Novelty),
+        "novel-shape capture must persist novelty, got {kinds:?}"
+    );
+
+    let index_hash = attachment_hash(&repo, &state, StateAttachmentKind::SemanticIndex);
+    let ctx = build_semantic_context(&repo, None, &state, index_hash.as_ref(), None, None).unwrap();
+    assert!(ctx.changed_paths.contains(&PathBuf::from("changed.rs")));
+    let fns = ctx
+        .new_functions
+        .get(&PathBuf::from("changed.rs"))
+        .expect("changed.rs must be parsed");
+    assert_eq!(fns.len(), 4, "parse only the changed file: {fns:?}");
+}

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -19,14 +19,42 @@ use super::repository_semantic_context::{
     PARSE_BUDGET_BYTES, load_semantic_tree, parse_tree_functions_sized,
 };
 
-/// Additional files parsed beyond the emit-scope `changed_paths`. Hitting
-/// this bound fail-closes (`corpus_complete = false`) so novelty /
-/// test_reachability stay quiet on a partial repo. Tens of files — well
-/// under the shared [`SemanticParseCache`] page cap (256).
-const CORPUS_FILE_BUDGET: usize = 32;
-/// Extra bytes parsed for the corpus walk (on top of changed-file parses).
+/// Shared new-state parse budget for changed-path parsing and the
+/// remaining index walk. Hitting either bound fail-closes
+/// (`corpus_complete = false`) so novelty / test_reachability stay
+/// quiet rather than scoring a partial or unbounded repo. Tens of
+/// files — well under the shared [`SemanticParseCache`] page cap (256).
+pub(crate) const CORPUS_FILE_BUDGET: usize = 32;
+/// Aggregate bytes parsed for the new-state function corpus.
 /// Two times the per-file semantic-index opaque threshold.
-const CORPUS_BYTE_BUDGET: usize = PARSE_BUDGET_BYTES.saturating_mul(2);
+pub(crate) const CORPUS_BYTE_BUDGET: usize = PARSE_BUDGET_BYTES.saturating_mul(2);
+
+/// Running file/byte totals for the new-state corpus. Shared by the
+/// changed-path parse and [`populate_new_function_corpus`].
+#[derive(Clone, Debug, Default)]
+pub(crate) struct CorpusBudget {
+    files: usize,
+    bytes: usize,
+}
+
+impl CorpusBudget {
+    pub(crate) fn try_add(&mut self, bytes: usize) -> bool {
+        if self.files >= CORPUS_FILE_BUDGET {
+            return false;
+        }
+        let next = self.bytes.saturating_add(bytes);
+        if next > CORPUS_BYTE_BUDGET {
+            return false;
+        }
+        self.files += 1;
+        self.bytes = next;
+        true
+    }
+
+    pub(crate) fn has_room(&self) -> bool {
+        self.files < CORPUS_FILE_BUDGET && self.bytes <= CORPUS_BYTE_BUDGET
+    }
+}
 
 pub(crate) fn collect_changed_symbols(
     changed_paths: &BTreeSet<PathBuf>,
@@ -41,7 +69,7 @@ pub(crate) fn collect_changed_symbols(
         let prior_fns = prior_functions.get(path);
         for fn_def in new_fns {
             if function_changed(prior_fns.map(Vec::as_slice), fn_def) {
-                changed.insert((path.clone(), fn_def.name.clone()));
+                changed.insert((path.clone(), fn_def.symbol_identity()));
             }
         }
     }
@@ -52,7 +80,10 @@ fn function_changed(prior_fns: Option<&[FunctionDef]>, new_fn: &FunctionDef) -> 
     let Some(prior_fns) = prior_fns else {
         return true;
     };
-    match prior_fns.iter().find(|prior| prior.name == new_fn.name) {
+    match prior_fns
+        .iter()
+        .find(|prior| prior.symbol_identity() == new_fn.symbol_identity())
+    {
         None => true,
         Some(prior) => prior.content != new_fn.content,
     }
@@ -66,23 +97,25 @@ pub(crate) fn populate_new_function_corpus(
     new_root: Option<&SemanticIndexRoot>,
     new_tree: &ContentHash,
     cache: &SemanticParseCache,
+    budget: &mut CorpusBudget,
     new_functions: &mut BTreeMap<PathBuf, Vec<FunctionDef>>,
 ) -> Result<bool> {
     let Some(root) = new_root else {
         return Ok(false);
     };
+    if !budget.has_room() {
+        return Ok(false);
+    }
     let mut files = Vec::new();
     if !collect_function_file_paths(source, root, &mut files)? {
         return Ok(false);
     }
-    let mut extra_files = 0usize;
-    let mut extra_bytes = 0usize;
     for path in files {
         let rel = PathBuf::from(&path);
         if new_functions.contains_key(&rel) {
             continue;
         }
-        if extra_files >= CORPUS_FILE_BUDGET {
+        if !budget.has_room() {
             return Ok(false);
         }
         let Some((functions, bytes)) =
@@ -101,11 +134,9 @@ pub(crate) fn populate_new_function_corpus(
             );
             return Ok(false);
         }
-        extra_bytes = extra_bytes.saturating_add(bytes);
-        if extra_bytes > CORPUS_BYTE_BUDGET {
+        if !budget.try_add(bytes) {
             return Ok(false);
         }
-        extra_files += 1;
         new_functions.insert(rel, functions);
     }
     Ok(true)

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -88,16 +88,25 @@ pub(crate) fn populate_new_function_corpus(
         let Some((functions, bytes)) =
             parse_tree_functions_sized(source, Some(new_tree), &path, cache)
         else {
-            continue;
+            warn!(
+                path,
+                "semantic corpus: index-listed function file failed to parse; fail-closed"
+            );
+            return Ok(false);
         };
+        if functions.is_empty() {
+            warn!(
+                path,
+                "semantic corpus: index-listed function file yielded no functions; fail-closed"
+            );
+            return Ok(false);
+        }
         extra_bytes = extra_bytes.saturating_add(bytes);
         if extra_bytes > CORPUS_BYTE_BUDGET {
             return Ok(false);
         }
         extra_files += 1;
-        if !functions.is_empty() {
-            new_functions.insert(rel, functions);
-        }
+        new_functions.insert(rel, functions);
     }
     Ok(true)
 }
@@ -168,80 +177,5 @@ fn join_semantic_path(prefix: &str, name: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-
-    fn fdef(name: &str, content: &str) -> FunctionDef {
-        FunctionDef {
-            name: name.to_string(),
-            signature: format!("fn {name}()"),
-            start_line: 1,
-            end_line: 3,
-            content: content.to_string(),
-        }
-    }
-
-    #[test]
-    fn changed_symbols_ignore_untouched_siblings() {
-        let path = PathBuf::from("lib.rs");
-        let mut changed_paths = BTreeSet::new();
-        changed_paths.insert(path.clone());
-        let mut prior = BTreeMap::new();
-        prior.insert(
-            path.clone(),
-            vec![
-                fdef("keep", "fn keep() { 1 }"),
-                fdef("edit", "fn edit() { 1 }"),
-            ],
-        );
-        let mut new = BTreeMap::new();
-        new.insert(
-            path.clone(),
-            vec![
-                fdef("keep", "fn keep() { 1 }"),
-                fdef("edit", "fn edit() { 2 }"),
-            ],
-        );
-        let symbols = collect_changed_symbols(&changed_paths, &prior, &new);
-        assert_eq!(symbols, BTreeSet::from([(path, "edit".to_string())]));
-    }
-
-    #[test]
-    fn missing_index_is_incomplete() {
-        assert!(
-            !populate_new_function_corpus(
-                &FailingSource,
-                None,
-                &ContentHash::compute(b"tree"),
-                SemanticParseCache::shared(),
-                &mut BTreeMap::new(),
-            )
-            .unwrap()
-        );
-    }
-
-    struct FailingSource;
-
-    impl ObjectSource for FailingSource {
-        fn get_tree(
-            &self,
-            _hash: &ContentHash,
-        ) -> objects::error::Result<Option<objects::object::Tree>> {
-            Ok(None)
-        }
-
-        fn get_blob(
-            &self,
-            _hash: &ContentHash,
-        ) -> objects::error::Result<Option<objects::object::Blob>> {
-            Ok(None)
-        }
-
-        fn get_state(
-            &self,
-            _id: &objects::object::StateId,
-        ) -> objects::error::Result<Option<objects::object::State>> {
-            Ok(None)
-        }
-    }
-}
+#[path = "repository_semantic_corpus_tests.rs"]
+mod tests;

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -19,12 +19,9 @@ use super::repository_semantic_context::{
     PARSE_BUDGET_BYTES, load_semantic_tree, parse_tree_functions_sized,
 };
 
-/// Shared new-state parse budget for changed-path parsing and the
-/// remaining index walk. Hitting either bound fail-closes
-/// (`corpus_complete = false`) so novelty / test_reachability stay
-/// quiet rather than scoring a partial or unbounded repo. Tens of
-/// files — well under the shared [`SemanticParseCache`] page cap (256).
-pub(crate) const CORPUS_FILE_BUDGET: usize = 32;
+/// File page for the new-state corpus. Alias of the shared parse-cache
+/// page so a filled page is a bound, not a smaller product universe.
+pub(crate) const CORPUS_FILE_BUDGET: usize = SemanticParseCache::DEFAULT_MAX_ENTRIES;
 /// Aggregate bytes parsed for the new-state function corpus.
 /// Two times the per-file semantic-index opaque threshold.
 pub(crate) const CORPUS_BYTE_BUDGET: usize = PARSE_BUDGET_BYTES.saturating_mul(2);
@@ -107,9 +104,6 @@ pub(crate) fn populate_new_function_corpus(
     let Some(root) = new_root else {
         return Ok(false);
     };
-    if !budget.has_room() {
-        return Ok(false);
-    }
     let skip: BTreeSet<PathBuf> = new_functions.keys().cloned().collect();
     let mut files = Vec::new();
     if !collect_function_file_paths(source, root, budget.remaining_files(), &skip, &mut files)? {
@@ -119,9 +113,6 @@ pub(crate) fn populate_new_function_corpus(
         let rel = PathBuf::from(&path);
         if new_functions.contains_key(&rel) {
             continue;
-        }
-        if !budget.has_room() {
-            return Ok(false);
         }
         let Some((functions, bytes)) =
             parse_tree_functions_sized(source, Some(new_tree), &path, cache)
@@ -157,9 +148,6 @@ pub(crate) fn collect_function_file_paths(
     let mut stack = vec![(String::new(), root.tree, 0usize)];
     let mut inspected = 0usize;
     while let Some((prefix, hash, depth)) = stack.pop() {
-        if out.len() >= remaining {
-            return Ok(false);
-        }
         if depth > MAX_SEMANTIC_TREE_DEPTH {
             return Ok(false);
         }
@@ -182,12 +170,17 @@ pub(crate) fn collect_function_file_paths(
                     if skip.contains(&PathBuf::from(&path)) {
                         continue;
                     }
-                    if out.len() >= remaining || inspected >= remaining {
+                    if remaining > 0 && inspected >= remaining {
                         return Ok(false);
                     }
                     inspected += 1;
                     match load_semantic_file(source, &entry.node) {
-                        Ok(file) if file_has_function(&file) => out.push(path),
+                        Ok(file) if file_has_function(&file) => {
+                            if remaining == 0 || out.len() >= remaining {
+                                return Ok(false);
+                            }
+                            out.push(path);
+                        }
                         Ok(_) => {}
                         Err(err) => {
                             warn!(

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -48,10 +48,6 @@ impl CorpusBudget {
         true
     }
 
-    pub(crate) fn has_room(&self) -> bool {
-        self.files < CORPUS_FILE_BUDGET && self.bytes <= CORPUS_BYTE_BUDGET
-    }
-
     pub(crate) fn remaining_files(&self) -> usize {
         CORPUS_FILE_BUDGET.saturating_sub(self.files)
     }

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -7,8 +7,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 
 use objects::object::{
-    ContentHash, ObjectSource, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot,
-    SymbolKindTag,
+    ContentHash, LeafPolicy, ObjectSource, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot,
+    SymbolKindTag, resolve_tree_path,
 };
 use semantic::{SemanticParseCache, parser::FunctionDef};
 use tracing::warn;
@@ -155,6 +155,7 @@ pub(crate) fn collect_function_file_paths(
     out: &mut Vec<String>,
 ) -> Result<bool> {
     let mut stack = vec![(String::new(), root.tree, 0usize)];
+    let mut inspected = 0usize;
     while let Some((prefix, hash, depth)) = stack.pop() {
         if out.len() >= remaining {
             return Ok(false);
@@ -181,9 +182,10 @@ pub(crate) fn collect_function_file_paths(
                     if skip.contains(&PathBuf::from(&path)) {
                         continue;
                     }
-                    if out.len() >= remaining {
+                    if out.len() >= remaining || inspected >= remaining {
                         return Ok(false);
                     }
+                    inspected += 1;
                     match load_semantic_file(source, &entry.node) {
                         Ok(file) if file_has_function(&file) => out.push(path),
                         Ok(_) => {}
@@ -215,6 +217,50 @@ fn file_has_function(file: &SemanticFileNode) -> bool {
     file.symbols
         .iter()
         .any(|symbol| symbol.kind == SymbolKindTag::Function)
+}
+
+/// Pair added paths with deleted paths that share an exact blob hash.
+/// Destination → source. Each hash is used at most once.
+pub(crate) fn pair_exact_blob_renames(
+    source: &impl ObjectSource,
+    prior_tree: Option<&ContentHash>,
+    new_tree: &ContentHash,
+    added: &[PathBuf],
+    deleted: &[PathBuf],
+) -> Result<BTreeMap<PathBuf, PathBuf>> {
+    let Some(prior_tree) = prior_tree else {
+        return Ok(BTreeMap::new());
+    };
+    let mut unused_deleted: BTreeMap<ContentHash, PathBuf> = BTreeMap::new();
+    for path in deleted {
+        if let Some(hash) = blob_hash_at_path(source, prior_tree, &path.to_string_lossy())? {
+            unused_deleted.entry(hash).or_insert_with(|| path.clone());
+        }
+    }
+    let mut renames = BTreeMap::new();
+    for path in added {
+        let Some(hash) = blob_hash_at_path(source, new_tree, &path.to_string_lossy())? else {
+            continue;
+        };
+        if let Some(old_path) = unused_deleted.remove(&hash) {
+            renames.insert(path.clone(), old_path);
+        }
+    }
+    Ok(renames)
+}
+
+fn blob_hash_at_path(
+    source: &impl ObjectSource,
+    tree: &ContentHash,
+    path: &str,
+) -> Result<Option<ContentHash>> {
+    let resolved = resolve_tree_path(
+        source,
+        tree,
+        std::path::Path::new(path),
+        LeafPolicy::BlobOnly,
+    )?;
+    Ok(resolved.and_then(|target| target.content_hash))
 }
 
 fn join_semantic_path(prefix: &str, name: &str) -> String {

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -1,0 +1,247 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Bounded new-state function corpus for capture-time risk signals.
+
+#![cfg(feature = "tree-sitter-symbols")]
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use objects::object::{
+    ContentHash, ObjectSource, SemanticEntryKind, SemanticFileNode, SemanticIndexRoot,
+    SymbolKindTag,
+};
+use semantic::{SemanticParseCache, parser::FunctionDef};
+use tracing::warn;
+
+use crate::{Result, repository_semantic_query::MAX_SEMANTIC_TREE_DEPTH};
+
+use super::repository_semantic_context::{
+    PARSE_BUDGET_BYTES, load_semantic_tree, parse_tree_functions_sized,
+};
+
+/// Additional files parsed beyond the emit-scope `changed_paths`. Hitting
+/// this bound fail-closes (`corpus_complete = false`) so novelty /
+/// test_reachability stay quiet on a partial repo. Tens of files — well
+/// under the shared [`SemanticParseCache`] page cap (256).
+const CORPUS_FILE_BUDGET: usize = 32;
+/// Extra bytes parsed for the corpus walk (on top of changed-file parses).
+/// Two times the per-file semantic-index opaque threshold.
+const CORPUS_BYTE_BUDGET: usize = PARSE_BUDGET_BYTES.saturating_mul(2);
+
+pub(crate) fn collect_changed_symbols(
+    changed_paths: &BTreeSet<PathBuf>,
+    prior_functions: &BTreeMap<PathBuf, Vec<FunctionDef>>,
+    new_functions: &BTreeMap<PathBuf, Vec<FunctionDef>>,
+) -> BTreeSet<(PathBuf, String)> {
+    let mut changed = BTreeSet::new();
+    for path in changed_paths {
+        let Some(new_fns) = new_functions.get(path) else {
+            continue;
+        };
+        let prior_fns = prior_functions.get(path);
+        for fn_def in new_fns {
+            if function_changed(prior_fns.map(Vec::as_slice), fn_def) {
+                changed.insert((path.clone(), fn_def.name.clone()));
+            }
+        }
+    }
+    changed
+}
+
+fn function_changed(prior_fns: Option<&[FunctionDef]>, new_fn: &FunctionDef) -> bool {
+    let Some(prior_fns) = prior_fns else {
+        return true;
+    };
+    match prior_fns.iter().find(|prior| prior.name == new_fn.name) {
+        None => true,
+        Some(prior) => prior.content != new_fn.content,
+    }
+}
+
+/// Walk the new semantic index and parse remaining function-bearing files
+/// into `new_functions`. Returns `true` only when the walk finished inside
+/// the page/byte budgets. Missing or unreadable indexes fail closed.
+pub(crate) fn populate_new_function_corpus(
+    source: &impl ObjectSource,
+    new_root: Option<&SemanticIndexRoot>,
+    new_tree: &ContentHash,
+    cache: &SemanticParseCache,
+    new_functions: &mut BTreeMap<PathBuf, Vec<FunctionDef>>,
+) -> Result<bool> {
+    let Some(root) = new_root else {
+        return Ok(false);
+    };
+    let mut files = Vec::new();
+    if !collect_function_file_paths(source, root, &mut files)? {
+        return Ok(false);
+    }
+    let mut extra_files = 0usize;
+    let mut extra_bytes = 0usize;
+    for path in files {
+        let rel = PathBuf::from(&path);
+        if new_functions.contains_key(&rel) {
+            continue;
+        }
+        if extra_files >= CORPUS_FILE_BUDGET {
+            return Ok(false);
+        }
+        let Some((functions, bytes)) =
+            parse_tree_functions_sized(source, Some(new_tree), &path, cache)
+        else {
+            continue;
+        };
+        extra_bytes = extra_bytes.saturating_add(bytes);
+        if extra_bytes > CORPUS_BYTE_BUDGET {
+            return Ok(false);
+        }
+        extra_files += 1;
+        if !functions.is_empty() {
+            new_functions.insert(rel, functions);
+        }
+    }
+    Ok(true)
+}
+
+fn collect_function_file_paths(
+    source: &impl ObjectSource,
+    root: &SemanticIndexRoot,
+    out: &mut Vec<String>,
+) -> Result<bool> {
+    let mut stack = vec![(String::new(), root.tree, 0usize)];
+    while let Some((prefix, hash, depth)) = stack.pop() {
+        if depth > MAX_SEMANTIC_TREE_DEPTH {
+            return Ok(false);
+        }
+        let node = match load_semantic_tree(source, &hash) {
+            Ok(node) => node,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    "semantic corpus: index node unreadable; fail-closed"
+                );
+                return Ok(false);
+            }
+        };
+        for entry in node.entries.iter().rev() {
+            let path = join_semantic_path(&prefix, &entry.name);
+            match entry.kind {
+                SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
+                SemanticEntryKind::Opaque => {}
+                SemanticEntryKind::File => match load_semantic_file(source, &entry.node) {
+                    Ok(file) if file_has_function(&file) => out.push(path),
+                    Ok(_) => {}
+                    Err(err) => {
+                        warn!(
+                            error = %err,
+                            path,
+                            "semantic corpus: file node unreadable; fail-closed"
+                        );
+                        return Ok(false);
+                    }
+                },
+            }
+        }
+    }
+    Ok(true)
+}
+
+fn load_semantic_file(source: &impl ObjectSource, hash: &ContentHash) -> Result<SemanticFileNode> {
+    let blob = source.get_blob(hash)?.ok_or_else(|| {
+        objects::error::HeddleError::NotFound(format!("semantic file node {hash}"))
+    })?;
+    SemanticFileNode::decode(blob.content())
+        .map_err(|err| objects::error::HeddleError::InvalidObject(err.to_string()))
+}
+
+fn file_has_function(file: &SemanticFileNode) -> bool {
+    file.symbols
+        .iter()
+        .any(|symbol| symbol.kind == SymbolKindTag::Function)
+}
+
+fn join_semantic_path(prefix: &str, name: &str) -> String {
+    if prefix.is_empty() {
+        name.to_string()
+    } else {
+        format!("{prefix}/{name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fdef(name: &str, content: &str) -> FunctionDef {
+        FunctionDef {
+            name: name.to_string(),
+            signature: format!("fn {name}()"),
+            start_line: 1,
+            end_line: 3,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn changed_symbols_ignore_untouched_siblings() {
+        let path = PathBuf::from("lib.rs");
+        let mut changed_paths = BTreeSet::new();
+        changed_paths.insert(path.clone());
+        let mut prior = BTreeMap::new();
+        prior.insert(
+            path.clone(),
+            vec![
+                fdef("keep", "fn keep() { 1 }"),
+                fdef("edit", "fn edit() { 1 }"),
+            ],
+        );
+        let mut new = BTreeMap::new();
+        new.insert(
+            path.clone(),
+            vec![
+                fdef("keep", "fn keep() { 1 }"),
+                fdef("edit", "fn edit() { 2 }"),
+            ],
+        );
+        let symbols = collect_changed_symbols(&changed_paths, &prior, &new);
+        assert_eq!(symbols, BTreeSet::from([(path, "edit".to_string())]));
+    }
+
+    #[test]
+    fn missing_index_is_incomplete() {
+        assert!(
+            !populate_new_function_corpus(
+                &FailingSource,
+                None,
+                &ContentHash::compute(b"tree"),
+                SemanticParseCache::shared(),
+                &mut BTreeMap::new(),
+            )
+            .unwrap()
+        );
+    }
+
+    struct FailingSource;
+
+    impl ObjectSource for FailingSource {
+        fn get_tree(
+            &self,
+            _hash: &ContentHash,
+        ) -> objects::error::Result<Option<objects::object::Tree>> {
+            Ok(None)
+        }
+
+        fn get_blob(
+            &self,
+            _hash: &ContentHash,
+        ) -> objects::error::Result<Option<objects::object::Blob>> {
+            Ok(None)
+        }
+
+        fn get_state(
+            &self,
+            _id: &objects::object::StateId,
+        ) -> objects::error::Result<Option<objects::object::State>> {
+            Ok(None)
+        }
+    }
+}

--- a/crates/repo/src/repository_semantic_corpus.rs
+++ b/crates/repo/src/repository_semantic_corpus.rs
@@ -54,6 +54,10 @@ impl CorpusBudget {
     pub(crate) fn has_room(&self) -> bool {
         self.files < CORPUS_FILE_BUDGET && self.bytes <= CORPUS_BYTE_BUDGET
     }
+
+    pub(crate) fn remaining_files(&self) -> usize {
+        CORPUS_FILE_BUDGET.saturating_sub(self.files)
+    }
 }
 
 pub(crate) fn collect_changed_symbols(
@@ -106,8 +110,9 @@ pub(crate) fn populate_new_function_corpus(
     if !budget.has_room() {
         return Ok(false);
     }
+    let skip: BTreeSet<PathBuf> = new_functions.keys().cloned().collect();
     let mut files = Vec::new();
-    if !collect_function_file_paths(source, root, &mut files)? {
+    if !collect_function_file_paths(source, root, budget.remaining_files(), &skip, &mut files)? {
         return Ok(false);
     }
     for path in files {
@@ -142,13 +147,18 @@ pub(crate) fn populate_new_function_corpus(
     Ok(true)
 }
 
-fn collect_function_file_paths(
+pub(crate) fn collect_function_file_paths(
     source: &impl ObjectSource,
     root: &SemanticIndexRoot,
+    remaining: usize,
+    skip: &BTreeSet<PathBuf>,
     out: &mut Vec<String>,
 ) -> Result<bool> {
     let mut stack = vec![(String::new(), root.tree, 0usize)];
     while let Some((prefix, hash, depth)) = stack.pop() {
+        if out.len() >= remaining {
+            return Ok(false);
+        }
         if depth > MAX_SEMANTIC_TREE_DEPTH {
             return Ok(false);
         }
@@ -167,18 +177,26 @@ fn collect_function_file_paths(
             match entry.kind {
                 SemanticEntryKind::Dir => stack.push((path, entry.node, depth + 1)),
                 SemanticEntryKind::Opaque => {}
-                SemanticEntryKind::File => match load_semantic_file(source, &entry.node) {
-                    Ok(file) if file_has_function(&file) => out.push(path),
-                    Ok(_) => {}
-                    Err(err) => {
-                        warn!(
-                            error = %err,
-                            path,
-                            "semantic corpus: file node unreadable; fail-closed"
-                        );
+                SemanticEntryKind::File => {
+                    if skip.contains(&PathBuf::from(&path)) {
+                        continue;
+                    }
+                    if out.len() >= remaining {
                         return Ok(false);
                     }
-                },
+                    match load_semantic_file(source, &entry.node) {
+                        Ok(file) if file_has_function(&file) => out.push(path),
+                        Ok(_) => {}
+                        Err(err) => {
+                            warn!(
+                                error = %err,
+                                path,
+                                "semantic corpus: file node unreadable; fail-closed"
+                            );
+                            return Ok(false);
+                        }
+                    }
+                }
             }
         }
     }

--- a/crates/repo/src/repository_semantic_corpus_tests.rs
+++ b/crates/repo/src/repository_semantic_corpus_tests.rs
@@ -10,11 +10,15 @@ use objects::object::{
 };
 use semantic::{SemanticParseCache, parser::FunctionDef};
 
-use super::{collect_changed_symbols, populate_new_function_corpus};
+use super::{
+    CORPUS_BYTE_BUDGET, CORPUS_FILE_BUDGET, CorpusBudget, collect_changed_symbols,
+    populate_new_function_corpus,
+};
 
 fn fdef(name: &str, content: &str) -> FunctionDef {
     FunctionDef {
         name: name.to_string(),
+        container: String::new(),
         signature: format!("fn {name}()"),
         start_line: 1,
         end_line: 3,
@@ -44,7 +48,62 @@ fn changed_symbols_ignore_untouched_siblings() {
         ],
     );
     let symbols = collect_changed_symbols(&changed_paths, &prior, &new);
-    assert_eq!(symbols, BTreeSet::from([(path, "edit".to_string())]));
+    assert_eq!(
+        symbols,
+        BTreeSet::from([(path, fdef("edit", "fn edit() { 2 }").symbol_identity())])
+    );
+}
+
+#[test]
+fn changed_symbols_distinguish_duplicate_names_by_container() {
+    let path = PathBuf::from("lib.rs");
+    let mut changed_paths = BTreeSet::new();
+    changed_paths.insert(path.clone());
+    let foo_run = FunctionDef {
+        name: "run".to_string(),
+        container: "Foo".to_string(),
+        signature: "run()".to_string(),
+        start_line: 1,
+        end_line: 3,
+        content: "fn run() { 1 }".to_string(),
+    };
+    let bar_run = FunctionDef {
+        name: "run".to_string(),
+        container: "Bar".to_string(),
+        signature: "run()".to_string(),
+        start_line: 5,
+        end_line: 7,
+        content: "fn run() { 1 }".to_string(),
+    };
+    let mut foo_edited = foo_run.clone();
+    foo_edited.content = "fn run() { 2 }".to_string();
+    let mut prior = BTreeMap::new();
+    prior.insert(path.clone(), vec![foo_run, bar_run.clone()]);
+    let mut new = BTreeMap::new();
+    new.insert(path.clone(), vec![foo_edited.clone(), bar_run.clone()]);
+    let symbols = collect_changed_symbols(&changed_paths, &prior, &new);
+    assert_eq!(
+        symbols,
+        BTreeSet::from([(path, foo_edited.symbol_identity())])
+    );
+    assert!(
+        !symbols
+            .iter()
+            .any(|(_, id)| id == &bar_run.symbol_identity()),
+        "editing Foo::run must not mark Bar::run: {symbols:?}"
+    );
+}
+
+#[test]
+fn corpus_budget_rejects_file_and_byte_overflow() {
+    let mut budget = CorpusBudget::default();
+    for _ in 0..CORPUS_FILE_BUDGET {
+        assert!(budget.try_add(1));
+    }
+    assert!(!budget.try_add(1), "file ceiling must fail-close");
+    let mut bytes = CorpusBudget::default();
+    assert!(bytes.try_add(CORPUS_BYTE_BUDGET));
+    assert!(!bytes.try_add(1), "byte ceiling must fail-close");
 }
 
 #[test]
@@ -55,6 +114,7 @@ fn missing_index_is_incomplete() {
             None,
             &ContentHash::compute(b"tree"),
             SemanticParseCache::shared(),
+            &mut CorpusBudget::default(),
             &mut BTreeMap::new(),
         )
         .unwrap()
@@ -103,6 +163,7 @@ fn index_listed_parse_miss_is_incomplete() {
             Some(&root),
             &ContentHash::compute(b"missing-source-tree"),
             SemanticParseCache::shared(),
+            &mut CorpusBudget::default(),
             &mut BTreeMap::new(),
         )
         .unwrap(),

--- a/crates/repo/src/repository_semantic_corpus_tests.rs
+++ b/crates/repo/src/repository_semantic_corpus_tests.rs
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for the capture-time function corpus walk.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::path::PathBuf;
+
+use objects::object::{
+    ContentHash, ObjectSource, SemanticEntryKind, SemanticFileFacts, SemanticFileNode,
+    SemanticIndexRoot, SemanticTreeEntry, SemanticTreeNode, SymbolEntry, SymbolKindTag,
+};
+use semantic::{SemanticParseCache, parser::FunctionDef};
+
+use super::{collect_changed_symbols, populate_new_function_corpus};
+
+fn fdef(name: &str, content: &str) -> FunctionDef {
+    FunctionDef {
+        name: name.to_string(),
+        signature: format!("fn {name}()"),
+        start_line: 1,
+        end_line: 3,
+        content: content.to_string(),
+    }
+}
+
+#[test]
+fn changed_symbols_ignore_untouched_siblings() {
+    let path = PathBuf::from("lib.rs");
+    let mut changed_paths = BTreeSet::new();
+    changed_paths.insert(path.clone());
+    let mut prior = BTreeMap::new();
+    prior.insert(
+        path.clone(),
+        vec![
+            fdef("keep", "fn keep() { 1 }"),
+            fdef("edit", "fn edit() { 1 }"),
+        ],
+    );
+    let mut new = BTreeMap::new();
+    new.insert(
+        path.clone(),
+        vec![
+            fdef("keep", "fn keep() { 1 }"),
+            fdef("edit", "fn edit() { 2 }"),
+        ],
+    );
+    let symbols = collect_changed_symbols(&changed_paths, &prior, &new);
+    assert_eq!(symbols, BTreeSet::from([(path, "edit".to_string())]));
+}
+
+#[test]
+fn missing_index_is_incomplete() {
+    assert!(
+        !populate_new_function_corpus(
+            &FailingSource,
+            None,
+            &ContentHash::compute(b"tree"),
+            SemanticParseCache::shared(),
+            &mut BTreeMap::new(),
+        )
+        .unwrap()
+    );
+}
+
+#[test]
+fn index_listed_parse_miss_is_incomplete() {
+    let file = SemanticFileNode::new(
+        "rust",
+        "0",
+        1,
+        ContentHash::compute(b"src"),
+        ContentHash::compute(b"scaffold"),
+        SemanticFileFacts {
+            symbols: vec![SymbolEntry {
+                name: "foo".to_string(),
+                kind: SymbolKindTag::Function,
+                container_path: Vec::new(),
+                semantic_hash: ContentHash::compute(b"foo"),
+                span: (1, 2),
+            }],
+            ..SemanticFileFacts::default()
+        },
+    );
+    let file_bytes = file.encode().unwrap();
+    let file_hash = ContentHash::compute(&file_bytes);
+    let (tree_node, _) = SemanticTreeNode::new(vec![SemanticTreeEntry {
+        name: "lib.rs".to_string(),
+        kind: SemanticEntryKind::File,
+        node: file_hash,
+        semantic_digest: file.semantic_digest,
+    }]);
+    let tree_bytes = tree_node.encode().unwrap();
+    let tree_hash = ContentHash::compute(&tree_bytes);
+    let root = SemanticIndexRoot::new(1, BTreeMap::new(), tree_hash, tree_node.semantic_digest());
+
+    let mut blobs = HashMap::new();
+    blobs.insert(file_hash, file_bytes);
+    blobs.insert(tree_hash, tree_bytes);
+    let source = IndexOnlySource { blobs };
+
+    assert!(
+        !populate_new_function_corpus(
+            &source,
+            Some(&root),
+            &ContentHash::compute(b"missing-source-tree"),
+            SemanticParseCache::shared(),
+            &mut BTreeMap::new(),
+        )
+        .unwrap(),
+        "a listed function file that fails to parse must fail-close the corpus"
+    );
+}
+
+struct IndexOnlySource {
+    blobs: HashMap<ContentHash, Vec<u8>>,
+}
+
+impl ObjectSource for IndexOnlySource {
+    fn get_tree(
+        &self,
+        _hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Tree>> {
+        Ok(None)
+    }
+
+    fn get_blob(
+        &self,
+        hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Blob>> {
+        Ok(self
+            .blobs
+            .get(hash)
+            .map(|bytes| objects::object::Blob::new(bytes.clone())))
+    }
+
+    fn get_state(
+        &self,
+        _id: &objects::object::StateId,
+    ) -> objects::error::Result<Option<objects::object::State>> {
+        Ok(None)
+    }
+}
+
+struct FailingSource;
+
+impl ObjectSource for FailingSource {
+    fn get_tree(
+        &self,
+        _hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Tree>> {
+        Ok(None)
+    }
+
+    fn get_blob(
+        &self,
+        _hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Blob>> {
+        Ok(None)
+    }
+
+    fn get_state(
+        &self,
+        _id: &objects::object::StateId,
+    ) -> objects::error::Result<Option<objects::object::State>> {
+        Ok(None)
+    }
+}

--- a/crates/repo/src/repository_semantic_corpus_tests.rs
+++ b/crates/repo/src/repository_semantic_corpus_tests.rs
@@ -268,6 +268,62 @@ fn function_index_file(name: &str) -> SemanticFileNode {
 }
 
 #[test]
+fn page_full_with_no_remaining_function_files_is_complete() {
+    let (root, source) = index_with_function_files(3);
+    let mut budget = CorpusBudget::default();
+    for _ in 0..CORPUS_FILE_BUDGET {
+        assert!(budget.try_add(1));
+    }
+    let mut new_functions = BTreeMap::new();
+    for index in 0..3 {
+        new_functions.insert(
+            PathBuf::from(format!("f{index}.rs")),
+            vec![fdef(&format!("f{index}"), "fn f() { 1 }")],
+        );
+    }
+    assert!(
+        populate_new_function_corpus(
+            &source,
+            Some(&root),
+            &ContentHash::compute(b"tree"),
+            SemanticParseCache::shared(),
+            &mut budget,
+            &mut new_functions,
+        )
+        .unwrap(),
+        "a full page must still be complete when the leftover index is empty"
+    );
+}
+
+#[test]
+fn page_full_with_remaining_function_files_is_incomplete() {
+    let (root, source) = index_with_function_files(4);
+    let mut budget = CorpusBudget::default();
+    for _ in 0..CORPUS_FILE_BUDGET {
+        assert!(budget.try_add(1));
+    }
+    let mut new_functions = BTreeMap::new();
+    for index in 0..3 {
+        new_functions.insert(
+            PathBuf::from(format!("f{index}.rs")),
+            vec![fdef(&format!("f{index}"), "fn f() { 1 }")],
+        );
+    }
+    assert!(
+        !populate_new_function_corpus(
+            &source,
+            Some(&root),
+            &ContentHash::compute(b"tree"),
+            SemanticParseCache::shared(),
+            &mut budget,
+            &mut new_functions,
+        )
+        .unwrap(),
+        "a full page with leftover function files must stay incomplete"
+    );
+}
+
+#[test]
 fn missing_index_is_incomplete() {
     assert!(
         !populate_new_function_corpus(

--- a/crates/repo/src/repository_semantic_corpus_tests.rs
+++ b/crates/repo/src/repository_semantic_corpus_tests.rs
@@ -168,6 +168,85 @@ fn index_with_function_files(count: usize) -> (SemanticIndexRoot, CountingSource
     )
 }
 
+#[test]
+fn index_walk_stops_when_non_function_files_exhaust_inspect_budget() {
+    let type_only = CORPUS_FILE_BUDGET + 20;
+    let (root, source) = index_with_type_only_files(type_only);
+    let mut files = Vec::new();
+    assert!(
+        !collect_function_file_paths(
+            &source,
+            &root,
+            CORPUS_FILE_BUDGET,
+            &BTreeSet::new(),
+            &mut files,
+        )
+        .unwrap(),
+        "inspecting more than the remaining budget must fail-close"
+    );
+    assert!(
+        files.is_empty(),
+        "type-only index must collect no functions"
+    );
+    assert!(
+        source.file_loads.get() <= CORPUS_FILE_BUDGET,
+        "must not decode every non-function file: loaded {}",
+        source.file_loads.get()
+    );
+}
+
+fn index_with_type_only_files(count: usize) -> (SemanticIndexRoot, CountingSource) {
+    let mut blobs = HashMap::new();
+    let mut file_hashes = BTreeSet::new();
+    let mut entries = Vec::new();
+    for index in 0..count {
+        let file = type_index_file(&format!("t{index}"));
+        let file_bytes = file.encode().unwrap();
+        let file_hash = ContentHash::compute(&file_bytes);
+        file_hashes.insert(file_hash);
+        blobs.insert(file_hash, file_bytes);
+        entries.push(SemanticTreeEntry {
+            name: format!("t{index}.rs"),
+            kind: SemanticEntryKind::File,
+            node: file_hash,
+            semantic_digest: file.semantic_digest,
+        });
+    }
+    let (tree_node, _) = SemanticTreeNode::new(entries);
+    let tree_bytes = tree_node.encode().unwrap();
+    let tree_hash = ContentHash::compute(&tree_bytes);
+    blobs.insert(tree_hash, tree_bytes);
+    let root = SemanticIndexRoot::new(1, BTreeMap::new(), tree_hash, tree_node.semantic_digest());
+    (
+        root,
+        CountingSource {
+            blobs,
+            file_hashes,
+            file_loads: Cell::new(0),
+        },
+    )
+}
+
+fn type_index_file(name: &str) -> SemanticFileNode {
+    SemanticFileNode::new(
+        "rust",
+        "0",
+        1,
+        ContentHash::compute(name.as_bytes()),
+        ContentHash::compute(name.as_bytes()),
+        SemanticFileFacts {
+            symbols: vec![SymbolEntry {
+                name: name.to_string(),
+                kind: SymbolKindTag::Type,
+                container_path: Vec::new(),
+                semantic_hash: ContentHash::compute(name.as_bytes()),
+                span: (1, 2),
+            }],
+            ..SemanticFileFacts::default()
+        },
+    )
+}
+
 fn function_index_file(name: &str) -> SemanticFileNode {
     SemanticFileNode::new(
         "rust",

--- a/crates/repo/src/repository_semantic_corpus_tests.rs
+++ b/crates/repo/src/repository_semantic_corpus_tests.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Tests for the capture-time function corpus walk.
 
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::PathBuf;
 
@@ -12,7 +13,7 @@ use semantic::{SemanticParseCache, parser::FunctionDef};
 
 use super::{
     CORPUS_BYTE_BUDGET, CORPUS_FILE_BUDGET, CorpusBudget, collect_changed_symbols,
-    populate_new_function_corpus,
+    collect_function_file_paths, populate_new_function_corpus,
 };
 
 fn fdef(name: &str, content: &str) -> FunctionDef {
@@ -107,6 +108,87 @@ fn corpus_budget_rejects_file_and_byte_overflow() {
 }
 
 #[test]
+fn index_walk_stops_when_file_budget_exhausted() {
+    let extra = 20;
+    let total = CORPUS_FILE_BUDGET + extra;
+    let (root, source) = index_with_function_files(total);
+    let mut files = Vec::new();
+    assert!(
+        !collect_function_file_paths(
+            &source,
+            &root,
+            CORPUS_FILE_BUDGET,
+            &BTreeSet::new(),
+            &mut files,
+        )
+        .unwrap(),
+        "more function files than the remaining budget must fail-close"
+    );
+    assert!(
+        files.len() <= CORPUS_FILE_BUDGET,
+        "walk must not collect the whole index: {}",
+        files.len()
+    );
+    assert!(
+        source.file_loads.get() <= CORPUS_FILE_BUDGET,
+        "default capture must not decode every index file: loaded {}",
+        source.file_loads.get()
+    );
+}
+
+fn index_with_function_files(count: usize) -> (SemanticIndexRoot, CountingSource) {
+    let mut blobs = HashMap::new();
+    let mut file_hashes = BTreeSet::new();
+    let mut entries = Vec::new();
+    for index in 0..count {
+        let file = function_index_file(&format!("f{index}"));
+        let file_bytes = file.encode().unwrap();
+        let file_hash = ContentHash::compute(&file_bytes);
+        file_hashes.insert(file_hash);
+        blobs.insert(file_hash, file_bytes);
+        entries.push(SemanticTreeEntry {
+            name: format!("f{index}.rs"),
+            kind: SemanticEntryKind::File,
+            node: file_hash,
+            semantic_digest: file.semantic_digest,
+        });
+    }
+    let (tree_node, _) = SemanticTreeNode::new(entries);
+    let tree_bytes = tree_node.encode().unwrap();
+    let tree_hash = ContentHash::compute(&tree_bytes);
+    blobs.insert(tree_hash, tree_bytes);
+    let root = SemanticIndexRoot::new(1, BTreeMap::new(), tree_hash, tree_node.semantic_digest());
+    (
+        root,
+        CountingSource {
+            blobs,
+            file_hashes,
+            file_loads: Cell::new(0),
+        },
+    )
+}
+
+fn function_index_file(name: &str) -> SemanticFileNode {
+    SemanticFileNode::new(
+        "rust",
+        "0",
+        1,
+        ContentHash::compute(name.as_bytes()),
+        ContentHash::compute(name.as_bytes()),
+        SemanticFileFacts {
+            symbols: vec![SymbolEntry {
+                name: name.to_string(),
+                kind: SymbolKindTag::Function,
+                container_path: Vec::new(),
+                semantic_hash: ContentHash::compute(name.as_bytes()),
+                span: (1, 2),
+            }],
+            ..SemanticFileFacts::default()
+        },
+    )
+}
+
+#[test]
 fn missing_index_is_incomplete() {
     assert!(
         !populate_new_function_corpus(
@@ -169,6 +251,41 @@ fn index_listed_parse_miss_is_incomplete() {
         .unwrap(),
         "a listed function file that fails to parse must fail-close the corpus"
     );
+}
+
+struct CountingSource {
+    blobs: HashMap<ContentHash, Vec<u8>>,
+    file_hashes: BTreeSet<ContentHash>,
+    file_loads: Cell<usize>,
+}
+
+impl ObjectSource for CountingSource {
+    fn get_tree(
+        &self,
+        _hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Tree>> {
+        Ok(None)
+    }
+
+    fn get_blob(
+        &self,
+        hash: &ContentHash,
+    ) -> objects::error::Result<Option<objects::object::Blob>> {
+        if self.file_hashes.contains(hash) {
+            self.file_loads.set(self.file_loads.get() + 1);
+        }
+        Ok(self
+            .blobs
+            .get(hash)
+            .map(|bytes| objects::object::Blob::new(bytes.clone())))
+    }
+
+    fn get_state(
+        &self,
+        _id: &objects::object::StateId,
+    ) -> objects::error::Result<Option<objects::object::State>> {
+        Ok(None)
+    }
 }
 
 struct IndexOnlySource {

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -18,7 +18,7 @@ use objects::{
     store::ObjectStore,
 };
 use state_review::{
-    ReviewSignalsConfig, SemanticContext,
+    ReviewSignalsConfig,
     config::{
         InvariantAdjacencyConfig, NoveltyConfig, PatternDeviationConfig,
         SelfFlaggedUncertaintyConfig, TestReachabilityConfig,
@@ -26,6 +26,8 @@ use state_review::{
     registry::run_all,
 };
 use tracing::warn;
+
+use crate::repository_semantic_context::build_semantic_context;
 
 use crate::{Repository, Result, repository::ReviewSignalsToml};
 
@@ -43,15 +45,19 @@ impl Repository {
         &self,
         prior: Option<&State>,
         new: &State,
+        new_index: Option<&ContentHash>,
     ) -> Result<Option<ContentHash>> {
         let cfg = signals_config_from_repo(&self.config().review.signals);
-        // The default empty `SemanticContext` covers self-flagged-uncertainty
-        // and invariant-adjacency, both of which only need state-level
-        // metadata. Tree-sitter-driven modules (novelty, test-reachability,
-        // pattern-deviation) stay quiet rather than failing — that's a
-        // first-ship trade-off, not a permanent one. Follow-on work
-        // populates `SemanticContext` from the snapshot's tree.
-        let ctx = SemanticContext::new();
+        let ctx = match build_semantic_context(self, prior, new, new_index) {
+            Ok(ctx) => ctx,
+            Err(err) => {
+                warn!(
+                    error = %err,
+                    "failed to build SemanticContext; running state-only signals"
+                );
+                state_review::SemanticContext::new()
+            }
+        };
         // The registry expects a non-Option prior. Use the new state itself
         // when none is available (initial snapshot) — the modules fire on
         // their own diagnostic content, not on diff vs prior, except where
@@ -179,6 +185,71 @@ mod tests {
             repo.latest_state_attachment(&state.id(), crate::StateAttachmentKind::RiskSignals)
                 .unwrap()
                 .is_none()
+        );
+    }
+
+    fn attached_risk_modules(repo: &Repository, state: &objects::object::State) -> Vec<String> {
+        let Some(attachment) = repo
+            .latest_state_attachment(&state.id(), crate::StateAttachmentKind::RiskSignals)
+            .unwrap()
+        else {
+            return Vec::new();
+        };
+        let objects::object::StateAttachmentBody::RiskSignals(hash) = attachment.body else {
+            panic!("expected risk-signals attachment");
+        };
+        let blob = repo.store().get_blob(&hash).unwrap().unwrap();
+        RiskSignalBlob::decode(blob.content())
+            .unwrap()
+            .signals
+            .into_iter()
+            .map(|signal| signal.producer.module)
+            .collect()
+    }
+
+    #[test]
+    fn snapshot_fmt_sweep_persists_no_tree_sitter_signals() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let attribution = Attribution::human(Principal::new("Fmt", "fmt@example.com"));
+        std::fs::write(temp.path().join("hello.rs"), "fn foo() -> i32 { 1 }\n").unwrap();
+        repo.snapshot_with_attribution(Some("seed".to_string()), None, attribution.clone())
+            .unwrap();
+        std::fs::write(temp.path().join("hello.rs"), "fn foo() -> i32 {\n    1\n}\n").unwrap();
+        let reformatted = repo
+            .snapshot_with_attribution(Some("fmt".to_string()), None, attribution)
+            .unwrap();
+
+        assert!(
+            attached_risk_modules(&repo, &reformatted)
+                .iter()
+                .all(|module| !module.contains("tree_sitter")),
+            "fmt-sweep must not persist tree-sitter signals: {:?}",
+            attached_risk_modules(&repo, &reformatted)
+        );
+    }
+
+    #[test]
+    fn snapshot_novel_shape_persists_novelty() {
+        let temp = TempDir::new().unwrap();
+        let repo = Repository::init_default(temp.path()).unwrap();
+        let attribution = Attribution::human(Principal::new("Nov", "nov@example.com"));
+        std::fs::write(
+            temp.path().join("changed.rs"),
+            "fn alpha() { let total = first + second + third + fourth; }\n\
+             fn beta() { for widget in inventory { ship(widget); } }\n\
+             fn gamma() { match colour { Red => stop(), Green => go() } }\n\
+             fn delta() { while pending { dequeue().handle(); } flush(); }\n",
+        )
+        .unwrap();
+        let state = repo
+            .snapshot_with_attribution(Some("novel".to_string()), None, attribution)
+            .unwrap();
+
+        let modules = attached_risk_modules(&repo, &state);
+        assert!(
+            modules.iter().any(|module| module == "novelty.tree_sitter"),
+            "semantic change must persist novelty, got {modules:?}"
         );
     }
 }

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -46,18 +46,21 @@ impl Repository {
         prior: Option<&State>,
         new: &State,
         new_index: Option<&ContentHash>,
+        source_blobs: Option<&std::collections::HashMap<ContentHash, &[u8]>>,
+        source_trees: Option<&std::collections::HashMap<ContentHash, &objects::object::Tree>>,
     ) -> Result<Option<ContentHash>> {
         let cfg = signals_config_from_repo(&self.config().review.signals);
-        let ctx = match build_semantic_context(self, prior, new, new_index) {
-            Ok(ctx) => ctx,
-            Err(err) => {
-                warn!(
-                    error = %err,
-                    "failed to build SemanticContext; running state-only signals"
-                );
-                state_review::SemanticContext::new()
-            }
-        };
+        let ctx =
+            match build_semantic_context(self, prior, new, new_index, source_blobs, source_trees) {
+                Ok(ctx) => ctx,
+                Err(err) => {
+                    warn!(
+                        error = %err,
+                        "failed to build SemanticContext; running state-only signals"
+                    );
+                    state_review::SemanticContext::new()
+                }
+            };
         // The registry expects a non-Option prior. Use the new state itself
         // when none is available (initial snapshot) — the modules fire on
         // their own diagnostic content, not on diff vs prior, except where
@@ -215,7 +218,11 @@ mod tests {
         std::fs::write(temp.path().join("hello.rs"), "fn foo() -> i32 { 1 }\n").unwrap();
         repo.snapshot_with_attribution(Some("seed".to_string()), None, attribution.clone())
             .unwrap();
-        std::fs::write(temp.path().join("hello.rs"), "fn foo() -> i32 {\n    1\n}\n").unwrap();
+        std::fs::write(
+            temp.path().join("hello.rs"),
+            "fn foo() -> i32 {\n    1\n}\n",
+        )
+        .unwrap();
         let reformatted = repo
             .snapshot_with_attribution(Some("fmt".to_string()), None, attribution)
             .unwrap();

--- a/crates/repo/src/repository_signals.rs
+++ b/crates/repo/src/repository_signals.rs
@@ -50,7 +50,7 @@ impl Repository {
         source_trees: Option<&std::collections::HashMap<ContentHash, &objects::object::Tree>>,
     ) -> Result<Option<ContentHash>> {
         let cfg = signals_config_from_repo(&self.config().review.signals);
-        let ctx =
+        let ctx = if tree_sitter_producers_enabled(&cfg) {
             match build_semantic_context(self, prior, new, new_index, source_blobs, source_trees) {
                 Ok(ctx) => ctx,
                 Err(err) => {
@@ -60,7 +60,10 @@ impl Repository {
                     );
                     state_review::SemanticContext::new()
                 }
-            };
+            }
+        } else {
+            state_review::SemanticContext::new()
+        };
         // The registry expects a non-Option prior. Use the new state itself
         // when none is available (initial snapshot) — the modules fire on
         // their own diagnostic content, not on diff vs prior, except where
@@ -94,6 +97,10 @@ impl Repository {
     }
 }
 
+fn tree_sitter_producers_enabled(cfg: &ReviewSignalsConfig) -> bool {
+    cfg.novelty.enabled || cfg.test_reachability.enabled || cfg.pattern_deviation.enabled
+}
+
 /// Map the TOML-shaped repo config into the `state_review` crate's typed
 /// config. Kept as a free function so tests can exercise it without spinning
 /// up a `Repository`.
@@ -124,6 +131,7 @@ pub(crate) fn signals_config_from_repo(t: &ReviewSignalsToml) -> ReviewSignalsCo
 #[cfg(test)]
 mod tests {
     use objects::object::{Attribution, Principal, RiskSignalBlob};
+    use state_review::ReviewSignalsConfig;
     use tempfile::TempDir;
 
     use super::*;
@@ -238,6 +246,8 @@ mod tests {
 
     #[test]
     fn snapshot_novel_shape_persists_novelty() {
+        // Native SnapshotSource::Worktree: new.tree is not in repo.store()
+        // until stage_snapshot_objects returns. Overlay maps must resolve it.
         let temp = TempDir::new().unwrap();
         let repo = Repository::init_default(temp.path()).unwrap();
         let attribution = Attribution::human(Principal::new("Nov", "nov@example.com"));
@@ -256,7 +266,18 @@ mod tests {
         let modules = attached_risk_modules(&repo, &state);
         assert!(
             modules.iter().any(|module| module == "novelty.tree_sitter"),
-            "semantic change must persist novelty, got {modules:?}"
+            "worktree capture must persist novelty, got {modules:?}"
         );
+    }
+
+    #[test]
+    fn tree_sitter_producers_enabled_is_false_when_all_disabled() {
+        let mut cfg = ReviewSignalsConfig::default();
+        cfg.novelty.enabled = false;
+        cfg.test_reachability.enabled = false;
+        cfg.pattern_deviation.enabled = false;
+        assert!(!tree_sitter_producers_enabled(&cfg));
+        cfg.novelty.enabled = true;
+        assert!(tree_sitter_producers_enabled(&cfg));
     }
 }

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -503,10 +503,27 @@ impl SnapshotMutation<'_> {
                 }
             }
 
+            let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
+                blobs
+                    .iter()
+                    .map(|(hash, bytes)| (*hash, bytes.as_slice()))
+                    .collect::<std::collections::HashMap<_, _>>()
+            });
+            let mut source_trees = supplied_blobs.as_ref().map(|(_, trees)| {
+                trees
+                    .iter()
+                    .map(|pending| (pending.hash(), pending))
+                    .collect::<std::collections::HashMap<_, _>>()
+            });
+            if let Some(trees) = source_trees.as_mut() {
+                trees.insert(tree.hash(), &tree);
+            }
             match self.repo.compute_and_persist_signals(
                 prior_state.as_ref(),
                 &state,
                 semantic_index.as_ref(),
+                source_blobs.as_ref(),
+                source_trees.as_ref(),
             ) {
                 Ok(Some(hash)) => risk_signals = Some(hash),
                 Ok(None) => {}

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -463,19 +463,8 @@ impl SnapshotMutation<'_> {
                 Some(id) => self.repo.store.get_state(&id).ok().flatten(),
                 None => None,
             };
-            match self
-                .repo
-                .compute_and_persist_signals(prior_state.as_ref(), &state)
-            {
-                Ok(Some(hash)) => risk_signals = Some(hash),
-                Ok(None) => {}
-                Err(err) => {
-                    tracing::warn!(error = %err, "risk signal computation failed; continuing without signals");
-                }
-            }
-
-            // Eager semantic index: parse only changed blobs, reusing the
-            // parent index for unchanged subtrees. Never fails the capture.
+            // Eager semantic index first so risk-signal prune can use merkle
+            // digests (`semantic_changed`) instead of an empty SemanticContext.
             let semantic_result = if let Some((blobs, trees)) = supplied_blobs.as_ref() {
                 let source_blobs = blobs
                     .iter()
@@ -511,6 +500,18 @@ impl SnapshotMutation<'_> {
                 Ok((None, _)) => {}
                 Err(err) => {
                     tracing::warn!(error = %err, "semantic index computation failed; continuing without index");
+                }
+            }
+
+            match self.repo.compute_and_persist_signals(
+                prior_state.as_ref(),
+                &state,
+                semantic_index.as_ref(),
+            ) {
+                Ok(Some(hash)) => risk_signals = Some(hash),
+                Ok(None) => {}
+                Err(err) => {
+                    tracing::warn!(error = %err, "risk signal computation failed; continuing without signals");
                 }
             }
 

--- a/crates/repo/src/repository_snapshot.rs
+++ b/crates/repo/src/repository_snapshot.rs
@@ -503,27 +503,23 @@ impl SnapshotMutation<'_> {
                 }
             }
 
-            let source_blobs = supplied_blobs.as_ref().map(|(blobs, _)| {
-                blobs
-                    .iter()
-                    .map(|(hash, bytes)| (*hash, bytes.as_slice()))
-                    .collect::<std::collections::HashMap<_, _>>()
-            });
-            let mut source_trees = supplied_blobs.as_ref().map(|(_, trees)| {
-                trees
-                    .iter()
-                    .map(|pending| (pending.hash(), pending))
-                    .collect::<std::collections::HashMap<_, _>>()
-            });
-            if let Some(trees) = source_trees.as_mut() {
-                trees.insert(tree.hash(), &tree);
+            // Worktree trees live in PreparedSnapshotArtifact until
+            // stage_snapshot_objects returns. Always overlay the in-memory
+            // root (and any packed blobs) so build_semantic_context can
+            // resolve new.tree without a store read.
+            let mut source_blobs = std::collections::HashMap::new();
+            let mut source_trees = std::collections::HashMap::new();
+            if let Some((blobs, trees)) = supplied_blobs.as_ref() {
+                source_blobs.extend(blobs.iter().map(|(hash, bytes)| (*hash, bytes.as_slice())));
+                source_trees.extend(trees.iter().map(|pending| (pending.hash(), pending)));
             }
+            source_trees.insert(tree.hash(), &tree);
             match self.repo.compute_and_persist_signals(
                 prior_state.as_ref(),
                 &state,
                 semantic_index.as_ref(),
-                source_blobs.as_ref(),
-                source_trees.as_ref(),
+                Some(&source_blobs),
+                Some(&source_trees),
             ) {
                 Ok(Some(hash)) => risk_signals = Some(hash),
                 Ok(None) => {}

--- a/crates/semantic/src/analysis/analysis_similarity.rs
+++ b/crates/semantic/src/analysis/analysis_similarity.rs
@@ -84,6 +84,30 @@ pub fn compute_similarity_with_language(
     }
 }
 
+/// AST kind-bag similarity with no token fallback.
+///
+/// `None` means a language has no grammar or either side failed to
+/// parse. Callers that must not invent a novelty/uniqueness signal
+/// from identifier tokens should treat that as fail-closed.
+pub fn try_compute_ast_similarity(a: &str, b: &str, language: Language) -> Option<f64> {
+    try_compute_ast_similarity_for_languages(a, language, b, language)
+}
+
+/// Like [`try_compute_ast_similarity`], but each side uses its own grammar.
+pub fn try_compute_ast_similarity_for_languages(
+    a: &str,
+    a_language: Language,
+    b: &str,
+    b_language: Language,
+) -> Option<f64> {
+    if a_language == Language::Unknown || b_language == Language::Unknown {
+        return None;
+    }
+    let counts_a = ast_node_counts(a, a_language)?;
+    let counts_b = ast_node_counts(b, b_language)?;
+    Some(count_similarity(&counts_a, &counts_b))
+}
+
 pub(super) struct PreparedSimilarity {
     method: SimilarityMethod,
     lines: Option<HashSet<String>>,

--- a/crates/semantic/src/analysis/analysis_tests.rs
+++ b/crates/semantic/src/analysis/analysis_tests.rs
@@ -689,6 +689,36 @@ fn test_compute_similarity_ast_fallback() {
 }
 
 #[test]
+fn ast_similarity_ignores_renamed_identifiers() {
+    let a = "fn get_user() { fetch_user(); }";
+    let b = "fn get_order() { fetch_order(); }";
+    let tokens = compute_similarity(a, b, SimilarityMethod::Tokens);
+    let ast =
+        super::analysis_similarity::try_compute_ast_similarity(a, b, crate::parser::Language::Rust)
+            .expect("both snippets must parse");
+    assert!(
+        tokens < 0.85,
+        "token Jaccard must treat renamed identifiers as distant: {tokens}"
+    );
+    assert!(
+        ast >= 0.85,
+        "AST kind bags must treat same-shape renames as similar: {ast}"
+    );
+}
+
+#[test]
+fn try_compute_ast_similarity_fail_closes_without_grammar() {
+    assert_eq!(
+        super::analysis_similarity::try_compute_ast_similarity(
+            "fn get_user() { fetch_user(); }",
+            "fn get_order() { fetch_order(); }",
+            crate::parser::Language::Unknown,
+        ),
+        None
+    );
+}
+
+#[test]
 fn test_classify_comments_only_handles_deep_ast_without_recursion() {
     let old = nested_rust_modules(512, "// old\nfn deeply_nested() { println!(\"hi\"); }");
     let new = nested_rust_modules(512, "// new\nfn deeply_nested() { println!(\"hi\"); }");

--- a/crates/semantic/src/analysis/mod.rs
+++ b/crates/semantic/src/analysis/mod.rs
@@ -22,7 +22,10 @@ pub(crate) use analysis_functions::detect_function_changes_with_parsed;
 pub(crate) use analysis_imports::detect_import_changes_with_parsed;
 pub use analysis_imports::{detect_import_changes, detect_import_changes_with_manifest};
 pub use analysis_renames::detect_file_renames;
-pub use analysis_similarity::{SimilarityMethod, compute_similarity};
+pub use analysis_similarity::{
+    SimilarityMethod, compute_similarity, try_compute_ast_similarity,
+    try_compute_ast_similarity_for_languages,
+};
 pub use hot_spots::{
     HotEventKind, HotSpot, HotSpotKey, HotSpotKeyValue, HotSpotParams, HotSpotsReport,
     analyze_actor_histogram, analyze_hot_spots,

--- a/crates/semantic/src/cache.rs
+++ b/crates/semantic/src/cache.rs
@@ -42,7 +42,9 @@ pub struct SemanticParseCache {
 }
 
 impl SemanticParseCache {
-    const DEFAULT_MAX_ENTRIES: usize = 256;
+    /// Shared parse-cache page. Capture-time corpus file budget uses this
+    /// same cap so a real repo is not fail-closed by a smaller universe.
+    pub const DEFAULT_MAX_ENTRIES: usize = 256;
 
     /// Create a bounded parse cache.
     pub fn new(max_entries: usize) -> Self {

--- a/crates/semantic/src/parser/mod.rs
+++ b/crates/semantic/src/parser/mod.rs
@@ -18,5 +18,5 @@ pub use parser_deps::extract_dependencies;
 pub use parser_language::Language;
 #[cfg(test)]
 pub(crate) use parser_pool::{parse_count, reset_parse_count};
-pub use parser_types::{FunctionDef, Import, ImportKind};
+pub use parser_types::{CallSite, FunctionDef, Import, ImportKind};
 pub use syntax_index::{FunctionRef, ImportRef, SyntaxIndex};

--- a/crates/semantic/src/parser/parser_core.rs
+++ b/crates/semantic/src/parser/parser_core.rs
@@ -3,13 +3,13 @@
 
 use std::sync::{Arc, OnceLock};
 
-use objects::object::ContentHash;
+use objects::object::{ContentHash, OccurrenceRole};
 use tree_sitter::{Node, Tree as TSTree};
 
 use super::{
     parser_language::Language,
     parser_pool::parse_fresh,
-    parser_types::{FunctionDef, Import},
+    parser_types::{CallSite, FunctionDef, Import},
     syntax_index::{FunctionRef, ImportRef, SyntaxIndex},
 };
 
@@ -91,6 +91,20 @@ impl ParsedFile {
     /// Extract function definitions from the file.
     pub fn extract_functions(&self) -> Vec<FunctionDef> {
         self.functions().map(FunctionRef::to_owned).collect()
+    }
+
+    /// Call expressions from the syntax index. Comments and string
+    /// literals are not call nodes, so they do not appear here.
+    pub fn extract_calls(&self) -> Vec<CallSite> {
+        self.syntax_index()
+            .occurrences()
+            .iter()
+            .filter(|occurrence| occurrence.role == OccurrenceRole::Call)
+            .map(|occurrence| CallSite {
+                name: occurrence.name.clone(),
+                qualifier: occurrence.qualifier.clone(),
+            })
+            .collect()
     }
 
     /// Extract imports from the file.

--- a/crates/semantic/src/parser/parser_core.rs
+++ b/crates/semantic/src/parser/parser_core.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{Arc, OnceLock};
 
-use objects::object::{ContentHash, OccurrenceRole};
+use objects::object::{ContentHash, OccurrenceRole, ScopeEntry, ScopeKind};
 use tree_sitter::{Node, Tree as TSTree};
 
 use super::{
@@ -107,6 +107,28 @@ impl ParsedFile {
             .collect()
     }
 
+    /// Calls owned by the outermost function in this parse.
+    /// Nested function and closure bodies are excluded.
+    pub fn extract_own_calls(&self) -> Vec<CallSite> {
+        let index = self.syntax_index();
+        let scopes = index.semantic_scopes();
+        let Some(owner) = outermost_function_scope(scopes) else {
+            return Vec::new();
+        };
+        index
+            .occurrences()
+            .iter()
+            .filter(|occurrence| {
+                occurrence.role == OccurrenceRole::Call
+                    && nearest_function_scope(scopes, occurrence.scope) == Some(owner)
+            })
+            .map(|occurrence| CallSite {
+                name: occurrence.name.clone(),
+                qualifier: occurrence.qualifier.clone(),
+            })
+            .collect()
+    }
+
     /// Extract imports from the file.
     pub fn extract_imports(&self) -> Vec<Import> {
         self.imports().map(ImportRef::to_owned).collect()
@@ -116,4 +138,33 @@ impl ParsedFile {
     pub fn is_function_kind(kind: &str, language: Language) -> bool {
         super::syntax_index::is_function_kind(kind, language)
     }
+}
+
+fn outermost_function_scope(scopes: &[ScopeEntry]) -> Option<u32> {
+    scopes.iter().find_map(|scope| {
+        if scope.kind != ScopeKind::Function {
+            return None;
+        }
+        let mut parent = scope.parent;
+        while let Some(id) = parent {
+            let entry = scopes.get(id as usize)?;
+            if entry.kind == ScopeKind::Function {
+                return None;
+            }
+            parent = entry.parent;
+        }
+        Some(scope.local_id)
+    })
+}
+
+fn nearest_function_scope(scopes: &[ScopeEntry], scope: u32) -> Option<u32> {
+    let mut current = Some(scope);
+    while let Some(id) = current {
+        let entry = scopes.get(id as usize)?;
+        if entry.kind == ScopeKind::Function {
+            return Some(id);
+        }
+        current = entry.parent;
+    }
+    None
 }

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -342,6 +342,64 @@ export const handlers = {
 }
 
 #[test]
+fn extract_calls_includes_python_call_nodes() {
+    let source = r#"
+def target():
+    return 1
+
+def test_target():
+    target()
+"#;
+    let parsed = ParsedFile::parse(source, Language::Python).expect("Should parse");
+    let calls = parsed.extract_calls();
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.name == "target" && call.qualifier.is_empty()),
+        "python call nodes must be extracted: {calls:?}"
+    );
+}
+
+#[test]
+fn extract_own_calls_excludes_nested_function_and_closure() {
+    let rust = r#"
+fn test_x() {
+    fn unused() {
+        target();
+    }
+    let unused_closure = || {
+        other();
+    };
+}
+"#;
+    let parsed = ParsedFile::parse(rust, Language::Rust).expect("Should parse");
+    let own = parsed.extract_own_calls();
+    assert!(
+        own.iter()
+            .all(|call| call.name != "target" && call.name != "other"),
+        "nested rust calls must not leak to the outer function: {own:?}"
+    );
+
+    let js = r#"
+function test_x() {
+    function unused() {
+        target();
+    }
+    const unused_arrow = () => {
+        other();
+    };
+}
+"#;
+    let parsed = ParsedFile::parse(js, Language::JavaScript).expect("Should parse");
+    let own = parsed.extract_own_calls();
+    assert!(
+        own.iter()
+            .all(|call| call.name != "target" && call.name != "other"),
+        "nested js calls must not leak to the outer function: {own:?}"
+    );
+}
+
+#[test]
 fn extract_calls_uses_tree_not_comment_or_string_substrings() {
     let source = r#"
 fn test_it() {

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -317,6 +317,31 @@ mod b {
 }
 
 #[test]
+fn extract_functions_includes_javascript_object_literal_methods() {
+    let source = r#"
+export const handlers = {
+    save: async () => {
+        await persist();
+    },
+    load: function () {
+        return fetchItem();
+    },
+};
+"#;
+    let parsed = ParsedFile::parse(source, Language::JavaScript).expect("Should parse");
+    let functions = parsed.extract_functions();
+    let names: Vec<&str> = functions.iter().map(|f| f.name.as_str()).collect();
+    assert!(
+        names.contains(&"save"),
+        "object-literal arrow method must extract: {names:?}"
+    );
+    assert!(
+        names.contains(&"load"),
+        "object-literal function method must extract: {names:?}"
+    );
+}
+
+#[test]
 fn extract_calls_uses_tree_not_comment_or_string_substrings() {
     let source = r#"
 fn test_it() {

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -250,6 +250,72 @@ fn test_extract_functions_handles_deeply_nested_modules() {
     assert_eq!(functions[0].name, "deeply_nested");
 }
 
+#[test]
+fn extract_functions_qualifies_impl_methods_by_container() {
+    let source = r#"
+impl Foo {
+    fn run() { 1 }
+}
+impl Bar {
+    fn run() { 2 }
+}
+"#;
+    let parsed = ParsedFile::parse(source, Language::Rust).expect("Should parse");
+    let functions = parsed.extract_functions();
+    let identities: Vec<String> = functions.iter().map(|f| f.symbol_identity()).collect();
+    assert!(
+        identities
+            .iter()
+            .any(|id| id.contains("Foo") && id.contains("run")),
+        "Foo::run must be qualified: {identities:?}"
+    );
+    assert!(
+        identities
+            .iter()
+            .any(|id| id.contains("Bar") && id.contains("run")),
+        "Bar::run must be qualified: {identities:?}"
+    );
+    assert_ne!(
+        functions[0].symbol_identity(),
+        functions[1].symbol_identity()
+    );
+}
+
+#[test]
+fn extract_functions_qualifies_nested_mod_impl_methods() {
+    let source = r#"
+mod a {
+    impl Foo {
+        fn run() { 1 }
+    }
+}
+mod b {
+    impl Foo {
+        fn run() { 2 }
+    }
+}
+"#;
+    let parsed = ParsedFile::parse(source, Language::Rust).expect("Should parse");
+    let functions = parsed.extract_functions();
+    let identities: Vec<String> = functions.iter().map(|f| f.symbol_identity()).collect();
+    assert!(
+        identities
+            .iter()
+            .any(|id| id.contains("a") && id.contains("Foo") && id.contains("run")),
+        "a::Foo::run must be qualified: {identities:?}"
+    );
+    assert!(
+        identities
+            .iter()
+            .any(|id| id.contains("b") && id.contains("Foo") && id.contains("run")),
+        "b::Foo::run must be qualified: {identities:?}"
+    );
+    assert_ne!(
+        functions[0].symbol_identity(),
+        functions[1].symbol_identity()
+    );
+}
+
 #[cfg(feature = "lang-cpp")]
 #[test]
 fn test_cpp_templated_qualified_function_names() {

--- a/crates/semantic/src/parser/parser_tests.rs
+++ b/crates/semantic/src/parser/parser_tests.rs
@@ -316,6 +316,43 @@ mod b {
     );
 }
 
+#[test]
+fn extract_calls_uses_tree_not_comment_or_string_substrings() {
+    let source = r#"
+fn test_it() {
+    Bar::run();
+    foo.run();
+    covered();
+    // TODO: call orphan()
+    let _ = "orphan()";
+}
+"#;
+    let parsed = ParsedFile::parse(source, Language::Rust).expect("Should parse");
+    let calls = parsed.extract_calls();
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.name == "run" && call.qualifier == ["Bar"]),
+        "path call Bar::run: {calls:?}"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.name == "run" && call.qualifier == ["foo"]),
+        "receiver call foo.run: {calls:?}"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|call| call.name == "covered" && call.qualifier.is_empty()),
+        "bare call covered: {calls:?}"
+    );
+    assert!(
+        calls.iter().all(|call| call.name != "orphan"),
+        "comment/string must not create call edges: {calls:?}"
+    );
+}
+
 #[cfg(feature = "lang-cpp")]
 #[test]
 fn test_cpp_templated_qualified_function_names() {

--- a/crates/semantic/src/parser/parser_types.rs
+++ b/crates/semantic/src/parser/parser_types.rs
@@ -37,6 +37,15 @@ impl FunctionDef {
     }
 }
 
+/// A call expression extracted from the parsed tree, not source text.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CallSite {
+    pub name: String,
+    /// Path or receiver segments ahead of the callee (`Bar` in `Bar::run`,
+    /// `foo` in `foo.run()`). Empty for a bare `run()`.
+    pub qualifier: Vec<String>,
+}
+
 /// An import statement.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Import {

--- a/crates/semantic/src/parser/parser_types.rs
+++ b/crates/semantic/src/parser/parser_types.rs
@@ -15,15 +15,20 @@ pub struct FunctionDef {
 }
 
 impl FunctionDef {
+    /// `container::name`, or the bare name when the parser saw no container.
+    pub fn qualified_name(&self) -> String {
+        if self.container.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}::{}", self.container, self.name)
+        }
+    }
+
     /// Identity that distinguishes `Foo::run` from `Bar::run` and
     /// overloads that share a bare name. Used as the capture-time
     /// `changed_symbols` key.
     pub fn symbol_identity(&self) -> String {
-        let qualified = if self.container.is_empty() {
-            self.name.clone()
-        } else {
-            format!("{}::{}", self.container, self.name)
-        };
+        let qualified = self.qualified_name();
         if self.signature.is_empty() {
             qualified
         } else {

--- a/crates/semantic/src/parser/parser_types.rs
+++ b/crates/semantic/src/parser/parser_types.rs
@@ -5,10 +5,31 @@
 #[derive(Clone, Debug, PartialEq)]
 pub struct FunctionDef {
     pub name: String,
+    /// Enclosing impl / type / module / receiver, when the parser can
+    /// see one. Empty for a file-scope function.
+    pub container: String,
     pub signature: String,
     pub start_line: usize,
     pub end_line: usize,
     pub content: String,
+}
+
+impl FunctionDef {
+    /// Identity that distinguishes `Foo::run` from `Bar::run` and
+    /// overloads that share a bare name. Used as the capture-time
+    /// `changed_symbols` key.
+    pub fn symbol_identity(&self) -> String {
+        let qualified = if self.container.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}::{}", self.container, self.name)
+        };
+        if self.signature.is_empty() {
+            qualified
+        } else {
+            format!("{qualified}|{}", self.signature)
+        }
+    }
 }
 
 /// An import statement.

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -974,18 +974,33 @@ fn is_function_node(node: &Node<'_>, language: Language) -> bool {
             matches!(
                 node.kind(),
                 "function_declaration" | "method_definition" | "generator_function_declaration"
-            ) || (node.kind() == "variable_declarator"
-                && node
-                    .child_by_field_name("value")
-                    .is_some_and(|value| is_javascript_function_value(value.kind())))
+            ) || javascript_bound_function(node)
         }
         _ => is_function_kind(node.kind(), language),
     }
 }
 
+fn javascript_bound_function(node: &Node<'_>) -> bool {
+    matches!(node.kind(), "variable_declarator" | "pair")
+        && node
+            .child_by_field_name("value")
+            .is_some_and(|value| is_javascript_function_value(value.kind()))
+}
+
 fn function_name<'a>(node: &Node<'_>, source: &'a str) -> Option<&'a str> {
     if let Some(name) = node.child_by_field_name("name") {
         return Some(&source[name.byte_range()]);
+    }
+    if let Some(key) = node.child_by_field_name("key") {
+        if matches!(
+            key.kind(),
+            "identifier" | "property_identifier" | "private_property_identifier"
+        ) {
+            return Some(&source[key.byte_range()]);
+        }
+        if let Some(name) = first_identifier_in_subtree(key, source) {
+            return Some(name);
+        }
     }
     if let Some(declarator) = node.child_by_field_name("declarator") {
         if let Some(name) = c_function_name(declarator, source) {
@@ -1222,7 +1237,7 @@ fn line_offsets(source: &str) -> Vec<usize> {
 fn is_javascript_function_value(kind: &str) -> bool {
     matches!(
         kind,
-        "arrow_function" | "function_expression" | "generator_function"
+        "arrow_function" | "function" | "function_expression" | "generator_function"
     )
 }
 

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -42,6 +42,7 @@ pub struct ImportRef<'a> {
 #[derive(Debug)]
 struct IndexedFunction {
     name: String,
+    container: String,
     signature: String,
     start_line: usize,
     end_line: usize,
@@ -72,6 +73,7 @@ impl SyntaxIndex {
             {
                 index.functions.push(IndexedFunction {
                     name: name.to_string(),
+                    container: function_container(&node, source),
                     signature: function_signature(&node, source),
                     start_line: node.start_position().row,
                     end_line: node.end_position().row,
@@ -171,6 +173,10 @@ impl FunctionRef<'_> {
         &self.inner.name
     }
 
+    pub fn container(&self) -> &str {
+        &self.inner.container
+    }
+
     pub fn signature(&self) -> &str {
         &self.inner.signature
     }
@@ -190,6 +196,7 @@ impl FunctionRef<'_> {
     pub fn to_owned(self) -> FunctionDef {
         FunctionDef {
             name: self.name().to_string(),
+            container: self.container().to_string(),
             signature: self.signature().to_string(),
             start_line: self.start_line(),
             end_line: self.end_line(),
@@ -1038,6 +1045,107 @@ fn first_identifier_in_subtree<'a>(node: Node<'_>, source: &'a str) -> Option<&'
         push_children_reverse(current, &mut stack);
     }
     None
+}
+
+fn function_container(node: &Node<'_>, source: &str) -> String {
+    if node.kind() == "method_declaration"
+        && let Some(receiver) = go_receiver_type(node, source)
+    {
+        return receiver;
+    }
+    let mut parts = Vec::new();
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        match parent.kind() {
+            "impl_item" => {
+                if let Some(name) = rust_impl_type_name(&parent, source) {
+                    parts.push(name);
+                }
+            }
+            "mod_item"
+            | "trait_item"
+            | "class_definition"
+            | "class_declaration"
+            | "class_specifier"
+            | "struct_specifier"
+            | "interface_declaration" => {
+                if let Some(name) = parent.child_by_field_name("name") {
+                    let text = source[name.byte_range()].trim();
+                    if !text.is_empty() {
+                        parts.push(text.to_string());
+                    }
+                }
+            }
+            _ => {}
+        }
+        current = parent.parent();
+    }
+    parts.reverse();
+    parts.join("::")
+}
+
+fn rust_impl_type_name(node: &Node<'_>, source: &str) -> Option<String> {
+    if let Some(type_node) = node.child_by_field_name("type") {
+        let name = first_type_identifier(&type_node, source);
+        if !name.trim().is_empty() {
+            return Some(name);
+        }
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if matches!(
+            child.kind(),
+            "type_parameters" | "where_clause" | "declaration_list"
+        ) {
+            continue;
+        }
+        if matches!(
+            child.kind(),
+            "type_identifier" | "generic_type" | "scoped_type_identifier"
+        ) {
+            let name = first_type_identifier(&child, source);
+            if !name.trim().is_empty() {
+                return Some(name);
+            }
+        }
+    }
+    None
+}
+
+fn go_receiver_type(node: &Node<'_>, source: &str) -> Option<String> {
+    let params = node.child_by_field_name("receiver")?;
+    let mut cursor = params.walk();
+    for child in params.children(&mut cursor) {
+        if child.kind() == "parameter_declaration"
+            && let Some(type_node) = child.child_by_field_name("type")
+        {
+            let text = source[type_node.byte_range()].trim_start_matches('*');
+            if !text.is_empty() {
+                return Some(text.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn first_type_identifier(node: &Node<'_>, source: &str) -> String {
+    match node.kind() {
+        "type_identifier" | "identifier" => source[node.byte_range()].to_string(),
+        "generic_type" | "scoped_type_identifier" => {
+            let mut cursor = node.walk();
+            let mut last = None;
+            for child in node.children(&mut cursor) {
+                if matches!(child.kind(), "type_identifier" | "identifier") {
+                    last = Some(source[child.byte_range()].to_string());
+                }
+            }
+            match last {
+                Some(name) => name,
+                None => source[node.byte_range()].to_string(),
+            }
+        }
+        _ => source[node.byte_range()].to_string(),
+    }
 }
 
 fn function_signature(node: &Node<'_>, source: &str) -> String {

--- a/crates/semantic/src/parser/syntax_index.rs
+++ b/crates/semantic/src/parser/syntax_index.rs
@@ -805,13 +805,17 @@ fn is_definition_name(node: Node<'_>) -> bool {
         )
 }
 
+fn is_call_expression(kind: &str) -> bool {
+    matches!(kind, "call_expression" | "call")
+}
+
 fn is_call_target(mut node: Node<'_>) -> bool {
     while let Some(parent) = node.parent() {
         if is_path_node(parent.kind()) {
             node = parent;
             continue;
         }
-        if parent.kind() == "call_expression" {
+        if is_call_expression(parent.kind()) {
             return parent
                 .child_by_field_name("function")
                 .is_some_and(|function| function.id() == node.id());

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -13,11 +13,11 @@ use std::path::PathBuf;
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
 use semantic::{
-    analysis::{SimilarityMethod, compute_similarity},
-    parser::FunctionDef,
+    analysis::try_compute_ast_similarity_for_languages,
+    parser::{FunctionDef, Language},
 };
 
-use crate::{config::ReviewSignalsConfig, registry::SemanticContext};
+use crate::{config::ReviewSignalsConfig, registry::SemanticContext, truncate_reason};
 
 const VERSION: u32 = 1;
 const MODULE_ID: &str = "novelty.tree_sitter";
@@ -63,13 +63,9 @@ pub fn run(
         .iter()
         .filter(|(path, fn_def)| ctx.is_emit_target(path, fn_def))
     {
-        let max_sim = corpus
-            .iter()
-            .filter(|(p, f)| !(p == path && f.symbol_identity() == fn_def.symbol_identity()))
-            .map(|(_, other)| {
-                compute_similarity(&other.content, &fn_def.content, SimilarityMethod::Tokens) as f32
-            })
-            .fold(0.0_f32, f32::max);
+        let Some(max_sim) = max_structural_similarity(path, fn_def, &corpus) else {
+            continue;
+        };
         if max_sim < novelty_threshold {
             let reason = format!(
                 "function shape unique in repo (max sibling similarity {:.0}%)",
@@ -88,175 +84,32 @@ pub fn run(
     out
 }
 
-use crate::truncate_reason;
+fn max_structural_similarity(
+    path: &std::path::Path,
+    fn_def: &FunctionDef,
+    corpus: &[(PathBuf, FunctionDef)],
+) -> Option<f32> {
+    let language = Language::from_path(path);
+    if language == Language::Unknown {
+        return None;
+    }
+    let mut best: Option<f32> = None;
+    for (other_path, other) in corpus {
+        if other_path == path && other.symbol_identity() == fn_def.symbol_identity() {
+            continue;
+        }
+        let other_language = Language::from_path(other_path);
+        let score = try_compute_ast_similarity_for_languages(
+            &other.content,
+            other_language,
+            &fn_def.content,
+            language,
+        )?;
+        best = Some(best.map_or(score as f32, |current| current.max(score as f32)));
+    }
+    best
+}
 
 #[cfg(test)]
-mod tests {
-    use objects::object::{Attribution, ContentHash, Principal};
-
-    use super::*;
-
-    fn empty_state() -> State {
-        State::new_snapshot(
-            ContentHash::compute(b"tree"),
-            vec![],
-            Attribution::human(Principal::new("Alice", "alice@example.com")),
-        )
-    }
-
-    #[test]
-    fn quiet_with_small_corpus() {
-        // Empty SemanticContext = corpus of zero. Stays quiet.
-        let cfg = ReviewSignalsConfig::default();
-        let ctx = SemanticContext::new();
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(signals.is_empty());
-    }
-
-    #[test]
-    fn quiet_when_disabled() {
-        let mut cfg = ReviewSignalsConfig::default();
-        cfg.novelty.enabled = false;
-        let ctx = SemanticContext::new();
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(signals.is_empty());
-    }
-
-    fn fdef(name: &str, body: &str) -> FunctionDef {
-        FunctionDef {
-            name: name.to_string(),
-            container: String::new(),
-            signature: format!("fn {name}()"),
-            start_line: 1,
-            end_line: 3,
-            content: body.to_string(),
-        }
-    }
-
-    #[test]
-    fn novelty_scoped_to_changed_files() {
-        // Corpus of four files, each with a structurally distinct function, so
-        // every function is "novel" against the rest of the repo. Only
-        // `changed.rs` is in the changed set, so novelty must report exactly
-        // one signal — for that file's function — not one per corpus function.
-        let cfg = ReviewSignalsConfig::default();
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("a.rs"),
-            vec![fdef(
-                "alpha",
-                "let total = first + second + third + fourth;",
-            )],
-        );
-        ctx.new_functions.insert(
-            PathBuf::from("b.rs"),
-            vec![fdef("beta", "for widget in inventory { ship(widget); }")],
-        );
-        ctx.new_functions.insert(
-            PathBuf::from("c.rs"),
-            vec![fdef(
-                "gamma",
-                "match colour { Red => stop(), Green => go() }",
-            )],
-        );
-        ctx.new_functions.insert(
-            PathBuf::from("changed.rs"),
-            vec![fdef(
-                "delta",
-                "while pending { dequeue().handle(); } flush();",
-            )],
-        );
-        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols.insert((
-            PathBuf::from("changed.rs"),
-            fdef("delta", "").symbol_identity(),
-        ));
-
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-
-        assert_eq!(
-            signals.len(),
-            1,
-            "novelty should fire only for the changed file, got: {signals:?}"
-        );
-        assert_eq!(signals[0].anchor.file, "changed.rs");
-        assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
-    }
-
-    #[test]
-    fn novelty_stays_quiet_when_changed_symbols_empty() {
-        let cfg = ReviewSignalsConfig::default();
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("changed.rs"),
-            vec![
-                fdef("alpha", "let total = first + second + third + fourth;"),
-                fdef("beta", "for widget in inventory { ship(widget); }"),
-                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
-                fdef("delta", "while pending { dequeue().handle(); } flush();"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(
-            signals.is_empty(),
-            "empty changed_symbols must not fall back to changed_paths: {signals:?}"
-        );
-    }
-
-    #[test]
-    fn novelty_scoped_to_changed_symbols() {
-        let cfg = ReviewSignalsConfig::default();
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("changed.rs"),
-            vec![
-                fdef("alpha", "let total = first + second + third + fourth;"),
-                fdef("beta", "for widget in inventory { ship(widget); }"),
-                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
-                fdef("delta", "while pending { dequeue().handle(); } flush();"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols.insert((
-            PathBuf::from("changed.rs"),
-            fdef("delta", "").symbol_identity(),
-        ));
-
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert_eq!(
-            signals.len(),
-            1,
-            "novelty must not fire on untouched siblings: {signals:?}"
-        );
-        assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
-    }
-
-    #[test]
-    fn novelty_stays_quiet_when_corpus_incomplete() {
-        let cfg = ReviewSignalsConfig::default();
-        let mut ctx = SemanticContext::new();
-        ctx.corpus_complete = false;
-        ctx.new_functions.insert(
-            PathBuf::from("changed.rs"),
-            vec![
-                fdef("alpha", "let total = first + second + third + fourth;"),
-                fdef("beta", "for widget in inventory { ship(widget); }"),
-                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
-                fdef("delta", "while pending { dequeue().handle(); } flush();"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols.insert((
-            PathBuf::from("changed.rs"),
-            fdef("delta", "").symbol_identity(),
-        ));
-
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(
-            signals.is_empty(),
-            "incomplete corpus must fail-closed: {signals:?}"
-        );
-    }
-}
+#[path = "novelty_tests.rs"]
+mod tests;

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -166,6 +166,8 @@ mod tests {
             )],
         );
         ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+        ctx.changed_symbols
+            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
 
         let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
 
@@ -176,6 +178,28 @@ mod tests {
         );
         assert_eq!(signals[0].anchor.file, "changed.rs");
         assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
+    }
+
+    #[test]
+    fn novelty_stays_quiet_when_changed_symbols_empty() {
+        let cfg = ReviewSignalsConfig::default();
+        let mut ctx = SemanticContext::new();
+        ctx.new_functions.insert(
+            PathBuf::from("changed.rs"),
+            vec![
+                fdef("alpha", "let total = first + second + third + fourth;"),
+                fdef("beta", "for widget in inventory { ship(widget); }"),
+                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
+                fdef("delta", "while pending { dequeue().handle(); } flush();"),
+            ],
+        );
+        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+
+        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+        assert!(
+            signals.is_empty(),
+            "empty changed_symbols must not fall back to changed_paths: {signals:?}"
+        );
     }
 
     #[test]

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -61,11 +61,11 @@ pub fn run(
     let mut out = Vec::new();
     for (path, fn_def) in corpus
         .iter()
-        .filter(|(path, fn_def)| ctx.is_emit_target(path, &fn_def.name))
+        .filter(|(path, fn_def)| ctx.is_emit_target(path, fn_def))
     {
         let max_sim = corpus
             .iter()
-            .filter(|(p, f)| !(p == path && f.name == fn_def.name))
+            .filter(|(p, f)| !(p == path && f.symbol_identity() == fn_def.symbol_identity()))
             .map(|(_, other)| {
                 compute_similarity(&other.content, &fn_def.content, SimilarityMethod::Tokens) as f32
             })
@@ -125,6 +125,7 @@ mod tests {
     fn fdef(name: &str, body: &str) -> FunctionDef {
         FunctionDef {
             name: name.to_string(),
+            container: String::new(),
             signature: format!("fn {name}()"),
             start_line: 1,
             end_line: 3,
@@ -166,8 +167,10 @@ mod tests {
             )],
         );
         ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols
-            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("changed.rs"),
+            fdef("delta", "").symbol_identity(),
+        ));
 
         let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
 
@@ -216,8 +219,10 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols
-            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("changed.rs"),
+            fdef("delta", "").symbol_identity(),
+        ));
 
         let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
         assert_eq!(
@@ -243,8 +248,10 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("changed.rs"));
-        ctx.changed_symbols
-            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("changed.rs"),
+            fdef("delta", "").symbol_identity(),
+        ));
 
         let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
         assert!(

--- a/crates/state_review/src/modules/novelty.rs
+++ b/crates/state_review/src/modules/novelty.rs
@@ -29,7 +29,7 @@ pub fn run(
     cfg: &ReviewSignalsConfig,
     ctx: &SemanticContext,
 ) -> Vec<RiskSignal> {
-    if !cfg.novelty.enabled {
+    if !cfg.novelty.enabled || !ctx.corpus_complete {
         return Vec::new();
     }
     let tolerance = cfg.novelty.tolerance.clamp(0.0, 1.0);
@@ -61,7 +61,7 @@ pub fn run(
     let mut out = Vec::new();
     for (path, fn_def) in corpus
         .iter()
-        .filter(|(path, _)| ctx.changed_paths.contains(path))
+        .filter(|(path, fn_def)| ctx.is_emit_target(path, &fn_def.name))
     {
         let max_sim = corpus
             .iter()
@@ -176,5 +176,56 @@ mod tests {
         );
         assert_eq!(signals[0].anchor.file, "changed.rs");
         assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
+    }
+
+    #[test]
+    fn novelty_scoped_to_changed_symbols() {
+        let cfg = ReviewSignalsConfig::default();
+        let mut ctx = SemanticContext::new();
+        ctx.new_functions.insert(
+            PathBuf::from("changed.rs"),
+            vec![
+                fdef("alpha", "let total = first + second + third + fourth;"),
+                fdef("beta", "for widget in inventory { ship(widget); }"),
+                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
+                fdef("delta", "while pending { dequeue().handle(); } flush();"),
+            ],
+        );
+        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+        ctx.changed_symbols
+            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
+
+        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+        assert_eq!(
+            signals.len(),
+            1,
+            "novelty must not fire on untouched siblings: {signals:?}"
+        );
+        assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
+    }
+
+    #[test]
+    fn novelty_stays_quiet_when_corpus_incomplete() {
+        let cfg = ReviewSignalsConfig::default();
+        let mut ctx = SemanticContext::new();
+        ctx.corpus_complete = false;
+        ctx.new_functions.insert(
+            PathBuf::from("changed.rs"),
+            vec![
+                fdef("alpha", "let total = first + second + third + fourth;"),
+                fdef("beta", "for widget in inventory { ship(widget); }"),
+                fdef("gamma", "match colour { Red => stop(), Green => go() }"),
+                fdef("delta", "while pending { dequeue().handle(); } flush();"),
+            ],
+        );
+        ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+        ctx.changed_symbols
+            .insert((PathBuf::from("changed.rs"), "delta".to_string()));
+
+        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+        assert!(
+            signals.is_empty(),
+            "incomplete corpus must fail-closed: {signals:?}"
+        );
     }
 }

--- a/crates/state_review/src/modules/novelty_tests.rs
+++ b/crates/state_review/src/modules/novelty_tests.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Novelty module tests.
+
+use std::path::PathBuf;
+
+use objects::object::{Attribution, ContentHash, Principal, State};
+
+use super::*;
+
+fn empty_state() -> State {
+    State::new_snapshot(
+        ContentHash::compute(b"tree"),
+        vec![],
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    )
+}
+
+fn fdef(name: &str, body: &str) -> FunctionDef {
+    FunctionDef {
+        name: name.to_string(),
+        container: String::new(),
+        signature: format!("fn {name}()"),
+        start_line: 1,
+        end_line: 3,
+        content: body.to_string(),
+    }
+}
+
+fn distinct_bodies() -> [&'static str; 4] {
+    [
+        "fn alpha() { let total = first + second + third + fourth; }",
+        "fn beta() { for widget in inventory { ship(widget); } }",
+        "fn gamma() { match colour { Red => stop(), Green => go() } }",
+        "fn delta() { while pending { dequeue().handle(); } flush(); }",
+    ]
+}
+
+#[test]
+fn quiet_with_small_corpus() {
+    let cfg = ReviewSignalsConfig::default();
+    let ctx = SemanticContext::new();
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn quiet_when_disabled() {
+    let mut cfg = ReviewSignalsConfig::default();
+    cfg.novelty.enabled = false;
+    let ctx = SemanticContext::new();
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn novelty_scoped_to_changed_files() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    let [alpha, beta, gamma, delta] = distinct_bodies();
+    ctx.new_functions
+        .insert(PathBuf::from("a.rs"), vec![fdef("alpha", alpha)]);
+    ctx.new_functions
+        .insert(PathBuf::from("b.rs"), vec![fdef("beta", beta)]);
+    ctx.new_functions
+        .insert(PathBuf::from("c.rs"), vec![fdef("gamma", gamma)]);
+    ctx.new_functions
+        .insert(PathBuf::from("changed.rs"), vec![fdef("delta", delta)]);
+    ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("changed.rs"),
+        fdef("delta", "").symbol_identity(),
+    ));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+
+    assert_eq!(
+        signals.len(),
+        1,
+        "novelty should fire only for the changed file, got: {signals:?}"
+    );
+    assert_eq!(signals[0].anchor.file, "changed.rs");
+    assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
+}
+
+#[test]
+fn novelty_stays_quiet_when_changed_symbols_empty() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    let [alpha, beta, gamma, delta] = distinct_bodies();
+    ctx.new_functions.insert(
+        PathBuf::from("changed.rs"),
+        vec![
+            fdef("alpha", alpha),
+            fdef("beta", beta),
+            fdef("gamma", gamma),
+            fdef("delta", delta),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(
+        signals.is_empty(),
+        "empty changed_symbols must not fall back to changed_paths: {signals:?}"
+    );
+}
+
+#[test]
+fn novelty_scoped_to_changed_symbols() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    let [alpha, beta, gamma, delta] = distinct_bodies();
+    ctx.new_functions.insert(
+        PathBuf::from("changed.rs"),
+        vec![
+            fdef("alpha", alpha),
+            fdef("beta", beta),
+            fdef("gamma", gamma),
+            fdef("delta", delta),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("changed.rs"),
+        fdef("delta", "").symbol_identity(),
+    ));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert_eq!(
+        signals.len(),
+        1,
+        "novelty must not fire on untouched siblings: {signals:?}"
+    );
+    assert_eq!(signals[0].anchor.symbol.as_deref(), Some("delta"));
+}
+
+#[test]
+fn novelty_stays_quiet_when_corpus_incomplete() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    ctx.corpus_complete = false;
+    let [alpha, beta, gamma, delta] = distinct_bodies();
+    ctx.new_functions.insert(
+        PathBuf::from("changed.rs"),
+        vec![
+            fdef("alpha", alpha),
+            fdef("beta", beta),
+            fdef("gamma", gamma),
+            fdef("delta", delta),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("changed.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("changed.rs"),
+        fdef("delta", "").symbol_identity(),
+    ));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(
+        signals.is_empty(),
+        "incomplete corpus must fail-closed: {signals:?}"
+    );
+}
+
+#[test]
+fn same_shape_renamed_identifiers_do_not_fire_novelty() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("users.rs"),
+        vec![fdef("get_user", "fn get_user() { fetch_user(); }")],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("orders.rs"),
+        vec![fdef("get_order", "fn get_order() { fetch_order(); }")],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("a.rs"),
+        vec![fdef(
+            "alpha",
+            "fn alpha() { let total = first + second + third + fourth; }",
+        )],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("b.rs"),
+        vec![fdef(
+            "beta",
+            "fn beta() { for widget in inventory { ship(widget); } }",
+        )],
+    );
+    ctx.changed_paths.insert(PathBuf::from("users.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("users.rs"),
+        fdef("get_user", "").symbol_identity(),
+    ));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(
+        signals.is_empty(),
+        "same-shape renamed identifiers must not fire novelty: {signals:?}"
+    );
+}
+
+#[test]
+fn unknown_language_fail_closes_without_novelty() {
+    let cfg = ReviewSignalsConfig::default();
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("notes.txt"),
+        vec![fdef("get_user", "fn get_user() { fetch_user(); }")],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("a.rs"),
+        vec![fdef(
+            "alpha",
+            "fn alpha() { let total = first + second + third + fourth; }",
+        )],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("b.rs"),
+        vec![fdef(
+            "beta",
+            "fn beta() { for widget in inventory { ship(widget); } }",
+        )],
+    );
+    ctx.new_functions.insert(
+        PathBuf::from("c.rs"),
+        vec![fdef(
+            "gamma",
+            "fn gamma() { match colour { Red => stop(), Green => go() } }",
+        )],
+    );
+    ctx.changed_paths.insert(PathBuf::from("notes.txt"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("notes.txt"),
+        fdef("get_user", "").symbol_identity(),
+    ));
+
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(
+        signals.is_empty(),
+        "unknown language must fail-closed without novelty: {signals:?}"
+    );
+}

--- a/crates/state_review/src/modules/pattern_deviation.rs
+++ b/crates/state_review/src/modules/pattern_deviation.rs
@@ -37,6 +37,9 @@ pub fn run(
     for (path, new_fns) in &ctx.new_functions {
         let prior_fns: Option<&Vec<FunctionDef>> = ctx.prior_functions.get(path);
         for fn_def in new_fns {
+            if !ctx.is_emit_target(path, &fn_def.name) {
+                continue;
+            }
             let prior_same = prior_fns.and_then(|fns| fns.iter().find(|f| f.name == fn_def.name));
             // 1. Compare against the prior version of this same symbol.
             if let Some(prior_fn) = prior_same {
@@ -174,12 +177,13 @@ mod tests {
             )],
         );
         ctx.new_functions.insert(
-            path,
+            path.clone(),
             vec![fdef(
                 "score",
                 "fn score(socket: &mut Socket) -> usize { while socket.poll() { rotate_key(); } 0 }",
             )],
         );
+        ctx.changed_symbols.insert((path, "score".to_string()));
         let new = state_with_change_id(9);
 
         let signals = run(&empty_state(), &new, &cfg, &ctx);
@@ -203,7 +207,7 @@ mod tests {
         cfg.pattern_deviation.threshold = 0.5;
         let mut ctx = SemanticContext::new();
         ctx.new_functions.insert(
-            path,
+            path.clone(),
             vec![
                 fdef(
                     "load_user",
@@ -219,6 +223,8 @@ mod tests {
                 ),
             ],
         );
+        ctx.changed_symbols
+            .insert((path, "decode_wire".to_string()));
 
         let signals = run(&empty_state(), &state_with_change_id(10), &cfg, &ctx);
 
@@ -230,6 +236,38 @@ mod tests {
                     && signal.reason.contains("sibling exemplars")
             }),
             "expected sibling pattern deviation for decode_wire, got: {signals:?}"
+        );
+    }
+
+    #[test]
+    fn pattern_deviation_scoped_to_changed_symbols() {
+        let path = PathBuf::from("src/workers.rs");
+        let mut cfg = ReviewSignalsConfig::default();
+        cfg.pattern_deviation.threshold = 0.5;
+        let mut ctx = SemanticContext::new();
+        ctx.new_functions.insert(
+            path.clone(),
+            vec![
+                fdef(
+                    "load_user",
+                    "fn load_user() { let record = fetch_user(); validate(record); save(record); }",
+                ),
+                fdef(
+                    "load_order",
+                    "fn load_order() { let record = fetch_order(); validate(record); save(record); }",
+                ),
+                fdef(
+                    "decode_wire",
+                    "fn decode_wire() { while socket.poll() { rotate_key(); decode_frame(); } }",
+                ),
+            ],
+        );
+        ctx.changed_symbols.insert((path, "load_user".to_string()));
+
+        let signals = run(&empty_state(), &state_with_change_id(10), &cfg, &ctx);
+        assert!(
+            signals.is_empty(),
+            "untouched sibling decode_wire must not fire: {signals:?}"
         );
     }
 }

--- a/crates/state_review/src/modules/pattern_deviation.rs
+++ b/crates/state_review/src/modules/pattern_deviation.rs
@@ -37,10 +37,13 @@ pub fn run(
     for (path, new_fns) in &ctx.new_functions {
         let prior_fns: Option<&Vec<FunctionDef>> = ctx.prior_functions.get(path);
         for fn_def in new_fns {
-            if !ctx.is_emit_target(path, &fn_def.name) {
+            if !ctx.is_emit_target(path, fn_def) {
                 continue;
             }
-            let prior_same = prior_fns.and_then(|fns| fns.iter().find(|f| f.name == fn_def.name));
+            let prior_same = prior_fns.and_then(|fns| {
+                fns.iter()
+                    .find(|f| f.symbol_identity() == fn_def.symbol_identity())
+            });
             // 1. Compare against the prior version of this same symbol.
             if let Some(prior_fn) = prior_same {
                 let similarity = compute_similarity(
@@ -66,8 +69,10 @@ pub fn run(
                 // 2. New symbol — compare against siblings (other functions
                 // in the same file). If max similarity to any sibling is
                 // below 1 - threshold, it diverges from the local style.
-                let siblings: Vec<&FunctionDef> =
-                    new_fns.iter().filter(|f| f.name != fn_def.name).collect();
+                let siblings: Vec<&FunctionDef> = new_fns
+                    .iter()
+                    .filter(|f| f.symbol_identity() != fn_def.symbol_identity())
+                    .collect();
                 if siblings.is_empty() {
                     continue;
                 }
@@ -139,6 +144,7 @@ mod tests {
     fn fdef(name: &str, content: &str) -> FunctionDef {
         FunctionDef {
             name: name.to_string(),
+            container: String::new(),
             signature: format!("fn {name}()"),
             start_line: 1,
             end_line: 3,
@@ -183,7 +189,8 @@ mod tests {
                 "fn score(socket: &mut Socket) -> usize { while socket.poll() { rotate_key(); } 0 }",
             )],
         );
-        ctx.changed_symbols.insert((path, "score".to_string()));
+        ctx.changed_symbols
+            .insert((path, fdef("score", "").symbol_identity()));
         let new = state_with_change_id(9);
 
         let signals = run(&empty_state(), &new, &cfg, &ctx);
@@ -224,7 +231,7 @@ mod tests {
             ],
         );
         ctx.changed_symbols
-            .insert((path, "decode_wire".to_string()));
+            .insert((path, fdef("decode_wire", "").symbol_identity()));
 
         let signals = run(&empty_state(), &state_with_change_id(10), &cfg, &ctx);
 
@@ -262,7 +269,8 @@ mod tests {
                 ),
             ],
         );
-        ctx.changed_symbols.insert((path, "load_user".to_string()));
+        ctx.changed_symbols
+            .insert((path, fdef("load_user", "").symbol_identity()));
 
         let signals = run(&empty_state(), &state_with_change_id(10), &cfg, &ctx);
         assert!(

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -33,7 +33,7 @@ pub fn run(
     cfg: &ReviewSignalsConfig,
     ctx: &SemanticContext,
 ) -> Vec<RiskSignal> {
-    if !cfg.test_reachability.enabled {
+    if !cfg.test_reachability.enabled || !ctx.corpus_complete {
         return Vec::new();
     }
     let computed_at = new
@@ -78,6 +78,9 @@ pub fn run(
     for (path, fns) in &ctx.new_functions {
         for fn_def in fns {
             let key = (path.as_path(), fn_def.name.as_str());
+            if !ctx.is_emit_target(path, &fn_def.name) {
+                continue;
+            }
             if test_set.contains(&key) {
                 continue;
             }
@@ -225,6 +228,7 @@ mod tests {
                 fdef("test_covered", "fn test_covered() { covered(); }"),
             ],
         );
+        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
 
         let signals = run(
             &empty_state(),
@@ -250,6 +254,7 @@ mod tests {
                 fdef("test_covered", "fn test_covered() { helper(); }"),
             ],
         );
+        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
 
         let signals = run(
             &empty_state(),
@@ -274,6 +279,7 @@ mod tests {
                 fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
             ],
         );
+        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
 
         let signals = run(
             &empty_state(),
@@ -297,6 +303,7 @@ mod tests {
                 fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
             ],
         );
+        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
 
         let signals = run(
             &empty_state(),
@@ -306,6 +313,56 @@ mod tests {
         );
 
         assert_eq!(signal_symbols(&signals), BTreeSet::from(["alpha", "beta"]));
+    }
+
+    #[test]
+    fn unreachable_scoped_to_changed_symbols() {
+        let mut ctx = SemanticContext::new();
+        ctx.new_functions.insert(
+            PathBuf::from("src/lib.rs"),
+            vec![
+                fdef("orphan", "fn orphan() { do_work(); }"),
+                fdef("sibling", "fn sibling() { do_other(); }"),
+                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+            ],
+        );
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
+
+        let signals = run(
+            &empty_state(),
+            &empty_state(),
+            &cfg_with_one_required_test(),
+            &ctx,
+        );
+
+        assert_eq!(signal_symbols(&signals), BTreeSet::from(["orphan"]));
+    }
+
+    #[test]
+    fn unreachable_stays_quiet_when_corpus_incomplete() {
+        let mut ctx = SemanticContext::new();
+        ctx.corpus_complete = false;
+        ctx.new_functions.insert(
+            PathBuf::from("src/lib.rs"),
+            vec![
+                fdef("orphan", "fn orphan() { do_work(); }"),
+                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+            ],
+        );
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
+
+        let signals = run(
+            &empty_state(),
+            &empty_state(),
+            &cfg_with_one_required_test(),
+            &ctx,
+        );
+        assert!(
+            signals.is_empty(),
+            "incomplete corpus must fail-closed: {signals:?}"
+        );
     }
 
     fn signal_symbols(signals: &[RiskSignal]) -> BTreeSet<&str> {

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -78,7 +78,7 @@ pub fn run(
     for (path, fns) in &ctx.new_functions {
         for fn_def in fns {
             let key = (path.as_path(), fn_def.name.as_str());
-            if !ctx.is_emit_target(path, &fn_def.name) {
+            if !ctx.is_emit_target(path, fn_def) {
                 continue;
             }
             if test_set.contains(&key) {
@@ -168,6 +168,7 @@ mod tests {
     fn fdef(name: &str, content: &str) -> FunctionDef {
         FunctionDef {
             name: name.to_string(),
+            container: String::new(),
             signature: format!("fn {name}()"),
             start_line: 1,
             end_line: 3,
@@ -280,8 +281,10 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/lib.rs"),
+            fdef("orphan", "").symbol_identity(),
+        ));
 
         let signals = run(
             &empty_state(),
@@ -306,10 +309,14 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/lib.rs"), "alpha".to_string()));
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/lib.rs"), "beta".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/lib.rs"),
+            fdef("alpha", "").symbol_identity(),
+        ));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/lib.rs"),
+            fdef("beta", "").symbol_identity(),
+        ));
 
         let signals = run(
             &empty_state(),
@@ -332,8 +339,10 @@ mod tests {
                 fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
             ],
         );
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/lib.rs"),
+            fdef("orphan", "").symbol_identity(),
+        ));
 
         let signals = run(
             &empty_state(),
@@ -356,8 +365,10 @@ mod tests {
                 fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
             ],
         );
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/lib.rs"),
+            fdef("orphan", "").symbol_identity(),
+        ));
 
         let signals = run(
             &empty_state(),

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -83,7 +83,7 @@ pub fn run(
         let caller_key = (caller.path, caller.identity.as_str());
         let calls = calls_in(caller.def, caller.path, cache);
         for call in calls {
-            match resolve_call(&call, &catalog, &containers) {
+            match resolve_call(&call, caller, &catalog, &containers) {
                 CallResolve::Hits(callees) => {
                     for callee in callees {
                         if caller.path == callee.path && caller.identity == callee.identity {
@@ -148,12 +148,13 @@ fn calls_in(def: &FunctionDef, path: &Path, cache: &SemanticParseCache) -> Vec<C
     }
     cache
         .parse(&def.content, language)
-        .map(|parsed| parsed.extract_calls())
+        .map(|parsed| parsed.extract_own_calls())
         .unwrap_or_default()
 }
 
 fn resolve_call<'a>(
     call: &CallSite,
+    caller: &CatalogEntry<'a>,
     catalog: &'a [CatalogEntry<'a>],
     containers: &HashSet<&str>,
 ) -> CallResolve<'a> {
@@ -165,12 +166,7 @@ fn resolve_call<'a>(
         return CallResolve::None;
     }
     if call.qualifier.is_empty() {
-        return CallResolve::Hits(
-            named
-                .into_iter()
-                .filter(|entry| entry.def.container.is_empty())
-                .collect(),
-        );
+        return resolve_bare_call(caller, named);
     }
     let joined = call.qualifier.join("::");
     let exact: Vec<&CatalogEntry<'_>> = named
@@ -192,6 +188,26 @@ fn resolve_call<'a>(
         return CallResolve::Hits(named);
     }
     CallResolve::Ambiguous
+}
+
+fn resolve_bare_call<'a>(
+    caller: &CatalogEntry<'a>,
+    named: Vec<&'a CatalogEntry<'a>>,
+) -> CallResolve<'a> {
+    let same_container: Vec<&CatalogEntry<'_>> = named
+        .iter()
+        .copied()
+        .filter(|entry| entry.def.container == caller.def.container)
+        .collect();
+    if !same_container.is_empty() {
+        return CallResolve::Hits(same_container);
+    }
+    CallResolve::Hits(
+        named
+            .into_iter()
+            .filter(|entry| entry.def.container.is_empty())
+            .collect(),
+    )
 }
 
 fn qualifier_matches_container(container: &str, qualifier: &[String], joined: &str) -> bool {

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -41,16 +41,26 @@ pub fn run(
         .map(|dt| dt.timestamp())
         .unwrap_or_else(|| new.created_at.timestamp());
 
+    let catalog: Vec<CatalogEntry<'_>> = ctx
+        .new_functions
+        .iter()
+        .flat_map(|(path, fns)| {
+            fns.iter().map(|def| CatalogEntry {
+                path: path.as_path(),
+                identity: def.symbol_identity(),
+                def,
+            })
+        })
+        .collect();
+    let all_fns: HashMap<(&Path, &str), &FunctionDef> = catalog
+        .iter()
+        .map(|entry| ((entry.path, entry.identity.as_str()), entry.def))
+        .collect();
+
     let mut test_set: HashSet<(&Path, &str)> = HashSet::new();
-    let mut all_fns: HashMap<(&Path, &str), &FunctionDef> = HashMap::new();
-    for (path, fns) in &ctx.new_functions {
-        let lang = Language::from_path(path);
-        for fn_def in fns {
-            let key = (path.as_path(), fn_def.name.as_str());
-            all_fns.insert(key, fn_def);
-            if is_test_function(&fn_def.name, lang) {
-                test_set.insert(key);
-            }
+    for (&key, def) in &all_fns {
+        if is_test_function(&def.name, Language::from_path(key.0)) {
+            test_set.insert(key);
         }
     }
 
@@ -58,50 +68,53 @@ pub fn run(
         return Vec::new();
     }
 
-    let mut callers_of: HashMap<&str, Vec<(&Path, &str)>> = HashMap::new();
-    let names: Vec<&str> = all_fns.keys().map(|(_, n)| *n).collect();
-    for (&(caller_path, caller_name), caller_def) in &all_fns {
-        for &callee_name in &names {
-            if callee_name == caller_name {
+    let mut callers_of: HashMap<(&Path, &str), Vec<(&Path, &str)>> = HashMap::new();
+    for caller in &catalog {
+        for callee in &catalog {
+            if caller.path == callee.path && caller.identity == callee.identity {
                 continue;
             }
-            if body_mentions(&caller_def.content, callee_name) {
+            if mentions_callee(&caller.def.content, callee.def) {
                 callers_of
-                    .entry(callee_name)
+                    .entry((callee.path, callee.identity.as_str()))
                     .or_default()
-                    .push((caller_path, caller_name));
+                    .push((caller.path, caller.identity.as_str()));
             }
         }
     }
 
     let mut out = Vec::new();
-    for (path, fns) in &ctx.new_functions {
-        for fn_def in fns {
-            let key = (path.as_path(), fn_def.name.as_str());
-            if !ctx.is_emit_target(path, fn_def) {
-                continue;
-            }
-            if test_set.contains(&key) {
-                continue;
-            }
-            if !reaches_test(key, &callers_of, &test_set) {
-                out.push(RiskSignal {
-                    kind: RiskSignalKind::TestReachability,
-                    anchor: SignalAnchor::symbol(path.to_string_lossy(), &fn_def.name),
-                    reason: REASON_TEXT.to_string(),
-                    producer: ProducerId::new(MODULE_ID, VERSION),
-                    computed_at,
-                    computed_against: Some(new.state_id),
-                });
-            }
+    for entry in &catalog {
+        let key = (entry.path, entry.identity.as_str());
+        if !ctx.is_emit_target(entry.path, entry.def) {
+            continue;
+        }
+        if test_set.contains(&key) {
+            continue;
+        }
+        if !reaches_test(key, &callers_of, &test_set) {
+            out.push(RiskSignal {
+                kind: RiskSignalKind::TestReachability,
+                anchor: SignalAnchor::symbol(entry.path.to_string_lossy(), &entry.def.name),
+                reason: REASON_TEXT.to_string(),
+                producer: ProducerId::new(MODULE_ID, VERSION),
+                computed_at,
+                computed_against: Some(new.state_id),
+            });
         }
     }
     out
 }
 
+struct CatalogEntry<'a> {
+    path: &'a Path,
+    identity: String,
+    def: &'a FunctionDef,
+}
+
 fn reaches_test<'a>(
     start: (&'a Path, &'a str),
-    callers_of: &HashMap<&str, Vec<(&'a Path, &'a str)>>,
+    callers_of: &HashMap<(&'a Path, &'a str), Vec<(&'a Path, &'a str)>>,
     test_set: &HashSet<(&Path, &str)>,
 ) -> bool {
     let mut visited: HashSet<(&Path, &str)> = HashSet::new();
@@ -112,7 +125,7 @@ fn reaches_test<'a>(
         if test_set.contains(&node) {
             return true;
         }
-        if let Some(callers) = callers_of.get(node.1) {
+        if let Some(callers) = callers_of.get(&node) {
             for &caller in callers {
                 if visited.insert(caller) {
                     queue.push_back(caller);
@@ -136,6 +149,14 @@ fn is_test_function(name: &str, lang: Language) -> bool {
         Language::Zig => name.starts_with("test:"),
         _ => false,
     }
+}
+
+fn mentions_callee(body: &str, callee: &FunctionDef) -> bool {
+    if callee.container.is_empty() {
+        return body_mentions(body, &callee.name);
+    }
+    body_mentions(body, &callee.qualified_name())
+        || body_mentions(body, &format!("{}.{}", callee.container, callee.name))
 }
 
 fn body_mentions(body: &str, name: &str) -> bool {
@@ -166,9 +187,13 @@ mod tests {
     }
 
     fn fdef(name: &str, content: &str) -> FunctionDef {
+        fdef_in("", name, content)
+    }
+
+    fn fdef_in(container: &str, name: &str, content: &str) -> FunctionDef {
         FunctionDef {
             name: name.to_string(),
-            container: String::new(),
+            container: container.to_string(),
             signature: format!("fn {name}()"),
             start_line: 1,
             end_line: 3,
@@ -387,5 +412,39 @@ mod tests {
             .iter()
             .filter_map(|signal| signal.anchor.symbol.as_deref())
             .collect()
+    }
+
+    #[test]
+    fn qualified_call_does_not_cover_same_bare_name() {
+        let path = PathBuf::from("src/lib.rs");
+        let foo_run = fdef_in("Foo", "run", "fn run() { do_foo(); }");
+        let bar_run = fdef_in("Bar", "run", "fn run() { do_bar(); }");
+        let mut ctx = SemanticContext::new();
+        ctx.new_functions.insert(
+            path.clone(),
+            vec![
+                foo_run.clone(),
+                bar_run.clone(),
+                fdef("test_bar", "fn test_bar() { Bar::run(); }"),
+            ],
+        );
+        ctx.changed_symbols
+            .insert((path.clone(), foo_run.symbol_identity()));
+        ctx.changed_symbols
+            .insert((path, bar_run.symbol_identity()));
+
+        let signals = run(
+            &empty_state(),
+            &empty_state(),
+            &cfg_with_one_required_test(),
+            &ctx,
+        );
+
+        assert_eq!(
+            signals.len(),
+            1,
+            "Bar::run is tested; Foo::run must stay unreachable: {signals:?}"
+        );
+        assert_eq!(signal_symbols(&signals), BTreeSet::from(["run"]));
     }
 }

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -18,7 +18,10 @@ use std::{
 };
 
 use objects::object::{ProducerId, RiskSignal, RiskSignalKind, SignalAnchor, State};
-use semantic::{Language, parser::FunctionDef};
+use semantic::{
+    Language, SemanticParseCache,
+    parser::{CallSite, FunctionDef},
+};
 
 use crate::{config::ReviewSignalsConfig, registry::SemanticContext};
 
@@ -68,17 +71,34 @@ pub fn run(
         return Vec::new();
     }
 
+    let containers: HashSet<&str> = catalog
+        .iter()
+        .map(|entry| entry.def.container.as_str())
+        .filter(|container| !container.is_empty())
+        .collect();
+    let cache = SemanticParseCache::shared();
     let mut callers_of: HashMap<(&Path, &str), Vec<(&Path, &str)>> = HashMap::new();
+    let mut silenced_methods: HashSet<String> = HashSet::new();
     for caller in &catalog {
-        for callee in &catalog {
-            if caller.path == callee.path && caller.identity == callee.identity {
-                continue;
-            }
-            if mentions_callee(&caller.def.content, callee.def) {
-                callers_of
-                    .entry((callee.path, callee.identity.as_str()))
-                    .or_default()
-                    .push((caller.path, caller.identity.as_str()));
+        let caller_key = (caller.path, caller.identity.as_str());
+        let calls = calls_in(caller.def, caller.path, cache);
+        for call in calls {
+            match resolve_call(&call, &catalog, &containers) {
+                CallResolve::Hits(callees) => {
+                    for callee in callees {
+                        if caller.path == callee.path && caller.identity == callee.identity {
+                            continue;
+                        }
+                        callers_of
+                            .entry((callee.path, callee.identity.as_str()))
+                            .or_default()
+                            .push(caller_key);
+                    }
+                }
+                CallResolve::Ambiguous if test_set.contains(&caller_key) => {
+                    silenced_methods.insert(call.name.clone());
+                }
+                CallResolve::Ambiguous | CallResolve::None => {}
             }
         }
     }
@@ -90,6 +110,9 @@ pub fn run(
             continue;
         }
         if test_set.contains(&key) {
+            continue;
+        }
+        if !entry.def.container.is_empty() && silenced_methods.contains(&entry.def.name) {
             continue;
         }
         if !reaches_test(key, &callers_of, &test_set) {
@@ -110,6 +133,74 @@ struct CatalogEntry<'a> {
     path: &'a Path,
     identity: String,
     def: &'a FunctionDef,
+}
+
+enum CallResolve<'a> {
+    Hits(Vec<&'a CatalogEntry<'a>>),
+    Ambiguous,
+    None,
+}
+
+fn calls_in(def: &FunctionDef, path: &Path, cache: &SemanticParseCache) -> Vec<CallSite> {
+    let language = Language::from_path(path);
+    if matches!(language, Language::Unknown) {
+        return Vec::new();
+    }
+    cache
+        .parse(&def.content, language)
+        .map(|parsed| parsed.extract_calls())
+        .unwrap_or_default()
+}
+
+fn resolve_call<'a>(
+    call: &CallSite,
+    catalog: &'a [CatalogEntry<'a>],
+    containers: &HashSet<&str>,
+) -> CallResolve<'a> {
+    let named: Vec<&CatalogEntry<'_>> = catalog
+        .iter()
+        .filter(|entry| entry.def.name == call.name)
+        .collect();
+    if named.is_empty() {
+        return CallResolve::None;
+    }
+    if call.qualifier.is_empty() {
+        return CallResolve::Hits(
+            named
+                .into_iter()
+                .filter(|entry| entry.def.container.is_empty())
+                .collect(),
+        );
+    }
+    let joined = call.qualifier.join("::");
+    let exact: Vec<&CatalogEntry<'_>> = named
+        .iter()
+        .copied()
+        .filter(|entry| qualifier_matches_container(&entry.def.container, &call.qualifier, &joined))
+        .collect();
+    if !exact.is_empty() {
+        return CallResolve::Hits(exact);
+    }
+    if known_container(
+        &joined,
+        call.qualifier.last().map(String::as_str),
+        containers,
+    ) {
+        return CallResolve::None;
+    }
+    if named.len() == 1 {
+        return CallResolve::Hits(named);
+    }
+    CallResolve::Ambiguous
+}
+
+fn qualifier_matches_container(container: &str, qualifier: &[String], joined: &str) -> bool {
+    !container.is_empty()
+        && (container == joined || qualifier.last().is_some_and(|segment| segment == container))
+}
+
+fn known_container(joined: &str, last: Option<&str>, containers: &HashSet<&str>) -> bool {
+    containers.contains(joined) || last.is_some_and(|segment| containers.contains(segment))
 }
 
 fn reaches_test<'a>(
@@ -144,307 +235,11 @@ fn is_test_function(name: &str, lang: Language) -> bool {
             name.starts_with("test") || name.starts_with("it") || name.starts_with("describe")
         }
         Language::Go => name.starts_with("Test"),
-        // Zig `test "…"` / `test Name` blocks are extracted as functions named
-        // `test:"…"` / `test:Name` by the symbol resolver.
         Language::Zig => name.starts_with("test:"),
         _ => false,
     }
 }
 
-fn mentions_callee(body: &str, callee: &FunctionDef) -> bool {
-    if callee.container.is_empty() {
-        return body_mentions(body, &callee.name);
-    }
-    body_mentions(body, &callee.qualified_name())
-        || body_mentions(body, &format!("{}.{}", callee.container, callee.name))
-}
-
-fn body_mentions(body: &str, name: &str) -> bool {
-    let needle = format!("{name}(");
-    body.contains(&needle)
-}
-
 #[cfg(test)]
-mod tests {
-    use std::{collections::BTreeSet, path::PathBuf};
-
-    use objects::object::{Attribution, ContentHash, Principal, RiskSignalKind};
-
-    use super::*;
-
-    fn empty_state() -> State {
-        State::new_snapshot(
-            ContentHash::compute(b"tree"),
-            vec![],
-            Attribution::human(Principal::new("Alice", "alice@example.com")),
-        )
-    }
-
-    fn cfg_with_one_required_test() -> ReviewSignalsConfig {
-        let mut cfg = ReviewSignalsConfig::default();
-        cfg.test_reachability.min_test_functions_in_repo = 1;
-        cfg
-    }
-
-    fn fdef(name: &str, content: &str) -> FunctionDef {
-        fdef_in("", name, content)
-    }
-
-    fn fdef_in(container: &str, name: &str, content: &str) -> FunctionDef {
-        FunctionDef {
-            name: name.to_string(),
-            container: container.to_string(),
-            signature: format!("fn {name}()"),
-            start_line: 1,
-            end_line: 3,
-            content: content.to_string(),
-        }
-    }
-
-    #[test]
-    fn quiet_when_disabled() {
-        let mut cfg = ReviewSignalsConfig::default();
-        cfg.test_reachability.enabled = false;
-        let ctx = SemanticContext::new();
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(signals.is_empty());
-    }
-
-    #[test]
-    fn quiet_with_no_tests_in_corpus() {
-        let cfg = ReviewSignalsConfig::default();
-        let ctx = SemanticContext::new();
-        let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
-        assert!(signals.is_empty());
-    }
-
-    #[test]
-    fn reason_text_marks_static_reachability() {
-        assert!(REASON_TEXT.contains("static reachability"));
-        assert!(REASON_TEXT.contains("not runtime coverage"));
-    }
-
-    #[test]
-    fn rust_test_naming_heuristic_recognises_underscore_prefixes() {
-        assert!(is_test_function("test_main_branch", Language::Rust));
-        assert!(is_test_function("login_test", Language::Rust));
-        assert!(!is_test_function("login", Language::Rust));
-    }
-
-    #[test]
-    fn python_test_naming_heuristic() {
-        assert!(is_test_function("test_endpoint", Language::Python));
-        assert!(is_test_function("setUp", Language::Python));
-        assert!(!is_test_function("endpoint", Language::Python));
-    }
-
-    #[test]
-    fn go_test_naming_heuristic() {
-        assert!(is_test_function("TestRouter", Language::Go));
-        assert!(!is_test_function("Router", Language::Go));
-    }
-
-    #[test]
-    fn direct_test_reachability_stays_quiet() {
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("covered", "fn covered() { do_work(); }"),
-                fdef("test_covered", "fn test_covered() { covered(); }"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert!(
-            signals.is_empty(),
-            "direct test caller should cover: {signals:?}"
-        );
-    }
-
-    #[test]
-    fn transitive_test_reachability_stays_quiet() {
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("covered", "fn covered() { do_work(); }"),
-                fdef("helper", "fn helper() { covered(); }"),
-                fdef("test_covered", "fn test_covered() { helper(); }"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert!(
-            signals.is_empty(),
-            "transitive test caller should cover all callees: {signals:?}"
-        );
-    }
-
-    #[test]
-    fn unreachable_symbol_fires() {
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("orphan", "fn orphan() { do_work(); }"),
-                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-        ctx.changed_symbols.insert((
-            PathBuf::from("src/lib.rs"),
-            fdef("orphan", "").symbol_identity(),
-        ));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert_eq!(signal_symbols(&signals), BTreeSet::from(["orphan"]));
-        assert_eq!(signals[0].kind, RiskSignalKind::TestReachability);
-    }
-
-    #[test]
-    fn unreachable_cycle_fires_once_per_cycled_symbol() {
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("alpha", "fn alpha() { beta(); }"),
-                fdef("beta", "fn beta() { alpha(); }"),
-                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
-            ],
-        );
-        ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
-        ctx.changed_symbols.insert((
-            PathBuf::from("src/lib.rs"),
-            fdef("alpha", "").symbol_identity(),
-        ));
-        ctx.changed_symbols.insert((
-            PathBuf::from("src/lib.rs"),
-            fdef("beta", "").symbol_identity(),
-        ));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert_eq!(signal_symbols(&signals), BTreeSet::from(["alpha", "beta"]));
-    }
-
-    #[test]
-    fn unreachable_scoped_to_changed_symbols() {
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("orphan", "fn orphan() { do_work(); }"),
-                fdef("sibling", "fn sibling() { do_other(); }"),
-                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
-            ],
-        );
-        ctx.changed_symbols.insert((
-            PathBuf::from("src/lib.rs"),
-            fdef("orphan", "").symbol_identity(),
-        ));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert_eq!(signal_symbols(&signals), BTreeSet::from(["orphan"]));
-    }
-
-    #[test]
-    fn unreachable_stays_quiet_when_corpus_incomplete() {
-        let mut ctx = SemanticContext::new();
-        ctx.corpus_complete = false;
-        ctx.new_functions.insert(
-            PathBuf::from("src/lib.rs"),
-            vec![
-                fdef("orphan", "fn orphan() { do_work(); }"),
-                fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
-            ],
-        );
-        ctx.changed_symbols.insert((
-            PathBuf::from("src/lib.rs"),
-            fdef("orphan", "").symbol_identity(),
-        ));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-        assert!(
-            signals.is_empty(),
-            "incomplete corpus must fail-closed: {signals:?}"
-        );
-    }
-
-    fn signal_symbols(signals: &[RiskSignal]) -> BTreeSet<&str> {
-        signals
-            .iter()
-            .filter_map(|signal| signal.anchor.symbol.as_deref())
-            .collect()
-    }
-
-    #[test]
-    fn qualified_call_does_not_cover_same_bare_name() {
-        let path = PathBuf::from("src/lib.rs");
-        let foo_run = fdef_in("Foo", "run", "fn run() { do_foo(); }");
-        let bar_run = fdef_in("Bar", "run", "fn run() { do_bar(); }");
-        let mut ctx = SemanticContext::new();
-        ctx.new_functions.insert(
-            path.clone(),
-            vec![
-                foo_run.clone(),
-                bar_run.clone(),
-                fdef("test_bar", "fn test_bar() { Bar::run(); }"),
-            ],
-        );
-        ctx.changed_symbols
-            .insert((path.clone(), foo_run.symbol_identity()));
-        ctx.changed_symbols
-            .insert((path, bar_run.symbol_identity()));
-
-        let signals = run(
-            &empty_state(),
-            &empty_state(),
-            &cfg_with_one_required_test(),
-            &ctx,
-        );
-
-        assert_eq!(
-            signals.len(),
-            1,
-            "Bar::run is tested; Foo::run must stay unreachable: {signals:?}"
-        );
-        assert_eq!(signal_symbols(&signals), BTreeSet::from(["run"]));
-    }
-}
+#[path = "test_reachability_tests.rs"]
+mod tests;

--- a/crates/state_review/src/modules/test_reachability.rs
+++ b/crates/state_review/src/modules/test_reachability.rs
@@ -280,6 +280,8 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/lib.rs"), "orphan".to_string()));
 
         let signals = run(
             &empty_state(),
@@ -304,6 +306,10 @@ mod tests {
             ],
         );
         ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/lib.rs"), "alpha".to_string()));
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/lib.rs"), "beta".to_string()));
 
         let signals = run(
             &empty_state(),

--- a/crates/state_review/src/modules/test_reachability_tests.rs
+++ b/crates/state_review/src/modules/test_reachability_tests.rs
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Tests for static test-reachability.
+
+use std::{collections::BTreeSet, path::PathBuf};
+
+use objects::object::{Attribution, ContentHash, Principal, RiskSignal, RiskSignalKind};
+
+use super::*;
+
+fn empty_state() -> State {
+    State::new_snapshot(
+        ContentHash::compute(b"tree"),
+        vec![],
+        Attribution::human(Principal::new("Alice", "alice@example.com")),
+    )
+}
+
+fn cfg_with_one_required_test() -> ReviewSignalsConfig {
+    let mut cfg = ReviewSignalsConfig::default();
+    cfg.test_reachability.min_test_functions_in_repo = 1;
+    cfg
+}
+
+fn fdef(name: &str, content: &str) -> FunctionDef {
+    fdef_in("", name, content)
+}
+
+fn fdef_in(container: &str, name: &str, content: &str) -> FunctionDef {
+    FunctionDef {
+        name: name.to_string(),
+        container: container.to_string(),
+        signature: format!("fn {name}()"),
+        start_line: 1,
+        end_line: 3,
+        content: content.to_string(),
+    }
+}
+
+fn signal_symbols(signals: &[RiskSignal]) -> BTreeSet<&str> {
+    signals
+        .iter()
+        .filter_map(|signal| signal.anchor.symbol.as_deref())
+        .collect()
+}
+
+#[test]
+fn quiet_when_disabled() {
+    let mut cfg = ReviewSignalsConfig::default();
+    cfg.test_reachability.enabled = false;
+    let ctx = SemanticContext::new();
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn quiet_with_no_tests_in_corpus() {
+    let cfg = ReviewSignalsConfig::default();
+    let ctx = SemanticContext::new();
+    let signals = run(&empty_state(), &empty_state(), &cfg, &ctx);
+    assert!(signals.is_empty());
+}
+
+#[test]
+fn reason_text_marks_static_reachability() {
+    assert!(REASON_TEXT.contains("static reachability"));
+    assert!(REASON_TEXT.contains("not runtime coverage"));
+}
+
+#[test]
+fn rust_test_naming_heuristic_recognises_underscore_prefixes() {
+    assert!(is_test_function("test_main_branch", Language::Rust));
+    assert!(is_test_function("login_test", Language::Rust));
+    assert!(!is_test_function("login", Language::Rust));
+}
+
+#[test]
+fn python_test_naming_heuristic() {
+    assert!(is_test_function("test_endpoint", Language::Python));
+    assert!(is_test_function("setUp", Language::Python));
+    assert!(!is_test_function("endpoint", Language::Python));
+}
+
+#[test]
+fn go_test_naming_heuristic() {
+    assert!(is_test_function("TestRouter", Language::Go));
+    assert!(!is_test_function("Router", Language::Go));
+}
+
+#[test]
+fn direct_test_reachability_stays_quiet() {
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("covered", "fn covered() { do_work(); }"),
+            fdef("test_covered", "fn test_covered() { covered(); }"),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "direct test caller should cover: {signals:?}"
+    );
+}
+
+#[test]
+fn transitive_test_reachability_stays_quiet() {
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("covered", "fn covered() { do_work(); }"),
+            fdef("helper", "fn helper() { covered(); }"),
+            fdef("test_covered", "fn test_covered() { helper(); }"),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "transitive test caller should cover all callees: {signals:?}"
+    );
+}
+
+#[test]
+fn unreachable_symbol_fires() {
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("orphan", "fn orphan() { do_work(); }"),
+            fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("src/lib.rs"),
+        fdef("orphan", "").symbol_identity(),
+    ));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(signal_symbols(&signals), BTreeSet::from(["orphan"]));
+    assert_eq!(signals[0].kind, RiskSignalKind::TestReachability);
+}
+
+#[test]
+fn unreachable_cycle_fires_once_per_cycled_symbol() {
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("alpha", "fn alpha() { beta(); }"),
+            fdef("beta", "fn beta() { alpha(); }"),
+            fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+        ],
+    );
+    ctx.changed_paths.insert(PathBuf::from("src/lib.rs"));
+    ctx.changed_symbols.insert((
+        PathBuf::from("src/lib.rs"),
+        fdef("alpha", "").symbol_identity(),
+    ));
+    ctx.changed_symbols.insert((
+        PathBuf::from("src/lib.rs"),
+        fdef("beta", "").symbol_identity(),
+    ));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(signal_symbols(&signals), BTreeSet::from(["alpha", "beta"]));
+}
+
+#[test]
+fn unreachable_scoped_to_changed_symbols() {
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("orphan", "fn orphan() { do_work(); }"),
+            fdef("sibling", "fn sibling() { do_other(); }"),
+            fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+        ],
+    );
+    ctx.changed_symbols.insert((
+        PathBuf::from("src/lib.rs"),
+        fdef("orphan", "").symbol_identity(),
+    ));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(signal_symbols(&signals), BTreeSet::from(["orphan"]));
+}
+
+#[test]
+fn unreachable_stays_quiet_when_corpus_incomplete() {
+    let mut ctx = SemanticContext::new();
+    ctx.corpus_complete = false;
+    ctx.new_functions.insert(
+        PathBuf::from("src/lib.rs"),
+        vec![
+            fdef("orphan", "fn orphan() { do_work(); }"),
+            fdef("test_irrelevant", "fn test_irrelevant() { assert!(true); }"),
+        ],
+    );
+    ctx.changed_symbols.insert((
+        PathBuf::from("src/lib.rs"),
+        fdef("orphan", "").symbol_identity(),
+    ));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "incomplete corpus must fail-closed: {signals:?}"
+    );
+}
+
+#[test]
+fn qualified_call_does_not_cover_same_bare_name() {
+    let path = PathBuf::from("src/lib.rs");
+    let foo_run = fdef_in("Foo", "run", "fn run() { do_foo(); }");
+    let bar_run = fdef_in("Bar", "run", "fn run() { do_bar(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            foo_run.clone(),
+            bar_run.clone(),
+            fdef("test_bar", "fn test_bar() { Bar::run(); }"),
+        ],
+    );
+    ctx.changed_symbols
+        .insert((path.clone(), foo_run.symbol_identity()));
+    ctx.changed_symbols
+        .insert((path, bar_run.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(
+        signals.len(),
+        1,
+        "Bar::run is tested; Foo::run must stay unreachable: {signals:?}"
+    );
+    assert_eq!(signal_symbols(&signals), BTreeSet::from(["run"]));
+}
+
+#[test]
+fn module_qualified_call_does_not_cover_other_module() {
+    let path = PathBuf::from("src/lib.rs");
+    let foo_run = fdef_in("foo", "run", "fn run() { do_foo(); }");
+    let bar_run = fdef_in("bar", "run", "fn run() { do_bar(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            foo_run.clone(),
+            bar_run.clone(),
+            fdef("test_foo", "fn test_foo() { foo::run(); }"),
+        ],
+    );
+    ctx.changed_symbols
+        .insert((path.clone(), foo_run.symbol_identity()));
+    ctx.changed_symbols
+        .insert((path, bar_run.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(
+        signals.len(),
+        1,
+        "foo::run must not mark bar::run reachable: {signals:?}"
+    );
+}
+
+#[test]
+fn unique_receiver_call_covers_the_only_method() {
+    let path = PathBuf::from("src/lib.rs");
+    let foo_run = fdef_in("Foo", "run", "fn run() { do_foo(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            foo_run.clone(),
+            fdef(
+                "test_foo",
+                "fn test_foo() { let instance = Foo; instance.run(); }",
+            ),
+        ],
+    );
+    ctx.changed_symbols
+        .insert((path, foo_run.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "unique receiver call must cover Foo::run: {signals:?}"
+    );
+}
+
+#[test]
+fn ambiguous_receiver_call_fail_closes_instead_of_warning() {
+    let path = PathBuf::from("src/lib.rs");
+    let foo_run = fdef_in("Foo", "run", "fn run() { do_foo(); }");
+    let bar_run = fdef_in("Bar", "run", "fn run() { do_bar(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            foo_run.clone(),
+            bar_run.clone(),
+            fdef(
+                "test_foo",
+                "fn test_foo() { let instance = Foo; instance.run(); }",
+            ),
+        ],
+    );
+    ctx.changed_symbols
+        .insert((path.clone(), foo_run.symbol_identity()));
+    ctx.changed_symbols
+        .insert((path, bar_run.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "ambiguous instance.run() must fail-closed, not warn: {signals:?}"
+    );
+}
+
+#[test]
+fn comment_todo_call_does_not_mark_reachable() {
+    let path = PathBuf::from("src/lib.rs");
+    let orphan = fdef("orphan", "fn orphan() { do_work(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            orphan.clone(),
+            fdef(
+                "test_irrelevant",
+                "fn test_irrelevant() { /* TODO: call orphan() */ let _ = \"orphan()\"; }",
+            ),
+        ],
+    );
+    ctx.changed_symbols.insert((path, orphan.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(
+        signal_symbols(&signals),
+        BTreeSet::from(["orphan"]),
+        "comment/string must not create a caller edge: {signals:?}"
+    );
+}

--- a/crates/state_review/src/modules/test_reachability_tests.rs
+++ b/crates/state_review/src/modules/test_reachability_tests.rs
@@ -374,6 +374,85 @@ fn ambiguous_receiver_call_fail_closes_instead_of_warning() {
 }
 
 #[test]
+fn bare_call_resolves_to_caller_container() {
+    let path = PathBuf::from("src/lib.rs");
+    let target = fdef_in("a", "target", "fn target() { do_work(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            target.clone(),
+            fdef_in("a", "test_target", "fn test_target() { target(); }"),
+        ],
+    );
+    ctx.changed_symbols.insert((path, target.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "bare target() in mod a must cover a::target: {signals:?}"
+    );
+}
+
+#[test]
+fn nested_function_call_does_not_cover_outer_callee() {
+    let path = PathBuf::from("src/lib.rs");
+    let target = fdef("target", "fn target() { do_work(); }");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            target.clone(),
+            fdef("test_x", "fn test_x() { fn unused() { target(); } }"),
+        ],
+    );
+    ctx.changed_symbols.insert((path, target.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert_eq!(
+        signal_symbols(&signals),
+        BTreeSet::from(["target"]),
+        "nested unused() call must not cover target: {signals:?}"
+    );
+}
+
+#[test]
+fn python_direct_call_covers_target() {
+    let path = PathBuf::from("mod.py");
+    let target = fdef("target", "def target():\n    return 1\n");
+    let mut ctx = SemanticContext::new();
+    ctx.new_functions.insert(
+        path.clone(),
+        vec![
+            target.clone(),
+            fdef("test_target", "def test_target():\n    target()\n"),
+        ],
+    );
+    ctx.changed_symbols.insert((path, target.symbol_identity()));
+
+    let signals = run(
+        &empty_state(),
+        &empty_state(),
+        &cfg_with_one_required_test(),
+        &ctx,
+    );
+    assert!(
+        signals.is_empty(),
+        "python test_target() must cover target: {signals:?}"
+    );
+}
+
+#[test]
 fn comment_todo_call_does_not_mark_reachable() {
     let path = PathBuf::from("src/lib.rs");
     let orphan = fdef("orphan", "fn orphan() { do_work(); }");

--- a/crates/state_review/src/registry.rs
+++ b/crates/state_review/src/registry.rs
@@ -25,12 +25,13 @@ pub struct SemanticContext {
     pub prior_functions: BTreeMap<PathBuf, Vec<FunctionDef>>,
     pub new_functions: BTreeMap<PathBuf, Vec<FunctionDef>>,
     /// Repo-relative paths that actually changed in this review pass.
-    /// Emit-scope for modules that have no symbol-level delta. Empty
-    /// together with an empty `changed_symbols` emits nothing.
+    /// Used to build `changed_symbols` and to prune fmt-only churn.
+    /// Not an emit-scope: an empty `changed_symbols` emits nothing even
+    /// when this set is non-empty (non-function file-level edits).
     pub changed_paths: BTreeSet<PathBuf>,
     /// `(path, function name)` pairs that actually changed. Production
-    /// capture always fills this. Novelty / test_reachability /
-    /// pattern_deviation emit only for this set when it is non-empty.
+    /// emit-scope for novelty / test_reachability / pattern_deviation.
+    /// Empty means emit nothing — including when `changed_paths` is not.
     pub changed_symbols: BTreeSet<(PathBuf, String)>,
     /// Whether `new_functions` is a complete new-state corpus under the
     /// capture-time page/byte budgets. Novelty and test_reachability
@@ -56,17 +57,13 @@ impl SemanticContext {
         Self::default()
     }
 
-    /// Diff-scoped emit check. Production fills `changed_symbols`.
-    /// Empty `changed_symbols` falls back to `changed_paths`. Empty
-    /// both (fmt-sweep, or an unscoped context) emits nothing.
+    /// Production emit-scope is `changed_symbols` only. Empty means
+    /// emit nothing — a digest change with no function body/name delta
+    /// must not fire on untouched siblings.
     pub fn is_emit_target(&self, path: &Path, name: &str) -> bool {
-        if !self.changed_symbols.is_empty() {
-            return self
-                .changed_symbols
-                .iter()
-                .any(|(changed_path, changed_name)| changed_path == path && changed_name == name);
-        }
-        !self.changed_paths.is_empty() && self.changed_paths.contains(path)
+        self.changed_symbols
+            .iter()
+            .any(|(changed_path, changed_name)| changed_path == path && changed_name == name)
     }
 }
 
@@ -130,6 +127,20 @@ mod tests {
             end_line: 3,
             content: content.to_string(),
         }
+    }
+
+    #[test]
+    fn empty_changed_symbols_emits_nothing_even_when_paths_changed() {
+        let mut ctx = SemanticContext::new();
+        ctx.changed_paths.insert(PathBuf::from("lib.rs"));
+        assert!(
+            !ctx.is_emit_target(std::path::Path::new("lib.rs"), "sibling"),
+            "digest-only file change must not emit on untouched functions"
+        );
+        ctx.changed_symbols
+            .insert((PathBuf::from("lib.rs"), "edited".to_string()));
+        assert!(ctx.is_emit_target(std::path::Path::new("lib.rs"), "edited"));
+        assert!(!ctx.is_emit_target(std::path::Path::new("lib.rs"), "sibling"));
     }
 
     #[test]

--- a/crates/state_review/src/registry.rs
+++ b/crates/state_review/src/registry.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::{BTreeMap, BTreeSet},
-    path::PathBuf,
+    path::{Path, PathBuf},
 };
 
 use objects::object::{RiskSignal, State};
@@ -20,21 +20,53 @@ use crate::config::ReviewSignalsConfig;
 /// We hold extracted [`FunctionDef`]s rather than the parser's `ParsedFile`
 /// because `ParsedFile` owns a `TSTree` which isn't `Clone`/`Send`-friendly
 /// for sharing across modules.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct SemanticContext {
     pub prior_functions: BTreeMap<PathBuf, Vec<FunctionDef>>,
     pub new_functions: BTreeMap<PathBuf, Vec<FunctionDef>>,
-    /// Repo-relative paths that actually changed in this review pass. Modules
-    /// that should only report on the diff (e.g. novelty) scope their emitted
-    /// signals to this set while still comparing against the full
-    /// `new_functions` corpus. Empty means "no changed files known" — such a
-    /// module stays quiet rather than scanning the whole repo.
+    /// Repo-relative paths that actually changed in this review pass.
+    /// Emit-scope for modules that have no symbol-level delta. Empty
+    /// together with an empty `changed_symbols` emits nothing.
     pub changed_paths: BTreeSet<PathBuf>,
+    /// `(path, function name)` pairs that actually changed. Production
+    /// capture always fills this. Novelty / test_reachability /
+    /// pattern_deviation emit only for this set when it is non-empty.
+    pub changed_symbols: BTreeSet<(PathBuf, String)>,
+    /// Whether `new_functions` is a complete new-state corpus under the
+    /// capture-time page/byte budgets. Novelty and test_reachability
+    /// stay quiet when this is false rather than scoring a partial repo.
+    /// `Default` is `true` so hand-built unit-test contexts keep firing.
+    pub corpus_complete: bool,
+}
+
+impl Default for SemanticContext {
+    fn default() -> Self {
+        Self {
+            prior_functions: BTreeMap::new(),
+            new_functions: BTreeMap::new(),
+            changed_paths: BTreeSet::new(),
+            changed_symbols: BTreeSet::new(),
+            corpus_complete: true,
+        }
+    }
 }
 
 impl SemanticContext {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Diff-scoped emit check. Production fills `changed_symbols`.
+    /// Empty `changed_symbols` falls back to `changed_paths`. Empty
+    /// both (fmt-sweep, or an unscoped context) emits nothing.
+    pub fn is_emit_target(&self, path: &Path, name: &str) -> bool {
+        if !self.changed_symbols.is_empty() {
+            return self
+                .changed_symbols
+                .iter()
+                .any(|(changed_path, changed_name)| changed_path == path && changed_name == name);
+        }
+        !self.changed_paths.is_empty() && self.changed_paths.contains(path)
     }
 }
 
@@ -141,6 +173,8 @@ mod tests {
                 "fn score(socket: &mut Socket) -> usize { while socket.poll() { rotate_key(); } 0 }",
             )],
         );
+        ctx.changed_symbols
+            .insert((PathBuf::from("src/scoring.rs"), "score".to_string()));
 
         let signals = run_all(&prior, &new, &cfg, &ctx);
         let ordering: Vec<(String, String)> = signals

--- a/crates/state_review/src/registry.rs
+++ b/crates/state_review/src/registry.rs
@@ -29,9 +29,10 @@ pub struct SemanticContext {
     /// Not an emit-scope: an empty `changed_symbols` emits nothing even
     /// when this set is non-empty (non-function file-level edits).
     pub changed_paths: BTreeSet<PathBuf>,
-    /// `(path, function name)` pairs that actually changed. Production
-    /// emit-scope for novelty / test_reachability / pattern_deviation.
-    /// Empty means emit nothing — including when `changed_paths` is not.
+    /// `(path, FunctionDef::symbol_identity())` pairs that actually
+    /// changed. Production emit-scope for novelty / test_reachability /
+    /// pattern_deviation. Empty means emit nothing — including when
+    /// `changed_paths` is not.
     pub changed_symbols: BTreeSet<(PathBuf, String)>,
     /// Whether `new_functions` is a complete new-state corpus under the
     /// capture-time page/byte budgets. Novelty and test_reachability
@@ -59,11 +60,13 @@ impl SemanticContext {
 
     /// Production emit-scope is `changed_symbols` only. Empty means
     /// emit nothing — a digest change with no function body/name delta
-    /// must not fire on untouched siblings.
-    pub fn is_emit_target(&self, path: &Path, name: &str) -> bool {
+    /// must not fire on untouched siblings. Identity is
+    /// [`FunctionDef::symbol_identity`], not the bare name.
+    pub fn is_emit_target(&self, path: &Path, fn_def: &FunctionDef) -> bool {
+        let identity = fn_def.symbol_identity();
         self.changed_symbols
             .iter()
-            .any(|(changed_path, changed_name)| changed_path == path && changed_name == name)
+            .any(|(changed_path, changed_id)| changed_path == path && changed_id == &identity)
     }
 }
 
@@ -122,6 +125,7 @@ mod tests {
     fn fdef(name: &str, content: &str) -> FunctionDef {
         FunctionDef {
             name: name.to_string(),
+            container: String::new(),
             signature: format!("fn {name}()"),
             start_line: 1,
             end_line: 3,
@@ -133,14 +137,16 @@ mod tests {
     fn empty_changed_symbols_emits_nothing_even_when_paths_changed() {
         let mut ctx = SemanticContext::new();
         ctx.changed_paths.insert(PathBuf::from("lib.rs"));
+        let sibling = fdef("sibling", "");
+        let edited = fdef("edited", "");
         assert!(
-            !ctx.is_emit_target(std::path::Path::new("lib.rs"), "sibling"),
+            !ctx.is_emit_target(std::path::Path::new("lib.rs"), &sibling),
             "digest-only file change must not emit on untouched functions"
         );
         ctx.changed_symbols
-            .insert((PathBuf::from("lib.rs"), "edited".to_string()));
-        assert!(ctx.is_emit_target(std::path::Path::new("lib.rs"), "edited"));
-        assert!(!ctx.is_emit_target(std::path::Path::new("lib.rs"), "sibling"));
+            .insert((PathBuf::from("lib.rs"), edited.symbol_identity()));
+        assert!(ctx.is_emit_target(std::path::Path::new("lib.rs"), &edited));
+        assert!(!ctx.is_emit_target(std::path::Path::new("lib.rs"), &sibling));
     }
 
     #[test]
@@ -184,8 +190,10 @@ mod tests {
                 "fn score(socket: &mut Socket) -> usize { while socket.poll() { rotate_key(); } 0 }",
             )],
         );
-        ctx.changed_symbols
-            .insert((PathBuf::from("src/scoring.rs"), "score".to_string()));
+        ctx.changed_symbols.insert((
+            PathBuf::from("src/scoring.rs"),
+            fdef("score", "").symbol_identity(),
+        ));
 
         let signals = run_all(&prior, &new, &cfg, &ctx);
         let ordering: Vec<(String, String)> = signals


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bounces heddle#1468 on HEAD `f8916e38`. Capture-time risk signals still come from `SemanticContext`. No second PR. Call-graph P1s (bare call → container, Python `call` nodes, own-scope calls) and the inspect-every-file / rename / object-literal work stay as-is.

Remaining ship-blocker: `CORPUS_FILE_BUDGET = 32` was a private smaller universe than `SemanticParseCache::DEFAULT_MAX_ENTRIES` (256). Hitting 32 fail-closed (`corpus_complete = false`), so novelty / test_reachability stayed quiet on any real repo.

This revision:

- Reuses the shared parse-cache page as the file budget (`SemanticParseCache::DEFAULT_MAX_ENTRIES`). No parallel 32-file ceiling.
- Leaves the byte budget fail-closed (`PARSE_BUDGET_BYTES * 2`).
- After changed-path parse fills the page, the index walk still distinguishes an empty leftover universe from a leftover function file. A full page with no remaining function files stays complete.
- Fail-closed page size is the allowed bound. A hard 32-file product limit is not.

Closes HeddleCo/heddle#1069.

Out of scope: heddle 473 (locked review epic). This pull request does not touch that issue.

## Red commit
`f8916e38` — bounce HEAD.

## Test evidence

HEAD `b282b8e1`.

```
cargo test -p heddle-repo --features tree-sitter-symbols --lib -- semantic
   Compiling heddle-repo v0.12.0 (/workspace/crates/repo)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 3.28s
     Running unittests src/lib.rs (target/debug/deps/repo-5f7d4b00804145db)

running 47 tests
test repository_semantic_context::tests::more_than_thirty_two_function_files_can_complete_the_corpus ... ok
test repository_semantic_corpus::tests::page_full_with_no_remaining_function_files_is_complete ... ok
test repository_semantic_corpus::tests::page_full_with_remaining_function_files_is_incomplete ... ok
test repository_semantic_context::tests::wide_changed_path_parse_marks_corpus_incomplete_when_file_budget_exceeded ... ok
test repository_semantic_context::tests::mass_delete_skips_prior_parse_and_does_not_blow_the_budget ... ok
...
test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 687 filtered out; finished in 1.03s

cargo test -p heddle-repo --features tree-sitter-symbols --lib -- corpus
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running unittests src/lib.rs (target/debug/deps/repo-5f7d4b00804145db)

running 13 tests
test repository_semantic_corpus::tests::page_full_with_no_remaining_function_files_is_complete ... ok
test repository_semantic_corpus::tests::page_full_with_remaining_function_files_is_incomplete ... ok
test repository_semantic_context::tests::more_than_thirty_two_function_files_can_complete_the_corpus ... ok
test repository_semantic_context::tests::wide_changed_path_parse_marks_corpus_incomplete_when_file_budget_exceeded ... ok
...
test result: ok. 13 passed; 0 failed; 0 ignored; 0 measured; 721 filtered out; finished in 0.14s

cargo clippy -p heddle-repo --features tree-sitter-symbols --lib -- -D warnings
    Checking heddle-semantic v0.12.0 (/workspace/crates/semantic)
    Checking heddle-state-review v0.12.0 (/workspace/crates/state_review)
    Checking heddle-repo v0.12.0 (/workspace/crates/repo)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.72s
```

## Manual verification

N/A — covered by the tests above.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c38f0cf-4310-472a-bd35-a0c53839a355?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c38f0cf-4310-472a-bd35-a0c53839a355&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782463&installation_model_id=21489&pr_number=1468&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1468&signature=5707eb4e8bb89306492b4c2c67b1af37c43d320c93178b265cbf5629387318e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->