### PR TITLE
Make Tree objects streamable and range-resumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ## Unreleased
 
+### Added
+
+- **Streamable HTR4 tree encoding.** Trees store uncompressed
+  length-prefixed frames so a reader can page entries and persist a
+  resume cursor without materializing the full directory. Object-store
+  backends hash on finish; ranged resume requires a hashed body, not a
+  hash-shaped path (heddle#1457).
+
+### Changed
+
+- **Durable trees are HTR4.** Loose, packed, ingest, and wire tree bodies
+  use the canonical encoding. Migration `0005_streamable_tree_encoding`
+  rewrites leftover msgpack trees on repo open (heddle#1457).
+
 ## 0.14.0 - 2026-08-21
 
 - Rebuilt the workspace on `heddle-api` 0.12 and

--- a/crates/ingest/src/importer.rs
+++ b/crates/ingest/src/importer.rs
@@ -802,13 +802,8 @@ impl<'a, B: ImportPackSink> PackedImport<'a, B> {
 
         let tree = Tree::from_entries(entries);
         let hash = tree.hash();
-        // `to_vec_named` (struct-as-map) matches objects's convention.
-        // Every reader in `store/fs/fs_impl.rs` and `store/mod.rs` calls
-        // `rmp_serde::from_slice` which defaults to struct-as-map; the
-        // earlier `to_vec` here produced struct-as-array bytes that
-        // round-tripped through the pack but failed deserialization with
-        // "invalid type: integer N, expected struct Tree".
-        let data = rmp_serde::to_vec_named(&tree)
+        let data = tree
+            .encode_canonical()
             .map_err(|e| IngestError::Other(format!("serialize tree for import pack: {e}")))?;
         if self.emit_objects {
             self.builder.add(hash, PackObjectType::Tree, data)?;

--- a/crates/object-model/src/error.rs
+++ b/crates/object-model/src/error.rs
@@ -3,7 +3,7 @@
 
 use std::{error::Error, fmt, io, path::Path};
 
-use crate::object::{ContentHash, StateId, TreeError};
+use crate::object::{ContentHash, StateId, TreeError, TreeStreamError};
 
 /// Structured recovery details that can cross the embeddable facade boundary.
 #[derive(Debug, Clone, PartialEq)]
@@ -258,6 +258,17 @@ pub enum HeddleError {
     MissingObject { object_type: String, id: String },
     #[error("invalid tree entry: {0}")]
     InvalidTreeEntry(#[from] TreeError),
+    #[error("tree stream error: {0}")]
+    TreeStream(TreeStreamError),
+}
+
+impl From<TreeStreamError> for HeddleError {
+    fn from(error: TreeStreamError) -> Self {
+        match error {
+            TreeStreamError::Invalid(error) => Self::InvalidTreeEntry(error),
+            other => Self::TreeStream(other),
+        }
+    }
 }
 
 impl HeddleError {

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -43,8 +43,11 @@ mod structured_conflict_tests;
 mod suggestion_core;
 mod timeline;
 mod tree;
+mod tree_canonical;
 mod tree_diff;
 mod tree_path;
+mod tree_source;
+mod tree_stream;
 pub mod tree_walk;
 mod visibility_tier;
 
@@ -149,6 +152,16 @@ pub use timeline::{
 pub use tree::{
     EntryType, FileMode, Tree, TreeDecodeError, TreeEntry, TreeEntryTarget, TreeError,
     validate_name as validate_tree_entry_name,
+};
+pub use tree_canonical::{
+    TREE_CANONICAL_MAGIC, TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header,
+    is_canonical_tree,
+};
+pub use tree_source::{
+    BytesTreeSource, FileTreeSource, OpenedTreeBody, TreeBodyIntegrity, TreeByteSource,
+};
+pub use tree_stream::{
+    TreeEntryReader, TreePage, TreePageLimits, TreeResumeCursor, TreeStreamError,
 };
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;

--- a/crates/object-model/src/object/mod.rs
+++ b/crates/object-model/src/object/mod.rs
@@ -157,12 +157,6 @@ pub use tree_canonical::{
     TREE_CANONICAL_MAGIC, TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_header,
     is_canonical_tree,
 };
-pub use tree_source::{
-    BytesTreeSource, FileTreeSource, OpenedTreeBody, TreeBodyIntegrity, TreeByteSource,
-};
-pub use tree_stream::{
-    TreeEntryReader, TreePage, TreePageLimits, TreeResumeCursor, TreeStreamError,
-};
 #[cfg(feature = "async-source")]
 pub use tree_diff::diff_trees_visit_async;
 pub use tree_diff::{diff_trees, diff_trees_visit};
@@ -170,6 +164,12 @@ pub use tree_diff::{diff_trees, diff_trees_visit};
 pub use tree_path::resolve_tree_path_async;
 pub use tree_path::{
     LeafPolicy, ResolvedTreeTarget, TreePathResolveError, resolve_tree_path, split_path,
+};
+pub use tree_source::{
+    BytesTreeSource, FileTreeSource, OpenedTreeBody, TreeBodyIntegrity, TreeByteSource,
+};
+pub use tree_stream::{
+    TreeEntryReader, TreePage, TreePageLimits, TreeResumeCursor, TreeStreamError,
 };
 pub use tree_walk::{TreeIntegrityEvent, walk_tree_integrity};
 pub use audience_tier::{AudienceParseError, AudienceTier, visible};

--- a/crates/object-model/src/object/tree.rs
+++ b/crates/object-model/src/object/tree.rs
@@ -259,6 +259,11 @@ pub fn validate_name(name: &str) -> Result<(), TreeError> {
             "entry name contains control characters".into(),
         ));
     }
+    if name.len() > u16::MAX as usize {
+        return Err(TreeError::InvalidName(
+            "entry name exceeds the HTR4 u16 length bound".into(),
+        ));
+    }
     Ok(())
 }
 

--- a/crates/object-model/src/object/tree.rs
+++ b/crates/object-model/src/object/tree.rs
@@ -449,6 +449,11 @@ impl TreeEntry {
         1 + 1 + self.target.encoded_payload_len() + self.name.len() + 1
     }
 
+    /// Owned name-plus-target bytes used by streaming page budgets.
+    pub fn decoded_size(&self) -> usize {
+        self.name.len() + self.target.encoded_payload_len()
+    }
+
     pub(crate) fn update_hasher(&self, hasher: &mut blake3::Hasher) {
         self.target.update_hasher(hasher);
         hasher.update(self.name.as_bytes());
@@ -473,6 +478,17 @@ impl Tree {
     pub fn from_entries(mut entries: Vec<TreeEntry>) -> Self {
         entries.sort_by(|a, b| a.name.cmp(&b.name));
         Self { entries }
+    }
+
+    /// Build a tree from entries that are already in canonical name order.
+    ///
+    /// Unlike [`Self::from_entries`], this does not sort. Decoders use it so
+    /// eager and streaming paths reject the same out-of-order or duplicate
+    /// encodings instead of silently canonicalizing them.
+    pub fn try_from_decoded_entries(entries: Vec<TreeEntry>) -> Result<Self, TreeError> {
+        let tree = Self { entries };
+        tree.validate()?;
+        Ok(tree)
     }
 
     pub fn validate(&self) -> Result<(), TreeError> {
@@ -691,9 +707,7 @@ impl TryFrom<EncodedTreeV2> for Tree {
         for entry in encoded.entries {
             entries.push(TreeEntry::try_from(entry)?);
         }
-        let tree = Tree::from_entries(entries);
-        tree.validate()?;
-        Ok(tree)
+        Tree::try_from_decoded_entries(entries)
     }
 }
 
@@ -760,14 +774,14 @@ fn required_git_format(format: Option<u8>, kind: u8) -> Result<u8, TreeError> {
     })
 }
 
-fn git_format_to_tag(format: GitObjectFormat) -> u8 {
+pub(crate) fn git_format_to_tag(format: GitObjectFormat) -> u8 {
     match format {
         GitObjectFormat::Sha1 => GIT_OBJECT_FORMAT_SHA1,
         GitObjectFormat::Sha256 => GIT_OBJECT_FORMAT_SHA256,
     }
 }
 
-fn git_format_from_tag(tag: u8) -> Result<GitObjectFormat, TreeError> {
+pub(crate) fn git_format_from_tag(tag: u8) -> Result<GitObjectFormat, TreeError> {
     match tag {
         GIT_OBJECT_FORMAT_SHA1 => Ok(GitObjectFormat::Sha1),
         GIT_OBJECT_FORMAT_SHA256 => Ok(GitObjectFormat::Sha256),

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -184,12 +184,11 @@ pub(crate) fn decode_entry_at(
             .map_err(|_| TreeStreamError::Malformed("frame length slice is not 4 bytes".into()))?,
     ) as usize;
     let frame_start = offset + 4;
-    let frame_end =
-        frame_start
-            .checked_add(frame_len)
-            .ok_or_else(|| TreeStreamError::TruncatedFrame {
-                offset: offset as u64,
-            })?;
+    let frame_end = frame_start
+        .checked_add(frame_len)
+        .ok_or(TreeStreamError::TruncatedFrame {
+            offset: offset as u64,
+        })?;
     if frame_end > payload_end {
         return Err(TreeStreamError::TruncatedFrame {
             offset: offset as u64,

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -10,9 +10,7 @@ use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
 
 use super::tree::{git_format_from_tag, git_format_to_tag};
 use super::tree_stream::TreeStreamError;
-use super::{
-    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
-};
+use super::{ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError};
 
 /// Durable encoding version stored in every HTR4 header and resume cursor.
 pub const TREE_ENCODING_VERSION: u8 = 4;
@@ -49,10 +47,7 @@ impl Tree {
                 .ok_or_else(|| TreeStreamError::Malformed("logical length overflow".into()))?;
             let frame = encode_entry_frame(entry)?;
             let frame_len = u32::try_from(frame.len()).map_err(|_| {
-                TreeStreamError::Malformed(format!(
-                    "entry '{}' frame exceeds u32",
-                    entry.name()
-                ))
+                TreeStreamError::Malformed(format!("entry '{}' frame exceeds u32", entry.name()))
             })?;
             payload.extend_from_slice(&frame_len.to_le_bytes());
             payload.extend_from_slice(&frame);
@@ -72,9 +67,14 @@ impl Tree {
     pub fn decode_canonical(data: &[u8]) -> Result<Self, TreeStreamError> {
         let header = decode_header(data)?;
         let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
-        if data.len() as u64 != expected_len {
+        if (data.len() as u64) < expected_len {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: data.len() as u64,
+            });
+        }
+        if (data.len() as u64) > expected_len {
             return Err(TreeStreamError::TrailingBytes {
-                extra: (data.len() as u64).saturating_sub(expected_len),
+                extra: data.len() as u64 - expected_len,
             });
         }
         let mut entries = Vec::new();
@@ -127,18 +127,24 @@ pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
     if version != TREE_ENCODING_VERSION {
         return Err(TreeStreamError::UnsupportedVersion { found: version });
     }
-    let tree_id = ContentHash::from_bytes(data[5..37].try_into().map_err(|_| {
-        TreeStreamError::Malformed("tree id slice is not 32 bytes".into())
-    })?);
-    let entry_count = u64::from_le_bytes(data[37..45].try_into().map_err(|_| {
-        TreeStreamError::Malformed("entry count slice is not 8 bytes".into())
-    })?);
-    let payload_len = u64::from_le_bytes(data[45..53].try_into().map_err(|_| {
-        TreeStreamError::Malformed("payload length slice is not 8 bytes".into())
-    })?);
-    let logical_len = u64::from_le_bytes(data[53..61].try_into().map_err(|_| {
-        TreeStreamError::Malformed("logical length slice is not 8 bytes".into())
-    })?);
+    let tree_id = ContentHash::from_bytes(
+        data[5..37]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("tree id slice is not 32 bytes".into()))?,
+    );
+    let entry_count = u64::from_le_bytes(
+        data[37..45]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("entry count slice is not 8 bytes".into()))?,
+    );
+    let payload_len =
+        u64::from_le_bytes(data[45..53].try_into().map_err(|_| {
+            TreeStreamError::Malformed("payload length slice is not 8 bytes".into())
+        })?);
+    let logical_len =
+        u64::from_le_bytes(data[53..61].try_into().map_err(|_| {
+            TreeStreamError::Malformed("logical length slice is not 8 bytes".into())
+        })?);
     Ok(TreeHeader {
         version,
         tree_id,
@@ -172,15 +178,18 @@ pub(crate) fn decode_entry_at(
             offset: offset as u64,
         });
     }
-    let frame_len = u32::from_le_bytes(data[offset..offset + 4].try_into().map_err(|_| {
-        TreeStreamError::Malformed("frame length slice is not 4 bytes".into())
-    })?) as usize;
+    let frame_len = u32::from_le_bytes(
+        data[offset..offset + 4]
+            .try_into()
+            .map_err(|_| TreeStreamError::Malformed("frame length slice is not 4 bytes".into()))?,
+    ) as usize;
     let frame_start = offset + 4;
-    let frame_end = frame_start
-        .checked_add(frame_len)
-        .ok_or_else(|| TreeStreamError::TruncatedFrame {
-            offset: offset as u64,
-        })?;
+    let frame_end =
+        frame_start
+            .checked_add(frame_len)
+            .ok_or_else(|| TreeStreamError::TruncatedFrame {
+                offset: offset as u64,
+            })?;
     if frame_end > payload_end {
         return Err(TreeStreamError::TruncatedFrame {
             offset: offset as u64,
@@ -235,9 +244,8 @@ fn encode_target(frame: &mut Vec<u8>, entry: &TreeEntry) -> Result<(), TreeStrea
                 TreeStreamError::Malformed("spoollink entry is missing target".into())
             })?;
             let spool_bytes = spool.as_str().as_bytes();
-            let spool_len = u16::try_from(spool_bytes.len()).map_err(|_| {
-                TreeStreamError::Malformed("spool id exceeds u16".into())
-            })?;
+            let spool_len = u16::try_from(spool_bytes.len())
+                .map_err(|_| TreeStreamError::Malformed("spool id exceeds u16".into()))?;
             frame.extend_from_slice(&spool_len.to_le_bytes());
             frame.extend_from_slice(spool_bytes);
             frame.extend_from_slice(state.as_bytes());
@@ -267,9 +275,9 @@ fn decode_target(
 }
 
 fn take_hash(payload: &[u8]) -> Result<ContentHash, TreeStreamError> {
-    let bytes: [u8; 32] = payload.try_into().map_err(|_| {
-        TreeStreamError::Malformed("malformed tree entry object id".into())
-    })?;
+    let bytes: [u8; 32] = payload
+        .try_into()
+        .map_err(|_| TreeStreamError::Malformed("malformed tree entry object id".into()))?;
     Ok(ContentHash::from_bytes(bytes))
 }
 
@@ -311,8 +319,9 @@ fn decode_spoollink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStrea
         .map_err(|_| TreeStreamError::Malformed("spool id is not UTF-8".into()))?;
     let spool_id = SpoolId::parse(spool)
         .map_err(|err| TreeStreamError::Malformed(format!("invalid spool id: {err}")))?;
-    let state = StateId::from_bytes(payload[spool_end..state_end].try_into().map_err(|_| {
-        TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
-    })?);
+    let state =
+        StateId::from_bytes(payload[spool_end..state_end].try_into().map_err(|_| {
+            TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
+        })?);
     TreeEntry::spoollink(name, spool_id, state).map_err(TreeStreamError::from)
 }

--- a/crates/object-model/src/object/tree_canonical.rs
+++ b/crates/object-model/src/object/tree_canonical.rs
@@ -1,0 +1,318 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Streamable canonical Tree encoding (HTR4).
+//!
+//! Each entry is a length-prefixed frame, so a reader can yield one entry or
+//! a caller-sized page and resume at a byte offset without decoding the prefix.
+//! Whole-object compression is not part of this encoding: a resume cursor must
+//! be able to seek without decompressing earlier frames.
+
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+
+use super::tree::{git_format_from_tag, git_format_to_tag};
+use super::tree_stream::TreeStreamError;
+use super::{
+    ContentHash, EntryType, FileMode, SpoolId, StateId, Tree, TreeEntry, TreeError,
+};
+
+/// Durable encoding version stored in every HTR4 header and resume cursor.
+pub const TREE_ENCODING_VERSION: u8 = 4;
+/// Frame discriminator for a single canonical tree.
+pub const TREE_CANONICAL_MAGIC: &[u8; 4] = b"HTR4";
+/// Fixed header size: magic + version + tree id + counts.
+pub const TREE_HEADER_LEN: usize = 4 + 1 + 32 + 8 + 8 + 8;
+
+/// Parsed HTR4 header. Counts and payload length are known before any entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreeHeader {
+    pub version: u8,
+    pub tree_id: ContentHash,
+    pub entry_count: u64,
+    pub payload_len: u64,
+    pub logical_len: u64,
+}
+
+/// True when `bytes` begin with the canonical tree discriminator.
+pub fn is_canonical_tree(bytes: &[u8]) -> bool {
+    bytes.starts_with(TREE_CANONICAL_MAGIC)
+}
+
+impl Tree {
+    /// Encode this tree as uncompressed HTR4.
+    pub fn encode_canonical(&self) -> Result<Vec<u8>, TreeStreamError> {
+        self.validate()?;
+        let tree_id = self.hash();
+        let mut payload = Vec::new();
+        let mut logical_len = 0u64;
+        for entry in self.entries() {
+            logical_len = logical_len
+                .checked_add(entry.encoded_len() as u64)
+                .ok_or_else(|| TreeStreamError::Malformed("logical length overflow".into()))?;
+            let frame = encode_entry_frame(entry)?;
+            let frame_len = u32::try_from(frame.len()).map_err(|_| {
+                TreeStreamError::Malformed(format!(
+                    "entry '{}' frame exceeds u32",
+                    entry.name()
+                ))
+            })?;
+            payload.extend_from_slice(&frame_len.to_le_bytes());
+            payload.extend_from_slice(&frame);
+        }
+        let mut out = Vec::with_capacity(TREE_HEADER_LEN + payload.len());
+        out.extend_from_slice(TREE_CANONICAL_MAGIC);
+        out.push(TREE_ENCODING_VERSION);
+        out.extend_from_slice(tree_id.as_bytes());
+        out.extend_from_slice(&(self.len() as u64).to_le_bytes());
+        out.extend_from_slice(&(payload.len() as u64).to_le_bytes());
+        out.extend_from_slice(&logical_len.to_le_bytes());
+        out.extend_from_slice(&payload);
+        Ok(out)
+    }
+
+    /// Decode a complete HTR4 body, validating order incrementally.
+    pub fn decode_canonical(data: &[u8]) -> Result<Self, TreeStreamError> {
+        let header = decode_header(data)?;
+        let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
+        if data.len() as u64 != expected_len {
+            return Err(TreeStreamError::TrailingBytes {
+                extra: (data.len() as u64).saturating_sub(expected_len),
+            });
+        }
+        let mut entries = Vec::new();
+        let mut offset = TREE_HEADER_LEN;
+        let payload_end = data.len();
+        for _ in 0..header.entry_count {
+            let (entry, consumed) = decode_entry_at(data, offset, payload_end)?;
+            entries.push(entry);
+            offset += consumed;
+        }
+        if offset != payload_end {
+            return Err(TreeStreamError::TrailingBytes {
+                extra: (payload_end - offset) as u64,
+            });
+        }
+        let tree = Tree::try_from_decoded_entries(entries)?;
+        let found = tree.hash();
+        if found != header.tree_id {
+            return Err(TreeStreamError::HashMismatch {
+                expected: header.tree_id,
+                found,
+            });
+        }
+        if tree
+            .entries()
+            .iter()
+            .map(|entry| entry.encoded_len() as u64)
+            .sum::<u64>()
+            != header.logical_len
+        {
+            return Err(TreeStreamError::Malformed(
+                "declared logical length does not match entries".into(),
+            ));
+        }
+        Ok(tree)
+    }
+}
+
+/// Parse the fixed HTR4 header. Does not read entry frames.
+pub fn decode_header(data: &[u8]) -> Result<TreeHeader, TreeStreamError> {
+    if data.len() < TREE_HEADER_LEN {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    if !is_canonical_tree(data) {
+        return Err(TreeStreamError::Malformed(
+            "bytes are not a canonical HTR4 tree".into(),
+        ));
+    }
+    let version = data[4];
+    if version != TREE_ENCODING_VERSION {
+        return Err(TreeStreamError::UnsupportedVersion { found: version });
+    }
+    let tree_id = ContentHash::from_bytes(data[5..37].try_into().map_err(|_| {
+        TreeStreamError::Malformed("tree id slice is not 32 bytes".into())
+    })?);
+    let entry_count = u64::from_le_bytes(data[37..45].try_into().map_err(|_| {
+        TreeStreamError::Malformed("entry count slice is not 8 bytes".into())
+    })?);
+    let payload_len = u64::from_le_bytes(data[45..53].try_into().map_err(|_| {
+        TreeStreamError::Malformed("payload length slice is not 8 bytes".into())
+    })?);
+    let logical_len = u64::from_le_bytes(data[53..61].try_into().map_err(|_| {
+        TreeStreamError::Malformed("logical length slice is not 8 bytes".into())
+    })?);
+    Ok(TreeHeader {
+        version,
+        tree_id,
+        entry_count,
+        payload_len,
+        logical_len,
+    })
+}
+
+pub(crate) fn encode_entry_frame(entry: &TreeEntry) -> Result<Vec<u8>, TreeStreamError> {
+    let name = entry.name().as_bytes();
+    let name_len = u16::try_from(name.len()).map_err(|_| {
+        TreeStreamError::Malformed(format!("entry name '{}' exceeds u16", entry.name()))
+    })?;
+    let mut frame = Vec::new();
+    frame.push(entry.mode().to_byte());
+    frame.push(entry.entry_type().to_byte());
+    frame.extend_from_slice(&name_len.to_le_bytes());
+    frame.extend_from_slice(name);
+    encode_target(&mut frame, entry)?;
+    Ok(frame)
+}
+
+pub(crate) fn decode_entry_at(
+    data: &[u8],
+    offset: usize,
+    payload_end: usize,
+) -> Result<(TreeEntry, usize), TreeStreamError> {
+    if offset + 4 > payload_end {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: offset as u64,
+        });
+    }
+    let frame_len = u32::from_le_bytes(data[offset..offset + 4].try_into().map_err(|_| {
+        TreeStreamError::Malformed("frame length slice is not 4 bytes".into())
+    })?) as usize;
+    let frame_start = offset + 4;
+    let frame_end = frame_start
+        .checked_add(frame_len)
+        .ok_or_else(|| TreeStreamError::TruncatedFrame {
+            offset: offset as u64,
+        })?;
+    if frame_end > payload_end {
+        return Err(TreeStreamError::TruncatedFrame {
+            offset: offset as u64,
+        });
+    }
+    let entry = decode_entry_frame(&data[frame_start..frame_end])?;
+    Ok((entry, 4 + frame_len))
+}
+
+pub(crate) fn decode_entry_frame(frame: &[u8]) -> Result<TreeEntry, TreeStreamError> {
+    if frame.len() < 4 {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    let mode = FileMode::from_byte(frame[0]).ok_or_else(|| {
+        TreeStreamError::Malformed(format!("malformed tree entry mode {}", frame[0]))
+    })?;
+    let kind = EntryType::from_byte(frame[1]).ok_or_else(|| {
+        TreeStreamError::Malformed(format!("malformed tree entry kind {}", frame[1]))
+    })?;
+    let name_len = u16::from_le_bytes([frame[2], frame[3]]) as usize;
+    let name_end = 4 + name_len;
+    if frame.len() < name_end {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    let name = std::str::from_utf8(&frame[4..name_end])
+        .map_err(|_| TreeStreamError::Malformed("tree entry name is not UTF-8".into()))?
+        .to_string();
+    let entry = decode_target(name, kind, mode, &frame[name_end..])?;
+    if entry.mode() != mode {
+        return Err(TreeStreamError::Malformed(format!(
+            "tree kind/mode mismatch for {}: {kind:?}/{mode:?}",
+            entry.name()
+        )));
+    }
+    Ok(entry)
+}
+
+fn encode_target(frame: &mut Vec<u8>, entry: &TreeEntry) -> Result<(), TreeStreamError> {
+    match entry.entry_type() {
+        EntryType::Blob | EntryType::Tree | EntryType::Symlink => {
+            frame.extend_from_slice(entry.require_content_hash().as_bytes());
+        }
+        EntryType::Gitlink => {
+            let target = entry.gitlink_target().ok_or_else(|| {
+                TreeStreamError::Malformed("gitlink entry is missing target".into())
+            })?;
+            frame.push(git_format_to_tag(target.format()));
+            frame.extend_from_slice(target.as_bytes());
+        }
+        EntryType::Spoollink => {
+            let (spool, state) = entry.spoollink_target().ok_or_else(|| {
+                TreeStreamError::Malformed("spoollink entry is missing target".into())
+            })?;
+            let spool_bytes = spool.as_str().as_bytes();
+            let spool_len = u16::try_from(spool_bytes.len()).map_err(|_| {
+                TreeStreamError::Malformed("spool id exceeds u16".into())
+            })?;
+            frame.extend_from_slice(&spool_len.to_le_bytes());
+            frame.extend_from_slice(spool_bytes);
+            frame.extend_from_slice(state.as_bytes());
+        }
+    }
+    Ok(())
+}
+
+fn decode_target(
+    name: String,
+    kind: EntryType,
+    mode: FileMode,
+    payload: &[u8],
+) -> Result<TreeEntry, TreeStreamError> {
+    match kind {
+        EntryType::Blob => TreeEntry::file(name, take_hash(payload)?, mode == FileMode::Executable)
+            .map_err(TreeStreamError::from),
+        EntryType::Tree => {
+            TreeEntry::directory(name, take_hash(payload)?).map_err(TreeStreamError::from)
+        }
+        EntryType::Symlink => {
+            TreeEntry::symlink(name, take_hash(payload)?).map_err(TreeStreamError::from)
+        }
+        EntryType::Gitlink => decode_gitlink(name, payload),
+        EntryType::Spoollink => decode_spoollink(name, payload),
+    }
+}
+
+fn take_hash(payload: &[u8]) -> Result<ContentHash, TreeStreamError> {
+    let bytes: [u8; 32] = payload.try_into().map_err(|_| {
+        TreeStreamError::Malformed("malformed tree entry object id".into())
+    })?;
+    Ok(ContentHash::from_bytes(bytes))
+}
+
+fn decode_gitlink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStreamError> {
+    if payload.is_empty() {
+        return Err(TreeStreamError::Malformed(
+            "malformed tree entry object id".into(),
+        ));
+    }
+    let format = git_format_from_tag(payload[0])?;
+    let oid = &payload[1..];
+    let expected = match format {
+        GitObjectFormat::Sha1 => 20,
+        GitObjectFormat::Sha256 => 32,
+    };
+    if oid.len() != expected {
+        return Err(TreeStreamError::Malformed(
+            "malformed tree entry object id".into(),
+        ));
+    }
+    let target = GitObjectId::from_raw(format, oid)
+        .map_err(|err| TreeError::InvalidStructure(format!("invalid gitlink target: {err}")))?;
+    TreeEntry::gitlink(name, target).map_err(TreeStreamError::from)
+}
+
+fn decode_spoollink(name: String, payload: &[u8]) -> Result<TreeEntry, TreeStreamError> {
+    if payload.len() < 2 {
+        return Err(TreeStreamError::TruncatedFrame { offset: 0 });
+    }
+    let spool_len = u16::from_le_bytes([payload[0], payload[1]]) as usize;
+    let spool_end = 2 + spool_len;
+    let state_end = spool_end + 32;
+    if payload.len() != state_end {
+        return Err(TreeStreamError::Malformed(
+            "malformed tree entry object id".into(),
+        ));
+    }
+    let spool = std::str::from_utf8(&payload[2..spool_end])
+        .map_err(|_| TreeStreamError::Malformed("spool id is not UTF-8".into()))?;
+    let spool_id = SpoolId::parse(spool)
+        .map_err(|err| TreeStreamError::Malformed(format!("invalid spool id: {err}")))?;
+    let state = StateId::from_bytes(payload[spool_end..state_end].try_into().map_err(|_| {
+        TreeStreamError::Malformed("spoollink state id is not 32 bytes".into())
+    })?);
+    TreeEntry::spoollink(name, spool_id, state).map_err(TreeStreamError::from)
+}

--- a/crates/object-model/src/object/tree_source.rs
+++ b/crates/object-model/src/object/tree_source.rs
@@ -64,8 +64,8 @@ impl BytesTreeSource {
 
 impl TreeByteSource for BytesTreeSource {
     fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
-        let start = usize::try_from(offset)
-            .map_err(|_| TreeStreamError::TruncatedFrame { offset })?;
+        let start =
+            usize::try_from(offset).map_err(|_| TreeStreamError::TruncatedFrame { offset })?;
         let end = start
             .checked_add(buf.len())
             .ok_or(TreeStreamError::TruncatedFrame { offset })?;

--- a/crates/object-model/src/object/tree_source.rs
+++ b/crates/object-model/src/object/tree_source.rs
@@ -12,15 +12,13 @@ use super::tree_stream::TreeStreamError;
 
 /// How a tree body may be trusted for content-address verification.
 ///
-/// Sequential reads from offset 0 can recompute the typed tree hash. Ranged
-/// resume skips the prefix, so it is allowed only for uncompressed loose HTR4
-/// files stored at the content-hash path. That hash-path placement is the
-/// documented verified-placement invariant: the filename is the tree id the
-/// bytes claim to be. Memory copies, pack extracts, and re-encoded bodies
-/// stay on [`Self::SequentialVerify`]. Silent weaker validation is not allowed.
+/// Sequential reads from offset 0 recompute the typed tree hash. Ranged
+/// resume skips the prefix and is allowed only after the caller has hashed
+/// these exact bytes. A hash-shaped path or an embedded tree id is not that
+/// proof. Object-store backends use [`Self::SequentialVerify`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TreeBodyIntegrity {
-    /// Loose uncompressed HTR4 at the content-hash path.
+    /// Caller hashed these exact bytes; prefix skip is allowed.
     VerifiedPlacement,
     /// The reader must start at entry 0 and call `finish_and_verify`.
     SequentialVerify,
@@ -93,8 +91,8 @@ impl TreeByteSource for BytesTreeSource {
     }
 }
 
-/// File-backed tree body. Resume seeks to the cursor offset; the prefix is
-/// not read.
+/// File-backed tree body. Sequential reads seek per frame; resume at
+/// ordinal > 0 is refused because a path is not a content-address proof.
 #[derive(Debug)]
 pub struct FileTreeSource {
     file: File,
@@ -104,11 +102,11 @@ pub struct FileTreeSource {
 }
 
 impl FileTreeSource {
-    pub fn verified_placement(file: File, len: u64) -> Self {
+    pub fn sequential_verify(file: File, len: u64) -> Self {
         Self {
             file,
             len,
-            integrity: TreeBodyIntegrity::VerifiedPlacement,
+            integrity: TreeBodyIntegrity::SequentialVerify,
             bytes_read: 0,
         }
     }

--- a/crates/object-model/src/object/tree_source.rs
+++ b/crates/object-model/src/object/tree_source.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Byte sources for streamable Tree reads.
+
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+};
+
+use bytes::Bytes;
+
+use super::tree_stream::TreeStreamError;
+
+/// How a tree body may be trusted for content-address verification.
+///
+/// Sequential reads from offset 0 can recompute the typed tree hash. Ranged
+/// resume skips the prefix, so it is allowed only when the store already bound
+/// these bytes to the tree id (hash-path placement, a verified pack index, or
+/// an equivalent documented invariant). Silent weaker validation is not allowed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TreeBodyIntegrity {
+    /// Bytes are already bound to the tree content id by the object source.
+    VerifiedPlacement,
+    /// The reader must start at entry 0 and call `finish_and_verify`.
+    SequentialVerify,
+}
+
+/// Random-access source of an uncompressed canonical tree body.
+pub trait TreeByteSource {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError>;
+    fn len(&self) -> u64;
+    fn integrity(&self) -> TreeBodyIntegrity;
+    fn bytes_read(&self) -> u64;
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// In-memory tree body, used by tests and stores that already hold the bytes.
+#[derive(Debug)]
+pub struct BytesTreeSource {
+    bytes: Bytes,
+    integrity: TreeBodyIntegrity,
+    bytes_read: u64,
+}
+
+impl BytesTreeSource {
+    pub fn verified_placement(bytes: impl Into<Bytes>) -> Self {
+        Self {
+            bytes: bytes.into(),
+            integrity: TreeBodyIntegrity::VerifiedPlacement,
+            bytes_read: 0,
+        }
+    }
+
+    pub fn sequential_verify(bytes: impl Into<Bytes>) -> Self {
+        Self {
+            bytes: bytes.into(),
+            integrity: TreeBodyIntegrity::SequentialVerify,
+            bytes_read: 0,
+        }
+    }
+}
+
+impl TreeByteSource for BytesTreeSource {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        let start = usize::try_from(offset)
+            .map_err(|_| TreeStreamError::TruncatedFrame { offset })?;
+        let end = start
+            .checked_add(buf.len())
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        let slice = self
+            .bytes
+            .get(start..end)
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        buf.copy_from_slice(slice);
+        self.bytes_read += buf.len() as u64;
+        Ok(())
+    }
+
+    fn len(&self) -> u64 {
+        self.bytes.len() as u64
+    }
+
+    fn integrity(&self) -> TreeBodyIntegrity {
+        self.integrity
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.bytes_read
+    }
+}
+
+/// File-backed tree body. Resume seeks to the cursor offset; the prefix is
+/// not read.
+#[derive(Debug)]
+pub struct FileTreeSource {
+    file: File,
+    len: u64,
+    integrity: TreeBodyIntegrity,
+    bytes_read: u64,
+}
+
+impl FileTreeSource {
+    pub fn verified_placement(file: File, len: u64) -> Self {
+        Self {
+            file,
+            len,
+            integrity: TreeBodyIntegrity::VerifiedPlacement,
+            bytes_read: 0,
+        }
+    }
+}
+
+impl TreeByteSource for FileTreeSource {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        if offset
+            .checked_add(buf.len() as u64)
+            .is_none_or(|end| end > self.len)
+        {
+            return Err(TreeStreamError::TruncatedFrame { offset });
+        }
+        self.file.seek(SeekFrom::Start(offset))?;
+        self.file.read_exact(buf)?;
+        self.bytes_read += buf.len() as u64;
+        Ok(())
+    }
+
+    fn len(&self) -> u64 {
+        self.len
+    }
+
+    fn integrity(&self) -> TreeBodyIntegrity {
+        self.integrity
+    }
+
+    fn bytes_read(&self) -> u64 {
+        self.bytes_read
+    }
+}
+
+/// Store-facing handle: either in-memory bytes or a seekable loose file.
+#[derive(Debug)]
+pub enum OpenedTreeBody {
+    Bytes(BytesTreeSource),
+    File(FileTreeSource),
+}
+
+impl TreeByteSource for OpenedTreeBody {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        match self {
+            Self::Bytes(source) => source.read_exact_at(offset, buf),
+            Self::File(source) => source.read_exact_at(offset, buf),
+        }
+    }
+
+    fn len(&self) -> u64 {
+        match self {
+            Self::Bytes(source) => source.len(),
+            Self::File(source) => source.len(),
+        }
+    }
+
+    fn integrity(&self) -> TreeBodyIntegrity {
+        match self {
+            Self::Bytes(source) => source.integrity(),
+            Self::File(source) => source.integrity(),
+        }
+    }
+
+    fn bytes_read(&self) -> u64 {
+        match self {
+            Self::Bytes(source) => source.bytes_read(),
+            Self::File(source) => source.bytes_read(),
+        }
+    }
+}

--- a/crates/object-model/src/object/tree_source.rs
+++ b/crates/object-model/src/object/tree_source.rs
@@ -13,12 +13,14 @@ use super::tree_stream::TreeStreamError;
 /// How a tree body may be trusted for content-address verification.
 ///
 /// Sequential reads from offset 0 can recompute the typed tree hash. Ranged
-/// resume skips the prefix, so it is allowed only when the store already bound
-/// these bytes to the tree id (hash-path placement, a verified pack index, or
-/// an equivalent documented invariant). Silent weaker validation is not allowed.
+/// resume skips the prefix, so it is allowed only for uncompressed loose HTR4
+/// files stored at the content-hash path. That hash-path placement is the
+/// documented verified-placement invariant: the filename is the tree id the
+/// bytes claim to be. Memory copies, pack extracts, and re-encoded bodies
+/// stay on [`Self::SequentialVerify`]. Silent weaker validation is not allowed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TreeBodyIntegrity {
-    /// Bytes are already bound to the tree content id by the object source.
+    /// Loose uncompressed HTR4 at the content-hash path.
     VerifiedPlacement,
     /// The reader must start at entry 0 and call `finish_and_verify`.
     SequentialVerify,

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -49,10 +49,12 @@ pub enum TreeStreamError {
 }
 
 /// Caller-sized page budget. Zero limits fail closed.
+///
+/// Fields stay private so callers cannot bypass [`Self::new`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TreePageLimits {
-    pub max_entries: usize,
-    pub max_decoded_bytes: usize,
+    max_entries: usize,
+    max_decoded_bytes: usize,
 }
 
 impl TreePageLimits {
@@ -64,6 +66,14 @@ impl TreePageLimits {
             max_entries,
             max_decoded_bytes,
         })
+    }
+
+    pub fn max_entries(&self) -> usize {
+        self.max_entries
+    }
+
+    pub fn max_decoded_bytes(&self) -> usize {
+        self.max_decoded_bytes
     }
 }
 
@@ -186,21 +196,26 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         &mut self,
         limits: TreePageLimits,
     ) -> Result<Option<TreePage>, TreeStreamError> {
+        if limits.max_entries() == 0 || limits.max_decoded_bytes() == 0 {
+            return Err(TreeStreamError::InvalidPageLimits);
+        }
         if self.cursor.ordinal == self.header.entry_count {
             return Ok(None);
         }
         let mut entries = Vec::new();
         let mut decoded_bytes = 0usize;
-        while entries.len() < limits.max_entries && self.cursor.ordinal < self.header.entry_count {
+        while entries.len() < limits.max_entries() && self.cursor.ordinal < self.header.entry_count
+        {
             let (entry, consumed) = self.take_next_entry()?;
             let size = entry.decoded_size();
-            if size > limits.max_decoded_bytes {
+            if size > limits.max_decoded_bytes() {
                 return Err(TreeStreamError::OversizedEntry {
                     decoded_bytes: size,
-                    max_decoded_bytes: limits.max_decoded_bytes,
+                    max_decoded_bytes: limits.max_decoded_bytes(),
                 });
             }
-            if !entries.is_empty() && decoded_bytes.saturating_add(size) > limits.max_decoded_bytes
+            if !entries.is_empty()
+                && decoded_bytes.saturating_add(size) > limits.max_decoded_bytes()
             {
                 self.pending = Some((entry, consumed));
                 break;
@@ -215,11 +230,27 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         }))
     }
 
+    /// Yield one decoded entry. Used by full-object collect without a page ceiling.
+    pub fn next_entry(&mut self) -> Result<Option<TreeEntry>, TreeStreamError> {
+        if self.cursor.ordinal == self.header.entry_count {
+            return Ok(None);
+        }
+        let (entry, consumed) = self.take_next_entry()?;
+        self.commit_entry(&entry, consumed)?;
+        Ok(Some(entry))
+    }
+
     pub fn finish_and_verify(&mut self) -> Result<(), TreeStreamError> {
         if self.cursor.ordinal != self.header.entry_count {
             return Err(TreeStreamError::UnexpectedEof {
                 expected: self.header.entry_count,
                 decoded: self.cursor.ordinal,
+            });
+        }
+        let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
+        if self.cursor.byte_offset != payload_end {
+            return Err(TreeStreamError::TrailingBytes {
+                extra: payload_end.abs_diff(self.cursor.byte_offset),
             });
         }
         if let Some(hasher) = self.hasher.take() {
@@ -245,12 +276,23 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
     }
 
     fn read_entry_at(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let payload_end = TREE_HEADER_LEN as u64 + self.header.payload_len;
         let mut len_buf = [0u8; 4];
         self.source.read_exact_at(offset, &mut len_buf)?;
-        let frame_len = u32::from_le_bytes(len_buf) as usize;
+        let frame_len = u64::from(u32::from_le_bytes(len_buf));
+        let frame_start = offset
+            .checked_add(4)
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        let frame_end = frame_start
+            .checked_add(frame_len)
+            .ok_or(TreeStreamError::TruncatedFrame { offset })?;
+        if frame_end > payload_end || frame_end > self.source.len() {
+            return Err(TreeStreamError::TruncatedFrame { offset });
+        }
+        let frame_len =
+            usize::try_from(frame_len).map_err(|_| TreeStreamError::TruncatedFrame { offset })?;
         let mut frame = vec![0u8; frame_len];
-        self.source
-            .read_exact_at(offset.saturating_add(4), &mut frame)?;
+        self.source.read_exact_at(frame_start, &mut frame)?;
         let entry = decode_entry_frame(&frame)?;
         Ok((entry, 4 + frame_len))
     }
@@ -351,9 +393,8 @@ impl Tree {
             None,
         )?;
         let mut entries = Vec::new();
-        let limits = TreePageLimits::new(usize::MAX, usize::MAX)?;
-        while let Some(page) = reader.next_page(limits)? {
-            entries.extend(page.entries);
+        while let Some(entry) = reader.next_entry()? {
+            entries.push(entry);
         }
         reader.finish_and_verify()?;
         Tree::try_from_decoded_entries(entries).map_err(TreeStreamError::from)

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Streaming Tree entry reader with persistable resume cursors.
+
+use serde::{Deserialize, Serialize};
+
+use super::{
+    ContentHash, Tree, TreeEntry, TreeError,
+    tree_canonical::{
+        TREE_ENCODING_VERSION, TREE_HEADER_LEN, TreeHeader, decode_entry_frame, decode_header,
+    },
+    tree_source::{TreeBodyIntegrity, TreeByteSource},
+};
+
+/// Failure while streaming or range-resuming a canonical tree.
+#[derive(Debug, thiserror::Error)]
+pub enum TreeStreamError {
+    #[error("invalid tree entry: {0}")]
+    Invalid(#[from] TreeError),
+    #[error("unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})")]
+    UnsupportedVersion { found: u8 },
+    #[error("tree resume cursor does not match this object: {0}")]
+    CursorMismatch(String),
+    #[error("truncated tree frame at byte {offset}")]
+    TruncatedFrame { offset: u64 },
+    #[error("tree payload has {extra} trailing byte(s) after declared end")]
+    TrailingBytes { extra: u64 },
+    #[error("tree ended after {decoded} of {expected} declared entries")]
+    UnexpectedEof { expected: u64, decoded: u64 },
+    #[error("tree entry exceeds page byte limit ({decoded_bytes} > {max_decoded_bytes})")]
+    OversizedEntry {
+        decoded_bytes: usize,
+        max_decoded_bytes: usize,
+    },
+    #[error("tree page limits must be nonzero")]
+    InvalidPageLimits,
+    #[error("ranged tree resume requires a verified-placement object source")]
+    UnverifiedRange,
+    #[error("malformed tree encoding: {0}")]
+    Malformed(String),
+    #[error("tree I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("decoded tree hash {found} does not match {expected}")]
+    HashMismatch {
+        expected: ContentHash,
+        found: ContentHash,
+    },
+}
+
+/// Caller-sized page budget. Zero limits fail closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TreePageLimits {
+    pub max_entries: usize,
+    pub max_decoded_bytes: usize,
+}
+
+impl TreePageLimits {
+    pub fn new(
+        max_entries: usize,
+        max_decoded_bytes: usize,
+    ) -> Result<Self, TreeStreamError> {
+        if max_entries == 0 || max_decoded_bytes == 0 {
+            return Err(TreeStreamError::InvalidPageLimits);
+        }
+        Ok(Self {
+            max_entries,
+            max_decoded_bytes,
+        })
+    }
+}
+
+/// Persistable entry-boundary cursor bound to a tree id and encoding version.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TreeResumeCursor {
+    pub(crate) tree_id: ContentHash,
+    pub(crate) encoding_version: u8,
+    pub(crate) ordinal: u64,
+    pub(crate) byte_offset: u64,
+    pub(crate) prev_name: Option<String>,
+}
+
+impl TreeResumeCursor {
+    pub fn start(tree_id: ContentHash) -> Self {
+        Self {
+            tree_id,
+            encoding_version: TREE_ENCODING_VERSION,
+            ordinal: 0,
+            byte_offset: TREE_HEADER_LEN as u64,
+            prev_name: None,
+        }
+    }
+
+    pub fn tree_id(&self) -> ContentHash {
+        self.tree_id
+    }
+
+    pub fn encoding_version(&self) -> u8 {
+        self.encoding_version
+    }
+
+    pub fn ordinal(&self) -> u64 {
+        self.ordinal
+    }
+
+    pub fn byte_offset(&self) -> u64 {
+        self.byte_offset
+    }
+
+    pub fn prev_name(&self) -> Option<&str> {
+        self.prev_name.as_deref()
+    }
+}
+
+/// One bounded page of decoded entries plus the cursor after the last entry.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TreePage {
+    pub entries: Vec<TreeEntry>,
+    pub resume_cursor: TreeResumeCursor,
+}
+
+/// Incremental HTR4 reader. Does not materialize a full `Vec<TreeEntry>`.
+#[derive(Debug)]
+pub struct TreeEntryReader<S: TreeByteSource> {
+    source: S,
+    header: TreeHeader,
+    cursor: TreeResumeCursor,
+    hasher: Option<blake3::Hasher>,
+    pending: Option<(TreeEntry, usize)>,
+    finished: bool,
+}
+
+impl<S: TreeByteSource> TreeEntryReader<S> {
+    pub fn open(
+        mut source: S,
+        expected_id: ContentHash,
+        resume: Option<&TreeResumeCursor>,
+    ) -> Result<Self, TreeStreamError> {
+        let mut header_buf = [0u8; TREE_HEADER_LEN];
+        source.read_exact_at(0, &mut header_buf)?;
+        let header = decode_header(&header_buf)?;
+        if header.tree_id != expected_id {
+            return Err(TreeStreamError::HashMismatch {
+                expected: expected_id,
+                found: header.tree_id,
+            });
+        }
+        let expected_len = TREE_HEADER_LEN as u64 + header.payload_len;
+        if source.len() < expected_len {
+            return Err(TreeStreamError::TruncatedFrame {
+                offset: source.len(),
+            });
+        }
+        if source.len() > expected_len {
+            return Err(TreeStreamError::TrailingBytes {
+                extra: source.len() - expected_len,
+            });
+        }
+        let cursor = resume.cloned().unwrap_or_else(|| TreeResumeCursor::start(expected_id));
+        validate_cursor(&header, &cursor)?;
+        if cursor.ordinal > 0 && source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
+            return Err(TreeStreamError::UnverifiedRange);
+        }
+        let hasher = (cursor.ordinal == 0)
+            .then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let mut reader = Self {
+            source,
+            header,
+            cursor,
+            hasher,
+            pending: None,
+            finished: false,
+        };
+        reader.arm_pending_at_cursor()?;
+        Ok(reader)
+    }
+
+    pub fn header(&self) -> &TreeHeader {
+        &self.header
+    }
+
+    pub fn bytes_read(&self) -> u64 {
+        self.source.bytes_read()
+    }
+
+    pub fn next_page(
+        &mut self,
+        limits: TreePageLimits,
+    ) -> Result<Option<TreePage>, TreeStreamError> {
+        if self.cursor.ordinal == self.header.entry_count {
+            return Ok(None);
+        }
+        let mut entries = Vec::new();
+        let mut decoded_bytes = 0usize;
+        while entries.len() < limits.max_entries && self.cursor.ordinal < self.header.entry_count {
+            let (entry, consumed) = self.take_next_entry()?;
+            let size = entry.decoded_size();
+            if size > limits.max_decoded_bytes {
+                return Err(TreeStreamError::OversizedEntry {
+                    decoded_bytes: size,
+                    max_decoded_bytes: limits.max_decoded_bytes,
+                });
+            }
+            if !entries.is_empty() && decoded_bytes.saturating_add(size) > limits.max_decoded_bytes {
+                self.pending = Some((entry, consumed));
+                break;
+            }
+            self.commit_entry(&entry, consumed)?;
+            decoded_bytes += size;
+            entries.push(entry);
+        }
+        Ok(Some(TreePage {
+            entries,
+            resume_cursor: self.cursor.clone(),
+        }))
+    }
+
+    pub fn finish_and_verify(&mut self) -> Result<(), TreeStreamError> {
+        if self.cursor.ordinal != self.header.entry_count {
+            return Err(TreeStreamError::UnexpectedEof {
+                expected: self.header.entry_count,
+                decoded: self.cursor.ordinal,
+            });
+        }
+        if let Some(hasher) = self.hasher.take() {
+            let found = ContentHash::from_bytes(hasher.finalize().into());
+            if found != self.header.tree_id {
+                return Err(TreeStreamError::HashMismatch {
+                    expected: self.header.tree_id,
+                    found,
+                });
+            }
+        } else if self.source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
+            return Err(TreeStreamError::UnverifiedRange);
+        }
+        self.finished = true;
+        Ok(())
+    }
+
+    fn take_next_entry(&mut self) -> Result<(TreeEntry, usize), TreeStreamError> {
+        if let Some(pending) = self.pending.take() {
+            return Ok(pending);
+        }
+        self.read_entry_at(self.cursor.byte_offset)
+    }
+
+    fn read_entry_at(&mut self, offset: u64) -> Result<(TreeEntry, usize), TreeStreamError> {
+        let mut len_buf = [0u8; 4];
+        self.source.read_exact_at(offset, &mut len_buf)?;
+        let frame_len = u32::from_le_bytes(len_buf) as usize;
+        let mut frame = vec![0u8; frame_len];
+        self.source
+            .read_exact_at(offset.saturating_add(4), &mut frame)?;
+        let entry = decode_entry_frame(&frame)?;
+        Ok((entry, 4 + frame_len))
+    }
+
+    fn commit_entry(&mut self, entry: &TreeEntry, consumed: usize) -> Result<(), TreeStreamError> {
+        if let Some(previous) = self.cursor.prev_name.as_deref()
+            && previous >= entry.name()
+        {
+            return Err(TreeError::InvalidStructure(
+                "entries must be strictly sorted by name".into(),
+            )
+            .into());
+        }
+        if let Some(hasher) = &mut self.hasher {
+            entry.update_hasher(hasher);
+        }
+        self.cursor.ordinal += 1;
+        self.cursor.byte_offset += consumed as u64;
+        self.cursor.prev_name = Some(entry.name().to_string());
+        Ok(())
+    }
+
+    fn arm_pending_at_cursor(&mut self) -> Result<(), TreeStreamError> {
+        if self.cursor.ordinal == 0 || self.cursor.ordinal == self.header.entry_count {
+            return Ok(());
+        }
+        let (entry, consumed) = self.read_entry_at(self.cursor.byte_offset)?;
+        if let Some(previous) = self.cursor.prev_name.as_deref()
+            && previous >= entry.name()
+        {
+            return Err(TreeStreamError::CursorMismatch(
+                "cursor previous name is not a valid predecessor".into(),
+            ));
+        }
+        self.pending = Some((entry, consumed));
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[path = "tree_stream_tests.rs"]
+mod tree_stream_tests;
+#[cfg(test)]
+#[path = "tree_stream_proptests.rs"]
+mod tree_stream_proptests;
+
+fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(), TreeStreamError> {
+    if cursor.encoding_version != TREE_ENCODING_VERSION {
+        return Err(TreeStreamError::CursorMismatch(format!(
+            "encoding version {} is not {TREE_ENCODING_VERSION}",
+            cursor.encoding_version
+        )));
+    }
+    if cursor.tree_id != header.tree_id {
+        return Err(TreeStreamError::CursorMismatch(
+            "cursor tree id does not match the opened object".into(),
+        ));
+    }
+    let payload_end = TREE_HEADER_LEN as u64 + header.payload_len;
+    if cursor.ordinal > header.entry_count {
+        return Err(TreeStreamError::CursorMismatch(
+            "cursor ordinal is past the declared entry count".into(),
+        ));
+    }
+    if cursor.ordinal == 0 {
+        if cursor.byte_offset != TREE_HEADER_LEN as u64 || cursor.prev_name.is_some() {
+            return Err(TreeStreamError::CursorMismatch(
+                "start cursor must be the first entry boundary".into(),
+            ));
+        }
+        return Ok(());
+    }
+    if cursor.ordinal == header.entry_count {
+        if cursor.byte_offset != payload_end {
+            return Err(TreeStreamError::CursorMismatch(
+                "end cursor is not the declared payload end".into(),
+            ));
+        }
+        return Ok(());
+    }
+    if cursor.byte_offset < TREE_HEADER_LEN as u64 || cursor.byte_offset >= payload_end {
+        return Err(TreeStreamError::CursorMismatch(
+            "cursor byte offset is not inside the payload".into(),
+        ));
+    }
+    Ok(())
+}
+
+impl Tree {
+    /// Decode HTR4 through the streaming reader and collect the eager `Tree`.
+    pub fn decode_canonical_streamed(data: &[u8]) -> Result<Self, TreeStreamError> {
+        let header = decode_header(data)?;
+        let mut reader = TreeEntryReader::open(
+            super::tree_source::BytesTreeSource::sequential_verify(bytes::Bytes::copy_from_slice(
+                data,
+            )),
+            header.tree_id,
+            None,
+        )?;
+        let mut entries = Vec::new();
+        let limits = TreePageLimits::new(usize::MAX, usize::MAX)?;
+        while let Some(page) = reader.next_page(limits)? {
+            entries.extend(page.entries);
+        }
+        reader.finish_and_verify()?;
+        Tree::try_from_decoded_entries(entries).map_err(TreeStreamError::from)
+    }
+}

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -133,6 +133,7 @@ pub struct TreeEntryReader<S: TreeByteSource> {
     header: TreeHeader,
     cursor: TreeResumeCursor,
     hasher: Option<blake3::Hasher>,
+    decoded_logical_len: u64,
     pending: Option<(TreeEntry, usize)>,
     finished: bool,
 }
@@ -177,6 +178,7 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
             header,
             cursor,
             hasher,
+            decoded_logical_len: 0,
             pending: None,
             finished: false,
         };
@@ -254,6 +256,11 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
             });
         }
         if let Some(hasher) = self.hasher.take() {
+            if self.decoded_logical_len != self.header.logical_len {
+                return Err(TreeStreamError::Malformed(
+                    "declared logical length does not match entries".into(),
+                ));
+            }
             let found = ContentHash::from_bytes(hasher.finalize().into());
             if found != self.header.tree_id {
                 return Err(TreeStreamError::HashMismatch {
@@ -309,6 +316,10 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
         if let Some(hasher) = &mut self.hasher {
             entry.update_hasher(hasher);
         }
+        self.decoded_logical_len = self
+            .decoded_logical_len
+            .checked_add(entry.encoded_len() as u64)
+            .ok_or_else(|| TreeStreamError::Malformed("logical length overflow".into()))?;
         self.cursor.ordinal += 1;
         self.cursor.byte_offset += consumed as u64;
         self.cursor.prev_name = Some(entry.name().to_string());
@@ -397,6 +408,14 @@ impl Tree {
             entries.push(entry);
         }
         reader.finish_and_verify()?;
-        Tree::try_from_decoded_entries(entries).map_err(TreeStreamError::from)
+        let tree = Tree::try_from_decoded_entries(entries).map_err(TreeStreamError::from)?;
+        let found = tree.hash();
+        if found != header.tree_id {
+            return Err(TreeStreamError::HashMismatch {
+                expected: header.tree_id,
+                found,
+            });
+        }
+        Ok(tree)
     }
 }

--- a/crates/object-model/src/object/tree_stream.rs
+++ b/crates/object-model/src/object/tree_stream.rs
@@ -16,7 +16,9 @@ use super::{
 pub enum TreeStreamError {
     #[error("invalid tree entry: {0}")]
     Invalid(#[from] TreeError),
-    #[error("unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})")]
+    #[error(
+        "unsupported tree encoding version {found} (this binary writes {TREE_ENCODING_VERSION})"
+    )]
     UnsupportedVersion { found: u8 },
     #[error("tree resume cursor does not match this object: {0}")]
     CursorMismatch(String),
@@ -54,10 +56,7 @@ pub struct TreePageLimits {
 }
 
 impl TreePageLimits {
-    pub fn new(
-        max_entries: usize,
-        max_decoded_bytes: usize,
-    ) -> Result<Self, TreeStreamError> {
+    pub fn new(max_entries: usize, max_decoded_bytes: usize) -> Result<Self, TreeStreamError> {
         if max_entries == 0 || max_decoded_bytes == 0 {
             return Err(TreeStreamError::InvalidPageLimits);
         }
@@ -154,13 +153,15 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                 extra: source.len() - expected_len,
             });
         }
-        let cursor = resume.cloned().unwrap_or_else(|| TreeResumeCursor::start(expected_id));
+        let cursor = resume
+            .cloned()
+            .unwrap_or_else(|| TreeResumeCursor::start(expected_id));
         validate_cursor(&header, &cursor)?;
         if cursor.ordinal > 0 && source.integrity() != TreeBodyIntegrity::VerifiedPlacement {
             return Err(TreeStreamError::UnverifiedRange);
         }
-        let hasher = (cursor.ordinal == 0)
-            .then(|| ContentHash::typed_hasher("tree", header.logical_len));
+        let hasher =
+            (cursor.ordinal == 0).then(|| ContentHash::typed_hasher("tree", header.logical_len));
         let mut reader = Self {
             source,
             header,
@@ -199,7 +200,8 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
                     max_decoded_bytes: limits.max_decoded_bytes,
                 });
             }
-            if !entries.is_empty() && decoded_bytes.saturating_add(size) > limits.max_decoded_bytes {
+            if !entries.is_empty() && decoded_bytes.saturating_add(size) > limits.max_decoded_bytes
+            {
                 self.pending = Some((entry, consumed));
                 break;
             }
@@ -289,11 +291,11 @@ impl<S: TreeByteSource> TreeEntryReader<S> {
 }
 
 #[cfg(test)]
-#[path = "tree_stream_tests.rs"]
-mod tree_stream_tests;
-#[cfg(test)]
 #[path = "tree_stream_proptests.rs"]
 mod tree_stream_proptests;
+#[cfg(test)]
+#[path = "tree_stream_tests.rs"]
+mod tree_stream_tests;
 
 fn validate_cursor(header: &TreeHeader, cursor: &TreeResumeCursor) -> Result<(), TreeStreamError> {
     if cursor.encoding_version != TREE_ENCODING_VERSION {

--- a/crates/object-model/src/object/tree_stream_proptests.rs
+++ b/crates/object-model/src/object/tree_stream_proptests.rs
@@ -13,9 +13,10 @@ fn name_strategy() -> impl Strategy<Value = String> {
 }
 
 fn entry_strategy() -> impl Strategy<Value = TreeEntry> {
-    let blob = (name_strategy(), any::<[u8; 8]>(), any::<bool>()).prop_map(|(name, bytes, exec)| {
-        TreeEntry::file(name, ContentHash::compute(&bytes), exec).expect("blob")
-    });
+    let blob =
+        (name_strategy(), any::<[u8; 8]>(), any::<bool>()).prop_map(|(name, bytes, exec)| {
+            TreeEntry::file(name, ContentHash::compute(&bytes), exec).expect("blob")
+        });
     let dir = (name_strategy(), any::<[u8; 8]>()).prop_map(|(name, bytes)| {
         TreeEntry::directory(name, ContentHash::compute(&bytes)).expect("dir")
     });

--- a/crates/object-model/src/object/tree_stream_proptests.rs
+++ b/crates/object-model/src/object/tree_stream_proptests.rs
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use proptest::prelude::*;
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+
+use crate::object::{
+    ContentHash, SpoolId, StateId, Tree, TreeEntry, TreeStreamError, is_canonical_tree,
+};
+
+fn name_strategy() -> impl Strategy<Value = String> {
+    prop::collection::vec(prop::char::range('a', 'z'), 1..=8)
+        .prop_map(|chars| chars.into_iter().collect())
+}
+
+fn entry_strategy() -> impl Strategy<Value = TreeEntry> {
+    let blob = (name_strategy(), any::<[u8; 8]>(), any::<bool>()).prop_map(|(name, bytes, exec)| {
+        TreeEntry::file(name, ContentHash::compute(&bytes), exec).expect("blob")
+    });
+    let dir = (name_strategy(), any::<[u8; 8]>()).prop_map(|(name, bytes)| {
+        TreeEntry::directory(name, ContentHash::compute(&bytes)).expect("dir")
+    });
+    let symlink = (name_strategy(), any::<[u8; 8]>()).prop_map(|(name, bytes)| {
+        TreeEntry::symlink(name, ContentHash::compute(&bytes)).expect("symlink")
+    });
+    let gitlink = (name_strategy(), any::<[u8; 20]>()).prop_map(|(name, oid)| {
+        TreeEntry::gitlink(
+            name,
+            GitObjectId::from_raw(GitObjectFormat::Sha1, &oid).expect("oid"),
+        )
+        .expect("gitlink")
+    });
+    let spoollink = (name_strategy(), any::<[u8; 32]>()).prop_map(|(name, state)| {
+        TreeEntry::spoollink(
+            name,
+            SpoolId::parse("acme/child").expect("spool"),
+            StateId::from_bytes(state),
+        )
+        .expect("spoollink")
+    });
+    prop_oneof![blob, dir, symlink, gitlink, spoollink]
+}
+
+fn unique_tree_strategy() -> impl Strategy<Value = Tree> {
+    prop::collection::vec(entry_strategy(), 0..=12).prop_map(|entries| {
+        let mut seen = std::collections::BTreeMap::new();
+        for entry in entries {
+            seen.insert(entry.name().to_string(), entry);
+        }
+        Tree::from_entries(seen.into_values().collect())
+    })
+}
+
+fn error_class(error: &TreeStreamError) -> &'static str {
+    match error {
+        TreeStreamError::Invalid(_) => "invalid",
+        TreeStreamError::UnsupportedVersion { .. } => "version",
+        TreeStreamError::CursorMismatch(_) => "cursor",
+        TreeStreamError::TruncatedFrame { .. } => "truncated",
+        TreeStreamError::TrailingBytes { .. } => "trailing",
+        TreeStreamError::UnexpectedEof { .. } => "eof",
+        TreeStreamError::OversizedEntry { .. } => "oversized",
+        TreeStreamError::InvalidPageLimits => "limits",
+        TreeStreamError::UnverifiedRange => "unverified",
+        TreeStreamError::Malformed(_) => "malformed",
+        TreeStreamError::Io(_) => "io",
+        TreeStreamError::HashMismatch { .. } => "hash",
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn eager_and_streaming_decoders_match_on_valid_trees(tree in unique_tree_strategy()) {
+        let bytes = tree.encode_canonical().expect("encode");
+        prop_assert!(is_canonical_tree(&bytes));
+        let eager = Tree::decode_canonical(&bytes).expect("eager");
+        let streamed = Tree::decode_canonical_streamed(&bytes).expect("streamed");
+        prop_assert_eq!(&eager, &tree);
+        prop_assert_eq!(streamed, tree);
+        let msgpack = rmp_serde::to_vec(&eager).expect("msgpack");
+        let via_msgpack: Tree = rmp_serde::from_slice(&msgpack).expect("serde");
+        prop_assert_eq!(via_msgpack, eager);
+    }
+
+    #[test]
+    fn eager_and_streaming_decoders_agree_on_corrupted_payloads(
+        tree in unique_tree_strategy(),
+        index in 0usize..64,
+        bit in 0u8..8,
+    ) {
+        let mut bytes = tree.encode_canonical().expect("encode");
+        if bytes.is_empty() {
+            return Ok(());
+        }
+        let index = index % bytes.len();
+        bytes[index] ^= 1 << bit;
+        let eager = Tree::decode_canonical(&bytes);
+        let streamed = Tree::decode_canonical_streamed(&bytes);
+        match (eager, streamed) {
+            (Ok(left), Ok(right)) => prop_assert_eq!(left, right),
+            (Err(_), Err(_)) => {}
+            (left, right) => {
+                prop_assert!(
+                    false,
+                    "eager={left:?} streamed={right:?} disagreed on success ({}/{})",
+                    left.as_ref().err().map(error_class).unwrap_or("ok"),
+                    right.as_ref().err().map(error_class).unwrap_or("ok"),
+                );
+            }
+        }
+    }
+}

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -66,10 +66,7 @@ fn streaming_pages_respect_entry_and_byte_limits() {
     assert_eq!(first.resume_cursor.ordinal(), 2);
     let second = reader.next_page(limits).expect("page").expect("some");
     assert_eq!(second.entries.len(), 2);
-    reader
-        .next_page(limits)
-        .expect("page")
-        .expect("remaining");
+    reader.next_page(limits).expect("page").expect("remaining");
     assert!(reader.next_page(limits).expect("eof").is_none());
     reader.finish_and_verify().expect("verify");
 }
@@ -290,12 +287,18 @@ fn malformed_mode_and_oid_are_rejected() {
     assert!(Tree::decode_canonical_streamed(&bytes).is_err());
 
     let mut oid_bytes = tree.encode_canonical().expect("encode");
-    let name_end = frame + 1 + 1 + 2 + 1;
-    oid_bytes[name_end] ^= 0xff;
+    let frame_len = u32::from_le_bytes(
+        oid_bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + 4]
+            .try_into()
+            .expect("len"),
+    );
+    oid_bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + 4].copy_from_slice(&(frame_len - 1).to_le_bytes());
+    oid_bytes.pop();
+    write_payload_len(&mut oid_bytes, (oid_bytes.len() - TREE_HEADER_LEN) as u64);
     let eager = Tree::decode_canonical(&oid_bytes).expect_err("eager oid");
     let streamed = Tree::decode_canonical_streamed(&oid_bytes).expect_err("stream oid");
-    assert!(eager.to_string().contains("object id") || eager.to_string().contains("hash"));
-    assert!(streamed.to_string().contains("object id") || streamed.to_string().contains("hash"));
+    assert!(eager.to_string().contains("object id"), "{eager}");
+    assert!(streamed.to_string().contains("object id"), "{streamed}");
 }
 
 #[test]
@@ -305,7 +308,11 @@ fn truncated_frame_and_trailing_bytes_are_errors() {
     let truncated = &bytes[..bytes.len() - 3];
     assert!(matches!(
         Tree::decode_canonical(truncated),
-        Err(TreeStreamError::TruncatedFrame { .. } | TreeStreamError::TrailingBytes { .. })
+        Err(TreeStreamError::TruncatedFrame { .. })
+    ));
+    assert!(matches!(
+        Tree::decode_canonical_streamed(truncated),
+        Err(TreeStreamError::TruncatedFrame { .. })
     ));
 
     let mut trailing = bytes.clone();

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -329,6 +329,38 @@ fn truncated_frame_and_trailing_bytes_are_errors() {
 }
 
 #[test]
+fn mismatched_logical_len_fails_eager_and_streamed() {
+    let tree = Tree::from_entries(vec![blob("a", b"1"), blob("b", b"2")]);
+    let mut bytes = tree.encode_canonical().expect("encode");
+    let actual_logical = u64::from_le_bytes(bytes[53..61].try_into().expect("logical"));
+    let forged_logical = actual_logical.saturating_add(8);
+    bytes[53..61].copy_from_slice(&forged_logical.to_le_bytes());
+    let forged_id = ContentHash::compute_typed_with_len("tree", forged_logical, |hasher| {
+        for entry in tree.entries() {
+            entry.update_hasher(hasher);
+        }
+    });
+    bytes[5..37].copy_from_slice(forged_id.as_bytes());
+
+    let eager = Tree::decode_canonical(&bytes).expect_err("eager logical_len");
+    let streamed = Tree::decode_canonical_streamed(&bytes).expect_err("stream logical_len");
+    assert!(
+        matches!(
+            eager,
+            TreeStreamError::HashMismatch { .. } | TreeStreamError::Malformed(_)
+        ),
+        "{eager}"
+    );
+    assert!(
+        matches!(
+            streamed,
+            TreeStreamError::HashMismatch { .. } | TreeStreamError::Malformed(_)
+        ),
+        "{streamed}"
+    );
+}
+
+#[test]
 fn leftover_payload_after_declared_count_is_trailing_bytes() {
     let tree = Tree::from_entries(vec![blob("a", b"1"), blob("b", b"2")]);
     let bytes = tree.encode_canonical().expect("encode");

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -322,6 +322,47 @@ fn truncated_frame_and_trailing_bytes_are_errors() {
         Tree::decode_canonical(&trailing),
         Err(TreeStreamError::TrailingBytes { extra: 1 })
     ));
+    assert!(matches!(
+        Tree::decode_canonical_streamed(&trailing),
+        Err(TreeStreamError::TrailingBytes { extra: 1 })
+    ));
+}
+
+#[test]
+fn leftover_payload_after_declared_count_is_trailing_bytes() {
+    let tree = Tree::from_entries(vec![blob("a", b"1"), blob("b", b"2")]);
+    let bytes = tree.encode_canonical().expect("encode");
+    let first = frame_at(&bytes, 0);
+    let mut short_count = bytes.clone();
+    short_count[37..45].copy_from_slice(&1u64.to_le_bytes());
+    write_payload_len(&mut short_count, (first + frame_at(&bytes, first)) as u64);
+    let eager = Tree::decode_canonical(&short_count).expect_err("eager leftover");
+    let streamed = Tree::decode_canonical_streamed(&short_count).expect_err("stream leftover");
+    assert!(
+        matches!(eager, TreeStreamError::TrailingBytes { .. }),
+        "{eager}"
+    );
+    assert!(
+        matches!(streamed, TreeStreamError::TrailingBytes { .. }),
+        "{streamed}"
+    );
+}
+
+#[test]
+fn huge_frame_prefix_is_truncated_without_allocating() {
+    let tree = Tree::from_entries(vec![blob("a", b"1")]);
+    let mut bytes = tree.encode_canonical().expect("encode");
+    bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+    let eager = Tree::decode_canonical(&bytes).expect_err("eager huge");
+    let streamed = Tree::decode_canonical_streamed(&bytes).expect_err("stream huge");
+    assert!(
+        matches!(eager, TreeStreamError::TruncatedFrame { .. }),
+        "{eager}"
+    );
+    assert!(
+        matches!(streamed, TreeStreamError::TruncatedFrame { .. }),
+        "{streamed}"
+    );
 }
 
 #[test]
@@ -344,6 +385,13 @@ fn empty_tree_streams_and_verifies() {
             .is_none()
     );
     reader.finish_and_verify().expect("empty verify");
+}
+
+#[test]
+fn name_over_u16_is_rejected_at_the_model_boundary() {
+    let name = "n".repeat(u16::MAX as usize + 1);
+    let error = TreeEntry::file(name, ContentHash::compute(b"x"), false).expect_err("too long");
+    assert!(error.to_string().contains("u16"));
 }
 
 #[test]

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -294,7 +294,8 @@ fn malformed_mode_and_oid_are_rejected() {
     );
     oid_bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + 4].copy_from_slice(&(frame_len - 1).to_le_bytes());
     oid_bytes.pop();
-    write_payload_len(&mut oid_bytes, (oid_bytes.len() - TREE_HEADER_LEN) as u64);
+    let payload_len = (oid_bytes.len() - TREE_HEADER_LEN) as u64;
+    write_payload_len(&mut oid_bytes, payload_len);
     let eager = Tree::decode_canonical(&oid_bytes).expect_err("eager oid");
     let streamed = Tree::decode_canonical_streamed(&oid_bytes).expect_err("stream oid");
     assert!(eager.to_string().contains("object id"), "{eager}");

--- a/crates/object-model/src/object/tree_stream_tests.rs
+++ b/crates/object-model/src/object/tree_stream_tests.rs
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use sley::{ObjectFormat as GitObjectFormat, ObjectId as GitObjectId};
+
+use crate::object::{
+    BytesTreeSource, ContentHash, SpoolId, StateId, TREE_ENCODING_VERSION, TREE_HEADER_LEN, Tree,
+    TreeBodyIntegrity, TreeByteSource, TreeEntry, TreeEntryReader, TreePageLimits,
+    TreeResumeCursor, TreeStreamError, is_canonical_tree,
+};
+
+fn blob(name: &str, payload: &[u8]) -> TreeEntry {
+    TreeEntry::file(name, ContentHash::compute(payload), false).expect("file entry")
+}
+
+fn sample_tree() -> Tree {
+    Tree::from_entries(vec![
+        blob("a", b"a"),
+        blob("b", b"b"),
+        TreeEntry::directory("c", ContentHash::compute(b"dir")).expect("dir"),
+        TreeEntry::symlink("d", ContentHash::compute(b"link")).expect("link"),
+        TreeEntry::gitlink(
+            "e",
+            GitObjectId::from_raw(GitObjectFormat::Sha1, &[7; 20]).expect("oid"),
+        )
+        .expect("gitlink"),
+        TreeEntry::spoollink(
+            "f",
+            SpoolId::parse("acme/child").expect("spool"),
+            StateId::from_bytes([3; 32]),
+        )
+        .expect("spoollink"),
+    ])
+}
+
+fn open_reader(tree: &Tree) -> (Vec<u8>, TreeEntryReader<BytesTreeSource>) {
+    let bytes = tree.encode_canonical().expect("encode");
+    let reader = TreeEntryReader::open(
+        BytesTreeSource::sequential_verify(bytes.clone()),
+        tree.hash(),
+        None,
+    )
+    .expect("open");
+    (bytes, reader)
+}
+
+#[test]
+fn canonical_round_trip_matches_eager_tree() {
+    let tree = sample_tree();
+    let bytes = tree.encode_canonical().expect("encode");
+    assert!(is_canonical_tree(&bytes));
+    assert_eq!(Tree::decode_canonical(&bytes).expect("decode"), tree);
+    assert_eq!(
+        Tree::decode_canonical_streamed(&bytes).expect("streamed"),
+        tree
+    );
+}
+
+#[test]
+fn streaming_pages_respect_entry_and_byte_limits() {
+    let tree = sample_tree();
+    let (_bytes, mut reader) = open_reader(&tree);
+    let limits = TreePageLimits::new(2, usize::MAX).expect("limits");
+    let first = reader.next_page(limits).expect("page").expect("some");
+    assert_eq!(first.entries.len(), 2);
+    assert_eq!(first.entries[0].name(), "a");
+    assert_eq!(first.resume_cursor.ordinal(), 2);
+    let second = reader.next_page(limits).expect("page").expect("some");
+    assert_eq!(second.entries.len(), 2);
+    reader
+        .next_page(limits)
+        .expect("page")
+        .expect("remaining");
+    assert!(reader.next_page(limits).expect("eof").is_none());
+    reader.finish_and_verify().expect("verify");
+}
+
+#[test]
+fn resume_cursor_survives_restart_without_rereading_prefix() {
+    let tree = sample_tree();
+    let (bytes, mut reader) = open_reader(&tree);
+    let limits = TreePageLimits::new(2, usize::MAX).expect("limits");
+    let first = reader.next_page(limits).expect("page").expect("some");
+    let cursor = first.resume_cursor;
+    let prefix_end = cursor.byte_offset();
+    drop(reader);
+
+    let mut spy = OffsetSpy::new(bytes);
+    let mut resumed = TreeEntryReader::open(&mut spy, tree.hash(), Some(&cursor)).expect("resume");
+    let rest = resumed
+        .next_page(TreePageLimits::new(64, usize::MAX).expect("limits"))
+        .expect("page")
+        .expect("some");
+    assert_eq!(rest.entries[0].name(), "c");
+    resumed.finish_and_verify().expect("verify");
+    assert!(
+        spy.reads
+            .iter()
+            .all(|(offset, _)| *offset == 0 || *offset >= prefix_end),
+        "resume must not transfer prefix bytes below {prefix_end}, reads={:?}",
+        spy.reads
+    );
+}
+
+struct OffsetSpy {
+    inner: BytesTreeSource,
+    reads: Vec<(u64, usize)>,
+}
+
+impl OffsetSpy {
+    fn new(bytes: Vec<u8>) -> Self {
+        Self {
+            inner: BytesTreeSource::verified_placement(bytes),
+            reads: Vec::new(),
+        }
+    }
+}
+
+impl TreeByteSource for OffsetSpy {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        self.reads.push((offset, buf.len()));
+        self.inner.read_exact_at(offset, buf)
+    }
+    fn len(&self) -> u64 {
+        self.inner.len()
+    }
+    fn integrity(&self) -> TreeBodyIntegrity {
+        self.inner.integrity()
+    }
+    fn bytes_read(&self) -> u64 {
+        self.inner.bytes_read()
+    }
+}
+
+impl TreeByteSource for &mut OffsetSpy {
+    fn read_exact_at(&mut self, offset: u64, buf: &mut [u8]) -> Result<(), TreeStreamError> {
+        <OffsetSpy as TreeByteSource>::read_exact_at(self, offset, buf)
+    }
+    fn len(&self) -> u64 {
+        <OffsetSpy as TreeByteSource>::len(self)
+    }
+    fn integrity(&self) -> TreeBodyIntegrity {
+        <OffsetSpy as TreeByteSource>::integrity(self)
+    }
+    fn bytes_read(&self) -> u64 {
+        <OffsetSpy as TreeByteSource>::bytes_read(self)
+    }
+}
+
+#[test]
+fn resume_rejects_unverified_source() {
+    let tree = sample_tree();
+    let (bytes, mut reader) = open_reader(&tree);
+    let page = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("page")
+        .expect("some");
+    let error = TreeEntryReader::open(
+        BytesTreeSource::sequential_verify(bytes),
+        tree.hash(),
+        Some(&page.resume_cursor),
+    )
+    .expect_err("unverified range");
+    assert!(matches!(error, TreeStreamError::UnverifiedRange));
+}
+
+#[test]
+fn resume_rejects_foreign_tree_id_and_encoding_version() {
+    let tree = sample_tree();
+    let bytes = tree.encode_canonical().expect("encode");
+    let mut cursor = TreeResumeCursor::start(ContentHash::compute(b"other"));
+    let error = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes.clone()),
+        tree.hash(),
+        Some(&cursor),
+    )
+    .expect_err("foreign id");
+    assert!(matches!(
+        error,
+        TreeStreamError::CursorMismatch(_) | TreeStreamError::HashMismatch { .. }
+    ));
+
+    cursor = TreeResumeCursor::start(tree.hash());
+    cursor.encoding_version = TREE_ENCODING_VERSION + 1;
+    let error = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes),
+        tree.hash(),
+        Some(&cursor),
+    )
+    .expect_err("version");
+    assert!(matches!(error, TreeStreamError::CursorMismatch(_)));
+}
+
+#[test]
+fn resume_rejects_mid_frame_byte_offset() {
+    let tree = sample_tree();
+    let bytes = tree.encode_canonical().expect("encode");
+    let mut cursor = TreeResumeCursor::start(tree.hash());
+    cursor.ordinal = 1;
+    cursor.byte_offset = TREE_HEADER_LEN as u64 + 1;
+    cursor.prev_name = Some("a".into());
+    let error = TreeEntryReader::open(
+        BytesTreeSource::verified_placement(bytes),
+        tree.hash(),
+        Some(&cursor),
+    )
+    .expect_err("mid-frame");
+    assert!(matches!(
+        error,
+        TreeStreamError::CursorMismatch(_)
+            | TreeStreamError::Malformed(_)
+            | TreeStreamError::TruncatedFrame { .. }
+            | TreeStreamError::Invalid(_)
+    ));
+}
+
+#[test]
+fn zero_page_limits_fail_closed() {
+    assert!(matches!(
+        TreePageLimits::new(0, 16),
+        Err(TreeStreamError::InvalidPageLimits)
+    ));
+    assert!(matches!(
+        TreePageLimits::new(16, 0),
+        Err(TreeStreamError::InvalidPageLimits)
+    ));
+}
+
+#[test]
+fn oversized_entry_is_explicit() {
+    let tree = Tree::from_entries(vec![blob("wide", b"payload")]);
+    let (_bytes, mut reader) = open_reader(&tree);
+    let limits = TreePageLimits::new(8, 1).expect("limits");
+    let error = reader.next_page(limits).expect_err("oversized");
+    assert!(matches!(
+        error,
+        TreeStreamError::OversizedEntry {
+            max_decoded_bytes: 1,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn duplicate_name_and_order_fail_identically() {
+    let tree = Tree::from_entries(vec![blob("a", b"1"), blob("b", b"2")]);
+    let bytes = tree.encode_canonical().expect("encode");
+    let swapped = Tree::from_entries(vec![blob("a", b"1"), blob("b", b"2")])
+        .encode_canonical()
+        .expect("encode");
+    // Rebuild an illegal payload by swapping the two frames after the header.
+    let first = frame_at(&bytes, 0);
+    let second = frame_at(&bytes, first);
+    let mut illegal = bytes[..TREE_HEADER_LEN].to_vec();
+    illegal.extend_from_slice(&bytes[TREE_HEADER_LEN + first..TREE_HEADER_LEN + first + second]);
+    illegal.extend_from_slice(&bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + first]);
+    // Keep declared counts; order is now b then a.
+    let eager = Tree::decode_canonical(&illegal).expect_err("eager order");
+    let streamed = Tree::decode_canonical_streamed(&illegal).expect_err("stream order");
+    assert!(matches!(eager, TreeStreamError::Invalid(_)));
+    assert!(matches!(streamed, TreeStreamError::Invalid(_)));
+
+    // Duplicate: copy first frame twice.
+    illegal = bytes[..TREE_HEADER_LEN].to_vec();
+    illegal.extend_from_slice(&bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + first]);
+    illegal.extend_from_slice(&bytes[TREE_HEADER_LEN..TREE_HEADER_LEN + first]);
+    write_payload_len(&mut illegal, (first * 2) as u64);
+    let eager = Tree::decode_canonical(&illegal).expect_err("eager dup");
+    let streamed = Tree::decode_canonical_streamed(&illegal).expect_err("stream dup");
+    assert!(matches!(eager, TreeStreamError::Invalid(_)));
+    assert!(matches!(streamed, TreeStreamError::Invalid(_)));
+    let _ = (swapped, bytes);
+}
+
+fn frame_at(bytes: &[u8], rel: usize) -> usize {
+    let offset = TREE_HEADER_LEN + rel;
+    4 + u32::from_le_bytes(bytes[offset..offset + 4].try_into().expect("len")) as usize
+}
+
+fn write_payload_len(bytes: &mut [u8], payload_len: u64) {
+    bytes[45..53].copy_from_slice(&payload_len.to_le_bytes());
+}
+
+#[test]
+fn malformed_mode_and_oid_are_rejected() {
+    let tree = Tree::from_entries(vec![blob("a", b"1")]);
+    let mut bytes = tree.encode_canonical().expect("encode");
+    let frame = TREE_HEADER_LEN + 4;
+    bytes[frame] = 99;
+    assert!(Tree::decode_canonical(&bytes).is_err());
+    assert!(Tree::decode_canonical_streamed(&bytes).is_err());
+
+    let mut oid_bytes = tree.encode_canonical().expect("encode");
+    let name_end = frame + 1 + 1 + 2 + 1;
+    oid_bytes[name_end] ^= 0xff;
+    let eager = Tree::decode_canonical(&oid_bytes).expect_err("eager oid");
+    let streamed = Tree::decode_canonical_streamed(&oid_bytes).expect_err("stream oid");
+    assert!(eager.to_string().contains("object id") || eager.to_string().contains("hash"));
+    assert!(streamed.to_string().contains("object id") || streamed.to_string().contains("hash"));
+}
+
+#[test]
+fn truncated_frame_and_trailing_bytes_are_errors() {
+    let tree = sample_tree();
+    let bytes = tree.encode_canonical().expect("encode");
+    let truncated = &bytes[..bytes.len() - 3];
+    assert!(matches!(
+        Tree::decode_canonical(truncated),
+        Err(TreeStreamError::TruncatedFrame { .. } | TreeStreamError::TrailingBytes { .. })
+    ));
+
+    let mut trailing = bytes.clone();
+    trailing.push(0x0a);
+    assert!(matches!(
+        Tree::decode_canonical(&trailing),
+        Err(TreeStreamError::TrailingBytes { extra: 1 })
+    ));
+}
+
+#[test]
+fn declared_count_mismatch_is_an_error() {
+    let tree = Tree::from_entries(vec![blob("a", b"1")]);
+    let mut bytes = tree.encode_canonical().expect("encode");
+    bytes[37..45].copy_from_slice(&2u64.to_le_bytes());
+    assert!(Tree::decode_canonical(&bytes).is_err());
+    assert!(Tree::decode_canonical_streamed(&bytes).is_err());
+}
+
+#[test]
+fn empty_tree_streams_and_verifies() {
+    let tree = Tree::new();
+    let (_bytes, mut reader) = open_reader(&tree);
+    assert!(
+        reader
+            .next_page(TreePageLimits::new(8, 64).expect("limits"))
+            .expect("page")
+            .is_none()
+    );
+    reader.finish_and_verify().expect("empty verify");
+}
+
+#[test]
+fn source_integrity_is_explicit() {
+    assert_eq!(
+        BytesTreeSource::verified_placement(vec![0]).integrity(),
+        TreeBodyIntegrity::VerifiedPlacement
+    );
+    assert_eq!(
+        BytesTreeSource::sequential_verify(vec![0]).integrity(),
+        TreeBodyIntegrity::SequentialVerify
+    );
+}

--- a/crates/objects/Cargo.toml
+++ b/crates/objects/Cargo.toml
@@ -83,6 +83,11 @@ name = "line_diff_blame"
 harness = false
 required-features = ["bench", "memory-backend"]
 
+[[bench]]
+name = "tree_stream"
+harness = false
+required-features = ["bench"]
+
 [[example]]
 name = "train_tree_state_dictionary"
 required-features = ["zstd"]

--- a/crates/objects/benches/object_enumeration.rs
+++ b/crates/objects/benches/object_enumeration.rs
@@ -88,7 +88,7 @@ fn build_fixture() -> EnumerationFixture {
         builder.add(
             tree.hash(),
             ObjectType::Tree,
-            rmp_serde::to_vec(&tree).unwrap(),
+            tree.encode_canonical().unwrap(),
         );
 
         let action = fixture_action(index);

--- a/crates/objects/benches/tree_stream.rs
+++ b/crates/objects/benches/tree_stream.rs
@@ -124,6 +124,8 @@ fn bench_tree_stream(c: &mut Criterion) {
     let limits = TreePageLimits::new(512, usize::MAX).expect("limits");
     while resumed.next_page(limits).expect("page").is_some() {}
     resumed.finish_and_verify().expect("verify");
+    let bytes_read = resumed.bytes_read();
+    drop(resumed);
     let prefix = cursor.byte_offset();
     let reread_prefix: u64 = spy
         .reads
@@ -132,8 +134,7 @@ fn bench_tree_stream(c: &mut Criterion) {
         .map(|(_, len)| *len as u64)
         .sum();
     eprintln!(
-        "wide-tree resume: prefix_end={prefix} bytes_read={} prefix_bytes_reread={reread_prefix} peak_rss_kb_after={:?}",
-        resumed.bytes_read(),
+        "wide-tree resume: prefix_end={prefix} bytes_read={bytes_read} prefix_bytes_reread={reread_prefix} peak_rss_kb_after={:?}",
         peak_rss_kb()
     );
 }

--- a/crates/objects/benches/tree_stream.rs
+++ b/crates/objects/benches/tree_stream.rs
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+//! Wide-tree streaming benchmarks.
+//!
+//! Default size is 50_000 entries so CI-adjacent local runs finish quickly.
+//! For the million-entry acceptance run:
+//!
+//! ```text
+//! HEDDLE_WIDE_TREE_ENTRIES=1000000 cargo bench -p heddle-objects --bench tree_stream --features bench
+//! ```
+//!
+//! Reports throughput, bytes reread after resume, and peak RSS (VmHWM).
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use objects::object::{
+    BytesTreeSource, ContentHash, Tree, TreeByteSource, TreeEntry, TreeEntryReader, TreePageLimits,
+};
+
+fn wide_tree(entries: usize) -> Tree {
+    Tree::from_entries(
+        (0..entries)
+            .map(|index| {
+                TreeEntry::file(
+                    format!("f{index:08}"),
+                    ContentHash::compute(index.to_le_bytes().as_slice()),
+                    false,
+                )
+                .expect("entry")
+            })
+            .collect(),
+    )
+}
+
+fn peak_rss_kb() -> Option<u64> {
+    let status = std::fs::read_to_string("/proc/self/status").ok()?;
+    status.lines().find_map(|line| {
+        let value = line.strip_prefix("VmHWM:")?;
+        value.split_whitespace().next()?.parse().ok()
+    })
+}
+
+fn stream_all(bytes: &[u8], tree_id: ContentHash, page: usize) {
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::sequential_verify(bytes.to_vec()),
+        tree_id,
+        None,
+    )
+    .expect("open");
+    let limits = TreePageLimits::new(page, usize::MAX).expect("limits");
+    while let Some(chunk) = reader.next_page(limits).expect("page") {
+        black_box(chunk.entries.len());
+    }
+    reader.finish_and_verify().expect("verify");
+}
+
+fn bench_tree_stream(c: &mut Criterion) {
+    let entries = std::env::var("HEDDLE_WIDE_TREE_ENTRIES")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(50_000);
+    let tree = wide_tree(entries);
+    let bytes = tree.encode_canonical().expect("encode");
+    let tree_id = tree.hash();
+    eprintln!(
+        "wide-tree bench: entries={entries} encoded_bytes={} peak_rss_kb_before={:?}",
+        bytes.len(),
+        peak_rss_kb()
+    );
+
+    let mut group = c.benchmark_group("tree_stream");
+    group.throughput(Throughput::Elements(entries as u64));
+    group.bench_function(BenchmarkId::new("eager_decode", entries), |bencher| {
+        bencher.iter(|| {
+            black_box(Tree::decode_canonical(black_box(&bytes)).expect("decode"));
+        });
+    });
+    group.bench_function(BenchmarkId::new("stream_pages_512", entries), |bencher| {
+        bencher.iter(|| stream_all(black_box(&bytes), tree_id, 512));
+    });
+    group.finish();
+
+    let mut reader = TreeEntryReader::open(
+        BytesTreeSource::sequential_verify(bytes.clone()),
+        tree_id,
+        None,
+    )
+    .expect("open");
+    let first = reader
+        .next_page(TreePageLimits::new(512, usize::MAX).expect("limits"))
+        .expect("page")
+        .expect("some");
+    let cursor = first.resume_cursor;
+    drop(reader);
+
+    struct Spy {
+        inner: BytesTreeSource,
+        reads: Vec<(u64, usize)>,
+    }
+    impl TreeByteSource for &mut Spy {
+        fn read_exact_at(
+            &mut self,
+            offset: u64,
+            buf: &mut [u8],
+        ) -> Result<(), objects::object::TreeStreamError> {
+            self.reads.push((offset, buf.len()));
+            self.inner.read_exact_at(offset, buf)
+        }
+        fn len(&self) -> u64 {
+            self.inner.len()
+        }
+        fn integrity(&self) -> objects::object::TreeBodyIntegrity {
+            self.inner.integrity()
+        }
+        fn bytes_read(&self) -> u64 {
+            self.inner.bytes_read()
+        }
+    }
+    let mut spy = Spy {
+        inner: BytesTreeSource::verified_placement(bytes.clone()),
+        reads: Vec::new(),
+    };
+    let mut resumed = TreeEntryReader::open(&mut spy, tree_id, Some(&cursor)).expect("resume");
+    let limits = TreePageLimits::new(512, usize::MAX).expect("limits");
+    while resumed.next_page(limits).expect("page").is_some() {}
+    resumed.finish_and_verify().expect("verify");
+    let prefix = cursor.byte_offset();
+    let reread_prefix: u64 = spy
+        .reads
+        .iter()
+        .filter(|(offset, _)| *offset > 0 && *offset < prefix)
+        .map(|(_, len)| *len as u64)
+        .sum();
+    eprintln!(
+        "wide-tree resume: prefix_end={prefix} bytes_read={} prefix_bytes_reread={reread_prefix} peak_rss_kb_after={:?}",
+        resumed.bytes_read(),
+        peak_rss_kb()
+    );
+}
+
+criterion_group!(benches, bench_tree_stream);
+criterion_main!(benches);

--- a/crates/objects/src/store/codec.rs
+++ b/crates/objects/src/store/codec.rs
@@ -7,7 +7,7 @@ use heddle_format::compression::{
 };
 
 use crate::{
-    object::{Action, ActionId, ContentHash, State, Tree, TreeDecodeError},
+    object::{Action, ActionId, ContentHash, State, Tree},
     store::{HeddleError, Result},
 };
 
@@ -23,12 +23,10 @@ pub fn decode_blob_content(data: &[u8]) -> Result<Vec<u8>> {
     }
 }
 
-pub fn encode_tree(tree: &Tree, config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
-    let hash = tree.hash();
-    let serialized = rmp_serde::to_vec(tree)?;
-    let data = compress_with_dictionary(&serialized, config, CompressionDictionary::TreeStateV1)?
-        .unwrap_or(serialized);
-    Ok((hash, data))
+pub fn encode_tree(tree: &Tree, _config: &CompressionConfig) -> Result<(ContentHash, Vec<u8>)> {
+    // Canonical trees stay uncompressed so a resume cursor can seek to an
+    // entry frame without decompressing the prefix.
+    Ok((tree.hash(), tree.encode_canonical()?))
 }
 
 pub fn decode_tree(data: &[u8]) -> Result<Tree> {
@@ -37,10 +35,7 @@ pub fn decode_tree(data: &[u8]) -> Result<Tree> {
 }
 
 pub fn decode_tree_serialized(data: &[u8]) -> Result<Tree> {
-    Tree::decode_current_msgpack(data).map_err(|error| match error {
-        TreeDecodeError::Decode(error) => HeddleError::from(error),
-        TreeDecodeError::Invalid(error) => HeddleError::InvalidTreeEntry(error),
-    })
+    Tree::decode_canonical(data).map_err(HeddleError::from)
 }
 
 /// Return the serialized tree body stored in a loose object, decompressing
@@ -140,7 +135,10 @@ mod tests {
         let (_, encoded_tree) = encode_tree(&tree, &CompressionConfig::default()).unwrap();
         let encoded_state = encode_state(&state, &CompressionConfig::default()).unwrap();
 
-        assert_eq!(&encoded_tree[9..13], &1_u32.to_be_bytes());
+        assert!(
+            crate::object::is_canonical_tree(&encoded_tree),
+            "trees stay uncompressed HTR4 so resume can seek"
+        );
         assert_eq!(&encoded_state[9..13], &1_u32.to_be_bytes());
     }
 
@@ -164,7 +162,7 @@ mod tests {
                     })
                     .collect(),
             );
-            let serialized_tree = rmp_serde::to_vec(&tree).unwrap();
+            let serialized_tree = tree.encode_canonical().unwrap();
             let (_, encoded_tree) = encode_tree(&tree, &config).unwrap();
             assert_eq!(decode_tree_body(&encoded_tree).unwrap(), serialized_tree);
 

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -596,7 +596,7 @@ impl FsStore {
             let body = codec::decode_tree_body(data.as_slice())?;
             if is_canonical_tree(&body) {
                 return Ok(Some(TreeEntryReader::open(
-                    OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(body)),
+                    OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
                     *tree_id,
                     cursor,
                 )?));
@@ -608,7 +608,7 @@ impl FsStore {
             && is_canonical_tree(&data)
         {
             return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(data)),
+                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
                 *tree_id,
                 cursor,
             )?));
@@ -682,7 +682,6 @@ impl FsStore {
             && let Some((obj_type, data)) = manager.get_hashed_object(hash)?
             && obj_type == ObjectType::Tree
         {
-            validate_tree_serialized(&data, *hash)?;
             return Ok(Some(data));
         }
 
@@ -1223,7 +1222,7 @@ impl ObjectStore for FsStore {
             && is_canonical_tree(&data)
         {
             return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(data)),
+                OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(data)),
                 *tree_id,
                 cursor,
             )?));

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -585,7 +585,7 @@ impl FsStore {
         {
             let file = File::open(&path)?;
             return Ok(Some(TreeEntryReader::open(
-                OpenedTreeBody::File(FileTreeSource::verified_placement(file, len)),
+                OpenedTreeBody::File(FileTreeSource::sequential_verify(file, len)),
                 *tree_id,
                 cursor,
             )?));

--- a/crates/objects/src/store/fs/fs_impl.rs
+++ b/crates/objects/src/store/fs/fs_impl.rs
@@ -3,7 +3,7 @@
 
 use std::{
     collections::HashSet,
-    fs::{self, OpenOptions},
+    fs::{self, File, OpenOptions},
     path::{Path, PathBuf},
 };
 
@@ -23,8 +23,9 @@ use super::{
 };
 use crate::{
     object::{
-        Action, ActionId, AnnotatedTag, Blob, ContentHash, State, StateAttachment,
-        StateAttachmentId, StateId, Tree,
+        Action, ActionId, AnnotatedTag, Blob, BytesTreeSource, ContentHash, FileTreeSource,
+        OpenedTreeBody, State, StateAttachment, StateAttachmentId, StateId, TREE_CANONICAL_MAGIC,
+        Tree, TreeEntryReader, TreeResumeCursor, is_canonical_tree,
     },
     store::{
         HeddleError, ObjectStore, Result, SidecarStore, SnapshotCommitDescriptor, codec,
@@ -568,6 +569,49 @@ impl FsStore {
             && let Some(size) = manager.get_hashed_object_size(hash)?
         {
             return Ok(Some(size));
+        }
+        Ok(None)
+    }
+
+    fn try_open_tree_once(
+        &self,
+        tree_id: &ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        let path = hash_path(&trees_dir(&self.root), tree_id);
+        if path.exists()
+            && let Some((header, len)) = read_file_header(&path, TREE_CANONICAL_MAGIC.len())?
+            && header.starts_with(TREE_CANONICAL_MAGIC)
+        {
+            let file = File::open(&path)?;
+            return Ok(Some(TreeEntryReader::open(
+                OpenedTreeBody::File(FileTreeSource::verified_placement(file, len)),
+                *tree_id,
+                cursor,
+            )?));
+        }
+        if path.exists()
+            && let Some(data) = read_file_bytes(&path)?
+        {
+            let body = codec::decode_tree_body(data.as_slice())?;
+            if is_canonical_tree(&body) {
+                return Ok(Some(TreeEntryReader::open(
+                    OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(body)),
+                    *tree_id,
+                    cursor,
+                )?));
+            }
+        }
+        if let Ok(manager) = self.pack_manager().read()
+            && let Some((obj_type, data)) = manager.get_hashed_object(tree_id)?
+            && obj_type == ObjectType::Tree
+            && is_canonical_tree(&data)
+        {
+            return Ok(Some(TreeEntryReader::open(
+                OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(data)),
+                *tree_id,
+                cursor,
+            )?));
         }
         Ok(None)
     }
@@ -1157,9 +1201,32 @@ impl ObjectStore for FsStore {
             None
         };
         if let Some(tree) = external_tree {
-            return rmp_serde::to_vec_named(&tree)
-                .map(Some)
-                .map_err(|error| HeddleError::InvalidObject(error.to_string()));
+            return tree.encode_canonical().map(Some).map_err(HeddleError::from);
+        }
+        Ok(None)
+    }
+
+    fn open_tree(
+        &self,
+        tree_id: &ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        if let Some(reader) = self.try_open_tree_once(tree_id, cursor)? {
+            return Ok(Some(reader));
+        }
+        if self.reload_packs_if_stale()?
+            && let Some(reader) = self.try_open_tree_once(tree_id, cursor)?
+        {
+            return Ok(Some(reader));
+        }
+        if let Some(data) = ObjectStore::get_tree_serialized(self, tree_id)?
+            && is_canonical_tree(&data)
+        {
+            return Ok(Some(TreeEntryReader::open(
+                OpenedTreeBody::Bytes(BytesTreeSource::verified_placement(data)),
+                *tree_id,
+                cursor,
+            )?));
         }
         Ok(None)
     }
@@ -1502,9 +1569,9 @@ impl ObjectStore for FsStore {
                 if let Some(blob) = self.get_blob(hash)? {
                     return Ok(Some((ObjectType::Blob, blob.into_content())));
                 }
-                // Raw storage body: skips a full tree decode + re-encode on
-                // the pack-building path. Byte-compatible with `to_vec_named`
-                // (the receiver installs through `put_tree_serialized`).
+                // Raw canonical storage body: skips a full tree decode +
+                // re-encode on the pack-building path (the receiver installs
+                // through `put_tree_serialized`).
                 if let Some(tree_data) = self.get_tree_serialized(hash)? {
                     return Ok(Some((ObjectType::Tree, tree_data)));
                 }

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -227,11 +227,7 @@ impl FsStore {
         if (commit_artifact.is_some() || !ObjectStore::has_tree_locally(self, &tree_hash)?)
             && seen_trees.insert(tree_hash)
         {
-            builder.add(
-                tree_hash,
-                PackObjectType::Tree,
-                tree.encode_canonical()?,
-            );
+            builder.add(tree_hash, PackObjectType::Tree, tree.encode_canonical()?);
             staged_trees.push((tree_hash, tree.clone()));
         }
 

--- a/crates/objects/src/store/fs/fs_pack.rs
+++ b/crates/objects/src/store/fs/fs_pack.rs
@@ -219,7 +219,7 @@ impl FsStore {
                 builder.add(
                     authored_hash,
                     PackObjectType::Tree,
-                    rmp_serde::to_vec_named(&authored_tree)?,
+                    authored_tree.encode_canonical()?,
                 );
                 staged_trees.push((authored_hash, authored_tree));
             }
@@ -230,7 +230,7 @@ impl FsStore {
             builder.add(
                 tree_hash,
                 PackObjectType::Tree,
-                rmp_serde::to_vec_named(tree)?,
+                tree.encode_canonical()?,
             );
             staged_trees.push((tree_hash, tree.clone()));
         }
@@ -503,7 +503,7 @@ impl FsStore {
                 continue;
             }
             if let Some(tree) = ObjectStore::get_tree(self, hash)? {
-                let data = rmp_serde::to_vec(&tree)?;
+                let data = tree.encode_canonical()?;
                 seen.insert(id);
                 builder.add(*hash, PackObjectType::Tree, data);
             }

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1032,8 +1032,8 @@ fn test_tree_roundtrip() {
 }
 
 #[test]
-fn loose_htr4_resume_skips_the_encoded_prefix() {
-    use crate::object::{TREE_HEADER_LEN, TreePageLimits};
+fn loose_htr4_open_is_sequential_and_hashes() {
+    use crate::object::{TreePageLimits, TreeStreamError};
 
     let (_temp, store) = create_test_store();
     let blob = ContentHash::compute(b"resume-leaf");
@@ -1042,28 +1042,26 @@ fn loose_htr4_resume_skips_the_encoded_prefix() {
         TreeEntry::file("b.txt", blob, true).unwrap(),
     ]);
     let hash = store.put_tree(&tree).unwrap();
-    let encoded_len = store.get_tree_serialized(&hash).unwrap().unwrap().len() as u64;
     let mut reader = store.open_tree(&hash, None).unwrap().unwrap();
     let first = reader
         .next_page(TreePageLimits::new(1, usize::MAX).unwrap())
         .unwrap()
         .unwrap();
-    let prefix_end = first.resume_cursor.byte_offset();
-    drop(reader);
-
-    let mut resumed = store
-        .open_tree(&hash, Some(&first.resume_cursor))
-        .unwrap()
-        .unwrap();
-    let rest = resumed
+    assert_eq!(first.entries[0].name(), "a.txt");
+    let rest = reader
         .next_page(TreePageLimits::new(8, usize::MAX).unwrap())
         .unwrap()
         .unwrap();
     assert_eq!(rest.entries[0].name(), "b.txt");
-    resumed.finish_and_verify().unwrap();
-    let suffix = encoded_len.saturating_sub(prefix_end);
-    assert!(resumed.bytes_read() <= TREE_HEADER_LEN as u64 + suffix);
-    assert!(resumed.bytes_read() < encoded_len);
+    reader.finish_and_verify().unwrap();
+
+    let error = store
+        .open_tree(&hash, Some(&first.resume_cursor))
+        .expect_err("hash-path is not a content-address proof");
+    assert!(matches!(
+        error,
+        HeddleError::TreeStream(TreeStreamError::UnverifiedRange)
+    ));
 }
 
 #[test]

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -581,7 +581,7 @@ fn install_pack_accepts_valid_mixed_native_pack() {
     builder.add(
         tree_hash,
         PackObjectType::Tree,
-        rmp_serde::to_vec_named(&tree).unwrap(),
+        tree.encode_canonical().unwrap(),
     );
     builder.add_id(
         PackObjectId::StateId(state.id()),
@@ -853,7 +853,7 @@ fn gc_preserves_and_repacks_loose_v2_tree_shadow_over_packed_v1_body() {
     let tree = Tree::from_entries(vec![TreeEntry::file("file.txt", blob_hash, false).unwrap()]);
     let tree_hash = tree.hash();
     let legacy_bytes = legacy_tree_v1_bytes_for_test("file.txt", blob_hash);
-    let current_bytes = rmp_serde::to_vec(&tree).unwrap();
+    let current_bytes = tree.encode_canonical().unwrap();
 
     let mut builder = PackBuilder::new(CompressionConfig::default());
     builder.add(tree_hash, PackObjectType::Tree, legacy_bytes);
@@ -1297,40 +1297,14 @@ fn test_get_action_rejects_wrong_object_swap() {
 
 #[test]
 fn test_get_tree_rejects_invalid_deserialized_entry_name() {
-    #[derive(serde::Serialize)]
-    struct EncodedTree {
-        version: u8,
-        entries: Vec<EncodedTreeEntry>,
-    }
-
-    #[derive(serde::Serialize)]
-    struct EncodedTreeEntry {
-        name: String,
-        kind: u8,
-        hash: Option<ContentHash>,
-        executable: Option<bool>,
-        git_format: Option<u8>,
-        git_oid: Option<Vec<u8>>,
-        spool_id: Option<crate::object::SpoolId>,
-        spool_state_id: Option<StateId>,
-    }
-
     let (_temp, store) = create_test_store();
-
-    let invalid_tree = EncodedTree {
-        version: 3,
-        entries: vec![EncodedTreeEntry {
-            name: "bad/name".to_string(),
-            kind: 0,
-            hash: Some(ContentHash::compute(b"blob")),
-            executable: Some(false),
-            git_format: None,
-            git_oid: None,
-            spool_id: None,
-            spool_state_id: None,
-        }],
-    };
-    let tree_hash = ContentHash::compute(b"invalid tree fixture");
+    let tree = Tree::from_entries(vec![
+        TreeEntry::file("ab", ContentHash::compute(b"blob"), false).unwrap(),
+    ]);
+    let tree_hash = tree.hash();
+    let mut bytes = tree.encode_canonical().unwrap();
+    let name_at = crate::object::TREE_HEADER_LEN + 4 + 1 + 1 + 2;
+    bytes[name_at + 1] = b'/';
     let tree_path = store
         .root
         .join("objects/trees")
@@ -1338,7 +1312,7 @@ fn test_get_tree_rejects_invalid_deserialized_entry_name() {
         .join(&tree_hash.to_hex()[2..]);
     let parent = tree_path.parent().unwrap();
     std::fs::create_dir_all(parent).unwrap();
-    std::fs::write(&tree_path, rmp_serde::to_vec(&invalid_tree).unwrap()).unwrap();
+    std::fs::write(&tree_path, bytes).unwrap();
 
     let error = store
         .get_tree(&tree_hash)

--- a/crates/objects/src/store/fs/fs_tests.rs
+++ b/crates/objects/src/store/fs/fs_tests.rs
@@ -1032,6 +1032,41 @@ fn test_tree_roundtrip() {
 }
 
 #[test]
+fn loose_htr4_resume_skips_the_encoded_prefix() {
+    use crate::object::{TREE_HEADER_LEN, TreePageLimits};
+
+    let (_temp, store) = create_test_store();
+    let blob = ContentHash::compute(b"resume-leaf");
+    let tree = Tree::from_entries(vec![
+        TreeEntry::file("a.txt", blob, false).unwrap(),
+        TreeEntry::file("b.txt", blob, true).unwrap(),
+    ]);
+    let hash = store.put_tree(&tree).unwrap();
+    let encoded_len = store.get_tree_serialized(&hash).unwrap().unwrap().len() as u64;
+    let mut reader = store.open_tree(&hash, None).unwrap().unwrap();
+    let first = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    let prefix_end = first.resume_cursor.byte_offset();
+    drop(reader);
+
+    let mut resumed = store
+        .open_tree(&hash, Some(&first.resume_cursor))
+        .unwrap()
+        .unwrap();
+    let rest = resumed
+        .next_page(TreePageLimits::new(8, usize::MAX).unwrap())
+        .unwrap()
+        .unwrap();
+    assert_eq!(rest.entries[0].name(), "b.txt");
+    resumed.finish_and_verify().unwrap();
+    let suffix = encoded_len.saturating_sub(prefix_end);
+    assert!(resumed.bytes_read() <= TREE_HEADER_LEN as u64 + suffix);
+    assert!(resumed.bytes_read() < encoded_len);
+}
+
+#[test]
 fn test_state_roundtrip() {
     let (_temp, store) = create_test_store();
 

--- a/crates/objects/src/store/fs/repack/compact.rs
+++ b/crates/objects/src/store/fs/repack/compact.rs
@@ -196,7 +196,7 @@ fn add_tree_frames(
             ids.clear();
             tree_bytes = 0;
         }
-        let source = rmp_serde::to_vec_named(&tree).map_err(HeddleError::from)?;
+        let source = tree.encode_canonical().map_err(HeddleError::from)?;
         logical_bytes = logical_bytes.saturating_add(source.len() as u64);
         tree_bytes = tree_bytes.saturating_add(tree_size);
         trees.push(tree);

--- a/crates/objects/src/store/fs/repack/tests/integrity.rs
+++ b/crates/objects/src/store/fs/repack/tests/integrity.rs
@@ -53,7 +53,7 @@ fn repack_preserves_every_typed_identity_byte_identically() {
         (
             PackObjectId::Hash(tree_hash),
             ObjectType::Tree,
-            rmp_serde::to_vec_named(&tree).unwrap(),
+            tree.encode_canonical().unwrap(),
         ),
         (
             PackObjectId::StateId(state_id),
@@ -63,7 +63,7 @@ fn repack_preserves_every_typed_identity_byte_identically() {
         (
             PackObjectId::Hash(tree_two_hash),
             ObjectType::Tree,
-            rmp_serde::to_vec_named(&tree_two).unwrap(),
+            tree_two.encode_canonical().unwrap(),
         ),
         (
             PackObjectId::StateId(state_two_id),
@@ -256,7 +256,7 @@ fn corrupted_compact_metadata_frame_is_rejected_before_cutover() {
     builder.add_id(
         PackObjectId::Hash(tree_hash),
         ObjectType::Tree,
-        rmp_serde::to_vec_named(&tree).unwrap(),
+        tree.encode_canonical().unwrap(),
     );
     builder.add_id(
         PackObjectId::StateId(state_id),

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -8,8 +8,9 @@ use std::{collections::HashMap, sync::RwLock};
 
 use crate::{
     object::{
-        Action, ActionId, AnnotatedTag, Blob, ContentHash, State, StateAttachment,
-        StateAttachmentId, StateId, Tree,
+        Action, ActionId, AnnotatedTag, Blob, BytesTreeSource, ContentHash, OpenedTreeBody, State,
+        StateAttachment, StateAttachmentId, StateId, Tree, TreeEntryReader, TreeResumeCursor,
+        is_canonical_tree,
     },
     store::{HeddleError, ObjectStore, Result, SidecarStore},
     sync::RwLockExt,
@@ -119,6 +120,26 @@ impl ObjectStore for InMemoryStore {
             Some(bytes) => Ok(Some(Tree::decode_canonical(bytes)?)),
             None => Ok(None),
         }
+    }
+
+    fn open_tree(
+        &self,
+        tree_id: &ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        let Some(body) = self.trees.read_or_poisoned().get(tree_id).cloned() else {
+            return Ok(None);
+        };
+        if !is_canonical_tree(&body) {
+            return Err(HeddleError::InvalidObject(
+                "tree body is not the streamable canonical encoding".to_string(),
+            ));
+        }
+        Ok(Some(TreeEntryReader::open(
+            OpenedTreeBody::Bytes(BytesTreeSource::sequential_verify(body)),
+            *tree_id,
+            cursor,
+        )?))
     }
 
     fn get_tree_serialized(&self, hash: &ContentHash) -> Result<Option<Vec<u8>>> {

--- a/crates/objects/src/store/memory.rs
+++ b/crates/objects/src/store/memory.rs
@@ -116,7 +116,7 @@ impl ObjectStore for InMemoryStore {
 
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
         match self.trees.read_or_poisoned().get(hash) {
-            Some(bytes) => Ok(Some(rmp_serde::from_slice(bytes)?)),
+            Some(bytes) => Ok(Some(Tree::decode_canonical(bytes)?)),
             None => Ok(None),
         }
     }
@@ -129,7 +129,7 @@ impl ObjectStore for InMemoryStore {
         let hash = tree.hash();
         self.trees
             .write_or_poisoned()
-            .insert(hash, rmp_serde::to_vec(tree)?);
+            .insert(hash, tree.encode_canonical()?);
         Ok(hash)
     }
 

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -607,8 +607,8 @@ pub trait ObjectStore: Send + Sync {
         self.has_blob(hash)
     }
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>>;
-    /// Open a streamable HTR4 tree body. Resume skips the encoded prefix when
-    /// the backend exposes verified placement or a ranged file handle.
+    /// Open a streamable HTR4 tree body. Store backends use sequential
+    /// verify: resume at ordinal > 0 is refused until the bytes are hashed.
     fn open_tree(
         &self,
         tree_id: &ContentHash,

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -731,10 +731,7 @@ pub trait ObjectStore: Send + Sync {
                     return Ok(Some((pack::ObjectType::Blob, blob.content().to_vec())));
                 }
                 if let Some(tree) = self.get_tree(hash)? {
-                    return Ok(Some((
-                        pack::ObjectType::Tree,
-                        tree.encode_canonical()?,
-                    )));
+                    return Ok(Some((pack::ObjectType::Tree, tree.encode_canonical()?)));
                 }
                 if let Some(action) = self.get_action(&ActionId::from_hash(*hash))? {
                     return Ok(Some((

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -4,8 +4,8 @@
 use std::{path::PathBuf, sync::Arc};
 
 use crate::object::{
-    Action, ActionId, AnnotatedTag, Blob, ContentHash, State, StateAttachment, StateAttachmentId,
-    StateId, Tree,
+    Action, ActionId, AnnotatedTag, Blob, ContentHash, OpenedTreeBody, State, StateAttachment,
+    StateAttachmentId, StateId, Tree, TreeEntryReader, TreeResumeCursor, is_canonical_tree,
 };
 
 pub mod codec;
@@ -151,6 +151,15 @@ impl ObjectStore for AnyStore {
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>> {
         match self {
             AnyStore::Fs(inner) => ObjectStore::get_tree(inner, hash),
+        }
+    }
+    fn open_tree(
+        &self,
+        tree_id: &ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        match self {
+            AnyStore::Fs(inner) => ObjectStore::open_tree(inner, tree_id, cursor),
         }
     }
     fn get_tree_serialized(&self, hash: &ContentHash) -> Result<Option<Vec<u8>>> {
@@ -598,6 +607,27 @@ pub trait ObjectStore: Send + Sync {
         self.has_blob(hash)
     }
     fn get_tree(&self, hash: &ContentHash) -> Result<Option<Tree>>;
+    /// Open a streamable HTR4 tree body. Resume skips the encoded prefix when
+    /// the backend exposes verified placement or a ranged file handle.
+    fn open_tree(
+        &self,
+        tree_id: &ContentHash,
+        cursor: Option<&TreeResumeCursor>,
+    ) -> Result<Option<TreeEntryReader<OpenedTreeBody>>> {
+        let Some(body) = self.get_tree_serialized(tree_id)? else {
+            return Ok(None);
+        };
+        if !is_canonical_tree(&body) {
+            return Err(HeddleError::InvalidObject(
+                "tree body is not the streamable canonical encoding".to_string(),
+            ));
+        }
+        Ok(Some(TreeEntryReader::open(
+            OpenedTreeBody::Bytes(crate::object::BytesTreeSource::verified_placement(body)),
+            *tree_id,
+            cursor,
+        )?))
+    }
     fn put_tree(&self, tree: &Tree) -> Result<ContentHash>;
     fn has_tree(&self, hash: &ContentHash) -> Result<bool>;
     /// Return whether the tree is owned by this store, excluding any configured
@@ -634,7 +664,7 @@ pub trait ObjectStore: Send + Sync {
         self.put_blob_with_hash(&Blob::from_slice(data), hash)
     }
 
-    /// Return the raw rmp-encoded tree body for `hash`.
+    /// Return the raw canonical tree body for `hash`.
     ///
     /// This is a migration seam, not a runtime compatibility reader: callers
     /// that need current tree semantics should use [`ObjectStore::get_tree`].
@@ -642,15 +672,13 @@ pub trait ObjectStore: Send + Sync {
     /// canonicalize older tree encodings without reintroducing fallback decode
     /// into the durable `Tree` type.
     fn get_tree_serialized(&self, hash: &ContentHash) -> Result<Option<Vec<u8>>> {
-        Ok(self
-            .get_tree(hash)?
-            .map(|tree| rmp_serde::to_vec(&tree))
-            .transpose()?)
+        self.get_tree(hash)?
+            .map(|tree| tree.encode_canonical().map_err(HeddleError::from))
+            .transpose()
     }
 
     fn put_tree_serialized(&self, data: &[u8], hash: ContentHash) -> Result<ContentHash> {
-        let tree: Tree = rmp_serde::from_slice(data)?;
-        tree.validate()?;
+        let tree = Tree::decode_canonical(data)?;
         if tree.hash() != hash {
             return Err(HeddleError::Corruption {
                 expected: hash,
@@ -705,7 +733,7 @@ pub trait ObjectStore: Send + Sync {
                 if let Some(tree) = self.get_tree(hash)? {
                     return Ok(Some((
                         pack::ObjectType::Tree,
-                        rmp_serde::to_vec_named(&tree)?,
+                        tree.encode_canonical()?,
                     )));
                 }
                 if let Some(action) = self.get_action(&ActionId::from_hash(*hash))? {
@@ -974,7 +1002,7 @@ mod any_store_tests {
         assert!(store.has_tree(&tree_hash).unwrap());
         assert!(store.list_trees().unwrap().contains(&tree_hash));
         let tree2 = Tree::new();
-        let tree2_bytes = rmp_serde::to_vec_named(&tree2).unwrap();
+        let tree2_bytes = tree2.encode_canonical().unwrap();
         assert_eq!(
             store
                 .put_tree_serialized(&tree2_bytes, tree2.hash())

--- a/crates/objects/src/store/mod.rs
+++ b/crates/objects/src/store/mod.rs
@@ -623,7 +623,7 @@ pub trait ObjectStore: Send + Sync {
             ));
         }
         Ok(Some(TreeEntryReader::open(
-            OpenedTreeBody::Bytes(crate::object::BytesTreeSource::verified_placement(body)),
+            OpenedTreeBody::Bytes(crate::object::BytesTreeSource::sequential_verify(body)),
             *tree_id,
             cursor,
         )?))
@@ -664,13 +664,13 @@ pub trait ObjectStore: Send + Sync {
         self.put_blob_with_hash(&Blob::from_slice(data), hash)
     }
 
-    /// Return the raw canonical tree body for `hash`.
+    /// Return the stored tree body for `hash`, without requiring HTR4.
     ///
     /// This is a migration seam, not a runtime compatibility reader: callers
     /// that need current tree semantics should use [`ObjectStore::get_tree`].
-    /// Backends with direct raw storage override this so one-shot migrations can
-    /// canonicalize older tree encodings without reintroducing fallback decode
-    /// into the durable `Tree` type.
+    /// Loose and packed backends must return the raw stored bytes so one-shot
+    /// migrations can canonicalize older encodings without a current-decoder
+    /// gate. Default impls that only have `get_tree` re-encode current trees.
     fn get_tree_serialized(&self, hash: &ContentHash) -> Result<Option<Vec<u8>>> {
         self.get_tree(hash)?
             .map(|tree| tree.encode_canonical().map_err(HeddleError::from))

--- a/crates/objects/src/store/store_compliance.rs
+++ b/crates/objects/src/store/store_compliance.rs
@@ -90,7 +90,7 @@ fn tree_round_trip<S: ObjectStore>(store: &S) {
 }
 
 fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
-    use crate::object::{TreeEntry, TreePageLimits};
+    use crate::object::{TREE_HEADER_LEN, TreeEntry, TreePageLimits};
 
     let blob = ContentHash::compute(b"compliance-stream");
     let tree = Tree::from_entries(vec![
@@ -98,6 +98,11 @@ fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
         TreeEntry::file("b.txt", blob, true).expect("b"),
     ]);
     let hash = store.put_tree(&tree).expect("put_tree failed");
+    let encoded_len = store
+        .get_tree_serialized(&hash)
+        .expect("serialized")
+        .expect("tree body")
+        .len() as u64;
     let mut reader = store
         .open_tree(&hash, None)
         .expect("open_tree")
@@ -108,6 +113,7 @@ fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
         .expect("first page");
     assert_eq!(page.entries.len(), 1);
     assert_eq!(page.entries[0].name(), "a.txt");
+    let prefix_end = page.resume_cursor.byte_offset();
     let mut resumed = store
         .open_tree(&hash, Some(&page.resume_cursor))
         .expect("resume")
@@ -118,6 +124,17 @@ fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
         .expect("rest");
     assert_eq!(rest.entries[0].name(), "b.txt");
     resumed.finish_and_verify().expect("verify");
+    let suffix = encoded_len.saturating_sub(prefix_end);
+    assert!(
+        resumed.bytes_read() <= TREE_HEADER_LEN as u64 + suffix,
+        "resume transferred {} bytes; header+suffix is {}",
+        resumed.bytes_read(),
+        TREE_HEADER_LEN as u64 + suffix
+    );
+    assert!(
+        resumed.bytes_read() < encoded_len,
+        "resume must not transfer the complete encoded tree"
+    );
 }
 
 fn tree_missing_returns_none<S: ObjectStore>(store: &S) {

--- a/crates/objects/src/store/store_compliance.rs
+++ b/crates/objects/src/store/store_compliance.rs
@@ -90,7 +90,8 @@ fn tree_round_trip<S: ObjectStore>(store: &S) {
 }
 
 fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
-    use crate::object::{TREE_HEADER_LEN, TreeEntry, TreePageLimits};
+    use crate::error::HeddleError;
+    use crate::object::{TreeEntry, TreePageLimits, TreeStreamError};
 
     let blob = ContentHash::compute(b"compliance-stream");
     let tree = Tree::from_entries(vec![
@@ -98,11 +99,6 @@ fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
         TreeEntry::file("b.txt", blob, true).expect("b"),
     ]);
     let hash = store.put_tree(&tree).expect("put_tree failed");
-    let encoded_len = store
-        .get_tree_serialized(&hash)
-        .expect("serialized")
-        .expect("tree body")
-        .len() as u64;
     let mut reader = store
         .open_tree(&hash, None)
         .expect("open_tree")
@@ -113,28 +109,25 @@ fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
         .expect("first page");
     assert_eq!(page.entries.len(), 1);
     assert_eq!(page.entries[0].name(), "a.txt");
-    let prefix_end = page.resume_cursor.byte_offset();
-    let mut resumed = store
-        .open_tree(&hash, Some(&page.resume_cursor))
-        .expect("resume")
-        .expect("tree body");
-    let rest = resumed
+    let rest = reader
         .next_page(TreePageLimits::new(8, usize::MAX).expect("limits"))
         .expect("page")
         .expect("rest");
     assert_eq!(rest.entries[0].name(), "b.txt");
-    resumed.finish_and_verify().expect("verify");
-    let suffix = encoded_len.saturating_sub(prefix_end);
-    assert!(
-        resumed.bytes_read() <= TREE_HEADER_LEN as u64 + suffix,
-        "resume transferred {} bytes; header+suffix is {}",
-        resumed.bytes_read(),
-        TREE_HEADER_LEN as u64 + suffix
-    );
-    assert!(
-        resumed.bytes_read() < encoded_len,
-        "resume must not transfer the complete encoded tree"
-    );
+    reader.finish_and_verify().expect("verify");
+
+    match store.open_tree(&hash, Some(&page.resume_cursor)) {
+        Ok(Some(mut resumed)) => {
+            let rest = resumed
+                .next_page(TreePageLimits::new(8, usize::MAX).expect("limits"))
+                .expect("page")
+                .expect("rest");
+            assert_eq!(rest.entries[0].name(), "b.txt");
+            resumed.finish_and_verify().expect("verify");
+        }
+        Err(HeddleError::TreeStream(TreeStreamError::UnverifiedRange)) => {}
+        other => panic!("resume must succeed on verified placement or fail closed: {other:?}"),
+    }
 }
 
 fn tree_missing_returns_none<S: ObjectStore>(store: &S) {

--- a/crates/objects/src/store/store_compliance.rs
+++ b/crates/objects/src/store/store_compliance.rs
@@ -25,6 +25,7 @@ pub fn run_compliance_tests<S: ObjectStore>(store: &S) {
     blob_list(store);
     tree_round_trip(store);
     tree_missing_returns_none(store);
+    tree_streaming_round_trip(store);
     state_round_trip(store);
     state_has(store);
     state_list(store);
@@ -86,6 +87,37 @@ fn tree_round_trip<S: ObjectStore>(store: &S) {
         .expect("get_tree failed")
         .expect("tree missing after put");
     assert_eq!(got.hash(), hash, "tree hash changed after round-trip");
+}
+
+fn tree_streaming_round_trip<S: ObjectStore>(store: &S) {
+    use crate::object::{TreeEntry, TreePageLimits};
+
+    let blob = ContentHash::compute(b"compliance-stream");
+    let tree = Tree::from_entries(vec![
+        TreeEntry::file("a.txt", blob, false).expect("a"),
+        TreeEntry::file("b.txt", blob, true).expect("b"),
+    ]);
+    let hash = store.put_tree(&tree).expect("put_tree failed");
+    let mut reader = store
+        .open_tree(&hash, None)
+        .expect("open_tree")
+        .expect("tree body");
+    let page = reader
+        .next_page(TreePageLimits::new(1, usize::MAX).expect("limits"))
+        .expect("page")
+        .expect("first page");
+    assert_eq!(page.entries.len(), 1);
+    assert_eq!(page.entries[0].name(), "a.txt");
+    let mut resumed = store
+        .open_tree(&hash, Some(&page.resume_cursor))
+        .expect("resume")
+        .expect("tree body");
+    let rest = resumed
+        .next_page(TreePageLimits::new(8, usize::MAX).expect("limits"))
+        .expect("page")
+        .expect("rest");
+    assert_eq!(rest.entries[0].name(), "b.txt");
+    resumed.finish_and_verify().expect("verify");
 }
 
 fn tree_missing_returns_none<S: ObjectStore>(store: &S) {

--- a/crates/objects/src/transfer/graph.rs
+++ b/crates/objects/src/transfer/graph.rs
@@ -829,7 +829,7 @@ fn object_info_from_event(
             }))
         }
         StateClosureEvent::Tree { hash, tree } => {
-            let tree_bytes = rmp_serde::to_vec_named(tree)?;
+            let tree_bytes = tree.encode_canonical().map_err(HeddleError::from)?;
             Ok(Some(ObjectInfo {
                 id: ObjectId::Hash(hash),
                 obj_type: ObjectType::Tree,

--- a/crates/pack/src/store/pack/manager_tests.rs
+++ b/crates/pack/src/store/pack/manager_tests.rs
@@ -98,7 +98,7 @@ fn write_hot_tree_pack(
     builder.add(
         tree.hash(),
         ObjectType::Tree,
-        rmp_serde::to_vec_named(tree).unwrap(),
+        tree.encode_canonical().unwrap(),
     );
     let (pack, index, _) = builder.build().unwrap();
     let pack_path = root.join(format!("{name}.pack"));
@@ -191,7 +191,7 @@ fn random_access_record_wins_over_solid_frame_for_concurrent_reads() {
     );
     let manager = Arc::new(manager);
 
-    let expected = Arc::new(rmp_serde::to_vec_named(&trees[0]).unwrap());
+    let expected = Arc::new(trees[0].encode_canonical().unwrap());
     let readers = (0..8)
         .map(|_| {
             let manager = Arc::clone(&manager);

--- a/crates/pack/src/store/pack/pack_reader.rs
+++ b/crates/pack/src/store/pack/pack_reader.rs
@@ -902,7 +902,7 @@ fn decode_compact_object(
         {
             let tree = heddle_object_model::compact::extract_tree(data, *hash)
                 .map_err(|error| compact_extract_error(requested_id, error))?;
-            rmp_serde::to_vec_named(&tree)
+            tree.encode_canonical()
                 .map(Some)
                 .map_err(|error| StoreError::InvalidObject(error.to_string()))
         }
@@ -960,7 +960,8 @@ fn decode_compact_objects(
                 .into_iter()
                 .map(|tree| {
                     let id = PackObjectId::Hash(tree.hash());
-                    let bytes = rmp_serde::to_vec_named(&tree)
+                    let bytes = tree
+                        .encode_canonical()
                         .map_err(|error| StoreError::InvalidObject(error.to_string()))?;
                     Ok((id, ObjectType::Tree, bytes))
                 })

--- a/crates/pack/src/store/pack/streaming_builder.rs
+++ b/crates/pack/src/store/pack/streaming_builder.rs
@@ -1068,7 +1068,7 @@ mod tests {
                 (
                     *id,
                     ObjectType::Tree,
-                    rmp_serde::to_vec_named(tree).unwrap().len() as u64,
+                    tree.encode_canonical().unwrap().len() as u64,
                 )
             })
             .collect::<Vec<_>>();
@@ -1082,7 +1082,7 @@ mod tests {
         for (id, tree) in ids.iter().zip(&trees) {
             let (object_type, bytes) = reader.get_object(id).unwrap().unwrap();
             assert_eq!(object_type, ObjectType::Tree);
-            assert_eq!(bytes, rmp_serde::to_vec_named(tree).unwrap());
+            assert_eq!(bytes, tree.encode_canonical().unwrap());
         }
     }
 

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -207,6 +207,12 @@ pub static MIGRATIONS: &[Migration] = &[
         applies_to: SchemaTarget::AnnotatedTags,
         run: run_first_class_annotated_tags,
     },
+    Migration {
+        id: "0005_streamable_tree_encoding",
+        description: "Rewrite durable trees into the streamable HTR4 canonical encoding",
+        applies_to: SchemaTarget::Trees,
+        run: run_streamable_tree_encoding,
+    },
 ];
 
 /// Returns true when every registered migration id is already recorded in
@@ -296,6 +302,9 @@ fn run_canonicalize_tree_entries(ctx: &mut MigrationCtx<'_>) -> Result<()> {
         let Some(raw) = ctx.repo.store().get_tree_serialized(&tree_hash)? else {
             continue;
         };
+        if objects::object::is_canonical_tree(&raw) {
+            continue;
+        }
 
         if let Ok(tree) = rmp_serde::from_slice::<objects::object::Tree>(&raw) {
             tree.validate()?;
@@ -322,9 +331,9 @@ fn run_canonicalize_tree_entries(ctx: &mut MigrationCtx<'_>) -> Result<()> {
                 found,
             });
         }
-        let canonical = rmp_serde::to_vec(&tree).map_err(|err| {
+        let canonical = tree.encode_canonical().map_err(|err| {
             HeddleError::InvalidObject(format!(
-                "failed to encode canonical V2 tree {} during 0003_canonicalize_tree_entries: {err}",
+                "failed to encode canonical HTR4 tree {} during 0003_canonicalize_tree_entries: {err}",
                 tree_hash.short()
             ))
         })?;
@@ -339,6 +348,47 @@ fn run_canonicalize_tree_entries(ctx: &mut MigrationCtx<'_>) -> Result<()> {
             })?;
     }
 
+    Ok(())
+}
+
+fn run_streamable_tree_encoding(ctx: &mut MigrationCtx<'_>) -> Result<()> {
+    for tree_hash in ctx.repo.store().list_trees()? {
+        let Some(raw) = ctx.repo.store().get_tree_serialized(&tree_hash)? else {
+            continue;
+        };
+        if objects::object::is_canonical_tree(&raw) {
+            continue;
+        }
+        let tree = rmp_serde::from_slice::<objects::object::Tree>(&raw).map_err(|err| {
+            HeddleError::InvalidObject(format!(
+                "failed to decode msgpack tree {} during 0005_streamable_tree_encoding: {err}",
+                tree_hash.short()
+            ))
+        })?;
+        tree.validate()?;
+        let found = tree.hash();
+        if found != tree_hash {
+            return Err(HeddleError::Corruption {
+                expected: tree_hash,
+                found,
+            });
+        }
+        let canonical = tree.encode_canonical().map_err(|err| {
+            HeddleError::InvalidObject(format!(
+                "failed to encode HTR4 tree {} during 0005_streamable_tree_encoding: {err}",
+                tree_hash.short()
+            ))
+        })?;
+        ctx.repo
+            .store()
+            .put_tree_serialized(&canonical, tree_hash)
+            .map_err(|err| {
+                HeddleError::InvalidObject(format!(
+                    "failed to write HTR4 tree {} during 0005_streamable_tree_encoding: {err}",
+                    tree_hash.short()
+                ))
+            })?;
+    }
     Ok(())
 }
 
@@ -568,6 +618,7 @@ mod tests {
                 "0002_canonicalize_thread_records",
                 "0003_canonicalize_tree_entries",
                 "0004_first_class_annotated_tags",
+                "0005_streamable_tree_encoding",
             ],
             "the deletion-wave migration ids must stay ordered and reviewable",
         );
@@ -621,12 +672,48 @@ mod tests {
             .get_tree_serialized(&tree_hash)
             .unwrap()
             .expect("raw tree exists after migration");
-        rmp_serde::from_slice::<Tree>(&raw_after).expect("tree is canonical V2 after migration");
+        assert!(
+            objects::object::is_canonical_tree(&raw_after),
+            "tree is HTR4 after migration"
+        );
+        assert_eq!(
+            Tree::decode_canonical(&raw_after).expect("canonical decode"),
+            decoded
+        );
 
         let config = repo_config::RepoConfig::load(&config_path).unwrap();
         assert_eq!(
             config.repository.version,
             repo_config::SUPPORTED_REPO_FORMAT
+        );
+    }
+
+    #[test]
+    fn migration_0005_rewrites_msgpack_trees_to_htr4() {
+        let (_temp, repo) = fresh_repo();
+        remove_ledger(&repo);
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("file.txt", ContentHash::compute(b"body"), false).unwrap(),
+        ]);
+        let tree_hash = tree.hash();
+        let msgpack = rmp_serde::to_vec(&tree).unwrap();
+        write_loose_tree_bytes(&repo, tree_hash, &msgpack);
+        assert!(
+            !objects::object::is_canonical_tree(&msgpack),
+            "fixture must be the superseded msgpack body"
+        );
+
+        apply_pending(&repo).unwrap();
+
+        let raw = repo
+            .store()
+            .get_tree_serialized(&tree_hash)
+            .unwrap()
+            .expect("rewritten tree");
+        assert!(objects::object::is_canonical_tree(&raw));
+        assert_eq!(
+            repo.store().get_tree(&tree_hash).unwrap().unwrap(),
+            tree
         );
     }
 

--- a/crates/repo/src/migration.rs
+++ b/crates/repo/src/migration.rs
@@ -711,10 +711,55 @@ mod tests {
             .unwrap()
             .expect("rewritten tree");
         assert!(objects::object::is_canonical_tree(&raw));
-        assert_eq!(
-            repo.store().get_tree(&tree_hash).unwrap().unwrap(),
-            tree
+        assert_eq!(repo.store().get_tree(&tree_hash).unwrap().unwrap(), tree);
+    }
+
+    #[test]
+    fn migration_0005_rewrites_packed_msgpack_trees_to_htr4() {
+        use objects::store::{
+            CompressionConfig,
+            pack::{ObjectType, PackBuilder},
+        };
+
+        let (_temp, repo) = fresh_repo();
+        remove_ledger(&repo);
+        let tree = Tree::from_entries(vec![
+            TreeEntry::file("packed.txt", ContentHash::compute(b"packed-body"), false).unwrap(),
+        ]);
+        let tree_hash = tree.hash();
+        let msgpack = rmp_serde::to_vec(&tree).unwrap();
+        assert!(!objects::object::is_canonical_tree(&msgpack));
+
+        let mut builder = PackBuilder::new(CompressionConfig::disabled());
+        builder.add(tree_hash, ObjectType::Tree, msgpack.clone());
+        let (pack, index, _) = builder.build().unwrap();
+        let packs = repo.heddle_dir().join("packs");
+        std::fs::create_dir_all(&packs).unwrap();
+        std::fs::write(packs.join("legacy-msgpack-tree.pack"), pack).unwrap();
+        std::fs::write(packs.join("legacy-msgpack-tree.idx"), index).unwrap();
+
+        assert!(
+            repo.store().get_tree(&tree_hash).is_err(),
+            "current runtime reader must reject packed msgpack before migration"
         );
+        assert_eq!(
+            repo.store()
+                .get_tree_serialized(&tree_hash)
+                .unwrap()
+                .expect("raw packed tree exists"),
+            msgpack,
+            "packed raw-read seam must return leftover msgpack without HTR4 validation"
+        );
+
+        apply_pending(&repo).unwrap();
+
+        let raw = repo
+            .store()
+            .get_tree_serialized(&tree_hash)
+            .unwrap()
+            .expect("rewritten tree");
+        assert!(objects::object::is_canonical_tree(&raw));
+        assert_eq!(repo.store().get_tree(&tree_hash).unwrap().unwrap(), tree);
     }
 
     #[test]

--- a/crates/wire/src/object_transfer.rs
+++ b/crates/wire/src/object_transfer.rs
@@ -140,8 +140,8 @@ pub fn load_requested_object(store: &impl ObjectStore, req: &ObjectRequest) -> R
         ObjectId::Hash(hash) => {
             if let Some(blob) = store.get_blob(hash)? {
                 (ObjectType::Blob, blob.content().to_vec())
-            } else if let Some(tree) = store.get_tree(hash)? {
-                (ObjectType::Tree, rmp_serde::to_vec_named(&tree)?)
+            } else if let Some(data) = store.get_tree_serialized(hash)? {
+                (ObjectType::Tree, data)
             } else {
                 return Err(ProtocolError::ObjectNotFound(hash.to_hex()));
             }
@@ -182,12 +182,9 @@ pub fn load_object_data(
             .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?
             .content()
             .to_vec(),
-        (ObjectId::Hash(hash), ObjectType::Tree) => {
-            let tree = store
-                .get_tree(hash)?
-                .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?;
-            rmp_serde::to_vec_named(&tree)?
-        }
+        (ObjectId::Hash(hash), ObjectType::Tree) => store
+            .get_tree_serialized(hash)?
+            .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?,
         (ObjectId::Hash(hash), ObjectType::AnnotatedTag) => store
             .get_annotated_tag(hash)?
             .ok_or_else(|| ProtocolError::ObjectNotFound(hash.to_hex()))?
@@ -240,7 +237,9 @@ pub fn store_received_object(store: &impl ObjectStore, data: &ObjectData) -> Res
             store.put_blob_bytes_with_hash(&data.data, *hash)?;
         }
         (ObjectId::Hash(hash), ObjectType::Tree) => {
-            let tree: Tree = rmp_serde::from_slice(&data.data)?;
+            let tree = Tree::decode_canonical(&data.data).map_err(|error| {
+                ProtocolError::InvalidState(format!("invalid tree object: {error}"))
+            })?;
             tree.validate().map_err(|error| {
                 ProtocolError::InvalidState(format!("invalid tree object: {error}"))
             })?;
@@ -395,10 +394,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(tree_data.obj_type, ObjectType::Tree);
-        assert_eq!(
-            rmp_serde::from_slice::<Tree>(&tree_data.data).unwrap(),
-            tree
-        );
+        assert_eq!(Tree::decode_canonical(&tree_data.data).unwrap(), tree);
         store_received_object(&dest, &tree_data).unwrap();
         assert_eq!(dest.get_tree(&tree_hash).unwrap().unwrap(), tree);
 
@@ -472,7 +468,7 @@ mod tests {
         let blob = Blob::from("tree leaf");
         let blob_hash = store.put_blob(&blob).unwrap();
         let tree = Tree::from_entries(vec![TreeEntry::file("leaf.txt", blob_hash, false).unwrap()]);
-        let tree_bytes = rmp_serde::to_vec_named(&tree).unwrap();
+        let tree_bytes = tree.encode_canonical().unwrap();
         let wrong_hash = ContentHash::from_bytes([4; 32]);
 
         let error = store_received_object(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Introduce uncompressed HTR4 as the canonical Tree encoding: length-prefixed entry frames, declared count/payload/logical length, and a content-id header so a worker can page entries without materializing a full `Vec<TreeEntry>`.
- Add `TreeEntryReader` plus a persistable `TreeResumeCursor`. Store backends use `SequentialVerify`: resume at ordinal > 0 is refused and `finish_and_verify` hashes. A hash-shaped path is not a content-address proof.
- Sequential finish accumulates each entry's encoded length and rejects a header `logical_len` that does not match the decoded entries, so streamed and eager decoders agree.
- `get_tree_serialized` is the raw stored-body seam (loose and packed) so `0005_streamable_tree_encoding` can rewrite leftover msgpack pack bodies. Ingest packs and wire transfer emit/accept HTR4.
- Streaming frames are bounded before alloc; leftover payload after the declared count is `TrailingBytes`; `TreePageLimits` fields are private and fail-closed.

## Closes

Closes HeddleCo/heddle#1457

## Red commit
`a4909f90`

## Test evidence
```
$ cargo test -p heddle-object-model --lib
test result: ok. 234 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
```

Includes `mismatched_logical_len_fails_eager_and_streamed`.

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e546d1cd-392a-45cb-b4ee-1a28c7d562c1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e546d1cd-392a-45cb-b4ee-1a28c7d562c1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789782925&installation_model_id=21489&pr_number=1471&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1471&signature=5ebc5143fac4d74e5a9b2afc040a32cd5c93ec4b68d414fc5004447524b47485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->