### PR TITLE
Make context set ride heddle diff --context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
   use the canonical encoding. Migration `0005_streamable_tree_encoding`
   rewrites leftover msgpack trees on repo open (heddle#1457).
 
+### Fixed
+
+- **Live annotations ride `diff --context`.** After `context set`,
+  `heddle diff --context` shows the annotation on the existing `context` /
+  `broader_guidance` fields, including Git-overlay worktrees and
+  path-filtered clean diffs (heddle#1459).
+
 ## 0.14.0 - 2026-08-21
 
 - Rebuilt the workspace on `heddle-api` 0.12 and

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -7,8 +7,8 @@ use anyhow::{Result, anyhow};
 use objects::worktree::WorktreeStatus;
 use repo::{Config, Repository, RepositoryCapability, discover_heddle_root};
 use verbs::{
-    DiffOptions, DiffReport, PlainGitDiffProbe, diff as core_diff, diff_worktree_status,
-    plain_git_head_diff,
+    DiffOptions, DiffReport, PlainGitDiffProbe, attach_show_context, diff as core_diff,
+    diff_worktree_status, plain_git_head_diff, worktree_context_state,
 };
 
 use super::{
@@ -252,14 +252,21 @@ fn authority_worktree_diff(
     status: &WorktreeStatus,
     options: &DiffOptions,
 ) -> Result<DiffReport> {
-    if repo.capability() == RepositoryCapability::GitOverlay {
-        return plain_git_head_diff(
+    let mut report = if repo.capability() == RepositoryCapability::GitOverlay {
+        plain_git_head_diff(
             &PlainGitDiffProbe {
                 root: repo.root().to_path_buf(),
                 changes: clone_worktree_status(status),
             },
             options,
-        );
+        )?
+    } else {
+        diff_worktree_status(status, options, Some(repo), true)?
+    };
+    if options.show_context
+        && let Some(state) = worktree_context_state(repo)?
+    {
+        attach_show_context(repo, &mut report, &state, options.paths.is_empty())?;
     }
-    diff_worktree_status(status, options, Some(repo), true)
+    Ok(report)
 }

--- a/crates/cli/src/cli/commands/diff/diff_compute.rs
+++ b/crates/cli/src/cli/commands/diff/diff_compute.rs
@@ -266,7 +266,7 @@ fn authority_worktree_diff(
     if options.show_context
         && let Some(state) = worktree_context_state(repo)?
     {
-        attach_show_context(repo, &mut report, &state, options.paths.is_empty())?;
+        attach_show_context(repo, &mut report, &state, &options.paths)?;
     }
     Ok(report)
 }

--- a/crates/cli/tests/cli_integration/context_rides_diff.rs
+++ b/crates/cli/tests/cli_integration/context_rides_diff.rs
@@ -131,3 +131,49 @@ fn context_set_rides_clean_native_diff() {
 
     assert_annotation_rides(dir, "lib.rs", "visible on a clean tree");
 }
+
+#[test]
+fn context_set_rides_path_filtered_clean_diff() {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    heddle(&["init"], Some(dir)).expect("init");
+    std::fs::write(dir.join("lib.rs"), "fn seed() {}\n").expect("write lib.rs");
+    std::fs::write(dir.join("other.rs"), "fn other() {}\n").expect("write other.rs");
+    heddle(&["capture", "-m", "seed"], Some(dir)).expect("capture");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.rs",
+            "--kind",
+            "rationale",
+            "-m",
+            "requested path still rides",
+        ],
+        Some(dir),
+    )
+    .expect("context set");
+
+    let matching = heddle(&["diff", "--context", "--", "lib.rs"], Some(dir))
+        .unwrap_or_else(|err| panic!("diff --context -- lib.rs should succeed: {err}"));
+    assert!(
+        matching.contains("Applicable Context:"),
+        "filtered clean diff must render context for the requested path:\n{matching}"
+    );
+    assert!(
+        matching.contains("requested path still rides"),
+        "filtered clean diff must show the lib.rs annotation:\n{matching}"
+    );
+
+    let other = heddle(&["diff", "--context", "--", "other.rs"], Some(dir))
+        .unwrap_or_else(|err| panic!("diff --context -- other.rs should succeed: {err}"));
+    assert!(
+        !other.contains("requested path still rides"),
+        "unrelated path filter must stay quiet:\n{other}"
+    );
+    assert!(
+        !other.contains("Applicable Context:"),
+        "unrelated path filter must not render a context header:\n{other}"
+    );
+}

--- a/crates/cli/tests/cli_integration/context_rides_diff.rs
+++ b/crates/cli/tests/cli_integration/context_rides_diff.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+//! heddle#1459 — `context set` must ride `diff --context`.
+//!
+//! Isolation (`context set` + `context get`) already works. The field walk
+//! failed because Git-overlay worktree diffs skipped the existing
+//! `context` / `broader_guidance` report fields.
+
+use std::path::Path;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+use super::{git_hermetic, heddle};
+
+fn assert_annotation_rides(dir: &Path, path: &str, content: &str) {
+    let get = heddle(&["context", "get", "--path", path], Some(dir))
+        .unwrap_or_else(|err| panic!("context get should pass isolation: {err}"));
+    assert!(
+        get.contains(content),
+        "context get must show the annotation:\n{get}"
+    );
+
+    let text = heddle(&["diff", "--context"], Some(dir))
+        .unwrap_or_else(|err| panic!("diff --context should succeed: {err}"));
+    assert!(
+        text.contains("Applicable Context:"),
+        "diff --context must render the context header:\n{text}"
+    );
+    assert!(
+        text.contains(content),
+        "diff --context must show the annotation after context set:\n{text}"
+    );
+
+    let json = heddle(&["diff", "--context", "--output", "json"], Some(dir))
+        .unwrap_or_else(|err| panic!("diff --context json should succeed: {err}"));
+    let parsed: Value =
+        serde_json::from_str(json.trim()).unwrap_or_else(|err| panic!("json diff: {err}\n{json}"));
+    assert_eq!(parsed["output_kind"], "diff");
+    let entries = parsed["context"]
+        .as_array()
+        .unwrap_or_else(|| panic!("diff json must keep the existing context field:\n{json}"));
+    let found = entries.iter().any(|entry| {
+        entry["path"] == path
+            && entry["annotations"].as_array().is_some_and(|annotations| {
+                annotations
+                    .iter()
+                    .any(|annotation| annotation["content"] == content)
+            })
+    });
+    assert!(
+        found,
+        "existing diff context field must carry the annotation:\n{json}"
+    );
+}
+
+#[test]
+fn context_set_rides_native_worktree_diff() {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    heddle(&["init"], Some(dir)).expect("init");
+    std::fs::write(dir.join("lib.rs"), "fn seed() {}\n").expect("write seed");
+    heddle(&["capture", "-m", "seed"], Some(dir)).expect("capture");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.rs",
+            "--kind",
+            "invariant",
+            "-m",
+            "must stay lowercase",
+        ],
+        Some(dir),
+    )
+    .expect("context set");
+    std::fs::write(dir.join("lib.rs"), "fn seed() { dirty(); }\n").expect("dirty file");
+
+    assert_annotation_rides(dir, "lib.rs", "must stay lowercase");
+}
+
+#[test]
+fn context_set_rides_git_overlay_worktree_diff() {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    git_hermetic(&["init", "-q", "-b", "main", "."], dir);
+    std::fs::write(dir.join("lib.rs"), "fn seed() {}\n").expect("write seed");
+    git_hermetic(&["add", "lib.rs"], dir);
+    git_hermetic(&["commit", "-qm", "seed"], dir);
+    heddle(&["init"], Some(dir)).expect("heddle init");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.rs",
+            "--kind",
+            "invariant",
+            "-m",
+            "overlay annotation must ride",
+        ],
+        Some(dir),
+    )
+    .expect("context set");
+    std::fs::write(dir.join("lib.rs"), "fn seed() { dirty(); }\n").expect("dirty file");
+
+    assert_annotation_rides(dir, "lib.rs", "overlay annotation must ride");
+}
+
+#[test]
+fn context_set_rides_clean_native_diff() {
+    let temp = TempDir::new().expect("tempdir");
+    let dir = temp.path();
+    heddle(&["init"], Some(dir)).expect("init");
+    std::fs::write(dir.join("lib.rs"), "fn seed() {}\n").expect("write seed");
+    heddle(&["capture", "-m", "seed"], Some(dir)).expect("capture");
+    heddle(
+        &[
+            "context",
+            "set",
+            "--path",
+            "lib.rs",
+            "--kind",
+            "rationale",
+            "-m",
+            "visible on a clean tree",
+        ],
+        Some(dir),
+    )
+    .expect("context set");
+
+    assert_annotation_rides(dir, "lib.rs", "visible on a clean tree");
+}

