### PR TITLE
whoami must not adopt a plain Git checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ GitHub App, etc.) lives in the closed `HeddleCo/weft` and
 
 ### Fixed
 
+- **`whoami` does not adopt a plain Git checkout.** A read-only identity
+  query now probes with `Repository::open_existing` (the same
+  `discover_heddle_root` path other inspect commands use) and never
+  bootstraps a `.heddle` sidecar or rewrites Git excludes (heddle#1487).
+
 - **`whoami` reports the capture actor before hosted auth.** `init --principal-*`
   writes `user_config` and `status` already showed that principal. `whoami` now
   prints the same capture actor first and hosted authentication as a second

--- a/crates/cli/src/hosted_runtime/whoami.rs
+++ b/crates/cli/src/hosted_runtime/whoami.rs
@@ -13,7 +13,7 @@ use cli_shared::{
     resolve_principal_without_repo,
 };
 use crypto::Ed25519Signer;
-use repo::{Repository, discover_heddle_root};
+use repo::Repository;
 use serde::Serialize;
 use weft_client_shim::CliContext;
 
@@ -148,22 +148,21 @@ async fn resolve_whoami(ctx: &dyn CliContext, server: &str) -> Result<WhoamiOutp
 
 /// Who the next capture is attributed to.
 ///
-/// Observe-only: probe with [`discover_heddle_root`] and open only an
-/// already-present store. `Repository::open` on a plain Git tree would
-/// bootstrap a `.heddle` sidecar. A discovered store that fails to open is
-/// surfaced, not rewritten as "no repository."
+/// Observe-only: [`Repository::open_existing`] probes with
+/// [`repo::discover_heddle_root`] and opens only an already-present store.
+/// [`Repository::open`] on a plain Git tree would bootstrap a `.heddle`
+/// sidecar and rewrite Git excludes. A discovered store that fails to open
+/// is surfaced, not rewritten as "no repository."
 fn resolve_capture_actor(ctx: &dyn CliContext) -> Result<CaptureActor> {
     let user_config = UserConfig::load_default()?;
     let start = match ctx.repo_path() {
         Some(path) => path.to_path_buf(),
         None => std::env::current_dir().context("get current working directory")?,
     };
-    let resolved = match discover_heddle_root(&start) {
-        Some(root) => resolve_principal(
-            &Repository::open(&root)
-                .with_context(|| format!("open Heddle store at {}", root.display()))?,
-            &user_config,
-        )?,
+    let resolved = match Repository::open_existing(&start)
+        .with_context(|| format!("open Heddle store at {}", start.display()))?
+    {
+        Some(repo) => resolve_principal(&repo, &user_config)?,
         None => resolve_principal_without_repo(&user_config),
     };
     Ok(CaptureActor::from_resolved(&resolved))

--- a/crates/cli/tests/whoami_capture_actor.rs
+++ b/crates/cli/tests/whoami_capture_actor.rs
@@ -142,23 +142,32 @@ fn whoami_does_not_bootstrap_a_plain_git_tree() {
         "git init failed: {}",
         String::from_utf8_lossy(&init.stderr)
     );
+    let exclude = git.join(".git/info/exclude");
+    if let Some(parent) = exclude.parent() {
+        std::fs::create_dir_all(parent).expect("exclude dir");
+    }
+    let exclude_before = "# project\n*.tmp\n";
+    std::fs::write(&exclude, exclude_before).expect("seed exclude");
+    let nested = git.join("src");
+    std::fs::create_dir_all(&nested).expect("nested dir");
 
     let whoami = isolated_command(&git, &home, &["whoami", "--output", "json"])
         .output()
         .expect("run whoami");
     assert_success(&whoami, "whoami in plain git");
+    let nested_whoami = isolated_command(&nested, &home, &["whoami"])
+        .output()
+        .expect("run whoami from subdirectory");
+    assert_success(&nested_whoami, "whoami from subdirectory of plain git");
     assert!(
         !git.join(".heddle").exists(),
         "whoami must not create .heddle"
     );
-    let exclude = git.join(".git/info/exclude");
-    if exclude.is_file() {
-        let text = std::fs::read_to_string(&exclude).expect("read exclude");
-        assert!(
-            !text.contains(".heddle"),
-            "whoami must not write git excludes:\n{text}"
-        );
-    }
+    let text = std::fs::read_to_string(&exclude).expect("read exclude");
+    assert_eq!(
+        text, exclude_before,
+        "whoami must not rewrite git excludes:\n{text}"
+    );
     let value: Value = serde_json::from_slice(&whoami.stdout).expect("whoami json");
     assert_eq!(value["capture_actor"]["name"], "Luke");
     assert_eq!(value["capture_actor"]["source"], "user_config");

--- a/crates/repo/src/repository.rs
+++ b/crates/repo/src/repository.rs
@@ -1132,6 +1132,20 @@ impl Repository {
         Self::open_with_mode(path.as_ref(), RepositoryOpenMode::Normal)
     }
 
+    /// Open a Heddle store only when one already exists at `path` or an ancestor.
+    ///
+    /// [`Repository::open`] bootstraps a `.heddle` sidecar and Git excludes
+    /// for a plain Git checkout. Observe-only commands (whoami, status,
+    /// verify, doctor) must probe with [`discover_heddle_root`] first so a
+    /// read-only query never adopts the tree.
+    pub fn open_existing(path: impl AsRef<Path>) -> Result<Option<Self>> {
+        let path = path.as_ref();
+        let Some(root) = discover_heddle_root(path) else {
+            return Ok(None);
+        };
+        Ok(Some(Self::open(&root)?))
+    }
+
     /// Open only enough repository state to run explicit oplog recovery.
     ///
     /// This deliberately bypasses oplog validation, open hooks, ref-tail

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -329,8 +329,33 @@ fn open_refuses_legacy_oplog_before_mutating_repository() {
 }
 
 /// Mutating commands historically bootstrap plain Git via `Repository::open`.
-/// Observe-only CLI paths (status/verify/doctor) must not call open until a
-/// `.heddle` sidecar already exists — see `verify_execution_context_from_cli`.
+/// Observe-only CLI paths (status/verify/doctor/whoami) must not call open
+/// until a `.heddle` sidecar already exists — see `verify_execution_context_from_cli`.
+#[test]
+fn open_existing_does_not_bootstrap_plain_git() {
+    let temp_dir = TempDir::new().unwrap();
+    let root = temp_dir.path();
+    sley::Repository::init(root).expect("init valid Git worktree");
+    let exclude = root.join(".git/info/exclude");
+    if let Some(parent) = exclude.parent() {
+        fs::create_dir_all(parent).expect("exclude dir");
+    }
+    fs::write(&exclude, "# project\n").expect("seed exclude");
+
+    let opened =
+        Repository::open_existing(root).expect("observe-only open must not fail on plain Git");
+    assert!(opened.is_none(), "plain Git must stay unadopted");
+    assert!(
+        !root.join(".heddle").exists(),
+        "open_existing must not create .heddle"
+    );
+    let text = fs::read_to_string(&exclude).expect("read exclude");
+    assert_eq!(
+        text, "# project\n",
+        "open_existing must not rewrite Git excludes"
+    );
+}
+
 #[test]
 fn open_bootstraps_plain_git_sidecar_for_mutators() {
     let temp_dir = TempDir::new().unwrap();

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -366,7 +366,10 @@ fn open_existing_opens_an_already_present_store() {
         .expect("existing store must open")
         .expect("existing store must be present");
     assert_eq!(
-        opened.root().canonicalize().expect("canonicalize opened root"),
+        opened
+            .root()
+            .canonicalize()
+            .expect("canonicalize opened root"),
         root.canonicalize().expect("canonicalize fixture root")
     );
 }

--- a/crates/repo/src/repository_tests.rs
+++ b/crates/repo/src/repository_tests.rs
@@ -357,6 +357,21 @@ fn open_existing_does_not_bootstrap_plain_git() {
 }
 
 #[test]
+fn open_existing_opens_an_already_present_store() {
+    let (temp_dir, repo) = create_test_repo();
+    let root = temp_dir.path();
+    drop(repo);
+
+    let opened = Repository::open_existing(root)
+        .expect("existing store must open")
+        .expect("existing store must be present");
+    assert_eq!(
+        opened.root().canonicalize().expect("canonicalize opened root"),
+        root.canonicalize().expect("canonicalize fixture root")
+    );
+}
+
+#[test]
 fn open_bootstraps_plain_git_sidecar_for_mutators() {
     let temp_dir = TempDir::new().unwrap();
     let root = temp_dir.path();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `whoami` is a read-only identity query. Calling `Repository::open` on a plain Git checkout bootstraps `.heddle` and rewrites Git excludes, so a `whoami` without `-C` unexpectedly adopted the tree (residual from heddle#1444).
- Inspect commands already probe with `discover_heddle_root` before opening. This PR names that path `Repository::open_existing` and routes `whoami` through it. No new repo type; no `whoami --login`.
- A discovered store that fails to open still fails closed. A plain Git checkout stays unadopted.

## Closes

Closes HeddleCo/heddle#1487

## Red commit
`413735cf13948961c991d05affd21f3eb11b3464`

## Test evidence
```
$ cargo test -p heddle-repo open_existing -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/repo-df2db64f9b44eb24)

running 2 tests
test repository::repository_tests::open_existing_does_not_bootstrap_plain_git ... ok
test repository::repository_tests::open_existing_opens_an_already_present_store ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 677 filtered out; finished in 0.02s

$ cargo test -p heddle-cli --test whoami_capture_actor -- --nocapture
     Running tests/whoami_capture_actor.rs (target/debug/deps/whoami_capture_actor-4f4c1f5ba8a1a8c1)

running 4 tests
test whoami_help_names_capture_actor_and_hosted_auth_as_different_objects ... ok
test whoami_fails_closed_on_a_broken_heddle_store ... ok
test whoami_does_not_bootstrap_a_plain_git_tree ... ok
test whoami_reports_init_principal_then_unauthenticated_hosted ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.10s

$ cargo test -p heddle-cli --lib hosted_runtime::whoami -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/cli-6145f8682400ee99)

running 5 tests
test hosted_runtime::whoami::tests::capture_actor_from_resolved_maps_user_config ... ok
test hosted_runtime::whoami::tests::biscuit_literal_and_role_helpers_cover_escaped_and_unknown_values ... ok
test hosted_runtime::whoami::tests::human_output_renders_authoritative_identity_and_local_token_facts ... ok
test hosted_runtime::whoami::tests::local_unauthenticated_identity_has_actionable_output ... ok
test hosted_runtime::whoami::tests::without_repo_uses_user_config_when_env_unset ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 744 filtered out; finished in 0.00s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-50a8e93a-6d8c-43d4-884f-4cba0a1ec4f5?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-50a8e93a-6d8c-43d4-884f-4cba0a1ec4f5&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1515"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824477&installation_model_id=21489&pr_number=1515&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1515&signature=ed587804d9e0b34f7e6896004494fdb8af98e2e7c5e6e63afaf273e2b6214754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->