### PR TITLE
fix(cli): bind claim consent expiry and keep claim URLs on-origin

### DIFF
--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -264,7 +264,9 @@ pub(crate) fn promote_consent_message(
 ///
 /// Rejects when the bound `expiresAt` has elapsed, the pair is not the same
 /// issuance, or either signature fails over the counted statement that includes
-/// the claim-state id and expiry.
+/// the claim-state id and expiry. This is the weft-matching check; the CLI
+/// only issues consents.
+#[cfg(test)]
 pub(crate) fn verify_promotion_consents(
     agent_public_key: &[u8],
     handle: &str,
@@ -391,6 +393,7 @@ struct ConsentBinding<'a> {
     expires_at: [u8; 8],
 }
 
+#[cfg(test)]
 fn verify_consent_signature(
     statement: &[u8],
     agent_public_key: &[u8],

--- a/crates/cli/src/hosted_runtime/claim_authorization.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization.rs
@@ -125,12 +125,14 @@ struct AgentAccountSummary {
     agent_label: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AgentConsent {
     pub(crate) account_id: String,
     pub(crate) node_id: String,
     pub(crate) signature: String,
+    pub(crate) authorization_hash: String,
+    pub(crate) expires_at: i64,
 }
 
 pub(crate) fn resolved_reply(state: &ClaimState, body: &[u8]) -> Result<Vec<u8>, CallFailure> {
@@ -214,11 +216,7 @@ pub(crate) fn signed_pre_consent(
     refuse_stale_consent(state)?;
     let statement = pre_consent_message(state, handle, nonce)?;
     let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
-    Ok(AgentConsent {
-        account_id: state.owner_id.to_string(),
-        node_id: state.node_id.clone(),
-        signature,
-    })
+    Ok(bound_consent(state, signature))
 }
 
 pub(crate) fn signed_promote_consent(
@@ -230,11 +228,7 @@ pub(crate) fn signed_promote_consent(
     refuse_stale_consent(state)?;
     let statement = promote_consent_message(state, handle, credential_id)?;
     let signature = URL_SAFE_NO_PAD.encode(signer.sign(&statement).map_err(internal_failure)?);
-    Ok(AgentConsent {
-        account_id: state.owner_id.to_string(),
-        node_id: state.node_id.clone(),
-        signature,
-    })
+    Ok(bound_consent(state, signature))
 }
 
 pub(crate) fn pre_consent_message(
@@ -242,13 +236,14 @@ pub(crate) fn pre_consent_message(
     handle: &str,
     nonce: &[u8],
 ) -> Result<Vec<u8>, CallFailure> {
-    encode_counted(&[
-        PRE_CONSENT_DOMAIN,
-        state.owner_id.to_string().as_bytes(),
-        handle.as_bytes(),
-        state.node_id.as_bytes(),
+    encode_pre_consent(
+        &state.owner_id.to_string(),
+        handle,
+        &state.node_id,
         nonce,
-    ])
+        state.authorization_hash(),
+        state.expires_at_millis,
+    )
 }
 
 pub(crate) fn promote_consent_message(
@@ -256,15 +251,68 @@ pub(crate) fn promote_consent_message(
     handle: &str,
     credential_id: &str,
 ) -> Result<Vec<u8>, CallFailure> {
-    encode_counted(&[
-        PROMOTE_CONSENT_DOMAIN,
-        state.owner_id.to_string().as_bytes(),
-        handle.as_bytes(),
-        credential_id.as_bytes(),
-    ])
+    encode_promote_consent(
+        &state.owner_id.to_string(),
+        handle,
+        credential_id,
+        state.authorization_hash(),
+        state.expires_at_millis,
+    )
+}
+
+/// Verifies a pre/promote pair from the consent payload, not local claim TTL.
+///
+/// Rejects when the bound `expiresAt` has elapsed, the pair is not the same
+/// issuance, or either signature fails over the counted statement that includes
+/// the claim-state id and expiry.
+pub(crate) fn verify_promotion_consents(
+    agent_public_key: &[u8],
+    handle: &str,
+    nonce: &[u8],
+    credential_id: &str,
+    pre: &AgentConsent,
+    promote: &AgentConsent,
+    now_millis: i64,
+) -> Result<(), CallFailure> {
+    if pre.account_id != promote.account_id
+        || pre.node_id != promote.node_id
+        || pre.authorization_hash != promote.authorization_hash
+        || pre.expires_at != promote.expires_at
+    {
+        return Err(failure(
+            CallFailureCode::PermissionDenied,
+            "claim consents are not a matching pair",
+        ));
+    }
+    consent_binding_parts(&pre.authorization_hash, pre.expires_at)?;
+    if now_millis >= pre.expires_at {
+        return Err(failure(
+            CallFailureCode::Unauthenticated,
+            "claim consent has expired",
+        ));
+    }
+    let pre_statement = encode_pre_consent(
+        &pre.account_id,
+        handle,
+        &pre.node_id,
+        nonce,
+        &pre.authorization_hash,
+        pre.expires_at,
+    )?;
+    let promote_statement = encode_promote_consent(
+        &promote.account_id,
+        handle,
+        credential_id,
+        &promote.authorization_hash,
+        promote.expires_at,
+    )?;
+    verify_consent_signature(&pre_statement, agent_public_key, &pre.signature)?;
+    verify_consent_signature(&promote_statement, agent_public_key, &promote.signature)?;
+    Ok(())
 }
 
 fn refuse_stale_consent(state: &ClaimState) -> Result<(), CallFailure> {
+    consent_binding_parts(state.authorization_hash(), state.expires_at_millis)?;
     if state.consent_unexpired(chrono::Utc::now().timestamp_millis()) {
         return Ok(());
     }
@@ -272,6 +320,91 @@ fn refuse_stale_consent(state: &ClaimState) -> Result<(), CallFailure> {
         CallFailureCode::Unauthenticated,
         "claim consent has expired",
     ))
+}
+
+fn bound_consent(state: &ClaimState, signature: String) -> AgentConsent {
+    AgentConsent {
+        account_id: state.owner_id.to_string(),
+        node_id: state.node_id.clone(),
+        signature,
+        authorization_hash: state.authorization_hash().to_string(),
+        expires_at: state.expires_at_millis,
+    }
+}
+
+fn encode_pre_consent(
+    account_id: &str,
+    handle: &str,
+    node_id: &str,
+    nonce: &[u8],
+    authorization_hash: &str,
+    expires_at_millis: i64,
+) -> Result<Vec<u8>, CallFailure> {
+    let binding = consent_binding_parts(authorization_hash, expires_at_millis)?;
+    encode_counted(&[
+        PRE_CONSENT_DOMAIN,
+        account_id.as_bytes(),
+        handle.as_bytes(),
+        node_id.as_bytes(),
+        nonce,
+        binding.authorization_hash.as_bytes(),
+        &binding.expires_at,
+    ])
+}
+
+fn encode_promote_consent(
+    account_id: &str,
+    handle: &str,
+    credential_id: &str,
+    authorization_hash: &str,
+    expires_at_millis: i64,
+) -> Result<Vec<u8>, CallFailure> {
+    let binding = consent_binding_parts(authorization_hash, expires_at_millis)?;
+    encode_counted(&[
+        PROMOTE_CONSENT_DOMAIN,
+        account_id.as_bytes(),
+        handle.as_bytes(),
+        credential_id.as_bytes(),
+        binding.authorization_hash.as_bytes(),
+        &binding.expires_at,
+    ])
+}
+
+fn consent_binding_parts(
+    authorization_hash: &str,
+    expires_at_millis: i64,
+) -> Result<ConsentBinding<'_>, CallFailure> {
+    if authorization_hash.is_empty() || expires_at_millis <= 0 {
+        return Err(failure(
+            CallFailureCode::FailedPrecondition,
+            "claim consent is not bound to an issuance",
+        ));
+    }
+    Ok(ConsentBinding {
+        authorization_hash,
+        expires_at: expires_at_millis.to_be_bytes(),
+    })
+}
+
+struct ConsentBinding<'a> {
+    authorization_hash: &'a str,
+    expires_at: [u8; 8],
+}
+
+fn verify_consent_signature(
+    statement: &[u8],
+    agent_public_key: &[u8],
+    signature: &str,
+) -> Result<(), CallFailure> {
+    let signature = URL_SAFE_NO_PAD
+        .decode(signature)
+        .map_err(|_| invalid_failure("invalid claim consent signature"))?;
+    Ed25519Signer::verify_with_public_key(statement, agent_public_key, &signature).map_err(|_| {
+        failure(
+            CallFailureCode::Unauthenticated,
+            "claim consent signature is invalid",
+        )
+    })
 }
 
 fn encode_counted(parts: &[&[u8]]) -> Result<Vec<u8>, CallFailure> {

--- a/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
+++ b/crates/cli/src/hosted_runtime/claim_authorization_tests.rs
@@ -11,8 +11,9 @@ use tokio::sync::Mutex;
 
 use super::{
     claim_authorization::{
-        consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
+        AgentConsent, consent_reply, pre_consent_message, promote_consent_message, resolved_reply,
         signed_pre_consent, signed_promote_consent, validate_credential_id, validate_handle,
+        verify_promotion_consents,
     },
     hosted::claim_protocol::{
         CLAIM_ALPN_V1, CLAIM_CONSENT_METHOD, CLAIM_RESOLVE_METHOD, ClaimHandler, ClaimProtocol,
@@ -33,10 +34,8 @@ fn state(node_id: String) -> ClaimState {
     )
 }
 
-fn signature(value: &serde_json::Value) -> Vec<u8> {
-    URL_SAFE_NO_PAD
-        .decode(value["consent"]["signature"].as_str().unwrap())
-        .expect("signature encoding")
+fn consent_from_reply(value: &serde_json::Value) -> AgentConsent {
+    serde_json::from_value(value["consent"].clone()).expect("consent payload")
 }
 
 #[derive(Clone)]
@@ -49,32 +48,27 @@ struct MockWeftAccount {
 struct MockPromotion<'a> {
     handle: &'a str,
     nonce: &'a [u8],
-    pre_signature: &'a [u8],
     credential_id: &'a str,
-    promote_signature: &'a [u8],
+    pre: &'a AgentConsent,
+    promote: &'a AgentConsent,
+    now_millis: i64,
 }
 
 impl MockWeftAccount {
-    fn promote(
-        &mut self,
-        claim: &ClaimState,
-        agent_public_key: &[u8],
-        promotion: &MockPromotion<'_>,
-    ) -> bool {
-        if self.root_credential_id.is_some()
-            || !claim.consent_unexpired(chrono::Utc::now().timestamp_millis())
-            || Ed25519Signer::verify_with_public_key(
-                &pre_consent_message(claim, promotion.handle, promotion.nonce).unwrap(),
-                agent_public_key,
-                promotion.pre_signature,
-            )
-            .is_err()
-            || Ed25519Signer::verify_with_public_key(
-                &promote_consent_message(claim, promotion.handle, promotion.credential_id).unwrap(),
-                agent_public_key,
-                promotion.promote_signature,
-            )
-            .is_err()
+    fn promote(&mut self, agent_public_key: &[u8], promotion: &MockPromotion<'_>) -> bool {
+        if self.root_credential_id.is_some() {
+            return false;
+        }
+        if verify_promotion_consents(
+            agent_public_key,
+            promotion.handle,
+            promotion.nonce,
+            promotion.credential_id,
+            promotion.pre,
+            promotion.promote,
+            promotion.now_millis,
+        )
+        .is_err()
         {
             return false;
         }
@@ -112,6 +106,10 @@ fn consent_signatures_round_trip_the_local_builders() {
 
     assert_eq!(pre.account_id, OWNER_ID);
     assert_eq!(promote.account_id, OWNER_ID);
+    assert_eq!(pre.authorization_hash, claim.authorization_hash());
+    assert_eq!(promote.authorization_hash, claim.authorization_hash());
+    assert_eq!(pre.expires_at, claim.expires_at_millis);
+    assert_eq!(promote.expires_at, claim.expires_at_millis);
 }
 
 #[test]
@@ -131,6 +129,8 @@ fn consent_builders_encode_the_v1_counted_fields() {
             b"human-handle",
             claim.node_id.as_bytes(),
             nonce,
+            claim.authorization_hash().as_bytes(),
+            &claim.expires_at_millis.to_be_bytes(),
         ])
     );
     assert_eq!(
@@ -140,6 +140,8 @@ fn consent_builders_encode_the_v1_counted_fields() {
             OWNER_ID.as_bytes(),
             b"human-handle",
             b"Y3JlZGVudGlhbA",
+            claim.authorization_hash().as_bytes(),
+            &claim.expires_at_millis.to_be_bytes(),
         ])
     );
 }
@@ -163,10 +165,24 @@ fn expired_consent_is_not_produced_or_accepted() {
     let pre_bytes = pre_consent_message(&claim, "human-handle", nonce).expect("expired encoding");
     let promote_bytes = promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA")
         .expect("expired encoding");
-    let pre_signature = signer.sign(&pre_bytes).expect("sign stale pre-consent");
-    let promote_signature = signer
-        .sign(&promote_bytes)
-        .expect("sign stale promote-consent");
+    let pre = AgentConsent {
+        account_id: claim.owner_id.to_string(),
+        node_id: claim.node_id.clone(),
+        signature: URL_SAFE_NO_PAD.encode(signer.sign(&pre_bytes).expect("sign stale pre-consent")),
+        authorization_hash: claim.authorization_hash().to_string(),
+        expires_at: claim.expires_at_millis,
+    };
+    let promote = AgentConsent {
+        account_id: claim.owner_id.to_string(),
+        node_id: claim.node_id.clone(),
+        signature: URL_SAFE_NO_PAD.encode(
+            signer
+                .sign(&promote_bytes)
+                .expect("sign stale promote-consent"),
+        ),
+        authorization_hash: claim.authorization_hash().to_string(),
+        expires_at: claim.expires_at_millis,
+    };
     let mut account = MockWeftAccount {
         owner_id: claim.owner_id,
         spool_owner_id: claim.owner_id,
@@ -174,17 +190,78 @@ fn expired_consent_is_not_produced_or_accepted() {
     };
     assert!(
         !account.promote(
-            &claim,
             signer.public_key(),
             &MockPromotion {
                 handle: "human-handle",
                 nonce,
-                pre_signature: &pre_signature,
                 credential_id: "Y3JlZGVudGlhbA",
-                promote_signature: &promote_signature,
+                pre: &pre,
+                promote: &promote,
+                now_millis: chrono::Utc::now().timestamp_millis(),
             },
         ),
-        "expired consent must not be accepted locally"
+        "expired consent must not be accepted from the bound expiry"
+    );
+}
+
+#[test]
+fn expired_consent_signature_is_rejected_after_bound_expiry() {
+    let signer = Ed25519Signer::generate().expect("signer");
+    let mut claim = state(hex::encode(signer.public_key()));
+    let expires_at = chrono::Utc::now().timestamp_millis() + 60_000;
+    assert!(claim.reissue(b"claim-secret", expires_at));
+    let nonce = b"0123456789abcdef";
+
+    let pre =
+        signed_pre_consent(&claim, "human-handle", nonce, &signer).expect("signed pre-consent");
+    let promote = signed_promote_consent(&claim, "human-handle", "Y3JlZGVudGlhbA", &signer)
+        .expect("signed promote-consent");
+
+    verify_promotion_consents(
+        signer.public_key(),
+        "human-handle",
+        nonce,
+        "Y3JlZGVudGlhbA",
+        &pre,
+        &promote,
+        expires_at - 1,
+    )
+    .expect("signature must verify before the bound expiry");
+
+    let mut later_local_ttl = state(hex::encode(signer.public_key()));
+    assert!(later_local_ttl.reissue(b"later-secret", expires_at + 60_000));
+    assert!(
+        later_local_ttl.consent_unexpired(expires_at),
+        "local claim TTL remaining must not keep a stale signature alive"
+    );
+    assert!(
+        verify_promotion_consents(
+            signer.public_key(),
+            "human-handle",
+            nonce,
+            "Y3JlZGVudGlhbA",
+            &pre,
+            &promote,
+            expires_at,
+        )
+        .is_err(),
+        "server-side verify must reject once now >= signed expiresAt"
+    );
+
+    let mut stretched = pre.clone();
+    stretched.expires_at = expires_at + 60_000;
+    assert!(
+        verify_promotion_consents(
+            signer.public_key(),
+            "human-handle",
+            nonce,
+            "Y3JlZGVudGlhbA",
+            &stretched,
+            &promote,
+            expires_at,
+        )
+        .is_err(),
+        "extending expiresAt on the payload must not revive the signature"
     );
 }
 
@@ -196,6 +273,19 @@ fn counted(parts: &[&[u8]]) -> Vec<u8> {
         encoded.extend_from_slice(part);
     }
     encoded
+}
+
+#[test]
+fn unbound_claim_state_cannot_encode_consent() {
+    let claim = state("11".repeat(32));
+    assert!(
+        pre_consent_message(&claim, "human-handle", b"0123456789abcdef").is_err(),
+        "dormant state has no claim-state id or expiry to bind"
+    );
+    assert!(
+        promote_consent_message(&claim, "human-handle", "Y3JlZGVudGlhbA").is_err(),
+        "dormant state has no claim-state id or expiry to bind"
+    );
 }
 
 #[test]
@@ -394,6 +484,7 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
         panic!("pre-consent must succeed");
     };
     let pre: serde_json::Value = serde_json::from_slice(&pre).unwrap();
+    let pre_consent = consent_from_reply(&pre);
 
     let credential_id = "Y3JlZGVudGlhbA";
     let promote_body = serde_json::json!({
@@ -413,8 +504,10 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
         panic!("promote-consent must succeed");
     };
     let promote: serde_json::Value = serde_json::from_slice(&promote).unwrap();
+    let promote_consent = consent_from_reply(&promote);
 
     let state = authorization.state.lock().await;
+    let now = chrono::Utc::now().timestamp_millis();
     let mut account = MockWeftAccount {
         owner_id: state.owner_id,
         spool_owner_id: state.owner_id,
@@ -423,27 +516,27 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
     let mut forged = account.clone();
     assert!(
         !forged.promote(
-            &state,
             authorization.signer.public_key(),
             &MockPromotion {
                 handle: "human-handle",
                 nonce,
-                pre_signature: &signature(&pre),
                 credential_id: "Zm9yZ2Vk",
-                promote_signature: &signature(&promote),
+                pre: &pre_consent,
+                promote: &promote_consent,
+                now_millis: now,
             },
         ),
         "a forged credential binding must be rejected"
     );
     assert!(account.promote(
-        &state,
         authorization.signer.public_key(),
         &MockPromotion {
             handle: "human-handle",
             nonce,
-            pre_signature: &signature(&pre),
             credential_id,
-            promote_signature: &signature(&promote),
+            pre: &pre_consent,
+            promote: &promote_consent,
+            now_millis: now,
         },
     ));
     assert_eq!(
@@ -457,14 +550,14 @@ async fn iroh_claim_happy_path_and_deny_paths_match_weft_promotion() {
         "spool ownership remains anchored to the stable owner UUID"
     );
     assert!(!account.promote(
-        &state,
         authorization.signer.public_key(),
         &MockPromotion {
             handle: "human-handle",
             nonce,
-            pre_signature: &signature(&pre),
             credential_id,
-            promote_signature: &signature(&promote),
+            pre: &pre_consent,
+            promote: &promote_consent,
+            now_millis: now,
         },
     ));
     assert!(state.is_claimed());

--- a/crates/cli/src/hosted_runtime/identity_tests.rs
+++ b/crates/cli/src/hosted_runtime/identity_tests.rs
@@ -26,6 +26,11 @@ fn claim_url_uses_selected_server_origin() {
         claim_link_url("api.heddle.sh", "aa", "c2VjcmV0").expect("default hosted origin"),
         "https://heddle.sh/claim/hcl1.aa.c2VjcmV0"
     );
+    assert_eq!(
+        claim_link_url("https://api.heddle.sh", "aa", "c2VjcmV0")
+            .expect("canonical hosted API origin"),
+        "https://heddle.sh/claim/hcl1.aa.c2VjcmV0"
+    );
 }
 
 #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bind the claim-state id (`authorizationHash`, hex SHA-256 of the claim secret) and `expiresAt` (8-byte big-endian `expires_at_millis`) into both counted consent statements. Local TTL-before-sign stays as defense in depth only.
- `verify_promotion_consents` reconstructs those statements from the consent payload and rejects when `now >= expiresAt`, when the pair is not the same issuance, or when a caller stretches `expiresAt` on the wire. That is the server-side stale-signature reject; it does not consult local claim TTL.
- Claim links already use the selected HTTPS origin (#1429). Official `api.heddle.sh` still prints `https://heddle.sh/claim/...`; any other server uses its own origin. HTTP / userinfo / unparseable authorities are refused.

## Closes

Closes HeddleCo/heddle#1404

## Red commit

`8100a9d5` — main still signed domain + owner + handle + nonce/credential only. The new tests fail there because the counted statements have no issuance hash or expiry, and verify is payload-bound rather than `ClaimState.consent_unexpired`.

## Test evidence

```
$ cargo test -p heddle-cli --lib -- hosted_runtime::claim_authorization hosted_runtime::identity hosted_runtime::identity_state

running 15 tests
test hosted_runtime::claim_authorization_tests::expired_consent_is_not_produced_or_accepted ... ok
test hosted_runtime::claim_authorization_tests::consent_builders_encode_the_v1_counted_fields ... ok
test hosted_runtime::claim_authorization_tests::consent_signatures_round_trip_the_local_builders ... ok
test hosted_runtime::claim_authorization_tests::expired_consent_signature_is_rejected_after_bound_expiry ... ok
test hosted_runtime::claim_authorization_tests::malformed_claim_inputs_are_rejected ... ok
test hosted_runtime::claim_authorization_tests::unbound_claim_state_cannot_encode_consent ... ok
test hosted_runtime::identity_state::tests::prepared_claim_is_bound_to_one_handle_and_nonce ... ok
test hosted_runtime::identity_state::tests::reissue_invalidates_the_previous_secret ... ok
test hosted_runtime::identity_tests::claim_url_refuses_non_https_and_never_rewrites_custom_hosts_to_heddle ... ok
test hosted_runtime::identity_tests::claim_url_uses_selected_server_origin ... ok
test hosted_runtime::identity_tests::invite_is_never_selected_when_any_credential_exists ... ok
test hosted_runtime::identity_tests::provisioning_is_only_the_no_credential_fallback ... ok
test hosted_runtime::identity_state::tests::expired_secret_is_rejected_and_not_persisted_in_plaintext ... ok
test hosted_runtime::claim_authorization_tests::expired_iroh_claim_link_is_rejected_before_dispatch ... ok
test hosted_runtime::claim_authorization_tests::iroh_claim_happy_path_and_deny_paths_match_weft_promotion ... ok

test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 736 filtered out; finished in 0.11s
```

## Manual verification

N/A — covered by tests.

## Weft follow-up (do not close weft#1545)

Landed weft still rebuilds the v1 field list without the two trailing fields. After this PR, reconstruction is:

1. claim-state id = hex SHA-256 of the claim secret (`authorizationHash`)
2. expiry = `expiresAt` as 8-byte big-endian `i64`

Reject `now >= expiresAt`. Do not restore `HEDDLE_SERVER_BISCUIT_PRIVATE_KEY`. Production API host remains `api.heddle.sh`.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c607c56b-f3f0-4d18-b76d-319874c9540a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c607c56b-f3f0-4d18-b76d-319874c9540a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1508"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789816617&installation_model_id=21489&pr_number=1508&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1508&signature=585396505bf0c07986072691c2ff948e0f713f00f21328a18bf657581e9ce059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->