--- a/crates/cli/tests/cli_workflow.rs
+++ b/crates/cli/tests/cli_workflow.rs
@@ -12,6 +12,8 @@ use support::*;
 
 #[path = "cli_integration/context_recovery_advice.rs"]
 mod context_recovery_advice;
+#[path = "cli_integration/context_rides_diff.rs"]
+mod context_rides_diff;
 #[path = "cli_integration/current_context_advice.rs"]
 mod current_context_advice;
 #[path = "cli_integration/diff_patch_conformance.rs"]

--- a/crates/verbs/src/diff/context.rs
+++ b/crates/verbs/src/diff/context.rs
@@ -7,41 +7,66 @@
 
 use anyhow::Result;
 use objects::{
-    object::{Annotation, AnnotationStatus, ContextTarget, State, StateAttachmentBody},
+    object::{
+        Annotation, AnnotationStatus, ContentHash, ContextTarget, State, StateAttachmentBody,
+    },
     store::ObjectStore,
 };
-use repo::{Repository, StateAttachmentKind};
+use repo::{ChangedPathFilters, Repository, StateAttachmentKind};
 
 use super::types::{ContextSnippet, DiffReport, FileContextEntry};
 
-/// Fill `report.context` and `report.broader_guidance` from the state's
-/// latest Context attachment.
+/// Fill `report.context` and `report.broader_guidance` from one Context
+/// attachment snapshot.
 ///
