### PR TITLE
ready --repo from another cwd must not emit bare heddle land

### DIFF
--- a/crates/cli/src/cli/commands/ready_cmd.rs
+++ b/crates/cli/src/cli/commands/ready_cmd.rs
@@ -400,7 +400,8 @@ pub async fn cmd_ready(cli: &Cli, args: ReadyArgs) -> Result<()> {
         && decision.integration_clear
     {
         report.thread_health = "ready".to_string();
-        report.recommended_action = land_action_for_ready(&repo, &thread.id);
+        report.recommended_action =
+            land_action_for_ready(&repo, &thread.id, cli.repo.as_deref(), &cwd);
         report.refresh_recommended_action_metadata();
     }
 

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //! Shared commands for the ready -> land thread landing loop.
 
+use std::path::Path;
+
+use heddle_core::{recovery_scope_checkout, scope_action_to_repo};
+
 use super::command_catalog::heddle_action;
 pub(crate) use super::command_catalog::{land_local_command, merge_preview_command};
 
@@ -27,8 +31,36 @@ pub(crate) fn land_action_when(thread_id: &str, current_checkout: bool) -> Strin
     }
 }
 
-pub(crate) fn land_action_for_ready(repo: &repo::Repository, thread_id: &str) -> String {
-    land_action_when(thread_id, checkout_is_thread(repo, thread_id))
+/// Ready next-action for a checkout that may have been selected with `--repo`.
+///
+/// `--thread` stays omitted when that checkout's current thread is the one
+/// being readied. `--repo` is kept only when the checkout was selected
+/// explicitly and is not the process cwd (heddle#1473).
+pub(crate) fn land_action_for_ready(
+    repo: &repo::Repository,
+    thread_id: &str,
+    explicit_repo: Option<&Path>,
+    cwd: &Path,
+) -> String {
+    land_action_for_selected_checkout(
+        thread_id,
+        checkout_is_thread(repo, thread_id),
+        explicit_repo,
+        cwd,
+    )
+}
+
+fn land_action_for_selected_checkout(
+    thread_id: &str,
+    current_thread: bool,
+    explicit_repo: Option<&Path>,
+    cwd: &Path,
+) -> String {
+    let action = land_action_when(thread_id, current_thread);
+    match explicit_repo.filter(|path| recovery_scope_checkout(path, cwd).is_some()) {
+        Some(path) => scope_action_to_repo(&action, &path.display().to_string()),
+        None => action,
+    }
 }
 
 fn checkout_is_thread(repo: &repo::Repository, thread_id: &str) -> bool {
@@ -94,6 +126,38 @@ mod tests {
         assert_eq!(
             switch_thread_command("feature with spaces"),
             "heddle thread switch 'feature with spaces'"
+        );
+    }
+
+    #[test]
+    fn explicit_repo_keeps_repo_and_thread_only_when_needed() {
+        use super::super::command_catalog::validate_recommended_action;
+
+        let checkout = Path::new("/work/threads/feature");
+        let other = Path::new("/work/main");
+
+        let current_via_repo =
+            land_action_for_selected_checkout("feature/demo", true, Some(checkout), other);
+        assert_eq!(current_via_repo, "heddle --repo /work/threads/feature land");
+        validate_recommended_action(&current_via_repo)
+            .unwrap_or_else(|e| panic!("explicit-repo current-thread land must validate: {e}"));
+
+        let named_via_repo =
+            land_action_for_selected_checkout("feature/demo", false, Some(other), checkout);
+        assert_eq!(
+            named_via_repo,
+            "heddle --repo /work/main land --thread feature/demo"
+        );
+        validate_recommended_action(&named_via_repo)
+            .unwrap_or_else(|e| panic!("explicit-repo named-thread land must validate: {e}"));
+
+        assert_eq!(
+            land_action_for_selected_checkout("feature/demo", true, Some(checkout), checkout),
+            "heddle land"
+        );
+        assert_eq!(
+            land_action_for_selected_checkout("feature/demo", true, None, other),
+            "heddle land"
         );
     }
 }

--- a/crates/cli/src/cli/commands/thread_landing.rs
+++ b/crates/cli/src/cli/commands/thread_landing.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 
-use heddle_core::{recovery_scope_checkout, scope_action_to_repo};
+use heddle_core::{recovery_scope_checkout, status::next_action::thread_flag_args};
 
 use super::command_catalog::heddle_action;
 pub(crate) use super::command_catalog::{land_local_command, merge_preview_command};
@@ -56,11 +56,22 @@ fn land_action_for_selected_checkout(
     explicit_repo: Option<&Path>,
     cwd: &Path,
 ) -> String {
-    let action = land_action_when(thread_id, current_thread);
-    match explicit_repo.filter(|path| recovery_scope_checkout(path, cwd).is_some()) {
-        Some(path) => scope_action_to_repo(&action, &path.display().to_string()),
-        None => action,
+    let Some(path) = explicit_repo.filter(|path| recovery_scope_checkout(path, cwd).is_some())
+    else {
+        return land_action_when(thread_id, current_thread);
+    };
+    // `heddle_action` quotes through the shared single-quote helper.
+    // Do not splice `--repo` via `scope_action_to_repo`: that double-quotes
+    // and leaves `$` / backticks expandable if the next action is pasted.
+    let mut argv = vec![
+        "--repo".to_string(),
+        path.display().to_string(),
+        "land".to_string(),
+    ];
+    if !current_thread {
+        argv.extend(thread_flag_args(thread_id));
     }
+    heddle_action(argv)
 }
 
 fn checkout_is_thread(repo: &repo::Repository, thread_id: &str) -> bool {
@@ -158,6 +169,58 @@ mod tests {
         assert_eq!(
             land_action_for_selected_checkout("feature/demo", true, None, other),
             "heddle land"
+        );
+    }
+
+    #[test]
+    fn explicit_repo_single_quotes_shell_metacharacters() {
+        use super::super::command_catalog::validate_recommended_action;
+
+        let other = Path::new("/work/main");
+        for (path, raw) in [
+            (Path::new("/tmp/work-$(whoami)"), "/tmp/work-$(whoami)"),
+            (Path::new("/tmp/work-`id`"), "/tmp/work-`id`"),
+            (Path::new("/tmp/$HOME-checkout"), "/tmp/$HOME-checkout"),
+        ] {
+            let action = land_action_for_selected_checkout("feature/demo", true, Some(path), other);
+            let expected = heddle_action(["--repo", raw, "land"]);
+            assert_eq!(action, expected, "path {raw}");
+            assert_eq!(
+                action,
+                format!("heddle --repo '{raw}' land"),
+                "metacharacter --repo must be single-quoted: {action}"
+            );
+            assert!(
+                !action.contains(&format!("\"{raw}\"")),
+                "must not use expandable double quotes: {action}"
+            );
+            validate_recommended_action(&action)
+                .unwrap_or_else(|e| panic!("quoted --repo land must validate for {raw}: {e}"));
+
+            let named = land_action_for_selected_checkout("feature/demo", false, Some(path), other);
+            assert_eq!(
+                named,
+                heddle_action(["--repo", raw, "land", "--thread", "feature/demo"]),
+                "named-thread path {raw}"
+            );
+            validate_recommended_action(&named).unwrap_or_else(|e| {
+                panic!("quoted --repo land --thread must validate for {raw}: {e}")
+            });
+        }
+
+        let expandable = heddle_core::quote_recommended_action_arg("/tmp/work-$(whoami)");
+        assert_eq!(
+            expandable, "\"/tmp/work-$(whoami)\"",
+            "the rejected helper still double-quotes `$()` — that is the P1"
+        );
+        assert_ne!(
+            land_action_for_selected_checkout(
+                "feature/demo",
+                true,
+                Some(Path::new("/tmp/work-$(whoami)")),
+                other,
+            ),
+            format!("heddle --repo {expandable} land")
         );
     }
 }

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -219,13 +219,7 @@ fn ready_via_repo_flag_from_another_cwd_keeps_repo_on_land() {
 
     let expected_current = format!("heddle --repo {execution_path} land");
     let ready = json(
-        &[
-            "--repo",
-            &execution_path,
-            "--output",
-            "json",
-            "ready",
-        ],
+        &["--repo", &execution_path, "--output", "json", "ready"],
         main.path(),
     );
     assert_eq!(ready["next_action"], expected_current, "{ready}");
@@ -244,13 +238,7 @@ fn ready_via_repo_flag_from_another_cwd_keeps_repo_on_land() {
     assert_no_banned_next_actions(&ready);
 
     let same_cwd = json(
-        &[
-            "--repo",
-            &execution_path,
-            "--output",
-            "json",
-            "ready",
-        ],
+        &["--repo", &execution_path, "--output", "json", "ready"],
         checkout,
     );
     assert_eq!(same_cwd["next_action"], "heddle land", "{same_cwd}");
@@ -262,7 +250,10 @@ fn ready_via_repo_flag_from_another_cwd_keeps_repo_on_land() {
         "--repo pointing at the process cwd must stay an invisible default: {same_cwd}"
     );
 
-    let expected_named = format!("heddle --repo {} land --thread feature/repo-ready", main.path().display());
+    let expected_named = format!(
+        "heddle --repo {} land --thread feature/repo-ready",
+        main.path().display()
+    );
     let named = json(
         &[
             "--repo",

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -280,6 +280,54 @@ fn ready_via_repo_flag_from_another_cwd_keeps_repo_on_land() {
 }
 
 #[test]
+fn ready_via_repo_flag_quotes_shell_metacharacters() {
+    let main = setup_native_repo();
+    let checkout_owner = TempDir::new().unwrap();
+    let checkout_arg = checkout_owner.path().join("work-$(whoami)");
+    let started = json(
+        &[
+            "--output",
+            "json",
+            "start",
+            "feature/meta-ready",
+            "--path",
+            checkout_arg.to_str().expect("utf8 path"),
+        ],
+        main.path(),
+    );
+    let execution_path = started["execution_path"]
+        .as_str()
+        .expect("start should report execution_path")
+        .to_string();
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout)).unwrap();
+
+    let ready = json(
+        &["--repo", &execution_path, "--output", "json", "ready"],
+        main.path(),
+    );
+    let quoted = repo::shell_quote(&execution_path);
+    let expected = format!("heddle --repo {quoted} land");
+    assert_eq!(ready["next_action"], expected, "{ready}");
+    assert_eq!(ready["recommended_action"], expected, "{ready}");
+    assert!(
+        quoted.starts_with('\'') && quoted.ends_with('\''),
+        "metacharacter --repo must be single-quoted: {quoted}"
+    );
+    assert!(
+        !ready["next_action"]
+            .as_str()
+            .expect("ready next_action should be a string")
+            .contains(&format!("\"{execution_path}\"")),
+        "must not double-quote a $() path: {ready}"
+    );
+    assert_no_banned_next_actions(&ready);
+
+    drop(checkout_owner);
+}
+
+#[test]
 fn presence_show_multi_match_next_is_not_help_catalog() {
     use chrono::Utc;
     use objects::store::{

--- a/crates/cli/tests/cli_integration/next_action_contract.rs
+++ b/crates/cli/tests/cli_integration/next_action_contract.rs
@@ -211,6 +211,84 @@ fn ready_from_isolated_checkout_recommends_bare_land() {
 }
 
 #[test]
+fn ready_via_repo_flag_from_another_cwd_keeps_repo_on_land() {
+    let (main, checkout_owner, execution_path) = setup_managed_thread("feature/repo-ready");
+    let checkout = std::path::Path::new(&execution_path);
+    std::fs::write(checkout.join("feature.txt"), "feature\n").unwrap();
+    heddle(&["capture", "-m", "feature"], Some(checkout)).unwrap();
+
+    let expected_current = format!("heddle --repo {execution_path} land");
+    let ready = json(
+        &[
+            "--repo",
+            &execution_path,
+            "--output",
+            "json",
+            "ready",
+        ],
+        main.path(),
+    );
+    assert_eq!(ready["next_action"], expected_current, "{ready}");
+    assert_eq!(ready["recommended_action"], expected_current, "{ready}");
+    assert_eq!(
+        ready["report"]["recommended_action"], expected_current,
+        "{ready}"
+    );
+    let next = ready["next_action"]
+        .as_str()
+        .expect("ready next_action should be a string");
+    assert!(
+        next.contains("--repo") && !next.contains("--thread"),
+        "explicit --repo ready of that checkout's current thread must keep --repo and omit --thread: {ready}"
+    );
+    assert_no_banned_next_actions(&ready);
+
+    let same_cwd = json(
+        &[
+            "--repo",
+            &execution_path,
+            "--output",
+            "json",
+            "ready",
+        ],
+        checkout,
+    );
+    assert_eq!(same_cwd["next_action"], "heddle land", "{same_cwd}");
+    assert!(
+        !same_cwd["next_action"]
+            .as_str()
+            .expect("same-cwd next_action")
+            .contains("--repo"),
+        "--repo pointing at the process cwd must stay an invisible default: {same_cwd}"
+    );
+
+    let expected_named = format!("heddle --repo {} land --thread feature/repo-ready", main.path().display());
+    let named = json(
+        &[
+            "--repo",
+            main.path().to_str().expect("main path utf8"),
+            "--output",
+            "json",
+            "ready",
+            "--thread",
+            "feature/repo-ready",
+        ],
+        checkout,
+    );
+    assert_eq!(named["next_action"], expected_named, "{named}");
+    assert!(
+        named["next_action"]
+            .as_str()
+            .expect("named next_action")
+            .contains("--thread"),
+        "explicit --repo ready of a non-current thread must keep --thread: {named}"
+    );
+    assert_no_banned_next_actions(&named);
+
+    drop(checkout_owner);
+}
+
+#[test]
 fn presence_show_multi_match_next_is_not_help_catalog() {
     use chrono::Utc;
     use objects::store::{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Residual from heddle#1466: `heddle --repo /path/to/isolated-checkout ready` from another cwd treated that checkout's current thread as "already here" and emitted bare `heddle land`.
- Ready now keeps `--repo` whenever the checkout was selected explicitly and is not the process cwd, and keeps `--thread` only when that checkout's current thread is not the one being readied.
- Codex P1: scoped land next_action now goes through `heddle_action` so `--repo` is single-quoted. `scope_action_to_repo` double-quotes and leaves `$` / backticks expandable.

## Closes

Closes HeddleCo/heddle#1473

Do not fold into #473. Do not close #473.

## Red commit
`8cf9186c`

## Test evidence
```
$ cargo test -p heddle-cli --lib -- thread_landing --nocapture
running 5 tests
test cli::commands::thread_landing::tests::landing_commands_are_stable_and_copy_pasteable ... ok
test cli::commands::thread_landing::tests::explicit_repo_keeps_repo_and_thread_only_when_needed ... ok
test cli::commands::thread_landing::tests::switch_thread_command_is_stable_and_copy_pasteable ... ok
test cli::commands::thread_landing::tests::land_breadcrumbs_handle_leading_dash_thread_ids ... ok
test cli::commands::thread_landing::tests::explicit_repo_single_quotes_shell_metacharacters ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 742 filtered out; finished in 0.03s

$ cargo test -p heddle-cli --test cli_integration -- \
    ready_via_repo_flag_from_another_cwd_keeps_repo_on_land \
    ready_via_repo_flag_quotes_shell_metacharacters \
    ready_from_isolated_checkout_recommends_bare_land \
    --nocapture
running 3 tests
test next_action_contract::ready_from_isolated_checkout_recommends_bare_land ... ok
test next_action_contract::ready_via_repo_flag_quotes_shell_metacharacters ... ok
test next_action_contract::ready_via_repo_flag_from_another_cwd_keeps_repo_on_land ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 959 filtered out; finished in 0.31s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc376ac0-2fa5-450a-a013-64935d1835f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc376ac0-2fa5-450a-a013-64935d1835f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789788079&installation_model_id=21489&pr_number=1502&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1502&signature=741ed1430e9a569afd5323ccb049eafdcd04a4aedc6f0294ac11ca2540e00e50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->