### PR TITLE
Backfill query actors before applying --actor filters

### DIFF
--- a/crates/cli/tests/cli_integration/capture_vocabulary.rs
+++ b/crates/cli/tests/cli_integration/capture_vocabulary.rs
@@ -135,6 +135,37 @@ fn query_verb_capture_finds_captures_case_insensitively() {
 }
 
 #[test]
+fn query_actor_filter_returns_backfilled_capture() {
+    let temp = TempDir::new().unwrap();
+    heddle(&["init"], Some(temp.path())).unwrap();
+    std::fs::write(temp.path().join("note.txt"), "query actor slice\n").unwrap();
+    heddle(&["capture", "-m", "probe history"], Some(temp.path())).unwrap();
+
+    let json = heddle(
+        &[
+            "query",
+            "--actor",
+            "heddle@example.com",
+            "--verb",
+            "capture",
+            "--output",
+            "json",
+        ],
+        Some(temp.path()),
+    )
+    .unwrap_or_else(|err| panic!("query --actor should find the backfilled capture: {err}"));
+    let report: Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(report["output_kind"], "query");
+    let hits = report["hits"].as_array().expect("hits array");
+    assert!(
+        hits.iter().any(|hit| {
+            hit["verb"] == "snapshot" && hit["actor_email"].as_str() == Some("heddle@example.com")
+        }),
+        "filtered query must return the capture after actor backfill: {report}"
+    );
+}
+
+#[test]
 fn query_unknown_verb_errors_instead_of_empty_search() {
     let temp = TempDir::new().unwrap();
     heddle(&["init"], Some(temp.path())).unwrap();

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -76,21 +76,27 @@ const OPLOG_FALLBACK_SCAN_WINDOW: usize = 100_000;
 
 pub fn query(ctx: &ExecutionContext, req: QueryRequest) -> Result<QueryReport> {
     let repo = ctx.require_repo()?;
-    let q = build_query(&req)?;
-    let mut scan = q.clone();
-    scan.actor = None;
-    scan.limit = None;
-    let mut hits = query_combined(repo.heddle_dir(), &scan)?;
-    for hit in &mut hits {
-        fill_actor_email_from_state(repo, hit)?;
-    }
-    hits.retain(|hit| hit.matches(&q));
-    if let Some(limit) = q.limit {
-        hits.truncate(limit);
+    let mut q = build_query(&req)?;
+    let actor = q.actor.take();
+    let limit = q.limit.take();
+    let hits = query_combined(repo.heddle_dir(), &q)?;
+    q.actor = actor;
+    let mut selected = Vec::new();
+    for mut hit in hits {
+        fill_actor_email_from_state(repo, &mut hit)?;
+        if !hit.matches(&q) {
+            continue;
+        }
+        selected.push(hit);
+        if let Some(limit) = limit
+            && selected.len() >= limit
+        {
+            break;
+        }
     }
     Ok(QueryReport {
         output_kind: "query",
-        hits: hits.into_iter().map(hit_to_report).collect(),
+        hits: selected.into_iter().map(hit_to_report).collect(),
     })
 }
 

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -77,9 +77,16 @@ const OPLOG_FALLBACK_SCAN_WINDOW: usize = 100_000;
 pub fn query(ctx: &ExecutionContext, req: QueryRequest) -> Result<QueryReport> {
     let repo = ctx.require_repo()?;
     let q = build_query(&req)?;
-    let mut hits = query_combined(repo.heddle_dir(), &q)?;
+    let mut scan = q.clone();
+    scan.actor = None;
+    scan.limit = None;
+    let mut hits = query_combined(repo.heddle_dir(), &scan)?;
     for hit in &mut hits {
         fill_actor_email_from_state(repo, hit)?;
+    }
+    hits.retain(|hit| hit.matches(&q));
+    if let Some(limit) = q.limit {
+        hits.truncate(limit);
     }
     Ok(QueryReport {
         output_kind: "query",
@@ -389,9 +396,10 @@ mod tests {
         )
         .unwrap();
         assert!(
-            report.hits.iter().any(|hit| {
-                hit.verb == "snapshot" && hit.actor_email == "heddle@example.com"
-            }),
+            report
+                .hits
+                .iter()
+                .any(|hit| hit.verb == "snapshot" && hit.actor_email == "heddle@example.com"),
             "actor filter must match the backfilled capture: {report:?}"
         );
     }

--- a/crates/core/src/query.rs
+++ b/crates/core/src/query.rs
@@ -349,4 +349,50 @@ mod tests {
         assert_eq!(details.kind, "unknown_query_verb");
         assert!(details.error.contains("captur"));
     }
+
+    #[test]
+    fn actor_filter_returns_backfilled_capture() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = repo::Repository::init_default(temp.path()).unwrap();
+        std::fs::write(temp.path().join("note.txt"), "probe\n").unwrap();
+        repo.snapshot_with_attribution(
+            Some("probe history".into()),
+            None,
+            objects::object::Attribution::human(objects::object::Principal::new(
+                "Heddle Test",
+                "heddle@example.com",
+            )),
+        )
+        .unwrap();
+
+        let stored = indexed_from_oplog_entry(
+            &oplog::OpLog::new_unattributed(repo.heddle_dir())
+                .recent(100)
+                .unwrap()
+                .into_iter()
+                .find(|entry| entry.operation.verb() == "snapshot")
+                .expect("snapshot oplog entry"),
+        );
+        assert!(
+            stored.actor_email.is_empty(),
+            "fixture must store an empty oplog actor so the filter exercises backfill"
+        );
+
+        let ctx = ExecutionContext::builder().repo(repo).build();
+        let report = query(
+            &ctx,
+            QueryRequest {
+                actor: "heddle@example.com".into(),
+                verbs: vec!["capture".into()],
+                ..QueryRequest::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            report.hits.iter().any(|hit| {
+                hit.verb == "snapshot" && hit.actor_email == "heddle@example.com"
+            }),
+            "actor filter must match the backfilled capture: {report:?}"
+        );
+    }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `query` scanned the oplog/index with `q.actor` before filling empty stored actors from the captured state, so `heddle query --actor heddle@example.com --verb capture` dropped a default-config capture that an unfiltered query already reported.
- Scan keeps verb/symbol/thread/since. Actor and limit are taken off that pass (`query_combined` already scans unbounded).
- Walk hits in seq order: `fill_actor_email_from_state`, then `matches` (including `--actor`), push, stop at `q.limit`. No second helper and no extra `Query` clone.

## Closes

Closes HeddleCo/heddle#1482

## Red commit

`f98a0d38ee17f0966b227874f7c3a2628b6e15a0`

## Test evidence

```
$ cargo test -p heddle-core query -- --nocapture
   Compiling heddle-core v0.12.0 (/workspace/crates/core)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 2.93s
     Running unittests src/lib.rs (target/debug/deps/heddle_core-bc4e4de5b874ca71)

running 4 tests
test query::tests::resolve_query_verbs_maps_capture_case_insensitively ... ok
test query::tests::build_query_uses_resolved_capture_verb ... ok
test query::tests::unknown_query_verb_is_an_error ... ok
test query::tests::actor_filter_returns_backfilled_capture ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 447 filtered out; finished in 0.02s

$ cargo test -p heddle-cli --test cli_integration capture_vocabulary -- --nocapture
   Compiling heddle-core v0.12.0 (/workspace/crates/core)
   Compiling heddle-cli-render v0.12.0 (/workspace/crates/cli-render)
   Compiling heddle-cli-contract v0.12.0 (/workspace/crates/cli-contract)
   Compiling heddle-cli v0.12.0 (/workspace/crates/cli)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 12.32s
     Running tests/cli_integration.rs (target/debug/deps/cli_integration-94edbd86e8e07fd3)

running 5 tests
test capture_vocabulary::save_suggests_capture ... ok
test capture_vocabulary::query_actor_filter_returns_backfilled_capture ... ok
test capture_vocabulary::query_unknown_verb_errors_instead_of_empty_search ... ok
test capture_vocabulary::query_verb_capture_finds_captures_case_insensitively ... ok
test capture_vocabulary::status_log_and_capture_text_use_capture_vocabulary ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 964 filtered out; finished in 0.17s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-00e1ef0f-c027-4952-a89a-0e8adc6ca49c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-00e1ef0f-c027-4952-a89a-0e8adc6ca49c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1510"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824373&installation_model_id=21489&pr_number=1510&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1510&signature=5ecc055744e1852bda441279aed1098cd56f5d3acded3bd33eb6a909ba293215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->