### PR TITLE
Add missing workspace crates to the crates.io publish set

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -88,6 +88,7 @@ env:
     heddle-refs
     heddle-merge
     heddle-semantic
+    heddle-semantic-recovery
     heddle-state-review
     heddle-wire
     heddle-repo
@@ -98,6 +99,8 @@ env:
     heddle-core
     heddle-daemon
     heddle-mount
+    heddle-ci-config
+    heddle-ci-engine
     heddle-cli-args
     heddle-cli-render
     heddle-cli-contract

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -232,15 +232,17 @@ jobs:
               404)
                 # Crate-or-version not found. Could be: (a) this crate
                 # is brand-new (never published), or (b) only this
-                # version is new. We don't need to distinguish — both
-                # are "publish" actions for us. We still check the
-                # crate-level endpoint to detect downgrades.
+                # version is new. Both are publish actions. The
+                # crate-level probe distinguishes them so first-time
+                # uploads can be spaced for crates.io's 1-per-10-minutes
+                # new-crate quota, and so we can refuse downgrades.
                 latest_url="https://crates.io/api/v1/crates/${crate}"
                 latest_status=$(curl -sS -o /tmp/latest.json -w '%{http_code}' \
                                   -H 'User-Agent: heddle-publish-workflow (https://github.com/HeddleCo/heddle)' \
                                   --max-time 30 \
                                   --retry 3 --retry-delay 4 --retry-connrefused \
                                   "$latest_url" || echo 'CURL_FAIL')
+                first_publish=false
                 if [[ "$latest_status" == "200" ]]; then
                   # Downgrade guard. `jq // empty` falls through both
                   # the stable and total max fields; if both are
@@ -256,13 +258,18 @@ jobs:
                       exit 1
                     fi
                   fi
-                elif [[ "$latest_status" != "404" ]]; then
+                elif [[ "$latest_status" == "404" ]]; then
+                  # Brand-new crate. crates.io allows one new crate per
+                  # 10 minutes; the publish job uses this flag to space
+                  # first-time uploads instead of treating a 429 as fatal.
+                  first_publish=true
+                else
                   echo "::error::crates.io lookup for ${crate} returned ${latest_status}"
                   exit 1
                 fi
-                echo "publish: ${crate}@${local_version}"
-                to_publish=$(jq -c --arg c "$crate" --arg v "$local_version" \
-                  '. + [{crate: $c, version: $v}]' <<<"$to_publish")
+                echo "publish: ${crate}@${local_version}${first_publish:+ (first publish)}"
+                to_publish=$(jq -c --arg c "$crate" --arg v "$local_version" --argjson first "$first_publish" \
+                  '. + [{crate: $c, version: $v, first_publish: $first}]' <<<"$to_publish")
                 had_action=1
                 ;;
               *)
@@ -296,7 +303,7 @@ jobs:
     # merge to main.
     if: needs.validate-publish.outputs.has_publishes == 'true'
     runs-on: ubuntu-24.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     environment: release
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -333,14 +340,19 @@ jobs:
           # Pretty-print the publish plan up front so the workflow log
           # has a clean record before any side effects.
           echo "Publish plan:"
-          jq -r '.[] | "  - \(.crate)@\(.version)"' <<<"$TO_PUBLISH"
+          jq -r '.[] | "  - \(.crate)@\(.version)\(if .first_publish then " (first publish)" else "" end)"' <<<"$TO_PUBLISH"
 
           published_summary=()