-/// When the report has changed paths, only those files are annotated
-/// (plus a renamed file's old path). When the change set is empty and
-/// `include_unanchored` is true, every active file annotation rides the
-/// report so `context set` is visible on a clean `diff --context`.
+/// Selection:
+/// - changed report paths (including a rename `old_path`) when present;
+/// - otherwise the requested `path_filters` on a clean / filtered-empty
+///   tree, so `diff --context -- lib.rs` still rides;
+/// - otherwise every active file annotation (unfiltered clean tree).
 pub fn attach_show_context(
     repo: &Repository,
     report: &mut DiffReport,
     state: &State,
-    include_unanchored: bool,
+    path_filters: &[String],
 ) -> Result<()> {
-    let mut paths: Vec<String> = report
+    let Some(context_root) = context_root_for_state(repo, state)? else {
+        report.context = Some(Vec::new());
+        report.broader_guidance = Some(Vec::new());
+        return Ok(());
+    };
+
+    let mut change_paths: Vec<String> = report
         .changes
         .iter()
         .flat_map(|change| std::iter::once(change.path.clone()).chain(change.old_path.clone()))
         .collect();
-    paths.sort();
-    paths.dedup();
+    change_paths.sort();
+    change_paths.dedup();
+    let filters = ChangedPathFilters::try_from_paths(path_filters)?;
 
-    report.context = Some(collect_file_context(
-        repo,
-        state,
-        &paths,
-        include_unanchored && paths.is_empty(),
-    )?);
-    report.broader_guidance = Some(collect_state_guidance(repo, state)?);
+    let listed = repo.list_context_entries(&context_root, None)?;
+    let mut file_entries = Vec::new();
+    let mut broader_guidance = Vec::new();
+    for entry in listed {
+        match entry.target {
+            ContextTarget::File { path } => {
+                if !file_path_requested(&path, &change_paths, &filters) {
+                    continue;
+                }
+                let annotations = active_snippets(&entry.blob.annotations);
+                if !annotations.is_empty() {
+                    file_entries.push(FileContextEntry { path, annotations });
+                }
+            }
+            ContextTarget::State { state_id } if state_id == state.state_id => {
+                broader_guidance = active_snippets(&entry.blob.annotations);
+            }
+            ContextTarget::State { .. } => {}
+        }
+    }
+    report.context = Some(file_entries);
+    report.broader_guidance = Some(broader_guidance);
     Ok(())
 }
 
@@ -69,10 +94,7 @@ pub(crate) fn summarize_context(content: &str) -> String {
     }
 }
 
