### PR TITLE
fix(cli): TLS CA discovery uses the -C selected repository

### DIFF
--- a/crates/cli-shared/src/config/user_config.rs
+++ b/crates/cli-shared/src/config/user_config.rs
@@ -4,6 +4,7 @@ use std::{
     env, fs,
     io::Read,
     path::{Path, PathBuf},
+    sync::OnceLock,
 };
 
 use objects::{
@@ -18,6 +19,11 @@ use serde::{Deserialize, Serialize};
 use wire::AuthToken;
 
 use crate::client_config::ClientConfig;
+
+/// CLI-selected repository start (`-C` / `--repo`, else startup cwd).
+/// Recorded once so later `UserConfig::load_default()` calls still discover
+/// TLS CA from that checkout instead of a later process cwd.
+static REMOTE_TLS_REPO_START: OnceLock<PathBuf> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct UserConfig {
@@ -457,13 +463,38 @@ impl UserConfig {
         Ok(matches!(mode, UserAutoCaptureMode::Command))
     }
 
+    /// Record the CLI-selected repository start used for TLS CA discovery.
+    ///
+    /// Startup sets this from `-C` / `--repo` (or the process cwd) before
+    /// commands open a repository, so later hosted config assembly honors
+    /// the same checkout.
+    pub fn set_remote_tls_repo_start(path: PathBuf) {
+        let _ = REMOTE_TLS_REPO_START.set(path);
+    }
+
     /// Resolve the shared custom CA bundle used by hosted and Git transports.
+    ///
+    /// `repo_start` is the CLI-selected repository path (`-C` / `--repo`).
+    /// When omitted, uses the start recorded at process startup, then the
+    /// process cwd.
     ///
     /// Precedence, highest first: `HEDDLE_REMOTE_TLS_CA_CERT`, user-config
     /// `[remote] tls_ca_certificate_path`, then the same key in repository
-    /// `.heddle/config.toml` discovered from `start` (or the process cwd).
-    pub fn remote_tls_ca_certificate_pem(&self) -> anyhow::Result<Option<String>> {
-        self.remote_tls_ca_certificate_pem_from(env::current_dir().ok().as_deref())
+    /// `.heddle/config.toml` discovered from that start path.
+    pub fn remote_tls_ca_certificate_pem(
+        &self,
+        repo_start: Option<&Path>,
+    ) -> anyhow::Result<Option<String>> {
+        let cwd;
+        let start = if let Some(path) = repo_start {
+            Some(path)
+        } else if let Some(path) = REMOTE_TLS_REPO_START.get() {
+            Some(path.as_path())
+        } else {
+            cwd = env::current_dir().ok();
+            cwd.as_deref()
+        };
+        self.remote_tls_ca_certificate_pem_from(start)
     }
 
     fn remote_tls_ca_certificate_pem_from(
@@ -520,7 +551,7 @@ impl UserConfig {
         if let Some(domain) = &self.remote.tls_domain_name {
             config = config.with_tls_domain_name(domain.clone());
         }
-        if let Some(pem) = self.remote_tls_ca_certificate_pem()? {
+        if let Some(pem) = self.remote_tls_ca_certificate_pem(None)? {
             config = config.with_tls_ca_certificate_pem(pem);
         }
         if let Some(path) = &self.remote.auth_proof_key_pem_path {
@@ -1331,6 +1362,44 @@ mod tests {
             .expect("user CA should win");
         assert_eq!(pem.as_deref(), Some("user ca pem"));
         fs::remove_dir_all(root).expect("remove temp dir");
+    }
+
+    #[test]
+    fn remote_tls_ca_selected_start_is_not_another_repo() {
+        let _env = RemoteEnvGuard::clean();
+        let parent = unique_temp_path("heddle-repo-tls-ca-dash-c");
+        let cwd_root = parent.join("cwd-repo");
+        let selected_root = parent.join("selected-repo");
+        fs::create_dir_all(&cwd_root).expect("create cwd repo");
+        fs::create_dir_all(&selected_root).expect("create selected repo");
+        let cwd_ca = cwd_root.join("ca.pem");
+        let selected_ca = selected_root.join("ca.pem");
+        fs::write(&cwd_ca, "cwd ca pem").expect("write cwd CA");
+        fs::write(&selected_ca, "selected ca pem").expect("write selected CA");
+        write_discoverable_repo(
+            &cwd_root,
+            &format!(
+                "\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                cwd_ca.display()
+            ),
+        );
+        write_discoverable_repo(
+            &selected_root,
+            &format!(
+                "\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+                selected_ca.display()
+            ),
+        );
+
+        let selected = UserConfig::default()
+            .remote_tls_ca_certificate_pem(Some(&selected_root))
+            .expect("selected repo CA should load");
+        let other = UserConfig::default()
+            .remote_tls_ca_certificate_pem(Some(&cwd_root))
+            .expect("cwd repo CA should load");
+        assert_eq!(selected.as_deref(), Some("selected ca pem"));
+        assert_eq!(other.as_deref(), Some("cwd ca pem"));
+        fs::remove_dir_all(parent).expect("remove temp dir");
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -236,7 +236,11 @@ async fn async_main() -> Result<()> {
             std::process::exit(code.into());
         }
     };
-    let git_tls_ca_pem = match user_config.remote_tls_ca_certificate_pem() {
+    let repo_start = cli.repo.clone().or_else(|| std::env::current_dir().ok());
+    if let Some(path) = repo_start.as_ref() {
+        UserConfig::set_remote_tls_repo_start(path.clone());
+    }
+    let git_tls_ca_pem = match user_config.remote_tls_ca_certificate_pem(repo_start.as_deref()) {
         Ok(ca_pem) => ca_pem,
         Err(err) => {
             let code = HeddleExitCode::from_error(&err);

--- a/crates/cli/tests/hosted_bootstrap_tls.rs
+++ b/crates/cli/tests/hosted_bootstrap_tls.rs
@@ -167,18 +167,7 @@ impl LoginFixture {
                 .expect("write user config CA");
                 command.env("HEDDLE_CONFIG", config);
             }
-            CaSource::RepoConfig => {
-                let repo_config = self.repo.join(".heddle/config.toml");
-                let current = std::fs::read_to_string(&repo_config).expect("read repo config");
-                std::fs::write(
-                    repo_config,
-                    format!(
-                        "{current}\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
-                        self.ca_path.display()
-                    ),
-                )
-                .expect("write repo config CA");
-            }
+            CaSource::RepoConfig => write_repo_tls_ca(&self.repo, &self.ca_path),
         }
         command.output().expect("run heddle auth login")
     }
@@ -228,10 +217,51 @@ fn auth_login_honours_repo_config_tls_ca_certificate_path() {
 }
 
 #[test]
+fn auth_login_honours_dash_c_repo_ca_not_cwd() {
+    let fixture = LoginFixture::new();
+    write_repo_tls_ca(&fixture.repo, &fixture.ca_path);
+
+    let cwd_repo = fixture.temp.path().join("cwd-repo");
+    std::fs::create_dir_all(&cwd_repo).expect("create cwd repo dir");
+    let init = heddle_command(&fixture.temp, &cwd_repo)
+        .args(["init"])
+        .output()
+        .expect("init cwd repo");
+    assert!(init.status.success(), "init cwd repo: {}", stderr(&init));
+
+    let CertifiedKey { cert, .. } =
+        generate_simple_self_signed(vec!["127.0.0.1".to_string()]).expect("cwd decoy CA");
+    let cwd_ca = fixture.temp.path().join("cwd-ca.pem");
+    std::fs::write(&cwd_ca, cert.pem()).expect("write cwd decoy CA");
+    write_repo_tls_ca(&cwd_repo, &cwd_ca);
+
+    let output = heddle_command(&fixture.temp, &cwd_repo)
+        .arg("-C")
+        .arg(&fixture.repo)
+        .args(["auth", "login", "--server", &fixture.server])
+        .output()
+        .expect("run heddle -C auth login");
+    assert_tls_honored(&output, "-C selected repo config");
+}
+
+#[test]
 fn auth_login_honours_env_tls_ca_cert() {
     let fixture = LoginFixture::new();
     let output = fixture.login(CaSource::Env);
     assert_tls_honored(&output, "HEDDLE_REMOTE_TLS_CA_CERT");
+}
+
+fn write_repo_tls_ca(repo: &Path, ca_path: &Path) {
+    let repo_config = repo.join(".heddle/config.toml");
+    let current = std::fs::read_to_string(&repo_config).expect("read repo config");
+    std::fs::write(
+        repo_config,
+        format!(
+            "{current}\n[remote]\ntls_ca_certificate_path = \"{}\"\n",
+            ca_path.display()
+        ),
+    )
+    .expect("write repo config CA");
 }
 
 fn assert_tls_honored(output: &Output, source: &str) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Startup discovered `[remote] tls_ca_certificate_path` from the process cwd, so `heddle -C /path/to/repo …` could ignore that checkout's CA and apply another repository's CA instead.
- The resolver now receives the CLI-selected start (`cli.repo` / `-C`, else startup cwd) and records it so later hosted config assembly uses the same checkout.
- Sibling heddle#1497 (env var vs missing repo CA) is intentionally left unchanged.

## Closes

Closes HeddleCo/heddle#1496

## Red commit
`903b6f1421fb1624656fdc17132c8e4918967d25`

The red commit added `auth_login_honours_dash_c_repo_ca_not_cwd`. Before the fix it applied the cwd decoy CA and failed TLS with `BadSignature`. After the fix it honors the `-C` repo CA and fails after TLS on missing descriptor trust.

## Test evidence
```
$ cargo test -p heddle-cli-shared remote_tls_ca -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/cli_shared-a6850b479be9e0d8)

running 4 tests
test config::user_config::tests::remote_tls_ca_selected_start_is_not_another_repo ... ok
test config::user_config::tests::remote_tls_ca_honours_repo_config_when_user_config_is_unset ... ok
test config::user_config::tests::remote_tls_ca_unknown_repo_remote_key_fails_closed ... ok
test config::user_config::tests::remote_tls_ca_user_config_overrides_repo_config ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 44 filtered out; finished in 0.00s

$ cargo test -p heddle-cli --test hosted_bootstrap_tls -- --nocapture
     Running tests/hosted_bootstrap_tls.rs (target/debug/deps/hosted_bootstrap_tls-9b03b13bcd41ea8d)

running 5 tests
user config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:43549)
Next: heddle status
Also: heddle help auth login

repo config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:45879)
Next: heddle status
Also: heddle help auth login

test auth_login_honours_user_config_tls_ca_certificate_path ... ok
test auth_login_honours_repo_config_tls_ca_certificate_path ... HEDDLE_REMOTE_TLS_CA_CERT: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:36509)
Next: heddle status
Also: heddle help auth login

ok
test auth_login_honours_env_tls_ca_cert ... ok
-C selected repo config: TLS honored; login failed after bootstrap:
Error: remote error: server does not publish descriptor trust; configure both values or upgrade the server (canonical server: https://127.0.0.1:34143)
Next: heddle status
Also: heddle help auth login

test auth_login_honours_dash_c_repo_ca_not_cwd ... ok
untrusted login names the CA configuration:
2026-08-20T13:30:14.513259Z ERROR rustls_platform_verifier::verification::others: failed to verify TLS certificate: invalid peer certificate: UnknownIssuer
Error: remote error: hosted bootstrap HTTPS request failed: error sending request for url (https://127.0.0.1:34111/.well-known/heddle/iroh-descriptor-key): client error (Connect): invalid peer certificate: UnknownIssuer; trust this server's CA with HEDDLE_REMOTE_TLS_CA_CERT=/path/to/ca.pem
Next: heddle help remotes

test auth_login_without_ca_names_remote_tls_configuration ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s

$ cargo test -p heddle-cli-shared hosted_runtime_config -- --nocapture
     Running unittests src/lib.rs (target/debug/deps/cli_shared-a6850b479be9e0d8)

running 12 tests
test config::user_config::tests::hosted_runtime_config_loads_descriptor_trust_from_environment ... ok
test config::user_config::tests::hosted_runtime_config_missing_env_tls_ca_path_fails_closed ... ok
test config::user_config::tests::hosted_runtime_config_absent_security_settings_uses_defaults ... ok
test config::user_config::tests::hosted_runtime_config_invalid_env_tls_value_fails_closed ... ok
test config::user_config::tests::hosted_runtime_config_loads_provider_knobs_from_user_config_and_env ... ok
test config::user_config::tests::hosted_runtime_config_rejects_key_only_environment_descriptor_trust ... ok
test config::user_config::tests::hosted_runtime_config_rejects_invalid_provider_env_knob ... ok
test config::user_config::tests::hosted_runtime_config_missing_tls_ca_path_fails_closed ... ok
test config::user_config::tests::hosted_runtime_config_rejects_key_only_file_descriptor_trust ... ok
test config::user_config::tests::hosted_runtime_config_rejects_public_key_only_environment_descriptor_trust ... ok
test config::user_config::tests::hosted_runtime_config_rejects_public_key_only_file_descriptor_trust ... ok
test config::user_config::tests::hosted_runtime_config_valid_security_files_are_applied ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 36 filtered out; finished in 0.00s

$ cargo clippy -p heddle-cli-shared -p heddle-cli -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.25s
```

## Manual verification

N/A — covered by tests.

## Blocked by → resolved

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8f33d309-63e5-4cf4-828f-0a20f042b8ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f33d309-63e5-4cf4-828f-0a20f042b8ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/HeddleCo/codesmith/heddle/pr/1516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789824563&installation_model_id=21489&pr_number=1516&repository=HeddleCo%2Fheddle&return_to=https%3A%2F%2Fgithub.com%2FHeddleCo%2Fheddle%2Fpull%2F1516&signature=253a1e96e63cd9fbdd606d6485a1089ed15756679329c40c82c98554b3166588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->