+          mapfile -t publish_lines < <(jq -r '.[] | "\(.crate)\t\(.version)\t\(.first_publish // false)"' <<<"$TO_PUBLISH")
+          publish_count=${#publish_lines[@]}
+          publish_idx=0
 
-          while read -r line; do
+          for line in "${publish_lines[@]}"; do
             [[ -z "$line" ]] && continue
             crate=$(echo "$line" | cut -f1)
             version=$(echo "$line" | cut -f2)
+            first_publish=$(echo "$line" | cut -f3)
+            publish_idx=$((publish_idx+1))
 
             attempt=0
             max_attempts=3
@@ -374,6 +386,20 @@ jobs:
                 break
               fi
 
+              # crates.io returns 429 for the new-crate quota (1 per
+              # 10 minutes) and the existing-crate quota (1 per minute).
+              # Those are transient; fail-closed only after retries.
+              if echo "$out" | grep -qiE '429|rate.?limit|too many requests'; then
+                if (( attempt >= max_attempts )); then
+                  echo "::error::${crate}@${version} failed after ${max_attempts} rate-limit retries"
+                  exit 1
+                fi
+                sleep_for=600
+                echo "=== crates.io rate limit, sleeping ${sleep_for}s before retry ==="
+                sleep "$sleep_for"
+                continue
+              fi
+
               # Retry policy: 5xx-shaped errors (status codes,
               # connection drops, timeouts) get exponential backoff.
               # Anything else fails loud — we don't want to retry
@@ -395,14 +421,19 @@ jobs:
               exit 1
             done
 
-            # crates.io's index propagates within seconds for the
-            # sparse index, but the registry still has a brief window
-            # where a freshly-published crate isn't visible to the
-            # NEXT `cargo publish` that depends on it. A 30s pause
-            # between publishes keeps the dep chain happy without
-            # adding meaningful wall-clock cost on small bumps.
-            sleep 30
-          done < <(jq -r '.[] | "\(.crate)\t\(.version)"' <<<"$TO_PUBLISH")
+            # Space publishes to match crates.io quotas and give the
+            # sparse index a moment to see the crate the next publish
+            # may depend on. Skip the pause after the last crate.
+            if (( publish_idx < publish_count )); then
+              if [[ "$first_publish" == "true" ]]; then
+                sleep_for=600
+              else
+                sleep_for=60
+              fi
+              echo "=== waiting ${sleep_for}s before next publish ==="
+              sleep "$sleep_for"
+            fi
+          done
 
           # GitHub Actions step summary — a tidy receipt of what
           # shipped. Visible on the workflow run page; surviving even

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -48,6 +48,10 @@ name = "heddle-oplog"
 release = true
 
 [[package]]
+name = "heddle-semantic-recovery"
+release = true
+
+[[package]]
 name = "heddle-repo"
 release = true
 
@@ -85,6 +89,14 @@ release = true
 
 [[package]]
 name = "heddle-daemon"
+release = true
+
+[[package]]
+name = "heddle-ci-config"
+release = true
+
+[[package]]
+name = "heddle-ci-engine"
 release = true
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Investigated heddle#1475 against landed HEAD, not the mid-PR Codex comment. `heddle-cli-macro` existed at `cad75f71` (the review commit) and was a versioned path dep of `heddle-cli-args` / `heddle-cli-contract`. `#1449` then dropped the crate in `445e55be` because it only stamped a string constant. Current main has no `crates/cli-macro/` and no consumer depends on it.
- Adding a deleted crate to `PUBLISHABLE_CRATES` would fail `validate-publish` (`lists 'heddle-cli-macro' but no crates/*/Cargo.toml has it`) — the same class of abort `#976` fixed when `heddle-review` was deleted but left in the publish set.
- The same publish-set hole is live for crates that still exist: `heddle-repo` has a versioned path dep on `heddle-semantic-recovery`, and `heddle-cli` has versioned path deps on `heddle-ci-config` and `heddle-ci-engine`. None of those three were in `PUBLISHABLE_CRATES` or `release-plz.toml`. `scripts/check-publish-pipeline.sh` reported all three as missing.
- This PR lists those three crates ahead of their consumers in both publish lists. It does not restore `heddle-cli-macro`.
- Codex P2 on the first revision: first-time crates.io uploads are 1 per 10 minutes, and a 429 was non-retriable. Classify now marks `first_publish`, the publish loop waits 10 minutes after a new crate (60 seconds after an existing-crate bump), and 429s retry instead of aborting the release.

## Closes

Closes HeddleCo/heddle#1475

Does not close #473.

## Red commit

N/A — not a Rust PR

## Test evidence

```
$ bash scripts/check-publish-pipeline.sh
ok: push-to-main trigger present
ok: no workflow_dispatch trigger (anti-pattern correctly absent)
ok: validate-publish job present
ok: publish job present
ok: publish job depends on validate-publish
ok: publish step reads secrets.CRATES_IO_API_KEY
ok: CARGO_REGISTRY_TOKEN env var declared
ok: publish job uses approval-protected release environment
ok: CARGO_REGISTRY_TOKEN is scoped to the cargo publish step
ok: external action pinned: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
ok: external action pinned: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
ok: external action pinned: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4
ok: external action pinned: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
ok: explicit PUBLISHABLE_CRATES list present
ok: RELEASING.md documents publish-crates.yml
ok: push trigger restricted to main branch
ok: workflow_dispatch correctly absent
ok: validate-publish exports commit_sha output
ok: validate-publish exports to_publish output
ok: validate-publish exports has_publishes output
ok: publish job declares needs: validate-publish
ok: publish job gates execution on has_publishes
ok: publish job pins checkout to validated commit_sha
ok: env var key is exactly CARGO_REGISTRY_TOKEN (the name cargo reads)
ok: CARGO_REGISTRY_TOKEN wired from secrets.CRATES_IO_API_KEY
ok: toml parser available (tomllib)
ok: publishable crates have publishable versioned path dependencies (115 dependency pairs)
ok: PUBLISHABLE_CRATES is topologically ordered (111 publish-order dependency pairs)
ok: satisfies() self-test: caret semantics for bare 0 and 0.0 (cargo default widens to <1.0.0 / <0.1.0)
ok: satisfies() self-test: prerelease versions excluded from non-prerelease requirements (= opts in)
ok: satisfies() self-test: wildcard requirements rejected (1.2.* surfaces as unsupported)
ok: satisfies() self-test: caret prerelease lower-bound ordering (alpha.0 fails alpha.1; release sat. prerelease)
ok: satisfies() self-test: prerelease requirements pin to same (M,m,p) tuple (cargo's documented rule)
ok: satisfies() self-test: exact `=` ignores build metadata on both sides (semver §10)
ok: satisfies() self-test: partial `=` requirements widen to ranges (=4 → <5.0.0-0; =4.2 → <4.3.0-0)
ok: internal workspace consumers satisfy publishable crate versions (115 req/version pairs, 31 publishable crates)
publish-pipeline check passed
```

Also confirmed the two publish lists name the same 31 crates, and `scripts/check-release-pipeline.sh` still passes.

## Manual verification

N/A — covered by tests.

## What this is not

- Not a restore of `heddle-cli-macro`. `#1449` dropped it on purpose; `#205` stays open for construction-enforced clap + schema pairing.
- Not the heddle#473 catalog fold.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9cda70c-8b9e-44d0-9c29-4527c181dd10?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9cda70c-8b9e-44d0-9c29-4527c181dd10&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789787242&installation_model_id=21489&pr_number=1501&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1501&signature=ca0d44d4c4f238cccd6dc603965fc404b592faed75f8e8b875f2affab479be9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->