-fn context_root_for_state(
-    repo: &Repository,
-    state: &State,
-) -> Result<Option<objects::object::ContentHash>> {
+fn context_root_for_state(repo: &Repository, state: &State) -> Result<Option<ContentHash>> {
     Ok(repo
         .latest_state_attachment(&state.state_id, StateAttachmentKind::Context)?
         .and_then(|attachment| match attachment.body {
@@ -81,53 +103,11 @@ fn context_root_for_state(
         }))
 }
 
-fn collect_file_context(
-    repo: &Repository,
-    state: &State,
-    paths: &[String],
-    include_unanchored: bool,
-) -> Result<Vec<FileContextEntry>> {
-    let Some(context_root) = context_root_for_state(repo, state)? else {
-        return Ok(Vec::new());
-    };
-
-    let paths = if include_unanchored && paths.is_empty() {
-        let mut listed = Vec::new();
-        for entry in repo.list_context_entries(&context_root, None)? {
-            if let ContextTarget::File { path } = entry.target {
-                listed.push(path);
-            }
-        }
-        listed
-    } else {
-        paths.to_vec()
-    };
-
-    let mut entries = Vec::new();
-    for path in paths {
-        let Ok(target) = ContextTarget::file(path.clone()) else {
-            continue;
-        };
-        let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
-            continue;
-        };
-        let annotations = active_snippets(&blob.annotations);
-        if !annotations.is_empty() {
-            entries.push(FileContextEntry { path, annotations });
-        }
+fn file_path_requested(path: &str, change_paths: &[String], filters: &ChangedPathFilters) -> bool {
+    if !change_paths.is_empty() {
+        return change_paths.iter().any(|changed| changed == path);
     }
-    Ok(entries)
-}
-
-fn collect_state_guidance(repo: &Repository, state: &State) -> Result<Vec<ContextSnippet>> {
-    let Some(context_root) = context_root_for_state(repo, state)? else {
-        return Ok(Vec::new());
-    };
-    let target = ContextTarget::state(state.state_id);
-    let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
-        return Ok(Vec::new());
-    };
-    Ok(active_snippets(&blob.annotations))
+    filters.is_empty() || filters.matches(path)
 }
 
 fn active_snippets(annotations: &[Annotation]) -> Vec<ContextSnippet> {
@@ -201,6 +181,16 @@ mod tests {
         DiffReport::new(Some("HEAD".to_string()), None, changes, None, None, None)
     }
 
+    fn annotation_content(report: &DiffReport, path: &str) -> Option<String> {
+        report.context.as_ref().and_then(|entries| {
+            entries.iter().find_map(|entry| {
+                (entry.path == path)
+                    .then(|| entry.annotations.first().map(|a| a.content.clone()))
+                    .flatten()
+            })
+        })
+    }
+
     #[test]
     fn context_set_attachment_rides_diff_for_changed_path() {
         let temp = TempDir::new().expect("tempdir");
@@ -208,14 +198,12 @@ mod tests {
         let state = annotate_state(&repo, "lib.rs", "must stay lowercase");
         let mut report = report_with(&["lib.rs"]);
 
-        attach_show_context(&repo, &mut report, &state, false).expect("attach");
+        attach_show_context(&repo, &mut report, &state, &[]).expect("attach");
 
-        let context = report.context.expect("context field");
-        assert_eq!(context.len(), 1);
-        assert_eq!(context[0].path, "lib.rs");
-        assert_eq!(context[0].annotations.len(), 1);
-        assert_eq!(context[0].annotations[0].kind, "invariant");
-        assert_eq!(context[0].annotations[0].content, "must stay lowercase");
+        assert_eq!(
+            annotation_content(&report, "lib.rs").as_deref(),
+            Some("must stay lowercase")
+        );
     }
 
     #[test]
@@ -225,14 +213,36 @@ mod tests {
         let state = annotate_state(&repo, "lib.rs", "visible without a file change");
         let mut report = report_with(&[]);
 
-        attach_show_context(&repo, &mut report, &state, true).expect("attach");
+        attach_show_context(&repo, &mut report, &state, &[]).expect("attach");
 
-        let context = report.context.expect("context field");
-        assert_eq!(context.len(), 1);
-        assert_eq!(context[0].path, "lib.rs");
         assert_eq!(
-            context[0].annotations[0].content,
-            "visible without a file change"
+            annotation_content(&report, "lib.rs").as_deref(),
+            Some("visible without a file change")
+        );
+    }
+
+    #[test]
+    fn path_filter_on_clean_tree_looks_up_requested_paths() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        let state = annotate_state(&repo, "lib.rs", "requested path still rides");
+        let mut matching = report_with(&[]);
+        attach_show_context(&repo, &mut matching, &state, &["lib.rs".to_string()])
+            .expect("attach matching filter");
+        assert_eq!(
+            annotation_content(&matching, "lib.rs").as_deref(),
+            Some("requested path still rides")
+        );
+
+        let mut other = report_with(&[]);
+        attach_show_context(&repo, &mut other, &state, &["other.rs".to_string()])
+            .expect("attach other filter");
+        assert!(
+            other
+                .context
+                .as_ref()
+                .is_none_or(|entries| entries.is_empty()),
+            "unrelated path filter must stay quiet"
         );
     }
 
@@ -243,7 +253,7 @@ mod tests {
         let state = annotate_state(&repo, "lib.rs", "not this path");
         let mut report = report_with(&[]);
 
-        attach_show_context(&repo, &mut report, &state, false).expect("attach");
+        attach_show_context(&repo, &mut report, &state, &["other.rs".to_string()]).expect("attach");
 
         assert!(
             report

--- a/crates/verbs/src/diff/context.rs
+++ b/crates/verbs/src/diff/context.rs
@@ -1,0 +1,281 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Attach live context annotations to an existing [`DiffReport`].
+//!
+//! `context set` writes a Context state-attachment. `diff --context` must
+//! populate the existing report fields from that attachment — the same
+//! store `context get` reads — without a second view RPC.
+
+use anyhow::Result;
+use objects::{
+    object::{Annotation, AnnotationStatus, ContextTarget, State, StateAttachmentBody},
+    store::ObjectStore,
+};
+use repo::{Repository, StateAttachmentKind};
+
+use super::types::{ContextSnippet, DiffReport, FileContextEntry};
+
+/// Fill `report.context` and `report.broader_guidance` from the state's
+/// latest Context attachment.
+///
+/// When the report has changed paths, only those files are annotated
+/// (plus a renamed file's old path). When the change set is empty and
+/// `include_unanchored` is true, every active file annotation rides the
+/// report so `context set` is visible on a clean `diff --context`.
+pub fn attach_show_context(
+    repo: &Repository,
+    report: &mut DiffReport,
+    state: &State,
+    include_unanchored: bool,
+) -> Result<()> {
+    let mut paths: Vec<String> = report
+        .changes
+        .iter()
+        .flat_map(|change| std::iter::once(change.path.clone()).chain(change.old_path.clone()))
+        .collect();
+    paths.sort();
+    paths.dedup();
+
+    report.context = Some(collect_file_context(
+        repo,
+        state,
+        &paths,
+        include_unanchored && paths.is_empty(),
+    )?);
+    report.broader_guidance = Some(collect_state_guidance(repo, state)?);
+    Ok(())
+}
+
+/// HEAD / current-state used by worktree diffs.
+pub fn worktree_context_state(repo: &Repository) -> Result<Option<State>> {
+    if let Some(state) = repo.current_state()? {
+        return Ok(Some(state));
+    }
+    let Some(id) = repo.head()? else {
+        return Ok(None);
+    };
+    Ok(repo.store().get_state(&id)?)
+}
+
+pub(crate) fn summarize_context(content: &str) -> String {
+    let first_line = content
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("");
+    let char_count = first_line.chars().count();
+    if char_count <= 88 {
+        first_line.to_string()
+    } else {
+        format!("{}...", first_line.chars().take(85).collect::<String>())
+    }
+}
+
+fn context_root_for_state(
+    repo: &Repository,
+    state: &State,
+) -> Result<Option<objects::object::ContentHash>> {
+    Ok(repo
+        .latest_state_attachment(&state.state_id, StateAttachmentKind::Context)?
+        .and_then(|attachment| match attachment.body {
+            StateAttachmentBody::Context(hash) => Some(hash),
+            _ => None,
+        }))
+}
+
+fn collect_file_context(
+    repo: &Repository,
+    state: &State,
+    paths: &[String],
+    include_unanchored: bool,
+) -> Result<Vec<FileContextEntry>> {
+    let Some(context_root) = context_root_for_state(repo, state)? else {
+        return Ok(Vec::new());
+    };
+
+    let paths = if include_unanchored && paths.is_empty() {
+        let mut listed = Vec::new();
+        for entry in repo.list_context_entries(&context_root, None)? {
+            if let ContextTarget::File { path } = entry.target {
+                listed.push(path);
+            }
+        }
+        listed
+    } else {
+        paths.to_vec()
+    };
+
+    let mut entries = Vec::new();
+    for path in paths {
+        let Ok(target) = ContextTarget::file(path.clone()) else {
+            continue;
+        };
+        let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
+            continue;
+        };
+        let annotations = active_snippets(&blob.annotations);
+        if !annotations.is_empty() {
+            entries.push(FileContextEntry { path, annotations });
+        }
+    }
+    Ok(entries)
+}
+
+fn collect_state_guidance(repo: &Repository, state: &State) -> Result<Vec<ContextSnippet>> {
+    let Some(context_root) = context_root_for_state(repo, state)? else {
+        return Ok(Vec::new());
+    };
+    let target = ContextTarget::state(state.state_id);
+    let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
+        return Ok(Vec::new());
+    };
+    Ok(active_snippets(&blob.annotations))
+}
+
+fn active_snippets(annotations: &[Annotation]) -> Vec<ContextSnippet> {
+    annotations
+        .iter()
+        .filter(|annotation| annotation.status == AnnotationStatus::Active)
+        .filter_map(|annotation| {
+            annotation
+                .current_revision()
+                .map(|revision| ContextSnippet {
+                    annotation_id: annotation.annotation_id.clone(),
+                    kind: revision.kind.to_string(),
+                    content: summarize_context(&revision.content),
+                    revision_count: annotation.revisions.len(),
+                })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use objects::object::{
+        Annotation, AnnotationKind, AnnotationScope, Attribution, ContextBlob, ContextTarget,
+        Principal, StateAttachment, StateAttachmentBody,
+    };
+    use repo::Repository;
+    use tempfile::TempDir;
+
+    use super::{attach_show_context, summarize_context};
+    use crate::diff::types::{DiffReport, FileChange};
+
+    fn annotate_state(repo: &Repository, path: &str, content: &str) -> objects::object::State {
+        std::fs::write(repo.root().join(path), "seed\n").expect("write seed file");
+        let state = repo
+            .snapshot(Some("seed".into()), None)
+            .expect("snapshot seed");
+        let target = ContextTarget::file(path).expect("file target");
+        let blob = ContextBlob::new(vec![Annotation::new(
+            AnnotationScope::File,
+            AnnotationKind::Invariant,
+            content.to_string(),
+            Vec::new(),
+            "test@example.com".to_string(),
+            1_700_000_000,
+            None,
+            Some(state.state_id),
+        )]);
+        let root = repo
+            .set_context_blob(None, &target, &blob)
+            .expect("store context blob");
+        repo.put_state_attachment(&StateAttachment {
+            state_id: state.state_id,
+            body: StateAttachmentBody::Context(root),
+            attribution: Attribution::human(Principal::new("test", "test@example.com")),
+            created_at: chrono::Utc::now(),
+            supersedes: None,
+        })
+        .expect("attach context");
+        state
+    }
+
+    fn report_with(paths: &[&str]) -> DiffReport {
+        let changes = paths
+            .iter()
+            .map(|path| FileChange {
+                path: (*path).to_string(),
+                kind: "modified".to_string(),
+                ..FileChange::default()
+            })
+            .collect();
+        DiffReport::new(Some("HEAD".to_string()), None, changes, None, None, None)
+    }
+
+    #[test]
+    fn context_set_attachment_rides_diff_for_changed_path() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        let state = annotate_state(&repo, "lib.rs", "must stay lowercase");
+        let mut report = report_with(&["lib.rs"]);
+
+        attach_show_context(&repo, &mut report, &state, false).expect("attach");
+
+        let context = report.context.expect("context field");
+        assert_eq!(context.len(), 1);
+        assert_eq!(context[0].path, "lib.rs");
+        assert_eq!(context[0].annotations.len(), 1);
+        assert_eq!(context[0].annotations[0].kind, "invariant");
+        assert_eq!(context[0].annotations[0].content, "must stay lowercase");
+    }
+
+    #[test]
+    fn context_set_attachment_rides_clean_diff_when_unanchored() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        let state = annotate_state(&repo, "lib.rs", "visible without a file change");
+        let mut report = report_with(&[]);
+
+        attach_show_context(&repo, &mut report, &state, true).expect("attach");
+
+        let context = report.context.expect("context field");
+        assert_eq!(context.len(), 1);
+        assert_eq!(context[0].path, "lib.rs");
+        assert_eq!(
+            context[0].annotations[0].content,
+            "visible without a file change"
+        );
+    }
+
+    #[test]
+    fn path_filter_does_not_dump_unrelated_annotations() {
+        let temp = TempDir::new().expect("tempdir");
+        let repo = Repository::init_default(temp.path()).expect("init");
+        let state = annotate_state(&repo, "lib.rs", "not this path");
+        let mut report = report_with(&[]);
+
+        attach_show_context(&repo, &mut report, &state, false).expect("attach");
+
+        assert!(
+            report
+                .context
+                .as_ref()
+                .is_none_or(|entries| entries.is_empty()),
+            "filtered empty change set must not list every annotation"
+        );
+    }
+
+    #[test]
+    fn summarize_context_truncates_on_char_boundary_not_byte_index() {
+        let first_line = format!("{}中中", "a".repeat(83));
+        assert!(first_line.len() > 88);
+        assert!(!first_line.is_char_boundary(85));
+        let summary = summarize_context(&format!("{first_line}\nsecond line"));
+        assert_eq!(summary, first_line);
+    }
+
+    #[test]
+    fn summarize_context_char_cap_truncates_multibyte_line() {
+        let first_line = format!("{}中中中", "a".repeat(86));
+        assert!(first_line.chars().count() > 88);
+        let summary = summarize_context(&first_line);
+        let expected = format!("{}...", "a".repeat(85));
+        assert_eq!(summary, expected);
+    }
+
+    #[test]
+    fn summarize_context_ascii_truncation_unchanged() {
+        let line = "b".repeat(90);
+        let summary = summarize_context(&line);
+        assert_eq!(summary, format!("{}...", "b".repeat(85)));
+    }
+}

--- a/crates/verbs/src/diff/mod.rs
+++ b/crates/verbs/src/diff/mod.rs
@@ -11,8 +11,8 @@ use merge::RenameCandidateIndex;
 use objects::{
     HeddleError, RecoveryDetails,
     object::{
-        AnnotationStatus, Blob, ContentHash, ContextTarget, DiffKind, EntryType, FileChangeSet,
-        FileMode, SemanticChange, State, StateId, Tree, TreeEntry,
+        Blob, ContentHash, DiffKind, EntryType, FileChangeSet, FileMode, SemanticChange, State,
+        StateId, Tree, TreeEntry,
     },
     store::ObjectStore,
     worktree::{WorktreeStatus, diff_blobs},
@@ -26,10 +26,12 @@ use sley::{EntryKind, Repository as SleyRepository};
 
 use crate::ExecutionContext;
 
+mod context;
 mod patch;
 mod path_filter;
 mod types;
 
+pub use context::{attach_show_context, worktree_context_state};
 pub use patch::{render_diff_patch, render_diff_patch_bytes, write_diff_patch};
 pub use types::*;
 
@@ -192,18 +194,16 @@ pub fn diff(ctx: &ExecutionContext, options: DiffOptions) -> Result<DiffReport> 
         options.to.clone(),
         file_changes,
         semantic_changes,
-        context_state
-            .as_ref()
-            .map(|state| collect_file_context(repo, state, &changes))
-            .transpose()?,
-        context_state
-            .as_ref()
-            .map(|state| collect_state_guidance(repo, state))
-            .transpose()?,
+        None,
+        None,
         stats,
     );
     output.worktree_mode = options.to.is_none();
-    finalize_diff_report(output, &options)
+    let mut output = finalize_diff_report(output, &options)?;
+    if let Some(state) = context_state.as_ref() {
+        attach_show_context(repo, &mut output, state, options.paths.is_empty())?;
+    }
+    Ok(output)
 }
 
 fn file_changes_from_change_set(
@@ -353,7 +353,14 @@ pub fn diff_worktree_status(
     };
     let mut output = DiffReport::new(Some("HEAD".to_string()), None, changes, None, None, None);
     output.worktree_mode = true;
-    finalize_diff_report(output, options)
+    let mut output = finalize_diff_report(output, options)?;
+    if options.show_context
+        && let Some(repo) = repo
+        && let Some(state) = worktree_context_state(repo)?
+    {
+        attach_show_context(repo, &mut output, &state, options.paths.is_empty())?;
+    }
+    Ok(output)
 }
 
 /// Compute a HEAD-vs-worktree report for a plain Git repository discovered by
@@ -1665,84 +1672,6 @@ fn hunk_span(lines: &[LineDiff], start: usize, end: usize) -> (usize, usize, usi
     (old_start, old_len, new_start, new_len)
 }
 
-fn collect_file_context(
-    repo: &Repository,
-    state: &State,
-    changes: &FileChangeSet,
-) -> Result<Vec<FileContextEntry>> {
-    let Some(context_root) = repo.inherit_parent_context(state)? else {
-        return Ok(Vec::new());
-    };
-
-    let mut entries = Vec::new();
-    for change in changes {
-        let target = ContextTarget::file(change.path.clone())?;
-        let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
-            continue;
-        };
-        let annotations = blob
-            .annotations
-            .iter()
-            .filter(|annotation| annotation.status == AnnotationStatus::Active)
-            .filter_map(|annotation| {
-                annotation
-                    .current_revision()
-                    .map(|revision| ContextSnippet {
-                        annotation_id: annotation.annotation_id.clone(),
-                        kind: revision.kind.to_string(),
-                        content: summarize_context(&revision.content),
-                        revision_count: annotation.revisions.len(),
-                    })
-            })
-            .collect::<Vec<_>>();
-        if !annotations.is_empty() {
-            entries.push(FileContextEntry {
-                path: change.path.clone(),
-                annotations,
-            });
-        }
-    }
-    Ok(entries)
-}
-
-fn collect_state_guidance(repo: &Repository, state: &State) -> Result<Vec<ContextSnippet>> {
-    let Some(context_root) = repo.inherit_parent_context(state)? else {
-        return Ok(Vec::new());
-    };
-    let target = ContextTarget::state(state.state_id);
-    let Some(blob) = repo.get_context_blob(&context_root, &target)? else {
-        return Ok(Vec::new());
-    };
-    Ok(blob
-        .annotations
-        .iter()
-        .filter(|annotation| annotation.status == AnnotationStatus::Active)
-        .filter_map(|annotation| {
-            annotation
-                .current_revision()
-                .map(|revision| ContextSnippet {
-                    annotation_id: annotation.annotation_id.clone(),
-                    kind: revision.kind.to_string(),
-                    content: summarize_context(&revision.content),
-                    revision_count: annotation.revisions.len(),
-                })
-        })
-        .collect())
-}
-
-fn summarize_context(content: &str) -> String {
-    let first_line = content
-        .lines()
-        .find(|line| !line.trim().is_empty())
-        .unwrap_or("");
-    let char_count = first_line.chars().count();
-    if char_count <= 88 {
-        first_line.to_string()
-    } else {
-        format!("{}...", first_line.chars().take(85).collect::<String>())
-    }
-}
-
 fn get_worktree_diff(
     repo: &Repository,
     from_tree: Option<&Tree>,
@@ -2624,7 +2553,7 @@ mod tests {
     use super::{
         DiffStats, FileChange, FileEolState, LineCounts, LineDiff, RENAME_SIMILARITY_THRESHOLD,
         RenameDetectionStats, change_line_counts, detect_clear_renames_with_stats, lcs_len,
-        prepare_rename_blob, rename_similarity, summarize_context, unified_hunks,
+        prepare_rename_blob, rename_similarity, unified_hunks,
     };
 
     type RenameSummary = Vec<(String, String, Option<String>, Option<f64>)>;
@@ -3007,35 +2936,6 @@ mod tests {
             Some("@ -1,2 +1,4 @@"),
             "display trim must not rewrite the `@@` header: {display:?}"
         );
-    }
-
-    /// Byte-index truncation at 85 panicked when a multi-byte code point straddled
-    /// that offset (HEDDLE-DR-7 / #879). Summaries must truncate on char boundaries.
-    #[test]
-    fn summarize_context_truncates_on_char_boundary_not_byte_index() {
-        let first_line = format!("{}中中", "a".repeat(83));
-        assert!(first_line.len() > 88);
-        assert!(!first_line.is_char_boundary(85));
-
-        let summary = summarize_context(&format!("{first_line}\nsecond line"));
-        assert_eq!(summary, first_line);
-    }
-
-    #[test]
-    fn summarize_context_char_cap_truncates_multibyte_line() {
-        let first_line = format!("{}中中中", "a".repeat(86));
-        assert!(first_line.chars().count() > 88);
-
-        let summary = summarize_context(&first_line);
-        let expected = format!("{}...", "a".repeat(85));
-        assert_eq!(summary, expected);
-    }
-
-    #[test]
-    fn summarize_context_ascii_truncation_unchanged() {
-        let line = "b".repeat(90);
-        let summary = summarize_context(&line);
-        assert_eq!(summary, format!("{}...", "b".repeat(85)));
     }
 
     /// Characterization: core::diff maps minimal-policy not-found failures to

--- a/crates/verbs/src/diff/mod.rs
+++ b/crates/verbs/src/diff/mod.rs
@@ -201,7 +201,7 @@ pub fn diff(ctx: &ExecutionContext, options: DiffOptions) -> Result<DiffReport> 
     output.worktree_mode = options.to.is_none();
     let mut output = finalize_diff_report(output, &options)?;
     if let Some(state) = context_state.as_ref() {
-        attach_show_context(repo, &mut output, state, options.paths.is_empty())?;
+        attach_show_context(repo, &mut output, state, &options.paths)?;
     }
     Ok(output)
 }
@@ -358,7 +358,7 @@ pub fn diff_worktree_status(
         && let Some(repo) = repo
         && let Some(state) = worktree_context_state(repo)?
     {
-        attach_show_context(repo, &mut output, &state, options.paths.is_empty())?;
+        attach_show_context(repo, &mut output, &state, &options.paths)?;
     }
     Ok(output)
 }

--- a/crates/verbs/src/lib.rs
+++ b/crates/verbs/src/lib.rs
@@ -270,11 +270,10 @@ pub use revert_plan::{
 pub use save::{
     CaptureAgentReport, CaptureAttribution, CaptureDiagnostics, CaptureOptions,
     CapturePrincipalReport, CaptureProfile, CaptureReport, CommitGitIndexPlan, GitScope, SavePlan,
-    SaveReport, SaveVerb, capture,
-    commit_next_action_from_trust, commit_scope_text, complete_current_thread_manual_resolution,
-    execute_save, plan_commit_git_index, plan_commit_git_index_only, plan_creates_new_state,
-    plan_git_scope, plan_writes_git_checkpoint, recover_published_git_checkpoint,
-    split_git_extra_paths, staged_commit_summary, tree_leaf_name,
+    SaveReport, SaveVerb, capture, commit_next_action_from_trust, commit_scope_text,
+    complete_current_thread_manual_resolution, execute_save, plan_commit_git_index,
+    plan_commit_git_index_only, plan_creates_new_state, plan_git_scope, plan_writes_git_checkpoint,
+    recover_published_git_checkpoint, split_git_extra_paths, staged_commit_summary, tree_leaf_name,
 };
 pub use semantic_plan::{
     HOT_EVENT_KIND_TOKENS, HotEventKindToken, hot_event_kind_label, human_event_kind,

--- a/crates/verbs/src/lib.rs
+++ b/crates/verbs/src/lib.rs
@@ -127,9 +127,10 @@ pub use contract::{
 pub use diff::{
     ContextSnippet, DiffOptions, DiffReport, DiffStats, FileChange, FileContextEntry, FileEolState,
     LineCounts, LineDiff, PlainGitDiffProbe, SemanticChangeEntry, SymlinkChange,
-    change_line_counts, compute_state_diff, compute_tree_diff, diff, diff_worktree_status,
-    plain_git_head_diff, render_diff_patch, render_diff_patch_bytes, should_render_modified_pair,
-    trim_added_decorations_for_display, write_diff_patch,
+    attach_show_context, change_line_counts, compute_state_diff, compute_tree_diff, diff,
+    diff_worktree_status, plain_git_head_diff, render_diff_patch, render_diff_patch_bytes,
+    should_render_modified_pair, trim_added_decorations_for_display, worktree_context_state,
+    write_diff_patch,
 };
 pub use fsck::{FsckError, FsckOptions, FsckRepair, FsckReport, fsck};
 pub use gc_plan::{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- After `heddle context set`, `heddle diff --context` shows the annotation on the existing `context` / `broader_guidance` fields.
- Git-overlay worktree diffs attach the live Context state-attachment — no second view RPC.
- Path-filtered clean diffs now look up the requested paths (and rename `old_path`). `diff --context -- lib.rs` rides; `diff --context -- other.rs` stays quiet.
- One attachment snapshot per report; listed blobs are reused instead of re-fetched.
- Review ride stays a follow-up; this PR does not touch #1069.

## Closes

Closes HeddleCo/heddle#1459

## Red commit
`4ed4b1eb`

## Test evidence
```
$ cargo test -p heddle-core --lib diff::context -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.55s
     Running unittests src/lib.rs (target/debug/deps/heddle_core-bc4e4de5b874ca71)

running 7 tests
test diff::context::tests::context_set_attachment_rides_diff_for_changed_path ... ok
test diff::context::tests::path_filter_does_not_dump_unrelated_annotations ... ok
test diff::context::tests::context_set_attachment_rides_clean_diff_when_unanchored ... ok
test diff::context::tests::summarize_context_ascii_truncation_unchanged ... ok
test diff::context::tests::summarize_context_char_cap_truncates_multibyte_line ... ok
test diff::context::tests::path_filter_on_clean_tree_looks_up_requested_paths ... ok
test diff::context::tests::summarize_context_truncates_on_char_boundary_not_byte_index ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 446 filtered out; finished in 0.05s

$ cargo test -p heddle-cli --test cli_integration -- context_rides -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 13.30s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 4 tests
test context_rides_diff::context_set_rides_path_filtered_clean_diff ... ok
test context_rides_diff::context_set_rides_native_worktree_diff ... ok
test context_rides_diff::context_set_rides_clean_native_diff ... ok
test context_rides_diff::context_set_rides_git_overlay_worktree_diff ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 958 filtered out; finished in 0.16s

$ cargo test -p heddle-core --lib diff::
test result: ok. 35 passed; 0 failed; 1 ignored; 0 measured; 417 filtered out; finished in 0.12s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-933eb7cf-798e-48cd-bca7-1153b2087f90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-933eb7cf-798e-48cd-bca7-1153b2087f90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782595&installation_model_id=21489&pr_number=1470&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1470&signature=b320dbe695ac8c748a6c04ec4f1cdfee1c4bcba3a7006ad6a04d0d29772a98a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->